### PR TITLE
test: expand proptest coverage for compat, templates, and feature-flag crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "bitnet-runtime-feature-flags-core",
  "insta",
  "proptest",
+ "serde_json",
 ]
 
 [[package]]
@@ -933,6 +934,7 @@ dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
  "proptest",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -21,6 +21,7 @@ bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+serde_json.workspace = true
 
 [features]
 default = []

--- a/crates/bitnet-runtime-feature-flags-core/tests/property_tests.rs
+++ b/crates/bitnet-runtime-feature-flags-core/tests/property_tests.rs
@@ -4,7 +4,8 @@
 
 use bitnet_bdd_grid_core::BitnetFeature;
 use bitnet_runtime_feature_flags_core::{
-    FeatureActivation, active_features_from_activation, feature_line_from_activation,
+    FeatureActivation, active_features_from_activation, feature_labels_from_activation,
+    feature_line_from_activation,
 };
 use proptest::prelude::*;
 
@@ -47,6 +48,73 @@ proptest! {
         let activation = FeatureActivation::default();
         let labels = activation.to_labels();
         prop_assert!(labels.is_empty(), "expected empty, got: {:?}", labels);
+    }
+}
+
+proptest! {
+    /// Enabling `gpu` (without cuda) places "gpu" in the label list.
+    #[test]
+    fn prop_gpu_activation_implies_gpu_label(any_bool: bool) {
+        let activation = FeatureActivation { gpu: true, cpu: any_bool, ..Default::default() };
+        let labels = feature_labels_from_activation(activation);
+        prop_assert!(
+            labels.contains(&"gpu".to_string()),
+            "gpu=true but 'gpu' absent from labels: {:?}", labels
+        );
+    }
+
+    /// All labels returned by `feature_labels_from_activation` are non-empty strings.
+    #[test]
+    fn prop_all_labels_nonempty(
+        cpu in any::<bool>(),
+        gpu in any::<bool>(),
+        cuda in any::<bool>(),
+        inference in any::<bool>(),
+    ) {
+        let activation = FeatureActivation { cpu, gpu, cuda, inference, ..Default::default() };
+        for label in feature_labels_from_activation(activation) {
+            prop_assert!(!label.is_empty(), "label must not be empty");
+        }
+    }
+
+    /// CPU and GPU features can coexist; both labels appear when both are enabled.
+    #[test]
+    fn prop_cpu_and_gpu_can_coexist(_unused in Just(())) {
+        let activation = FeatureActivation { cpu: true, gpu: true, ..Default::default() };
+        let labels = feature_labels_from_activation(activation);
+        prop_assert!(labels.contains(&"cpu".to_string()), "labels: {:?}", labels);
+        prop_assert!(labels.contains(&"gpu".to_string()), "labels: {:?}", labels);
+    }
+
+    /// The label vector for any activation serializes to valid JSON.
+    ///
+    /// `Vec<String>` is always serializable; this guards against unexpected
+    /// control characters or non-UTF-8 content slipping into label strings.
+    #[test]
+    fn prop_labels_serialize_to_valid_json(
+        cpu in any::<bool>(),
+        gpu in any::<bool>(),
+        cuda in any::<bool>(),
+    ) {
+        let activation = FeatureActivation { cpu, gpu, cuda, ..Default::default() };
+        let labels = feature_labels_from_activation(activation);
+        let json = serde_json::to_string(&labels)
+            .expect("Vec<String> labels must always serialize to JSON");
+        prop_assert!(
+            json.starts_with('['),
+            "serialized labels must be a JSON array, got: {json:?}"
+        );
+    }
+
+    /// `FeatureActivation` debug string is always non-empty.
+    #[test]
+    fn prop_feature_activation_debug_is_nonempty(
+        cpu in any::<bool>(),
+        gpu in any::<bool>(),
+    ) {
+        let activation = FeatureActivation { cpu, gpu, ..Default::default() };
+        let debug = format!("{activation:?}");
+        prop_assert!(!debug.is_empty(), "Debug output of FeatureActivation must not be empty");
     }
 }
 

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -65,3 +65,4 @@ runtime-profile-integration-tests = ["integration-tests"]
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+serde_json.workspace = true


### PR DESCRIPTION
## Summary


## Changes

### `bitnet-compat`
- **`prop_nonexistent_gguf_path_returns_err`** — non-existent `.gguf` paths return `Err`, never panic
- **`prop_empty_path_is_rejected`** — empty string path is always rejected
- **`prop_null_byte_path_is_rejected`** — null-byte paths are rejected at OS level
- **`prop_crate_version_is_semver`** — `CARGO_PKG_VERSION` follows the `X.Y.Z` semver pattern

### `bitnet-prompt-templates`
- **`prop_system_prompt_appears_in_instruct_output`** — system prompt text appears in Instruct output
- **`prop_raw_type_apply_is_identity`** — `TemplateType::Raw.apply()` is the identity transform
- **`prop_instruct_output_ends_with_answer_marker`** — Instruct output always ends with `\nA:`
- **`prop_template_type_display_roundtrip`** — `Display → FromStr` round-trip for all template variants
- **`prop_nonempty_input_produces_nonempty_output`** — non-empty input always produces non-empty output

### `bitnet-runtime-feature-flags`
- **`prop_gpu_activation_implies_gpu_label`** — `gpu=true` → `"gpu"` in labels
- **`prop_all_labels_nonempty`** — all label strings are non-empty
- **`prop_default_activation_yields_none_line`** — default activation → `"features: none"`
- **`prop_labels_serialize_to_valid_json`** — label vector serializes to a valid JSON array
- **`prop_feature_activation_debug_is_nonempty`** — Debug output is non-empty

### `bitnet-runtime-feature-flags-core`
- **`prop_gpu_activation_implies_gpu_label`**
- **`prop_all_labels_nonempty`**
- **`prop_cpu_and_gpu_can_coexist`** — CPU and GPU features can coexist, both appear in labels
- **`prop_labels_serialize_to_valid_json`**
- **`prop_feature_activation_debug_is_nonempty`**

Also adds `serde_json` as a dev-dependency to both feature-flag crates (already in workspace deps) to support the JSON serialization property tests.

## Test Results

All tests pass:
- `bitnet-compat`: 9/9 ✅
- `bitnet-prompt-templates`: 13/13 ✅
- `bitnet-runtime-feature-flags`: 10/10 ✅
- `bitnet-runtime-feature-flags-core`: 11/11 ✅