### PR TITLE
chore: fix stale MSRV cache key in compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Cache (MSRV)
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          # MSRV-specific key to avoid collisions with 1.90/stable
-          shared-key: msrv-1_89
+          # MSRV-specific key to avoid collisions with stable
+          shared-key: msrv-1_92
 
       - name: Warm fetch (locked)
         run: cargo fetch --locked


### PR DESCRIPTION
## Summary

The `shared-key` in the MSRV job of `.github/workflows/compatibility.yml` was left as `msrv-1_89` after the MSRV was bumped to **1.92.0**. This stale key means the CI cache could collide with (or be confused by) artifacts from the old 1.89 toolchain.

## Change

```diff
-          shared-key: msrv-1_89
+          shared-key: msrv-1_92
```

## Verification

All other MSRV references are already consistent at 1.92.0:
- `rust-toolchain.toml`: `channel = "1.92.0"` ✅
- `Cargo.toml` workspace `rust-version`: `"1.92.0"` ✅
- `README.md` badge: `MSRV-1.92.0` ✅
- `CLAUDE.md`: `MSRV: 1.92.0` ✅
- `contracts.yml` toolchain: `"1.92.0"` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for Rust version compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->