### PR TITLE
ci: make markdownlint npm install resilient to 403 errors

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -13,7 +13,7 @@ jobs:
     continue-on-error: true  # Informational while stabilizing docs
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
-      - run: npm -g i markdownlint-cli2
+      - run: npm -g i markdownlint-cli2 || echo "markdownlint-cli2 install failed (network/registry issue), skipping lint"
       - name: Lint markdown (informational)
         run: |
-          markdownlint-cli2 --config .markdownlint.jsonc "**/*.md" "!archive/**" "!CROSSVAL_IMPLEMENTATION_COMPLETE.md" || true
+          command -v markdownlint-cli2 && markdownlint-cli2 --config .markdownlint.jsonc "**/*.md" "!archive/**" "!CROSSVAL_IMPLEMENTATION_COMPLETE.md" || true


### PR DESCRIPTION
The `markdownlint-cli2` npm install step was failing with `403 Forbidden` when the npm registry was unavailable, causing the CI job to fail even though it has `continue-on-error: true`.

## Changes

- Add `|| echo ...` fallback to the npm install step
- Guard the lint invocation with `command -v markdownlint-cli2` so the job gracefully skips linting when the tool couldn't be installed
- Result: job succeeds regardless of npm registry availability

The lint itself still runs when the tool is available, so this is purely a resilience improvement.