### PR TITLE
ci: add PR/issue templates to Core workflow path filters

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -2,7 +2,7 @@ name: CI (Core)
 
 # Core gating checks that MUST pass for PR merges (Linux-only).
 # This workflow is designed to be fast, reliable, and reproducible locally via ci/local.sh
-# Note: This workflow triggers on changes to crates/**, Cargo.{toml,lock}, .github/workflows/**, README.md, docs/**, SECURITY.md, and issue templates
+# Note: This workflow triggers on changes to crates/**, Cargo.{toml,lock}, .github/workflows/**, .github/pull_request_template.md, .github/ISSUE_TEMPLATE/**, README.md, docs/**, SECURITY.md
 # Workflow hardening: concurrency + timeouts applied across all workflows in #485
 
 on:
@@ -13,10 +13,11 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/**'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/**'
       - 'README.md'
       - 'docs/**'
       - 'SECURITY.md'
-      - '.github/ISSUE_TEMPLATE/**'
   push:
     branches: [ main ]
     paths:
@@ -24,10 +25,11 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/**'
+      - '.github/pull_request_template.md'
+      - '.github/ISSUE_TEMPLATE/**'
       - 'README.md'
       - 'docs/**'
       - 'SECURITY.md'
-      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### **User description**
## Summary

Adds `.github/pull_request_template.md` and `.github/ISSUE_TEMPLATE/**` to CI (Core) workflow path filters.

## Problem

PR #504 (template update) showed 'Expected' status for required checks because the template file wasn't in the Core workflow's path filter. This blocked the merge and required a workaround (doc nudge to trigger checks).

## Solution

Add template paths to both `pull_request` and `push` path filters in `ci-core.yml`:
- `.github/pull_request_template.md`
- `.github/ISSUE_TEMPLATE/**`

## Benefits

- Template/issue template changes now trigger required Core checks automatically
- No more workarounds needed for meta-file PRs
- Maintains same CI coverage for governance/contribution files

## Testing

This PR itself will validate the fix - Core checks should run on this template path change.

## Related

- Follow-up to #504 (PR template receipt hygiene checklist)


___

### **PR Type**
Enhancement


___

### **Description**
- Add PR and issue template paths to Core workflow triggers

- Ensures CI runs when governance/contribution files change

- Prevents 'Expected' check status blocking template PRs

- Updates workflow documentation to reflect new path filters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ci-core.yml"] -->|add paths| B["pull_request trigger"]
  A -->|add paths| C["push trigger"]
  B -->|monitor| D[".github/pull_request_template.md"]
  B -->|monitor| E[".github/ISSUE_TEMPLATE/**"]
  C -->|monitor| D
  C -->|monitor| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci-core.yml</strong><dd><code>Add template paths to Core workflow triggers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci-core.yml

<ul><li>Added <code>.github/pull_request_template.md</code> to both <code>pull_request</code> and <code>push</code> <br>path filters<br> <li> Added <code>.github/ISSUE_TEMPLATE/**</code> to both triggers (reordered for <br>consistency)<br> <li> Updated workflow documentation comment to reflect new monitored paths<br> <li> Ensures template changes automatically trigger required Core checks</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/505/files#diff-31bd198ce2c6956ed10bdfe25a233b755f3a201ad094a67c449115ef76d9ff43">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).