### PR TITLE
🛡️ Sentinel: [HIGH] Enforce CORS origin validation

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Enforce CORS origin validation

🚨 Severity: HIGH
💡 Vulnerability: Overly Permissive CORS Configuration
The `configure_cors` function was previously hardcoded to allow all origins (`Access-Control-Allow-Origin: *`), regardless of the configuration settings. This could allow malicious websites to interact with the BitNet server API if it's exposed to the internet.

🎯 Impact:
Attackers could potentially perform Cross-Site Request Forgery (CSRF) attacks or exfiltrate sensitive data if the server is used in a browser context.

🔧 Fix:
Updated `configure_cors` to accept `&SecurityConfig` and use `config.allowed_origins`.
- If `allowed_origins` contains `*`, it retains the wildcard behavior.
- Otherwise, it parses the allowed origins and configures the `CorsLayer` to only accept those specific origins.
- Invalid origins in the config are logged as warnings and ignored.
- If no valid origins are found (and not wildcard), the CORS middleware effectively blocks cross-origin requests, which is a fail-safe default.

✅ Verification:
Added unit tests in `crates/bitnet-server/src/security.rs` (`test_cors_configuration`) that simulate requests using `axum::Router` and `tower::ServiceExt::oneshot` to verify that:
1. Wildcard config returns `*`.
2. Specific allowed origin returns that origin.
3. Disallowed origin does not receive the allow header (blocked).

Ran `cargo test -p bitnet-server security::tests` to verify.

---
*PR created automatically by Jules for task [13387568047471521527](https://jules.google.com/task/13387568047471521527) started by @EffortlessSteven*