### PR TITLE
🛡️ Sentinel: [HIGH] Restrict CORS origins based on config

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Restrict CORS origins based on config

🚨 Severity: HIGH
💡 Vulnerability: Overly permissive CORS configuration allowed all origins (`*`) by default in the server middleware, ignoring the `allowed_origins` setting in `SecurityConfig`.
🎯 Impact: Malicious websites could make authorized requests to the API if authentication was weak or relied on IP/Network restrictions, or simply consume resources.
🔧 Fix:
- Updated `configure_cors` in `crates/bitnet-server/src/security.rs` to accept `&SecurityConfig`.
- Implemented logic to set `AllowOrigin` based on `config.allowed_origins`.
- Updated `BitNetServer::create_app` in `crates/bitnet-server/src/lib.rs` to pass the configuration.
✅ Verification:
- Added `test_configure_cors` in `crates/bitnet-server/src/security.rs`.
- Ran `cargo test -p bitnet-server` successfully.

---
*PR created automatically by Jules for task [4566561341297772059](https://jules.google.com/task/4566561341297772059) started by @EffortlessSteven*