### PR TITLE
🎨 Palette: Add keyboard navigation to browser example tabs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 ## 2024-05-22 - Mocking WASM for Frontend Verification
 **Learning:** Frontend code that imports WASM modules (like `pkg/bitnet_wasm.js`) fails to run in isolation if the WASM build artifacts are missing.
 **Action:** Create a mock JS file that exports the necessary functions and classes (even if empty) to allow the frontend logic to execute and be verified without a full WASM build.
+
+## 2024-05-22 - Keyboard Navigation in Custom Tabs
+**Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
+**Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -21,6 +21,9 @@ let benchmarkSuite = null;
 // Initialize the application
 async function initApp() {
     try {
+        // Setup keyboard navigation for tabs
+        setupTabNavigation();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -549,6 +552,44 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard navigation for tabs
+function setupTabNavigation() {
+    const tabsContainer = document.querySelector('.tabs');
+    if (!tabsContainer) return;
+
+    tabsContainer.addEventListener('keydown', (e) => {
+        const tabs = Array.from(document.querySelectorAll('.tab'));
+        const activeTab = document.activeElement;
+        const index = tabs.indexOf(activeTab);
+
+        if (index === -1) return; // Focus not on a tab
+
+        let nextIndex = index;
+        let handled = false;
+
+        if (e.key === 'ArrowRight') {
+            nextIndex = (index + 1) % tabs.length;
+            handled = true;
+        } else if (e.key === 'ArrowLeft') {
+            nextIndex = (index - 1 + tabs.length) % tabs.length;
+            handled = true;
+        } else if (e.key === 'Home') {
+            nextIndex = 0;
+            handled = true;
+        } else if (e.key === 'End') {
+            nextIndex = tabs.length - 1;
+            handled = true;
+        }
+
+        if (handled) {
+            e.preventDefault();
+            const nextTab = tabs[nextIndex];
+            nextTab.focus();
+            nextTab.click(); // Activate the tab
+        }
+    });
+}
 
 // Make functions globally available
 window.loadModel = loadModel;


### PR DESCRIPTION
💡 What: Added full keyboard navigation support for the tabs in the browser example.
🎯 Why: The previous implementation relied solely on click events, making it difficult for keyboard users to navigate between sections efficiently.
📸 Before/After: No visual changes, but behavioral improvement verified via Playwright script showing focus moving with arrow keys.
♿ Accessibility: Supports ArrowRight/ArrowLeft/Home/End keys for navigating the tab list, fulfilling ARIA authoring practices for `role="tablist"`.


---
*PR created automatically by Jules for task [14475259408153707242](https://jules.google.com/task/14475259408153707242) started by @EffortlessSteven*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keyboard navigation for tabs is now available. Users can navigate between tabs using arrow keys, as well as Home and End keys for quick navigation to the first and last tabs.

* **Documentation**
  * Added documentation describing keyboard navigation implementation for custom tab components following accessibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->