### PR TITLE
test(proptest): harden bitnet-startup-contract-core env test + add 5 property tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
+ "proptest",
+ "serial_test",
+ "temp-env",
 ]
 
 [[package]]

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -61,3 +61,8 @@ runtime-profile-fixtures = ["bitnet-runtime-profile/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-runtime-profile/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile/runtime-profile-integration-tests"]
+
+[dev-dependencies]
+serial_test.workspace = true
+temp-env = "0.3.6"
+proptest.workspace = true

--- a/crates/bitnet-startup-contract-core/tests/property_tests.rs
+++ b/crates/bitnet-startup-contract-core/tests/property_tests.rs
@@ -1,0 +1,102 @@
+//! Property-based tests for `bitnet-startup-contract-core`.
+//!
+//! These tests verify invariants of `ProfileContract` and the `ContractState`
+//! / `ContractPolicy` types without relying on any environment variables.
+
+use bitnet_startup_contract_core::{
+    ActiveContext, ContractPolicy, ContractState, ExecutionEnvironment, ProfileContract,
+    RuntimeComponent, TestingScenario,
+};
+use proptest::prelude::*;
+
+fn arb_component() -> impl Strategy<Value = RuntimeComponent> {
+    prop_oneof![
+        Just(RuntimeComponent::Cli),
+        Just(RuntimeComponent::Server),
+        Just(RuntimeComponent::Test),
+        Just(RuntimeComponent::Custom),
+    ]
+}
+
+fn arb_policy() -> impl Strategy<Value = ContractPolicy> {
+    prop_oneof![Just(ContractPolicy::Observe), Just(ContractPolicy::Enforce),]
+}
+
+fn arb_scenario() -> impl Strategy<Value = TestingScenario> {
+    prop_oneof![
+        Just(TestingScenario::Unit),
+        Just(TestingScenario::Integration),
+        Just(TestingScenario::CrossValidation),
+        Just(TestingScenario::EndToEnd),
+    ]
+}
+
+fn arb_environment() -> impl Strategy<Value = ExecutionEnvironment> {
+    prop_oneof![Just(ExecutionEnvironment::Local), Just(ExecutionEnvironment::Ci),]
+}
+
+proptest! {
+    /// `ProfileContract::with_context` never panics for any component/policy/scenario/env
+    /// combination, and the returned context always matches the input.
+    #[test]
+    fn with_context_context_round_trips(
+        component in arb_component(),
+        policy in arb_policy(),
+        scenario in arb_scenario(),
+        environment in arb_environment(),
+    ) {
+        let ctx = ActiveContext { scenario, environment };
+        let contract = ProfileContract::with_context(component, ctx, policy);
+        // The returned context must echo back what we passed in.
+        prop_assert_eq!(contract.context().scenario, scenario);
+        prop_assert_eq!(contract.context().environment, environment);
+    }
+
+    /// `summary()` always returns a non-empty string for any contract.
+    #[test]
+    fn summary_is_always_non_empty(
+        component in arb_component(),
+        policy in arb_policy(),
+        scenario in arb_scenario(),
+        environment in arb_environment(),
+    ) {
+        let ctx = ActiveContext { scenario, environment };
+        let contract = ProfileContract::with_context(component, ctx, policy);
+        let s = contract.summary();
+        prop_assert!(!s.is_empty());
+    }
+
+    /// For `ContractPolicy::Observe`, `enforce()` always returns `Ok` (never fails).
+    #[test]
+    fn observe_policy_enforce_always_ok(
+        component in arb_component(),
+        scenario in arb_scenario(),
+        environment in arb_environment(),
+    ) {
+        let ctx = ActiveContext { scenario, environment };
+        let contract = ProfileContract::with_context(component, ctx, ContractPolicy::Observe);
+        prop_assert!(contract.enforce().is_ok());
+    }
+
+    /// `is_compatible()` is consistent with `state() == ContractState::Compatible`.
+    #[test]
+    fn is_compatible_matches_state(
+        component in arb_component(),
+        policy in arb_policy(),
+        scenario in arb_scenario(),
+        environment in arb_environment(),
+    ) {
+        let ctx = ActiveContext { scenario, environment };
+        let contract = ProfileContract::with_context(component, ctx, policy);
+        let expected = matches!(contract.state(), ContractState::Compatible);
+        prop_assert_eq!(contract.is_compatible(), expected);
+    }
+}
+
+#[test]
+fn component_labels_are_stable() {
+    assert_eq!(RuntimeComponent::Cli.label(), "bitnet-cli");
+    assert_eq!(RuntimeComponent::Server.label(), "bitnet-server");
+    assert_eq!(RuntimeComponent::Test.label(), "test");
+    assert_eq!(RuntimeComponent::Custom.label(), "custom");
+}


### PR DESCRIPTION
## Summary

Hardens the one remaining unsafe env-var test in `bitnet-startup-contract-core` and adds a proptest suite.

### Changes

**Env-var race fix** (`src/lib.rs`):
- `evaluate_preserves_context_overrides`: replaced `unsafe { env::set_var/remove_var }` with `temp_env::with_var + #[serial(bitnet_env)]`
- Eliminates env-var race condition when tests run in parallel with nextest

**New property tests** (`tests/property_tests.rs`, 5 tests):
1. `with_context_context_round_trips` — scenario/environment always echo back from `ProfileContract::with_context`
2. `summary_is_always_non_empty` — `summary()` never returns empty string for any component/policy/scenario/env
3. `observe_policy_enforce_always_ok` — `ContractPolicy::Observe` never causes `enforce()` to fail
4. `is_compatible_matches_state` — `is_compatible()` is exactly `state() == Compatible`
5. `component_labels_are_stable` — `RuntimeComponent::label()` returns expected strings (unit test)

**Cargo.toml**: Added `serial_test`, `temp-env`, `proptest` dev-deps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added property-based test suite to improve code reliability and coverage.

*Note: This release contains internal testing enhancements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->