### PR TITLE
test(policy-facades): add snapshot tests for 5 thin wrapper crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,6 +936,7 @@ dependencies = [
  "bitnet-bdd-grid",
  "bitnet-runtime-context",
  "bitnet-runtime-feature-flags",
+ "insta",
  "serial_test",
  "temp-env",
 ]
@@ -1120,6 +1121,7 @@ dependencies = [
  "bitnet-feature-contract",
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-core",
+ "insta",
 ]
 
 [[package]]
@@ -1139,6 +1141,7 @@ dependencies = [
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-contract",
  "bitnet-testing-policy-kit",
+ "insta",
 ]
 
 [[package]]
@@ -1160,6 +1163,7 @@ name = "bitnet-testing-policy-tests"
 version = "0.1.0"
 dependencies = [
  "bitnet-testing-policy-runtime",
+ "insta",
 ]
 
 [[package]]
@@ -1167,6 +1171,7 @@ name = "bitnet-testing-profile"
 version = "0.1.0"
 dependencies = [
  "bitnet-runtime-profile",
+ "insta",
 ]
 
 [[package]]

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -64,5 +64,6 @@ runtime-profile-trend = ["bitnet-runtime-feature-flags/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profile-integration-tests"]
 
 [dev-dependencies]
+insta.workspace = true
 serial_test.workspace = true
 temp-env = "0.3.6"

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
@@ -1,0 +1,41 @@
+//! Snapshot tests for bitnet-runtime-profile-contract-core.
+//!
+//! Pins: active_profile_summary() format, is_supported() semantics,
+//! violations() shape, and canonical_grid() cell count stability.
+
+use bitnet_runtime_profile_contract_core::{
+    ExecutionEnvironment, TestingScenario, active_profile_for, active_profile_summary,
+    canonical_grid,
+};
+
+#[test]
+fn canonical_grid_cell_count_stable() {
+    let grid = canonical_grid();
+    insta::assert_snapshot!(grid.rows().len().to_string());
+}
+
+#[test]
+fn active_profile_summary_format_stable() {
+    let summary = active_profile_summary();
+    // Should start with "scenario=" whether or not we're in CI
+    assert!(
+        summary.starts_with("scenario="),
+        "summary should start with 'scenario=' but got: {summary}"
+    );
+    insta::assert_snapshot!(summary.contains("scenario=").to_string());
+}
+
+#[test]
+fn active_profile_unit_local_has_cell() {
+    let profile = active_profile_for(TestingScenario::Unit, ExecutionEnvironment::Local);
+    insta::assert_snapshot!(profile.cell.is_some().to_string());
+}
+
+#[test]
+fn active_profile_unit_local_supported_without_gpu() {
+    let profile = active_profile_for(TestingScenario::Unit, ExecutionEnvironment::Local);
+    // Unit/Local should not require GPU features — it's always supported in CPU mode
+    let (missing, _forbidden) = profile.violations();
+    let labels: Vec<String> = missing.labels();
+    insta::assert_debug_snapshot!(labels);
+}

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_summary_format_stable.snap
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_summary_format_stable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
+expression: "summary.contains(\"scenario=\").to_string()"
+---
+true

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_has_cell.snap
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_has_cell.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
+expression: profile.cell.is_some().to_string()
+---
+true

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_supported_without_gpu.snap
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_supported_without_gpu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
+expression: labels
+---
+[]

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__canonical_grid_cell_count_stable.snap
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__canonical_grid_cell_count_stable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
+expression: grid.rows().len().to_string()
+---
+8

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -62,3 +62,6 @@ runtime-profile-fixtures = ["bitnet-runtime-feature-flags/runtime-profile-fixtur
 runtime-profile-reporting = ["bitnet-runtime-feature-flags/runtime-profile-reporting", "bitnet-testing-policy-core/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-feature-flags/runtime-profile-trend", "bitnet-testing-policy-core/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profile-integration-tests", "bitnet-testing-policy-core/runtime-profile-integration-tests"]
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
@@ -1,0 +1,29 @@
+//! Snapshot tests for bitnet-testing-policy-contract.
+//!
+//! Pins: PolicyContract::detect() succeeds, drift_check() is None when consistent,
+//! and feature_contract_snapshot() is_consistent() with itself.
+
+use bitnet_testing_policy_contract::{PolicyContract, drift_check, feature_contract_snapshot};
+
+#[test]
+fn policy_contract_detect_succeeds() {
+    let contract = PolicyContract::detect();
+    // snapshot the Debug representation to pin the struct shape
+    let debug_str = format!("{:?}", contract);
+    insta::assert_snapshot!(debug_str.starts_with("PolicyContract").to_string());
+}
+
+#[test]
+fn feature_contract_snapshot_is_self_consistent() {
+    let snapshot = feature_contract_snapshot();
+    // When policy features match runtime features, snapshot is consistent
+    insta::assert_snapshot!(snapshot.is_consistent().to_string());
+}
+
+#[test]
+fn drift_check_matches_consistency() {
+    let consistent = feature_contract_snapshot().is_consistent();
+    let has_drift = drift_check().is_some();
+    // drift_check returns Some iff is_consistent() is false
+    insta::assert_snapshot!((consistent == !has_drift).to_string());
+}

--- a/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__drift_check_matches_consistency.snap
+++ b/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__drift_check_matches_consistency.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
+expression: (consistent == !has_drift).to_string()
+---
+true

--- a/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__feature_contract_snapshot_is_self_consistent.snap
+++ b/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__feature_contract_snapshot_is_self_consistent.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
+expression: snapshot.is_consistent().to_string()
+---
+true

--- a/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__policy_contract_detect_succeeds.snap
+++ b/crates/bitnet-testing-policy-contract/tests/snapshots/snapshot_tests__policy_contract_detect_succeeds.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
+expression: "debug_str.starts_with(\"PolicyContract\").to_string()"
+---
+true

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -59,3 +59,6 @@ runtime-profile-fixtures = ["bitnet-runtime-feature-flags/runtime-profile-fixtur
 runtime-profile-reporting = ["bitnet-runtime-feature-flags/runtime-profile-reporting", "bitnet-testing-policy-contract/runtime-profile-reporting", "bitnet-testing-policy-kit/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-feature-flags/runtime-profile-trend", "bitnet-testing-policy-contract/runtime-profile-trend", "bitnet-testing-policy-kit/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profile-integration-tests", "bitnet-testing-policy-contract/runtime-profile-integration-tests", "bitnet-testing-policy-kit/runtime-profile-integration-tests"]
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/bitnet-testing-policy-interop/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-policy-interop/tests/snapshot_tests.rs
@@ -1,0 +1,26 @@
+//! Snapshot tests for bitnet-testing-policy-interop.
+//!
+//! Pins: Environment alias is ExecutionEnvironment, canonical grid row count,
+//! and validate helpers delegate correctly.
+
+use bitnet_testing_policy_interop::{
+    Environment, ExecutionEnvironment, TestingScenario, canonical_grid, validate_active_profile_for,
+};
+
+#[test]
+fn environment_alias_works_as_execution_environment() {
+    // Environment is a type alias for ExecutionEnvironment; test that assignment compiles
+    let env: Environment = ExecutionEnvironment::Local;
+    insta::assert_debug_snapshot!(env);
+}
+
+#[test]
+fn canonical_grid_row_count_stable() {
+    insta::assert_snapshot!(canonical_grid().rows().len().to_string());
+}
+
+#[test]
+fn validate_unit_local_returns_some() {
+    let result = validate_active_profile_for(TestingScenario::Unit, ExecutionEnvironment::Local);
+    insta::assert_snapshot!(result.is_some().to_string());
+}

--- a/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__canonical_grid_row_count_stable.snap
+++ b/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__canonical_grid_row_count_stable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-interop/tests/snapshot_tests.rs
+expression: canonical_grid().rows().len().to_string()
+---
+8

--- a/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__environment_alias_works_as_execution_environment.snap
+++ b/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__environment_alias_works_as_execution_environment.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-interop/tests/snapshot_tests.rs
+expression: env
+---
+Local

--- a/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__validate_unit_local_returns_some.snap
+++ b/crates/bitnet-testing-policy-interop/tests/snapshots/snapshot_tests__validate_unit_local_returns_some.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-interop/tests/snapshot_tests.rs
+expression: result.is_some().to_string()
+---
+true

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-fixtures = ["bitnet-testing-policy-runtime/runtime-profile-fixtu
 runtime-profile-reporting = ["bitnet-testing-policy-runtime/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-testing-policy-runtime/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-testing-policy-runtime/runtime-profile-integration-tests"]
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/bitnet-testing-policy-tests/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-policy-tests/tests/snapshot_tests.rs
@@ -1,0 +1,32 @@
+//! Snapshot tests for bitnet-testing-policy-tests.
+//!
+//! Pins: PolicyDiagnostics::current() is constructible, GridScenario/GridEnvironment
+//! aliases, and context round-trips via from_context().
+
+use bitnet_testing_policy_tests::{
+    ConfigurationContext, ExecutionEnvironment, GridEnvironment, GridScenario, PolicyDiagnostics,
+    TestingScenario,
+};
+
+#[test]
+fn grid_scenario_alias_is_testing_scenario() {
+    let s: GridScenario = TestingScenario::Unit;
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn grid_environment_alias_is_execution_environment() {
+    let e: GridEnvironment = ExecutionEnvironment::Local;
+    insta::assert_debug_snapshot!(e);
+}
+
+#[test]
+fn policy_diagnostics_from_context_has_cell() {
+    let ctx = ConfigurationContext {
+        scenario: TestingScenario::Unit,
+        environment: ExecutionEnvironment::Local,
+        ..Default::default()
+    };
+    let diag = PolicyDiagnostics::from_context(&ctx);
+    insta::assert_snapshot!(diag.profile().cell.is_some().to_string());
+}

--- a/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__grid_environment_alias_is_execution_environment.snap
+++ b/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__grid_environment_alias_is_execution_environment.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-tests/tests/snapshot_tests.rs
+expression: e
+---
+Local

--- a/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__grid_scenario_alias_is_testing_scenario.snap
+++ b/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__grid_scenario_alias_is_testing_scenario.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-tests/tests/snapshot_tests.rs
+expression: s
+---
+Unit

--- a/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__policy_diagnostics_from_context_has_cell.snap
+++ b/crates/bitnet-testing-policy-tests/tests/snapshots/snapshot_tests__policy_diagnostics_from_context_has_cell.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-policy-tests/tests/snapshot_tests.rs
+expression: diag.profile().cell.is_some().to_string()
+---
+true

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -57,3 +57,6 @@ runtime-profile-fixtures = ["bitnet-runtime-profile/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-runtime-profile/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile/runtime-profile-integration-tests"]
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/bitnet-testing-profile/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-profile/tests/snapshot_tests.rs
@@ -1,0 +1,27 @@
+//! Snapshot tests for bitnet-testing-profile.
+//!
+//! Pins the stable re-export surface: conversion helpers are identity functions,
+//! type alias targets match expectations, and validate helpers delegate correctly.
+
+use bitnet_testing_profile::{
+    ExecutionEnvironment, TestingScenario, canonical_grid, from_grid_environment,
+    from_grid_scenario, to_grid_environment, to_grid_scenario,
+};
+
+#[test]
+fn conversion_helpers_are_identity() {
+    let scenario = TestingScenario::Unit;
+    let env = ExecutionEnvironment::Local;
+    // to_grid_* and from_grid_* must be no-ops
+    insta::assert_debug_snapshot!((
+        to_grid_scenario(scenario) == scenario,
+        to_grid_environment(env) == env,
+        from_grid_scenario(scenario) == scenario,
+        from_grid_environment(env) == env,
+    ));
+}
+
+#[test]
+fn canonical_grid_row_count_stable() {
+    insta::assert_snapshot!(canonical_grid().rows().len().to_string());
+}

--- a/crates/bitnet-testing-profile/tests/snapshots/snapshot_tests__canonical_grid_row_count_stable.snap
+++ b/crates/bitnet-testing-profile/tests/snapshots/snapshot_tests__canonical_grid_row_count_stable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-testing-profile/tests/snapshot_tests.rs
+expression: canonical_grid().rows().len().to_string()
+---
+8

--- a/crates/bitnet-testing-profile/tests/snapshots/snapshot_tests__conversion_helpers_are_identity.snap
+++ b/crates/bitnet-testing-profile/tests/snapshots/snapshot_tests__conversion_helpers_are_identity.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-testing-profile/tests/snapshot_tests.rs
+expression: "(to_grid_scenario(scenario) == scenario, to_grid_environment(env) == env,\nfrom_grid_scenario(scenario) == scenario, from_grid_environment(env) == env,)"
+---
+(
+    true,
+    true,
+    true,
+    true,
+)


### PR DESCRIPTION
## Summary

Adds `insta` snapshot coverage for the remaining policy and testing façade microcrates that previously lacked any snapshot tests.

## Changes

### New snapshot test files (5 crates, 15 tests total)

| Crate | Tests | What's pinned |
|-------|-------|--------------|
| `bitnet-runtime-profile-contract-core` | 4 | `canonical_grid` row count, `active_profile_summary` format prefix, Unit/Local has cell, Unit/Local missing-features empty in CPU mode |
| `bitnet-testing-profile` | 2 | Conversion helpers are identity no-ops, grid row count |
| `bitnet-testing-policy-contract` | 3 | `PolicyContract::detect()` struct prefix, `feature_contract_snapshot` self-consistency, `drift_check()` matches consistency |
| `bitnet-testing-policy-interop` | 3 | `Environment` alias is `ExecutionEnvironment`, grid row count, `validate_unit_local` returns `Some` |
| `bitnet-testing-policy-tests` | 3 | `GridScenario`/`GridEnvironment` aliases, `PolicyDiagnostics::from_context` has cell |

### Modified Cargo.toml files (5 crates)

Added `insta.workspace = true` to `[dev-dependencies]` for each crate.

## Why this matters

These are all thin re-export facades that sit at the top of the policy stack. Without snapshot coverage, silent signature regressions (renamed type aliases, changed function returns) would pass all existing tests undetected. These snapshots catch that class of regression.

## Test

```bash
cargo test -p bitnet-runtime-profile-contract-core -p bitnet-testing-profile -p bitnet-testing-policy-contract -p bitnet-testing-policy-interop -p bitnet-testing-policy-tests --no-default-features --features cpu
```

All 15 tests pass locally.