### PR TITLE
chore: update docs for PRs #772-#776

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to bitnet-rs will be documented in this file.
 - Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
 
 ### Added
+- `ci: add BDD grid-check job to CI Core workflow` — Standalone `grid-check` job in `ci-core.yml` runs `xtask grid-check --cpu-only` in parallel with the build matrix (#772)
+- `chore: docs update for PRs #765–#771` — CHANGELOG and CLAUDE.md updated to reflect merged PRs (#773)
+- `test(sampling): expand proptest coverage for bitnet-sampling` — 7 new proptests covering top_k, repetition_penalty, temperature entropy, multi-step, and reset invariants (#774)
+- `feat(ci): nightly scheduled fuzz workflow with corpus caching` — New `.github/workflows/nightly-fuzz.yml`; runs 7 fuzz targets for 60 s nightly, caches corpus per-target, uploads crash artifacts (#775)
+- `feat(inference): wire bitnet-logits into bitnet-inference (SRP integration)` — Replaced duplicate logits math in `generation/sampling.rs` with `bitnet-logits` crate (#776)
 - `feat(inference)`: BackendStartupSummary — startup logs `requested=X detected=[…] selected=Y` (#771)
 - `test(srp-crates): expanded proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core (#768)`
 - `test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests (#767)`

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#756.
+> **Last updated**: reflects implementation state after PRs #608–#776.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -114,6 +114,12 @@
 | CPU golden-path E2E test with receipt invariants | `crates/bitnet-inference/tests/cpu_golden_path.rs` | #766 |
 | test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests | `crates/bitnet-gguf/` | #767 |
 | test(srp-crates): expand proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core | `crates/bitnet-logits/`, `crates/bitnet-generation/`, `crates/bitnet-engine-core/` | #768 |
+| feat(inference): `BackendStartupSummary` — startup logs `requested=X detected=[…] selected=Y` | `crates/bitnet-inference/`, `crates/bitnet-server/` | #771 |
+| ci: standalone `grid-check` job in `ci-core.yml` running `xtask grid-check --cpu-only` | `.github/workflows/ci-core.yml` | #772 |
+| chore: CHANGELOG and CLAUDE.md docs update for PRs #765–#771 | `CHANGELOG.md`, `CLAUDE.md` | #773 |
+| test(sampling): 7 new proptests for `bitnet-sampling` (top_k, repetition_penalty, temperature entropy, multi-step, reset) | `crates/bitnet-sampling/tests/property_tests.rs` | #774 |
+| feat(ci): nightly scheduled fuzz workflow with corpus caching — 7 targets × 60 s, crash artifact upload | `.github/workflows/nightly-fuzz.yml` | #775 |
+| feat(inference): `bitnet-logits` wired as dependency of `bitnet-inference`; duplicate logits math in `generation/sampling.rs` replaced | `crates/bitnet-inference/`, `crates/bitnet-logits/` | #776 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
Updates CHANGELOG.md and `docs/reference/dual-backend-roadmap.md` for PRs #772–#776 merged to main.

## Changes
- **CHANGELOG.md**: Added 5 entries under `[Unreleased] ### Added` for #772–#776
- **dual-backend-roadmap.md**: Added 6 ✅ rows (#771–#776) to the implementation status table; updated "Last updated" header to #608–#776

## PRs documented
- #772 `ci`: BDD grid-check job in CI Core workflow
- #773 `chore`: comprehensive docs update for #765–#771
- #774 `test(sampling)`: 7 new proptests for bitnet-sampling
- #775 `feat(ci)`: nightly scheduled fuzz workflow with corpus caching
- #776 `feat(inference)`: bitnet-logits SRP integration into bitnet-inference