### PR TITLE
ci: increase fuzz build timeout to 60 minutes

### DIFF
--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -19,13 +19,14 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   # Always-on: build all fuzz targets (catches compilation regressions on every PR)
   fuzz-build:
     name: Fuzz targets build
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
@@ -35,10 +36,17 @@ jobs:
         with:
           toolchain: nightly
 
+      - name: Cache cargo-fuzz binary
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-${{ hashFiles('fuzz/Cargo.lock') }}
+
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          key: fuzz-build
+          key: fuzz-build-${{ hashFiles('fuzz/Cargo.lock') }}
+          workspaces: fuzz -> target
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
@@ -49,6 +57,7 @@ jobs:
           cargo fuzz build 2>&1
         env:
           RUSTUP_TOOLCHAIN: nightly
+          RUSTFLAGS: -C debuginfo=0
 
   # Scheduled only: run each fuzz target for a short time to catch new crashes
   fuzz-run:


### PR DESCRIPTION
## Problem

The "Fuzz targets build" CI job was consistently cancelled due to timeout. The fuzz workspace has 20+ binary targets across multiple crates (`bitnet-quantization`, `bitnet-models`, `bitnet-kernels`, `candle-core`, etc.), and a full clean compile regularly exceeds the previous 20-minute budget.

## Changes

| Change | Reason |
|---|---|
| `timeout-minutes: 20 → 60` | Gives enough headroom for cold-cache builds with 20+ fuzz targets |
| `CARGO_INCREMENTAL="0"` | Disables incremental compilation artifacts that waste time/space on CI |
| Cache `~/.cargo/bin/cargo-fuzz` keyed on `fuzz/Cargo.lock` hash | Avoids reinstalling `cargo-fuzz` on every run unless deps change |
| `Swatinem/rust-cache` key now includes `hashFiles('fuzz/Cargo.lock')` | Correct cache invalidation when fuzz dependencies change |
| `workspaces: fuzz -> target` | Scopes the Rust cache to the fuzz workspace target directory |
| `RUSTFLAGS: -C debuginfo=0` | Strips debug symbols during fuzz build, reducing compile time |

## Testing

Workflow change only; no Rust code changed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>