### PR TITLE
docs: changelog and roadmap for PRs #820-#826

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to bitnet-rs will be documented in this file.
 - `chore: fix stale MSRV cache key in compatibility workflow (1.89 → 1.92)` — prevents incorrect CI cache hits from cached 1.89 toolchain artifacts (#805)
 
 ### Added
+- `test: proptest coverage for bitnet-common` — 9 new property tests in `crates/bitnet-common/tests/property_tests.rs` (MockTensor shapes, QuantizationType round-trips, error types, device consistency, KernelCapabilities ordering, warn_once deduplication) (#826)
+- `test: expand proptest coverage for bitnet-sampling` — 7 new property tests in `crates/bitnet-sampling/tests/property_tests.rs` (temperature scaling, top-k/p filtering, repetition penalty, seed reproducibility, empty context, greedy determinism) (#825)
 - `test: proptest coverage for bitnet-receipts` — 14 new proptests in `crates/bitnet-receipts/tests/property_tests.rs` (schema version, builder, JSON round-trips, kernel ID validation, honest compute gates, token counts) (#823)
 - `test: proptest coverage for bitnet-validation` — 8 new proptests in `crates/bitnet-validation/tests/property_tests.rs` (LayerNorm bounds, error messages, policy keys, gate modes) (#822)
 - `test: proptest coverage for bitnet-models` — 13 new proptests in `crates/bitnet-models/tests/property_tests.rs` (ModelConfig validation, GgufTensorType element sizes, GGUF magic bytes, path safety) (#821)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#823.
+> **Last updated**: reflects implementation state after PRs #608–#826.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---


### PR DESCRIPTION
## Summary

Updates documentation to reflect PRs #825–#826 merged to main (PRs #819–#823 were documented in #824).

### Changes
- **CHANGELOG.md**: Added 2 entries under `[Unreleased] > Added`:
  - #826 `test: proptest coverage for bitnet-common` — 9 new property tests (MockTensor shapes, QuantizationType round-trips, error types, device consistency, KernelCapabilities ordering, warn_once deduplication)
  - #825 `test: expand proptest coverage for bitnet-sampling` — 7 new property tests (temperature scaling, top-k/p filtering, repetition penalty, seed reproducibility, empty context, greedy determinism)
- **docs/reference/dual-backend-roadmap.md**: Bumped "Last updated" from `#608–#823` → `#608–#826`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added 9 new property tests for bitnet-common
  * Added 7 new property tests for bitnet-sampling

* **Documentation**
  * Updated dual-backend roadmap reference documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->