### PR TITLE
test: add property tests for bitnet-sampling and bitnet-tokenizers

### DIFF
--- a/crates/bitnet-sampling/tests/sampling_proptests.rs
+++ b/crates/bitnet-sampling/tests/sampling_proptests.rs
@@ -1,0 +1,146 @@
+//! Property-based tests for `bitnet-sampling` – new invariant coverage.
+//!
+//! Each test exercises a distinct invariant:
+//!
+//!   1. `apply_temperature(1.0)` is an identity transform.
+//!   2. Top-K: at most K non-zero probabilities after filtering + softmax.
+//!   3. Top-P: retained nucleus cumulative mass is >= p.
+//!   4. Repetition penalty lowers the effective logit of penalised tokens.
+//!   5. Same seed + same logits -> same sampled token (reproducibility).
+//!   6. All-NEG_INFINITY-except-one -> that single token is always chosen.
+
+use bitnet_sampling::{
+    SamplingConfig, SamplingStrategy, apply_repetition_penalty, apply_temperature, apply_top_k,
+    apply_top_p, softmax_in_place,
+};
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn temperature_one_is_identity(
+        logits in prop::collection::vec(-20.0f32..20.0f32, 2..=64),
+    ) {
+        let mut scaled = logits.clone();
+        apply_temperature(&mut scaled, 1.0);
+        prop_assert_eq!(&scaled, &logits, "apply_temperature(1.0) must leave logits unchanged");
+
+        let mut probs_orig = logits.clone();
+        let mut probs_scaled = scaled.clone();
+        softmax_in_place(&mut probs_orig);
+        softmax_in_place(&mut probs_scaled);
+        for (a, b) in probs_orig.iter().zip(probs_scaled.iter()) {
+            prop_assert!(
+                (a - b).abs() < 1e-5,
+                "softmax probability {} vs {} differ after temp=1.0 no-op", a, b
+            );
+        }
+    }
+
+    #[test]
+    fn top_k_at_most_k_nonzero_probs(
+        logits in prop::collection::vec(-10.0f32..10.0f32, 2..=64),
+        k in 1usize..=32,
+    ) {
+        let effective_k = k.min(logits.len());
+        let mut buf = logits.clone();
+        apply_top_k(&mut buf, effective_k);
+        softmax_in_place(&mut buf);
+        let nonzero = buf.iter().filter(|&&p| p > 0.0).count();
+        prop_assert!(
+            nonzero <= effective_k,
+            "non-zero count {} exceeds top_k={}",
+            nonzero,
+            effective_k
+        );
+    }
+
+    #[test]
+    fn top_p_nucleus_covers_at_least_p_mass(
+        logits in prop::collection::vec(-10.0f32..10.0f32, 2..=64),
+        p in 0.05f32..0.99f32,
+    ) {
+        let mut probs = logits.clone();
+        softmax_in_place(&mut probs);
+        apply_top_p(&mut probs, p);
+        let nucleus_mass: f32 = probs.iter().filter(|&&x| x > 0.0).sum();
+        prop_assert!(
+            nucleus_mass >= p - 1e-4,
+            "nucleus mass {} < top_p={}", nucleus_mass, p
+        );
+    }
+
+    #[test]
+    fn repetition_penalty_lowers_penalised_token_logit(
+        pos_logit in 0.01f32..20.0f32,
+        neg_logit in -20.0f32..-0.01f32,
+        penalty in 1.01f32..5.0f32,
+    ) {
+        let mut buf_pos = vec![pos_logit, 0.5f32];
+        apply_repetition_penalty(&mut buf_pos, &[0u32], penalty);
+        prop_assert!(
+            buf_pos[0] < pos_logit,
+            "positive logit {} should decrease after penalty {}; got {}",
+            pos_logit, penalty, buf_pos[0]
+        );
+
+        let mut buf_neg = vec![neg_logit, 0.5f32];
+        apply_repetition_penalty(&mut buf_neg, &[0u32], penalty);
+        prop_assert!(
+            buf_neg[0] < neg_logit,
+            "negative logit {} should become more negative after penalty {}; got {}",
+            neg_logit, penalty, buf_neg[0]
+        );
+    }
+
+    #[test]
+    fn same_seed_and_logits_give_same_token(
+        logits in prop::collection::vec(-5.0f32..5.0f32, 2..=64),
+        seed in any::<u64>(),
+        temperature in 0.1f32..3.0f32,
+    ) {
+        let make = || {
+            SamplingStrategy::new(SamplingConfig {
+                temperature,
+                top_k: 0,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(seed),
+            })
+        };
+        let t1 = make().sample(&logits, &[]).unwrap();
+        let t2 = make().sample(&logits, &[]).unwrap();
+        prop_assert_eq!(
+            t1, t2,
+            "seed={} must yield identical tokens; got {} vs {}",
+            seed, t1, t2
+        );
+    }
+
+    #[test]
+    fn single_finite_logit_always_selected(
+        n_tokens in 2usize..=64,
+        hot_idx in 0usize..64,
+        hot_logit in -10.0f32..10.0f32,
+        temperature in 0.1f32..3.0f32,
+        seed in any::<u64>(),
+    ) {
+        let hot = hot_idx % n_tokens;
+        let mut logits = vec![f32::NEG_INFINITY; n_tokens];
+        logits[hot] = hot_logit;
+
+        let config = SamplingConfig {
+            temperature,
+            top_k: 0,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(seed),
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&logits, &[]).unwrap();
+        prop_assert_eq!(
+            token, hot as u32,
+            "with only token {} finite (logit={}), sampler must select it; got {}",
+            hot, hot_logit, token
+        );
+    }
+}

--- a/crates/bitnet-tokenizers/tests/tokenizer_proptests.rs
+++ b/crates/bitnet-tokenizers/tests/tokenizer_proptests.rs
@@ -1,0 +1,129 @@
+//! Property-based tests for `bitnet-tokenizers` – invariant coverage.
+//!
+//! Invariants tested:
+//!   1. MockTokenizer encode -> decode roundtrip recovers original text.
+//!   2. All token IDs returned by encode are in [0, vocab_size).
+//!   3. Encoding an empty string never panics and returns Ok.
+//!   4. Configured BOS / EOS special token IDs are within [0, vocab_size).
+//!   5. Registered special tokens resolve correctly via token_to_id.
+//!   6. Byte-level token IDs are always in [0, 256).
+//!   7. decode never panics for arbitrary valid token ID sequences.
+
+use bitnet_tokenizers::{BasicTokenizer, MockTokenizer, Tokenizer};
+use proptest::prelude::*;
+
+proptest! {
+    /// MockTokenizer is byte-level: encode maps each UTF-8 byte to its value,
+    /// decode reconstructs those bytes. The roundtrip must recover the original text.
+    #[test]
+    fn mock_tokenizer_encode_decode_roundtrip(
+        text in "[a-zA-Z0-9 !?,.:;'-]{1,80}",
+    ) {
+        let tok = MockTokenizer::new();
+        let tokens = tok.encode(&text, false, false)
+            .expect("MockTokenizer::encode must not fail");
+        prop_assert!(!tokens.is_empty(), "non-empty text must produce at least one token");
+        let recovered = tok.decode(&tokens)
+            .expect("MockTokenizer::decode must not fail");
+        prop_assert_eq!(recovered, text, "encode->decode must recover original text");
+    }
+
+    /// Every token ID produced by MockTokenizer::encode must be strictly less
+    /// than vocab_size() -- no ID escapes the vocabulary bounds.
+    #[test]
+    fn mock_tokenizer_token_ids_in_valid_range(
+        text in "[a-zA-Z0-9 ]{1,64}",
+    ) {
+        let tok = MockTokenizer::new();
+        let vocab = tok.vocab_size();
+        let tokens = tok.encode(&text, false, false)
+            .expect("encode must succeed");
+        for &id in &tokens {
+            prop_assert!(
+                (id as usize) < vocab,
+                "token ID {} is outside vocab range [0, {})", id, vocab
+            );
+        }
+    }
+
+    /// Encoding an empty string with any combination of flags must never panic
+    /// and must return Ok (not Err).
+    #[test]
+    fn empty_string_encoding_never_panics(
+        add_bos in any::<bool>(),
+        add_special in any::<bool>(),
+    ) {
+        let tok = MockTokenizer::new();
+        let result = tok.encode("", add_bos, add_special);
+        prop_assert!(
+            result.is_ok(),
+            "encoding empty string must succeed; got Err: {:?}",
+            result.err()
+        );
+    }
+
+    /// When BOS and EOS token IDs are explicitly configured, both accessors must
+    /// return IDs within [0, vocab_size) -- they are valid vocabulary indices.
+    #[test]
+    fn special_token_ids_are_in_valid_range(
+        vocab_size in 512usize..100_000usize,
+        bos_id in 0u32..256u32,
+        eos_id in 256u32..512u32,
+    ) {
+        prop_assume!((bos_id as usize) < vocab_size);
+        prop_assume!((eos_id as usize) < vocab_size);
+
+        let tok = BasicTokenizer::with_config(vocab_size, Some(bos_id), Some(eos_id), None);
+        if let Some(bos) = tok.bos_token_id() {
+            prop_assert!(
+                (bos as usize) < tok.vocab_size(),
+                "BOS id {} must be < vocab_size {}", bos, tok.vocab_size()
+            );
+        }
+        if let Some(eos) = tok.eos_token_id() {
+            prop_assert!(
+                (eos as usize) < tok.vocab_size(),
+                "EOS id {} must be < vocab_size {}", eos, tok.vocab_size()
+            );
+        }
+    }
+
+    /// A token string registered via MockTokenizer::with_special_tokens must be
+    /// retrievable by token_to_id with the exact same ID.
+    #[test]
+    fn mock_tokenizer_special_token_lookup_matches_registration(
+        token_id in 0u32..50257u32,
+    ) {
+        let tok = MockTokenizer::with_special_tokens(&[("<bos>", token_id)]);
+        let resolved = tok.token_to_id("<bos>");
+        prop_assert_eq!(
+            resolved,
+            Some(token_id),
+            "token_to_id must return registered ID for <bos>"
+        );
+    }
+
+    /// BasicTokenizer byte-level encoding (ASCII input, no special tokens)
+    /// produces only byte-range IDs in [0, 256).
+    #[test]
+    fn basic_tokenizer_byte_ids_in_byte_range(
+        text in "[a-z]{1,64}",
+    ) {
+        let tok = BasicTokenizer::new();
+        let tokens = tok.encode(&text, false, false).expect("encode must succeed");
+        for &id in &tokens {
+            prop_assert!(id < 256, "byte-level encoding must produce IDs < 256; got {}", id);
+        }
+    }
+
+    /// MockTokenizer::decode must always return Ok and never panic for any
+    /// sequence of arbitrary u32 values within [0, vocab_size).
+    #[test]
+    fn mock_tokenizer_decode_never_panics(
+        ids in prop::collection::vec(0u32..50257u32, 0..100),
+    ) {
+        let tok = MockTokenizer::new();
+        let result = tok.decode(&ids);
+        prop_assert!(result.is_ok(), "decode must not fail; got {:?}", result.err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds two new property test files to exercise invariants that were not covered by the existing `property_tests.rs` files.

### `crates/bitnet-sampling/tests/sampling_proptests.rs` (6 tests)

| Test | Invariant |
|------|-----------|
| `temperature_one_is_identity` | `apply_temperature(1.0)` is a no-op — logits and softmax output unchanged |
| `top_k_at_most_k_nonzero_probs` | After `apply_top_k(k)` + softmax, at most `k` non-zero probabilities |
| `top_p_nucleus_covers_at_least_p_mass` | Retained nucleus cumulative mass ≥ `p` after `apply_top_p` |
| `repetition_penalty_lowers_penalised_token_logit` | Penalty > 1 decreases positive logits and pushes negative logits further negative |
| `same_seed_and_logits_give_same_token` | Same seed + same logits → same sampled token (reproducibility) |
| `single_finite_logit_always_selected` | All-NEG_INFINITY-except-one → that token is always selected |

### `crates/bitnet-tokenizers/tests/tokenizer_proptests.rs` (7 tests)

| Test | Invariant |
|------|-----------|
| `mock_tokenizer_encode_decode_roundtrip` | `MockTokenizer` byte-level roundtrip recovers original text |
| `mock_tokenizer_token_ids_in_valid_range` | All encoded IDs are in `[0, vocab_size)` |
| `empty_string_encoding_never_panics` | Encoding `` with any flags returns `Ok` |
| `special_token_ids_are_in_valid_range` | Configured BOS/EOS IDs are within `[0, vocab_size)` |
| `mock_tokenizer_special_token_lookup_matches_registration` | Registered special tokens resolve correctly via `token_to_id` |
| `basic_tokenizer_byte_ids_in_byte_range` | ASCII input produces byte-range IDs only (< 256) |
| `mock_tokenizer_decode_never_panics` | `decode` never panics for arbitrary valid ID sequences |

## Testing

```
cargo test -p bitnet-sampling --no-default-features --test sampling_proptests
# 6 passed

cargo test -p bitnet-tokenizers --no-default-features --test tokenizer_proptests
# 7 passed
```