### PR TITLE
docs: update changelog and roadmap for PRs #861-#864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to bitnet-rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `test(inference): add property-based tests for inference invariants` — 20 property tests in `crates/bitnet-inference/tests/inference_proptests.rs` covering SamplingConfig, GenerationConfig, stop tokens, and receipt schema invariants (#861)
+- `feat(device-probe): extract bitnet-device-probe SRP microcrate` — new `crates/bitnet-device-probe/` SRP microcrate exporting SimdLevel, CpuProbe, DeviceProbe, probe_device(); 5 property tests (#862)
+- `feat(logits): extract bitnet-logits SRP microcrate` — named unit tests in `crates/bitnet-logits/tests/logits_tests.rs` for softmax, top-k, temperature, and argmax invariants (#863)
+- `test(e2e): add CPU golden path integration test` — extended CPU E2E golden path tests with 2 new always-on tests (#864)
 - `test: add property tests for bitnet-models` — 10 property tests in `crates/bitnet-models/tests/model_load_proptests.rs` covering config roundtrip, shape invariants, quantization type parsing, and flavor detection (#859)
 - `fix(ci): increase grid-check timeout to 20min; deduplicate cargo check calls` — BDD Grid Check timeout raised to 20 minutes; duplicate `cargo check` calls removed to speed up CI (#859)
 - `test: add property tests for runtime microcrates` — 51+ property tests across 6 thin façade crates: bitnet-feature-matrix, bitnet-runtime-bootstrap, bitnet-runtime-context, bitnet-startup-contract, bitnet-testing-policy, bitnet-testing-scenarios; plus sampling and tokenizer proptests (#857)

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#859.
+> **Last updated**: reflects implementation state after PRs #608–#864.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---


### PR DESCRIPTION
## Summary

Update CHANGELOG.md and roadmap for recently merged PRs:
- #861 inference proptests
- #862 device-probe microcrate
- #863 logits tests
- #864 E2E golden path tests

## Changes
- CHANGELOG.md: Added 4 new entries under Unreleased
- docs/reference/dual-backend-roadmap.md: Updated last-updated marker to #864

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>