### PR TITLE
🛡️ Sentinel: [MEDIUM] Restrict CORS origins based on SecurityConfig

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-10-21 - Overly Permissive CORS Configuration
+**Vulnerability:** The default CORS configuration was hardcoded to allow all origins (`*`), methods, and headers, even though `SecurityConfig` had an `allowed_origins` field.
+**Learning:** Middleware configurations in `bitnet-server` were not fully utilizing the `SecurityConfig` struct, leading to security features being defined but not enforced.
+**Prevention:** Ensure that all security-related middleware (CORS, Rate Limiting, etc.) are explicitly configured using the `SecurityConfig` passed from `BitNetServer`.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The CORS configuration was hardcoded to allow all origins (`*`) regardless of the `SecurityConfig` settings.
🎯 Impact: Malicious websites could make cross-origin requests to the API, potentially leading to CSRF-like attacks or data exfiltration if internal networks are exposed.
🔧 Fix: Updated `configure_cors` to use the `allowed_origins` from `SecurityConfig`. If specific origins are listed, only those are allowed. If `*` is present, it falls back to allowing all.
✅ Verification: Added integration tests in `crates/bitnet-server/src/security.rs` that verify:
    - Wildcard configuration still works.
    - Specific origin configuration restricts access correctly.
    - Blocked origins receive no `Access-Control-Allow-Origin` header.
    - Ran `cargo test -p bitnet-server --lib security::tests`.

---
*PR created automatically by Jules for task [8689039348081932365](https://jules.google.com/task/8689039348081932365) started by @EffortlessSteven*