### PR TITLE
ci: polish repin-actions workflow

### DIFF
--- a/.github/workflows/repin-actions.yml
+++ b/.github/workflows/repin-actions.yml
@@ -13,8 +13,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: repin-${{ github.ref }}
-  cancel-in-progress: true
+  group: repin-actions-${{ github.ref }}
+  cancel-in-progress: false  # Don't cancel in-flight repins
 
 jobs:
   repin:
@@ -111,9 +111,10 @@ jobs:
             # Push to remote
             git push -u origin "$BR"
 
-            # Create PR
+            # Create PR with labels, or update existing PR
             gh pr create \
               --title "ci: repin actions to latest upstream SHAs" \
+              --label "ci,automation,low-risk" \
               --body "$(cat <<'EOF'
 Automated weekly repin to keep action SHAs up-to-date with upstream tags.
 
@@ -127,9 +128,19 @@ the original tag reference in trailing comments for human readability.
 
 **Merge when ready:** Core CI checks must pass; other checks are advisory.
 EOF
-              )"
+              )" || {
+                # If PR already exists, update labels
+                PR_NUM=$(gh pr list --state open --head "$BR" --json number -q '.[0].number')
+                if [ -n "$PR_NUM" ]; then
+                  gh pr edit "$PR_NUM" --add-label "ci,automation,low-risk"
+                  echo "✓ PR already exists (#$PR_NUM), labels updated"
+                else
+                  echo "⚠ PR creation failed for unknown reason"
+                  exit 1
+                fi
+              }
 
-            echo "✓ PR created: ci/repin-$(date +%Y%m%d)"
+            echo "✓ Repin PR ready: $BR"
           else
             echo "ℹ No action pins changed - all actions are up-to-date"
           fi


### PR DESCRIPTION
### **User description**
## Summary

Improves the automated repin workflow with better automation hygiene and failure handling.

## Changes

### 1. Concurrency Control

**Before:**
```yaml
concurrency:
  group: repin-${{ github.ref }}
  cancel-in-progress: true
```

**After:**
```yaml
concurrency:
  group: repin-actions-${{ github.ref }}
  cancel-in-progress: false  # Don't cancel in-flight repins
```

**Why:** Prevents canceling in-flight repins that may be in the process of creating PRs. The more specific group name also avoids conflicts with other workflows.

### 2. Automatic Labeling

Repin PRs now automatically get tagged with:
- `ci` - Identifies CI-related changes
- `automation` - Marks automated PRs
- `low-risk` - Signals low-risk changes (immutable SHA updates)

**Benefits:**
- Easier triage and routing
- Can set up CODEOWNERS rules for auto-assignment
- Better visibility in PR lists

### 3. Graceful PR Handling

**New fallback logic:** If a PR already exists for the repin branch (e.g., workflow was re-run), the workflow now updates labels instead of failing.

```bash
gh pr create ... || {
  # If PR already exists, update labels instead of failing
  PR_NUM=$(gh pr list --state open --head "$BR" --json number -q '.[0].number')
  if [ -n "$PR_NUM" ]; then
    gh pr edit "$PR_NUM" --add-label "ci,automation,low-risk"
    echo "✓ PR already exists (#$PR_NUM), labels updated"
  fi
}
```

**Benefits:**
- More resilient to manual re-triggers
- Clearer error handling
- No silent failures

## Impact

Makes the automated repin workflow more robust and provides better metadata for automated PR management. Complements the supply-chain hardening from #476.

Relates to #476


___

### **PR Type**
Enhancement


___

### **Description**
- Improved concurrency control to prevent canceling in-flight repin PRs

- Added automatic labeling for repin PRs with ci, automation, low-risk tags

- Implemented graceful PR handling with fallback logic for existing PRs

- Enhanced error messaging and workflow resilience


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repin Workflow"] --> B["Concurrency Control"]
  A --> C["PR Creation"]
  B --> D["Prevent Cancellation"]
  C --> E["Add Labels"]
  C --> F["Handle Existing PR"]
  E --> G["ci, automation, low-risk"]
  F --> H["Update Labels or Fail"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repin-actions.yml</strong><dd><code>Enhanced concurrency control and PR labeling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/repin-actions.yml

<ul><li>Updated concurrency group name from <code>repin-</code> to <code>repin-actions-</code> for <br>specificity<br> <li> Changed <code>cancel-in-progress</code> from true to false to preserve in-flight <br>repin operations<br> <li> Added automatic labeling with <code>ci,automation,low-risk</code> tags to created <br>PRs<br> <li> Implemented fallback logic to update labels if PR already exists <br>instead of failing<br> <li> Enhanced error messaging with clearer status indicators</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/493/files#diff-5c4f48fac613ba3f70ecb448f27c6115436c69455591ff0d5352a068d7287fe4">+16/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).