### PR TITLE
🎨 Palette: Semantic Tabs for WASM Browser Example

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-24 - Semantic Tabs
+**Learning:** In browser examples, tabs implemented as `div`s with `onclick` are completely inaccessible to keyboard users and screen readers.
+**Action:** Use `<button role="tab">` elements for tabs, along with `role="tablist"` and `role="tabpanel"`. Ensure `aria-selected` is updated dynamically.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -188,16 +188,33 @@
             margin-bottom: 20px;
         }
 
-        .tab {
+        button.tab {
+            background-color: transparent;
+            color: inherit;
+            border: none;
+            border-radius: 0;
             padding: 12px 20px;
             cursor: pointer;
             border-bottom: 2px solid transparent;
             transition: all 0.2s;
+            font-size: 14px;
+            font-family: inherit;
         }
 
-        .tab.active {
+        button.tab:hover {
+            background-color: transparent;
+            color: #0056b3;
+        }
+
+        button.tab.active {
             border-bottom-color: #007bff;
             color: #007bff;
+        }
+
+        button.tab:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: -2px;
+            background-color: rgba(0, 123, 255, 0.05);
         }
 
         .tab-content {
@@ -225,16 +242,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist">
+        <button id="basic-tab-btn" class="tab active" role="tab" aria-selected="true" aria-controls="basic-tab" onclick="switchTab('basic', this)">Basic Inference</button>
+        <button id="streaming-tab-btn" class="tab" role="tab" aria-selected="false" aria-controls="streaming-tab" onclick="switchTab('streaming', this)">Streaming</button>
+        <button id="worker-tab-btn" class="tab" role="tab" aria-selected="false" aria-controls="worker-tab" onclick="switchTab('worker', this)">Web Workers</button>
+        <button id="benchmark-tab-btn" class="tab" role="tab" aria-selected="false" aria-controls="benchmark-tab" onclick="switchTab('benchmark', this)">Benchmarks</button>
+        <button id="settings-tab-btn" class="tab" role="tab" aria-selected="false" aria-controls="settings-tab" onclick="switchTab('settings', this)">Settings</button>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="basic-tab-btn">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +298,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="streaming-tab-btn">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +336,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="worker-tab-btn">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +364,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="benchmark-tab-btn">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +406,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="settings-tab-btn">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -445,22 +445,28 @@ function createGenerationConfig() {
 }
 
 // Tab switching
-function switchTab(tabName) {
+function switchTab(tabName, element) {
     // Hide all tab contents
     document.querySelectorAll('.tab-content').forEach(tab => {
         tab.classList.remove('active');
     });
 
-    // Remove active class from all tabs
+    // Remove active class from all tabs and update ARIA
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class to selected tab and update ARIA
+    // If element is not passed (e.g. called programmatically), try to find it
+    const activeTab = element || document.getElementById(`${tabName}-tab-btn`);
+    if (activeTab) {
+        activeTab.classList.add('active');
+        activeTab.setAttribute('aria-selected', 'true');
+    }
 }
 
 // Settings management


### PR DESCRIPTION
Converted div-based tabs to accessible buttons with proper ARIA roles and keyboard support. Verified visually and with playwright script.

---
*PR created automatically by Jules for task [13595097225561160432](https://jules.google.com/task/13595097225561160432) started by @EffortlessSteven*