### PR TITLE
docs: replace legacy performance claims with receipt-driven language

### DIFF
--- a/docs/howto/use-qk256-models.md
+++ b/docs/howto/use-qk256-models.md
@@ -224,20 +224,29 @@ cargo run -p bitnet-cli --features cpu,full-cli -- compat-check <model.gguf> --s
 
 ### QK256 Kernel Performance
 
-Expected inference speed (tokens/second) on various hardware:
+> **MVP Status**: The QK256 MVP uses scalar-only kernels (~0.1 tok/s for 2B models).
+> For quick validation, use `--max-new-tokens 4-16`.
+> SIMD acceleration is planned for v0.2.0 (targeting ≥3× uplift via AVX2 nibble-LUT + FMA tiling).
 
-**CPU (x86_64):**
-- AVX2: 15-25 tok/s (2B model, batch=1)
-- AVX-512: 25-35 tok/s (2B model, batch=1)
+Run the benchmark to measure and record actual throughput on your hardware:
 
-**CPU (ARM64):**
-- NEON: 10-20 tok/s (2B model, batch=1)
+```bash
+cargo run -p xtask -- benchmark --model <path/to/model.gguf> --tokens 128
+cargo run -p xtask -- verify-receipt
+```
 
-**GPU (NVIDIA):**
-- RTX 4090: 100-150 tok/s (2B model, batch=1)
-- A100: 200-400 tok/s (2B model, batch=1)
+**Target envelopes (v0.2.0 goals, not current MVP performance):**
 
-*Note: Actual performance depends on model size, batch size, sequence length, and hardware.*
+| Backend | Target tok/s | Model |
+|---------|-------------|-------|
+| CPU AVX2 | 15–25 | 2B, batch=1 |
+| CPU AVX-512 | 25–35 | 2B, batch=1 |
+| CPU NEON (ARM64) | 10–20 | 2B, batch=1 |
+| GPU RTX 4090 | 100–150 | 2B, batch=1 |
+| GPU A100 | 200–400 | 2B, batch=1 |
+
+*Actual performance depends on model size, batch size, sequence length, and hardware.
+Always measure with `cargo run -p xtask -- benchmark` to get a verifiable receipt.*
 
 ## Advanced Usage
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -287,7 +287,7 @@ You've successfully:
 3. **Automatic tokenizer discovery** extracted tokenizer from GGUF metadata, detected model architecture, and applied optimal configuration
 4. **Verified model compatibility** with enhanced GGUF loader, strict mode validation, and comprehensive tensor validation
 5. **Ran production-grade inference** with pure-Rust QK256 kernels, real transformer weights, and autoregressive generation
-6. **Benchmarked performance** achieving 20+ tokens/second with native CPU optimization
+6. **Benchmarked performance** — run `cargo run -p xtask -- benchmark --model <path> --tokens 128` to produce a verifiable receipt (typical CPU envelope: 10–25 tok/s for I2_S BitNet32-F16)
 7. **Generated validation receipts** with parity metrics, kernel IDs, and reproducible baselines in `docs/baselines/`
 
 ## Next Steps


### PR DESCRIPTION
Closes #459

## Summary

Replaces hardcoded performance numbers with receipt-driven language and benchmark commands. Docs now tell users *how* to measure performance rather than asserting unverifiable numbers.

## Changes

### `docs/quickstart.md`
- Line 290: Remove `"20+ tokens/second"` claim → replace with `cargo run -p xtask -- benchmark` command + typical CPU envelope `10–25 tok/s`

### `docs/howto/use-qk256-models.md`
- Add MVP status callout: QK256 currently uses scalar-only kernels (~0.1 tok/s for 2B models)
- Add benchmark + verify-receipt commands as canonical performance measurement
- Demote hardware numbers (AVX2: 15-25, A100: 200-400) from expected to "v0.2.0 goal targets"
- Table format makes the goal/current distinction clear at a glance

## Acceptance criteria (from #459)

- [x] No unverifiable bare performance numbers in docs
- [x] Every performance statement includes either a receipt command or an explicit "target/goal" label
- [x] QK256 MVP limitation (scalar ~0.1 tok/s) is documented where performance is discussed
- [x] `cargo run -p xtask -- benchmark` + `verify-receipt` are the recommended measurement workflow

## Testing

Docs-only change — no code compiled. CI will run markdown linting if enabled.