### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove hardcoded Grafana password

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-10-21 - Hardcoded Grafana Password in Docker Compose
+**Vulnerability:** Found `GF_SECURITY_ADMIN_PASSWORD=admin` hardcoded in `docker-compose.yml`.
+**Learning:** Development configurations often leak into production-like artifacts. Docker Compose files are frequently used for both local dev and production, creating a risk when defaults are insecure.
+**Prevention:** Use shell parameter expansion with error enforcement (`${VAR:?error}`) in configuration files to force explicit secret injection, rather than providing weak defaults.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
       - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GF_SECURITY_ADMIN_PASSWORD:?error: GF_SECURITY_ADMIN_PASSWORD must be set}
       - GF_USERS_ALLOW_SIGN_UP=false
     restart: unless-stopped
     profiles:


### PR DESCRIPTION
Removed hardcoded Grafana password from docker-compose.yml and replaced it with strict environment variable enforcement to improve security.

---
*PR created automatically by Jules for task [7217410174612929251](https://jules.google.com/task/7217410174612929251) started by @EffortlessSteven*