### PR TITLE
ci: exclude bitnet-py/bitnet-wasm from receipt verification builds

### DIFF
--- a/.github/workflows/verify-receipts.yml
+++ b/.github/workflows/verify-receipts.yml
@@ -176,7 +176,9 @@ jobs:
             ${{ runner.os }}-receipt-benchmark-
 
       - name: Build workspace (CPU features)
-        run: cargo build --workspace --release --no-default-features --features cpu --locked
+        run: |
+          cargo build --workspace --release --no-default-features --features cpu --locked \
+            --exclude bitnet-py --exclude bitnet-wasm
 
       # Note: Model download is optional for this test
       # The benchmark command can use mock mode if no model is available
@@ -316,7 +318,9 @@ jobs:
             ${{ runner.os }}-receipt-gpu-
 
       - name: Build workspace (GPU features)
-        run: cargo build --workspace --release --no-default-features --features gpu --locked
+        run: |
+          cargo build --workspace --release --no-default-features --features gpu --locked \
+            --exclude bitnet-py --exclude bitnet-wasm
 
       # Generate GPU receipt
       - name: Run GPU benchmark


### PR DESCRIPTION
### **User description**
## Summary

Fixes Python linking failure in the **Verify Generated Receipt (Benchmark)** workflow.

### Root Cause

The receipt verification workflow was building the entire workspace including `bitnet-py`, which depends on PyO3 and tries to link against `libpython3.12`. This shared library isn't available on the Ubuntu runner, causing the build to fail:

```
= note: /usr/bin/ld: cannot find -lpython3.12
error: could not compile `bitnet-py` (lib)
```

### Solution

Exclude `bitnet-py` and `bitnet-wasm` from workspace builds in both CPU and GPU lanes. The receipt verification workflow only needs:
- `xtask` for running benchmarks and verification
- `bitnet-cli` for inference (built transitively)

Python/WASM bindings aren't needed for receipt generation or validation.

### Changes

- **CPU build step**: Add `--exclude bitnet-py --exclude bitnet-wasm`
- **GPU build step**: Add `--exclude bitnet-py --exclude bitnet-wasm`

### Testing

This should allow the receipt verification workflow to build successfully without needing Python headers installed on the runner.

### Impact

- ✅ Reduces build time (fewer crates to compile)
- ✅ Removes unnecessary Python dependency from receipt lane
- ✅ Unblocks cancelled long-running jobs that depended on this lane


___

### **PR Type**
Bug fix


___

### **Description**
- Exclude bitnet-py and bitnet-wasm from receipt verification builds

- Fixes Python linking failure in verify-receipts.yml workflow

- Removes unnecessary PyO3 dependency from receipt generation lane

- Reduces build time by skipping unneeded Python/WASM bindings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Receipt Verification Workflow"] -->|Previously| B["Build entire workspace<br/>including bitnet-py"]
  B -->|PyO3 links libpython3.12| C["❌ Build fails<br/>libpython3.12 not found"]
  A -->|Now| D["Build workspace<br/>--exclude bitnet-py<br/>--exclude bitnet-wasm"]
  D -->|Only builds needed crates| E["✅ Build succeeds<br/>xtask + bitnet-cli"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify-receipts.yml</strong><dd><code>Exclude Python/WASM from receipt verification builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/verify-receipts.yml

<ul><li>Added <code>--exclude bitnet-py --exclude bitnet-wasm</code> flags to CPU build <br>step<br> <li> Added <code>--exclude bitnet-py --exclude bitnet-wasm</code> flags to GPU build <br>step<br> <li> Prevents PyO3 from attempting to link against unavailable <br>libpython3.12<br> <li> Reduces build scope to only required crates (xtask and bitnet-cli)</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/502/files#diff-2ca9d5e8a907ea9fdd671cd4065091a70d83738f84c01da107b8f74f4fbc70f8">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).