### PR TITLE
feat(tests): unblock template detection + KV cache tests; add Tokenizer::get_family_name

### DIFF
--- a/crates/bitnet-inference/src/layers/attention.rs
+++ b/crates/bitnet-inference/src/layers/attention.rs
@@ -29,6 +29,14 @@ impl KVCache {
         head_dim: usize,
         device: &Device,
     ) -> Result<Self> {
+        anyhow::ensure!(num_layers > 0, "num_layers must be > 0");
+        anyhow::ensure!(num_heads > 0, "num_heads must be > 0");
+        anyhow::ensure!(
+            head_dim > 0 && head_dim % 4 == 0,
+            "head_dim must be > 0 and divisible by 4"
+        );
+        anyhow::ensure!(max_seq_len > 0, "max_seq_len must be > 0");
+
         let mut k_cache = Vec::new();
         let mut v_cache = Vec::new();
 

--- a/crates/bitnet-inference/tests/kv_cache_validation.rs
+++ b/crates/bitnet-inference/tests/kv_cache_validation.rs
@@ -165,12 +165,18 @@ fn test_debug_assertions_in_hot_path() {
 /// - KVCache::new validates head_dim > 0 and divisible by 4
 /// - KVCache::new validates max_seq_len > 0
 #[test]
-#[ignore = "Integration test - requires KVCache::new implementation"]
 fn test_kv_cache_initialization_validation() {
-    panic!(
-        "AC3: KVCache initialization validation not yet implemented. \
-         Expected: KVCache::new uses anyhow::ensure! for parameter validation."
+    use bitnet_common::Device;
+    use bitnet_inference::layers::attention::KVCache;
+    assert!(KVCache::new(0, 1, 16, 64, &Device::Cpu).is_err(), "max_seq_len=0 should fail");
+    assert!(KVCache::new(2048, 0, 16, 64, &Device::Cpu).is_err(), "num_layers=0 should fail");
+    assert!(KVCache::new(2048, 1, 0, 64, &Device::Cpu).is_err(), "num_heads=0 should fail");
+    assert!(KVCache::new(2048, 1, 16, 0, &Device::Cpu).is_err(), "head_dim=0 should fail");
+    assert!(
+        KVCache::new(2048, 1, 16, 63, &Device::Cpu).is_err(),
+        "head_dim not div-by-4 should fail"
     );
+    assert!(KVCache::new(128, 2, 8, 64, &Device::Cpu).is_ok(), "valid params should succeed");
 }
 /// AC3: K/V cache validation warning message format
 ///

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -143,6 +143,24 @@ pub trait Tokenizer: Send + Sync {
     fn pad_token_id(&self) -> Option<u32> {
         None
     }
+
+    /// Returns the tokenizer family name based on known special tokens.
+    ///
+    /// Inspects special token IDs to determine the tokenizer family:
+    /// - `"llama3"` if `<|eot_id|>` or `<|start_header_id|>` is present
+    /// - `"mistral-instruct"` if `[INST]` is present but not LLaMA-3 markers
+    /// - `"unknown"` otherwise
+    fn get_family_name(&self) -> &'static str {
+        if self.token_to_id("<|eot_id|>").is_some()
+            || self.token_to_id("<|start_header_id|>").is_some()
+        {
+            "llama3"
+        } else if self.token_to_id("[INST]").is_some() {
+            "mistral-instruct"
+        } else {
+            "unknown"
+        }
+    }
 }
 
 /// Basic tokenizer implementation


### PR DESCRIPTION
## Summary

Unblocks 6 previously ignored tests across two test files by implementing the missing functionality they depended on.

## New functionality

### `Tokenizer::get_family_name()` (default trait method)

Added to `bitnet-tokenizers/src/lib.rs`. Inspects special-token presence to return a family hint:
- `"llama3"` — has `<|eot_id|>` or `<|start_header_id|>`  
- `"mistral-instruct"` — has `[INST]` but not LLaMA-3 markers
- `"unknown"` — fallback

### `KVCache::new()` parameter validation

- `num_layers > 0`
- `num_heads > 0`
- `head_dim > 0 && head_dim % 4 == 0`
- `max_seq_len > 0`

## Tests unblocked

`template_detection`:
- `test_detected_template_affects_formatting` — verifies Instruct ≠ Raw output
- `test_detection_overhead_minimal` — 10k detect calls in < 1s
- `test_tokenizer_llama3_family` — family name = "llama3" for LLaMA-3 markers
- `test_tokenizer_mistral_instruct_family` — family name = "mistral-instruct"
- `test_tokenizer_get_family_name_trait` — full trait contract check

`kv_cache_validation`:
- `test_kv_cache_initialization_validation` — validates all `KVCache::new` guards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tokenizer family detection capability for LLaMA 3, Mistral Instruct, and unknown tokenizers.

* **Improvements**
  * Added parameter validation checks during inference cache initialization.

* **Tests**
  * Expanded test coverage for cache parameter validation and template detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->