### PR TITLE
kv-pool v2: Entry wiring + create path (PR 2/5 for #319)

### DIFF
--- a/crates/bitnet-server/src/caching/performance_tuning.rs
+++ b/crates/bitnet-server/src/caching/performance_tuning.rs
@@ -48,15 +48,6 @@ pub struct PerformanceTuner {
     last_optimization: Instant,
 }
 
-/// Lightweight report used by `generate_report()`; keep simple for MSRV builds.
-#[derive(Debug, Clone)]
-pub struct PerformanceReport {
-    pub average_requests_per_second: f64,
-    pub average_latency_ms: f64,
-    pub current_config: CachingConfig,
-    pub sample_count: usize,
-}
-
 /// Tunable performance parameters
 #[derive(Debug, Clone)]
 pub struct PerformanceParameters {

--- a/crates/bitnet-server/tests/ac01_rest_api_inference.rs
+++ b/crates/bitnet-server/tests/ac01_rest_api_inference.rs
@@ -314,7 +314,7 @@ fn ac1_api_contract_schema_definitions_ok() -> Result<()> {
         "prompt", // string, minLength: 1, maxLength: 8192
     ];
 
-    let optional_request_fields = vec![
+    let optional_request_fields = [
         "max_tokens",              // integer, 1-2048, default: 100
         "model",                   // string, pattern: ^[a-zA-Z0-9_-]+$
         "temperature",             // number, 0.0-2.0, default: 0.7


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
Pool-backed KVCacheEntry with typed views and create path. Validated locally (822/822 tests). See PR_519_VALIDATION_SUMMARY.md for details.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace KVCacheEntry Vec<f32> fields with pool-backed typed views
  - Eliminates double-allocation and enables true memory reuse
  - Adds `key_mut()`, `value_mut()`, `key()`, `value()` accessor methods

- Implement `f32_slice_mut()` and `f32_slice()` in MemoryPool
  - Provides safe typed access to arena memory with bounds/alignment checks

- Update `create_cache_entry()` to allocate single aligned block split into [key][value]
  - Handles zero-initialization with `.expect()` for Result values
  - Adds debug assertions for split correctness

- Fix rebase conflicts and strict warnings
  - Replace modulo checks with `.is_multiple_of()` (clippy lint)
  - Remove duplicate PerformanceReport struct
  - Convert static vec to array in test (useless_vec lint)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["KVCacheEntry<br/>Vec fields"] -->|"Replace with<br/>pool offsets"| B["Pool-backed<br/>offsets + block"]
  B -->|"Accessor methods"| C["key_mut/value_mut<br/>key/value"]
  C -->|"Use MemoryPool"| D["f32_slice_mut<br/>f32_slice"]
  D -->|"Bounds/alignment<br/>checks"| E["Safe typed<br/>arena access"]
  F["create_cache_entry<br/>allocate"] -->|"Single block<br/>split [K][V]"| G["Zero-init<br/>both regions"]
  G -->|"Create entry"| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kv_cache.rs</strong><dd><code>Pool-backed entry with typed views and create path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-server/src/caching/kv_cache.rs

<ul><li>Replace <code>key_cache</code> and <code>value_cache</code> Vec<f32> fields with pool offsets <br>(<code>key_off</code>, <code>key_len_f32</code>, <code>val_off</code>, <code>val_len_f32</code>) and <code>block</code> reference<br> <li> Add <code>KVCacheEntry</code> impl block with four typed view accessors: <code>key_mut()</code>, <br><code>value_mut()</code>, <code>key()</code>, <code>value()</code><br> <li> Implement <code>MemoryPool::f32_slice_mut()</code> and <code>f32_slice()</code> for safe typed <br>arena access with alignment/bounds validation<br> <li> Update <code>create_cache_entry()</code> to allocate single aligned block, split <br>into key/value regions, and zero-initialize both with <code>.expect()</code> error <br>handling<br> <li> Make <code>align_up()</code> const fn and remove <code>#[cfg(test)]</code> gating; make <br><code>F32_BYTES</code> non-test constant<br> <li> Add <code>entry_views_round_trip()</code> test validating pool-backed entry <br>creation and typed view read/write<br> <li> Update test comments for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/523/files#diff-0fbc5d8cb52c8f25dfe102eb09fefdcf3064e81b8692719a425102aad8c8d001">+187/-21</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>performance_tuning.rs</strong><dd><code>Resolve PerformanceReport struct rebase conflict</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-server/src/caching/performance_tuning.rs

<ul><li>Move <code>PerformanceReport</code> struct definition before <code>PerformanceTuner</code> <br>(rebase conflict resolution)<br> <li> Struct definition unchanged; only reordered in file</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/523/files#diff-14a954b76ffffdcef9d9f2472d1d6d9999ae705a878281d7df9f168626b69862">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ac01_rest_api_inference.rs</strong><dd><code>Convert static vec to array literal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bitnet-server/tests/ac01_rest_api_inference.rs

<ul><li>Replace <code>vec![]</code> with array literal <code>[]</code> for static <br><code>optional_request_fields</code> data<br> <li> Fixes clippy useless_vec lint</ul>


</details>


  </td>
  <td><a href="https://github.com/EffortlessMetrics/BitNet-rs/pull/523/files#diff-ed0b4d6a95db6e0d749040ae1d8f807ddc635ef552f3429915f7205b5a801ad4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).