### PR TITLE
fix(crossval): implement AC5 source detection stubs, unblock 2 tests

### DIFF
--- a/crossval/tests/tokenizer_authority_tests.rs
+++ b/crossval/tests/tokenizer_authority_tests.rs
@@ -1736,11 +1736,14 @@ mod tc_ac5_source_detection {
     /// AC: AC5
     /// Spec: docs/specs/tokenizer-authority-integration-parity-both.md#AC5
     #[test]
-    #[ignore = "Requires file system fixture"]
     fn test_detect_source_external_tokenizer_json() {
-        // Tests feature spec: tokenizer-authority-integration-parity-both.md#AC5
-        // Verify: Path ending with "tokenizer.json" → External
-        todo!("AC5: Verify detect_tokenizer_source() returns External for tokenizer.json");
+        let path = Path::new("tests/fixtures/tokenizer.json");
+        let source = detect_tokenizer_source(path);
+        assert_eq!(
+            source,
+            TokenizerSource::External,
+            "Existing tokenizer.json file should be detected as External"
+        );
     }
 
     /// Test: detect_tokenizer_source() returns GgufEmbedded for model.gguf
@@ -1788,11 +1791,14 @@ mod tc_ac5_source_detection {
     /// AC: AC5
     /// Spec: docs/specs/tokenizer-authority-integration-parity-both.md#AC5
     #[test]
-    #[ignore = "Requires file system fixture"]
     fn test_detect_source_absolute_path() {
-        // Tests feature spec: tokenizer-authority-integration-parity-both.md#AC5
-        // Verify: Absolute path ending with "tokenizer.json" → External
-        todo!("AC5: Verify detect_tokenizer_source() with absolute paths");
+        let abs_path = std::env::current_dir().unwrap().join("tests/fixtures/tokenizer.json");
+        let source = detect_tokenizer_source(&abs_path);
+        assert_eq!(
+            source,
+            TokenizerSource::External,
+            "Existing tokenizer.json at absolute path should be detected as External"
+        );
     }
 
     /// Test: AutoDiscovered variant not yet implemented

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -39,6 +39,9 @@
 | GGUF header libfuzzer fuzz target | `fuzz/fuzz_targets/gguf_header.rs` | #649 |
 | Fuzz target registration completeness (all 11 targets in Cargo.toml + CI) | `fuzz/Cargo.toml`, `fuzz-ci.yml` | #649 |
 | Proptest for `bitnet-device-probe` and `bitnet-engine-core` | `crates/bitnet-device-probe/src/lib.rs`, `crates/bitnet-engine-core/src/lib.rs` | #650 |
+| Insta snapshot tests for 10 SRP microcrates (45 snapshots) | `crates/*/tests/snapshot_tests.rs` | #651 |
+| AC6 hash stubs implemented; TC3/TC4/tc_ac6 unblocked (88 tests pass, 6 ignored) | `crossval/tests/tokenizer_authority_tests.rs`, `crossval/tests/fixtures/` | #653 |
+| AC5 source detection stubs implemented; 2 remaining fixture tests unblocked | `crossval/tests/tokenizer_authority_tests.rs` | #654 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Implements two remaining AC5 source detection test stubs that were blocked on a fixture file. The fixture was added in PR #653 and is now available.

### Changes

- **`test_detect_source_external_tokenizer_json`** — Uses `tests/fixtures/tokenizer.json` (added in #653) to verify `detect_tokenizer_source()` returns `TokenizerSource::External` for an existing `tokenizer.json` file
- **`test_detect_source_absolute_path`** — Uses `std::env::current_dir().join("tests/fixtures/tokenizer.json")` for portable absolute-path testing
- Removed `#[ignore]` from both tests
- Updated `docs/reference/dual-backend-roadmap.md` to record PRs #651, #653, #654

### Test Results

All 6 `tc_ac5_source_detection` tests now pass (was 4/6 — 2 ignored).
