### PR TITLE
Validate tensor data when validation active

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -229,6 +229,9 @@ impl GgufLoader {
             let tensor_info = reader.get_tensor_info(i)?;
             let tensor_data = reader.get_tensor_data(i)?;
 
+            #[cfg(any(test, feature = "validation"))]
+            self.validate_tensor_data(&tensor_info, tensor_data)?;
+
             debug!(
                 "Loading tensor '{}' with shape {:?} and type {:?}",
                 tensor_info.name, tensor_info.shape, tensor_info.tensor_type
@@ -335,7 +338,6 @@ impl GgufLoader {
 
     /// Validate tensor data integrity
     #[cfg(any(test, feature = "validation"))]
-    #[allow(dead_code)]
     fn validate_tensor_data(
         &self,
         info: &crate::formats::gguf::TensorInfo,


### PR DESCRIPTION
## Summary
- validate tensor payloads in GGUF loader when running tests or using the `validation` feature
- remove outdated `dead_code` allowance on validation helper

## Testing
- `cargo test -p bitnet-models`
- `cargo test -p bitnet-models --features validation --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68bf0e0294b08333b8d1eb1ca89878be