### PR TITLE
fix(receipts): exclude mock-containing IDs from property test strategy

### DIFF
--- a/crates/bitnet-receipts/src/lib.rs
+++ b/crates/bitnet-receipts/src/lib.rs
@@ -1029,11 +1029,15 @@ mod property_tests {
         }
     }
 
-    // validate_kernel_ids accepts any kernel IDs that are non-empty and ≤128 chars.
+    // validate_kernel_ids accepts any kernel IDs that are non-empty, ≤128 chars, and
+    // do not contain the "mock" substring (which the honest-compute policy forbids).
     proptest! {
         #[test]
         fn validate_kernel_ids_accepts_valid_ids(
-            ids in prop::collection::vec("[a-z_]{1,32}", 1..=16),
+            ids in prop::collection::vec(
+                "[a-z_]{1,32}".prop_filter("must not contain 'mock'", |s| !s.contains("mock")),
+                1..=16
+            ),
         ) {
             let mut receipt =
                 InferenceReceipt::generate("cpu", ids.clone(), None).unwrap();


### PR DESCRIPTION
## Summary

The honest-compute policy forbids kernel IDs containing `mock` (case-insensitive) via `validate_honest_kernel_ids()`. The proptest strategy `[a-z_]{1,32}` can generate the string `"mock"`, causing the property test `validate_kernel_ids_accepts_valid_ids` to fail with:

```
minimal failing input: ids = ["mock"]
```

## Fix

Add `.prop_filter()` to the proptest strategy to exclude any generated ID containing `"mock"`. Also update the test comment to accurately describe the acceptance criterion (non-empty, ≤128 chars, **and** no mock keyword).

## Test

```
cargo test -p bitnet-receipts -- property_tests
# All 7 property tests pass
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation criteria for ID generation. Test suite now enforces stricter filtering when generating test cases, reducing false positives and improving test robustness. This strengthens property-based testing coverage and ensures more reliable validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->