### PR TITLE
🛡️ Sentinel: Fix rate limiter memory leak

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -322,7 +322,8 @@ impl BitNetServer {
             let mut interval = tokio::time::interval(Duration::from_secs(300)); // 5 minutes
             loop {
                 interval.tick().await;
-                concurrency_manager.cleanup_rate_limiters().await;
+                // Cleanup rate limiters inactive for 1 hour
+                concurrency_manager.cleanup_rate_limiters(Duration::from_secs(3600)).await;
             }
         });
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix potential memory leak in rate limiter

**Vulnerability:** The `ConcurrencyManager` stored per-IP rate limiters indefinitely, leading to unbounded memory growth (CWE-400) as new client IPs connected. The `cleanup_rate_limiters` method was a placeholder.

**Impact:** Long-running servers exposed to many unique client IPs could eventually exhaust memory, leading to a Denial of Service (DoS).

**Fix:**
1. Implemented `cleanup_rate_limiters` to remove rate limiters inactive for a specified duration.
2. Configured the server to run this cleanup every 5 minutes, removing entries older than 1 hour.
3. Added `per_ip_limiter_count` to stats for verification and monitoring.

**Verification:** Added a unit test `test_rate_limiter_cleanup` confirming that stale limiters are removed while active ones remain.

---
*PR created automatically by Jules for task [4545900307339484324](https://jules.google.com/task/4545900307339484324) started by @EffortlessSteven*