### PR TITLE
ci: add BDD grid-check job to CI Core

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -155,10 +155,33 @@ jobs:
             -p bitnet-testing-policy-interop \
             --no-default-features --features cpu
 
-      - name: BDD Grid Check (CPU cells)
+  # Job 2: BDD Grid Check (separate job for parallel execution and clear gate signal)
+  grid-check:
+    name: BDD Grid Check
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    env:
+      RUSTFLAGS: "-D warnings"
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.92.0"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: ci-core-grid-check
+
+      - name: Run BDD Grid Check (CPU cells)
         run: cargo run --locked --no-default-features -p xtask -- grid-check --cpu-only
 
-  # Job 2: Clippy linting
+  # Job 4: Clippy linting
   clippy:
     name: Clippy
     runs-on: ubuntu-22.04
@@ -227,7 +250,7 @@ jobs:
     name: CI Core Success
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [build-test-linux, clippy, docs]
+    needs: [build-test-linux, grid-check, clippy, docs]
     if: always()
     steps:
       - name: Summarize core results
@@ -235,6 +258,7 @@ jobs:
         run: |
           echo "Core results:"
           echo "  Build & Test: ${{ needs.build-test-linux.result }}"
+          echo "  Grid Check:   ${{ needs.grid-check.result }}"
           echo "  Clippy:       ${{ needs.clippy.result }}"
           echo "  Docs:         ${{ needs.docs.result }}"
 
@@ -243,6 +267,7 @@ jobs:
         run: |
           bad=0
           for r in "${{ needs.build-test-linux.result }}" \
+                   "${{ needs.grid-check.result }}" \
                    "${{ needs.clippy.result }}" \
                    "${{ needs.docs.result }}"; do
             [ "$r" = "success" ] || bad=1


### PR DESCRIPTION
Wires `xtask grid-check --cpu-only` into CI Core as a required job. Runs 8 BDD grid cells (CPU lane), takes ~12s.

## What changed

- Promotes the BDD grid check from an **inline step** inside `build-test-linux` to a **dedicated parallel job** (`grid-check`) with its own `Swatinem/rust-cache` key (`ci-core-grid-check`).
- Adds `grid-check` to the `ci-core-success` aggregator gate (`needs:` + result check), making it a required check for PR merges.
- Total CI wall-clock time is unchanged — the new job runs concurrently with Clippy and Docs.

Part of Phase 4: Make the BDD grid executable.