### PR TITLE
feat(fuzz): add generation_stop_checker fuzz target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -109,6 +109,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "generation_stop_checker"
+path = "fuzz_targets/generation_stop_checker.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "rope_table_gen"
 path = "fuzz_targets/rope_table_gen.rs"
 test = false

--- a/fuzz/fuzz_targets/generation_stop_checker.rs
+++ b/fuzz/fuzz_targets/generation_stop_checker.rs
@@ -1,0 +1,58 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_generation::{StopCriteria, check_stop};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    /// Token IDs that immediately trigger a stop.
+    stop_token_ids: Vec<u32>,
+    /// Raw bytes used to build stop strings; chunked into valid UTF-8 slices.
+    stop_strings_raw: Vec<u8>,
+    /// Hard cap on generated tokens (0 = unlimited).
+    max_tokens: u16,
+    /// Model EOS token, if any.
+    eos_token_id: Option<u32>,
+    /// The token being evaluated this step.
+    token_id: u32,
+    /// Tokens produced so far (capped to keep corpus manageable).
+    generated: Vec<u32>,
+    /// Decoded tail bytes – valid UTF-8 sub-slices used; remainder skipped.
+    decoded_tail_raw: Vec<u8>,
+}
+
+fuzz_target!(|input: Input| {
+    let stop_strings: Vec<String> = input
+        .stop_strings_raw
+        .chunks(8)
+        .filter_map(|b| std::str::from_utf8(b).ok())
+        .map(str::to_owned)
+        .take(4)
+        .collect();
+
+    let criteria = StopCriteria {
+        stop_token_ids: input.stop_token_ids.into_iter().take(16).collect(),
+        stop_strings,
+        max_tokens: input.max_tokens as usize,
+        eos_token_id: input.eos_token_id,
+    };
+
+    let generated: Vec<u32> = input.generated.into_iter().take(256).collect();
+    let decoded_tail = std::str::from_utf8(&input.decoded_tail_raw).unwrap_or("");
+
+    // Must never panic for any input.
+    let result = check_stop(&criteria, input.token_id, &generated, decoded_tail);
+
+    // Invariant: empty stop conditions → generation always continues.
+    if criteria.stop_token_ids.is_empty()
+        && criteria.stop_strings.is_empty()
+        && criteria.eos_token_id.is_none()
+        && criteria.max_tokens == 0
+    {
+        assert!(
+            result.is_none(),
+            "check_stop must return None when all stop conditions are empty, got {result:?}"
+        );
+    }
+});


### PR DESCRIPTION
## Summary

Adds a new libFuzzer fuzz target `generation_stop_checker` that exercises `check_stop` from the `bitnet-generation` crate.

### What it fuzzes

The target drives `check_stop` with fully arbitrary inputs:
- **token IDs** (u32) — the token produced at the current step
- **stop-token-ID list** (Vec<u32>, capped at 16)
- **stop strings** (derived from raw bytes, capped at 4 × 8-byte chunks)
- **generated tokens so far** (Vec<u32>, capped at 256)
- **decoded tail** (best-effort UTF-8 from raw bytes)
- **max_tokens** budget (u16)
- **EOS token ID** (Option<u32>)

### Properties verified

1. **No panics** — `check_stop` must not panic for any combination of inputs.
2. **Empty-conditions invariant** — when all stop conditions are empty (`stop_token_ids` is empty, `eos_token_id` is `None`, `max_tokens == 0`, `stop_strings` is empty), the result must always be `None`.

### Relationship to existing target

The existing `generation_stop_check` target covers the no-panic property. This new target adds the **empty-conditions invariant check** and uses a more direct `Vec<String>` construction path for stop strings.

### Verification

```
cargo check --manifest-path fuzz/Cargo.toml
```
Compiles cleanly (verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a fuzz testing target for the generation stopping mechanism to enhance code quality by validating stopping criteria logic across diverse randomized input combinations and ensuring robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->