### PR TITLE
feat: wire backend selection into CLI/server startup (Phase 3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-inference",
+ "bitnet-kernels",
  "bitnet-models",
  "bitnet-prompt-templates",
  "bitnet-quantization",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -26,6 +26,7 @@ path = "src/main.rs"
 bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
 bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.1.0" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.1.0" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.1.0" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.1.0" }
@@ -76,11 +77,13 @@ runtime-profile-core = [
 ]
 cpu = [
   "bitnet-inference/cpu",
+  "bitnet-kernels/cpu",
   "runtime-profile-core",
   "bitnet-runtime-bootstrap/runtime-profile-cpu",
 ]
 cuda = [
   "bitnet-inference/cuda",
+  "bitnet-kernels/cuda",
   "runtime-profile-core",
   "bitnet-runtime-bootstrap/runtime-profile-cuda",
 ]

--- a/crates/bitnet-kernels/src/device_features.rs
+++ b/crates/bitnet-kernels/src/device_features.rs
@@ -173,3 +173,23 @@ pub use bitnet_device_probe::DeviceCapabilities;
 pub fn detect_simd_level() -> bitnet_common::kernel_registry::SimdLevel {
     bitnet_device_probe::detect_simd_level()
 }
+
+/// Build a fully-populated [`KernelCapabilities`] by combining compile-time
+/// feature flags with a live runtime GPU probe.
+///
+/// This is the canonical way for binaries (CLI, server) to determine what
+/// backend to use at startup. Combine with [`bitnet_common::select_backend`]
+/// to get the startup log line:
+/// `requested=auto detected=[cpu-rust] selected=cpu-rust`.
+///
+/// Note: uses the `bitnet-kernels` crate's own feature flags (`cpu`, `cuda`)
+/// which are the authoritative source for kernel availability.
+pub fn current_kernel_capabilities() -> bitnet_common::kernel_registry::KernelCapabilities {
+    bitnet_common::kernel_registry::KernelCapabilities {
+        cpu_rust: cfg!(feature = "cpu"),
+        cuda_compiled: cfg!(any(feature = "gpu", feature = "cuda")),
+        cuda_runtime: gpu_available_runtime(),
+        cpp_ffi: false,
+        simd_level: detect_simd_level(),
+    }
+}

--- a/crates/bitnet-server/src/bin/server.rs
+++ b/crates/bitnet-server/src/bin/server.rs
@@ -72,6 +72,18 @@ async fn main() -> Result<()> {
         tracing::warn!(component = ?RuntimeComponent::Server, "Server startup contract reported issues");
     }
 
+    // Report backend selection at startup.
+    {
+        use bitnet_common::{BackendRequest, select_backend};
+        use bitnet_kernels::device_features::current_kernel_capabilities;
+
+        let caps = current_kernel_capabilities();
+        match select_backend(BackendRequest::Auto, &caps) {
+            Ok(result) => info!(backend_selection = %result.summary(), "backend selected"),
+            Err(e) => tracing::warn!(error = %e, "backend selection warning"),
+        }
+    }
+
     // Create server configuration
     let mut config = ServerConfig::default();
 


### PR DESCRIPTION
## Summary

Implements Phase 3.2 of the backend capability roadmap: wiring **backend selection as a deterministic, logged contract** into CLI and server startup.

## Changes

### `bitnet-common`: KernelCapabilities builders
- `with_cuda_runtime(bool)` — fills in runtime GPU probe result
- `with_cpp_ffi(bool)` — fills in FFI availability
- Docs updated to explain the split between compile-time and runtime detection

### `bitnet-kernels`: `current_kernel_capabilities()`
- New function that builds a fully-populated `KernelCapabilities` snapshot
- Uses the kernels crate's own feature flags (authoritative source) + `gpu_available_runtime()`

### `bitnet-cli`
- Adds `bitnet-kernels` as a direct dependency with proper `cpu`/`cuda` feature propagation
- At startup, logs: `backend selected, backend_selection: requested=X detected=[Y] selected=Z`
- Parses `--device cpu|gpu|cuda|auto` to select the `BackendRequest`

### `bitnet-server`
- Same startup backend selection logging

## Startup output (with `RUST_LOG=info`)

```
INFO  backend selected, backend_selection: requested=auto detected=[cpu-rust] selected=cpu-rust
```

Or on a CUDA machine:
```
INFO  backend selected, backend_selection: requested=auto detected=[cuda,cpu-rust] selected=cuda
```

## Tests

- 3 new unit tests for `with_cuda_runtime` / `with_cpp_ffi` builders
- All 142 bitnet-common + bitnet-kernels tests pass
- No regressions in bitnet-cli (same 4 pre-existing failures as main)