### PR TITLE
test: proptest coverage for bitnet-validation

### DIFF
--- a/crates/bitnet-validation/tests/property_tests.rs
+++ b/crates/bitnet-validation/tests/property_tests.rs
@@ -4,7 +4,8 @@
 //! factories against adversarial and fuzz-like string inputs.
 
 use bitnet_validation::{
-    detect_rules, is_ln_gamma, rules_bitnet_b158_f16, rules_bitnet_b158_i2s, rules_generic,
+    detect_rules, is_ln_gamma, load_policy, rules_bitnet_b158_f16, rules_bitnet_b158_i2s,
+    rules_generic,
 };
 use proptest::prelude::*;
 
@@ -107,6 +108,125 @@ proptest! {
     ) {
         let ruleset = detect_rules(&arch, file_type);
         prop_assert!(!ruleset.name.is_empty());
+    }
+}
+
+// ── Additional property tests ────────────────────────────────────────────────
+
+proptest! {
+    /// LayerNorm gamma invariant: any RMS within 0.01..=2.0 is accepted for
+    /// `attn_norm` weights in the I2_S ruleset (min=0.01, max=2.0).
+    #[test]
+    fn check_ln_accepts_in_range_rms_for_i2s_attn_norm(rms in 0.01f32..=2.0f32) {
+        let r = rules_bitnet_b158_i2s();
+        prop_assert!(
+            r.check_ln("blk.0.attn_norm.weight", rms),
+            "i2s attn_norm should accept rms={rms}"
+        );
+    }
+
+    /// LayerNorm gamma invariant: any RMS strictly below 0.01 is rejected for
+    /// `attn_norm` weights in the I2_S ruleset (min=0.01).
+    #[test]
+    fn check_ln_rejects_below_min_for_i2s_attn_norm(rms in 0.0001f32..0.0099f32) {
+        let r = rules_bitnet_b158_i2s();
+        prop_assert!(
+            !r.check_ln("blk.0.attn_norm.weight", rms),
+            "i2s attn_norm should reject rms={rms} (below min 0.01)"
+        );
+    }
+
+    /// LayerNorm gamma invariant: projection RMS above 0.40 is always rejected
+    /// in the F16 ruleset (proj_weight_rms_max = 0.40).
+    #[test]
+    fn check_proj_rms_rejects_above_max_for_f16(rms in 0.401f32..=100.0f32) {
+        let r = rules_bitnet_b158_f16();
+        prop_assert!(
+            !r.check_proj_rms(rms),
+            "f16 ruleset should reject proj rms={rms} (above max 0.40)"
+        );
+    }
+
+    /// Error message formatting: when `load_policy` fails because a key is
+    /// absent, the error message is always non-empty.
+    #[test]
+    fn load_policy_missing_key_has_nonempty_error_message(
+        key in "[a-z]{2,8}:[a-z]{2,8}",
+    ) {
+        // Sentinel key can never match the generated `key` (contains uppercase).
+        let yaml = "version: 1\nrules:\n  \"SENTINEL__\":\n    ln: []\n";
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), yaml).unwrap();
+        let err = load_policy(tmp.path(), &key).unwrap_err();
+        prop_assert!(
+            !err.to_string().is_empty(),
+            "error message should be non-empty for missing key {key:?}"
+        );
+    }
+
+    /// Policy key format: a key of the form "arch:variant" stored in the YAML
+    /// is successfully retrieved by `load_policy`.
+    #[test]
+    fn load_policy_arch_colon_variant_key_round_trips(
+        arch in "[a-z]{3,8}",
+        variant in "[a-z0-9]{2,8}",
+    ) {
+        let key = format!("{arch}:{variant}");
+        let yaml = format!("version: 1\nrules:\n  \"{key}\":\n    ln: []\n");
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), yaml.as_bytes()).unwrap();
+        let result = load_policy(tmp.path(), &key);
+        prop_assert!(
+            result.is_ok(),
+            "arch:variant key {key:?} should succeed; got: {:?}",
+            result.err()
+        );
+    }
+
+    /// Policy key format: the empty string key is never found in a policy that
+    /// stores only non-empty keys.
+    #[test]
+    fn load_policy_empty_key_is_not_found(
+        stored_key in "[a-z]{2,10}",
+    ) {
+        let yaml = format!("version: 1\nrules:\n  \"{stored_key}\":\n    ln: []\n");
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), yaml.as_bytes()).unwrap();
+        let result = load_policy(tmp.path(), "");
+        prop_assert!(result.is_err(), "empty key should not match stored key {stored_key:?}");
+    }
+
+    /// Validation gate modes: `detect_rules` with any arch containing "bitnet"
+    /// and file_type=1 always dispatches to the F16 ruleset.
+    #[test]
+    fn detect_rules_bitnet_arch_file_type_1_gives_f16(
+        prefix in "[a-z]{0,4}",
+        suffix in "[a-z]{0,4}",
+    ) {
+        let arch = format!("{prefix}bitnet{suffix}");
+        let r = detect_rules(&arch, 1);
+        prop_assert_eq!(
+            r.name.as_str(),
+            "bitnet-b1.58:f16",
+            "arch={:?} with file_type=1 should give f16 ruleset",
+            arch
+        );
+    }
+
+    /// Validation gate modes: `detect_rules` with a non-bitnet arch string
+    /// always falls back to the generic ruleset.
+    #[test]
+    fn detect_rules_non_bitnet_arch_gives_generic(
+        arch in "[a-z]{4,12}".prop_filter("not bitnet", |s| !s.contains("bitnet")),
+        file_type in 0u32..=10u32,
+    ) {
+        let r = detect_rules(&arch, file_type);
+        prop_assert_eq!(
+            r.name.as_str(),
+            "generic",
+            "arch={:?} should give generic ruleset",
+            arch
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Adds 8 new property-based tests to `crates/bitnet-validation/tests/property_tests.rs`, covering all six requested focus areas.

## New tests

| Test | Focus area |
|---|---|
| `check_ln_accepts_in_range_rms_for_i2s_attn_norm` | LayerNorm gamma invariants |
| `check_ln_rejects_below_min_for_i2s_attn_norm` | LayerNorm gamma invariants |
| `check_proj_rms_rejects_above_max_for_f16` | LayerNorm gamma invariants |
| `load_policy_missing_key_has_nonempty_error_message` | Error message formatting |
| `load_policy_arch_colon_variant_key_round_trips` | Policy key format |
| `load_policy_empty_key_is_not_found` | Policy key format |
| `detect_rules_bitnet_arch_file_type_1_gives_f16` | Validation gate modes |
| `detect_rules_non_bitnet_arch_gives_generic` | Validation gate modes |

## Notes on focus area mapping

The crate has no `ValidationResult` type or GGUF magic-byte parser, so those two focus areas were mapped to the closest real types: `load_policy -> anyhow::Result` for error invariants, and `detect_rules` dispatch for gate modes.

## Test results

```
running 18 tests ... test result: ok. 18 passed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>