### PR TITLE
docs: changelog and roadmap for PRs #836-#838

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- `test: add numerical accuracy integration tests for bitnet-quantization` — 6 new integration tests (I2S dequantize, TL1 LUT, TL2 symmetry, round-trip accuracy, QK256 block size, zero vector) (#838)
+- `test: add CPU golden path E2E validation tests` — 4 new E2E tests (stop token, receipt kernel IDs, schema version, max_tokens boundary) (#837)
+
 ## [v0.1.2] - 2026-02-27
 
 Test coverage expansion wave (proptests, fuzz targets, BDD grid), reduced ignored tests to 77.

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#834.
+> **Last updated**: reflects implementation state after PRs #608–#838.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---


### PR DESCRIPTION
## Summary

Updates `CHANGELOG.md` and `docs/reference/dual-backend-roadmap.md` to document recently merged PRs.

### Changes

**CHANGELOG.md** — new `[Unreleased]` entries (newest first):
- **#838** `test: add numerical accuracy integration tests for bitnet-quantization` — 6 new integration tests (I2S dequantize, TL1 LUT, TL2 symmetry, round-trip accuracy, QK256 block size, zero vector)
- **#837** `test: add CPU golden path E2E validation tests` — 4 new E2E tests (stop token, receipt kernel IDs, schema version, max_tokens boundary)

The `[v0.1.2]` release section (from #836) was already present.

**docs/reference/dual-backend-roadmap.md** — bumped "Last updated" from `#608–#834` → `#608–#838`.

### Checklist
- [x] `cargo fmt --all` passed
- [x] No source code changes