### PR TITLE
⚡ Bolt: Fix BatchEngine stats sharing and avoid atomic reallocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-11-14 - Atomic Counters in Structs
+**Learning:** In Rust, `Atomic` types (like `AtomicU64`) are not reference-counted. Embedding them directly in a struct means `Clone` creates *new* independent counters if not wrapped in `Arc`.
+**Action:** When implementing shared counters in a struct that will be cloned (e.g., for spawned tasks), always wrap them in `Arc<Atomic...>` to ensure updates are visible across clones.

--- a/crates/bitnet-server/src/batch_engine.rs
+++ b/crates/bitnet-server/src/batch_engine.rs
@@ -196,10 +196,10 @@ pub struct BatchEngine {
     processing_batches: Arc<RwLock<HashMap<String, ProcessingBatch>>>,
     batch_semaphore: Arc<Semaphore>,
     stats: Arc<BatchEngineStats>,
-    request_counter: AtomicU64,
-    batch_counter: AtomicU64,
-    total_processing_time: AtomicU64,
-    total_tokens_generated: AtomicU64,
+    request_counter: Arc<AtomicU64>,
+    batch_counter: Arc<AtomicU64>,
+    total_processing_time: Arc<AtomicU64>,
+    total_tokens_generated: Arc<AtomicU64>,
 }
 
 impl BatchEngine {
@@ -220,10 +220,10 @@ impl BatchEngine {
                 throughput_tokens_per_second: 0.0,
                 cache_hit_rate: 0.0,
             }),
-            request_counter: AtomicU64::new(0),
-            batch_counter: AtomicU64::new(0),
-            total_processing_time: AtomicU64::new(0),
-            total_tokens_generated: AtomicU64::new(0),
+            request_counter: Arc::new(AtomicU64::new(0)),
+            batch_counter: Arc::new(AtomicU64::new(0)),
+            total_processing_time: Arc::new(AtomicU64::new(0)),
+            total_tokens_generated: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -660,14 +660,10 @@ impl Clone for BatchEngine {
             processing_batches: Arc::clone(&self.processing_batches),
             batch_semaphore: Arc::clone(&self.batch_semaphore),
             stats: Arc::clone(&self.stats),
-            request_counter: AtomicU64::new(self.request_counter.load(Ordering::Relaxed)),
-            batch_counter: AtomicU64::new(self.batch_counter.load(Ordering::Relaxed)),
-            total_processing_time: AtomicU64::new(
-                self.total_processing_time.load(Ordering::Relaxed),
-            ),
-            total_tokens_generated: AtomicU64::new(
-                self.total_tokens_generated.load(Ordering::Relaxed),
-            ),
+            request_counter: Arc::clone(&self.request_counter),
+            batch_counter: Arc::clone(&self.batch_counter),
+            total_processing_time: Arc::clone(&self.total_processing_time),
+            total_tokens_generated: Arc::clone(&self.total_tokens_generated),
         }
     }
 }


### PR DESCRIPTION
* 💡 What: Wrapped `AtomicU64` counters in `BatchEngine` with `Arc` and updated `Clone` implementation.
* 🎯 Why: Previously, `Clone` created new independent atomic counters, causing statistics updates in background tasks to be lost and incurring unnecessary allocation/initialization overhead on every request.
* 📊 Impact: Corrects broken metrics (`total_batches_processed`, etc.) and avoids atomic initialization overhead per request.
* 🔬 Measurement: Verified with a reproduction test that `total_batches_processed` is now correctly incremented on the original instance.

---
*PR created automatically by Jules for task [8397907602609619753](https://jules.google.com/task/8397907602609619753) started by @EffortlessSteven*