### PR TITLE
test: expand property test coverage for bitnet-tokenizers

### DIFF
--- a/crates/bitnet-tokenizers/tests/property_tests.rs
+++ b/crates/bitnet-tokenizers/tests/property_tests.rs
@@ -207,3 +207,128 @@ proptest! {
         );
     }
 }
+
+// ── New expanded property tests ───────────────────────────────────────────────
+
+proptest! {
+    // Focus area 1: Token encoding length — at least 1 token, at most 4× char count.
+    // BasicTokenizer is byte-level: tokens == bytes, bytes ≤ 4× Unicode chars.
+    // Tests multi-byte UTF-8 characters (é, ñ) that produce more bytes than chars.
+    #[test]
+    fn prop_utf8_token_count_bounded_by_4x_chars(
+        text in "[a-z\u{00E9}\u{00F1}\u{4E2D}\u{6587}]{1,20}",
+    ) {
+        let t = BasicTokenizer::new(); // vocab_size=50257, all bytes 0–255 are valid
+        let tokens = t.encode(&text, false, false).expect("encode should succeed");
+        let char_count = text.chars().count();
+        prop_assert!(!tokens.is_empty(),
+            "non-empty text must produce at least 1 token");
+        prop_assert!(tokens.len() <= char_count * 4,
+            "token count {} must be ≤ 4× char count {}", tokens.len(), char_count);
+    }
+
+    // Focus area 2: Special token handling — bos/eos accessors return exactly what
+    // was configured, never a different value. Any Some(u32) is a valid u32.
+    #[test]
+    fn prop_bos_eos_accessor_matches_config(
+        vocab_size in 1000usize..100_000usize,
+        bos_id in 0u32..512u32,
+        eos_id in 512u32..1024u32,
+    ) {
+        let t = BasicTokenizer::with_config(vocab_size, Some(bos_id), Some(eos_id), None);
+        prop_assert_eq!(t.bos_token_id(), Some(bos_id),
+            "bos_token_id() must equal configured bos_id");
+        prop_assert_eq!(t.eos_token_id(), Some(eos_id),
+            "eos_token_id() must equal configured eos_id");
+    }
+
+    // Focus area 3: Vocabulary size invariants — vocab_size() always equals what
+    // was passed to with_config for any positive value.
+    #[test]
+    fn prop_vocab_size_equals_configured_value(
+        vocab_size in 1usize..500_000usize,
+    ) {
+        let t = BasicTokenizer::with_config(vocab_size, None, None, None);
+        prop_assert_eq!(t.vocab_size(), vocab_size,
+            "vocab_size() must equal the value passed to with_config");
+        prop_assert!(t.vocab_size() > 0,
+            "vocab_size() must always be positive");
+    }
+
+    // Focus area 4: Encode-decode consistency — every token produced by encode
+    // can be decoded individually (via decode(&[id])) without error.
+    #[test]
+    fn prop_each_encoded_token_individually_decodable(
+        text in "[a-z]{1,32}",
+    ) {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode should succeed");
+        for &tok in &tokens {
+            let result = t.decode(&[tok]);
+            prop_assert!(result.is_ok(),
+                "decode of single token {} must not fail", tok);
+        }
+    }
+
+    // Focus area 5: Config validation — TokenizerBuilder::from_file with a
+    // path into a non-existent directory must return Err, not panic.
+    #[test]
+    fn prop_missing_tokenizer_file_returns_err(
+        name in "[a-z]{12,20}",
+    ) {
+        // The parent directory itself does not exist, so the file definitely doesn't.
+        let path = std::path::PathBuf::from(format!(
+            "/tmp/bitnet_proptest_nonexistent_{}/tokenizer.json",
+            name
+        ));
+        let result = bitnet_tokenizers::TokenizerBuilder::from_file(&path);
+        prop_assert!(result.is_err(),
+            "loading from a non-existent path must return Err, not panic");
+    }
+
+    // Focus area 6: Token string round-trip — token_to_piece is deterministic:
+    // calling it twice with the same id returns the same result.
+    #[test]
+    fn prop_token_to_piece_is_deterministic(
+        id in 0u32..50257u32,
+    ) {
+        let t = BasicTokenizer::new();
+        let first = t.token_to_piece(id);
+        let second = t.token_to_piece(id);
+        prop_assert_eq!(first, second,
+            "token_to_piece({}) must return the same value on repeated calls", id);
+    }
+
+    // Bonus: EOS appended when add_special=true.
+    // When eos_token_id is configured and add_special=true, the final token of
+    // any non-empty encoding must be the EOS id.
+    #[test]
+    fn prop_eos_appended_when_add_special(
+        text in "[a-zA-Z]{1,32}",
+        eos_id in 256u32..50257u32,
+    ) {
+        let t = BasicTokenizer::with_config(50257, None, Some(eos_id), None);
+        let tokens = t.encode(&text, false, true).expect("encode should succeed");
+        prop_assert!(!tokens.is_empty(),
+            "non-empty text must produce at least 1 token");
+        prop_assert_eq!(*tokens.last().unwrap(), eos_id,
+            "last token must be EOS id {} when add_special=true", eos_id);
+    }
+
+    // Bonus: encode and decode are both deterministic (same input → same output).
+    #[test]
+    fn prop_encode_and_decode_are_deterministic(
+        text in "[a-z]{1,48}",
+    ) {
+        let t = BasicTokenizer::new();
+        let first_enc = t.encode(&text, false, false).expect("first encode");
+        let second_enc = t.encode(&text, false, false).expect("second encode");
+        prop_assert_eq!(&first_enc, &second_enc,
+            "encode must be deterministic for {:?}", text);
+
+        let first_dec = t.decode(&first_enc).expect("first decode");
+        let second_dec = t.decode(&first_enc).expect("second decode");
+        prop_assert_eq!(first_dec, second_dec,
+            "decode must be deterministic");
+    }
+}


### PR DESCRIPTION
## Summary

Expands property-based test coverage for the `bitnet-tokenizers` crate with 8 new `proptest` tests covering all 6 requested focus areas.

## New tests (8 added, 22 total)

| Test | Focus area |
|------|-----------|
| `prop_utf8_token_count_bounded_by_4x_chars` | Token encoding length — covers multi-byte UTF-8 (é, ñ, 中); asserts `1 ≤ tokens ≤ 4 × chars` |
| `prop_bos_eos_accessor_matches_config` | Special token handling — `bos_token_id()`/`eos_token_id()` return exactly the configured value |
| `prop_vocab_size_equals_configured_value` | Vocabulary size invariants — `vocab_size()` always equals configured value and is always > 0 |
| `prop_each_encoded_token_individually_decodable` | Encode-decode consistency — every token ID from `encode` can be individually decoded without error |
| `prop_missing_tokenizer_file_returns_err` | Config validation — `TokenizerBuilder::from_file` with missing file returns `Err`, never panics |
| `prop_token_to_piece_is_deterministic` | Token string round-trip — `token_to_piece(id)` is pure/deterministic |
| `prop_eos_appended_when_add_special` | Bonus: EOS id is always last token when `add_special=true` |
| `prop_encode_and_decode_are_deterministic` | Bonus: encode and decode are both pure functions |

## Verification

```
cargo test -p bitnet-tokenizers --no-default-features --features cpu --test property_tests
running 22 tests ... test result: ok. 22 passed; 0 failed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive expansion of test coverage for tokenizer functionality, adding validation tests for token encoding bounds relative to input size, accessor value correctness, vocabulary size consistency, encode-decode round-trip reliability with various inputs, error handling for missing configuration files, determinism of repeated token operations, and special token behavior with different configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->