### PR TITLE
fix(clippy): resolve all -D warnings errors across test and source files

### DIFF
--- a/crates/bitnet-common/tests/snapshot_tests.rs
+++ b/crates/bitnet-common/tests/snapshot_tests.rs
@@ -21,7 +21,7 @@ fn simd_level_display_all_variants() {
 fn simd_level_ordering_is_ascending() {
     // Snapshot the sorted order to document the contract: Scalar < Neon < SSE4.2 < AVX2 < AVX512
     let ordered = {
-        let mut v = vec![
+        let mut v = [
             SimdLevel::Avx512,
             SimdLevel::Scalar,
             SimdLevel::Neon,

--- a/crates/bitnet-engine-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-engine-core/tests/snapshot_tests.rs
@@ -4,7 +4,6 @@
 //! changes to the wire format are visible in code review.
 
 use bitnet_engine_core::{BackendInfo, SessionConfig, SessionMetrics};
-use serde_json;
 
 #[test]
 fn session_config_default_json_snapshot() {

--- a/crates/bitnet-generation/src/lib.rs
+++ b/crates/bitnet-generation/src/lib.rs
@@ -264,7 +264,7 @@ mod tests {
         ) {
             // Use a different id than stop_token_ids and max_tokens > generated_len.
             let criteria = make_criteria(&[9999], &[], 100, Some(9998));
-            let generated: Vec<u32> = (0..generated_len as u32).collect();
+            let generated: Vec<u32> = (0..u32::try_from(generated_len).unwrap()).collect();
             let result = check_stop(&criteria, id, &generated, "no-stop-string-here");
             proptest::prop_assert!(result.is_none());
         }

--- a/crates/bitnet-generation/tests/snapshot_tests.rs
+++ b/crates/bitnet-generation/tests/snapshot_tests.rs
@@ -9,7 +9,7 @@ use bitnet_generation::{GenerationConfig, StopCriteria, StopReason};
 fn stop_reason_debug_all_variants() {
     let reasons = [
         StopReason::MaxTokens,
-        StopReason::StopTokenId(128009),
+        StopReason::StopTokenId(128_009),
         StopReason::StopString("</s>".to_string()),
         StopReason::EosToken,
     ];
@@ -32,7 +32,7 @@ fn stop_criteria_default_debug_snapshot() {
 #[test]
 fn stop_criteria_with_token_ids_debug_snapshot() {
     let criteria = StopCriteria {
-        stop_token_ids: vec![128009, 2],
+        stop_token_ids: vec![128_009, 2],
         stop_strings: vec!["</s>".to_string()],
         max_tokens: 64,
         eos_token_id: Some(2),

--- a/crates/bitnet-quantization/src/device_aware_quantizer.rs
+++ b/crates/bitnet-quantization/src/device_aware_quantizer.rs
@@ -975,7 +975,7 @@ mod tests {
     #[test]
     fn test_fp32_passthrough_is_lossless() {
         let quantizer = DeviceAwareQuantizer::default();
-        let input = vec![1.5f32, -0.75, 0.0, 3.14, -100.0, 0.001];
+        let input = vec![1.5f32, -0.75, 0.0, 3.21, -100.0, 0.001];
 
         let result = quantizer.quantize_with_validation(&input, QuantizationType::FP32);
         assert!(result.is_ok(), "FP32 passthrough should succeed: {:?}", result.err());

--- a/crates/bitnet-tokenizers/tests/mutation_killer_tests.rs
+++ b/crates/bitnet-tokenizers/tests/mutation_killer_tests.rs
@@ -280,7 +280,7 @@ fn test_basic_tokenizer_token_to_piece_returns_actual_data() {
     );
     // For byte-level tokens, the piece is the UTF-8 char; for higher IDs it is <token_N>.
     // Either way the length should be at least 1.
-    assert!(piece_str.len() >= 1, "BasicTokenizer token_to_piece should have length >= 1");
+    assert!(!piece_str.is_empty(), "BasicTokenizer token_to_piece should have length >= 1");
 }
 
 /// KILLS MUTANTS: gguf_tokenizer.rs:97 token_to_piece mutations

--- a/crates/bitnet-validation/src/rules.rs
+++ b/crates/bitnet-validation/src/rules.rs
@@ -370,7 +370,7 @@ mod property_tests {
             let r = rules_bitnet_b158_f16();
             // f16 ruleset: proj_weight_rms_min=0.01, proj_weight_rms_max=0.40
             let accepted = r.check_proj_rms(rms);
-            let expected = rms >= 0.01 && rms <= 0.40;
+            let expected = (0.01f32..=0.40f32).contains(&rms);
             prop_assert_eq!(
                 accepted,
                 expected,


### PR DESCRIPTION
## Summary

Fixes all clippy `-D warnings` errors across test and source files, ensuring CI clippy gate stays clean.

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `bitnet-generation/tests/snapshot_tests.rs` | Long literal: `128009` | → `128_009` |
| `bitnet-generation/src/lib.rs` | `usize as u32` truncation cast in proptest | → `u32::try_from()` |
| `bitnet-engine-core/tests/snapshot_tests.rs` | Redundant `use serde_json;` import | Removed |
| `bitnet-validation/src/rules.rs` | Manual `RangeInclusive::contains` implementation | → `.contains()` |
| `bitnet-quantization/src/device_aware_quantizer.rs` | Approximate `f32::consts::PI` value (`3.14`) | → `3.21` (non-PI test value) |

## Testing

```
cargo clippy --all-targets --no-default-features --features cpu -- -D warnings  # clean
cargo nextest run --workspace --no-default-features --features cpu              # 2974/2974 pass
```

## Context

These were causing CI failures in the clippy gate. No behavioral changes.