### PR TITLE
🛡️ Sentinel: [HIGH] Fix CORS configuration ignoring allowed_origins

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-22 - Unapplied Security Configuration
+**Vulnerability:** The `configure_cors` function in `bitnet-server` was ignoring the `SecurityConfig` and defaulting to `AllowOrigin::any()`, effectively disabling CORS protection despite configuration options existing.
+**Learning:** Middleware configuration functions must strictly accept and apply the security configuration object. Existence of a configuration struct does not imply its usage.
+**Prevention:** Verify that all security-related configuration fields are actually referenced in the code, especially in middleware setup. Use unit tests to assert that configuration changes affect behavior.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -340,11 +340,30 @@ pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 /// CORS middleware configuration
-pub fn configure_cors() -> tower_http::cors::CorsLayer {
-    use tower_http::cors::{Any, CorsLayer};
+pub fn configure_cors(config: &SecurityConfig) -> tower_http::cors::CorsLayer {
+    use axum::http::HeaderValue;
+    use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+
+    let allow_origin = if config.allowed_origins.contains(&"*".to_string()) {
+        AllowOrigin::any()
+    } else {
+        let origins: Vec<HeaderValue> = config
+            .allowed_origins
+            .iter()
+            .filter_map(|origin| match HeaderValue::from_str(origin) {
+                Ok(val) => Some(val),
+                Err(_) => {
+                    warn!("Invalid origin in configuration: {}", origin);
+                    None
+                }
+            })
+            .collect();
+
+        AllowOrigin::list(origins)
+    };
 
     CorsLayer::new()
-        .allow_origin(Any)
+        .allow_origin(allow_origin)
         .allow_methods(Any)
         .allow_headers(Any)
         .max_age(std::time::Duration::from_secs(3600))

--- a/crates/bitnet-server/tests/cors_security.rs
+++ b/crates/bitnet-server/tests/cors_security.rs
@@ -1,0 +1,60 @@
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+    routing::get,
+};
+use bitnet_server::security::{SecurityConfig, configure_cors};
+use tower::ServiceExt; // for oneshot
+
+#[tokio::test]
+async fn test_cors_configuration() {
+    // 1. Setup SecurityConfig with restricted origins
+    let config = SecurityConfig {
+        allowed_origins: vec!["http://trusted.com".to_string()],
+        ..SecurityConfig::default()
+    };
+
+    // 2. Configure CORS middleware
+    let cors_layer = configure_cors(&config);
+
+    // 3. Create a simple router
+    let app = Router::new().route("/", get(|| async { "Hello, World!" })).layer(cors_layer);
+
+    // 4. Test valid origin
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("Origin", "http://trusted.com")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("access-control-allow-origin").unwrap().to_str().unwrap(),
+        "http://trusted.com"
+    );
+
+    // 5. Test invalid origin
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("Origin", "http://evil.com")
+                .header("Access-Control-Request-Method", "GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    // CORS middleware should NOT add Access-Control-Allow-Origin for invalid origins
+    assert!(response.headers().get("access-control-allow-origin").is_none());
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix CORS configuration ignoring allowed_origins

🚨 Severity: HIGH
💡 Vulnerability: The `configure_cors` function was hardcoded to `AllowOrigin::Any`, completely ignoring the `SecurityConfig.allowed_origins` setting. This meant the server was permissive to all cross-origin requests regardless of configuration.
🎯 Impact: Attackers could potentially perform Cross-Site Request Forgery (CSRF) or access sensitive data if the API relies solely on CORS for browser-based restrictions (though other auth mechanisms should exist). It breaks the expectation of the configuration file.
🔧 Fix: Updated `configure_cors` to use the values from `SecurityConfig`.
✅ Verification: Added `tests/cors_security.rs` which verifies that requests from trusted origins are allowed and requests from untrusted origins are rejected.

---
*PR created automatically by Jules for task [18229259435812243858](https://jules.google.com/task/18229259435812243858) started by @EffortlessSteven*