### PR TITLE
ci: add guardrail checks for action pins and MSRV consistency

### DIFF
--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -31,6 +31,23 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
       # Ensure scripts are executable in fresh clones
       - run: chmod +x scripts/*.sh || true
+
+      - name: Guard - no floating action refs
+        run: |
+          if rg -n --color=never -e '^\s*uses:\s*[^ @]+/[^ @]+@(v\d+|stable|main|master|latest)\b' .github/workflows; then
+            echo "❌ Floating GitHub Action refs detected (must use SHA pins)"
+            exit 1
+          fi
+          echo "✅ All actions pinned to SHA refs"
+
+      - name: Guard - MSRV consistency (1.89.0 only)
+        run: |
+          if rg -n --color=never -e '1\.90\.0' .github/workflows; then
+            echo "❌ Found stale toolchain 1.90.0 in workflows (MSRV is 1.89.0)"
+            exit 1
+          fi
+          echo "✅ MSRV consistent across all workflows (1.89.0)"
+
       - name: Check units
         run: ./scripts/check-units.sh || true
       - name: Check envlock


### PR DESCRIPTION
### **User description**
## Summary

Adds two blocking guards to prevent supply-chain and MSRV regressions after #476.

## Changes

### 1. No Floating Action Refs Guard

Detects unpinned GitHub Actions using tags (v1, main, master, latest) instead of immutable SHA refs.

**Example violation:**
```yaml
uses: actions/checkout@v4  # ❌ Floating ref
```

**Expected:**
```yaml
uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # ✅ SHA pin
```

### 2. MSRV Consistency Guard

Detects stale 1.90.0 toolchain references, ensuring all workflows use MSRV=1.89.0 as standardized in #486.

**Example violation:**
```yaml
rust-version: 1.90.0  # ❌ Stale MSRV
```

**Expected:**
```yaml
rust-version: 1.89.0  # ✅ Current MSRV
```

## Why This Matters

These guards fail fast on PRs, preventing accidental regressions to:
- Supply-chain hardening (100% SHA pins from #486)
- Toolchain alignment (MSRV=1.89.0 from #486)

## Testing

The guards run on all PRs touching workflows, crates, tests, or scripts. They're blocking (not informational) to catch regressions immediately.

Relates to #476


___

### **PR Type**
Enhancement


___

### **Description**
- Adds two blocking guardrail checks to CI/CD pipeline

- Detects unpinned GitHub Actions using floating tags

- Enforces MSRV consistency at 1.89.0 across workflows

- Prevents supply-chain and toolchain regressions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  PR["Pull Request"] -->|triggers| Guards["Guards Workflow"]
  Guards -->|checks| FloatingRefs["No Floating Action Refs"]
  Guards -->|checks| MSRVCheck["MSRV Consistency Check"]
  FloatingRefs -->|validates| SHAPins["SHA-pinned Actions"]
  MSRVCheck -->|validates| MSRV["1.89.0 Toolchain"]
  SHAPins -->|result| Pass["Pass/Fail"]
  MSRV -->|result| Pass
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>guards.yml</strong><dd><code>Add two blocking guardrail checks to CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/guards.yml

<ul><li>Added "Guard - no floating action refs" step to detect unpinned GitHub <br>Actions using tags (v1, main, master, latest)<br> <li> Added "Guard - MSRV consistency" step to detect stale 1.90.0 toolchain <br>references and enforce 1.89.0<br> <li> Both guards use <code>rg</code> (ripgrep) to scan workflow files and fail with <br>descriptive error messages<br> <li> Guards provide clear success/failure feedback with emoji indicators</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/492/files#diff-fc4842d8e25bc37328c347345b50ae6c6f5652888e06d35a96883480759873e9">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).