### PR TITLE
feat(fuzz): add transformer_config and gguf_kv_read fuzz targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -137,3 +137,15 @@ name = "quantization_input"
 path = "fuzz_targets/quantization_input.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "transformer_config"
+path = "fuzz_targets/transformer_config.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gguf_kv_read"
+path = "fuzz_targets/gguf_kv_read.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/gguf_kv_read.rs
+++ b/fuzz/fuzz_targets/gguf_kv_read.rs
@@ -1,0 +1,103 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_gguf::{GgufValueType, check_magic, parse_header, read_version};
+use bitnet_models::GgufReader;
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz input representing one GGUF key-value entry inside a synthetic GGUF stream.
+#[derive(Arbitrary, Debug)]
+struct GgufKvInput {
+    /// Arbitrary key bytes (may not be valid UTF-8 — the parser must handle it).
+    key: Vec<u8>,
+    /// Arbitrary value payload bytes.
+    value_bytes: Vec<u8>,
+    /// Raw value-type discriminant written into the stream.
+    value_type: u8,
+    /// Additional random bytes appended after the KV entry to stress the parser.
+    trailing: Vec<u8>,
+}
+
+fuzz_target!(|input: GgufKvInput| {
+    // Cap sizes to avoid OOM / timeout while still exercising boundary conditions.
+    if input.key.len() > 512 || input.value_bytes.len() > 4096 || input.trailing.len() > 256 {
+        return;
+    }
+
+    let buf = build_gguf_with_kv(&input.key, &input.value_bytes, input.value_type, &input.trailing);
+
+    // --- Pass 1: low-level bitnet_gguf primitives ---
+    // None of these must ever panic.
+    let _ = check_magic(&buf);
+    let _ = read_version(&buf);
+    let _ = parse_header(&buf);
+
+    // --- Pass 2: GgufValueType discriminant exhaustion ---
+    let _ = GgufValueType::from_u32(input.value_type as u32);
+    // Boundary and sentinel values must also be handled gracefully.
+    let _ = GgufValueType::from_u32(0);
+    let _ = GgufValueType::from_u32(u32::MAX);
+
+    // --- Pass 3: GgufReader metadata access ---
+    if buf.len() < 16 {
+        return;
+    }
+    if let Ok(reader) = GgufReader::new(&buf) {
+        let keys = reader.metadata_keys();
+        for key in &keys {
+            // Exercise every typed accessor — mismatched types must return None, not panic.
+            let _ = reader.get_string_metadata(key);
+            let _ = reader.get_u32_metadata(key);
+            let _ = reader.get_i32_metadata(key);
+            let _ = reader.get_f32_metadata(key);
+            let _ = reader.get_bool_metadata(key);
+            let _ = reader.get_string_array_metadata(key);
+            let _ = reader.get_bin_metadata(key);
+            let _ = reader.get_bin_or_u8_array(key);
+        }
+
+        // General reader invariants must hold regardless of content.
+        let _ = reader.metadata_count();
+        let _ = reader.tensor_count();
+        let _ = reader.alignment();
+        let _ = reader.version();
+        let _ = reader.validate();
+    }
+
+    // --- Pass 4: directly feed raw bytes into parse_header ---
+    // Try sub-slices to catch off-by-one errors at the header boundary.
+    for end in [8, 16, buf.len().min(32), buf.len()] {
+        let _ = parse_header(&buf[..end]);
+    }
+});
+
+/// Builds a minimal GGUF byte stream containing one key-value entry constructed
+/// from the fuzz inputs.
+fn build_gguf_with_kv(key: &[u8], value_bytes: &[u8], value_type: u8, trailing: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // GGUF magic bytes
+    buf.extend_from_slice(b"GGUF");
+    // Format version 3 (u32 LE)
+    buf.extend_from_slice(&3u32.to_le_bytes());
+    // tensor_count = 0 (u64 LE)
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    // metadata_kv_count = 1 (u64 LE)
+    buf.extend_from_slice(&1u64.to_le_bytes());
+
+    // Key: u64 length prefix, then raw bytes (possibly non-UTF-8)
+    let key_len = key.len().min(255);
+    buf.extend_from_slice(&(key_len as u64).to_le_bytes());
+    buf.extend_from_slice(&key[..key_len]);
+
+    // Value type as u32 LE
+    buf.extend_from_slice(&(value_type as u32).to_le_bytes());
+
+    // Value payload
+    buf.extend_from_slice(value_bytes);
+
+    // Optional trailing garbage to exercise parser robustness
+    buf.extend_from_slice(trailing);
+
+    buf
+}

--- a/fuzz/fuzz_targets/transformer_config.rs
+++ b/fuzz/fuzz_targets/transformer_config.rs
@@ -1,0 +1,116 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::BitNetConfig;
+use bitnet_models::GgufReader;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct TransformerConfigInput {
+    /// Raw bytes treated as a potential GGUF stream.
+    data: Vec<u8>,
+    /// Config field values used to build a synthetic GGUF-like payload.
+    hidden_size: u32,
+    n_heads: u8,
+    n_kv_heads: u8,
+    n_layers: u8,
+    vocab_size: u32,
+    context_len: u32,
+}
+
+fuzz_target!(|input: TransformerConfigInput| {
+    // --- Pass 1: parse arbitrary bytes as GGUF and extract transformer config fields ---
+    if input.data.len() >= 16 {
+        if let Ok(reader) = GgufReader::new(&input.data) {
+            // These must never panic on any well-formed parse result.
+            let _ = reader.get_string_metadata("general.architecture");
+            let _ = reader.get_u32_metadata("llm.embedding_length");
+            let _ = reader.get_u32_metadata("llm.attention.head_count");
+            let _ = reader.get_u32_metadata("llm.attention.head_count_kv");
+            let _ = reader.get_u32_metadata("llm.block_count");
+            let _ = reader.get_u32_metadata("llm.context_length");
+            let _ = reader.get_u32_metadata("llm.feed_forward_length");
+            let _ = reader.get_u32_metadata("llm.vocab_size");
+            let _ = reader.get_f32_metadata("llm.attention.layer_norm_rms_eps");
+            let _ = reader.get_f32_metadata("llm.rope.freq_base");
+            let _ = reader.get_u32_metadata("tokenizer.ggml.eos_token_id");
+            let _ = reader.get_u32_metadata("tokenizer.ggml.bos_token_id");
+            let _ = reader.get_u32_metadata("tokenizer.ggml.padding_token_id");
+            let _ = reader.get_string_array_metadata("tokenizer.ggml.tokens");
+            let _ = reader.validate();
+        }
+    }
+
+    // --- Pass 2: construct a GGUF stream with known transformer config KVs ---
+    let hidden = input.hidden_size.min(65536);
+    let n_heads = input.n_heads.max(1) as u32;
+    let n_kv_heads = input.n_kv_heads.max(1) as u32;
+    let n_layers = input.n_layers.max(1) as u32;
+    let vocab = input.vocab_size.min(1_000_000);
+    let ctx = input.context_len.min(1_048_576);
+
+    let buf = build_transformer_gguf(hidden, n_heads, n_kv_heads, n_layers, vocab, ctx);
+    if let Ok(reader) = GgufReader::new(&buf) {
+        let _ = reader.get_u32_metadata("llm.embedding_length");
+        let _ = reader.get_u32_metadata("llm.attention.head_count");
+        let _ = reader.get_u32_metadata("llm.attention.head_count_kv");
+        let _ = reader.get_u32_metadata("llm.block_count");
+        let _ = reader.get_u32_metadata("llm.vocab_size");
+        let _ = reader.get_u32_metadata("llm.context_length");
+        let _ = reader.metadata_keys();
+        let _ = reader.metadata_count();
+        let _ = reader.validate();
+    }
+
+    // --- Pass 3: fuzz BitNetConfig validation with derived field values ---
+    let config = BitNetConfig::builder()
+        .hidden_size(hidden as usize)
+        .num_heads(n_heads as usize)
+        .num_key_value_heads(n_kv_heads as usize)
+        .num_layers(n_layers as usize)
+        .vocab_size(vocab as usize)
+        .max_length(ctx as usize)
+        .build();
+    if let Ok(cfg) = config {
+        let _ = cfg.validate();
+    }
+});
+
+/// Builds a minimal valid GGUF byte stream containing transformer config key-value entries.
+fn build_transformer_gguf(
+    hidden_size: u32,
+    n_heads: u32,
+    n_kv_heads: u32,
+    n_layers: u32,
+    vocab_size: u32,
+    context_len: u32,
+) -> Vec<u8> {
+    const N_KV: u64 = 6;
+    let mut buf = Vec::new();
+
+    // GGUF magic + version 3
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&3u32.to_le_bytes());
+    // tensor_count = 0, metadata_kv_count = N_KV
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    buf.extend_from_slice(&N_KV.to_le_bytes());
+
+    write_kv_u32(&mut buf, "llm.embedding_length", hidden_size);
+    write_kv_u32(&mut buf, "llm.attention.head_count", n_heads);
+    write_kv_u32(&mut buf, "llm.attention.head_count_kv", n_kv_heads);
+    write_kv_u32(&mut buf, "llm.block_count", n_layers);
+    write_kv_u32(&mut buf, "llm.vocab_size", vocab_size);
+    write_kv_u32(&mut buf, "llm.context_length", context_len);
+
+    buf
+}
+
+/// Writes a single GGUF key-value entry of type UINT32 (type discriminant 5).
+fn write_kv_u32(buf: &mut Vec<u8>, key: &str, value: u32) {
+    // key: u64 length prefix + UTF-8 bytes
+    buf.extend_from_slice(&(key.len() as u64).to_le_bytes());
+    buf.extend_from_slice(key.as_bytes());
+    // value type UINT32 = 5
+    buf.extend_from_slice(&5u32.to_le_bytes());
+    buf.extend_from_slice(&value.to_le_bytes());
+}


### PR DESCRIPTION
## Summary

Adds two new fuzz targets to improve parser coverage:

### `fuzz/fuzz_targets/transformer_config.rs`
Fuzzes BitNet transformer config deserialization from GGUF-like byte streams:
- **Pass 1**: Parses arbitrary bytes as GGUF and extracts all transformer config metadata fields (hidden size, attention heads, KV heads, layer count, vocab size, context length, RoPE, etc.)
- **Pass 2**: Constructs a synthetic GGUF stream with specific config KV entries derived from fuzz inputs, then reads them back
- **Pass 3**: Exercises `BitNetConfig` builder + validation with the same derived field values to catch invalid-shape panics

### `fuzz/fuzz_targets/gguf_kv_read.rs`
Fuzzes GGUF key-value metadata reading with focus on:
- **Malformed keys**: arbitrary bytes (including non-UTF-8) in the key field
- **Invalid value types**: every possible `value_type` discriminant byte including out-of-range values
- **Oversized values**: large payloads in the value field
- **Trailing garbage**: random bytes appended after the KV entry
- **Multi-layer coverage**: both the low-level `bitnet_gguf` primitives (`parse_header`, `check_magic`, `read_version`, `GgufValueType::from_u32`) and the higher-level `GgufReader` (all typed accessors)

## Verification
- `cargo check --package bitnet-fuzz` passes cleanly
- `cargo fmt --all` applied
- `cargo generate-lockfile` run in `fuzz/`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>