### PR TITLE
ci: add Windows/macOS build probe to core lane

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -137,6 +137,35 @@ jobs:
       - name: Build documentation
         run: cargo doc --locked --no-deps --workspace --no-default-features --features cpu
 
+  # Job 5: Cross-platform build probe (informational, non-blocking)
+  build-probe:
+    name: Build on ${{ matrix.os }} (probe)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.90.0"
+          components: rustfmt, clippy
+          profile: minimal
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-core-${{ matrix.os }}
+
+      - name: Build (CPU, no tests)
+        run: |
+          cargo build --locked --workspace \
+            --no-default-features --features cpu
+
   # Summary job (required for branch protection)
   ci-core-success:
     name: CI Core Success


### PR DESCRIPTION
### **User description**
## Summary

Adds build-only probe for Windows and macOS to validate cross-platform compatibility claims without blocking PR merges.

Resolves #479

## Changes

**New Job**:  (informational, non-blocking)
- Matrix: `[windows-latest, macos-latest]`
- Build workspace with `--features cpu`
- No tests (build-only for speed)
- Uses MSRV 1.90.0
- 10-minute timeout per OS

**Key Design Decisions**:
1. **Not in `ci-core-success` needs** → informational only, doesn't gate merges
2. **Build-only** → keeps feedback fast (~2-3 min per OS)
3. **CPU features only** → sufficient to prove cross-platform build compatibility

## Testing

- [x] Workflow syntax validated
- [x] Job defined with proper matrix
- [x] `ci-core-success` still only depends on Linux jobs (build-test-linux, clippy, docs)

## Impact

**For Contributors**:
- Immediate visibility into Windows/macOS build breakage
- Non-blocking → doesn't slow down PR merges

**For Maintainers**:
- Validates README cross-platform claims
- Early warning for platform-specific issues
- Complements Linux-focused gating checks

## Related

- Resolves #479 (tracking issue for build probe)
- Part of post-#475 housekeeping
- Validates "Cross-Platform: Linux/macOS/Windows" claim in README

## Checklist

- [x] Job added to ci-core.yml
- [x] Matrix configured for windows-latest and macos-latest
- [x] Timeout set (10 minutes per OS)
- [x] Non-blocking (not in ci-core-success needs)
- [x] Uses --locked for determinism
- [x] Commit message references #479


___

### **PR Type**
Enhancement


___

### **Description**
- Adds cross-platform build probe job for Windows/macOS validation

- Build-only job (no tests) with CPU features for speed

- Uses MSRV 1.90.0 toolchain with 10-minute timeout

- Informational only, non-blocking to PR merges


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Core Workflow"] --> B["Build Probe Job"]
  B --> C["Matrix: windows-latest, macos-latest"]
  C --> D["Build with --features cpu"]
  D --> E["Informational Only"]
  E --> F["Does not gate ci-core-success"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-core.yml</strong><dd><code>Add cross-platform build probe job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-core.yml

<ul><li>Added new <code>build-probe</code> job with matrix strategy for Windows and macOS<br> <li> Configured to run build-only (no tests) with <code>--features cpu</code> flag<br> <li> Uses MSRV 1.90.0 toolchain with minimal profile and 10-minute timeout<br> <li> Implements Rust dependency caching with OS-specific cache keys<br> <li> Job remains informational and non-blocking to <code>ci-core-success</code> <br>requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/483/files#diff-31bd198ce2c6956ed10bdfe25a233b755f3a201ad094a67c449115ef76d9ff43">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).