### PR TITLE
release: v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.1.2] - 2026-02-27
+
+Test coverage expansion wave (proptests, fuzz targets, BDD grid), reduced ignored tests to 77.
+
 ### Fixed
 - `chore: fix stale MSRV cache key in compatibility workflow (1.89 → 1.92)` — prevents incorrect CI cache hits from cached 1.89 toolchain artifacts (#805)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitnet"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "insta",
  "proptest",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-common"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-test-support",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-compat"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-crossval"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-device-probe"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-engine-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-feature-matrix",
@@ -588,14 +588,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-matrix"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-profile-core",
 ]
 
 [[package]]
 name = "bitnet-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-generation"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ggml-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cc",
  "libc",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-gguf"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-honest-compute"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "insta",
  "proptest",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-inference"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -723,7 +723,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-kernels"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-logits"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "insta",
  "proptest",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-models"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-prompt-templates"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-tokenizers",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-py"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-quantization"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-receipts"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-rope"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "insta",
  "proptest",
@@ -893,21 +893,21 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-bootstrap"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-startup-contract",
 ]
 
 [[package]]
 name = "bitnet-runtime-context"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-context-core",
 ]
 
 [[package]]
 name = "bitnet-runtime-context-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags-core",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -937,21 +937,21 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-feature-matrix",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-profile-contract-core",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-runtime-context",
@@ -964,14 +964,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-profile-contract",
 ]
 
 [[package]]
 name = "bitnet-sampling"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-logits",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-server"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1038,7 +1038,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st-tools"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-validation",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st2gguf"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1078,14 +1078,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-startup-contract-core",
 ]
 
 [[package]]
 name = "bitnet-startup-contract-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-diagnostics"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-guard"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bindgen",
  "cc",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-test-support"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proptest",
  "serial_test",
@@ -1138,14 +1138,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-policy-core",
 ]
 
 [[package]]
 name = "bitnet-testing-policy-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-feature-contract",
  "bitnet-runtime-feature-flags",
@@ -1156,7 +1156,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-profile",
  "bitnet-testing-scenarios-core",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-interop"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-contract",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-kit"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-policy",
  "insta",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-policy-interop",
  "insta",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-tests"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-policy-runtime",
  "insta",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-profile"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-runtime-profile",
  "insta",
@@ -1212,14 +1212,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-scenarios-core",
 ]
 
 [[package]]
 name = "bitnet-testing-scenarios-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-scenarios-profile-core",
  "insta",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-profile-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bitnet-testing-profile",
  "insta",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tests"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tokenizers"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-transformer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-validation"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "insta",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-wasm"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -4825,7 +4825,7 @@ dependencies = [
 
 [[package]]
 name = "migrate-gen-config"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8593,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-build-helper"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ name = "bitnet"
 readme = "README.md"
 repository = "https://github.com/microsoft/BitNet"
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 # Disable automatic discovery of tests, benches, and examples
 # Many of these use outdated APIs and need updating
 # Note: The tests/ directory is a separate bitnet-tests workspace crate
@@ -139,7 +139,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/microsoft/BitNet"
 rust-version = "1.92.0"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 # Core crates - always included


### PR DESCRIPTION
Bumps version to 0.1.2. Test coverage expansion wave: 50+ new property tests, 5 new fuzz targets, BDD grid expanded to 18 cells, ignored tests reduced to 77.