### PR TITLE
🎨 Palette: Make browser tabs keyboard accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-22 - Vanilla JS Verification Strategy
+**Learning:** For frontend examples lacking a build system (no package.json), verifying interaction requires mocking missing WASM/module dependencies and serving static files via a temporary Python HTTP server.
+**Action:** Use `python3 -m http.server` and create dummy ES modules for verification scripts to avoid build dependency blockers.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -225,16 +225,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Application sections">
+        <div class="tab active" id="tab-basic" role="tab" aria-selected="true" aria-controls="basic-tab" tabindex="0" onclick="switchTab('basic')" onkeydown="handleTabKey(event)">Basic Inference</div>
+        <div class="tab" id="tab-streaming" role="tab" aria-selected="false" aria-controls="streaming-tab" tabindex="-1" onclick="switchTab('streaming')" onkeydown="handleTabKey(event)">Streaming</div>
+        <div class="tab" id="tab-worker" role="tab" aria-selected="false" aria-controls="worker-tab" tabindex="-1" onclick="switchTab('worker')" onkeydown="handleTabKey(event)">Web Workers</div>
+        <div class="tab" id="tab-benchmark" role="tab" aria-selected="false" aria-controls="benchmark-tab" tabindex="-1" onclick="switchTab('benchmark')" onkeydown="handleTabKey(event)">Benchmarks</div>
+        <div class="tab" id="tab-settings" role="tab" aria-selected="false" aria-controls="settings-tab" tabindex="-1" onclick="switchTab('settings')" onkeydown="handleTabKey(event)">Settings</div>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +281,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +319,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +347,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +389,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -454,13 +454,51 @@ function switchTab(tabName) {
     // Remove active class from all tabs
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
     // Add active class to selected tab
-    event.target.classList.add('active');
+    const activeTab = document.getElementById(`tab-${tabName}`);
+    activeTab.classList.add('active');
+    activeTab.setAttribute('aria-selected', 'true');
+    activeTab.setAttribute('tabindex', '0');
+    activeTab.focus();
+}
+
+// Handle keyboard navigation for tabs
+function handleTabKey(event) {
+    const tabs = Array.from(document.querySelectorAll('.tab'));
+    const currentIndex = tabs.indexOf(event.target);
+    let nextIndex = null;
+
+    switch (event.key) {
+        case 'ArrowRight':
+            nextIndex = (currentIndex + 1) % tabs.length;
+            break;
+        case 'ArrowLeft':
+            nextIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+            break;
+        case 'Home':
+            nextIndex = 0;
+            break;
+        case 'End':
+            nextIndex = tabs.length - 1;
+            break;
+        case 'Enter':
+        case ' ':
+            event.preventDefault();
+            event.target.click();
+            return;
+    }
+
+    if (nextIndex !== null) {
+        event.preventDefault();
+        tabs[nextIndex].click();
+    }
 }
 
 // Settings management
@@ -559,6 +597,7 @@ window.runKernelBenchmark = runKernelBenchmark;
 window.runMemoryBenchmark = runMemoryBenchmark;
 window.runLoadingBenchmark = runLoadingBenchmark;
 window.switchTab = switchTab;
+window.handleTabKey = handleTabKey;
 window.saveSettings = saveSettings;
 window.resetSettings = resetSettings;
 window.exportSettings = exportSettings;


### PR DESCRIPTION
This PR improves the accessibility of the BitNet WASM browser example by implementing the WAI-ARIA Tab Widget pattern.

**UX Improvements:**
- Users can now navigate tabs using the keyboard (Left/Right Arrows, Home, End).
- Screen readers will correctly announce the role of the tabs and their selected state.
- Focus management is handled using the "roving tabindex" technique.

**Verification:**
- Verified manually using a custom Playwright script (`verification/verify_tabs.py`) which confirmed the presence of correct roles and successful keyboard navigation.
- Visual inspection confirmed that the tab styling remains consistent.

---
*PR created automatically by Jules for task [9201939308051290810](https://jules.google.com/task/9201939308051290810) started by @EffortlessSteven*