### PR TITLE
fix(#399/#396): real validate_round_trip and bigram-dice semantic similarity

### DIFF
--- a/crates/bitnet-inference/src/production_engine.rs
+++ b/crates/bitnet-inference/src/production_engine.rs
@@ -224,15 +224,15 @@ impl DeviceManager {
     }
 
     pub fn validate_device_compatibility(&self, required_memory: u64) -> Result<()> {
-        if let Some(available) = self.capabilities.memory_bytes {
-            if available < required_memory {
-                return Err(BitNetError::Inference(InferenceError::GenerationFailed {
-                    reason: format!(
-                        "Device {:?} has {} bytes available but {} bytes required",
-                        self.primary_device, available, required_memory
-                    ),
-                }));
-            }
+        if let Some(available) = self.capabilities.memory_bytes
+            && available < required_memory
+        {
+            return Err(BitNetError::Inference(InferenceError::GenerationFailed {
+                reason: format!(
+                    "Device {:?} has {} bytes available but {} bytes required",
+                    self.primary_device, available, required_memory
+                ),
+            }));
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Two placeholder implementations replaced with real logic, plus three pre-existing clippy fixes.

### fix(#399) — Real `validate_round_trip` in `bitnet-quantization`

Previously the function always returned `Ok(true)` regardless of tolerance.
Now it dequantizes the tensor, computes the maximum absolute element-wise error,
and returns `Ok(err <= tolerance)`.

### fix(#396) — Character bigram Dice coefficient for semantic similarity

Previously: `let semantic_similarity = average_token_accuracy * 0.9;`
Now: [Sørensen–Dice coefficient](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient) over character bigrams.
This is a standard lightweight surface-level similarity metric used in NLP
when embeddings are not available.

### Clippy fixes (pre-existing)
- `cpu_opt.rs`: `div_ceil()` and iterator-over-slice instead of manual ceiling-divide + range loop
- `production_engine.rs`: collapse nested `if let / if` to satisfy `clippy::collapsible_if`

Closes #399, #396