### PR TITLE
test: proptest coverage for bitnet-kernels

### DIFF
--- a/crates/bitnet-kernels/tests/property_tests.rs
+++ b/crates/bitnet-kernels/tests/property_tests.rs
@@ -6,6 +6,11 @@
 //! - `FallbackKernel::quantize()`: output shape matches input for valid sizes
 //! - `device_features::gpu_compiled()`: deterministic (constant) across calls
 //! - `select_cpu_kernel()`: always succeeds and returns a valid provider
+//! - `SimdLevel`: ordering is reflexive, total, and has consistent fundamental invariants
+//! - MatMul dimensions: rows×cols ≤ usize::MAX for valid inputs up to 4096×4096
+//! - `KernelCapabilities`: compiled_backends() reflects the fields set in the snapshot
+//! - `device_capability_summary()`: always reports CPU available
+//! - `current_kernel_capabilities()`: cpu_rust matches the `cpu` feature flag
 
 use bitnet_common::QuantizationType;
 use bitnet_kernels::KernelProvider;
@@ -127,5 +132,142 @@ proptest! {
         let second = gpu_compiled();
         prop_assert_eq!(first, second,
             "gpu_compiled() must be a constant (compile-time predicate)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for new property tests
+// ---------------------------------------------------------------------------
+
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+
+fn arb_simd_level() -> impl Strategy<Value = SimdLevel> {
+    prop_oneof![
+        Just(SimdLevel::Scalar),
+        Just(SimdLevel::Neon),
+        Just(SimdLevel::Sse42),
+        Just(SimdLevel::Avx2),
+        Just(SimdLevel::Avx512),
+    ]
+}
+
+fn arb_caps() -> impl Strategy<Value = KernelCapabilities> {
+    (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>(), arb_simd_level()).prop_map(
+        |(cpu_rust, cuda_compiled, cuda_runtime, cpp_ffi, simd_level)| KernelCapabilities {
+            cpu_rust,
+            cuda_compiled,
+            cuda_runtime,
+            cpp_ffi,
+            simd_level,
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Properties: SimdLevel ordering
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// SimdLevel ordering is reflexive: every level compares equal to itself.
+    #[test]
+    fn prop_simd_level_ordering_reflexive(level in arb_simd_level()) {
+        prop_assert!(level <= level, "SimdLevel ordering must be reflexive");
+        prop_assert!(level >= level, "SimdLevel ordering must be reflexive");
+    }
+
+    /// SimdLevel ordering is total: for any two levels a ≤ b or b ≤ a.
+    #[test]
+    fn prop_simd_level_ordering_total(a in arb_simd_level(), b in arb_simd_level()) {
+        prop_assert!(a <= b || b <= a,
+            "SimdLevel ordering must be total: {a:?} vs {b:?}");
+    }
+
+    /// Fundamental ordering invariants: Scalar < Avx2 < Avx512 (and transitivity).
+    #[test]
+    fn prop_simd_level_fundamental_order(_seed in 0u32..1u32) {
+        prop_assert!(SimdLevel::Scalar < SimdLevel::Avx2,
+            "Scalar must be strictly less than Avx2");
+        prop_assert!(SimdLevel::Avx2 < SimdLevel::Avx512,
+            "Avx2 must be strictly less than Avx512");
+        prop_assert!(SimdLevel::Scalar < SimdLevel::Avx512,
+            "Scalar < Avx512 must hold (transitivity)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: MatMul dimensions
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// Matrix dimensions up to 4096×4096 do not overflow usize.
+    ///
+    /// This is a precondition for safe buffer allocation in matmul kernels.
+    #[test]
+    fn prop_matmul_dims_no_overflow(rows in 1usize..=4096, cols in 1usize..=4096) {
+        let product = rows.checked_mul(cols);
+        prop_assert!(product.is_some(),
+            "rows={rows} * cols={cols} must not overflow usize");
+        prop_assert!(
+            product.unwrap() <= isize::MAX as usize,
+            "rows*cols must fit within isize::MAX for pointer-arithmetic safety"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: KernelCapabilities round-trips
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// When cpu_rust=true the compiled_backends snapshot includes CpuRust.
+    #[test]
+    fn prop_kernel_caps_cpu_rust_appears_in_compiled_backends(
+        cuda_compiled in any::<bool>(),
+        cpp_ffi in any::<bool>(),
+    ) {
+        let caps = KernelCapabilities {
+            cpu_rust: true,
+            cuda_compiled,
+            cuda_runtime: false,
+            cpp_ffi,
+            simd_level: SimdLevel::Scalar,
+        };
+        let backends = caps.compiled_backends();
+        prop_assert!(backends.contains(&KernelBackend::CpuRust),
+            "cpu_rust=true must produce CpuRust in compiled_backends(); got {backends:?}");
+    }
+
+    /// When cuda_compiled=false the snapshot never contains Cuda backend.
+    #[test]
+    fn prop_kernel_caps_no_cuda_backend_when_not_compiled(caps in arb_caps()) {
+        // Force cuda_compiled = false, keep other fields
+        let caps = KernelCapabilities { cuda_compiled: false, ..caps };
+        let backends = caps.compiled_backends();
+        prop_assert!(!backends.contains(&KernelBackend::Cuda),
+            "Cuda must not appear in compiled_backends when cuda_compiled=false; got {backends:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: device_capability_summary and current_kernel_capabilities
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// device_capability_summary() always reports CPU is available.
+    #[test]
+    fn prop_device_capability_summary_always_has_cpu(_seed in 0u32..10u32) {
+        let summary = bitnet_kernels::device_features::device_capability_summary();
+        prop_assert!(summary.contains("CPU \u{2713}"),
+            "capability summary must always include 'CPU ✓'; got: {summary:?}");
+    }
+
+    /// current_kernel_capabilities().cpu_rust reflects the `cpu` feature flag.
+    #[test]
+    fn prop_current_kernel_caps_cpu_rust_matches_feature(_seed in 0u32..10u32) {
+        let caps = bitnet_kernels::device_features::current_kernel_capabilities();
+        let expected = cfg!(feature = "cpu");
+        prop_assert_eq!(caps.cpu_rust, expected,
+            "cpu_rust must equal cfg!(feature = \"cpu\"); \
+             got cpu_rust={} expected={}", caps.cpu_rust, expected);
     }
 }


### PR DESCRIPTION
## Summary

Adds 8 new property-based tests to `crates/bitnet-kernels/tests/property_tests.rs`, expanding the suite from 8 → 16 tests.

## New tests

| Test | Invariant |
|------|-----------|
| `prop_simd_level_ordering_reflexive` | `SimdLevel` ordering is reflexive (`a <= a`) for all variants |
| `prop_simd_level_ordering_total` | `SimdLevel` ordering is total: for any `a`, `b` — `a <= b || b <= a` |
| `prop_simd_level_fundamental_order` | `Scalar < Avx2 < Avx512` and transitivity hold |
| `prop_matmul_dims_no_overflow` | `rows * cols` ≤ `usize::MAX` for any dims ≤ 4096×4096 |
| `prop_kernel_caps_cpu_rust_appears_in_compiled_backends` | `cpu_rust=true` round-trips through `KernelCapabilities::compiled_backends()` |
| `prop_kernel_caps_no_cuda_backend_when_not_compiled` | `cuda_compiled=false` → no `Cuda` entry in `compiled_backends()` |
| `prop_device_capability_summary_always_has_cpu` | `device_capability_summary()` always contains `"CPU ✓"` |

## Verification

```
cargo test -p bitnet-kernels --no-default-features --features cpu --test property_tests
...
running 16 tests
... all ok ...
test result: ok. 16 passed; 0 failed; 0 ignored
```