### PR TITLE
chore: update docs for PRs #777-#779

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ### Changed
 - Project renamed from BitNet.rs to BitNet-rs throughout (1,531 files, 6,281 occurrences) (#755)
+- `refactor(quantization): dead code cleanup` — Removed unused `KernelProvider` imports and unused fields from `bitnet-quantization` (#779)
 
 ### Added
 - `ci: add BDD grid-check job to CI Core workflow` — Standalone `grid-check` job in `ci-core.yml` runs `xtask grid-check --cpu-only` in parallel with the build matrix (#772)
@@ -17,6 +18,7 @@ All notable changes to bitnet-rs will be documented in this file.
 - `test(sampling): expand proptest coverage for bitnet-sampling` — 7 new proptests covering top_k, repetition_penalty, temperature entropy, multi-step, and reset invariants (#774)
 - `feat(ci): nightly scheduled fuzz workflow with corpus caching` — New `.github/workflows/nightly-fuzz.yml`; runs 7 fuzz targets for 60 s nightly, caches corpus per-target, uploads crash artifacts (#775)
 - `feat(inference): wire bitnet-logits into bitnet-inference (SRP integration)` — Replaced duplicate logits math in `generation/sampling.rs` with `bitnet-logits` crate (#776)
+- `feat(ci): CUDA smoke lane weekly schedule with receipt upload` — `gpu-smoke.yml` updated with weekly schedule and receipt artifact upload (#777)
 - `feat(inference)`: BackendStartupSummary — startup logs `requested=X detected=[…] selected=Y` (#771)
 - `test(srp-crates): expanded proptest coverage for bitnet-logits, bitnet-generation, bitnet-engine-core (#768)`
 - `test(gguf): expanded property tests, snapshot tests, and unit tests for bitnet-gguf — 33 → 49 tests (#767)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ Essential guidance for working with the bitnet-rs neural network inference codeb
 - **SRP Microcrate Ecosystem** - `bitnet-logits`, `bitnet-gguf`, `bitnet-generation`, `bitnet-device-probe`, `bitnet-engine-core` wired into CI
 - **Feature Lattice** - `gpu` umbrella + `cuda` backend; orthogonal runtime reporting; CUDA-first but non-CUDA-ready
 - **Kernel Registry** - Centralized `KernelBackend`/`KernelCapabilities`/`SimdLevel` in `bitnet-common`
+- **Nightly Fuzz Workflow** — 7 fuzz targets × 60 s nightly with per-target corpus caching and crash artifact upload (`nightly-fuzz.yml`) (#775)
+- **CUDA Smoke Lane** — `gpu-smoke.yml` runs on weekly schedule, uploads receipt artifacts (#777)
 
 ### Current Limitations (MVP Phase)
 

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -120,14 +120,12 @@
 | test(sampling): 7 new proptests for `bitnet-sampling` (top_k, repetition_penalty, temperature entropy, multi-step, reset) | `crates/bitnet-sampling/tests/property_tests.rs` | #774 |
 | feat(ci): nightly scheduled fuzz workflow with corpus caching — 7 targets × 60 s, crash artifact upload | `.github/workflows/nightly-fuzz.yml` | #775 |
 | feat(inference): `bitnet-logits` wired as dependency of `bitnet-inference`; duplicate logits math in `generation/sampling.rs` replaced | `crates/bitnet-inference/`, `crates/bitnet-logits/` | #776 |
+| feat(ci): `gpu-smoke.yml` updated with weekly schedule and receipt artifact upload | `.github/workflows/gpu-smoke.yml` | #777 |
+| refactor(quantization): dead code cleanup — removed unused `KernelProvider` imports and unused fields | `crates/bitnet-quantization/` | #779 |
 
 ### 🔲 What's Planned
 
-1. **CUDA smoke lane** (self-hosted runner, nightly/manual)
-   - Allocate device, run small inference, upload parity receipt
-   - Blocked on having a CUDA-capable self-hosted runner
-
-2. **Scheduled fuzz/crossval evidence expansion**
+1. **Scheduled fuzz/crossval evidence expansion**
    - Nightly timeboxed fuzz runs with artifact upload (partially done via `fuzz-ci.yml`)
    - Real-model crossval producing receipts (gated on model download infrastructure)
 


### PR DESCRIPTION
Documentation update for recently merged PRs.

## Changes

- **CHANGELOG.md**: Added #777 (CUDA smoke lane weekly schedule + receipt upload) under `### Added`; added #779 (dead code cleanup in bitnet-quantization) under `### Changed`
- **docs/reference/dual-backend-roadmap.md**: Added ✅ rows for #777 and #779 in the implementation table; removed CUDA smoke lane from 🔲 planned (now implemented)
- **CLAUDE.md**: Added **Nightly Fuzz Workflow** and **CUDA Smoke Lane** to the "What's Working" section

PRs #772–#776 were already documented in #778.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project documentation and changelog to reflect latest development status.

* **Tests**
  * Expanded automated test coverage across sampling, inference, and quantization components.

* **Infrastructure**
  * Added nightly fuzz testing workflow with crash detection and artifact caching.
  * Added weekly GPU smoke tests with automated receipt uploads.
  * Added CI grid validation checks to core workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->