### PR TITLE
Improve tensor safety and cleanup env tests

### DIFF
--- a/crates/bitnet-common/src/types.rs
+++ b/crates/bitnet-common/src/types.rs
@@ -23,20 +23,6 @@ impl std::fmt::Display for QuantizationType {
     }
 }
 
-/// Device types for computation
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DeviceType {
-    Cpu,
-    Cuda(usize),
-    Metal,
-}
-
-impl Default for DeviceType {
-    fn default() -> Self {
-        Self::Cpu
-    }
-}
-
 /// Device abstraction for computation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Device {

--- a/crates/bitnet-common/tests/config_tests.rs
+++ b/crates/bitnet-common/tests/config_tests.rs
@@ -415,65 +415,29 @@ fn test_env_variable_overrides() {
         "BITNET_NUM_THREADS",
         "BITNET_BATCH_SIZE",
     ];
-    for var in &env_vars {
-        unsafe {
+    unsafe {
+        for var in &env_vars {
             env::remove_var(var);
         }
-    }
 
-    // Set environment variables
-    unsafe {
+        // Set environment variables
         env::set_var("BITNET_VOCAB_SIZE", "60000");
-    }
-    unsafe {
         env::set_var("BITNET_TEMPERATURE", "0.7");
-    }
-    unsafe {
         env::set_var("BITNET_USE_GPU", "true");
-    }
-    unsafe {
         env::set_var("BITNET_QUANTIZATION_TYPE", "TL2");
-    }
-    unsafe {
         env::set_var("BITNET_MEMORY_LIMIT", "2GB");
-    }
-    unsafe {
         env::set_var("BITNET_MODEL_FORMAT", "safetensors");
-    }
-    unsafe {
         env::set_var("BITNET_MODEL_PATH", "/test/path");
-    }
-    unsafe {
         env::set_var("BITNET_HIDDEN_SIZE", "8192");
-    }
-    unsafe {
         env::set_var("BITNET_NUM_LAYERS", "48");
-    }
-    unsafe {
         env::set_var("BITNET_NUM_HEADS", "64");
-    }
-    unsafe {
         env::set_var("BITNET_MAX_LENGTH", "4096");
-    }
-    unsafe {
         env::set_var("BITNET_MAX_NEW_TOKENS", "1024");
-    }
-    unsafe {
         env::set_var("BITNET_TOP_K", "30");
-    }
-    unsafe {
         env::set_var("BITNET_TOP_P", "0.85");
-    }
-    unsafe {
         env::set_var("BITNET_SEED", "123");
-    }
-    unsafe {
         env::set_var("BITNET_BLOCK_SIZE", "128");
-    }
-    unsafe {
         env::set_var("BITNET_NUM_THREADS", "16");
-    }
-    unsafe {
         env::set_var("BITNET_BATCH_SIZE", "8");
     }
 
@@ -499,8 +463,8 @@ fn test_env_variable_overrides() {
     assert_eq!(config.performance.batch_size, 8);
 
     // Clean up
-    for var in &env_vars {
-        unsafe {
+    unsafe {
+        for var in &env_vars {
             env::remove_var(var);
         }
     }
@@ -513,17 +477,9 @@ fn test_env_variable_special_values() {
     // Test "none" values
     unsafe {
         env::set_var("BITNET_TOP_K", "none");
-    }
-    unsafe {
         env::set_var("BITNET_TOP_P", "none");
-    }
-    unsafe {
         env::set_var("BITNET_SEED", "none");
-    }
-    unsafe {
         env::set_var("BITNET_NUM_THREADS", "auto");
-    }
-    unsafe {
         env::set_var("BITNET_MEMORY_LIMIT", "none");
     }
 
@@ -538,17 +494,9 @@ fn test_env_variable_special_values() {
     // Clean up
     unsafe {
         env::remove_var("BITNET_TOP_K");
-    }
-    unsafe {
         env::remove_var("BITNET_TOP_P");
-    }
-    unsafe {
         env::remove_var("BITNET_SEED");
-    }
-    unsafe {
         env::remove_var("BITNET_NUM_THREADS");
-    }
-    unsafe {
         env::remove_var("BITNET_MEMORY_LIMIT");
     }
 }
@@ -619,8 +567,6 @@ fn test_config_loader_precedence() {
     // Clean up env vars
     unsafe {
         env::remove_var("BITNET_VOCAB_SIZE");
-    }
-    unsafe {
         env::remove_var("BITNET_TEMPERATURE");
     }
 

--- a/crates/bitnet-common/tests/types_tests.rs
+++ b/crates/bitnet-common/tests/types_tests.rs
@@ -43,37 +43,6 @@ fn test_quantization_type_serialization() {
 }
 
 #[test]
-fn test_device_type_variants() {
-    let cpu = DeviceType::Cpu;
-    let cuda0 = DeviceType::Cuda(0);
-    let cuda1 = DeviceType::Cuda(1);
-    let metal = DeviceType::Metal;
-
-    assert_ne!(cpu, cuda0);
-    assert_ne!(cuda0, cuda1);
-    assert_ne!(cpu, metal);
-    assert_eq!(cuda0, DeviceType::Cuda(0));
-}
-
-#[test]
-fn test_device_type_default() {
-    assert_eq!(DeviceType::default(), DeviceType::Cpu);
-}
-
-#[test]
-fn test_device_type_serialization() {
-    let cpu = DeviceType::Cpu;
-    let json = serde_json::to_string(&cpu).unwrap();
-    let deserialized: DeviceType = serde_json::from_str(&json).unwrap();
-    assert_eq!(cpu, deserialized);
-
-    let cuda = DeviceType::Cuda(2);
-    let json = serde_json::to_string(&cuda).unwrap();
-    let deserialized: DeviceType = serde_json::from_str(&json).unwrap();
-    assert_eq!(cuda, deserialized);
-}
-
-#[test]
 fn test_device_variants() {
     let cpu = Device::Cpu;
     let cuda0 = Device::Cuda(0);
@@ -379,7 +348,6 @@ fn test_send_sync_traits() {
     fn assert_send_sync<T: Send + Sync>() {}
 
     assert_send_sync::<QuantizationType>();
-    assert_send_sync::<DeviceType>();
     assert_send_sync::<Device>();
     assert_send_sync::<GenerationConfig>();
     assert_send_sync::<ModelMetadata>();


### PR DESCRIPTION
## Summary
- track tensor device and avoid leaking memory when getting tensor slices
- remove redundant `DeviceType` enum in favor of `Device`
- drop unnecessary `unsafe` blocks in config tests
- mark environment variable manipulations in config tests as `unsafe` for Rust 2024

## Testing
- `cargo test -p bitnet-common`

------
https://chatgpt.com/codex/tasks/task_e_68ba1e31cb3c83338110a3905c6e22f7