### PR TITLE
docs(changelog): update test counts and add PR #722 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to BitNet.rs will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Property tests for `bitnet-compat` and `bitnet-st2gguf`** (PR #722): Adds proptest coverage to two crates that previously had no property-based tests — `bitnet-compat` (+5 tests: `diagnose()` determinism, issues are non-empty strings, minimal GGUF always has issues, `export_fixed()` passes idempotency check, fixing never increases issue count); `bitnet-st2gguf` (+9 tests: `is_layernorm_tensor` purity and boundary cases, `count_layernorm_tensors` bounds, `TensorDType` type codes and element sizes, `GgufWriter` tensor shape acceptance). Workspace total: **3,359 tests, all passing**.
+
 ### Fixed
-- **Workspace snapshot tests (4 tests across 3 crates)** (PR #720): Replaced exact-count/exact-value snapshot assertions with presence checks in `bitnet-runtime-feature-flags` (`feature_labels_count_with_cpu_feature`, `feature_line_format_stable`), `bitnet-startup-contract-core` (`cli_component_observe_is_compatible_or_has_state`), and `bitnet-testing-policy-kit` (`active_feature_labels_returns_list`). Cargo feature unification in workspace builds activates extra features (`fixtures`, `reporting`, `trend`, `quantization`) via other crates, making context-dependent exact-match snapshots fail. Full workspace run now: **3345 passed, 0 failed, 462 skipped**.
+- **Workspace snapshot tests (4 tests across 3 crates)** (PR #720): Replaced exact-count/exact-value snapshot assertions with presence checks in `bitnet-runtime-feature-flags` (`feature_labels_count_with_cpu_feature`, `feature_line_format_stable`), `bitnet-startup-contract-core` (`cli_component_observe_is_compatible_or_has_state`), and `bitnet-testing-policy-kit` (`active_feature_labels_returns_list`). Cargo feature unification in workspace builds activates extra features (`fixtures`, `reporting`, `trend`, `quantization`) via other crates, making context-dependent exact-match snapshots fail. Full workspace run now: **3,359 passed, 0 failed, 462 skipped**.
 
 ### Documentation
 - **Dual-Backend Roadmap update** (PR #719): Marks PRs #711–#717 as implemented in the roadmap tracking table; adds retrospective rows for previously-implemented but un-tracked items (Phase 6 SRP microcrates, BDD grid runner, CPU golden path, GPU smoke lane).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,7 +866,7 @@ BitNet.rs maintains a healthy test suite. All `#[ignore]` attributes include a
 justification string (enforced by pre-commit hooks):
 
 - **~462 tests skipped** in a full `--workspace` run — all with `#[ignore = "reason"]` justification
-- **3,345 tests run, all pass** in a normal `cargo nextest run --workspace --no-default-features --features cpu` run
+- **3,359 tests run, all pass** in a normal `cargo nextest run --workspace --no-default-features --features cpu` run
 - **Zero bare `#[ignore]`** attributes (no un-reasoned skips)
 
 ### Test Execution
@@ -950,7 +950,7 @@ fn test_qk256_full_model_inference() { /* ... */ }
 
 ### Working Test Categories
 
-These test suites pass reliably (3,345 tests run: 3,345 passed):
+These test suites pass reliably (3,359 tests run: 3,359 passed):
 
 - **quantization tests**: I2_S flavor detection, TL1/TL2, IQ2_S via FFI
 - **model loading tests**: GGUF and SafeTensors parsing
@@ -1140,7 +1140,7 @@ cargo test -p bitnet-models --no-default-features --features cpu
 
 **Current State**:
 
-- **3,345 tests run: 3,345 passed** in `cargo nextest run --workspace --no-default-features --features cpu`
+- **3,359 tests run: 3,359 passed** in `cargo nextest run --workspace --no-default-features --features cpu`
 - ~462 tests intentionally skipped in `--workspace` runs; all have `#[ignore = "reason"]` justification strings
 - Categories: real-model tests, CUDA tests, slow tests, crossval tests, TDD scaffolds
 - Complete test infrastructure: fixtures, receipts, strict mode, environment isolation, snapshot tests, property tests, fuzz

--- a/docs/development/test-suite.md
+++ b/docs/development/test-suite.md
@@ -5,8 +5,8 @@ This document covers the comprehensive test suite for BitNet.rs, including runni
 ## Test Status Summary
 
 **Current Test Results**:
-- **Total Enabled Tests**: 3,345+ (all pass)
-- **Passing Tests**: 3,345+ (100%)
+- **Total Enabled Tests**: 3,359+ (all pass)
+- **Passing Tests**: 3,359+ (100%)
 - **Properly Skipped Tests**: 462 (intentional: ignored, integration, fixtures)
 - **Execution Time**: ~162 seconds (with parallel execution)
 
@@ -312,7 +312,7 @@ BitNet.rs test suite is organized into distinct categories, each addressing spec
 | **Integration Tests** | 110+ | 🟡 Partial | End-to-end workflows (some blocked by issues) |
 | **Slow/Ignored Tests** | 70+ | ⏸️ Skipped | QK256 scalar kernels, architecture blockers |
 
-**Total Enabled**: 3,345+ tests
+**Total Enabled**: 3,359+ tests
 **Total Skipped**: 462 tests (intentional)
 **Pass Rate**: 100%
 
@@ -1183,7 +1183,7 @@ grep -r "#254\|#260\|#469" tests --include="*.rs"
 
 ### CI Behavior with Ignored Tests
 
-**In CI**: Only non-ignored tests run (3,345+ enabled tests)
+**In CI**: Only non-ignored tests run (3,359+ enabled tests)
 **Ignored tests**: Tracked separately, not blocking CI
 **Skipped tests**: 462 tests properly marked as skipped
 **Exit code**: Success (0) even with 462+ skipped tests


### PR DESCRIPTION
- Update workspace test count: 3,345 → 3,359 in CLAUDE.md and docs/development/test-suite.md
- Add CHANGELOG entry for PR #722 (proptest coverage for bitnet-compat + bitnet-st2gguf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for new property tests for bitnet-compat and bitnet-st2gguf modules
  * Updated test suite documentation to reflect current test statistics and status information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->