### PR TITLE
chore: update docs for PRs #767-#768 proptest expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to bitnet-rs will be documented in this file.
 - Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
 
 ### Added
+- `test(srp-crates): expanded proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core (#768)`
+- `test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests (#767)`
 - **`bitnet-device-probe` microcrate — `CpuCapabilities`/`GpuCapabilities` with proptest coverage** (#765)
 - **CPU golden-path E2E test with receipt invariants** (#766)
 - **Property tests for 6 infrastructure crates** (PR #762): Extends proptest coverage to 6 additional crates. Proptest workspace total: **50 crates**.

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -112,6 +112,8 @@
 | Proptest added to 6 infrastructure crates; proptest total: 44→50 crates | `crates/*/tests/property_tests.rs` | #762 |
 | `bitnet-device-probe` microcrate: `CpuCapabilities`/`GpuCapabilities` types with proptest coverage | `crates/bitnet-device-probe/` | #765 |
 | CPU golden-path E2E test with receipt invariants | `crates/bitnet-inference/tests/cpu_golden_path.rs` | #766 |
+| test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests | `crates/bitnet-gguf/` | #767 |
+| test(srp-crates): expand proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core | `crates/bitnet-logits/`, `crates/bitnet-generation/`, `crates/bitnet-engine-core/` | #768 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Updates CHANGELOG.md and the dual-backend roadmap tracking table for the two test-expansion PRs.

### Changes
- **CHANGELOG.md**: Added entries for:
  - `test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests (#767)`
  - `test(srp-crates): expanded proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core (#768)`
- **docs/reference/dual-backend-roadmap.md**: Added tracking rows for #767 and #768 in the ✅ implementation table.

PR #769 was a docs-only update and requires no CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for bitnet-gguf, increasing test count from 33 to 49.
  * Expanded proptest coverage for bitnet-logits, bitnet-generation, and bitnet-engine-core modules.

* **Documentation**
  * Updated documentation to reflect newly expanded test coverage across multiple components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->