### PR TITLE
docs: changelog and roadmap for PRs #813-#815

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to bitnet-rs will be documented in this file.
 - `chore: fix stale MSRV cache key in compatibility workflow (1.89 → 1.92)` — prevents incorrect CI cache hits from cached 1.89 toolchain artifacts (#805)
 
 ### Added
+- `feat(fuzz): add safetensors parser fuzz targets` — `fuzz/fuzz_targets/safetensors_metadata.rs` targets `SafeTensors::read_metadata()` header path; `fuzz/fuzz_targets/safetensors_parser.rs` replaced original stub; `fuzz/Cargo.toml` updated (#813)
+- `test(bdd): expand BDD grid coverage` — 5 new BDD grid cells added in `crates/bitnet-bdd-grid/src/lib.rs` (Unit/Ci, Integration/Ci, Performance/Local, Development/Local, Smoke/Ci); grid snapshot count updated from 8 to 13 (#814)
+- `test: add proptest coverage for bitnet-ffi` — `crates/bitnet-ffi/tests/property_tests.rs` with 31 tests (25 proptest + 6 unit): BitNetCConfig/BitNetCInferenceConfig round-trips, BitNetCError display invariants, MemoryStats arithmetic, thread-local error state (#815)
 - `test: add proptest coverage for bitnet-logits and bitnet-generation` — temperature scaling, softmax invariants, top-k filtering, repetition penalty (bitnet-logits); stop criteria, token accumulation, streaming order (bitnet-generation) (#806)
 - `feat(fuzz): add tokenizer_encode_decode fuzz target` — covers BasicTokenizer, UniversalTokenizer, wrapper tokenizers, and HfTokenizer BPE round-trips (#807)
 - `test: add 22 proptest cases for bitnet-quantization` — TL1/TL2/I2_S round-trip bounded error, scale positivity, block alignment, and edge cases (all-zeros, alternating signs) (#808)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#808.
+> **Last updated**: reflects implementation state after PRs #608–#815.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -144,6 +144,9 @@
 | test: add proptest coverage for bitnet-logits (temperature scaling, softmax invariants, top-k filtering, repetition penalty) and bitnet-generation (stop criteria, token accumulation, streaming order) | `crates/bitnet-logits/tests/property_tests.rs`, `crates/bitnet-generation/tests/property_tests.rs` | #806 |
 | feat(fuzz): add tokenizer_encode_decode fuzz target covering BasicTokenizer, UniversalTokenizer, wrapper tokenizers, and HfTokenizer BPE round-trips | `fuzz/fuzz_targets/tokenizer_encode_decode.rs` | #807 |
 | test: add 22 proptest cases for bitnet-quantization — TL1/TL2/I2_S round-trip bounded error, scale positivity, block alignment, and edge cases (all-zeros, alternating signs) | `crates/bitnet-quantization/tests/property_tests.rs` | #808 |
+| feat(fuzz): safetensors parser fuzz targets — `safetensors_metadata.rs` (header path) and `safetensors_parser.rs` (full parse); `fuzz/Cargo.toml` updated | `fuzz/fuzz_targets/safetensors_metadata.rs`, `fuzz/fuzz_targets/safetensors_parser.rs` | #813 |
+| test(bdd): 5 new BDD grid cells (Unit/Ci, Integration/Ci, Performance/Local, Development/Local, Smoke/Ci); snapshot count 8→13 | `crates/bitnet-bdd-grid/src/lib.rs` | #814 |
+| test(proptest): 31 property + unit tests for `bitnet-ffi` — BitNetCConfig/BitNetCInferenceConfig round-trips, BitNetCError display, MemoryStats arithmetic, thread-local error state | `crates/bitnet-ffi/tests/property_tests.rs` | #815 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Documents three PRs merged to main:

- **#813** safetensors parser fuzz targets — safetensors_metadata.rs targets the header path; safetensors_parser.rs replaces original stub; fuzz/Cargo.toml updated.
- **#814** BDD grid expansion — 5 new grid cells (Unit/Ci, Integration/Ci, Performance/Local, Development/Local, Smoke/Ci); snapshot count 8 to 13.
- **#815** proptest coverage for bitnet-ffi — 31 tests (25 proptest + 6 unit): config round-trips, error display invariants, MemoryStats arithmetic, thread-local error state.

## Changes

- CHANGELOG.md: Added entries for #813, #814, #815 under [Unreleased] / Added
- docs/reference/dual-backend-roadmap.md: Bumped Last updated to #815; added 3 rows to implementation table