### PR TITLE
Add GPU detection utilities and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,8 @@ dependencies = [
  "half",
  "log",
  "rayon",
+ "sysinfo",
+ "tempfile",
  "thiserror 2.0.16",
 ]
 
@@ -3448,7 +3450,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4177,6 +4179,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5895,6 +5906,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if 1.0.3",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6987,6 +7013,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7317,6 +7362,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bitnet-kernels",
  "bitnet-models",
  "chrono",
  "clap",

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -21,6 +21,7 @@ cudarc = { version = "0.17", optional = true, features = ["cuda-12000"] }
 cc = { version = "1.0", optional = true }
 bindgen = { version = "0.72", optional = true }
 half = { version = "2.3", optional = true }
+sysinfo = { version = "0.30" }
 
 [build-dependencies]
 bindgen = { version = "0.72", optional = true }
@@ -29,6 +30,7 @@ cc = { version = "1.0", optional = true }
 [dev-dependencies]
 criterion.workspace = true
 env_logger = "0.11"
+tempfile = "3"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 # x86-specific dependencies

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -9,7 +9,6 @@ pub mod device_aware;
 pub mod ffi;
 #[cfg(feature = "gpu")]
 pub mod gpu;
-#[cfg(feature = "gpu")]
 pub mod gpu_utils;
 
 /// Kernel provider trait

--- a/crates/bitnet-kernels/tests/gpu_info_mock.rs
+++ b/crates/bitnet-kernels/tests/gpu_info_mock.rs
@@ -1,0 +1,49 @@
+use bitnet_kernels::gpu_utils::get_gpu_info;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::tempdir;
+
+fn make_exec(path: &std::path::Path) {
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+#[test]
+fn test_gpu_info_mocked_scenarios() {
+    let original = std::env::var("PATH").unwrap_or_default();
+
+    // Scenario: no GPU present
+    {
+        let dir = tempdir().unwrap();
+        unsafe {
+            std::env::set_var("PATH", dir.path());
+            std::env::remove_var("BITNET_GPU_FAKE");
+        }
+        let info = get_gpu_info();
+        assert!(!info.any_available());
+    }
+
+    // Scenario: CUDA tools available
+    {
+        let dir = tempdir().unwrap();
+        let smi = dir.path().join("nvidia-smi");
+        fs::write(&smi, "#!/bin/sh\nexit 0\n").unwrap();
+        make_exec(&smi);
+        let nvcc = dir.path().join("nvcc");
+        fs::write(&nvcc, "#!/bin/sh\necho 'Cuda compilation tools, release 12.1, V12.1.0'\n")
+            .unwrap();
+        make_exec(&nvcc);
+        unsafe {
+            std::env::set_var("PATH", format!("{}:{}", dir.path().display(), original));
+            std::env::remove_var("BITNET_GPU_FAKE");
+        }
+        let info = get_gpu_info();
+        assert!(info.cuda);
+        assert!(info.cuda_version.unwrap_or_default().starts_with("12.1"));
+    }
+
+    unsafe {
+        std::env::set_var("PATH", original);
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,6 +23,7 @@ httpdate = "1"
 tempfile = "3"
 chrono = "0.4"
 bitnet-models = { path = "../crates/bitnet-models", default-features = false }
+bitnet-kernels = { path = "../crates/bitnet-kernels", default-features = false }
 
 [dev-dependencies]
 tiny_http = "0.12"


### PR DESCRIPTION
## Summary
- implement concrete GPU backend detection using system probes
- wire xtask commands to real GPU info function
- add tests to cover GPU/no-GPU detection scenarios

## Testing
- `cargo test -p bitnet-kernels --test gpu_info_mock`
- `cargo test -p xtask`


------
https://chatgpt.com/codex/tasks/task_e_68b83379322083338baf056db6eaec32