### PR TITLE
chore(deps): update remaining dependencies to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
  "bitnet-tokenizers",
  "candle-core",
  "cbindgen",
- "cudarc 0.17.5",
+ "cudarc 0.17.7",
  "futures",
  "log",
  "num_cpus",
@@ -608,7 +608,7 @@ dependencies = [
  "bytemuck",
  "cc",
  "criterion",
- "cudarc 0.17.5",
+ "cudarc 0.17.7",
  "env_logger",
  "half",
  "log",
@@ -721,7 +721,7 @@ dependencies = [
  "bitnet-tokenizers",
  "chrono",
  "clap",
- "cudarc 0.17.5",
+ "cudarc 0.17.7",
  "futures",
  "http-body-util",
  "hyper",
@@ -1165,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1601,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.17.5"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7342f14f265a572a93e6c2f26a566f5f9341d6bee7a8a72ce77bf328c917199f"
+checksum = "ff0da1a70ec91e66731c1752deb9fda3044f1154fe4ceb5873e3f96ed34cafa3"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ async-trait = "0.1.89"
 bitnet-tests = { path = "tests", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 criterion = "0.7.0"
-ctor = "0.6.0"
+ctor = "0.6.1"
 env_logger = "0.11.8"
 log = "0.4.28"
 rand = "0.9.2"
@@ -263,7 +263,7 @@ wasm-bindgen = "0.2.105"
 web-sys = "0.3.82"
 
 # GPU support
-cudarc = "0.17.5"
+cudarc = "0.17.7"
 
 # Testing and benchmarking
 criterion = { version = "0.7.0", features = ["html_reports"] }
@@ -277,7 +277,7 @@ reqwest = { version = "0.12.24", features = ["json"] }
 
 # Code quality
 bindgen = "0.72.1"
-cc = "1.2.43"
+cc = "1.2.45"
 
 # Build-time information
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -36,18 +36,18 @@ async-trait = "0.1.89"
 num_cpus = "1.17.0"
 tokio = { workspace = true }
 thiserror = { workspace = true }
-log = "0.4"
-async-stream = "0.3"
-wasm-bindgen-futures = { version = "0.4.53", optional = true }
+log = "0.4.28"
+async-stream = "0.3.6"
+wasm-bindgen-futures = { version = "0.4.55", optional = true }
 gloo-timers = { version = "0.3.0", features = ["futures"], optional = true }
-rustc_version_runtime = "0.3"
-chrono = "0.4"
+rustc_version_runtime = "0.3.0"
+chrono = "0.4.42"
 
 [dev-dependencies]
 tokio-test = "0.4.4"
-proptest = "1.7.0"
-tempfile = "3.22.0"
-chrono = "0.4"
+proptest = "1.9.0"
+tempfile = "3.23.0"
+chrono = "0.4.42"
 serial_test = "3.2.0"
 
 [features]

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -25,13 +25,13 @@ tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokenizers = { version = "0.22.1", default-features = false, features = ["onig", "unstable_wasm"] }
-tempfile = "3.22.0"
+tempfile = "3.23.0"
 base64 = "0.22.1"
 ahash = "0.8.12"
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream"], optional = true }
-futures-util = { version = "0.3", optional = true }
-dirs = "6.0"
-memmap2 = "0.9"
+reqwest = { version = "0.12.24", default-features = false, features = ["json", "stream"], optional = true }
+futures-util = { version = "0.3.31", optional = true }
+dirs = "6.0.0"
+memmap2 = "0.9.9"
 thiserror.workspace = true
 
 [features]
@@ -53,12 +53,12 @@ version = "0.12.0"
 optional = true
 
 [dependencies.sentencepiece-model]
-version = "0.1.0"
+version = "0.1.4"
 optional = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
-tempfile = "3.22.0"
+tempfile = "3.23.0"
 temp-env = "0.3.6"
 serial_test.workspace = true
 bitnet-tests = { path = "../../tests" }

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -34,7 +34,7 @@ toml = "0.9.8"
 
 # Cross-validation specific dependencies (feature-gated)
 bindgen = { version = "0.72.1", optional = true }
-cc = { version = "1.2.41", optional = true }
+cc = { version = "1.2.45", optional = true }
 # bitnet-sys is needed for bitnet.cpp cross-validation (enabled via bitnet-ffi)
 bitnet-sys = { path = "../crates/bitnet-sys", optional = true }
 
@@ -131,7 +131,7 @@ required-features = ["ffi"]
 
 [build-dependencies]
 bindgen = { version = "0.72.1", optional = true }
-cc = { version = "1.2.41", optional = true }
+cc = { version = "1.2.45", optional = true }
 
 [package.metadata.docs.rs]
 features = ["crossval"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -193,7 +193,7 @@ dirs = "6.0.0"
 # Testing utilities
 env_logger = "0.11.8"
 tempfile = "3.23.0"
-assert_cmd = "2.0.17"
+assert_cmd = "2.1.1"
 predicates = "3.1.3"
 serial_test.workspace = true
 
@@ -208,7 +208,7 @@ rayon = "1.11.0"
 chrono = { version = "0.4.42", features = ["serde"] }
 
 # Command line argument parsing
-clap = { version = "4.5.50", features = ["derive"] }
+clap = { version = "4.5.51", features = ["derive"] }
 
 # HTML escaping for reports
 html-escape = "0.2.13"


### PR DESCRIPTION
### **User description**
**Comprehensive dependency update batch (post-Dependabot merges)**

This PR updates additional dependencies that weren't covered by the individual Dependabot PRs.

### Workspace-level updates
- `cudarc`: 0.17.5 → 0.17.7 (GPU support)
- `cc`: 1.2.43 → 1.2.45 (build tooling)

### bitnet-inference updates
- `log`: 0.4 → 0.4.28 (explicit version)
- `async-stream`: 0.3 → 0.3.6
- `wasm-bindgen-futures`: 0.4.53 → 0.4.55
- `rustc_version_runtime`: 0.3 → 0.3.0 (explicit version)
- `chrono`: 0.4 → 0.4.42
- `proptest`: 1.7.0 → 1.9.0
- `tempfile`: 3.22.0 → 3.23.0

### bitnet-tokenizers updates
- `tempfile`: 3.22.0 → 3.23.0
- `reqwest`: 0.12 → 0.12.24 (explicit version)
- `futures-util`: 0.3 → 0.3.31 (explicit version)
- `memmap2`: 0.9 → 0.9.9 (explicit version)

All updates maintain compatibility with existing code and improve version specificity for reproducible builds.

**Dependencies**: None
**Breaking**: No


___

### **PR Type**
Enhancement


___

### **Description**
- Updates multiple dependencies to latest stable versions

- Improves version specificity for reproducible builds

- Enhances GPU support and build tooling capabilities

- Maintains full backward compatibility across all crates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workspace Dependencies"] --> B["cudarc 0.17.7"]
  A --> C["cc 1.2.45"]
  D["bitnet-inference"] --> E["log 0.4.28"]
  D --> F["async-stream 0.3.6"]
  D --> G["chrono 0.4.42"]
  D --> H["proptest 1.9.0"]
  I["bitnet-tokenizers"] --> J["reqwest 0.12.24"]
  I --> K["memmap2 0.9.9"]
  I --> L["futures-util 0.3.31"]
  M["Other Crates"] --> N["ctor 0.6.1"]
  M --> O["assert_cmd 2.1.1"]
  M --> P["clap 4.5.51"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Workspace-level dependency version updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Updates <code>ctor</code> from 0.6.0 to 0.6.1<br> <li> Updates <code>cudarc</code> from 0.17.5 to 0.17.7 for GPU support<br> <li> Updates <code>cc</code> from 1.2.43 to 1.2.45 for build tooling</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/517/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>bitnet-inference crate dependency updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-inference/Cargo.toml

<ul><li>Pins <code>log</code> to explicit version 0.4.28<br> <li> Updates <code>async-stream</code> from 0.3 to 0.3.6<br> <li> Updates <code>wasm-bindgen-futures</code> from 0.4.53 to 0.4.55<br> <li> Pins <code>rustc_version_runtime</code> to explicit version 0.3.0<br> <li> Updates <code>chrono</code> from 0.4 to 0.4.42<br> <li> Updates <code>proptest</code> from 1.7.0 to 1.9.0<br> <li> Updates <code>tempfile</code> from 3.22.0 to 3.23.0</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/517/files#diff-3b0fb4e72a9e2e018443fa93c8f1bd252da28e7ba53e448b44eab8301388cfca">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>bitnet-tokenizers crate dependency updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-tokenizers/Cargo.toml

<ul><li>Updates <code>tempfile</code> from 3.22.0 to 3.23.0<br> <li> Pins <code>reqwest</code> to explicit version 0.12.24<br> <li> Pins <code>futures-util</code> to explicit version 0.3.31<br> <li> Pins <code>dirs</code> to explicit version 6.0.0<br> <li> Pins <code>memmap2</code> to explicit version 0.9.9<br> <li> Updates <code>sentencepiece-model</code> from 0.1.0 to 0.1.4</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/517/files#diff-7a014b0ac7519b304fa2064811d757b857506df24e0208b70643091bf3a2350e">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>crossval crate cc build tool updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crossval/Cargo.toml

<ul><li>Updates <code>cc</code> from 1.2.41 to 1.2.45 in dependencies<br> <li> Updates <code>cc</code> from 1.2.41 to 1.2.45 in build-dependencies</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/517/files#diff-e23ca3090236135ce7aab2fb196b8295785123b44e93a95721d725cfdfa98855">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Test crate dependency version updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Cargo.toml

<ul><li>Updates <code>assert_cmd</code> from 2.0.17 to 2.1.1<br> <li> Updates <code>clap</code> from 4.5.50 to 4.5.51</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/517/files#diff-9abb8310fe65807f370f136db9528106606118c7e98654141b0bbd87b07639f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).