### PR TITLE
feat: implement tensor device transfer

### DIFF
--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -418,8 +418,9 @@ mod tests {
         assert_eq!(tensor.device(), &Device::Cpu);
 
         let tensor_gpu = tensor.with_device(Device::Cuda(0)).unwrap();
-        // Note: In CPU-only builds, this will still be CPU
-        // When GPU support is added, this will properly transfer to GPU
-        assert_eq!(tensor_gpu.device(), &Device::Cpu);
+        // Determine expected device based on runtime capabilities
+        let expected =
+            Device::from(&Device::Cuda(0).to_candle().unwrap_or_else(|_| candle_core::Device::Cpu));
+        assert_eq!(tensor_gpu.device(), &expected);
     }
 }

--- a/crates/bitnet-inference/src/tensor_ext.rs
+++ b/crates/bitnet-inference/src/tensor_ext.rs
@@ -1,18 +1,32 @@
 //! Tensor extension traits for device operations
 
-use bitnet_common::{ConcreteTensor, Device, Result};
+use bitnet_common::{BitNetError, ConcreteTensor, Device, Result, Tensor};
 
 /// Extension trait for tensor device operations
-#[allow(dead_code)]
 pub trait TensorDeviceExt {
     /// Create a new tensor on the specified device
     fn with_device(&self, device: Device) -> Result<ConcreteTensor>;
 }
 
 impl TensorDeviceExt for ConcreteTensor {
-    fn with_device(&self, _device: Device) -> Result<ConcreteTensor> {
-        // For CPU-only builds, moving to a device is a no-op - just clone
-        // When GPU support is added, this will actually transfer the tensor
-        Ok(self.clone())
+    fn with_device(&self, device: Device) -> Result<ConcreteTensor> {
+        let candle_device =
+            device.to_candle().map_err(|e| BitNetError::Validation(e.to_string()))?;
+        let target_device = Device::from(&candle_device);
+
+        if self.device() == &target_device {
+            return Ok(self.clone());
+        }
+
+        match self {
+            ConcreteTensor::BitNet(t) => {
+                let moved = t.as_candle().to_device(&candle_device)?;
+                Ok(ConcreteTensor::bitnet(moved))
+            }
+            ConcreteTensor::Mock(t) => {
+                let moved = t.clone().with_device(target_device);
+                Ok(ConcreteTensor::Mock(moved))
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable moving `ConcreteTensor` instances across devices using Candle
- remove unused dead code annotation
- adjust tests for configurable device expectations

## Testing
- `cargo fmt --all`
- `cargo test -p bitnet-inference` *(fails: crates/bitnet-inference/src/engine.rs - engine doctest missing `model` and `tokenizer`)*
- `cargo test -p bitnet-inference --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_68bf0dfc27248333aead6c195f27a151