### PR TITLE
test(proptest): add property-based tests for bitnet-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,7 @@ dependencies = [
  "memmap2",
  "num_cpus",
  "predicates",
+ "proptest",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "serde",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -64,6 +64,7 @@ half = "2.7.1"
 [dev-dependencies]
 assert_cmd = "2.1.1"
 predicates = "3.1.3"
+proptest.workspace = true
 tempfile = "3.23.0"
 serial_test = "3.2.0"
 insta = { workspace = true, features = ["json"] }

--- a/crates/bitnet-cli/tests/property_tests.rs
+++ b/crates/bitnet-cli/tests/property_tests.rs
@@ -1,0 +1,105 @@
+//! Property-based tests for bitnet-cli using proptest.
+//!
+//! Tests cover CLI argument parsing invariants:
+//! - max_tokens aliases (--max-tokens, --max-new-tokens, --n-predict)
+//! - temperature stays within parsed range
+//! - repetition_penalty stays within parsed range
+//! - top_k and top_p optional fields parse correctly
+//! - greedy mode invariants (overrides temperature)
+
+#![cfg(feature = "full-cli")]
+
+use bitnet_cli::commands::InferenceCommand;
+use clap::Parser;
+use proptest::prelude::*;
+
+/// Test CLI wrapper for parsing InferenceCommand
+#[derive(Parser)]
+struct TestCli {
+    #[command(flatten)]
+    cmd: InferenceCommand,
+}
+
+fn parse_args(args: &[&str]) -> Result<InferenceCommand, clap::Error> {
+    TestCli::try_parse_from(args).map(|c| c.cmd)
+}
+
+proptest! {
+    /// max_tokens: valid positive values are always accepted
+    #[test]
+    fn prop_max_tokens_positive_valid(n in 1usize..=4096usize) {
+        let n_str = n.to_string();
+        let args = ["bitnet", "--max-tokens", &n_str];
+        let cmd = parse_args(&args).expect("valid max_tokens should parse");
+        prop_assert_eq!(cmd.max_tokens, n);
+    }
+
+    /// max-new-tokens alias: must behave identically to --max-tokens
+    #[test]
+    fn prop_max_new_tokens_alias_same_as_primary(n in 1usize..=4096usize) {
+        let n_str = n.to_string();
+        let primary = parse_args(&["bitnet", "--max-tokens", &n_str]).expect("should parse");
+        let alias   = parse_args(&["bitnet", "--max-new-tokens", &n_str]).expect("should parse");
+        prop_assert_eq!(primary.max_tokens, alias.max_tokens);
+        prop_assert_eq!(primary.max_tokens, n);
+    }
+
+    /// n-predict alias: must behave identically to --max-tokens
+    #[test]
+    fn prop_n_predict_alias_same_as_primary(n in 1usize..=4096usize) {
+        let n_str = n.to_string();
+        let primary = parse_args(&["bitnet", "--max-tokens", &n_str]).expect("should parse");
+        let alias   = parse_args(&["bitnet", "--n-predict", &n_str]).expect("should parse");
+        prop_assert_eq!(primary.max_tokens, alias.max_tokens);
+    }
+
+    /// temperature: values ≥ 0.0 are accepted by clap (domain validation is in engine)
+    #[test]
+    fn prop_temperature_nonnegative_parses(
+        temp_int in 0u32..=300u32  // 0.0 to 3.0 in 0.01 steps
+    ) {
+        let temp = format!("{:.2}", temp_int as f32 / 100.0);
+        let cmd = parse_args(&["bitnet", "--temperature", &temp]).expect("should parse");
+        prop_assert!(cmd.temperature >= 0.0, "temperature should be >= 0.0");
+    }
+
+    /// repetition_penalty: values ≥ 0.0 parse correctly
+    #[test]
+    fn prop_repetition_penalty_parses(
+        penalty_int in 10u32..=500u32  // 0.1 to 5.0 in 0.01 steps
+    ) {
+        let penalty = format!("{:.2}", penalty_int as f32 / 100.0);
+        let cmd = parse_args(&["bitnet", "--repetition-penalty", &penalty]).expect("should parse");
+        prop_assert!(cmd.repetition_penalty >= 0.0);
+    }
+
+    /// top_k: positive integers parse as Some(k)
+    #[test]
+    fn prop_top_k_positive_parses(k in 1usize..=1000usize) {
+        let k_str = k.to_string();
+        let cmd = parse_args(&["bitnet", "--top-k", &k_str]).expect("should parse");
+        prop_assert_eq!(cmd.top_k, Some(k));
+    }
+
+    /// top_p: when not provided, is None
+    #[test]
+    fn prop_top_p_absent_is_none(_seed in 0u32..100u32) {
+        let cmd = parse_args(&["bitnet"]).expect("should parse");
+        prop_assert!(cmd.top_p.is_none(), "top_p should be None when not specified");
+    }
+
+    /// greedy: when set, greedy flag is true
+    #[test]
+    fn prop_greedy_flag_sets_greedy(_seed in 0u32..100u32) {
+        let cmd = parse_args(&["bitnet", "--greedy"]).expect("should parse");
+        prop_assert!(cmd.greedy);
+    }
+
+    /// seed: provided values are stored exactly
+    #[test]
+    fn prop_seed_stored_exactly(seed in 0u64..=u64::MAX) {
+        let seed_str = seed.to_string();
+        let cmd = parse_args(&["bitnet", "--seed", &seed_str]).expect("should parse");
+        prop_assert_eq!(cmd.seed, Some(seed));
+    }
+}


### PR DESCRIPTION
## Summary

Adds 9 proptest property tests to `bitnet-cli`, which previously had no property-based coverage. These tests focus on CLI argument parsing invariants — the most stable surface area to property-test in a CLI crate.

## New properties (+9 property tests)

| Property | Invariant |
|----------|-----------|
| `prop_max_tokens_positive_valid` | Valid positive values parse as `max_tokens` exactly |
| `prop_max_new_tokens_alias_same_as_primary` | `--max-new-tokens` alias is identical to `--max-tokens` |
| `prop_n_predict_alias_same_as_primary` | `--n-predict` alias is identical to `--max-tokens` |
| `prop_temperature_nonnegative_parses` | Temperature values ≥ 0.0 always parse successfully |
| `prop_repetition_penalty_parses` | Repetition penalty values ≥ 0.0 always parse |
| `prop_top_k_positive_parses` | Positive k values stored as `Some(k)` |
| `prop_top_p_absent_is_none` | `top_p` is `None` when not provided |
| `prop_greedy_flag_sets_greedy` | `--greedy` flag sets `greedy = true` |
| `prop_seed_stored_exactly` | Seed values (full u64 range) preserved exactly |

## Test results

```
bitnet-cli prop tests: 9 tests run, 9 passed
```

No regressions.