### PR TITLE
Add Hugging Face JSON tokenizer loading

### DIFF
--- a/crates/bitnet-tokenizers/src/loader.rs
+++ b/crates/bitnet-tokenizers/src/loader.rs
@@ -5,6 +5,24 @@ use serde_json::Value;
 use std::{fs, path::Path};
 
 /// Load a tokenizer from a file path
+///
+/// Supports multiple tokenizer formats:
+/// - `.gguf` - GGUF model files with embedded tokenizers
+/// - `.json` - Hugging Face tokenizer.json files (requires `model.type` field)
+/// - `.model` - SentencePiece model files (requires `spm` feature)
+///
+/// # Arguments
+/// * `path` - Path to the tokenizer file
+///
+/// # Returns
+/// A boxed tokenizer instance implementing the `Tokenizer` trait
+///
+/// # Errors
+/// Returns an error if:
+/// - The file cannot be read
+/// - The file format is unknown or invalid
+/// - The JSON structure is missing required fields
+/// - The tokenizer fails to load
 pub fn load_tokenizer(path: &Path) -> Result<Box<dyn Tokenizer>> {
     // Check file extension to determine tokenizer type
     let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");

--- a/crates/bitnet-tokenizers/tests/json_loader.rs
+++ b/crates/bitnet-tokenizers/tests/json_loader.rs
@@ -16,7 +16,7 @@ fn load_hf_tokenizer_json() {
     let model = WordLevel::from_file(vocab_file.path().to_str().unwrap(), "<unk>".into())
         .expect("create model");
     let mut tokenizer = HfTokenizer::new(model);
-    tokenizer.with_pre_tokenizer(tokenizers::pre_tokenizers::whitespace::Whitespace::default());
+    tokenizer.with_pre_tokenizer(tokenizers::pre_tokenizers::whitespace::Whitespace {});
     let json = tokenizer.to_string(true).expect("serialize tokenizer");
 
     let tmp = tempfile::Builder::new().suffix(".json").tempfile().expect("tmp file");
@@ -35,4 +35,83 @@ fn load_invalid_json_fails() {
     let tmp = tempfile::NamedTempFile::new().expect("tmp");
     std::fs::write(tmp.path(), "not json").unwrap();
     assert!(load_tokenizer(tmp.path()).is_err());
+}
+
+#[test]
+fn load_json_missing_model_type_fails() {
+    let tmp = tempfile::Builder::new().suffix(".json").tempfile().expect("tmp file");
+
+    // JSON without model.type field
+    let json = r#"{"version": "1.0", "truncation": null}"#;
+    std::fs::write(tmp.path(), json).expect("write json");
+
+    let result = load_tokenizer(tmp.path());
+    assert!(result.is_err());
+    if let Err(e) = result {
+        let err_msg = e.to_string();
+        assert!(err_msg.contains("missing 'model.type' field"));
+    }
+}
+
+#[test]
+fn load_json_with_special_tokens() {
+    use tokenizers::{Tokenizer as HfTokenizer, models::wordlevel::WordLevel};
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("<s>".to_string(), 0);
+    vocab.insert("</s>".to_string(), 1);
+    vocab.insert("hello".to_string(), 2);
+    vocab.insert("world".to_string(), 3);
+    vocab.insert("<unk>".to_string(), 4);
+
+    let vocab_file = tempfile::NamedTempFile::new().expect("vocab file");
+    let vocab_json = serde_json::to_string(&vocab).unwrap();
+    std::fs::write(vocab_file.path(), vocab_json).unwrap();
+
+    let model = WordLevel::from_file(vocab_file.path().to_str().unwrap(), "<unk>".into())
+        .expect("create model");
+    let mut tokenizer = HfTokenizer::new(model);
+    tokenizer.with_pre_tokenizer(tokenizers::pre_tokenizers::whitespace::Whitespace {});
+    let json = tokenizer.to_string(true).expect("serialize tokenizer");
+
+    let tmp = tempfile::Builder::new().suffix(".json").tempfile().expect("tmp file");
+    std::fs::write(tmp.path(), json).expect("write json");
+
+    let tok = load_tokenizer(tmp.path()).expect("load tokenizer");
+
+    // Test basic encoding
+    let ids = tok.encode("hello world", false, false).expect("encode");
+    assert_eq!(ids, vec![2, 3]);
+
+    // Test with BOS
+    let ids = tok.encode("hello world", true, false).expect("encode with BOS");
+    assert_eq!(ids, vec![0, 2, 3]); // <s> hello world
+
+    // Test that special tokens are detected
+    assert_eq!(tok.bos_token_id(), Some(0));
+    assert_eq!(tok.eos_token_id(), Some(1));
+}
+
+#[test]
+fn load_json_empty_text_encoding() {
+    use tokenizers::{Tokenizer as HfTokenizer, models::wordlevel::WordLevel};
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("<unk>".to_string(), 0);
+
+    let vocab_file = tempfile::NamedTempFile::new().expect("vocab file");
+    let vocab_json = serde_json::to_string(&vocab).unwrap();
+    std::fs::write(vocab_file.path(), vocab_json).unwrap();
+
+    let model = WordLevel::from_file(vocab_file.path().to_str().unwrap(), "<unk>".into())
+        .expect("create model");
+    let tokenizer = HfTokenizer::new(model);
+    let json = tokenizer.to_string(true).expect("serialize tokenizer");
+
+    let tmp = tempfile::Builder::new().suffix(".json").tempfile().expect("tmp file");
+    std::fs::write(tmp.path(), json).expect("write json");
+
+    let tok = load_tokenizer(tmp.path()).expect("load tokenizer");
+
+    // Test empty string encoding
+    let ids = tok.encode("", false, false).expect("encode empty");
+    assert_eq!(ids.len(), 0);
 }


### PR DESCRIPTION
## Summary
- support loading `tokenizer.json` files via `HfTokenizer`
- validate JSON structure and produce helpful errors
- test JSON loader with valid and invalid inputs

## Testing
- `cargo test -p bitnet-tokenizers`


------
https://chatgpt.com/codex/tasks/task_e_68ac9c0cc9048333ade9c006fe1fda0f