### PR TITLE
⚡ Bolt: Optimize batch engine allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-10-25 - Atomic Cloning Anti-Pattern
+**Learning:** `BatchEngine` uses `AtomicU64` fields that are manually cloned (value copied) when `self.clone()` is called for `tokio::spawn`. This creates independent counters in spawned tasks, leading to split-brain statistics where the main instance sees 0 for metrics updated by workers.
+**Action:** When implementing shared state for `tokio::spawn`, always wrap atomic counters in `Arc<AtomicU64>` or `Arc<struct_with_atomics>` instead of holding them directly in the struct if the struct is cloned.
+
+## 2024-10-25 - HashMap Key Allocations
+**Learning:** `optimize_batch_for_quantization` was allocating `String` keys for every request in the candidate list to group them. In high-throughput batching systems, these allocations in the hot path add up.
+**Action:** Use `HashMap<&str, ...>` with borrowed keys from the source data (which usually outlives the temporary map) to avoid allocations.

--- a/crates/bitnet-server/src/batch_engine.rs
+++ b/crates/bitnet-server/src/batch_engine.rs
@@ -378,12 +378,12 @@ impl BatchEngine {
         }
 
         // Analyze requests for quantization compatibility
-        let mut compatible_groups: HashMap<String, Vec<usize>> = HashMap::new();
+        let mut compatible_groups: HashMap<&str, Vec<usize>> = HashMap::new();
 
         for (index, pending) in candidates.iter().enumerate() {
             let quantization_type = pending.request.quantization_hint.as_deref().unwrap_or("I2S"); // Default to I2S quantization
 
-            compatible_groups.entry(quantization_type.to_string()).or_default().push(index);
+            compatible_groups.entry(quantization_type).or_default().push(index);
         }
 
         // Find the largest compatible group
@@ -391,12 +391,12 @@ impl BatchEngine {
             compatible_groups.into_iter().max_by_key(|(_, indices)| indices.len())?;
 
         // Recommend device based on quantization type and SIMD support
-        let recommended_device = self.recommend_device_for_quantization(&best_quantization).await;
+        let recommended_device = self.recommend_device_for_quantization(best_quantization).await;
 
         Some(QuantizationOptimization {
             batch_compatible_requests: best_indices,
             recommended_device,
-            quantization_type: best_quantization,
+            quantization_type: best_quantization.to_string(),
             simd_instruction_set: self.get_optimal_simd_instruction_set().await,
             memory_requirement_mb: self.estimate_memory_requirement(candidates).await,
         })
@@ -681,4 +681,50 @@ pub struct BatchEngineHealth {
     pub average_batch_size: f64,
     pub throughput_tokens_per_second: f64,
     pub issues: Vec<String>,
+}
+
+#[cfg(test)]
+impl PendingRequest {
+    fn new_test(request: BatchRequest) -> Self {
+        let (response_tx, _) = oneshot::channel();
+        Self { request, response_tx }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitnet_inference::GenerationConfig;
+
+    #[tokio::test]
+    async fn test_optimize_batch_allocations() {
+        let config = BatchEngineConfig {
+            quantization_aware: true,
+            ..Default::default()
+        };
+        let engine = BatchEngine::new(config);
+
+        let mut candidates = Vec::new();
+
+        // Create requests with different quantization hints
+        // Group 1: "I2S" (3 requests)
+        for _ in 0..3 {
+            let req = BatchRequest::new("test".to_string(), GenerationConfig::default())
+                .with_quantization_hint("I2S".to_string());
+            candidates.push(PendingRequest::new_test(req));
+        }
+
+        // Group 2: "TL1" (2 requests)
+        for _ in 0..2 {
+            let req = BatchRequest::new("test".to_string(), GenerationConfig::default())
+                .with_quantization_hint("TL1".to_string());
+            candidates.push(PendingRequest::new_test(req));
+        }
+
+        let optimization = engine.optimize_batch_for_quantization(&candidates).await.unwrap();
+
+        // Should select "I2S" as it has more requests
+        assert_eq!(optimization.quantization_type, "I2S");
+        assert_eq!(optimization.batch_compatible_requests.len(), 3);
+    }
 }


### PR DESCRIPTION
⚡ Bolt: Optimized batch engine allocation

💡 What:
Replaced the `HashMap<String, Vec<usize>>` with `HashMap<&str, Vec<usize>>` in `optimize_batch_for_quantization` within `crates/bitnet-server/src/batch_engine.rs`.

🎯 Why:
The previous implementation allocated a new `String` for every request in the candidate list to use as a map key. In a high-throughput inference server where `form_batch` is called frequently (potentially per request or in a tight loop), these allocations add unnecessary pressure to the allocator.

📊 Impact:
Reduces heap allocations during batch formation by N (where N is the number of candidates checked, typically up to `max_batch_size`). For a batch size of 16, this saves 16 string allocations per batch formation attempt.

🔬 Measurement:
Added a new unit test `test_optimize_batch_allocations` in `crates/bitnet-server/src/batch_engine.rs` to verify the grouping logic remains correct. Verified via `cargo test -p bitnet-server --lib batch_engine`.
Also verified no regressions in `ac04_batch_processing`.


---
*PR created automatically by Jules for task [3667659053835991170](https://jules.google.com/task/3667659053835991170) started by @EffortlessSteven*