### PR TITLE
Add mock embed/logits implementations for FFI testing

### DIFF
--- a/crates/bitnet-ffi/src/inference.rs
+++ b/crates/bitnet-ffi/src/inference.rs
@@ -3,9 +3,12 @@
 //! This module provides thread-safe inference operations, streaming support,
 //! and performance monitoring for the C API.
 
-use crate::{BitNetCError, BitNetCInferenceConfig, BitNetCPerformanceMetrics};
+use crate::{
+    get_model_manager, BitNetCError, BitNetCInferenceConfig, BitNetCPerformanceMetrics,
+};
 // use bitnet_common::PerformanceMetrics;
 use bitnet_inference::{InferenceConfig, InferenceEngine};
+use bitnet_common::Tensor;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;


### PR DESCRIPTION
## Summary
- replace `todo!` in FFI mock model's `embed` and `logits` with dummy tensor implementations
- document that these mocks are for C-API tests
- add unit test covering `embed` and `logits`

## Testing
- `cargo test -p bitnet-ffi test_mock_model_embed_and_logits`


------
https://chatgpt.com/codex/tasks/task_e_68ba653c5df083338eccea4217dbf092