### PR TITLE
ci: add --locked to perf workflows

### DIFF
--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -61,12 +61,12 @@ jobs:
           exit 0
 
       - name: Build workspace
-        run: cargo build --workspace --release --no-default-features --features cpu
+        run: cargo build --workspace --release --no-default-features --features cpu --locked
 
       - name: Download test model (if needed)
         run: |
           if [ ! -f "models/bitnet/ggml-model-i2_s.gguf" ]; then
-            cargo run -p xtask -- download-model --dry-run || echo "Model download not available in CI"
+            cargo run -p xtask --locked -- download-model --dry-run || echo "Model download not available in CI"
           fi
 
       - name: Run performance benchmarks
@@ -76,8 +76,8 @@ jobs:
           mkdir -p ci
 
           # Run xtask benchmark if available, otherwise use fallback
-          if cargo run -p xtask -- benchmark --help &>/dev/null; then
-            cargo run -p xtask -- benchmark \
+          if cargo run -p xtask --locked -- benchmark --help &>/dev/null; then
+            cargo run -p xtask --locked -- benchmark \
               --model models/bitnet/ggml-model-i2_s.gguf \
               --tokens 32 \
               --no-output \
@@ -111,7 +111,7 @@ jobs:
         id: bench_compare
         run: |
           # Compare against baseline (informational)
-          cargo run -p xtask -- bench-compare \
+          cargo run -p xtask --locked -- bench-compare \
             --baseline benchmarks/baseline/cpu/inference/inference_baseline.json \
             --current ci/inference.json \
             --thresholds benchmarks/thresholds/default.toml \

--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -103,14 +103,14 @@ jobs:
           cross build --release --target ${{ matrix.target }} --no-default-features --features cpu
           cross build --release --target ${{ matrix.target }} -p bitnet-cli --no-default-features --features cpu
         else
-          cargo build --release --target ${{ matrix.target }} --no-default-features --features cpu
-          cargo build --release --target ${{ matrix.target }} -p bitnet-cli --no-default-features --features cpu
+          cargo build --release --target ${{ matrix.target }} --no-default-features --features cpu --locked
+          cargo build --release --target ${{ matrix.target }} -p bitnet-cli --no-default-features --features cpu --locked
         fi
 
     - name: Generate test fixtures
       run: |
         echo "Generating deterministic test fixtures..."
-        cargo run -p xtask -- gen-fixtures --size small --output crossval/fixtures/
+        cargo run -p xtask --locked -- gen-fixtures --size small --output crossval/fixtures/
 
     - name: Run performance benchmarks
       run: |


### PR DESCRIPTION
### **User description**
Adds --locked to cargo build/test/run in perf-gate.yml and performance-tracking.yml to enforce lockfile determinism (8 commands total).

Part of #476 (--locked sweep).


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--locked` flag to 9 cargo commands across perf workflows

- Enforces Cargo.lock determinism in performance benchmarking CI

- Prevents dependency drift during performance testing and regression checks

- Applies to build, run, and benchmark commands in both workflows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["perf-gate.yml<br/>5 cargo commands"] -->|add --locked| B["Deterministic<br/>builds & tests"]
  C["performance-tracking.yml<br/>4 cargo commands"] -->|add --locked| B
  B --> D["Lockfile<br/>enforcement"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>perf-gate.yml</strong><dd><code>Add --locked to perf-gate cargo commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/perf-gate.yml

<ul><li>Added <code>--locked</code> flag to <code>cargo build --workspace</code> command<br> <li> Added <code>--locked</code> flag to 3 <code>cargo run -p xtask</code> commands (download-model, <br>benchmark, bench-compare)<br> <li> Ensures deterministic dependency resolution in performance gate <br>workflow</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/487/files#diff-8ff2f6a65a8622f52f8580949cb8cf0533a277c91c4126bf7ce5625ac4afc92b">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>performance-tracking.yml</strong><dd><code>Add --locked to performance-tracking cargo commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/performance-tracking.yml

<ul><li>Added <code>--locked</code> flag to 2 <code>cargo build</code> commands for main workspace and <br>bitnet-cli<br> <li> Added <code>--locked</code> flag to <code>cargo run -p xtask -- gen-fixtures</code> command<br> <li> Enforces lockfile compliance in cross-platform performance tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/487/files#diff-d9527cb46915f31b30a3cafb306ecb68f3328cde97144a41191cadf699ac8347">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).