### PR TITLE
ci: add fuzz/** to ci-core.yml path triggers

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -2,7 +2,7 @@ name: CI (Core)
 
 # Core gating checks that MUST pass for PR merges (Linux-only).
 # This workflow is designed to be fast, reliable, and reproducible locally via ci/local.sh
-# Note: This workflow triggers on changes to crates/**, crossval/**, tests/**, xtask/**, Cargo.{toml,lock}, .github/workflows/**, .github/pull_request_template.md, .github/ISSUE_TEMPLATE/**, README.md, docs/**, SECURITY.md
+# Note: This workflow triggers on changes to crates/**, crossval/**, tests/**, xtask/**, fuzz/**, Cargo.{toml,lock}, .github/workflows/**, .github/pull_request_template.md, .github/ISSUE_TEMPLATE/**, README.md, docs/**, SECURITY.md
 # Workflow hardening: concurrency + timeouts applied across all workflows in #485
 
 on:
@@ -26,6 +26,7 @@ on:
       - 'CONTRIBUTING.md'
       - 'SECURITY.md'
       - '.github/settings.yml'
+      - 'fuzz/**'
   push:
     branches: [ main ]
     paths:
@@ -46,6 +47,7 @@ on:
       - 'CONTRIBUTING.md'
       - 'SECURITY.md'
       - '.github/settings.yml'
+      - 'fuzz/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Problem

Fuzz target PRs (changes to `fuzz/**`) were not triggering the required CI checks (Build & Test, Clippy, Documentation, CI Core Success, Guards). This left fuzz PRs in a permanently unmergeable state.

## Fix

Add `fuzz/**` to both `pull_request.paths` and `push.paths` in `ci-core.yml`.

## Impact

- PRs touching only `fuzz/fuzz_targets/*.rs` or `fuzz/Cargo.toml` will now trigger the full CI gate
- Unblocks PR #799 (gguf_metadata_values fuzz target) and any future fuzz PRs

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to automatically run on additional test-related changes, ensuring broader test coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->