### PR TITLE
test: expand server and CLI integration tests

### DIFF
--- a/crates/bitnet-cli/tests/property_tests.rs
+++ b/crates/bitnet-cli/tests/property_tests.rs
@@ -102,4 +102,108 @@ proptest! {
         let cmd = parse_args(&["bitnet", "--seed", &seed_str]).expect("should parse");
         prop_assert_eq!(cmd.seed, Some(seed));
     }
+
+    /// --temperature 0.0 --greedy: both fields are stored correctly together
+    #[test]
+    fn prop_greedy_and_zero_temperature_both_stored(_seed in 0u32..100u32) {
+        let cmd = parse_args(&["bitnet", "--temperature", "0.0", "--greedy"])
+            .expect("should parse");
+        prop_assert!(cmd.greedy, "greedy flag must be true");
+        prop_assert_eq!(cmd.temperature, 0.0f32, "temperature must be 0.0");
+    }
+
+    /// stop sequences: all provided sequences are stored in order
+    #[test]
+    fn prop_stop_sequences_all_stored(
+        n in 1usize..=5usize,
+    ) {
+        // Build n unique stop sequences
+        let stops: Vec<String> = (0..n).map(|i| format!("<stop{i}>")).collect();
+        let mut args = vec!["bitnet"];
+        for s in &stops {
+            args.push("--stop");
+            args.push(s.as_str());
+        }
+        let cmd = parse_args(&args).expect("should parse");
+        prop_assert_eq!(cmd.stop.len(), n, "all stop sequences must be stored");
+        for s in &stops {
+            prop_assert!(cmd.stop.contains(s), "missing stop sequence: {s}");
+        }
+    }
+
+    /// stop-id: all provided token IDs are stored
+    #[test]
+    fn prop_stop_ids_all_stored(
+        id in 1u32..=200000u32,
+    ) {
+        let id_str = id.to_string();
+        let cmd = parse_args(&["bitnet", "--stop-id", &id_str]).expect("should parse");
+        prop_assert!(cmd.stop_id.contains(&id), "stop-id {id} must be stored");
+    }
+
+    /// --prompt-template: any string is accepted by clap (validation is deferred)
+    #[test]
+    fn prop_prompt_template_string_stored_verbatim(
+        template in "[a-z][a-z-]{0,19}",
+    ) {
+        let cmd = parse_args(&["bitnet", "--prompt-template", &template])
+            .expect("clap should accept any string for --prompt-template");
+        prop_assert_eq!(
+            cmd.prompt_template, template,
+            "--prompt-template value must be stored verbatim"
+        );
+    }
+}
+
+// ── Deterministic unit tests ─────────────────────────────────────────────────
+
+/// --prompt-template raw/instruct/llama3-chat each parse to the correct TemplateType.
+#[test]
+fn test_explicit_prompt_templates_parse_to_correct_type() {
+    use bitnet_inference::TemplateType;
+
+    let cases = [
+        ("raw", TemplateType::Raw),
+        ("instruct", TemplateType::Instruct),
+        ("llama3-chat", TemplateType::Llama3Chat),
+    ];
+
+    for (value, expected) in cases {
+        let cmd = parse_args(&["bitnet", "--prompt-template", value]).expect("should parse");
+        let resolved: TemplateType = cmd
+            .prompt_template
+            .parse()
+            .unwrap_or_else(|e| panic!("--prompt-template {value:?} should resolve: {e}"));
+        assert_eq!(resolved, expected, "wrong TemplateType for {value:?}");
+    }
+}
+
+/// An unknown --prompt-template value is stored verbatim and fails str::parse.
+#[test]
+fn test_unknown_prompt_template_fails_at_parse_time() {
+    use bitnet_inference::TemplateType;
+
+    let cmd = parse_args(&["bitnet", "--prompt-template", "totally-invalid-template"])
+        .expect("clap should accept any string");
+    let result: Result<TemplateType, _> = cmd.prompt_template.parse();
+    assert!(result.is_err(), "unknown template string should fail TemplateType::from_str");
+}
+
+/// --temperature 0.0 --greedy: the combination sets both fields correctly.
+#[test]
+fn test_greedy_zero_temperature_combination() {
+    let cmd = parse_args(&["bitnet", "--temperature", "0.0", "--greedy"]).expect("should parse");
+    assert!(cmd.greedy, "greedy must be true");
+    assert_eq!(cmd.temperature, 0.0f32, "temperature must be 0.0");
+}
+
+/// Multiple --stop-id values are all stored.
+#[test]
+fn test_multiple_stop_ids_stored() {
+    let cmd = parse_args(&["bitnet", "--stop-id", "128009", "--stop-id", "2", "--stop-id", "1"])
+        .expect("should parse");
+    assert_eq!(cmd.stop_id.len(), 3);
+    assert!(cmd.stop_id.contains(&128009u32));
+    assert!(cmd.stop_id.contains(&2u32));
+    assert!(cmd.stop_id.contains(&1u32));
 }


### PR DESCRIPTION
## Summary

Expands integration test coverage for `bitnet-server` and `bitnet-cli` without requiring a real model.

### `crates/bitnet-server/tests/property_tests.rs` (+10 tests, 21 total)

**New property-based tests:**
- `prop_security_validator_temperature_above_2_fails` — temperature > 2.0 always rejected
- `prop_security_validator_top_p_above_1_fails` — top_p > 1.0 always rejected
- `prop_validate_json_payload_valid_json_parses` — valid JSON within size limit parses
- `prop_validate_json_payload_rejects_oversized` — oversized payload always rejected
- `prop_concurrency_config_max_concurrent_requests_preserved` — ConcurrencyConfig field invariant
- `prop_concurrency_config_backpressure_threshold_preserved` — threshold stays in range

**New deterministic HTTP tests (axum `oneshot` pattern):**
- `test_health_endpoint_returns_200` — `GET /health` returns 200 with no model loaded
- `test_cors_reflects_allowed_origin` — preflight OPTIONS reflects the allowed origin header
- `test_cors_blocks_disallowed_origin` — no ACAO header for a blocked origin
- `test_validate_json_invalid_syntax_returns_error` — malformed JSON returns an error

### `crates/bitnet-cli/tests/property_tests.rs` (+8 tests, 17 total)

**New property-based tests:**
- `prop_greedy_and_zero_temperature_both_stored` — `--greedy --temperature 0.0` stores both fields
- `prop_stop_sequences_all_stored` — all `--stop` values are captured
- `prop_stop_ids_all_stored` — `--stop-id` values are captured
- `prop_prompt_template_string_stored_verbatim` — any letter-starting string accepted verbatim

**New deterministic unit tests:**
- `test_explicit_prompt_templates_parse_to_correct_type` — raw/instruct/llama3-chat resolve correctly
- `test_unknown_prompt_template_fails_at_parse_time` — unknown string fails `TemplateType::from_str`
- `test_greedy_zero_temperature_combination` — deterministic greedy + zero-temperature check
- `test_multiple_stop_ids_stored` — multiple `--stop-id` values all present

## Verification

```
cargo test -p bitnet-server --no-default-features --features cpu --test property_tests
# 21 passed; 0 failed

cargo test -p bitnet-cli --no-default-features --features cpu,full-cli --test property_tests
# 17 passed; 0 failed
```

No real model required. No bare `#[ignore]` markers added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced CLI argument parsing validation with comprehensive test coverage for greedy mode, temperature, stop sequences, and prompt templates.
  * Added extensive property-based and integration tests for server functionality, including configuration validation, request handling, health endpoints, and API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->