### PR TITLE
docs: changelog and roadmap for PRs #829-#834

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ All notable changes to bitnet-rs will be documented in this file.
 - `chore: fix stale MSRV cache key in compatibility workflow (1.89 → 1.92)` — prevents incorrect CI cache hits from cached 1.89 toolchain artifacts (#805)
 
 ### Added
+- `test: expand proptest coverage for thin-coverage crates` — 15 new property tests across bitnet-bdd-grid, bitnet-honest-compute, bitnet-rope, and bitnet-trace (#834)
+- `test: add snapshot tests for sampling, gguf, and receipts` — 5 new insta snapshots pinning GgufFileInfo display output and receipt schema version string for regression detection (#833)
 - `test: audit and reduce ignored tests` — reduced ignored test count from 91 → 77 by enabling tests that are no longer blocked (#831)
 - `test: expand server and CLI integration tests` — 18 new integration tests covering health endpoint, CORS, security validation, and CLI template parsing (#830)
+- `feat(fuzz): add transformer_config and gguf_kv_read fuzz targets` — 2 new fuzz targets covering TransformerConfig deserialization and GGUF KV key/value read paths (#829)
 - `test(bdd): expand BDD grid with new scenario cells` — 5 new BDD cells (18 total, was 13) in `crates/bitnet-bdd-grid/src/lib.rs` (#828)
 - `test: proptest coverage for bitnet-common` — 9 new property tests in `crates/bitnet-common/tests/property_tests.rs` (MockTensor shapes, QuantizationType round-trips, error types, device consistency, KernelCapabilities ordering, warn_once deduplication) (#826)
 - `test: expand proptest coverage for bitnet-sampling` — 7 new property tests in `crates/bitnet-sampling/tests/property_tests.rs` (temperature scaling, top-k/p filtering, repetition penalty, seed reproducibility, empty context, greedy determinism) (#825)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#831.
+> **Last updated**: reflects implementation state after PRs #608–#834.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---


### PR DESCRIPTION
## Summary

Updates CHANGELOG.md and docs/reference/dual-backend-roadmap.md for recently merged PRs.

### CHANGELOG additions (newest-first under [Unreleased] > Added)

- **#834** `test: expand proptest coverage for thin-coverage crates` — 15 new property tests across bitnet-bdd-grid, bitnet-honest-compute, bitnet-rope, bitnet-trace
- **#833** `test: add snapshot tests for sampling, gguf, and receipts` — 5 new insta snapshots pinning GgufFileInfo display and receipt schema version
- **#829** `feat(fuzz): add transformer_config and gguf_kv_read fuzz targets` — 2 new fuzz targets

PRs #831, #830, #828 were already documented by #832. PR #832 is docs-only and skipped per instructions.

### Roadmap update

- Bumped "Last updated" from `#608–#831` → `#608–#834`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded changelog with entries documenting test coverage improvements, new fuzz testing targets, snapshot testing capabilities, and testing infrastructure enhancements across multiple components.
  * Updated roadmap documentation with the latest revision references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->