### PR TITLE
Fix TL2 thread safety test compilation errors

### DIFF
--- a/crates/bitnet-quantization/tests/thread_safety.rs
+++ b/crates/bitnet-quantization/tests/thread_safety.rs
@@ -1,0 +1,54 @@
+use bitnet_quantization::tl2::TL2Quantizer;
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn test_tl2_lookup_table_thread_safety() {
+    let quantizer = Arc::new(TL2Quantizer::new());
+    let num_threads = 16;
+    let min_val = -2.0f32;
+    let max_val = 2.0f32;
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|_| {
+            let quantizer_clone = Arc::clone(&quantizer);
+            thread::spawn(move || {
+                let _table = quantizer_clone.get_or_create_lookup_table(min_val, max_val);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    // Implicitly, if we reach this point without panicking, the RwLock worked correctly
+}
+
+#[test]
+fn test_tl2_lookup_table_concurrent_access() {
+    let quantizer = Arc::new(TL2Quantizer::new());
+    let num_threads = 32;
+    let scales = [
+        (-1.0f32, 1.0f32),
+        (-2.0f32, 2.0f32),
+        (0.0f32, 4.0f32),
+        (-4.0f32, 4.0f32),
+    ];
+
+    let handles: Vec<_> = (0..num_threads)
+        .map(|i| {
+            let quantizer_clone = Arc::clone(&quantizer);
+            let (min_val, max_val) = scales[i % scales.len()];
+            thread::spawn(move || {
+                let table = quantizer_clone.get_or_create_lookup_table(min_val, max_val);
+                assert!(table.forward_len() == 256);
+                assert!(table.reverse_len() > 0);
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}


### PR DESCRIPTION
### **User description**
## Summary

Resolves compilation errors in TL2 thread safety tests that occurred after PR #198 merged the lookup table caching feature.

## Problem

After PR #198 introduced TL2 lookup table caching with `RwLock<HashMap<u32, VectorizedLookupTable>>`, the thread safety tests failed to compile due to:

- Missing `get_or_create_lookup_table()` method on `TL2Quantizer`  
- Direct access to private fields `forward` and `reverse` on `VectorizedLookupTable`

## Solution

**Added public testing methods:**
- `TL2Quantizer::get_or_create_lookup_table(min_val, max_val)` - converts min/max to scale and uses internal caching
- `VectorizedLookupTable::forward_len()` and `reverse_len()` - safe accessors for table sizes

**Updated tests:**
- Use proper public API instead of accessing private fields
- Maintain the same thread safety validation logic

## Testing

- ✅ All 28 quantization tests passing
- ✅ Thread safety tests working correctly  
- ✅ No clippy warnings
- ✅ TL2 lookup table caching functionality preserved

## Changes

- `crates/bitnet-quantization/src/tl2.rs`: Add public testing methods
- `crates/bitnet-quantization/tests/thread_safety.rs`: Update test implementation

The TL2 lookup table caching optimization from PR #198 remains fully functional with proper thread safety validation.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix TL2 thread safety test compilation errors

- Add public testing methods to TL2Quantizer and VectorizedLookupTable

- Create comprehensive thread safety tests for lookup table caching


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TL2Quantizer"] --> B["get_or_create_lookup_table()"]
  C["VectorizedLookupTable"] --> D["forward_len()"]
  C --> E["reverse_len()"]
  F["Thread Safety Tests"] --> B
  F --> D
  F --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>tl2.rs</strong><dd><code>Add public testing methods for thread safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-quantization/src/tl2.rs

<ul><li>Add <code>forward_len()</code> and <code>reverse_len()</code> accessor methods to <br><code>VectorizedLookupTable</code><br> <li> Add public <code>get_or_create_lookup_table()</code> method to <code>TL2Quantizer</code> for <br>testing<br> <li> Methods provide safe access to private fields for test validation</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/244/files#diff-c9196279f7ba756b416496a47ac60921b8fc860ec00e8f5157ca22b1f46a4efc">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>thread_safety.rs</strong><dd><code>Add comprehensive TL2 thread safety tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-quantization/tests/thread_safety.rs

<ul><li>Create new thread safety test file for TL2 quantizer<br> <li> Test concurrent lookup table creation with multiple threads<br> <li> Validate thread-safe access to cached lookup tables<br> <li> Use proper public API instead of accessing private fields</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/244/files#diff-d175d85f5c19a9705f99f9b94ca5e6a5cc315705520f35e41c90439b1d0e2fe0">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

