### PR TITLE
docs: remove transient CI trigger comment

### DIFF
--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -271,5 +271,3 @@ gh pr edit <PR> --add-label lut
 - [PR template](../../.github/pull_request_template.md) - Quick label checklist
 - [CI workflows](../../.github/workflows/) – Workflow files
 - [Branch protection](https://github.com/EffortlessMetrics/BitNet-rs/settings/branches) *(maintainers only)*
-
-<!-- ci: trigger core checks for pull_request paths filter -->


### PR DESCRIPTION
### **User description**
## Summary

Removes the temporary HTML comment added to `docs/ci/labels.md` in #490.

## Context

The comment was a workaround to satisfy the `ci-core.yml` paths filter when PRs only modified workflow files:

```html
<!-- ci: trigger core checks for pull_request paths filter -->
```

This "doc nudge" was necessary because `ci-core.yml` didn't include `.github/workflows/**` in its paths filter, so workflow-only PRs couldn't trigger Core-4 checks via the `pull_request` event.

## Why Remove It Now

PR #491 added `.github/workflows/**` to the `ci-core.yml` paths filter, so:

- ✅ Workflow-only PRs now automatically trigger Core-4 checks
- ✅ No more manual intervention or doc file edits needed
- ✅ The comment served its purpose and can be safely removed

## Impact

Clean documentation without unnecessary workaround comments. The CI behavior remains identical because the paths filter fix is now permanent.

Relates to #476, #490, #491


___

### **PR Type**
Documentation


___

### **Description**
- Removes temporary HTML comment from CI documentation

- Comment was workaround for ci-core.yml paths filter

- No longer needed after #491 added workflows to filter

- Cleans up documentation without affecting CI behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR #491: Add workflows to ci-core.yml paths"] -->|enables| B["Automatic workflow-only PR triggers"]
  B -->|makes obsolete| C["Temporary doc comment workaround"]
  C -->|removed by| D["This PR: Clean documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>labels.md</strong><dd><code>Remove temporary CI trigger comment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/ci/labels.md

<ul><li>Removes HTML comment that triggered CI checks for workflow-only PRs<br> <li> Comment was temporary workaround added in #490<br> <li> No longer necessary after #491 added <code>.github/workflows/**</code> to <br>ci-core.yml paths filter</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/495/files#diff-80600153fbc07febe28ec98c10bca9700f10188745241b2dda36cef258752f98">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).