### PR TITLE
fix(inference): fix config doctest using renamed method

### DIFF
--- a/crates/bitnet-inference/src/config.rs
+++ b/crates/bitnet-inference/src/config.rs
@@ -11,7 +11,7 @@
 //! ```
 //! # use bitnet_inference::config::GenerationConfig;
 //! let config = GenerationConfig::greedy()
-//!     .with_max_new_tokens(32)
+//!     .with_max_tokens(32)
 //!     .with_temperature(0.0);
 //! ```
 


### PR DESCRIPTION
The module-level doctest in `bitnet-inference/src/config.rs` called `with_max_new_tokens()` which was renamed to `with_max_tokens()`. This caused a doctest compilation failure in `cargo test --doc`.

## Change
- `config.rs` line 14: `with_max_new_tokens(32)` → `with_max_tokens(32)`

## Verification
`cargo test -p bitnet-inference --no-default-features --features cpu --doc` now passes all 16 doctests.