### PR TITLE
Add HuggingFace model loader and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Made health endpoint robust with option_env! for graceful fallbacks
 
 ### Added
+- **HuggingFace Model Loader**:
+  - Parse `config.json` for model metadata
+  - Load sharded SafeTensors weights into `BitNetModel`
+  - Integration test verifying a forward pass
 - **GGUF Validation API**:
   - Fast 24-byte header-only validation without loading full model
   - Production-ready parser with typed errors and non-exhaustive enums

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ### 🌐 **Cross-Platform Excellence**
 - **Native support** for Linux, macOS, and Windows
 - **Multiple backends**: CPU and GPU (CUDA) inference engines
-- **Universal model formats**: GGUF, SafeTensors, and HuggingFace
+- **Universal model formats**: GGUF, sharded SafeTensors (HuggingFace), and local HuggingFace directories
 - **Language bindings**: C API, Python, and WebAssembly
 
 ### 🔧 **Developer Experience**

--- a/crates/bitnet-models/src/formats/huggingface.rs
+++ b/crates/bitnet-models/src/formats/huggingface.rs
@@ -1,9 +1,14 @@
 //! HuggingFace format loader
 
-use crate::loader::{FormatLoader, LoadConfig};
+use crate::loader::{FormatLoader, LoadConfig, MmapFile};
 use crate::{BitNetModel, Model};
-use bitnet_common::{BitNetConfig, Device, ModelMetadata, Result};
-use std::path::Path;
+use bitnet_common::{BitNetConfig, BitNetError, Device, ModelError, ModelMetadata, Result};
+use candle_core::Tensor;
+use safetensors::{Dtype as SafeDtype, SafeTensors};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 
 /// HuggingFace format loader
@@ -29,13 +34,44 @@ impl FormatLoader for HuggingFaceLoader {
     fn extract_metadata(&self, path: &Path) -> Result<ModelMetadata> {
         debug!("Extracting HuggingFace metadata from: {}", path.display());
 
-        // TODO: Parse config.json to extract metadata
+        let config_path = path.join("config.json");
+        let cfg: Value = serde_json::from_slice(&fs::read(&config_path).map_err(BitNetError::Io)?)
+            .map_err(|e| BitNetError::Model(ModelError::InvalidFormat { format: e.to_string() }))?;
+
+        let name = cfg
+            .get("_name_or_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| path.file_name().and_then(|s| s.to_str()).unwrap_or("unknown"))
+            .to_string();
+
+        let version = cfg
+            .get("transformers_version")
+            .or_else(|| cfg.get("model_revision"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let architecture = cfg
+            .get("model_type")
+            .or_else(|| cfg.get("architectures").and_then(|v| v.get(0)))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let vocab_size = cfg.get("vocab_size").and_then(|v| v.as_u64()).unwrap_or(32000) as usize;
+
+        let context_length = cfg
+            .get("max_position_embeddings")
+            .or_else(|| cfg.get("n_positions"))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(2048) as usize;
+
         let metadata = ModelMetadata {
-            name: path.file_name().and_then(|s| s.to_str()).unwrap_or("unknown").to_string(),
-            version: "unknown".to_string(),
-            architecture: "bitnet".to_string(),
-            vocab_size: 32000,
-            context_length: 2048,
+            name,
+            version,
+            architecture,
+            vocab_size,
+            context_length,
             quantization: None,
         };
 
@@ -43,13 +79,199 @@ impl FormatLoader for HuggingFaceLoader {
         Ok(metadata)
     }
 
-    fn load(&self, path: &Path, device: &Device, _config: &LoadConfig) -> Result<Box<dyn Model>> {
+    fn load(&self, path: &Path, device: &Device, config: &LoadConfig) -> Result<Box<dyn Model>> {
         info!("Loading HuggingFace model from: {}", path.display());
 
-        // TODO: Implement HuggingFace loading
-        let config = BitNetConfig::default();
-        let model = BitNetModel::new(config, *device);
+        let model_config = self.parse_config(path)?;
+        let shard_files = self.find_shards(path)?;
 
+        let mut tensors = HashMap::new();
+        for shard in shard_files {
+            let data = if config.use_mmap {
+                let mmap = MmapFile::open(&shard)?;
+                mmap.as_slice().to_vec()
+            } else {
+                fs::read(&shard).map_err(BitNetError::Io)?
+            };
+            let st = SafeTensors::deserialize(&data).map_err(|e| {
+                BitNetError::Model(ModelError::InvalidFormat {
+                    format: format!("Failed to parse {}: {}", shard.display(), e),
+                })
+            })?;
+
+            for name in st.names() {
+                let view = st.tensor(name).map_err(|e| {
+                    BitNetError::Model(ModelError::LoadingFailed {
+                        reason: format!("Failed to get tensor '{}': {}", name, e),
+                    })
+                })?;
+                let tensor = self.convert_tensor(&view, device)?;
+                tensors.insert(name.to_string(), tensor);
+            }
+        }
+
+        let model = BitNetModel::from_gguf(model_config, tensors, *device)?;
         Ok(Box::new(model))
+    }
+}
+
+impl HuggingFaceLoader {
+    fn parse_config(&self, path: &Path) -> Result<BitNetConfig> {
+        let config_path = path.join("config.json");
+        let cfg: Value = serde_json::from_slice(&fs::read(&config_path).map_err(BitNetError::Io)?)
+            .map_err(|e| BitNetError::Model(ModelError::InvalidFormat { format: e.to_string() }))?;
+
+        let mut config = BitNetConfig::default();
+        config.model.format = bitnet_common::ModelFormat::HuggingFace;
+        if let Some(v) = cfg.get("vocab_size").and_then(|v| v.as_u64()) {
+            config.model.vocab_size = v as usize;
+        }
+        if let Some(v) =
+            cfg.get("hidden_size").or_else(|| cfg.get("n_embd")).and_then(|v| v.as_u64())
+        {
+            config.model.hidden_size = v as usize;
+        }
+        if let Some(v) =
+            cfg.get("num_hidden_layers").or_else(|| cfg.get("n_layer")).and_then(|v| v.as_u64())
+        {
+            config.model.num_layers = v as usize;
+        }
+        if let Some(v) =
+            cfg.get("num_attention_heads").or_else(|| cfg.get("n_head")).and_then(|v| v.as_u64())
+        {
+            config.model.num_heads = v as usize;
+        }
+        if let Some(v) =
+            cfg.get("intermediate_size").or_else(|| cfg.get("n_inner")).and_then(|v| v.as_u64())
+        {
+            config.model.intermediate_size = v as usize;
+        }
+        if let Some(v) = cfg
+            .get("max_position_embeddings")
+            .or_else(|| cfg.get("n_positions"))
+            .and_then(|v| v.as_u64())
+        {
+            config.model.max_position_embeddings = v as usize;
+        }
+
+        Ok(config)
+    }
+
+    fn find_shards(&self, path: &Path) -> Result<Vec<PathBuf>> {
+        let index_path = path.join("model.safetensors.index.json");
+        if index_path.exists() {
+            let idx: Value = serde_json::from_slice(
+                &fs::read(&index_path).map_err(BitNetError::Io)?,
+            )
+            .map_err(|e| {
+                BitNetError::Model(ModelError::InvalidFormat {
+                    format: format!("Failed to parse index: {}", e),
+                })
+            })?;
+            let mut files = HashSet::new();
+            if let Some(map) = idx.get("weight_map").and_then(|v| v.as_object()) {
+                for v in map.values() {
+                    if let Some(f) = v.as_str() {
+                        files.insert(path.join(f));
+                    }
+                }
+            }
+            Ok(files.into_iter().collect())
+        } else {
+            let mut shards = Vec::new();
+            for entry in fs::read_dir(path).map_err(BitNetError::Io)? {
+                let entry = entry.map_err(BitNetError::Io)?;
+                let p = entry.path();
+                if p.extension().and_then(|e| e.to_str()) == Some("safetensors") {
+                    shards.push(p);
+                }
+            }
+            Ok(shards)
+        }
+    }
+
+    fn convert_tensor(
+        &self,
+        tensor_view: &safetensors::tensor::TensorView,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let shape = tensor_view.shape();
+        let data = tensor_view.data();
+        let candle_device = Self::device_to_candle(device)?;
+
+        let tensor = match tensor_view.dtype() {
+            SafeDtype::F32 => {
+                let d = bytemuck::cast_slice::<u8, f32>(data);
+                Tensor::from_slice(d, shape, &candle_device)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?
+            }
+            SafeDtype::F16 => {
+                let half = bytemuck::cast_slice::<u8, u16>(data);
+                let float: Vec<f32> =
+                    half.iter().map(|&h| half::f16::from_bits(h).to_f32()).collect();
+                Tensor::from_slice(&float, shape, &candle_device)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?
+            }
+            SafeDtype::BF16 => {
+                let half = bytemuck::cast_slice::<u8, u16>(data);
+                let float: Vec<f32> =
+                    half.iter().map(|&h| half::bf16::from_bits(h).to_f32()).collect();
+                Tensor::from_slice(&float, shape, &candle_device)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?
+            }
+            SafeDtype::I32 => {
+                let int = bytemuck::cast_slice::<u8, i32>(data);
+                let uint: Vec<u32> = int.iter().map(|&x| x as u32).collect();
+                Tensor::from_slice(&uint, shape, &candle_device)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?
+            }
+            SafeDtype::I64 => {
+                let int = bytemuck::cast_slice::<u8, i64>(data);
+                Tensor::from_slice(int, shape, &candle_device)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?
+            }
+            SafeDtype::U8 => Tensor::from_slice(data, shape, &candle_device)
+                .map_err(|e| BitNetError::Validation(e.to_string()))?,
+            _ => {
+                return Err(BitNetError::Model(ModelError::InvalidFormat {
+                    format: format!("Unsupported dtype: {:?}", tensor_view.dtype()),
+                }));
+            }
+        };
+
+        Ok(tensor)
+    }
+
+    fn device_to_candle(device: &Device) -> Result<candle_core::Device> {
+        match device {
+            Device::Cpu => Ok(candle_core::Device::Cpu),
+            Device::Cuda(id) => {
+                #[cfg(feature = "gpu")]
+                {
+                    use candle_core::backend::BackendDevice;
+                    let cuda = candle_core::CudaDevice::new(*id)
+                        .map_err(|e| BitNetError::Validation(e.to_string()))?;
+                    Ok(candle_core::Device::Cuda(cuda))
+                }
+                #[cfg(not(feature = "gpu"))]
+                {
+                    let _ = id;
+                    Err(BitNetError::Validation(
+                        "CUDA support not enabled; rebuild with --features gpu".to_string(),
+                    ))
+                }
+            }
+            #[cfg(all(target_os = "macos", feature = "gpu"))]
+            Device::Metal => {
+                use candle_core::backend::BackendDevice;
+                let metal = candle_core::MetalDevice::new(0)
+                    .map_err(|e| BitNetError::Validation(e.to_string()))?;
+                Ok(candle_core::Device::Metal(metal))
+            }
+            #[cfg(not(all(target_os = "macos", feature = "gpu")))]
+            Device::Metal => Err(BitNetError::Validation(
+                "Metal support not enabled; rebuild with --features gpu on macOS".to_string(),
+            )),
+        }
     }
 }

--- a/crates/bitnet-models/tests/huggingface_forward.rs
+++ b/crates/bitnet-models/tests/huggingface_forward.rs
@@ -1,0 +1,85 @@
+//! Integration test for loading a minimal HuggingFace model and running a forward pass.
+
+use std::collections::BTreeMap;
+use std::fs;
+use tempfile::TempDir;
+
+use bitnet_common::Device as CommonDevice;
+use bitnet_common::Tensor;
+use bitnet_models::{
+    formats::huggingface::HuggingFaceLoader,
+    loader::{FormatLoader, LoadConfig},
+    transformer::KVCache,
+};
+use candle_core::Device as CandleDevice;
+use safetensors::tensor::{Dtype, TensorView};
+
+#[test]
+fn test_load_huggingface_and_forward() {
+    // Build a minimal HuggingFace model directory.
+    let dir = TempDir::new().unwrap();
+    let model_dir = dir.path();
+
+    // Write config.json
+    let config = serde_json::json!({
+        "_name_or_path": "test",
+        "model_type": "bitnet",
+        "vocab_size": 16,
+        "hidden_size": 4,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 1,
+        "intermediate_size": 8,
+        "max_position_embeddings": 8,
+    });
+    fs::write(model_dir.join("config.json"), serde_json::to_vec(&config).unwrap()).unwrap();
+
+    // Create minimal weights with embeddings and lm_head
+    let vocab_size = 16;
+    let hidden = 4;
+    let embed_data = vec![0f32; vocab_size * hidden];
+    let lm_head_data = vec![0f32; vocab_size * hidden];
+
+    let mut tensors = BTreeMap::new();
+    let embed_view =
+        TensorView::new(Dtype::F32, vec![vocab_size, hidden], bytemuck::cast_slice(&embed_data))
+            .unwrap();
+    tensors.insert("model.embed_tokens.weight", embed_view);
+    let lm_head_view =
+        TensorView::new(Dtype::F32, vec![vocab_size, hidden], bytemuck::cast_slice(&lm_head_data))
+            .unwrap();
+    tensors.insert("lm_head.weight", lm_head_view);
+
+    let data = safetensors::serialize(tensors.iter().map(|(k, v)| (*k, v)), None).unwrap();
+    let shard_name = "model-00001-of-00001.safetensors";
+    fs::write(model_dir.join(shard_name), &data).unwrap();
+
+    // Write index.json mapping tensors to shard
+    let mut weight_map = serde_json::Map::new();
+    weight_map.insert(
+        "model.embed_tokens.weight".to_string(),
+        serde_json::Value::String(shard_name.to_string()),
+    );
+    weight_map
+        .insert("lm_head.weight".to_string(), serde_json::Value::String(shard_name.to_string()));
+    let index = serde_json::json!({
+        "metadata": { "total_size": data.len() },
+        "weight_map": weight_map,
+    });
+    fs::write(model_dir.join("model.safetensors.index.json"), serde_json::to_vec(&index).unwrap())
+        .unwrap();
+
+    // Load model
+    let loader = HuggingFaceLoader;
+    let device = CommonDevice::Cpu;
+    let model = loader.load(model_dir, &device, &LoadConfig::default()).expect("load model");
+
+    // Embed and run forward
+    let tokens = vec![0u32, 1, 2, 3];
+    let embedded = model.embed(&tokens).unwrap();
+    let candle_device = CandleDevice::Cpu;
+    let mut cache = KVCache::new(model.config(), 1, &candle_device).unwrap();
+    let hidden = model.forward(&embedded, &mut cache).unwrap();
+
+    assert_eq!(hidden.shape()[0], 1); // batch
+    assert_eq!(hidden.shape()[1], tokens.len());
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,7 +14,7 @@ pub struct BitNetModel {
 }
 
 impl BitNetModel {
-    /// Load a model from a file path
+    /// Load a model from a local GGUF file, SafeTensors file, or HuggingFace directory
     pub async fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, BitNetError>;
     
     /// Load a model from HuggingFace Hub

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,6 +137,12 @@ bitnet-cli inference --model path/to/model.gguf --prompt "Hello"
 bitnet-cli inference --model path/to/model.safetensors --prompt "Hello"
 ```
 
+### HuggingFace Directory
+```bash
+# Load a local HuggingFace model directory
+bitnet-cli inference --model path/to/hf-model --prompt "Hello"
+```
+
 ### HuggingFace Hub
 ```bash
 # Load from HuggingFace Hub


### PR DESCRIPTION
## Summary
- parse HuggingFace `config.json` to fill model metadata and configuration
- load sharded SafeTensors weights into `BitNetModel`
- add integration test that loads a minimal HuggingFace model and runs a forward pass
- document HuggingFace loader usage in docs and changelog

## Testing
- `cargo test -p bitnet-models --test huggingface_forward`


------
https://chatgpt.com/codex/tasks/task_e_68ad6c86b1fc8333a921e3f981c6458c