### PR TITLE
🎨 Palette: Make browser example tabs accessible

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -193,11 +193,29 @@
             cursor: pointer;
             border-bottom: 2px solid transparent;
             transition: all 0.2s;
+            /* Reset button styles */
+            background: none;
+            color: inherit;
+            border: none;
+            border-bottom: 2px solid transparent;
+            border-radius: 0;
+            font-size: 16px;
+        }
+
+        .tab:hover {
+            background-color: rgba(0,0,0,0.05);
         }
 
         .tab.active {
             border-bottom-color: #007bff;
             color: #007bff;
+            font-weight: 500;
+        }
+
+        .tab:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: -2px;
+            background-color: rgba(0,123,255,0.05);
         }
 
         .tab-content {
@@ -225,16 +243,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Inference Modes">
+        <button class="tab active" role="tab" aria-selected="true" aria-controls="basic-tab" id="tab-basic" onclick="switchTab('basic')">Basic Inference</button>
+        <button class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="streaming-tab" id="tab-streaming" onclick="switchTab('streaming')">Streaming</button>
+        <button class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="worker-tab" id="tab-worker" onclick="switchTab('worker')">Web Workers</button>
+        <button class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="benchmark-tab" id="tab-benchmark" onclick="switchTab('benchmark')">Benchmarks</button>
+        <button class="tab" role="tab" aria-selected="false" tabindex="-1" aria-controls="settings-tab" id="tab-settings" onclick="switchTab('settings')">Settings</button>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +299,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +337,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +365,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +407,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -454,13 +454,54 @@ function switchTab(tabName) {
     // Remove active class from all tabs
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class and A11y attributes to selected tab
+    const selectedTab = document.getElementById(`tab-${tabName}`);
+    if (selectedTab) {
+        selectedTab.classList.add('active');
+        selectedTab.setAttribute('aria-selected', 'true');
+        selectedTab.setAttribute('tabindex', '0');
+        // Ensure focus follows if this wasn't a mouse click
+        if (document.activeElement !== selectedTab) {
+            selectedTab.focus();
+        }
+    }
+}
+
+// Handle keyboard navigation for tabs
+function handleTabKeydown(e) {
+    const tabs = Array.from(document.querySelectorAll('[role="tab"]'));
+    const index = tabs.indexOf(e.target);
+
+    let nextTab = null;
+
+    switch (e.key) {
+        case 'ArrowRight':
+            nextTab = tabs[(index + 1) % tabs.length];
+            break;
+        case 'ArrowLeft':
+            nextTab = tabs[(index - 1 + tabs.length) % tabs.length];
+            break;
+        case 'Home':
+            nextTab = tabs[0];
+            break;
+        case 'End':
+            nextTab = tabs[tabs.length - 1];
+            break;
+    }
+
+    if (nextTab) {
+        e.preventDefault();
+        // Trigger the click to switch tabs
+        nextTab.click();
+        nextTab.focus();
+    }
 }
 
 // Settings management
@@ -565,4 +606,10 @@ window.exportSettings = exportSettings;
 window.importSettings = importSettings;
 
 // Initialize the application when the page loads
-document.addEventListener('DOMContentLoaded', initApp);
+document.addEventListener('DOMContentLoaded', () => {
+    initApp();
+    // Initialize tab keyboard accessibility
+    document.querySelectorAll('[role="tab"]').forEach(tab => {
+        tab.addEventListener('keydown', handleTabKeydown);
+    });
+});


### PR DESCRIPTION
Improved the accessibility of the `bitnet-wasm` browser example by converting the tab navigation system to follow WAI-ARIA best practices. The tabs are now keyboard navigable and expose correct roles and states to assistive technologies.

---
*PR created automatically by Jules for task [6162307868382500259](https://jules.google.com/task/6162307868382500259) started by @EffortlessSteven*