### PR TITLE
fix(kernels): fix EnvVarGuard self-deadlock, re-enable SIMD receipt tests

### DIFF
--- a/crates/bitnet-kernels/tests/cpu_simd_receipts.rs
+++ b/crates/bitnet-kernels/tests/cpu_simd_receipts.rs
@@ -108,7 +108,7 @@ fn simd_vector_add(a: &[f32], b: &[f32]) -> Vec<f32> {
 }
 
 #[test]
-#[ignore = "Hanging test - investigating timeout issue"]
+#[serial_test::serial(bitnet_env)]
 fn test_simd_feature_detection_and_receipts() {
     // Set deterministic mode safely
     let _d = EnvVarGuard::set("BITNET_DETERMINISTIC", "1");
@@ -152,7 +152,7 @@ fn test_simd_feature_detection_and_receipts() {
 }
 
 #[test]
-#[ignore = "Hanging test - investigating timeout issue"]
+#[serial_test::serial(bitnet_env)]
 fn test_simd_quantization_simulation() {
     // Set deterministic mode safely
     let _d = EnvVarGuard::set("BITNET_DETERMINISTIC", "1");


### PR DESCRIPTION
Closes #434

## Root Cause

`EnvVarGuard::set` held the global `ENV_LOCK` mutex for the **entire lifetime** of the guard struct. When two guards were created in the same scope:

```rust
let _d = EnvVarGuard::set("BITNET_DETERMINISTIC", "1"); // acquires ENV_LOCK
let _t = EnvVarGuard::set("RAYON_NUM_THREADS", "1");   // tries to acquire ENV_LOCK → deadlock
```

`std::sync::Mutex` is **not reentrant**, so the second call blocks forever on the same thread.

## Fix

- **`env_guard.rs`**: Acquire `ENV_LOCK` only **briefly** during the `set` and `drop` operations, not across the guard's entire scope. Remove the `_guard: MutexGuard` field.
- **`cpu_simd_receipts.rs`**: Add `#[serial_test::serial(bitnet_env)]` to both previously-ignored tests, replacing the need for a continuously-held lock with test-level serialization.
- Remove `#[ignore]` from both tests — they now pass.

## Verification

```
running 3 tests
test test_simd_ordering_assertions ... ok
test test_simd_feature_detection_and_receipts ... ok
test test_simd_quantization_simulation ... ok

test result: ok. 3 passed; 0 failed; 0 ignored
```