### PR TITLE
docs: CHANGELOG + roadmap for PR #689 (bitnet-transformer property tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to BitNet.rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Property Tests for `bitnet-transformer`** (PR #689): 4 proptest properties covering KVCache invariants — seq_len tracks N append operations correctly, clear/reset semantics, overflow (capacity) rejection, and initial zero state
 - **Tracing Instrumentation for Template Detection** (PR #686): `bitnet-prompt-templates::TemplateType::detect()` now emits `debug!` on each branch (Llama3Chat, Instruct, Raw) and `warn!` on the Raw fallback; in-crate `#[traced_test]` unit tests verify log capture
 - **`tracing-test` 0.2.6 Added to Workspace** (PR #686): Shared dev-dep for crates that test tracing output
 

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#687.
+> **Last updated**: reflects implementation state after PRs #608–#689.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -58,6 +58,7 @@
 | 4 previously-ignored tests unblocked (kv_cache unique-layer-index, template_detection behavioral) | `crates/bitnet-inference/tests/` | #686 |
 | `tracing-test 0.2.6` added to workspace dependencies | `Cargo.toml` | #686 |
 | Fixture timeout fixed: >300s → ~1s (50k-vocab allocations replaced with 512-dim) | `crates/bitnet-quantization/tests/fixtures/models/qlinear_layer_data.rs` | #687 |
+| Property tests for `bitnet-transformer` KVCache invariants (4 proptest properties) | `crates/bitnet-transformer/tests/property_tests.rs` | #689 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Updates CHANGELOG and dual-backend roadmap to reflect PR #689 (merged).

### Changes
- `CHANGELOG.md`: Add entry for 4 proptest KVCache invariant tests in `bitnet-transformer`
- `docs/reference/dual-backend-roadmap.md`: Add ✅ row for PR #689; bump "last updated" to #689

No code changes — docs only.