### PR TITLE
Sentinel: [HIGH] Fix overly permissive CORS configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2025-05-18 - Overly Permissive CORS Configuration
+
+**Vulnerability:** The server was configured with `Allow-Origin: *` by default, ignoring user configuration.
+**Learning:** The `configure_cors` function hardcoded `Any` origin instead of using `SecurityConfig`.
+**Prevention:** Middleware configuration functions must take and use the configuration object. Unit tests now verify that `allowed_origins` setting is respected.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
Updated `configure_cors` to respect `SecurityConfig.allowed_origins`. Previously it hardcoded `Any` origin.
Added `test_configure_cors` to verify the fix.
Updated call site in `lib.rs` to pass configuration.

---
*PR created automatically by Jules for task [14055481825758847906](https://jules.google.com/task/14055481825758847906) started by @EffortlessSteven*