### PR TITLE
fix: resolve clippy -D warnings in SRP microcrates (engine-core, generation, logits)

### DIFF
--- a/crates/bitnet-engine-core/src/lib.rs
+++ b/crates/bitnet-engine-core/src/lib.rs
@@ -117,8 +117,12 @@ mod tests {
     fn session_metrics_default_is_zero() {
         let m = SessionMetrics::default();
         assert_eq!(m.total_tokens, 0);
-        assert_eq!(m.tokens_per_second, 0.0);
-        assert_eq!(m.time_to_first_token_ms, 0.0);
+        // Checking exact zero: these fields are initialized to literal 0.0
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(m.tokens_per_second, 0.0);
+            assert_eq!(m.time_to_first_token_ms, 0.0);
+        }
     }
 
     #[test]
@@ -129,9 +133,10 @@ mod tests {
 
     #[test]
     fn stop_reason_variants_accessible() {
-        let _max = StopReason::MaxTokens;
-        let _eos = StopReason::EosToken;
-        let _id = StopReason::StopTokenId(42);
-        let _str = StopReason::StopString("</s>".to_string());
+        // Just verify the variants are constructible
+        let _ = StopReason::MaxTokens;
+        let _ = StopReason::EosToken;
+        let _ = StopReason::StopTokenId(42);
+        let _ = StopReason::StopString("</s>".to_string());
     }
 }

--- a/crates/bitnet-generation/src/lib.rs
+++ b/crates/bitnet-generation/src/lib.rs
@@ -151,7 +151,7 @@ mod tests {
     ) -> StopCriteria {
         StopCriteria {
             stop_token_ids: stop_ids.to_vec(),
-            stop_strings: stop_strings.iter().map(|s| s.to_string()).collect(),
+            stop_strings: stop_strings.iter().map(ToString::to_string).collect(),
             max_tokens: max,
             eos_token_id: eos,
         }
@@ -241,7 +241,7 @@ mod tests {
                 assert_eq!(reason, StopReason::EosToken);
                 assert_eq!(stats.tokens_generated, 10);
             }
-            _ => panic!("expected Done event"),
+            StreamEvent::Token { .. } => panic!("expected Done event"),
         }
     }
 }

--- a/crates/bitnet-inference/tests/support/env_guard.rs
+++ b/crates/bitnet-inference/tests/support/env_guard.rs
@@ -1,2 +1,2 @@
 //! Environment variable guard re-exports for bitnet-inference tests.
-pub use bitnet_test_support::env_guard::{EnvGuard, EnvScope};
+pub use bitnet_test_support::env_guard::EnvGuard;

--- a/crates/bitnet-logits/src/lib.rs
+++ b/crates/bitnet-logits/src/lib.rs
@@ -239,7 +239,11 @@ mod tests {
         apply_top_p(&mut probs, 0.8);
         assert!(probs[0] > 0.0);
         assert!(probs[1] > 0.0);
-        assert_eq!(probs[2], 0.0);
+        // apply_top_p explicitly sets excluded tokens to exactly 0.0
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(probs[2], 0.0);
+        }
     }
 
     #[test]

--- a/crates/bitnet-models/tests/helpers/env_guard.rs
+++ b/crates/bitnet-models/tests/helpers/env_guard.rs
@@ -1,4 +1,5 @@
 //! Environment variable guard re-exports for bitnet-models tests.
 //!
 //! Re-exports canonical implementations from `bitnet-test-support`.
+#[allow(unused_imports)]
 pub use bitnet_test_support::env_guard::{EnvGuard, EnvScope};


### PR DESCRIPTION
## Summary

Fixes clippy `-D warnings` failures introduced when the SRP microcrates were extracted (PR #614 / #616).

## Changes

### `bitnet-engine-core`
- `SessionMetrics` default-is-zero test: wrap literal `0.0` equality in `#[allow(clippy::float_cmp)]` block (values are set to literal `0.0` in `Default`)
- `stop_reason_variants_accessible` test: renamed `_max/\_eos/\_id/\_str` bindings to `let _ =` to fix `no_effect_underscore_binding`

### `bitnet-generation`
- Test helper `make_criteria`: replaced `|s| s.to_string()` with `ToString::to_string` (redundant closure)

### `bitnet-logits`

### `bitnet-inference` tests
- `tests/support/env_guard.rs`: removed unused `EnvScope` re-export (no test in this package uses it)

### `bitnet-models` tests
- `tests/helpers/env_guard.rs`: added `#[allow(unused_imports)]` to re-export file (used by `gamma_rescaling_tests` but flagged as unused in other test binaries sharing the helpers module)

## Verification
- `cargo clippy --all-targets --no-default-features --features cpu -- -D warnings`: ✅ clean
- `cargo nextest run --profile ci --no-default-features --features cpu --workspace`: 2764 passed, 581 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Adjusted test assertions with lint suppressions for improved code quality.
  * Refined test match patterns for enhanced clarity.

* **Chores**
  * Narrowed internal test support module API exports.
  * Added lint suppression attributes to test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->