### PR TITLE
test(proptest): add property tests to bitnet-quantization and bitnet-models

### DIFF
--- a/crates/bitnet-models/tests/property_tests.rs
+++ b/crates/bitnet-models/tests/property_tests.rs
@@ -113,8 +113,7 @@ proptest! {
 #[test]
 fn reexport_tolerance_constant_matches_source() {
     use bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT as SRC;
-    assert_eq!(QK256_SIZE_TOLERANCE_PERCENT, SRC,
-        "re-exported constant must equal source");
+    assert_eq!(QK256_SIZE_TOLERANCE_PERCENT, SRC, "re-exported constant must equal source");
 }
 
 proptest! {

--- a/crates/bitnet-quantization/tests/property_tests.rs
+++ b/crates/bitnet-quantization/tests/property_tests.rs
@@ -8,10 +8,10 @@
 
 #![cfg(feature = "cpu")]
 
-use bitnet_quantization::{QK256_SIZE_TOLERANCE_PERCENT, qk256_tolerance_bytes};
 use bitnet_quantization::utils::{
-    calculate_scale, pack_2bit_values, unpack_2bit_values, quantize_value, dequantize_value,
+    calculate_scale, dequantize_value, pack_2bit_values, quantize_value, unpack_2bit_values,
 };
+use bitnet_quantization::{QK256_SIZE_TOLERANCE_PERCENT, qk256_tolerance_bytes};
 use proptest::prelude::*;
 
 // ── qk256_tolerance_bytes ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds property-based tests to two high-value crates completing the foundational proptest coverage suite.

## Changes

### `bitnet-quantization` (+12 properties)

Tests four public functions with mathematical invariants that must hold for all valid inputs:

| Function | Invariants tested |
|---|---|
| `qk256_tolerance_bytes` | ≥8 floor, ≤ input, monotone, proportional (within ceiling) |
| `calculate_scale` | always positive+finite; fallback=1.0 for all-zeros/all-NaN |
| `pack_2bit_values`/`unpack_2bit_values` | round-trip identity; packed len = ⌈n/4⌉ |
| `quantize_value`/`dequantize_value` | value in signed range; finite; order-preserving |

### `bitnet-models` (+8 properties)

Tests predicates and re-exports:

| Target | Invariants tested |
|---|---|
| `is_layernorm_weight` | all 8 LN suffixes always detected; never a projection; pure |
| `is_projection_weight` | all 14 proj suffixes always detected; never an LN; pure |
| Both predicates | never panic on arbitrary strings |
| Re-exports | `QK256_SIZE_TOLERANCE_PERCENT` and `qk256_tolerance_bytes` identical to source |

## Testing

All tests pass locally:
```
bitnet-quantization::property_tests: 12/12 passed
bitnet-models::property_tests: 8/8 passed
```