### PR TITLE
test: unblock 2 enhanced property tests (memory efficiency + deterministic)

### DIFF
--- a/crates/bitnet-models/tests/gguf_weight_loading_property_tests_enhanced.rs
+++ b/crates/bitnet-models/tests/gguf_weight_loading_property_tests_enhanced.rs
@@ -291,7 +291,6 @@ proptest! {
 
     #[test]
     #[serial(bitnet_env)]
-    #[ignore = "Issue #159: TDD placeholder - deterministic reproducibility implementation needed"]
     fn property_quantization_deterministic_reproducibility(
         tensor_data in prop::collection::vec(-3.0f32..3.0f32, 64..256),
         seed in 1u64..1000,
@@ -386,7 +385,6 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(30))]
 
     #[test]
-    #[ignore = "Issue #159: TDD placeholder - quantization memory efficiency implementation needed"]
     fn property_quantization_memory_efficiency(
         tensor_size in 1024usize..8192,
         quantization_type in prop::sample::select(vec!["I2S", "TL1", "TL2"]),
@@ -630,10 +628,8 @@ fn get_unique_values(data: &[f32]) -> Vec<f32> {
 
 /// Estimate memory usage of quantized tensor
 fn estimate_quantized_tensor_memory(quantized: &QuantizedTensor) -> usize {
-    // TODO: Replace with actual memory calculation when QuantizedTensor API is available
-    // For now, estimate based on tensor size and quantization type
-    let _ = quantized;
-    1024 // Placeholder estimate
+    // data is packed bits (Vec<u8>), scales are f32 per block
+    quantized.data.len() + quantized.scales.len() * std::mem::size_of::<f32>()
 }
 
 /// Simulate C++ reference quantization for testing

--- a/xtask/ci/inference.json
+++ b/xtask/ci/inference.json
@@ -14,7 +14,7 @@
     "path": "/home/steven/code/Rust/BitNet-rs/models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf"
   },
   "schema_version": "1.0.0",
-  "timestamp": "2026-02-25T02:03:41.929253477+00:00",
+  "timestamp": "2026-02-25T07:48:41.708845119+00:00",
   "tokens_generated": 4,
   "tokens_per_second": 200.0,
   "tokens_requested": 4


### PR DESCRIPTION
## Summary

Unblocks 2 previously ignored tests in `gguf_weight_loading_property_tests_enhanced.rs`:

### Changes

**Fix `estimate_quantized_tensor_memory` placeholder**
- Was returning constant `1024` regardless of tensor size
- Now correctly computes `quantized.data.len() + quantized.scales.len() * 4` bytes
- This reflects actual packed storage: 2-bit data (N/4 bytes) + f32 scales (N/32 × 4 bytes)

**Unblock `property_quantization_memory_efficiency`** (Issue #159)
- I2S 2-bit: ~3/32 ratio ≈ 0.094, well within the ≤ 0.123 bound
- TL1 2-bit: same packing, well within ≤ 0.195 bound
- TL2 2-bit: well within ≤ 0.33 bound
- All variants satisfy `memory_ratio < 0.5` requirement

**Unblock `property_quantization_deterministic_reproducibility`** (Issue #159)
- I2S quantization is pure deterministic math — same input always yields identical output
- Env vars BITNET_DETERMINISTIC/BITNET_SEED are set but not needed for this test

### Test Results
```
test property_quantization_memory_efficiency ... ok
test property_quantization_deterministic_reproducibility ... ok
```

Resolves 2 of the Issue #159 TDD placeholders.