### PR TITLE
docs: CHANGELOG + roadmap for PR #694 (bdd-grid-core proptest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to BitNet.rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Property Tests for `bitnet-bdd-grid-core`** (PR #694): 10 proptest properties — `TestingScenario`/`ExecutionEnvironment`/`BitnetFeature` Display→FromStr round-trips (all variants lossless); `FeatureSet` insert→contains, superset satisfaction, labels completeness; plus 4 unit error-case tests
 - **Property Tests for `bitnet-runtime-feature-flags-core`** (PR #692): 6 proptest properties verifying `FeatureActivation → FeatureSet` conversion invariants — `cuda ⇒ gpu`, `cpu ⇒ inference+kernels+tokenizers`, `feature_line` prefix, default activation empty labels, and 2 unit stability tests
 - **Property Tests for `bitnet-startup-contract-core`** (PR #691): 4 proptest properties verifying `ProfileContract` invariants — context round-trips, summary non-empty, `Observe` policy never fails `enforce()`, `is_compatible()` consistent with `state()`; plus 1 unit stability test (5 total)
 - **Property Tests for `bitnet-transformer`** (PR #689): 4 proptest properties covering KVCache invariants — seq_len tracks N append operations correctly, clear/reset semantics, overflow (capacity) rejection, and initial zero state

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#692.
+> **Last updated**: reflects implementation state after PRs #608–#694.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -61,6 +61,7 @@
 | Property tests for `bitnet-transformer` KVCache invariants (4 proptest properties) | `crates/bitnet-transformer/tests/property_tests.rs` | #689 |
 | Env-var race fixed in `bitnet-startup-contract-core`; 5 proptest properties added | `crates/bitnet-startup-contract-core/src/lib.rs`, `tests/property_tests.rs` | #691 |
 | 6 proptest properties for `bitnet-runtime-feature-flags-core` (cuda⇒gpu, cpu⇒inference+kernels+tokenizers, feature_line prefix) | `crates/bitnet-runtime-feature-flags-core/tests/property_tests.rs` | #692 |
+| 10 proptest properties for `bitnet-bdd-grid-core` (Display↔FromStr round-trips for all 3 enums; FeatureSet invariants) | `crates/bitnet-bdd-grid-core/tests/property_tests.rs` | #694 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Updates CHANGELOG and dual-backend roadmap for PR #694 (merged).

No code changes — docs only.