### PR TITLE
⚡ Bolt: Optimize SamplingStrategy with in-place operations

### DIFF
--- a/baseline_bench.txt
+++ b/baseline_bench.txt
@@ -1,0 +1,6 @@
+sampling_strategy_sample
+                        time:   [946.59 µs 947.60 µs 948.65 µs]
+Found 3 outliers among 100 measurements (3.00%)
+  1 (1.00%) low mild
+  1 (1.00%) high mild
+  1 (1.00%) high severe

--- a/optimized_bench.txt
+++ b/optimized_bench.txt
@@ -1,0 +1,7 @@
+sampling_strategy_sample
+                        time:   [656.29 µs 658.68 µs 661.33 µs]
+                        change: [−30.537% −30.184% −29.856%] (p = 0.00 < 0.05)
+                        Performance has improved.
+Found 2 outliers among 100 measurements (2.00%)
+  1 (1.00%) high mild
+  1 (1.00%) high severe


### PR DESCRIPTION
💡 What:
Optimized `SamplingStrategy::sample` in `crates/bitnet-inference/src/generation/sampling.rs` to minimize allocations and tensor conversions.
- Extracted logits to `Vec<f32>` only once at the beginning.
- Implemented `apply_repetition_penalty_inplace`, `apply_top_k_inplace`, `apply_top_p_inplace`, and `softmax_inplace` to operate directly on `Vec<f32>`.
- Added scratch buffers (`scratch_indices`, `scratch_probs`) to `SamplingStrategy` to reuse memory across generations.
- Removed dependency on `CandleTensor` for intermediate steps.

🎯 Why:
The previous implementation performed multiple `Tensor -> Vec` conversions and tensor allocations for each sampling step (repetition penalty, top-k, top-p, softmax), which dominated the sampling latency.

📊 Impact:
Benchmark shows **~30% reduction** in sampling time (from ~947µs to ~658µs per sample on CPU with 32k vocab).
This directly improves token generation speed, especially for CPU inference.

🔬 Measurement:
Measured using a temporary Criterion benchmark on `SamplingStrategy::sample` with random logits (vocab size 32000).
- Baseline: ~947µs
- Optimized: ~658µs
Unit tests were added to `crates/bitnet-inference/src/generation/sampling.rs` to verify correctness of in-place operations.

---
*PR created automatically by Jules for task [2263323968844360578](https://jules.google.com/task/2263323968844360578) started by @EffortlessSteven*