### PR TITLE
test(bdd-infra): add snapshot tests for 5 BDD infrastructure microcrates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ version = "0.1.0"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-feature-matrix",
+ "insta",
  "proptest",
 ]
 
@@ -894,6 +895,7 @@ name = "bitnet-runtime-feature-flags-core"
 version = "0.1.0"
 dependencies = [
  "bitnet-bdd-grid-core",
+ "insta",
  "proptest",
 ]
 
@@ -1044,6 +1046,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
+ "insta",
  "proptest",
  "serial_test",
  "temp-env",
@@ -1106,6 +1109,7 @@ version = "0.1.0"
 dependencies = [
  "bitnet-testing-profile",
  "bitnet-testing-scenarios-core",
+ "insta",
  "proptest",
 ]
 
@@ -1158,6 +1162,7 @@ name = "bitnet-testing-scenarios-core"
 version = "0.1.0"
 dependencies = [
  "bitnet-testing-scenarios-profile-core",
+ "insta",
  "num_cpus",
  "proptest",
 ]

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -18,6 +18,7 @@ bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.1.0" }
 
 [dev-dependencies]
 proptest.workspace = true
+insta.workspace = true
 
 [features]
 default = []

--- a/crates/bitnet-feature-contract/tests/snapshot_tests.rs
+++ b/crates/bitnet-feature-contract/tests/snapshot_tests.rs
@@ -1,0 +1,40 @@
+use bitnet_feature_contract::{FeatureContractSnapshot, feature_contract_snapshot};
+
+#[test]
+fn consistent_snapshot_when_policy_and_runtime_match() {
+    let snap =
+        feature_contract_snapshot(["cpu", "inference", "kernels"], ["cpu", "inference", "kernels"]);
+    insta::assert_snapshot!(format!(
+        "is_consistent={} missing={:?} extra={:?}",
+        snap.is_consistent(),
+        snap.missing_from_runtime,
+        snap.extra_from_runtime
+    ));
+}
+
+#[test]
+fn inconsistent_snapshot_when_policy_has_extra_feature() {
+    let snap = feature_contract_snapshot(["cpu", "inference", "kernels"], ["cpu"]);
+    insta::assert_snapshot!(format!(
+        "is_consistent={} missing={:?} extra={:?}",
+        snap.is_consistent(),
+        snap.missing_from_runtime,
+        snap.extra_from_runtime
+    ));
+}
+
+#[test]
+fn inconsistent_snapshot_runtime_has_extra() {
+    let snap: FeatureContractSnapshot = feature_contract_snapshot(["cpu"], ["cpu", "gpu", "cuda"]);
+    insta::assert_snapshot!(format!(
+        "is_consistent={} extra={:?}",
+        snap.is_consistent(),
+        snap.extra_from_runtime
+    ));
+}
+
+#[test]
+fn empty_both_sides_is_consistent() {
+    let snap = feature_contract_snapshot::<[&str; 0], [&str; 0], &str, &str>([], []);
+    insta::assert_snapshot!(format!("is_consistent={}", snap.is_consistent()));
+}

--- a/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__consistent_snapshot_when_policy_and_runtime_match.snap
+++ b/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__consistent_snapshot_when_policy_and_runtime_match.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-feature-contract/tests/snapshot_tests.rs
+expression: "format!(\"is_consistent={} missing={:?} extra={:?}\", snap.is_consistent(),\nsnap.missing_from_runtime, snap.extra_from_runtime)"
+---
+is_consistent=true missing=[] extra=[]

--- a/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__empty_both_sides_is_consistent.snap
+++ b/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__empty_both_sides_is_consistent.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-feature-contract/tests/snapshot_tests.rs
+expression: "format!(\"is_consistent={}\", snap.is_consistent())"
+---
+is_consistent=true

--- a/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__inconsistent_snapshot_runtime_has_extra.snap
+++ b/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__inconsistent_snapshot_runtime_has_extra.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-feature-contract/tests/snapshot_tests.rs
+expression: "format!(\"is_consistent={} extra={:?}\", snap.is_consistent(),\nsnap.extra_from_runtime)"
+---
+is_consistent=false extra=["cuda", "gpu"]

--- a/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__inconsistent_snapshot_when_policy_has_extra_feature.snap
+++ b/crates/bitnet-feature-contract/tests/snapshots/snapshot_tests__inconsistent_snapshot_when_policy_has_extra_feature.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-feature-contract/tests/snapshot_tests.rs
+expression: "format!(\"is_consistent={} missing={:?} extra={:?}\", snap.is_consistent(),\nsnap.missing_from_runtime, snap.extra_from_runtime)"
+---
+is_consistent=false missing=["inference", "kernels"] extra=[]

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -20,6 +20,7 @@ bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
 
 [dev-dependencies]
 proptest.workspace = true
+insta.workspace = true
 
 [features]
 default = []

--- a/crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
@@ -1,0 +1,33 @@
+use bitnet_runtime_feature_flags_core::{FeatureActivation, active_features_from_activation};
+
+#[test]
+fn cpu_only_activation_labels() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let mut labels = act.to_labels();
+    labels.sort();
+    insta::assert_snapshot!(labels.join("\n"));
+}
+
+#[test]
+fn gpu_and_cuda_activation_labels() {
+    let act = FeatureActivation { gpu: true, cuda: true, ..Default::default() };
+    let mut labels = act.to_labels();
+    labels.sort();
+    insta::assert_snapshot!(labels.join("\n"));
+}
+
+#[test]
+fn empty_activation_labels_is_empty() {
+    let act = FeatureActivation::default();
+    let labels = act.to_labels();
+    insta::assert_snapshot!(format!("count={}", labels.len()));
+}
+
+#[test]
+fn cpu_activation_feature_set_contains_inference() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let features = active_features_from_activation(act);
+    let mut labels: Vec<_> = features.labels().into_iter().collect();
+    labels.sort();
+    insta::assert_snapshot!(labels.join("\n"));
+}

--- a/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__cpu_activation_feature_set_contains_inference.snap
+++ b/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__cpu_activation_feature_set_contains_inference.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
+expression: "labels.join(\"\\n\")"
+---
+cpu
+inference
+kernels
+tokenizers

--- a/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__cpu_only_activation_labels.snap
+++ b/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__cpu_only_activation_labels.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
+expression: "labels.join(\"\\n\")"
+---
+cpu
+inference
+kernels
+tokenizers

--- a/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__empty_activation_labels_is_empty.snap
+++ b/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__empty_activation_labels_is_empty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
+expression: "format!(\"count={}\", labels.len())"
+---
+count=0

--- a/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__gpu_and_cuda_activation_labels.snap
+++ b/crates/bitnet-runtime-feature-flags-core/tests/snapshots/snapshot_tests__gpu_and_cuda_activation_labels.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-runtime-feature-flags-core/tests/snapshot_tests.rs
+expression: "labels.join(\"\\n\")"
+---
+cuda
+gpu
+inference
+kernels

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -66,3 +66,4 @@ runtime-profile-integration-tests = ["bitnet-runtime-profile/runtime-profile-int
 serial_test.workspace = true
 temp-env = "0.3.6"
 proptest.workspace = true
+insta.workspace = true

--- a/crates/bitnet-startup-contract-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-startup-contract-core/tests/snapshot_tests.rs
@@ -1,0 +1,35 @@
+use bitnet_startup_contract_core::{ContractPolicy, ProfileContract, RuntimeComponent};
+
+#[test]
+fn runtime_component_labels() {
+    let labels: Vec<_> = [
+        RuntimeComponent::Cli,
+        RuntimeComponent::Server,
+        RuntimeComponent::Test,
+        RuntimeComponent::Custom,
+    ]
+    .iter()
+    .map(|c| c.label())
+    .collect();
+    insta::assert_snapshot!(labels.join("\n"));
+}
+
+#[test]
+fn test_component_observe_summary_contains_state() {
+    let contract = ProfileContract::evaluate(RuntimeComponent::Test, ContractPolicy::Observe);
+    let summary = contract.summary();
+    // Pin that summary is non-empty and contains key structural tokens
+    insta::assert_snapshot!(format!(
+        "has_component={} has_state={} has_scenario={}",
+        summary.contains("test"),
+        summary.contains("state="),
+        summary.contains("scenario=")
+    ));
+}
+
+#[test]
+fn cli_component_observe_is_compatible_or_has_state() {
+    let contract = ProfileContract::evaluate(RuntimeComponent::Cli, ContractPolicy::Observe);
+    // Pin the compatible field value so it doesn't silently change
+    insta::assert_snapshot!(format!("is_compatible={}", contract.is_compatible()));
+}

--- a/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__cli_component_observe_is_compatible_or_has_state.snap
+++ b/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__cli_component_observe_is_compatible_or_has_state.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-startup-contract-core/tests/snapshot_tests.rs
+expression: "format!(\"is_compatible={}\", contract.is_compatible())"
+---
+is_compatible=false

--- a/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__component_observe_summary_contains_state.snap
+++ b/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__component_observe_summary_contains_state.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-startup-contract-core/tests/snapshot_tests.rs
+expression: "format!(\"has_component={} has_state={} has_scenario={}\",\nsummary.contains(\"test\"), summary.contains(\"state=\"),\nsummary.contains(\"scenario=\"))"
+---
+has_component=true has_state=true has_scenario=true

--- a/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__runtime_component_labels.snap
+++ b/crates/bitnet-startup-contract-core/tests/snapshots/snapshot_tests__runtime_component_labels.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-startup-contract-core/tests/snapshot_tests.rs
+expression: "labels.join(\"\\n\")"
+---
+bitnet-cli
+bitnet-server
+test
+custom

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -61,3 +61,4 @@ runtime-profile-integration-tests = ["bitnet-testing-profile/runtime-profile-int
 
 [dev-dependencies]
 proptest.workspace = true
+insta.workspace = true

--- a/crates/bitnet-testing-policy-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-policy-core/tests/snapshot_tests.rs
@@ -1,0 +1,38 @@
+use bitnet_testing_policy_core::{
+    ActiveContext, ExecutionEnvironment, PolicySnapshot, TestingScenario, active_profile_summary,
+};
+
+#[test]
+fn unit_local_policy_snapshot_summary_format() {
+    let snap = PolicySnapshot::from_active_context(ActiveContext {
+        scenario: TestingScenario::Unit,
+        environment: ExecutionEnvironment::Local,
+    });
+    let summary = snap.summary();
+    insta::assert_snapshot!(format!(
+        "has_scenario={} has_environment={} non_empty={}",
+        summary.contains("scenario="),
+        summary.contains("environment="),
+        !summary.is_empty()
+    ));
+}
+
+#[test]
+fn active_profile_summary_contains_scenario() {
+    let summary = active_profile_summary();
+    // The function returns a stable summary — pin that it has key tokens
+    insta::assert_snapshot!(format!(
+        "non_empty={} has_scenario={}",
+        !summary.is_empty(),
+        summary.contains("scenario=")
+    ));
+}
+
+#[test]
+fn integration_ci_snapshot_no_cell_or_has_summary() {
+    let snap = PolicySnapshot::from_active_context(ActiveContext {
+        scenario: TestingScenario::Integration,
+        environment: ExecutionEnvironment::Ci,
+    });
+    insta::assert_snapshot!(format!("summary_non_empty={}", !snap.summary().is_empty()));
+}

--- a/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__active_profile_summary_contains_scenario.snap
+++ b/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__active_profile_summary_contains_scenario.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-core/tests/snapshot_tests.rs
+expression: "format!(\"non_empty={} has_scenario={}\", !summary.is_empty(),\nsummary.contains(\"scenario=\"))"
+---
+non_empty=true has_scenario=true

--- a/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__integration_ci_snapshot_no_cell_or_has_summary.snap
+++ b/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__integration_ci_snapshot_no_cell_or_has_summary.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-core/tests/snapshot_tests.rs
+expression: "format!(\"summary_non_empty={}\", !snap.summary().is_empty())"
+---
+summary_non_empty=true

--- a/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__unit_local_policy_snapshot_summary_format.snap
+++ b/crates/bitnet-testing-policy-core/tests/snapshots/snapshot_tests__unit_local_policy_snapshot_summary_format.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-core/tests/snapshot_tests.rs
+expression: "format!(\"has_scenario={} has_environment={} non_empty={}\",\nsummary.contains(\"scenario=\"), summary.contains(\"environment=\"),\n!summary.is_empty())"
+---
+has_scenario=true has_environment=true non_empty=true

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -21,6 +21,7 @@ num_cpus = "1.17.0"
 
 [dev-dependencies]
 proptest.workspace = true
+insta.workspace = true
 
 [features]
 default = []

--- a/crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
@@ -1,0 +1,30 @@
+use bitnet_testing_scenarios_core::{EnvironmentType, ScenarioConfigManager, TestingScenario};
+
+#[test]
+fn scenario_descriptions_all_variants() {
+    let descs: Vec<_> = ScenarioConfigManager::available_scenarios()
+        .iter()
+        .map(|s| format!("{s:?}: {}", ScenarioConfigManager::scenario_description(s)))
+        .collect();
+    insta::assert_snapshot!(descs.join("\n"));
+}
+
+#[test]
+fn unit_scenario_config_timeout_secs() {
+    let manager = ScenarioConfigManager::new();
+    let cfg = manager.get_scenario_config(&TestingScenario::Unit);
+    insta::assert_snapshot!(format!("timeout={}s", cfg.test_timeout.as_secs()));
+}
+
+#[test]
+fn ci_environment_config_log_level() {
+    let manager = ScenarioConfigManager::new();
+    let cfg = manager.get_environment_config(&EnvironmentType::Ci);
+    insta::assert_snapshot!(format!("log_level={}", cfg.log_level));
+}
+
+#[test]
+fn available_scenarios_count() {
+    let count = ScenarioConfigManager::available_scenarios().len();
+    insta::assert_snapshot!(format!("count={count}"));
+}

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__available_scenarios_count.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__available_scenarios_count.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
+expression: "format!(\"count={count}\")"
+---
+count=7

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__ci_environment_config_log_level.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__ci_environment_config_log_level.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
+expression: "format!(\"log_level={}\", cfg.log_level)"
+---
+log_level=debug

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__scenario_descriptions_all_variants.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__scenario_descriptions_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
+expression: "descs.join(\"\\n\")"
+---
+Unit: Fast, isolated tests with minimal dependencies and quick feedback.
+Integration: End-to-end integration tests covering realistic flows and services.
+Performance: Sequential performance runs that measure latency and throughput.
+CrossValidation: A/B comparison (cross-validation) to check accuracy regressions.
+Debug: Verbose debug runs with thorough logging and artifact capture.
+Development: Local development defaults for quick iteration and diagnostics.
+Minimal: Tiny smoke test configuration for ultra-fast checks.

--- a/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__unit_scenario_config_timeout_secs.snap
+++ b/crates/bitnet-testing-scenarios-core/tests/snapshots/snapshot_tests__unit_scenario_config_timeout_secs.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-scenarios-core/tests/snapshot_tests.rs
+expression: "format!(\"timeout={}s\", cfg.test_timeout.as_secs())"
+---
+timeout=10s


### PR DESCRIPTION
## Summary

Adds insta snapshot tests to five microcrates that previously only had proptest property tests, completing snapshot coverage for the BDD infrastructure layer.

## Changes

### `bitnet-runtime-feature-flags-core` (4 new snapshots)
- `cpu_only_activation_labels`: pins `to_labels()` output for CPU-only activation
- `gpu_and_cuda_activation_labels`: pins combined GPU+CUDA label list
- `empty_activation_labels_is_empty`: pins empty activation → count=0
- `cpu_activation_feature_set_contains_inference`: pins `active_features_from_activation()` output (cpu activation implies inference+kernels+tokenizers)

### `bitnet-testing-scenarios-core` (4 new snapshots)
- `scenario_descriptions_all_variants`: pins all 7 scenario description strings
- `unit_scenario_config_timeout_secs`: pins Unit scenario timeout (10s default)
- `ci_environment_config_log_level`: pins CI environment default log level
- `available_scenarios_count`: pins the count of available scenarios

### `bitnet-startup-contract-core` (3 new snapshots)
- `runtime_component_labels`: pins `.label()` for all 4 `RuntimeComponent` variants (cli/server/test/custom)
- `test_component_observe_summary_contains_state`: pins that summary string contains `state=` and `scenario=` tokens
- `cli_component_observe_is_compatible_or_has_state`: pins `is_compatible()` value under Observe policy

### `bitnet-feature-contract` (4 new snapshots)
- `consistent_snapshot_when_policy_and_runtime_match`: pins `is_consistent=true` + empty missing/extra lists
- `inconsistent_snapshot_when_policy_has_extra_feature`: pins missing=[inference, kernels] when runtime only has cpu
- `inconsistent_snapshot_runtime_has_extra`: pins extra=[cuda, gpu] when runtime has more than policy
- `empty_both_sides_is_consistent`: pins `is_consistent=true` for empty inputs

### `bitnet-testing-policy-core` (3 new snapshots)
- `unit_local_policy_snapshot_summary_format`: pins summary structure tokens (has scenario= and environment=)
- `active_profile_summary_contains_scenario`: pins `active_profile_summary()` is non-empty and has `scenario=`
- `integration_ci_snapshot_no_cell_or_has_summary`: pins summary is non-empty

## Test count
| Crate | Before | After |
|-------|--------|-------|
| bitnet-runtime-feature-flags-core | 6 proptest, 0 snapshots | +4 snapshots |
| bitnet-testing-scenarios-core | 8 proptest, 0 snapshots | +4 snapshots |
| bitnet-startup-contract-core | 4 proptest, 0 snapshots | +3 snapshots |
| bitnet-feature-contract | 5 proptest + 3 unit, 0 snapshots | +4 snapshots |
| bitnet-testing-policy-core | 7 proptest, 0 snapshots | +3 snapshots |

Total: **18 new snapshot tests** across 5 crates.