### PR TITLE
ci: add 40-hex validation to repin workflow + preflight one-liner

### DIFF
--- a/.github/workflows/repin-actions.yml
+++ b/.github/workflows/repin-actions.yml
@@ -89,6 +89,23 @@ jobs:
           chmod +x /tmp/pin_actions.sh
           /tmp/pin_actions.sh || true
 
+      - name: Validate all pins are 40-hex SHAs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # After substitution, ensure all external actions use 40-hex SHAs
+          # (Guards will reject non-40-hex pins, so block the repin PR early)
+          if grep -RInE '^\s*uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+@' .github/workflows \
+             | grep -vE '^\s*uses:\s*\./' \
+             | grep -vE '@[0-9a-f]{40}\b'; then
+            echo "❌ Non-40-hex action pin(s) detected after repin"
+            echo "Refusing to open repin PR - Guards would reject it"
+            exit 1
+          fi
+
+          echo "✅ All external actions pinned to 40-hex SHAs"
+
       - name: Open PR if changes detected
         shell: bash
         env:


### PR DESCRIPTION
### **User description**
## Summary

Implements the two optional polish items from guardrail hardening:

### 1. Repin Workflow 40-Hex Validation

**New step**: `Validate all pins are 40-hex SHAs`
- Runs after pin substitution, before PR creation
- Blocks repin PR if any non-40-hex pins remain
- **Fail-fast**: Guards would reject it anyway, so catch it early
- **Result**: Repin bot never proposes invalid PRs

### 2. Comprehensive Preflight One-Liner

**Added to CONTRIBUTING.md**:
- Single fail-fast command that runs all guard checks
- Complements existing individual checks (kept for granular debugging)
- Mirrors exact CI guard logic locally
- **Usage**: Run before committing workflow changes

## Testing

- Repin workflow will validate itself on next scheduled run
- Local preflight one-liner tested manually

## Benefits

- **Developer experience**: Catch guard violations before push
- **Bot hygiene**: Repin never creates PRs that CI will reject
- **Consistency**: Local checks match CI exactly


___

### **PR Type**
Enhancement


___

### **Description**
- Add 40-hex SHA validation step to repin workflow
  - Blocks repin PR creation if non-40-hex pins detected
  - Prevents CI rejection by catching issues early

- Add comprehensive preflight one-liner to CONTRIBUTING.md
  - Single fail-fast command runs all guard checks locally
  - Mirrors exact CI guard logic for consistency

- Keep individual guard check commands for granular debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repin Workflow"] --> B["Pin Substitution"]
  B --> C["Validate 40-hex SHAs"]
  C --> D{Valid?}
  D -->|Yes| E["Open PR"]
  D -->|No| F["Block & Fail"]
  G["Developer"] --> H["Run Preflight One-Liner"]
  H --> I["All Guards Pass?"]
  I -->|Yes| J["Commit Safe"]
  I -->|No| K["Fix Issues"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repin-actions.yml</strong><dd><code>Add 40-hex SHA validation to repin workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/repin-actions.yml

<ul><li>Add new validation step after pin substitution<br> <li> Grep for external actions with non-40-hex SHAs<br> <li> Exit with error if invalid pins detected<br> <li> Echo success message if all pins are valid 40-hex</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/498/files#diff-5c4f48fac613ba3f70ecb448f27c6115436c69455591ff0d5352a068d7287fe4">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Add preflight one-liner for all guard checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Update label for individual guard checks section<br> <li> Add new comprehensive preflight one-liner command<br> <li> Combines all four guard checks into single fail-fast pipeline<br> <li> Provides developers with local CI validation before push</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/498/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).