### PR TITLE
chore: remove duplicate workspace members in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,6 @@ members = [
   "crates/bitnet-startup-contract-diagnostics",
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
-  # SRP microcrate extractions (phase-6)
-  "crates/bitnet-device-probe",
-  "crates/bitnet-logits",
-  "crates/bitnet-generation",
-  "crates/bitnet-engine-core",
-  "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crossval",
   "tests",


### PR DESCRIPTION
## Summary

Five SRP phase-6 crates were listed twice in `[workspace.members]`:
- `bitnet-device-probe`
- `bitnet-logits`
- `bitnet-generation`
- `bitnet-engine-core`
- `bitnet-gguf`

Each appeared once near the top (with comments) and once in the phase-6 block at the bottom. Cargo silently deduplicates them, so there was no functional impact — but the duplication was misleading and made the file harder to read.

This removes the bottom duplicate block (the one without comments) and keeps the annotated entries at the top.

## Verification

`cargo check --no-default-features --features cpu` passes after this change.