### PR TITLE
fix(tests): add missing #[serial(bitnet_env)] to env-mutating strict mode tests

### DIFF
--- a/crates/bitnet-common/tests/issue_260_strict_mode_tests.rs
+++ b/crates/bitnet-common/tests/issue_260_strict_mode_tests.rs
@@ -110,6 +110,7 @@ mod strict_mode_config_tests {
 
     /// Tests strict mode validation behavior
     #[test]
+    #[serial(bitnet_env)]
     fn test_strict_mode_validation_behavior() {
         println!("🔒 Strict Mode: Testing validation behavior");
 
@@ -186,6 +187,7 @@ mod strict_mode_config_tests {
 
     /// Tests granular strict mode configuration options
     #[test]
+    #[serial(bitnet_env)]
     fn test_granular_strict_mode_configuration() {
         println!("🔒 Strict Mode: Testing granular configuration");
 

--- a/crates/bitnet-inference/tests/strict_mode_runtime_guards.rs
+++ b/crates/bitnet-inference/tests/strict_mode_runtime_guards.rs
@@ -164,6 +164,7 @@ async fn test_attention_projection_validation() -> Result<()> {
 }
 /// Test that strict mode configuration is properly read from environment
 #[test]
+#[serial_test::serial(bitnet_env)]
 fn test_strict_mode_config_from_env() {
     let config = unsafe {
         std::env::set_var("BITNET_STRICT_MODE", "1");


### PR DESCRIPTION
## Summary

Two tests were mutating environment variables without the `#[serial(bitnet_env)]` attribute, causing race conditions in the CI Coverage job's parallel test runner.

### Root Cause

The Coverage CI job runs `cargo llvm-cov` which executes tests in parallel. Tests that mutate shared process state (environment variables) must use `#[serial(bitnet_env)]` to serialize their execution. Two test functions were missing this annotation:

- `test_granular_strict_mode_configuration` and `test_strict_mode_validation_behavior` in `bitnet-common/tests/issue_260_strict_mode_tests.rs` — both set `BITNET_STRICT_MODE`, `BITNET_STRICT_FAIL_ON_MOCK`, `BITNET_STRICT_REQUIRE_QUANTIZATION`, etc.
- `test_strict_mode_config_from_env` in `bitnet-inference/tests/strict_mode_runtime_guards.rs` — sets and removes `BITNET_STRICT_MODE`

### Fix

Added `#[serial(bitnet_env)]` to all three tests. No logic changes.

### Testing

- All 8 tests in `issue_260_strict_mode_tests.rs` pass locally
- All tests in `strict_mode_runtime_guards.rs` pass locally
- Fixes the intermittent Coverage CI failure: *"Strict mode should be enabled"*

Fixes: Coverage CI job failure on `test_granular_strict_mode_configuration`