### PR TITLE
docs: update test counts and roadmap for PRs #730-#733

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -866,7 +866,7 @@ BitNet.rs maintains a healthy test suite. All `#[ignore]` attributes include a
 justification string (enforced by pre-commit hooks):
 
 - **~462 tests skipped** in a full `--workspace` run — all with `#[ignore = "reason"]` justification
-- **3,384 tests run, all pass** in a normal `cargo nextest run --workspace --no-default-features --features cpu` run
+- **3,426 tests run, all pass** in a normal `cargo nextest run --workspace --no-default-features --features cpu` run
 - **Zero bare `#[ignore]`** attributes (no un-reasoned skips)
 
 ### Test Execution
@@ -950,7 +950,7 @@ fn test_qk256_full_model_inference() { /* ... */ }
 
 ### Working Test Categories
 
-These test suites pass reliably (3,384 tests run: 3,384 passed):
+These test suites pass reliably (3,426 tests run: 3,426 passed):
 
 - **quantization tests**: I2_S flavor detection, TL1/TL2, IQ2_S via FFI
 - **model loading tests**: GGUF and SafeTensors parsing
@@ -1140,7 +1140,7 @@ cargo test -p bitnet-models --no-default-features --features cpu
 
 **Current State**:
 
-- **3,384 tests run: 3,384 passed** in `cargo nextest run --workspace --no-default-features --features cpu`
+- **3,426 tests run: 3,426 passed** in `cargo nextest run --workspace --no-default-features --features cpu`
 - ~462 tests intentionally skipped in `--workspace` runs; all have `#[ignore = "reason"]` justification strings
 - Categories: real-model tests, CUDA tests, slow tests, crossval tests, TDD scaffolds
 - Complete test infrastructure: fixtures, receipts, strict mode, environment isolation, snapshot tests, property tests, fuzz

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#726.
+> **Last updated**: reflects implementation state after PRs #608–#733.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -85,6 +85,10 @@
 | Proptest for `bitnet-trace` (+6 JSON round-trip/hash/rms invariants) and `bitnet-kernels` (+8 provider/quantize invariants); proptest: 22→23 crates | `crates/bitnet-trace/tests/property_tests.rs`, `crates/bitnet-kernels/tests/property_tests.rs` | #724 |
 | Proptest for `bitnet-server` (+11 BatchEngineConfig/SecurityValidator invariants); proptest: 23→24 crates | `crates/bitnet-server/tests/property_tests.rs` | #725 |
 | Proptest for `bitnet-cli` (+9 CLI arg-parsing invariants); proptest: 24→26 crates; workspace: 3,359→3,384 tests | `crates/bitnet-cli/tests/property_tests.rs` | #726 |
+| Fix GPU mode compilation in `bitnet-receipts` (missing optional `bitnet-kernels` dep; let-chain type inference fix) | `crates/bitnet-receipts/Cargo.toml`, `src/lib.rs` | #731 |
+| Fix CLI tests: assert `.stderr(...)` not `.stdout(...)` for error messages logged via `tracing::error!` | `crates/bitnet-cli/tests/inspect_ln_stats.rs`, `validation_workflow.rs` | #730 |
+| Proptest for `bitnet-common` (+17), `bitnet-tokenizers` (+9), `bitnet-inference` (+16); proptest: 26→29 crates; workspace: 3,384→3,426 tests | `crates/*/tests/property_tests.rs` | #732 |
+| Proptest for `bitnet-quantization` (+12 math invariants) and `bitnet-models` (+8 predicate/re-export invariants) | `crates/bitnet-quantization/tests/property_tests.rs`, `crates/bitnet-models/tests/property_tests.rs` | #733 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
Updates CLAUDE.md and dual-backend-roadmap.md to reflect the recent batch of fixes and proptest additions.

## Changes
- **CLAUDE.md**: workspace test count 3,384 → 3,426
- **dual-backend-roadmap.md**: add entries for #730, #731, #732, #733; update last-updated header