### PR TITLE
refactor: simplify health checker and add GPU checks

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -85,7 +85,7 @@ impl BitNetServer {
         let monitoring = Arc::new(MonitoringSystem::new(config.monitoring.clone()).await?);
 
         // Initialize health checker
-        let health_checker = Arc::new(HealthChecker::new(monitoring.metrics()));
+        let health_checker = Arc::new(HealthChecker::new());
 
         // Initialize Prometheus exporter if enabled
         #[cfg(feature = "prometheus")]


### PR DESCRIPTION
## Summary
- drop unused metrics and component tracking from `HealthChecker`
- implement CUDA-based GPU health status query with `nvidia-smi`
- adjust server initialization to new health checker API

## Testing
- `cargo test -p bitnet-server`

------
https://chatgpt.com/codex/tasks/task_e_68bf0dfbac348333a04918e5f60c2ec4