### PR TITLE
docs: update CHANGELOG and roadmap for PR #678

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to BitNet.rs will be documented in this file.
 - **Fuzz Target Registration** (PR #649): `architecture_detection`, `tl_lut_helper`, `tokenizer_discovery`, `vocab_size_extraction` fuzz targets were present but not registered in `fuzz/Cargo.toml`; now properly wired
 
 ### Fixed
+- **Env-var race conditions eliminated across workspace** (PR #678): Replaced bare `unsafe { env::set_var/remove_var }` with `temp_env::with_var`/`with_vars`/`with_var_unset` + `#[serial(bitnet_env)]` in `bitnet-kernels` (3 tests in `issue_260_feature_gated_tests.rs`), `bitnet-models` (`test_iq2s_backend_selection`), `bitnet-trace` (5 integration tests + 1 unit test), and `bitnet-runtime-profile-contract-core` (4 tests); eliminates flaky test failures from cross-test env var races in parallel nextest runs
 - **Template detection + KV cache init tests unblocked** (PR #673): 3 tests previously failing due to missing `get_family_name()` and wrong KV cache test logic now pass without `#[ignore]`
 - **QK256, CLI, and simple inference tests unblocked** (PR #674): 9 TDD scaffold tests (`test_qk256_tolerance_*`, `test_help_text_snapshot`, `test_simple_real_inference`, etc.) activated by fixing stub implementations
 - **Receipts property test mock filter** (PR #675): `proptest` strategy for valid kernel IDs excluded "mock"-containing strings that are rejected by honest-compute policy (`0.99f32 as f64` precision issue also fixed)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#676.
+> **Last updated**: reflects implementation state after PRs #608–#678.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -47,6 +47,7 @@
 | QK256 tolerance, CLI snapshot, simple_real_inference tests unblocked | `crates/bitnet-quantization/`, `crates/bitnet-cli/` | #674 |
 | Receipts property test: mock-containing IDs excluded from strategy | `crates/bitnet-receipts/src/lib.rs` | #675 |
 | Issue #159 resolved: `MockGgufFileBuilder` uses real `GgufWriter` | `crates/bitnet-models/tests/gguf_weight_loading_tests.rs` | #676 |
+| Env-var race conditions eliminated: `serial+temp_env` across bitnet-kernels, bitnet-models, bitnet-trace, bitnet-runtime-profile-contract-core | `crates/bitnet-kernels/`, `crates/bitnet-models/`, `crates/bitnet-trace/`, `crates/bitnet-runtime-profile-contract-core/` | #678 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
Updates CHANGELOG.md and docs/reference/dual-backend-roadmap.md to document the env-var race condition fixes in PR #678.

## Changes

- **CHANGELOG.md**: Add Fixed entry for PR #678 — env-var race conditions eliminated across bitnet-kernels, bitnet-models, bitnet-trace, and bitnet-runtime-profile-contract-core via serial+temp_env pattern
- **dual-backend-roadmap.md**: Add PR #678 row to the ✅ Implemented table; bump 'Last updated' line to #678

These docs-only changes are safe to merge independently of PR #678.