### PR TITLE
test(transformer): expand property tests for KVCache, layer independence, config validation

### DIFF
--- a/crates/bitnet-transformer/tests/property_tests.rs
+++ b/crates/bitnet-transformer/tests/property_tests.rs
@@ -120,3 +120,150 @@ proptest! {
         prop_assert_eq!(cache.seq_len, 0, "fresh LayerKVCache must have seq_len 0");
     }
 }
+
+// ── Shape invariant after N appends ──────────────────────────────────────────
+
+proptest! {
+    /// After N single-token appends, `LayerKVCache` key and value tensors
+    /// must have shape `[batch, heads, N, head_dim]`.
+    #[test]
+    fn shape_invariant_after_n_appends(
+        n_steps in 1_usize..=6,
+        batch in 1_usize..=2,
+        heads in prop_oneof![Just(1_usize), Just(2), Just(4)],
+        head_dim in prop_oneof![Just(4_usize), Just(8)],
+    ) {
+        let max_seq = n_steps + 4;
+        let mut cache = LayerKVCache::new(batch, heads, max_seq, head_dim, &Device::Cpu).unwrap();
+
+        for _ in 0..n_steps {
+            let k = zeros_kv(batch, heads, 1, head_dim);
+            let v = zeros_kv(batch, heads, 1, head_dim);
+            cache.append(&k, &v).unwrap();
+        }
+
+        let expected = [batch, heads, n_steps, head_dim];
+        prop_assert_eq!(
+            cache.k.dims(),
+            expected.as_slice(),
+            "k shape after {} appends must be {:?}", n_steps, expected
+        );
+        prop_assert_eq!(
+            cache.v.dims(),
+            expected.as_slice(),
+            "v shape after {} appends must be {:?}", n_steps, expected
+        );
+    }
+}
+
+// ── Concurrent layer independence ─────────────────────────────────────────────
+
+proptest! {
+    /// Two separate `LayerKVCache` instances are fully independent:
+    /// appending to one must not affect the other's `seq_len`.
+    #[test]
+    fn concurrent_layer_independence(
+        n_a in 1_usize..=4,
+        n_b in 1_usize..=4,
+        heads in prop_oneof![Just(1_usize), Just(2)],
+        head_dim in prop_oneof![Just(4_usize), Just(8)],
+    ) {
+        let max_seq = n_a.max(n_b) + 4;
+        let mut cache_a = LayerKVCache::new(1, heads, max_seq, head_dim, &Device::Cpu).unwrap();
+        let mut cache_b = LayerKVCache::new(1, heads, max_seq, head_dim, &Device::Cpu).unwrap();
+
+        for _ in 0..n_a {
+            let k = zeros_kv(1, heads, 1, head_dim);
+            let v = zeros_kv(1, heads, 1, head_dim);
+            cache_a.append(&k, &v).unwrap();
+        }
+        prop_assert_eq!(cache_b.seq_len, 0, "appending to cache_a must not affect cache_b");
+
+        for _ in 0..n_b {
+            let k = zeros_kv(1, heads, 1, head_dim);
+            let v = zeros_kv(1, heads, 1, head_dim);
+            cache_b.append(&k, &v).unwrap();
+        }
+
+        prop_assert_eq!(cache_a.seq_len, n_a, "cache_a seq_len must equal n_a");
+        prop_assert_eq!(cache_b.seq_len, n_b, "cache_b seq_len must equal n_b");
+    }
+}
+
+// ── KVCache layer count ────────────────────────────────────────────────────────
+
+proptest! {
+    /// `KVCache::new` creates exactly `config.model.num_layers` layers.
+    #[test]
+    fn kv_cache_layer_count(
+        n_layers in 1_usize..=6,
+        heads in prop_oneof![Just(2_usize), Just(4)],
+        head_dim in prop_oneof![Just(4_usize), Just(8)],
+    ) {
+        let cfg = valid_config(heads, head_dim, 16);
+        let mut cfg = cfg;
+        cfg.model.num_layers = n_layers;
+        let kv = KVCache::new(&cfg, 1, &Device::Cpu).unwrap();
+        prop_assert_eq!(
+            kv.layers.len(),
+            n_layers,
+            "KVCache must have exactly {} layers", n_layers
+        );
+    }
+}
+
+// ── Config validation: head divisibility ──────────────────────────────────────
+
+proptest! {
+    /// `KVCache::new` returns an error when `hidden_size` is not divisible by `num_heads`.
+    #[test]
+    fn config_validation_head_divisibility(
+        heads in prop_oneof![Just(3_usize), Just(5), Just(7)],
+    ) {
+        // heads * 4 + 1 is never divisible by heads (since heads > 1)
+        let hidden_size = heads * 4 + 1;
+        let mut cfg = BitNetConfig::default();
+        cfg.model.num_layers = 1;
+        cfg.model.num_heads = heads;
+        cfg.model.num_key_value_heads = heads;
+        cfg.model.hidden_size = hidden_size;
+        cfg.model.max_position_embeddings = 16;
+        cfg.model.vocab_size = 32;
+
+        let result = KVCache::new(&cfg, 1, &Device::Cpu);
+        prop_assert!(
+            result.is_err(),
+            "KVCache must reject hidden_size={} not divisible by num_heads={}", hidden_size, heads
+        );
+    }
+}
+
+// ── seq_len monotonically increases ───────────────────────────────────────────
+
+proptest! {
+    /// After each multi-token append to `LayerKVCache`, `seq_len` increases
+    /// by exactly the number of tokens appended.
+    #[test]
+    fn seq_len_monotonically_increases(
+        n_steps in 1_usize..=5,
+        tokens_per_step in prop_oneof![Just(1_usize), Just(2), Just(3)],
+        heads in prop_oneof![Just(1_usize), Just(2)],
+        head_dim in prop_oneof![Just(4_usize), Just(8)],
+    ) {
+        let max_seq = n_steps * tokens_per_step + 4;
+        let mut cache = LayerKVCache::new(1, heads, max_seq, head_dim, &Device::Cpu).unwrap();
+
+        let mut expected_seq_len = 0_usize;
+        for step in 1..=n_steps {
+            let k = zeros_kv(1, heads, tokens_per_step, head_dim);
+            let v = zeros_kv(1, heads, tokens_per_step, head_dim);
+            cache.append(&k, &v).unwrap();
+            expected_seq_len += tokens_per_step;
+            prop_assert_eq!(
+                cache.seq_len,
+                expected_seq_len,
+                "seq_len after step {} must be {}", step, expected_seq_len
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds 5 new property-based tests to `crates/bitnet-transformer/tests/property_tests.rs`, expanding coverage of `KVCache` and `LayerKVCache` invariants.

## New Tests

| Test | Invariant |
|---|---|
| `shape_invariant_after_n_appends` | After N single-token appends, `k` and `v` tensors have shape `[batch, heads, N, head_dim]` |
| `concurrent_layer_independence` | Two separate `LayerKVCache` instances never share state |
| `kv_cache_layer_count` | `KVCache::new` creates exactly `config.num_layers` layers |
| `config_validation_head_divisibility` | `KVCache::new` returns an error when `hidden_size % num_heads != 0` |
| `seq_len_monotonically_increases` | Each append increases `seq_len` by exactly the appended token count |

## Test Results

All 9 property tests pass (4 pre-existing + 5 new):

```
running 9 tests
test config_validation_head_divisibility ... ok
test layer_kv_cache_initial_seq_len_is_always_zero ... ok
test kv_cache_layer_count ... ok
test kv_cache_clear_resets_seq_len ... ok
test seq_len_monotonically_increases ... ok
test shape_invariant_after_n_appends ... ok
test kv_cache_seq_len_equals_append_count ... ok
test layer_kv_cache_rejects_overflow ... ok
test concurrent_layer_independence ... ok

test result: ok. 9 passed; 0 failed; 0 ignored
```

`cargo fmt` and `cargo clippy -- -D warnings` both clean.