### PR TITLE
docs: changelog and roadmap for PRs #828-#831

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to bitnet-rs will be documented in this file.
 - `chore: fix stale MSRV cache key in compatibility workflow (1.89 → 1.92)` — prevents incorrect CI cache hits from cached 1.89 toolchain artifacts (#805)
 
 ### Added
+- `test: audit and reduce ignored tests` — reduced ignored test count from 91 → 77 by enabling tests that are no longer blocked (#831)
+- `test: expand server and CLI integration tests` — 18 new integration tests covering health endpoint, CORS, security validation, and CLI template parsing (#830)
+- `test(bdd): expand BDD grid with new scenario cells` — 5 new BDD cells (18 total, was 13) in `crates/bitnet-bdd-grid/src/lib.rs` (#828)
 - `test: proptest coverage for bitnet-common` — 9 new property tests in `crates/bitnet-common/tests/property_tests.rs` (MockTensor shapes, QuantizationType round-trips, error types, device consistency, KernelCapabilities ordering, warn_once deduplication) (#826)
 - `test: expand proptest coverage for bitnet-sampling` — 7 new property tests in `crates/bitnet-sampling/tests/property_tests.rs` (temperature scaling, top-k/p filtering, repetition penalty, seed reproducibility, empty context, greedy determinism) (#825)
 - `test: proptest coverage for bitnet-receipts` — 14 new proptests in `crates/bitnet-receipts/tests/property_tests.rs` (schema version, builder, JSON round-trips, kernel ID validation, honest compute gates, token counts) (#823)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#826.
+> **Last updated**: reflects implementation state after PRs #608–#831.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---


### PR DESCRIPTION
## Summary

Updates `CHANGELOG.md` and `docs/reference/dual-backend-roadmap.md` to document recently merged PRs.

### Changes

**CHANGELOG.md** — added to `[Unreleased] > Added` (newest first):
- **#831** `test: audit and reduce ignored tests` — reduced ignored test count from 91 → 77
- **#830** `test: expand server and CLI integration tests` — 18 new integration tests (health endpoint, CORS, security validation, CLI template parsing)
- **#828** `test(bdd): expand BDD grid with new scenario cells` — 5 new BDD cells (18 total, was 13)

**docs/reference/dual-backend-roadmap.md** — bumped "Last updated" from `#608–#826` to `#608–#831`.

### Checklist
- [x] `cargo fmt --all` run
- [x] Docs-only change (no code modified)