### PR TITLE
docs: update changelog and roadmap for PRs #753-#756

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+- Restrict model loading to configured directories via `BITNET_ALLOWED_MODEL_DIRECTORIES` (#753)
+- Harden model path validation: prevent symlink traversal and empty-string allowlist bypass (#756)
+
+### Changed
+- Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
+
 ### Added
+- Keyboard navigation (ArrowLeft/ArrowRight/Home/End) for WASM browser example tab list (#754)
 - **Property tests for `bitnet-test-support`** (PR #749): 10 new property + unit tests for `EnvGuard`/`EnvScope` API semantics — set/restore/remove round-trips, nested scope isolation, `model_path()`/`run_slow_tests()`/`run_e2e()` env helpers. Workspace total: **3,520 tests, all passing**. Proptest coverage spans **38 crates** (+2: `bitnet-test-support`, `bitnet-testing-scenarios-profile-core`).
 - **Property tests for `bitnet-testing-scenarios-profile-core`** (PR #750): 17 new property + unit tests for Default value invariants across 5 structs — `FixtureProfile`, `CrossValidationProfile`, `ComparisonToleranceProfile`, `ReportingProfile`, `ResourceConstraints`. Includes fuzz-grade shape coverage for numeric fields, URL/path fields, and nested struct coherence.
 - **CI env isolation fixes for `bitnet-runtime-context-core` and `bitnet-runtime-profile-contract-core`** (in PR #746): Tests that check `from_env_with_defaults()` Local default now use `temp_env::with_vars` to clear the `CI` env var so they pass in GitHub Actions. Snapshot tests for `active_context_default_fields` also isolated. `test_config_profile_defaults` snapshot uses `insta::with_settings!` filter to normalize the CPU-dependent `max_parallel_tests` field. Added `filters` feature to workspace insta definition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -956,7 +956,7 @@ These test suites pass reliably (3,520 tests run: 3,520 passed):
 - **model loading tests**: GGUF and SafeTensors parsing
 - **GGUF fixture tests**: QK256 dual-flavor detection, alignment validation (12/12 passing)
 - **snapshot tests**: Struct/output stability via insta (42 files, ~160 assertions, 192 snapshot files)
-- **property tests**: Randomised invariants via proptest (38 crates, 230+ properties)
+- **property tests**: Randomised invariants via proptest (44 crates, 230+ properties)
 - **tokenizer tests**: Universal tokenizer, auto-discovery
 - **cli tests**: Command-line parsing, flag validation
 - **device feature tests**: CPU/GPU compilation detection

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#750.
+> **Last updated**: reflects implementation state after PRs #608–#756.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -103,6 +103,10 @@
 | fix: serialize `find_bitnet_lib_dirs` tests with `#[serial(bitnet_env)]` to prevent `BITNET_CROSSVAL_LIBDIR` race condition in xtask | `xtask/src/cpp_setup_auto.rs` | #748 |
 | test(proptest): add 10 property + unit tests for `bitnet-test-support` (EnvGuard/EnvScope API semantics) | `crates/bitnet-test-support/tests/property_tests.rs` | #749 |
 | test(proptest): add 17 property + unit tests for `bitnet-testing-scenarios-profile-core` (Default value invariants, fuzz-grade shape coverage across 5 structs) | `crates/bitnet-testing-scenarios-profile-core/tests/property_tests.rs` | #750 |
+| Restrict model loading to configured directories via `BITNET_ALLOWED_MODEL_DIRECTORIES`; path canonicalization and directory containment check | `crates/bitnet-models/src/`, `crates/bitnet-server/src/` | #753 |
+| Keyboard navigation (ArrowLeft/ArrowRight/Home/End) for WASM browser example tab list | `examples/wasm/` | #754 |
+| Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) | workspace-wide | #755 |
+| Harden model path validation: prevent symlink traversal and empty-string allowlist bypass | `crates/bitnet-models/src/`, `crates/bitnet-server/src/` | #756 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
Updates CHANGELOG.md, dual-backend-roadmap.md, and CLAUDE.md to reflect:
- PR #753: model path security restriction
- PR #754: WASM keyboard navigation accessibility
- PR #755: project renamed BitNet.rs → BitNet-rs
- PR #756: security hardening (symlink/empty-string fixes)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted model loading to configured directories and hardened path validation against symlink traversal attacks.

* **Changed**
  * Project renamed from BitNet.rs to BitNet-rs.

* **New Features**
  * Added keyboard navigation (arrow keys and Home/End) to the WASM browser example.

* **Tests**
  * Expanded test coverage across 44 crates with validation, receipt verification, and environment isolation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->