### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Overly Permissive CORS Default
+**Vulnerability:** The server defaulted to allowing all origins (`*`) for CORS requests, which is unsafe for production environments as it exposes the API to CSRF-like attacks and data leakage.
+**Learning:** `tower-http`'s `CorsLayer` is powerful but requires explicit configuration to be secure. The project used `Any` for convenience but sacrificed security.
+**Prevention:** Always default to a restrictive CORS policy (empty or specific domain) and require explicit configuration for allowed origins. Use `SecurityConfig` to drive middleware configuration.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::{debug, warn};
+use axum::http::HeaderValue;
 
 /// Security configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,12 +341,30 @@ pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
 }
 
 /// CORS middleware configuration
-pub fn configure_cors() -> tower_http::cors::CorsLayer {
+pub fn configure_cors(config: &SecurityConfig) -> tower_http::cors::CorsLayer {
     use tower_http::cors::{Any, CorsLayer};
 
-    CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(Any)
+    let allow_any = config.allowed_origins.iter().any(|o| o == "*");
+
+    let cors = CorsLayer::new();
+    let cors = if allow_any {
+        cors.allow_origin(Any)
+    } else {
+        let allowed_origins: Vec<HeaderValue> = config.allowed_origins.iter()
+            .filter_map(|o| {
+                match o.parse::<HeaderValue>() {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        warn!("Invalid allowed origin '{}': {}", o, e);
+                        None
+                    }
+                }
+            })
+            .collect();
+        cors.allow_origin(allowed_origins)
+    };
+
+    cors.allow_methods(Any)
         .allow_headers(Any)
         .max_age(std::time::Duration::from_secs(3600))
 }
@@ -490,5 +509,77 @@ mod tests {
             validator.validate_inference_request(&request),
             Err(ValidationError::InvalidFieldValue(_))
         ));
+    }
+
+    #[tokio::test]
+    async fn test_cors_configuration() {
+        use tower::ServiceExt;
+        use tower::ServiceBuilder;
+        use axum::body::Body;
+        use axum::http::{Request, Response};
+
+        // Case 1: Specific origin
+        let config = SecurityConfig {
+            allowed_origins: vec!["http://example.com".to_string()],
+            ..Default::default()
+        };
+
+        let cors_layer = configure_cors(&config);
+
+        let service = ServiceBuilder::new()
+            .layer(cors_layer)
+            .service_fn(|_req: Request<Body>| async {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            });
+
+        // Test allowed origin
+        let req = Request::builder()
+            .header("Origin", "http://example.com")
+            .header("Access-Control-Request-Method", "GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            res.headers().get("access-control-allow-origin").unwrap(),
+            "http://example.com"
+        );
+
+        // Test disallowed origin
+        let req = Request::builder()
+            .header("Origin", "http://attacker.com")
+            .header("Access-Control-Request-Method", "GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service.clone().oneshot(req).await.unwrap();
+        assert!(res.headers().get("access-control-allow-origin").is_none());
+
+        // Case 2: Wildcard
+        let config_wildcard = SecurityConfig {
+            allowed_origins: vec!["*".to_string()],
+            ..Default::default()
+        };
+
+        let cors_layer_wildcard = configure_cors(&config_wildcard);
+        let service_wildcard = ServiceBuilder::new()
+            .layer(cors_layer_wildcard)
+            .service_fn(|_req: Request<Body>| async {
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            });
+
+        let req = Request::builder()
+            .header("Origin", "http://anywhere.com")
+            .header("Access-Control-Request-Method", "GET")
+            .body(Body::empty())
+            .unwrap();
+
+        let res = service_wildcard.oneshot(req).await.unwrap();
+        // With Any, it usually echoes the origin or returns * depending on configuration
+        // In tower-http 0.6 with allow_origin(Any), it usually returns *
+        assert_eq!(
+            res.headers().get("access-control-allow-origin").unwrap(),
+            "*"
+        );
     }
 }


### PR DESCRIPTION
Updated configure_cors to respect allowed_origins in SecurityConfig, preventing overly permissive defaults. Added unit test to verify behavior.

---
*PR created automatically by Jules for task [5313681393213772699](https://jules.google.com/task/5313681393213772699) started by @EffortlessSteven*