### PR TITLE
🛡️ Sentinel: [HIGH] Fix Overly Permissive CORS Configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-10-21 - Overly Permissive CORS Configuration
+**Vulnerability:** The server was configured to allow all origins (`*`) by default using `tower_http::cors::CorsLayer::allow_origin(Any)`, ignoring the `allowed_origins` setting in `SecurityConfig`.
+**Learning:** Middleware configuration functions must explicitly check and use application configuration objects rather than relying on library defaults or hardcoded values. In `tower-http` 0.6+, `CorsLayer` is not generic, and `allow_origin` accepts `Any` or `Vec<HeaderValue>`, simplifying conditional logic but requiring careful type handling.
+**Prevention:** Always verify middleware configuration against the intended security policy in the application config. Use integration tests that assert on response headers to catch misconfigurations.

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -296,7 +296,7 @@ impl BitNetServer {
             ))
             .layer(middleware::from_fn(enhanced_metrics_middleware))
             .layer(TraceLayer::new_for_http())
-            .layer(configure_cors());
+            .layer(configure_cors(&self.config.security));
 
         app
     }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Overly Permissive CORS Configuration

🚨 Severity: HIGH
💡 Vulnerability: The server was configured to allow all origins (`*`) by default, ignoring the `allowed_origins` setting in `SecurityConfig`. This could allow malicious websites to make authenticated requests on behalf of users (CSRF-like attacks if authentication relies on cookies or similar mechanisms, though here it seems to use Bearer tokens, it still exposes the API to unauthorized domains).
🎯 Impact: Attackers could potentially access sensitive API endpoints from malicious origins if users are authenticated.
🔧 Fix: Updated `configure_cors` to respect `SecurityConfig.allowed_origins`. It now allows specific origins or `*` if explicitly configured.
✅ Verification: Added unit tests in `crates/bitnet-server/src/security.rs` to verify the configuration logic. Ran `cargo test -p bitnet-server security` to confirm.


---
*PR created automatically by Jules for task [7963880839217569305](https://jules.google.com/task/7963880839217569305) started by @EffortlessSteven*