### PR TITLE
ci: add --locked to release & security workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,8 @@ jobs:
         run: |
           echo "🔍 Running Rust quality checks..."
           cargo fmt --all -- --check
-          cargo clippy --workspace --all-targets --features cpu -- -D warnings
-          cargo test --workspace --features cpu
+          cargo clippy --workspace --all-targets --features cpu -- -D warnings --locked
+          cargo test --workspace --features cpu --locked
 
       - name: Run security audit
         run: |
@@ -89,7 +89,7 @@ jobs:
           echo "📚 Validating documentation..."
           cargo doc --workspace --features cpu --no-deps --document-private-items
           # Check that README examples compile
-          cargo test --doc --features cpu
+          cargo test --doc --features cpu --locked
 
       - name: Check version consistency
         run: |
@@ -163,7 +163,7 @@ jobs:
           if [[ "${{ matrix.cross }}" == "true" ]]; then
             cross build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --bin bitnet
           else
-            cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --bin bitnet
+            cargo build --release --target ${{ matrix.target }} --features ${{ matrix.features }} --bin bitnet --locked
           fi
 
       - name: Create binary archive

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       run: cargo deny check
 
     - name: Run clippy security lints
-      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic
+      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic --locked
 
     - name: Check for unsafe code
       run: |


### PR DESCRIPTION
### **User description**
Enforces Cargo.lock fidelity in release.yml and security.yml for deterministic release builds and security audits.

Part of #476 (--locked sweep).


___

### **PR Type**
Enhancement


___

### **Description**
- Add `--locked` flag to Cargo commands in release workflow

- Add `--locked` flag to Cargo commands in security workflow

- Ensures deterministic builds using locked dependency versions

- Prevents dependency drift during releases and security audits


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflows"] --> B["release.yml"]
  A --> C["security.yml"]
  B --> D["cargo clippy --locked"]
  B --> E["cargo test --locked"]
  B --> F["cargo build --locked"]
  C --> G["cargo clippy --locked"]
  D --> H["Deterministic Builds"]
  E --> H
  F --> H
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release.yml</strong><dd><code>Add --locked flag to release cargo commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release.yml

<ul><li>Added <code>--locked</code> flag to <code>cargo clippy</code> command in quality checks<br> <li> Added <code>--locked</code> flag to <code>cargo test</code> command in quality checks<br> <li> Added <code>--locked</code> flag to <code>cargo test --doc</code> command in documentation <br>validation<br> <li> Added <code>--locked</code> flag to <code>cargo build --release</code> command in binary build <br>step</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/488/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>security.yml</strong><dd><code>Add --locked flag to security cargo commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/security.yml

<ul><li>Added <code>--locked</code> flag to <code>cargo clippy</code> command in security lints step<br> <li> Ensures locked dependency versions are used during security checks</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/488/files#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).