### PR TITLE
feat(tokenizers): add BPE backend and roundtrip tests

### DIFF
--- a/crates/bitnet-tokenizers/src/universal.rs
+++ b/crates/bitnet-tokenizers/src/universal.rs
@@ -2,7 +2,7 @@ use bitnet_common::Result;
 use std::path::Path;
 use tracing::{debug, warn};
 
-use crate::{Tokenizer, TokenizerConfig, MockTokenizer};
+use crate::{HfTokenizer, MockTokenizer, Tokenizer, TokenizerConfig};
 
 /// Universal tokenizer that auto-detects and handles all formats
 pub struct UniversalTokenizer {
@@ -14,6 +14,7 @@ pub struct UniversalTokenizer {
 enum TokenizerBackend {
     #[cfg(feature = "spm")]
     SentencePiece(crate::SmpTokenizer),
+    Hf(HfTokenizer),
     Mock(MockTokenizer),
 }
 
@@ -78,8 +79,25 @@ impl UniversalTokenizer {
     fn detect_and_create_backend(config: &TokenizerConfig) -> Result<TokenizerBackend> {
         match config.model_type.as_str() {
             "gpt2" | "bpe" | "llama" | "llama3" | "tiktoken" | "gpt4" | "cl100k" | "falcon" => {
-                debug!("Creating mock tokenizer for {}", config.model_type);
-                Ok(TokenizerBackend::Mock(MockTokenizer::new()))
+                if let (Some(vocab), Some(merges)) =
+                    (config.vocabulary.as_ref(), config.bpe_merges.as_ref())
+                {
+                    debug!("Creating HF tokenizer for {}", config.model_type);
+                    let tok = HfTokenizer::from_vocab_and_merges(vocab, merges).map_err(|e| {
+                        bitnet_common::BitNetError::Model(
+                            bitnet_common::ModelError::LoadingFailed {
+                                reason: format!("Tokenizer construction error: {}", e),
+                            },
+                        )
+                    })?;
+                    Ok(TokenizerBackend::Hf(tok))
+                } else {
+                    debug!(
+                        "Missing vocab or merges for {}, using mock tokenizer",
+                        config.model_type
+                    );
+                    Ok(TokenizerBackend::Mock(MockTokenizer::new()))
+                }
             }
             #[cfg(feature = "spm")]
             "smp" | "sentencepiece" => {
@@ -112,6 +130,7 @@ impl Tokenizer for UniversalTokenizer {
         let mut tokens = match &self.backend {
             #[cfg(feature = "spm")]
             TokenizerBackend::SentencePiece(t) => t.encode(&processed, false, add_special)?,
+            TokenizerBackend::Hf(t) => t.encode(&processed, false, add_special)?,
             TokenizerBackend::Mock(t) => t.encode(&processed, false, add_special)?,
         };
 
@@ -130,6 +149,7 @@ impl Tokenizer for UniversalTokenizer {
         match &self.backend {
             #[cfg(feature = "spm")]
             TokenizerBackend::SentencePiece(t) => t.decode(tokens),
+            TokenizerBackend::Hf(t) => t.decode(tokens),
             TokenizerBackend::Mock(t) => t.decode(tokens),
         }
     }
@@ -142,6 +162,7 @@ impl Tokenizer for UniversalTokenizer {
         match &self.backend {
             #[cfg(feature = "spm")]
             TokenizerBackend::SentencePiece(t) => t.token_to_piece(token),
+            TokenizerBackend::Hf(t) => t.token_to_piece(token),
             TokenizerBackend::Mock(t) => t.token_to_piece(token),
         }
     }

--- a/crates/bitnet-tokenizers/tests/universal_roundtrip.rs
+++ b/crates/bitnet-tokenizers/tests/universal_roundtrip.rs
@@ -4,10 +4,10 @@ use bitnet_tokenizers::{Tokenizer, TokenizerConfig, UniversalTokenizer};
 
 #[test]
 fn gpt2_bpe_roundtrip() {
-    // Test with minimal mock tokenizer behavior
+    // Minimal BPE tokenizer with vocab and merges using tokenizers crate
     let config = TokenizerConfig {
         model_type: "gpt2".to_string(),
-        vocab_size: 50257,  // Standard GPT-2 vocab size
+        vocab_size: 3,
         pre_tokenizer: None,
         add_bos: false,
         add_eos: false,
@@ -17,17 +17,21 @@ fn gpt2_bpe_roundtrip() {
         eos_token_id: None,
         pad_token_id: None,
         unk_token_id: None,
-        vocabulary: None,  // Let mock tokenizer handle this
-        bpe_merges: None,
+        vocabulary: Some(vec![
+            ("a".to_string(), 0.0),
+            ("b".to_string(), 0.0),
+            ("ab".to_string(), 0.0),
+        ]),
+        bpe_merges: Some(vec!["a b".to_string()]),
     };
 
     let tokenizer = UniversalTokenizer::new(config).expect("build gpt2 tokenizer");
     let ids = tokenizer.encode("ab", false, false).expect("encode");
-    assert!(!ids.is_empty(), "Should produce tokens");
-    
-    // Test that we can decode back
+    assert_eq!(ids, vec![2]);
+
+    // Test round trip
     let text = tokenizer.decode(&ids).expect("decode");
-    assert!(!text.is_empty(), "Should decode to non-empty text");
+    assert_eq!(text, "ab");
 }
 
 #[cfg(feature = "spm")]
@@ -35,7 +39,7 @@ fn gpt2_bpe_roundtrip() {
 fn sentencepiece_roundtrip() {
     let config = TokenizerConfig {
         model_type: "sentencepiece".to_string(),
-        vocab_size: 32000,  // Standard SentencePiece vocab size
+        vocab_size: 32000, // Standard SentencePiece vocab size
         pre_tokenizer: None,
         add_bos: false,
         add_eos: false,
@@ -45,14 +49,14 @@ fn sentencepiece_roundtrip() {
         eos_token_id: None,
         pad_token_id: None,
         unk_token_id: Some(0),
-        vocabulary: None,  // Let SentencePiece tokenizer handle this
+        vocabulary: None, // Let SentencePiece tokenizer handle this
         bpe_merges: None,
     };
 
     let tokenizer = UniversalTokenizer::new(config).expect("build sp tokenizer");
     let ids = tokenizer.encode("ab", false, false).expect("encode");
     assert!(!ids.is_empty(), "Should produce tokens");
-    
+
     // Test that we can decode back
     let text = tokenizer.decode(&ids).expect("decode");
     assert!(!text.is_empty(), "Should decode to non-empty text");


### PR DESCRIPTION
## Summary
- build `HfTokenizer` from vocab and merges for BPE models
- enable universal tokenizer to use the new backend instead of mock
- add roundtrip test verifying encode/decode via real BPE tokenizer

## Testing
- `cargo test -p bitnet-tokenizers --features integration-tests`


------
https://chatgpt.com/codex/tasks/task_e_68b8337d5bcc83338709868fb6a9ad79