### PR TITLE
⚡ Bolt: optimize batch grouping allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2025-10-21 - BatchEngine Clone Semantics
+**Learning:** The `BatchEngine` struct uses `AtomicU64` for metrics but clones them by value (creating new counters) instead of wrapping them in `Arc`. This means metrics collected in spawned tasks (which use a cloned engine) are lost and not aggregated in the main instance.
+**Action:** In future refactors, wrap shared metrics in `Arc<AtomicU64>` or a dedicated metrics struct behind `Arc`.
+
+## 2025-10-21 - HashMap Keys Allocation
+**Learning:** The codebase heavily uses `String` as map keys even when the data is already owned elsewhere. In `optimize_batch_for_quantization`, using `&str` keys saved significant allocations.
+**Action:** Look for patterns where `String` is used as a key but a reference would suffice, especially in hot loops like batch formation.

--- a/crates/bitnet-server/src/batch_engine.rs
+++ b/crates/bitnet-server/src/batch_engine.rs
@@ -378,12 +378,13 @@ impl BatchEngine {
         }
 
         // Analyze requests for quantization compatibility
-        let mut compatible_groups: HashMap<String, Vec<usize>> = HashMap::new();
+        // Optimization: Use &str keys to avoid string allocations for each candidate
+        let mut compatible_groups: HashMap<&str, Vec<usize>> = HashMap::new();
 
         for (index, pending) in candidates.iter().enumerate() {
             let quantization_type = pending.request.quantization_hint.as_deref().unwrap_or("I2S"); // Default to I2S quantization
 
-            compatible_groups.entry(quantization_type.to_string()).or_default().push(index);
+            compatible_groups.entry(quantization_type).or_default().push(index);
         }
 
         // Find the largest compatible group
@@ -391,12 +392,12 @@ impl BatchEngine {
             compatible_groups.into_iter().max_by_key(|(_, indices)| indices.len())?;
 
         // Recommend device based on quantization type and SIMD support
-        let recommended_device = self.recommend_device_for_quantization(&best_quantization).await;
+        let recommended_device = self.recommend_device_for_quantization(best_quantization).await;
 
         Some(QuantizationOptimization {
             batch_compatible_requests: best_indices,
             recommended_device,
-            quantization_type: best_quantization,
+            quantization_type: best_quantization.to_string(),
             simd_instruction_set: self.get_optimal_simd_instruction_set().await,
             memory_requirement_mb: self.estimate_memory_requirement(candidates).await,
         })
@@ -681,4 +682,43 @@ pub struct BatchEngineHealth {
     pub average_batch_size: f64,
     pub throughput_tokens_per_second: f64,
     pub issues: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::oneshot;
+
+    #[tokio::test]
+    async fn test_optimize_batch_for_quantization_grouping() {
+        let config = BatchEngineConfig {
+            quantization_aware: true,
+            ..BatchEngineConfig::default()
+        };
+        let engine = BatchEngine::new(config);
+
+        let req1 = BatchRequest::new("test1".to_string(), GenerationConfig::default())
+            .with_quantization_hint("I2S".to_string());
+        let req2 = BatchRequest::new("test2".to_string(), GenerationConfig::default())
+            .with_quantization_hint("TL1".to_string());
+        let req3 = BatchRequest::new("test3".to_string(), GenerationConfig::default())
+            .with_quantization_hint("I2S".to_string());
+
+        let (tx1, _) = oneshot::channel();
+        let (tx2, _) = oneshot::channel();
+        let (tx3, _) = oneshot::channel();
+
+        let candidates = vec![
+            PendingRequest { request: req1, response_tx: tx1 },
+            PendingRequest { request: req2, response_tx: tx2 },
+            PendingRequest { request: req3, response_tx: tx3 },
+        ];
+
+        let optimization = engine.optimize_batch_for_quantization(&candidates).await.expect("Should return optimization");
+
+        assert_eq!(optimization.quantization_type, "I2S");
+        assert_eq!(optimization.batch_compatible_requests.len(), 2);
+        assert!(optimization.batch_compatible_requests.contains(&0));
+        assert!(optimization.batch_compatible_requests.contains(&2));
+    }
 }


### PR DESCRIPTION
💡 What: Optimized `optimize_batch_for_quantization` to use `&str` keys instead of `String` keys for the quantization grouping map.
🎯 Why: The previous implementation allocated a new `String` for every candidate request, which is unnecessary since the keys are just borrowed from the requests. This reduces memory pressure and CPU cycles during batch formation.
📊 Impact: Reduces allocations from O(N) to O(1) (where N is batch candidates) for the grouping operation.
🔬 Measurement: Added a unit test `test_optimize_batch_for_quantization_grouping` to verify the logic remains correct. Confirmed with `cargo test`.

---
*PR created automatically by Jules for task [545806613075457020](https://jules.google.com/task/545806613075457020) started by @EffortlessSteven*