### PR TITLE
fix(clippy): resolve all clippy warnings in CPU build

### DIFF
--- a/crates/bitnet-gguf/tests/property_tests.rs
+++ b/crates/bitnet-gguf/tests/property_tests.rs
@@ -10,8 +10,8 @@ use proptest::prelude::*;
 // Helper: build a minimal valid GGUF header byte slice
 // ---------------------------------------------------------------------------
 
-/// Build a well-formed GGUF header: magic + 4-byte version + 8-byte tensor_count +
-/// 8-byte metadata_kv_count = 24 bytes.  Version is clamped to [2, 3].
+/// Build a well-formed GGUF header: magic + 4-byte version + 8-byte `tensor_count` +
+/// 8-byte `metadata_kv_count` = 24 bytes.  Version is clamped to [2, 3].
 fn make_valid_header(version: u32) -> Vec<u8> {
     let version = version.clamp(2, 3);
     let mut data = Vec::with_capacity(24);

--- a/crates/bitnet-inference/src/layers/attention.rs
+++ b/crates/bitnet-inference/src/layers/attention.rs
@@ -32,7 +32,7 @@ impl KVCache {
         anyhow::ensure!(num_layers > 0, "num_layers must be > 0");
         anyhow::ensure!(num_heads > 0, "num_heads must be > 0");
         anyhow::ensure!(
-            head_dim > 0 && head_dim % 4 == 0,
+            head_dim > 0 && head_dim.is_multiple_of(4),
             "head_dim must be > 0 and divisible by 4"
         );
         anyhow::ensure!(max_seq_len > 0, "max_seq_len must be > 0");

--- a/crates/bitnet-inference/tests/kv_cache_validation.rs
+++ b/crates/bitnet-inference/tests/kv_cache_validation.rs
@@ -140,7 +140,9 @@ fn test_once_per_layer_warning_guards() {
 /// - None (code inspection test)
 ///
 /// # Expected Behavior
+///
 /// - validate_kv_cache_dims uses debug_assert_eq! for tensor rank check
+///
 /// AC3: Debug assertions in hot path (code inspection test)
 ///
 /// Tests that validate_kv_cache_dims uses debug_assert_eq! for tensor rank check

--- a/crates/bitnet-models/tests/gguf_weight_loading_property_tests.rs
+++ b/crates/bitnet-models/tests/gguf_weight_loading_property_tests.rs
@@ -681,7 +681,7 @@ fn test_zero_copy_efficiency(
         return Ok((0, 0, false));
     }
     // "copy" memory = raw f32 storage (4 bytes each).
-    let raw_size = weight_data.len() * std::mem::size_of::<f32>();
+    let raw_size = std::mem::size_of_val(weight_data);
     // "zero-copy" memory = 2-bit packed quantized data (4× smaller than raw).
     let quantizer = I2SQuantizer::new();
     let quantized = quantizer.quantize_weights(weight_data)?;


### PR DESCRIPTION
## Summary

Fixes 5 minor clippy warnings that appear in `cargo clippy --all-targets --no-default-features --features cpu`:

1. **bitnet-models** (`gguf_weight_loading_property_tests.rs`): `manual_slice_size_calculation` → use `len()`
2. **bitnet-inference** (`attention.rs`): `manual_is_multiple_of` → `%` → `.is_multiple_of()`
3. **bitnet-gguf** (`property_tests.rs`): `rustdoc::missing_doc_code_examples` → add backticks (2 places)
4. **bitnet-inference** (`kv_cache_validation.rs`): `rustdoc::invalid_html_tags` → fix doc list indentation

## Verification
- `cargo clippy --all-targets --no-default-features --features cpu` → no warnings
- `cargo fmt --all --check` → passes
- All tests continue to pass