### PR TITLE
🛡️ Sentinel: [HIGH] Restrict CORS origins based on configuration

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Restrict CORS origins based on configuration

**Vulnerability:** Overly permissive CORS configuration (allowing `Any` origin) could allow malicious websites to make requests to the API on behalf of users if they are authenticated (e.g. via IP or future cookie auth).

**Fix:** Updated `configure_cors` to respect the `allowed_origins` field in `SecurityConfig`. It now properly configures `CorsLayer` to allow only whitelisted origins or `*` if explicitly configured. Invalid origins in configuration are logged and ignored.

**Verification:** Added `test_cors_configuration` unit test in `crates/bitnet-server/src/security.rs` which verifies:
- Wildcard `*` configuration allows any origin.
- Specific origin configuration allows only that origin.
- Disallowed origins are rejected (no `Access-Control-Allow-Origin` header).


---
*PR created automatically by Jules for task [17507526232640707616](https://jules.google.com/task/17507526232640707616) started by @EffortlessSteven*