### PR TITLE
fix(#392/#388): KVCache::slice_cache_tensor returns empty tensor for seq_len=0

### DIFF
--- a/crates/bitnet-inference/src/layers/attention.rs
+++ b/crates/bitnet-inference/src/layers/attention.rs
@@ -98,9 +98,8 @@ impl KVCache {
             let tensor_candle = tensor.to_candle()?;
             let shape = tensor_candle.shape();
             if !shape.dims().is_empty() {
-                let empty = tensor_candle
-                    .narrow(0, 0, 0)
-                    .context("Failed to create empty cache slice")?;
+                let empty =
+                    tensor_candle.narrow(0, 0, 0).context("Failed to create empty cache slice")?;
                 return Ok(BitNetTensor::new(empty));
             }
             return Ok(tensor.clone());
@@ -754,10 +753,6 @@ mod tests {
         let k = &kvcache.k_cache[0];
         let result = kvcache.slice_cache_tensor(k, 3).expect("slice should not fail");
         let shape = result.shape();
-        assert_eq!(
-            shape[0], 3,
-            "seq_len=3 should yield exactly 3 rows; got shape {:?}",
-            shape
-        );
+        assert_eq!(shape[0], 3, "seq_len=3 should yield exactly 3 rows; got shape {:?}", shape);
     }
 }


### PR DESCRIPTION
## Problem

`KVCache::slice_cache_tensor` returned the full pre-allocated cache tensor when called with `seq_len=0`, with a misleading comment "no slicing needed". A seq_len of 0 means zero tokens have been cached; callers should receive an empty (0-row) tensor.

## Fix

When `seq_len == 0`, narrow the first dimension to 0 via `tensor.narrow(0, 0, 0)` to produce an empty tensor. Non-zero seq_len handling is unchanged.

## Tests

2 new unit tests in `layers::attention::tests`:
- `test_get_sliced_cache_zero_len_returns_empty_tensor`: verifies shape[0]==0 for seq_len=0
- `test_get_sliced_cache_non_zero_slices_first_dim`: verifies shape[0]==seq_len for non-zero seq_len

Closes #392
Closes #388