### PR TITLE
feat(inference): use bitnet-logits for logits transforms (SRP integration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,7 @@ dependencies = [
  "bitnet-engine-core",
  "bitnet-generation",
  "bitnet-kernels",
+ "bitnet-logits",
  "bitnet-models",
  "bitnet-prompt-templates",
  "bitnet-quantization",

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -23,6 +23,7 @@ bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.1.0" }
 bitnet-receipts = { path = "../bitnet-receipts", version = "0.1.0" }
 bitnet-rope = { path = "../bitnet-rope", version = "0.1.0" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.1.0" }
 bitnet-sampling = { path = "../bitnet-sampling", version = "0.1.0" }
 bitnet-generation = { path = "../bitnet-generation", version = "0.1.0" }
 bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.1.0" }

--- a/crates/bitnet-inference/src/generation/sampling.rs
+++ b/crates/bitnet-inference/src/generation/sampling.rs
@@ -135,17 +135,19 @@ impl SamplingStrategy {
 
         let mut logits_vec = logits.flatten_all()?.to_vec1::<f32>()?;
 
-        // Apply penalty to repeated tokens
-        for (&token_id, &count) in &self.repetition_counts {
-            if token_id < logits_vec.len() && count > 0 {
-                let penalty_factor = self.current_repetition_penalty.powi(count as i32);
-                if logits_vec[token_id] > 0.0 {
-                    logits_vec[token_id] /= penalty_factor;
-                } else {
-                    logits_vec[token_id] *= penalty_factor;
-                }
-            }
-        }
+        // Expand each (token, count) pair into `count` repetitions of the token ID.
+        // Passing a token N times to apply_repetition_penalty produces penalty^N,
+        // which is equivalent to the original count-based exponential formula.
+        let token_ids: Vec<u32> = self
+            .repetition_counts
+            .iter()
+            .flat_map(|(&id, &count)| std::iter::repeat_n(id as u32, count))
+            .collect();
+        bitnet_logits::apply_repetition_penalty(
+            &mut logits_vec,
+            &token_ids,
+            self.current_repetition_penalty,
+        );
 
         CandleTensor::from_slice(&logits_vec, logits.shape(), logits.device())
             .context("Failed to create tensor from penalized logits")
@@ -154,32 +156,13 @@ impl SamplingStrategy {
     /// Apply top-k filtering
     fn apply_top_k(&self, logits: &CandleTensor, k: usize) -> Result<CandleTensor> {
         let mut logits_vec = logits.flatten_all()?.to_vec1::<f32>()?;
-        let vocab_size = logits_vec.len();
 
         // k=0 means "all tokens" — skip filtering entirely
-        if k == 0 || k >= vocab_size {
+        if k == 0 || k >= logits_vec.len() {
             return Ok(logits.clone());
         }
 
-        // O(N) partition: rearrange so that indices[0..k] are the top-k highest logits.
-        // This is significantly faster than a full sort for large vocabularies (32k+).
-        let mut indices: Vec<usize> = (0..vocab_size).collect();
-        indices.select_nth_unstable_by(k - 1, |&i, &j| {
-            logits_vec[j].partial_cmp(&logits_vec[i]).unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        // Keep exactly the k tokens in the top partition; mask all others.
-        // Using index-based masking (not value-based) ensures correct cardinality
-        // even when multiple tokens share the same logit value as the k-th token.
-        let mut keep = vec![false; vocab_size];
-        for &idx in &indices[..k] {
-            keep[idx] = true;
-        }
-        for (i, val) in logits_vec.iter_mut().enumerate() {
-            if !keep[i] {
-                *val = f32::NEG_INFINITY;
-            }
-        }
+        bitnet_logits::apply_top_k(&mut logits_vec, k);
 
         CandleTensor::from_slice(&logits_vec, logits.shape(), logits.device())
             .context("Failed to create tensor from top-k filtered logits")
@@ -187,41 +170,25 @@ impl SamplingStrategy {
 
     /// Apply nucleus (top-p) sampling
     fn apply_top_p(&self, logits: &CandleTensor, p: f32) -> Result<CandleTensor> {
-        let probabilities = candle_nn::ops::softmax(logits, candle_core::D::Minus1)?;
-        let prob_vec = probabilities.flatten_all()?.to_vec1::<f32>()?;
+        if p >= 1.0 {
+            return Ok(logits.clone());
+        }
+
         let logits_vec = logits.flatten_all()?.to_vec1::<f32>()?;
 
-        // Only consider candidates that are not already masked (NEG_INFINITY)
-        // and have non-negligible probability. Sorting a sparse subset is faster
-        // than sorting the full vocabulary (important at 32k-128k vocab sizes).
-        let mut candidates: Vec<usize> = (0..prob_vec.len())
-            .filter(|&i| logits_vec[i] > f32::NEG_INFINITY && prob_vec[i] > 0.0)
+        // Compute probabilities, then apply top-p to the probability distribution.
+        let mut probs = logits_vec.clone();
+        bitnet_logits::softmax_in_place(&mut probs);
+        bitnet_logits::apply_top_p(&mut probs, p);
+
+        // Mask logits where top-p filtering zeroed the corresponding probability.
+        let filtered: Vec<f32> = logits_vec
+            .into_iter()
+            .zip(probs.iter())
+            .map(|(l, &prob)| if prob == 0.0 { f32::NEG_INFINITY } else { l })
             .collect();
 
-        // Sort candidates by probability descending
-        candidates.sort_unstable_by(|&i, &j| {
-            prob_vec[j].partial_cmp(&prob_vec[i]).unwrap_or(std::cmp::Ordering::Equal)
-        });
-
-        // Find cutoff point where cumulative probability exceeds p
-        let mut cumulative_prob = 0.0;
-        let mut cutoff_idx = candidates.len();
-
-        for (i, &idx) in candidates.iter().enumerate() {
-            cumulative_prob += prob_vec[idx];
-            if cumulative_prob >= p {
-                cutoff_idx = i + 1;
-                break;
-            }
-        }
-
-        // Build filtered logits: keep nucleus tokens, mask the rest
-        let mut filtered_logits = vec![f32::NEG_INFINITY; prob_vec.len()];
-        for &idx in candidates.iter().take(cutoff_idx) {
-            filtered_logits[idx] = logits_vec[idx];
-        }
-
-        CandleTensor::from_slice(&filtered_logits, logits.shape(), logits.device())
+        CandleTensor::from_slice(&filtered, logits.shape(), logits.device())
             .context("Failed to create tensor from nucleus filtered logits")
     }
 


### PR DESCRIPTION
## Summary

Wire `bitnet-logits` as an actual dependency of `bitnet-inference` and replace the duplicated logits transform implementations in `sampling.rs`.

## Changes

- **`crates/bitnet-inference/Cargo.toml`**: Add `bitnet-logits = { path = "../bitnet-logits", version = "0.1.0" }` under `[dependencies]`.
- **`crates/bitnet-inference/src/generation/sampling.rs`**: Replace three private math helper methods with delegates to `bitnet_logits::*`:
  - `apply_top_k` → `bitnet_logits::apply_top_k`
  - `apply_top_p` → `bitnet_logits::softmax_in_place` + `bitnet_logits::apply_top_p` (extract probs, filter, reconstruct masked logits)
  - `apply_repetition_penalty` → `bitnet_logits::apply_repetition_penalty` with token IDs expanded by count, preserving the existing `penalty^count` exponential semantics

All public APIs and struct definitions are unchanged. All 16 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal sampling logic for improved code maintainability and consistency.
  * Refactored repetition penalty calculations with a more efficient two-step approach.
  * Optimized top-k selection logic by consolidating custom implementation into unified library functions.
  * Enhanced top-p nucleus sampling with improved early-exit conditions and probability-based result filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->