### PR TITLE
feat: add bitnet-logits microcrate

### DIFF
--- a/crates/bitnet-logits/tests/logits_tests.rs
+++ b/crates/bitnet-logits/tests/logits_tests.rs
@@ -1,0 +1,58 @@
+//! Task-spec property tests for `bitnet-logits`.
+//!
+//! These tests verify the core invariants required by the Phase 6 SRP
+//! extraction spec using the actual public API:
+//! - [`bitnet_logits::softmax_in_place`] (spec: `softmax`)
+//! - [`bitnet_logits::apply_top_k`]      (spec: `top_k_filter`)
+//! - [`bitnet_logits::apply_temperature`]
+//! - [`bitnet_logits::argmax`]
+
+use bitnet_logits::{apply_temperature, apply_top_k, argmax, softmax_in_place};
+use proptest::prelude::*;
+
+proptest! {
+    /// softmax output must sum to ≈1.0 for any finite input.
+    #[test]
+    fn test_softmax_sums_to_one(
+        logits in prop::collection::vec(-100.0f32..100.0f32, 1..100)
+    ) {
+        let mut v = logits;
+        softmax_in_place(&mut v);
+        let sum: f32 = v.iter().sum();
+        prop_assert!((sum - 1.0).abs() < 1e-5, "sum={sum}");
+    }
+
+    /// `apply_temperature(t=1.0)` must be a no-op.
+    #[test]
+    fn test_temperature_no_change_at_one(
+        logits in prop::collection::vec(-100.0f32..100.0f32, 1..100)
+    ) {
+        let original = logits.clone();
+        let mut v = logits;
+        apply_temperature(&mut v, 1.0);
+        prop_assert_eq!(v, original);
+    }
+
+    /// `argmax` must return a valid index and that index must hold the maximum value.
+    #[test]
+    fn test_argmax_within_bounds(
+        logits in prop::collection::vec(-100.0f32..100.0f32, 1..100)
+    ) {
+        let idx = argmax(&logits);
+        prop_assert!(idx < logits.len());
+        let max_val = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        prop_assert_eq!(logits[idx], max_val);
+    }
+
+    /// After `apply_top_k(k)`, at most `k` entries must be non-`NEG_INFINITY`.
+    #[test]
+    fn test_top_k_leaves_k_nonzero(
+        logits in prop::collection::vec(-10.0f32..10.0f32, 5..50),
+        k in 1usize..5,
+    ) {
+        let mut v = logits;
+        apply_top_k(&mut v, k);
+        let nonzero = v.iter().filter(|&&x| x != f32::NEG_INFINITY).count();
+        prop_assert!(nonzero <= k, "nonzero={nonzero} k={k}");
+    }
+}


### PR DESCRIPTION
## Summary

Add `bitnet-logits` crate providing pure logits transformation functions.

## What

The `bitnet-logits` crate already exists in the workspace (created as part of Phase 6 SRP extraction) and is already consumed by `bitnet-sampling`. This PR formalises the extraction by adding the task-spec property tests in `tests/logits_tests.rs`.

### Crate contents (`crates/bitnet-logits/`)

Pure functions on `&[f32]`/`&mut [f32]` — no tensor types, no external runtime deps:

| Task spec name | Actual API name | Notes |
|---|---|---|
| `apply_temperature` | `apply_temperature` | identity |
| `apply_repetition_penalty` | `apply_repetition_penalty` | takes token-id list |
| `softmax` | `softmax_in_place` | clearer name |
| `top_k_filter` | `apply_top_k` | consistent `apply_*` prefix |
| `top_p_filter` | `apply_top_p` | post-softmax probabilities |
| `argmax` | `argmax` | identity |

`bitnet-sampling` re-exports all six via `pub use bitnet_logits::*`.

### This PR adds

- `tests/logits_tests.rs`: four proptest invariants from the Phase 6 spec
  - `softmax_sums_to_one`
  - `temperature_no_change_at_one`
  - `argmax_within_bounds`
  - `top_k_leaves_k_nonzero`

## Why

Phase 6 SRP extraction: decouples logits math from sampling strategy state. Easy to property test. Reduces churn in `bitnet-inference` when sampling logic changes.

## Tests

- All 50 tests pass (`cargo test -p bitnet-logits --no-default-features`)
- Property tests: softmax sums to 1.0, argmax correctness, top-k size bounds, temperature identity
- Snapshot tests: deterministic output for key functions
- Doc-tests: all 8 examples in `lib.rs` pass