### PR TITLE
test(inference): remove stale WIP ignores from compilation stub tests (+9 tests)

### DIFF
--- a/crates/bitnet-inference/tests/full_engine_compilation_test.rs
+++ b/crates/bitnet-inference/tests/full_engine_compilation_test.rs
@@ -10,7 +10,6 @@
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_full_engine_feature_compiles() {}
 /// AC:5 - Test EngineConfig default works
 ///
@@ -20,7 +19,6 @@ fn test_ac5_full_engine_feature_compiles() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_engine_config_default_works() {}
 /// AC:5 - Test ProductionInferenceEngine::new compiles
 ///
@@ -30,7 +28,6 @@ fn test_ac5_engine_config_default_works() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_production_inference_engine_new_compiles() {}
 /// AC:5 - Test inference execution stub
 ///
@@ -40,7 +37,6 @@ fn test_ac5_production_inference_engine_new_compiles() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_inference_execution_stub() {}
 /// AC:5 - Test performance monitoring stub
 ///
@@ -49,7 +45,6 @@ fn test_ac5_inference_execution_stub() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_performance_monitoring_stub() {}
 /// AC:5 - Test prefill strategy configuration stub
 ///
@@ -58,7 +53,6 @@ fn test_ac5_performance_monitoring_stub() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_prefill_strategy_configuration_stub() {}
 /// AC:5 - Test batch processing stub
 ///
@@ -67,7 +61,6 @@ fn test_ac5_prefill_strategy_configuration_stub() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_batch_processing_stub() {}
 /// AC:5 - Test error handling stub
 ///
@@ -76,5 +69,4 @@ fn test_ac5_batch_processing_stub() {}
 /// Tests specification: inference-engine-type-visibility-spec.md#ac5-ensure-full-engine-feature-compiles
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac5_error_handling_stub() {}

--- a/crates/bitnet-inference/tests/type_exports_test.rs
+++ b/crates/bitnet-inference/tests/type_exports_test.rs
@@ -55,7 +55,6 @@ fn test_ac4_test_module_imports_available() {
 /// Tests specification: inference-engine-type-visibility-spec.md#ac4-export-production-engine-types
 #[cfg(feature = "full-engine")]
 #[test]
-#[ignore = "WIP: full-engine implementation in progress"]
 fn test_ac4_config_construction() {}
 /// AC:4 - Test engine types are feature-gated correctly
 ///


### PR DESCRIPTION
## Summary

Removes 9 stale `#[ignore = "WIP: full-engine implementation in progress"]` markers from two compilation stub test files in `bitnet-inference`.

### What changed

These test files contained empty body tests (`{}`) gated on `#[cfg(feature = "full-engine")]`:
- `tests/full_engine_compilation_test.rs` — 8 stubs (AC5: compile-only verification)
- `tests/type_exports_test.rs` — 1 stub (AC4: config construction)

All 9 tests have always passed when run with `--include-ignored --features cpu,full-engine`. The `#[ignore]` markers were never justified — these are pure compilation stubs that verify the feature compiles correctly, not tests waiting for WIP implementation.

### Why this matters

Ignoring compile-only stubs defeats their purpose: to catch when a refactor accidentally breaks the `full-engine` feature compilation path. By activating them, regressions to the feature gate are now caught on every CI run.

### Testing

All 9 previously-ignored tests now pass as part of the normal test suite.