### PR TITLE
🎨 Palette: Implement Accessible Tabs in Browser Example

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-03 - Accessible Tabs Implementation
+**Learning:** Tab interfaces using non-semantic elements (like `div`) require explicit ARIA roles (`tablist`, `tab`, `tabpanel`) and manual keyboard navigation (Arrow keys) to be accessible. Simply adding `onclick` is insufficient for keyboard and screen reader users.
+**Action:** When creating custom tabs, always implement the full WAI-ARIA Tab Design Pattern, including `aria-selected`, `tabindex` management, and keyboard event handlers for focus movement.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -225,16 +225,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Application Sections">
+        <div class="tab active" role="tab" aria-selected="true" tabindex="0" aria-controls="basic-tab" id="tab-basic" onclick="switchTab('basic')" onkeydown="handleTabKey(event)">Basic Inference</div>
+        <div class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="streaming-tab" id="tab-streaming" onclick="switchTab('streaming')" onkeydown="handleTabKey(event)">Streaming</div>
+        <div class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="worker-tab" id="tab-worker" onclick="switchTab('worker')" onkeydown="handleTabKey(event)">Web Workers</div>
+        <div class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="benchmark-tab" id="tab-benchmark" onclick="switchTab('benchmark')" onkeydown="handleTabKey(event)">Benchmarks</div>
+        <div class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="settings-tab" id="tab-settings" onclick="switchTab('settings')" onkeydown="handleTabKey(event)">Settings</div>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +281,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +319,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +347,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +389,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -451,16 +451,54 @@ function switchTab(tabName) {
         tab.classList.remove('active');
     });
 
-    // Remove active class from all tabs
+    // Remove active class from all tabs and update ARIA attributes
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class to selected tab and update ARIA attributes
+    const selectedTab = document.getElementById(`tab-${tabName}`);
+    if (selectedTab) {
+        selectedTab.classList.add('active');
+        selectedTab.setAttribute('aria-selected', 'true');
+        selectedTab.setAttribute('tabindex', '0');
+        selectedTab.focus();
+    }
+}
+
+// Handle keyboard navigation for tabs
+function handleTabKey(event) {
+    const tabs = Array.from(document.querySelectorAll('.tab'));
+    const currentTab = event.target;
+    const currentIndex = tabs.indexOf(currentTab);
+
+    let newIndex = -1;
+
+    switch(event.key) {
+        case 'ArrowRight':
+            newIndex = (currentIndex + 1) % tabs.length;
+            break;
+        case 'ArrowLeft':
+            newIndex = (currentIndex - 1 + tabs.length) % tabs.length;
+            break;
+        case 'Home':
+            newIndex = 0;
+            break;
+        case 'End':
+            newIndex = tabs.length - 1;
+            break;
+    }
+
+    if (newIndex !== -1) {
+        event.preventDefault();
+        tabs[newIndex].click();
+        tabs[newIndex].focus();
+    }
 }
 
 // Settings management
@@ -559,6 +597,7 @@ window.runKernelBenchmark = runKernelBenchmark;
 window.runMemoryBenchmark = runMemoryBenchmark;
 window.runLoadingBenchmark = runLoadingBenchmark;
 window.switchTab = switchTab;
+window.handleTabKey = handleTabKey;
 window.saveSettings = saveSettings;
 window.resetSettings = resetSettings;
 window.exportSettings = exportSettings;


### PR DESCRIPTION
Implemented the WAI-ARIA Tab Design Pattern in the browser example. This changes the `div`-based tabs to be fully accessible to screen readers and keyboard users.

**Changes:**
- `crates/bitnet-wasm/examples/browser/index.html`: Added ARIA roles and attributes.
- `crates/bitnet-wasm/examples/browser/main.js`: Added keyboard navigation logic and updated state management.
- `.Jules/palette.md`: Recorded accessibility learning.

**Verification:**
- Verified using a custom Playwright script (`verification/verify_tabs.py`) that checks for correct ARIA attribute toggling and state changes.
- Visually verified via screenshot that the "Streaming" tab activates correctly.

---
*PR created automatically by Jules for task [72497932115692173](https://jules.google.com/task/72497932115692173) started by @EffortlessSteven*