### PR TITLE
Clean up Prometheus module gating and remove unnecessary cast

### DIFF
--- a/crates/bitnet-quantization/src/i2s.rs
+++ b/crates/bitnet-quantization/src/i2s.rs
@@ -299,7 +299,7 @@ impl I2SQuantizer {
                 let i8_vec = _mm256_packs_epi16(i16_vec, i16_vec);
 
                 // Store 8 bytes
-                let result = _mm256_extract_epi64::<0>(i8_vec) as i64;
+                let result = _mm256_extract_epi64::<0>(i8_vec);
                 std::ptr::copy_nonoverlapping(
                     &result as *const i64 as *const i8,
                     output.as_mut_ptr().add(i * 8),

--- a/crates/bitnet-server/src/monitoring/prometheus.rs
+++ b/crates/bitnet-server/src/monitoring/prometheus.rs
@@ -1,7 +1,5 @@
 //! Prometheus metrics integration
 
-#![cfg(feature = "prometheus")]
-
 use anyhow::Result;
 use axum::{
     Router,


### PR DESCRIPTION
## Summary
- drop redundant `cfg` gate from `bitnet-server` Prometheus module
- remove superfluous `i64` cast in `bitnet-quantization`

## Testing
- `cargo check -p bitnet-server`
- `cargo test -p bitnet-server`
- `cargo clippy -p bitnet-server --no-deps -- -D warnings`
- `cargo check -p bitnet-quantization`
- `cargo clippy -p bitnet-quantization --no-deps -- -D warnings`
- `cargo test -p bitnet-quantization`

------
https://chatgpt.com/codex/tasks/task_e_68ba1e6e0e4083338cf85cd67da789f4