### PR TITLE
refactor(quantization): remove dead code and unused imports

### DIFF
--- a/crates/bitnet-quantization/src/device_aware_quantizer.rs
+++ b/crates/bitnet-quantization/src/device_aware_quantizer.rs
@@ -533,13 +533,11 @@ impl GPUQuantizer {
 #[derive(Debug, Clone)]
 pub struct AccuracyValidator {
     tolerance_config: ToleranceConfig,
-    #[allow(dead_code)]
-    reference_calculator: ReferenceCalculator,
 }
 
 impl AccuracyValidator {
     pub fn new(tolerance_config: ToleranceConfig) -> Self {
-        Self { tolerance_config, reference_calculator: ReferenceCalculator::new() }
+        Self { tolerance_config }
     }
 
     /// Validate I2S quantization accuracy with ±1e-5 relative error

--- a/crates/bitnet-quantization/src/i2s.rs
+++ b/crates/bitnet-quantization/src/i2s.rs
@@ -18,9 +18,7 @@ use bitnet_common::{
     BitNetError, BitNetTensor, QuantizationError, QuantizationType, Result, SecurityError,
     SecurityLimits, Tensor,
 };
-#[cfg(any(feature = "gpu", feature = "cuda"))]
-#[allow(unused_imports)]
-use bitnet_kernels::KernelProvider;
+
 use candle_core::Device;
 use std::sync::OnceLock;
 
@@ -234,12 +232,6 @@ impl I2SQuantizer {
     /// Legacy wrapper that defaults to CPU dequantization
     pub fn dequantize_tensor(&self, tensor: &QuantizedTensor) -> Result<BitNetTensor> {
         self.dequantize(tensor, &Device::Cpu)
-    }
-
-    #[cfg(any(feature = "gpu", feature = "cuda"))]
-    #[allow(dead_code)]
-    fn quantize_cuda(&self, tensor: &BitNetTensor) -> Result<QuantizedTensor> {
-        self.quantize_cuda_with_limits(tensor, &SecurityLimits::default())
     }
 
     #[cfg(any(feature = "gpu", feature = "cuda"))]

--- a/crates/bitnet-quantization/src/tl1.rs
+++ b/crates/bitnet-quantization/src/tl1.rs
@@ -10,9 +10,7 @@ use crate::utils::{
 };
 use crate::{QuantizedTensor, QuantizerTrait};
 use bitnet_common::{BitNetTensor, QuantizationError, QuantizationType, Result, Tensor};
-#[cfg(any(feature = "gpu", feature = "cuda"))]
-#[allow(unused_imports)]
-use bitnet_kernels::KernelProvider;
+
 use candle_core::Device;
 use rayon::prelude::*;
 use std::collections::HashMap;

--- a/crates/bitnet-quantization/src/tl2.rs
+++ b/crates/bitnet-quantization/src/tl2.rs
@@ -10,9 +10,7 @@ use crate::utils::{
 };
 use crate::{QuantizedTensor, QuantizerTrait};
 use bitnet_common::{BitNetTensor, QuantizationError, QuantizationType, Result, Tensor};
-#[cfg(any(feature = "gpu", feature = "cuda"))]
-#[allow(unused_imports)]
-use bitnet_kernels::KernelProvider;
+
 use candle_core::Device;
 use rayon::prelude::*;
 use std::{collections::HashMap, sync::RwLock};


### PR DESCRIPTION
## Summary

Audited `#[allow(dead_code)]` and `#[allow(unused_imports)]` suppressions in `crates/bitnet-quantization/src/`.

### Removed

| File | Item | Reason |
|------|------|--------|
| `i2s.rs` | `#[allow(unused_imports)] use bitnet_kernels::KernelProvider` | GPU-gated import never referenced; GPU code uses `CudaKernel` directly |
| `i2s.rs` | `fn quantize_cuda` (+ allow) | Private, dead wrapper—never called; `quantize_cuda_with_limits` is the real dispatch entry point |
| `tl1.rs` | `#[allow(unused_imports)] use bitnet_kernels::KernelProvider` | Same as above |
| `tl2.rs` | `#[allow(unused_imports)] use bitnet_kernels::KernelProvider` | Same as above |
| `device_aware_quantizer.rs` | `AccuracyValidator::reference_calculator` field (+ allow) | Private field that was assigned in `new()` but never read |

### Left unchanged

- `CPUQuantizer::tolerance_config`: genuinely stored-but-unread, but removing it would change the public `new(tolerance_config)` constructor signature (used in external tests).
- `GPUQuantizer::tolerance_config` / `device_id`: fields are conditionally used across CPU/GPU build configurations; allows are still needed in CPU-only builds.

### Verification

- `cargo build --no-default-features --features cpu -p bitnet-quantization` ✅
- `cargo clippy --no-default-features --features cpu -p bitnet-quantization -- -D warnings` ✅
- `cargo test --no-default-features --features cpu -p bitnet-quantization` ✅ (all tests pass)