### PR TITLE
test: add snapshot tests for sampling, gguf, and receipts

### DIFF
--- a/crates/bitnet-gguf/tests/snapshots/snapshot_tests__parse_header_v2_success.snap
+++ b/crates/bitnet-gguf/tests/snapshots/snapshot_tests__parse_header_v2_success.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-gguf/tests/snapshot_tests.rs
+expression: info
+---
+GgufFileInfo {
+    version: 2,
+    tensor_count: 5,
+    metadata_count: 3,
+    alignment: 32,
+}

--- a/crates/bitnet-gguf/tests/snapshots/snapshot_tests__parse_header_v3_success.snap
+++ b/crates/bitnet-gguf/tests/snapshots/snapshot_tests__parse_header_v3_success.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-gguf/tests/snapshot_tests.rs
+expression: info
+---
+GgufFileInfo {
+    version: 3,
+    tensor_count: 10,
+    metadata_count: 7,
+    alignment: 64,
+}

--- a/crates/bitnet-gguf/tests/snapshots/snapshot_tests__read_version_v2.snap
+++ b/crates/bitnet-gguf/tests/snapshots/snapshot_tests__read_version_v2.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-gguf/tests/snapshot_tests.rs
+expression: version
+---
+Some(
+    2,
+)

--- a/crates/bitnet-gguf/tests/snapshots/snapshot_tests__read_version_v3.snap
+++ b/crates/bitnet-gguf/tests/snapshots/snapshot_tests__read_version_v3.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-gguf/tests/snapshot_tests.rs
+expression: version
+---
+Some(
+    3,
+)

--- a/crates/bitnet-receipts/tests/snapshot_tests.rs
+++ b/crates/bitnet-receipts/tests/snapshot_tests.rs
@@ -9,7 +9,9 @@
 //! - Backend summary field in receipt
 //! - `to_json_string()` output for round-trip fidelity
 
-use bitnet_receipts::{InferenceReceipt, ModelInfo, PerformanceBaseline, TestResults};
+use bitnet_receipts::{
+    InferenceReceipt, ModelInfo, PerformanceBaseline, RECEIPT_SCHEMA_VERSION, TestResults,
+};
 
 /// Normalize non-deterministic fields for stable snapshots.
 fn normalize(mut r: InferenceReceipt) -> InferenceReceipt {
@@ -142,4 +144,10 @@ fn snapshot_to_json_string_output() {
     insta::assert_json_snapshot!("to_json_string_output", reparsed, {
         ".timestamp" => "[timestamp]",
     });
+}
+
+#[test]
+fn snapshot_schema_version_constant() {
+    // Pin the schema version string so any spec-level bump is immediately visible.
+    insta::assert_snapshot!("schema_version_constant", RECEIPT_SCHEMA_VERSION);
 }

--- a/crates/bitnet-receipts/tests/snapshots/snapshot_tests__schema_version_constant.snap
+++ b/crates/bitnet-receipts/tests/snapshots/snapshot_tests__schema_version_constant.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-receipts/tests/snapshot_tests.rs
+expression: RECEIPT_SCHEMA_VERSION
+---
+1.0.0


### PR DESCRIPTION
## Summary

Expands snapshot test coverage in three crates where gaps existed.

### bitnet-gguf
The existing snapshot tests only covered **error paths** (bad magic, wrong version, etc.). Added four new tests that pin the `GgufFileInfo` debug output for **successful** parses:
- `parse_header_v2_success` — minimal valid v2 header (24 bytes), verifies `alignment` defaults to 32
- `parse_header_v3_success` — minimal valid v3 header (28 bytes), verifies `alignment` is read from file
- `read_version_v2` / `read_version_v3` — pin `read_version()` return values for both supported versions

### bitnet-receipts
Added:
- `snapshot_schema_version_constant` — pins `RECEIPT_SCHEMA_VERSION = "1.0.0"` so any spec-level schema bump shows up immediately in snapshot diffs

### bitnet-sampling
Already had full coverage of the requested cases (default, greedy, typical configs + output snapshots). No changes needed.

## Test run
```
cargo test -p bitnet-gguf --no-default-features   # 15 passed
cargo test -p bitnet-receipts --no-default-features  # 8 passed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added snapshot tests for GGUF header parsing across protocol versions (v2 and v3) and version reading operations.
  * Added snapshot test validating receipt schema version constant to detect changes.

* **New Features**
  * Introduced publicly exported receipt schema version constant for external code reference and integration purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->