### PR TITLE
ci: add nightly fuzz run workflow

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -1,0 +1,69 @@
+name: Nightly Fuzz
+
+on:
+  schedule:
+    - cron: "0 2 * * *"  # 2am UTC nightly
+  workflow_dispatch:      # manual trigger
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-C debuginfo=0"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - quantization_i2s
+          - quantization_tl1
+          - quantization_tl2
+          - gguf_parser
+          - safetensors_parser
+          - tokenizer_discovery
+          - kernel_matmul
+          - quantization_input
+          - transformer_config
+          - gguf_kv_read
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Install Rust toolchain (nightly for fuzz)
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1  # nightly
+        with:
+          components: llvm-tools-preview
+
+      - name: Cache cargo registry
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: fuzz-nightly-${{ matrix.target }}-${{ hashFiles('fuzz/Cargo.lock') }}
+          restore-keys: |
+            fuzz-nightly-${{ matrix.target }}-
+            fuzz-nightly-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run fuzz target (${{ matrix.target }}) for 60s
+        run: |
+          cargo fuzz run ${{ matrix.target }} -- -max_total_time=60 -print_final_stats=1
+        working-directory: fuzz
+
+      - name: Upload fuzz artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  # v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}-${{ github.run_id }}
+          path: |
+            fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 30


### PR DESCRIPTION
## Summary
Add a nightly scheduled workflow that runs all fuzz targets for 60 seconds each.

## What
- New workflow: `.github/workflows/fuzz-nightly.yml`
- Runs nightly at 2am UTC + manual trigger
- Matrix: all 10 fuzz targets
- 60s per target (vs 30s in PR CI)
- Uploads crash artifacts on failure (30-day retention)
- Separate from PR CI to avoid blocking merges

## Why
Phase 7: graduate fuzz into scheduled evidence pipeline.
Crashes are uploaded as artifacts for investigation without blocking PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal testing infrastructure with automated nightly quality assurance runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->