### PR TITLE
Fix and improve bitnet-ggml-ffi

### DIFF
--- a/crates/bitnet-ggml-ffi/README.md
+++ b/crates/bitnet-ggml-ffi/README.md
@@ -18,11 +18,11 @@ To specify which compiler to use, set the `CC` and `CXX` environment variables:
 ```bash
 # Use GCC (default on most Linux systems)
 export CC=gcc CXX=g++
-cargo build --no-default-features --features ffi
+cargo build --no-default-features --features iq2s-ffi
 
 # Use Clang
-export CC=clang CXX=clang++  
-cargo build --no-default-features --features ffi
+export CC=clang CXX=clang++
+cargo build --no-default-features --features iq2s-ffi
 ```
 
 ### GGML_DEPRECATED Macro
@@ -34,3 +34,4 @@ The GGML header includes compiler-specific deprecation warnings that work with b
 - **MSVC**: Uses `__declspec(deprecated(hint))` with `_MSC_VER` detection
 
 This ensures deprecation warnings are properly displayed across all supported compiler toolchains.
+

--- a/crates/bitnet-ggml-ffi/build.rs
+++ b/crates/bitnet-ggml-ffi/build.rs
@@ -17,7 +17,14 @@ fn main() {
                  Or set crates/bitnet-ggml-ffi/csrc/VENDORED_GGML_COMMIT"
             );
         }
+        let ggml_quants_src =
+            fs::read_to_string("csrc/ggml/src/ggml-quants.c").expect("read ggml-quants.c");
+
         let mut build = cc::Build::new();
+        if ggml_quants_src.contains("assert(k % QK_IQ2_S == 0)") {
+            build.define("BITNET_IQ2S_DEQUANT_NEEDS_QK_MULTIPLE", None);
+        }
+
         build
             .file("csrc/ggml_quants_shim.c")
             .file("csrc/ggml_consts.c")  // Constants extraction
@@ -45,3 +52,4 @@ fn main() {
         println!("cargo:rerun-if-changed=csrc/VENDORED_GGML_COMMIT");
     }
 }
+

--- a/crates/bitnet-ggml-ffi/csrc/ggml_consts.c
+++ b/crates/bitnet-ggml-ffi/csrc/ggml_consts.c
@@ -18,7 +18,10 @@ int32_t bitnet_iq2s_block_size_bytes(void) {
 // Helper to check if GGML's dequantize_row_iq2_s requires n to be multiple of QK
 // This is critical for tail handling safety
 int32_t bitnet_iq2s_requires_qk_multiple(void) {
-    // Most GGML dequantizers assume n % QK == 0
-    // Return 1 to indicate this requirement (safer assumption)
+    // Derived at build time by scanning GGML's source.
+#ifdef BITNET_IQ2S_DEQUANT_NEEDS_QK_MULTIPLE
     return 1;
+#else
+    return 0;
+#endif
 }

--- a/crates/bitnet-ggml-ffi/csrc/ggml_quants_shim.c
+++ b/crates/bitnet-ggml-ffi/csrc/ggml_quants_shim.c
@@ -8,10 +8,11 @@
 #include "ggml/src/ggml-quants.c"
 
 // Export stable symbol names for Rust to link.
-void bitnet_dequantize_row_iq2_s(const void *src, float *dst, int n) {
-    dequantize_row_iq2_s(src, dst, (int64_t)n);
+void bitnet_dequantize_row_iq2_s(const void *src, float *dst, int64_t n) {
+    dequantize_row_iq2_s(src, dst, n);
 }
 
 size_t bitnet_quantize_iq2_s(const float *src, void *dst, int64_t nrow, int64_t n_per_row) {
     return quantize_iq2_s(src, dst, nrow, n_per_row, NULL);
 }
+

--- a/crates/bitnet-ggml-ffi/src/lib.rs
+++ b/crates/bitnet-ggml-ffi/src/lib.rs
@@ -1,14 +1,18 @@
-#![allow(clippy::missing_safety_doc)]
-
 use core::ffi::c_void;
 
 #[cfg(feature = "iq2s-ffi")]
 use libc::{c_int, size_t};
 
 #[cfg(feature = "iq2s-ffi")]
+// FFI bindings to the C shim exposing GGML's IQ2_S helpers.
 unsafe extern "C" {
-    // Exposed by our shim; wraps GGML's reference quantizer/dequantizer for IQ2_S.
-    fn bitnet_dequantize_row_iq2_s(src: *const c_void, dst: *mut f32, n: c_int);
+    /// # Safety
+    /// - `src` and `dst` must be valid for reads and writes of `n` elements respectively.
+    /// - Behavior is undefined if the pointers are null and `n` is non-zero.
+    fn bitnet_dequantize_row_iq2_s(src: *const c_void, dst: *mut f32, n: i64);
+
+    /// # Safety
+    /// See GGML's `quantize_iq2_s` implementation for requirements on the pointers and sizes.
     fn bitnet_quantize_iq2_s(
         src: *const f32,
         dst: *mut c_void,
@@ -88,7 +92,7 @@ pub const GGML_COMMIT: &str = "not-compiled";
 /// - `n` must be a multiple of `iq2s_qk()` (256) for correctness
 #[cfg(feature = "iq2s-ffi")]
 pub unsafe fn dequantize_row_iq2_s(src: *const c_void, dst: *mut f32, n: usize) {
-    unsafe { bitnet_dequantize_row_iq2_s(src, dst, n as c_int) };
+    unsafe { bitnet_dequantize_row_iq2_s(src, dst, n as i64) };
 }
 
 /// Quantizes multiple rows of f32 data into IQ2_S format.
@@ -132,3 +136,4 @@ pub unsafe fn quantize_iq2_s(
 ) -> usize {
     panic!("IQ2_S support not compiled: enable feature `iq2s-ffi`");
 }
+

--- a/crates/bitnet-ggml-ffi/tests/default.rs
+++ b/crates/bitnet-ggml-ffi/tests/default.rs
@@ -1,0 +1,6 @@
+#![cfg(not(feature = "iq2s-ffi"))]
+
+#[test]
+fn iq2s_disabled_by_default() {
+    assert!(!bitnet_ggml_ffi::has_iq2s());
+}


### PR DESCRIPTION
## Summary
- document correct `iq2s-ffi` feature in README
- widen dequantize length parameter and expose runtime tail requirement
- ensure default tests run and restore safety docs linting

## Testing
- `cargo test -p bitnet-ggml-ffi`
- `cargo test -p bitnet-ggml-ffi --features iq2s-ffi,integration-tests`
- `cargo clippy -p bitnet-ggml-ffi --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68ba1e44daa08333b84f14677e4b143d