### PR TITLE
docs: update CHANGELOG, CLAUDE.md, and roadmap for PRs #760-#762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to bitnet-rs will be documented in this file.
 - Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
 
 ### Added
+- **Property tests for 6 infrastructure crates** (PR #762): Extends proptest coverage to 6 additional crates. Proptest workspace total: **50 crates**.
 - Keyboard navigation (ArrowLeft/ArrowRight/Home/End) for WASM browser example tab list (#754)
 - **Property tests for `bitnet-test-support`** (PR #749): 10 new property + unit tests for `EnvGuard`/`EnvScope` API semantics — set/restore/remove round-trips, nested scope isolation, `model_path()`/`run_slow_tests()`/`run_e2e()` env helpers. Workspace total: **3,520 tests, all passing**. Proptest coverage spans **38 crates** (+2: `bitnet-test-support`, `bitnet-testing-scenarios-profile-core`).
 - **Property tests for `bitnet-testing-scenarios-profile-core`** (PR #750): 17 new property + unit tests for Default value invariants across 5 structs — `FixtureProfile`, `CrossValidationProfile`, `ComparisonToleranceProfile`, `ReportingProfile`, `ResourceConstraints`. Includes fuzz-grade shape coverage for numeric fields, URL/path fields, and nested struct coherence.
@@ -20,6 +21,8 @@ All notable changes to bitnet-rs will be documented in this file.
 - **Property tests for `bitnet-testing-policy-tests`** (PR #745): 8 new property/unit tests for `PolicyDiagnostics` invariants — `from_context_is_deterministic`, `is_grid_compatible_coherent_with_violations` (key: `is_grid_compatible() ↔ violations().is_some_and(|m,f| m.is_empty() && f.is_empty())`), `summary_never_panics_and_contains_scenario`, `feature_contract_consistent_does_not_panic`, `diagnostics_for_context_matches_from_context`, `profile_config_does_not_panic`, plus 2 unit tests (unit/local and e2e/ci). Workspace total: **3,493 tests, all passing**. Proptest coverage spans **36 crates**.
 
 ### Fixed
+- **TL2 kernel fix** (PR #761): Replaced `matmul_i2s` with a `dequantize+matmul` pipeline (same pattern as TL1 fix in #760), eliminating 3 compounding bugs that caused incorrect TL2 quantization results.
+- **TL1 kernel fix** (PR #760): Replaced `matmul_i2s` with a `dequantize+matmul` pipeline, fixing 3 compounding bugs that caused incorrect TL1 quantization results.
 - **xtask `find_bitnet_lib_dirs` race condition** (PR #748): `test_find_bitnet_lib_dirs_both_tiers` was failing intermittently because `test_find_bitnet_lib_dirs_env_override` used a nested-function anti-pattern for `#[serial(bitnet_env)]` — the inner function's attribute doesn't actually serialize the outer `#[test]`. Fixed by adding `#[serial(bitnet_env)]` directly to all 5 related tests and flattening the nested-function pattern.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -956,7 +956,7 @@ These test suites pass reliably (3,520 tests run: 3,520 passed):
 - **model loading tests**: GGUF and SafeTensors parsing
 - **GGUF fixture tests**: QK256 dual-flavor detection, alignment validation (12/12 passing)
 - **snapshot tests**: Struct/output stability via insta (42 files, ~160 assertions, 192 snapshot files)
-- **property tests**: Randomised invariants via proptest (44 crates, 230+ properties)
+- **property tests**: Randomised invariants via proptest (50 crates, 230+ properties)
 - **tokenizer tests**: Universal tokenizer, auto-discovery
 - **cli tests**: Command-line parsing, flag validation
 - **device feature tests**: CPU/GPU compilation detection

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -107,6 +107,9 @@
 | Keyboard navigation (ArrowLeft/ArrowRight/Home/End) for WASM browser example tab list | `examples/wasm/` | #754 |
 | Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) | workspace-wide | #755 |
 | Harden model path validation: prevent symlink traversal and empty-string allowlist bypass | `crates/bitnet-models/src/`, `crates/bitnet-server/src/` | #756 |
+| TL1 kernel fix: replaced `matmul_i2s` with `dequantize+matmul` pipeline; fixed 3 compounding bugs | `crates/bitnet-quantization/`, `crates/bitnet-kernels/` | #760 |
+| TL2 kernel fix: replaced `matmul_i2s` with `dequantize+matmul` pipeline (same pattern as #760) | `crates/bitnet-quantization/`, `crates/bitnet-kernels/` | #761 |
+| Proptest added to 6 infrastructure crates; proptest total: 44→50 crates | `crates/*/tests/property_tests.rs` | #762 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Docs-only update for recent and in-flight PRs.

### Changes

| File | Change |
|---|---|
|  | Added  entries for TL1 (#760) and TL2 (#761) kernel fixes; added `### Added` entry for proptest expansion (#762) |
|  | Updated proptest crate count 44 → 50 (+6 crates from #762) |
| `docs/reference/dual-backend-roadmap.md` | Added ✅ rows for #760, #761, #762 |

### PR Coverage

- **#760** – TL1 kernel fix: replaced `matmul_i2s` with `dequantize+matmul`, 3 compounding bugs fixed
- **#761** – TL2 kernel fix: same pattern as #760
- **#762** – proptest added to 6 infrastructure crates (44 → 50 total)

No code changes — docs only.