### PR TITLE
feat(ci): add nightly scheduled fuzz workflow with corpus caching

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -1,0 +1,73 @@
+name: Nightly Fuzz
+
+on:
+  schedule:
+    - cron: "0 2 * * *"  # 02:00 UTC daily
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-fuzz-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fuzz:
+    name: "Fuzz (${{ matrix.target }})"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - quantization_i2s
+          - quantization_tl1
+          - quantization_tl2
+          - gguf_parser
+          - safetensors_parser
+          - kernel_matmul
+          - tokenizer_discovery
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Install nightly Rust (required by cargo-fuzz)
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
+        with:
+          toolchain: nightly
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          key: nightly-fuzz-${{ matrix.target }}
+
+      - name: Restore fuzz corpus
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run fuzz target (60 seconds)
+        run: |
+          cd fuzz
+          cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -rss_limit_mb=4096 -timeout=10 2>&1
+        env:
+          RUSTUP_TOOLCHAIN: nightly
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4
+        with:
+          name: fuzz-crashes-${{ matrix.target }}-${{ github.run_id }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          retention-days: 30

--- a/docs/development/test-suite.md
+++ b/docs/development/test-suite.md
@@ -681,7 +681,10 @@ cargo nextest run -p bitnet-sampling --no-default-features --features cpu prop
 
 ### Fuzz Testing (cargo-fuzz)
 
-BitNet-rs has 13 fuzz targets covering parsers, kernels, and tokenizers. Fuzz targets run nightly via `.github/workflows/fuzz-ci.yml` (60 seconds per target, `01:00 UTC`).
+BitNet-rs has 13 fuzz targets covering parsers, kernels, and tokenizers. Two CI workflows handle fuzz testing:
+
+- **`.github/workflows/fuzz-ci.yml`** — runs on every push/PR (build check) and nightly (short run, all 13 targets).
+- **`.github/workflows/nightly-fuzz.yml`** — dedicated nightly scheduled run (02:00 UTC daily) or manual trigger via `workflow_dispatch`. Runs 7 core targets for 60 seconds each with `-rss_limit_mb=4096`, **caches the corpus** between runs (`fuzz-corpus-<target>` cache key), and uploads crash artifacts on failure.
 
 **Running fuzz tests manually:**
 
@@ -716,7 +719,9 @@ done
 | `prompt_template` | Prompt template formatting |
 | `receipt_json` | Receipt JSON deserialisation |
 
-**Corpus:** Seed corpora live in `fuzz/corpus/<target>/`. CI uploads crash artifacts to GitHub Actions on failure.
+**Corpus:** Seed corpora live in `fuzz/corpus/<target>/`. The nightly fuzz workflow (`.github/workflows/nightly-fuzz.yml`) caches the corpus between runs so each nightly session builds on prior coverage. CI uploads crash artifacts to GitHub Actions on failure.
+
+**Manual nightly fuzz run:** Trigger `.github/workflows/nightly-fuzz.yml` via `workflow_dispatch` on GitHub Actions to run the 7 core targets outside the normal schedule.
 
 ### Enhanced Mock Infrastructure and Tokenizer Testing
 


### PR DESCRIPTION
## Summary

Adds a dedicated nightly fuzz workflow () separate from the existing `fuzz-ci.yml`.

## Changes

### `.github/workflows/nightly-fuzz.yml` (new)
- **Triggers**: `schedule: [{cron: "0 2 * * *"}]` (02:00 UTC daily) + `workflow_dispatch`
- **Matrix**: 7 core targets — `quantization_i2s`, `quantization_tl1`, `quantization_tl2`, `gguf_parser`, `safetensors_parser`, `kernel_matmul`, `tokenizer_discovery`
- **Run**: 60 seconds per target with `-rss_limit_mb=4096` and `-timeout=10`
- **Corpus caching**: `actions/cache@v4` with key `fuzz-corpus-<target>` so each nightly session builds on prior coverage
- **Crash artifacts**: uploaded with `actions/upload-artifact@v4` as `fuzz-crashes-<target>-<run_id>` (30-day retention) on failure
- Follows repo patterns: pinned SHA action refs, `ubuntu-22.04`, `dtolnay/rust-toolchain nightly`, `Swatinem/rust-cache`

### `docs/development/test-suite.md`
- Documents the new workflow and corpus caching alongside the existing `fuzz-ci.yml`