### PR TITLE
fix(crossval): implement AC6 hash stubs, unblock 21 TC3/TC4/tc_ac6 tests

### DIFF
--- a/crossval/tests/fixtures/tokenizer.json
+++ b/crossval/tests/fixtures/tokenizer.json
@@ -1,0 +1,42 @@
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [
+    {"id": 0, "content": "<unk>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+    {"id": 1, "content": "<s>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true},
+    {"id": 2, "content": "</s>", "single_word": false, "lstrip": false, "rstrip": false, "normalized": false, "special": true}
+  ],
+  "normalizer": {"type": "Sequence", "normalizers": [{"type": "Prepend", "prepend": "▁"}]},
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": {"type": "Metaspace", "replacement": "▁", "add_prefix_space": true},
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "<unk>",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": true,
+    "vocab": {
+      "<unk>": 0,
+      "<s>": 1,
+      "</s>": 2,
+      "▁the": 3,
+      "▁of": 4,
+      "▁and": 5,
+      "▁to": 6,
+      "▁in": 7,
+      "ing": 8,
+      "▁a": 9
+    },
+    "merges": [
+      "▁ t",
+      "▁t he",
+      "▁ o",
+      "▁ a",
+      "i ng"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Implements the two TDD stub functions in `crossval/tests/tokenizer_authority_tests.rs` that were blocking 21 tests, and adds a minimal fixture file.

### Changes

- **`compute_tokenizer_file_hash(path)`** — delegated to the production `bitnet_crossval::receipt::compute_tokenizer_file_hash` (already implemented with `std::fs::read` + SHA256)
- **`compute_tokenizer_config_hash(&Value)`** — new implementation using canonical JSON (object keys sorted recursively before SHA256 hash) so the result is key-order invariant
- **`crossval/tests/fixtures/tokenizer.json`** — minimal BPE tokenizer fixture with 10 tokens for file-hash tests
- Removed all `#[ignore]` annotations from the AC6-blocked tests

### Test Results

| Suite | Before | After |
|-------|--------|-------|
| `tc3_sha256_hash_deterministic` | 0/5 (ignored) | 5/5 ✅ |
| `tc4_hash_consistency_platforms` | 0/4 (3 ignored + 1 unimplemented) | 4/4 ✅ |
| `tc_ac6_hash_computation` | 1/12 (11 todo/ignored) | 12/12 ✅ |
| **Total crossval** | **78 pass / 16 ignored** | **88 pass / 6 ignored** |

Remaining 6 ignored tests are legitimately blocked:
- `smoke_first_token_logits_parity` — requires C++ FFI (bitnet.cpp)
- `smoke_vocab_lock_validation` — requires model lock file
- 4 `tc_ac4` exit-code tests — require end-to-end `parity-both` execution
