### PR TITLE
chore: comprehensive docs update for PRs #765-#771

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to bitnet-rs will be documented in this file.
 - Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
 
 ### Added
+- `feat(inference)`: BackendStartupSummary — startup logs `requested=X detected=[…] selected=Y` (#771)
 - `test(srp-crates): expanded proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core (#768)`
 - `test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests (#767)`
 - **`bitnet-device-probe` microcrate — `CpuCapabilities`/`GpuCapabilities` with proptest coverage** (#765)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Essential guidance for working with the bitnet-rs neural network inference codeb
 - **EnvGuard Environment Isolation** - Robust parallel test execution with `#[serial(bitnet_env)]`
 - **Receipt Verification** - Schema v1.0.0 with 8 validation gates (25/25 tests passing)
 - **Strict Mode Runtime Guards** - Production safety enforcement (12/12 tests passing)
-- **Runtime Backend Selection** - `BackendCapabilities` snapshot at startup with `requested=X detected=[…] selected=Y` logging
+- **Runtime Backend Selection** - `BackendStartupSummary` emits `requested=X detected=[…] selected=Y` at startup; `BackendCapabilities` snapshot captured in receipts (#771)
 - **CPU Golden Path E2E Tests** - 5 deterministic end-to-end tests always running in PR CI (no model download)
 - **SRP Microcrate Ecosystem** - `bitnet-logits`, `bitnet-gguf`, `bitnet-generation`, `bitnet-device-probe`, `bitnet-engine-core` wired into CI
 - **Feature Lattice** - `gpu` umbrella + `cuda` backend; orthogonal runtime reporting; CUDA-first but non-CUDA-ready


### PR DESCRIPTION
## Summary

Docs-only update covering the full PRs #765–#771 batch.

### Changes

**CHANGELOG.md** — add missing #771 entry to `[Unreleased]`:
- `feat(inference)`: BackendStartupSummary — startup logs `requested=X detected=[…] selected=Y` (#771)
- Entries for #765, #766, #767, #768 were already present (added in #769)

**CLAUDE.md** — update the *Runtime Backend Selection* bullet in **What's Working** to reference the `BackendStartupSummary` struct by name and cite #771 (previously described the behavior without naming the type)

**README.md** — no changes needed; already had correct entries for backend reporting and CPU golden-path tests

### Checklist
- [x] Docs only — no code changes
- [x] No new markdown files created
- [x] All five PRs (#765–#771, excluding #769/#770 which were docs PRs) reflected
- [x] No duplicate entries