### PR TITLE
fix(tests): update runtime-feature-flags snapshots for --features cpu

### DIFF
--- a/crates/bitnet-runtime-feature-flags/tests/snapshot_tests.rs
+++ b/crates/bitnet-runtime-feature-flags/tests/snapshot_tests.rs
@@ -8,8 +8,8 @@ fn feature_line_starts_with_features_prefix() {
 }
 
 #[test]
-fn feature_labels_without_features_is_empty() {
-    // When no features are compiled, labels must be empty
+fn feature_labels_count_with_cpu_feature() {
+    // When compiled with --features cpu, labels must be non-empty
     let labels = feature_labels();
     insta::assert_snapshot!(&labels.len().to_string());
 }

--- a/crates/bitnet-runtime-feature-flags/tests/snapshots/snapshot_tests__feature_labels_count_with_cpu_feature.snap
+++ b/crates/bitnet-runtime-feature-flags/tests/snapshots/snapshot_tests__feature_labels_count_with_cpu_feature.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/bitnet-runtime-feature-flags/tests/snapshot_tests.rs
+assertion_line: 14
 expression: "&labels.len().to_string()"
 ---
-0
+4

--- a/crates/bitnet-runtime-feature-flags/tests/snapshots/snapshot_tests__feature_line_format_stable.snap
+++ b/crates/bitnet-runtime-feature-flags/tests/snapshots/snapshot_tests__feature_line_format_stable.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/bitnet-runtime-feature-flags/tests/snapshot_tests.rs
+assertion_line: 20
 expression: feature_line()
 ---
-features: none
+features: cpu, inference, kernels, tokenizers


### PR DESCRIPTION
## Problem

The `bitnet-runtime-feature-flags` snapshot tests were originally generated without any features enabled. They captured `0` labels and `features: none`. However, all tests run with `--features cpu`, so the suite was failing with:

- `feature_labels_without_features_is_empty` — old snap: 0, new: 4
- `feature_line_format_stable` — old snap: 'features: none', new: 'features: cpu, inference, kernels, tokenizers'

## Fix

- Update both snapshot files to match the `--features cpu` reality (4 compiled features)
- Rename `feature_labels_without_features_is_empty` → `feature_labels_count_with_cpu_feature` (the old name was misleading and the opposite of what the test should assert)

## Test

```
cargo nextest run -p bitnet-runtime-feature-flags --no-default-features --features cpu
# Summary: 4 tests run: 4 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated internal test naming and documentation for clarity.

**Note:** This release contains only internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->