### PR TITLE
test(snapshot): add snapshot tests wave 2 for generation and engine-core

### DIFF
--- a/crates/bitnet-engine-core/tests/snapshot_tests.rs
+++ b/crates/bitnet-engine-core/tests/snapshot_tests.rs
@@ -49,3 +49,19 @@ fn session_metrics_default_json_snapshot() {
     let json = serde_json::to_string_pretty(&metrics).unwrap();
     insta::assert_snapshot!("session_metrics_default_json", json);
 }
+
+#[test]
+fn generation_stats_default_json_snapshot() {
+    use bitnet_engine_core::GenerationStats;
+    let stats = GenerationStats::default();
+    let json = serde_json::to_string_pretty(&stats).unwrap();
+    insta::assert_snapshot!("generation_stats_default_json", json);
+}
+
+#[test]
+fn generation_stats_with_values_json_snapshot() {
+    use bitnet_engine_core::GenerationStats;
+    let stats = GenerationStats { tokens_generated: 64, tokens_per_second: 12.3 };
+    let json = serde_json::to_string_pretty(&stats).unwrap();
+    insta::assert_snapshot!("generation_stats_with_values_json", json);
+}

--- a/crates/bitnet-engine-core/tests/snapshots/snapshot_tests__generation_stats_default_json.snap
+++ b/crates/bitnet-engine-core/tests/snapshots/snapshot_tests__generation_stats_default_json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-engine-core/tests/snapshot_tests.rs
+expression: json
+---
+{
+  "tokens_generated": 0,
+  "tokens_per_second": 0.0
+}

--- a/crates/bitnet-engine-core/tests/snapshots/snapshot_tests__generation_stats_with_values_json.snap
+++ b/crates/bitnet-engine-core/tests/snapshots/snapshot_tests__generation_stats_with_values_json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-engine-core/tests/snapshot_tests.rs
+expression: json
+---
+{
+  "tokens_generated": 64,
+  "tokens_per_second": 12.3
+}

--- a/crates/bitnet-generation/tests/snapshot_tests.rs
+++ b/crates/bitnet-generation/tests/snapshot_tests.rs
@@ -3,7 +3,9 @@
 //! Pins the serialized forms of generation contracts — stopping criteria,
 //! stream events, and configuration — to catch unintended wire-format changes.
 
-use bitnet_generation::{GenerationConfig, StopCriteria, StopReason};
+use bitnet_generation::{
+    GenerationConfig, GenerationStats, StopCriteria, StopReason, StreamEvent, TokenEvent,
+};
 
 #[test]
 fn stop_reason_debug_all_variants() {
@@ -38,4 +40,33 @@ fn stop_criteria_with_token_ids_debug_snapshot() {
         eos_token_id: Some(2),
     };
     insta::assert_debug_snapshot!("stop_criteria_with_values", criteria);
+}
+
+#[test]
+fn generation_stats_default_json_snapshot() {
+    let stats = GenerationStats::default();
+    let json = serde_json::to_string_pretty(&stats).unwrap();
+    insta::assert_snapshot!("generation_stats_default_json", json);
+}
+
+#[test]
+fn generation_stats_with_values_json_snapshot() {
+    let stats = GenerationStats { tokens_generated: 42, tokens_per_second: 15.5 };
+    let json = serde_json::to_string_pretty(&stats).unwrap();
+    insta::assert_snapshot!("generation_stats_with_values_json", json);
+}
+
+#[test]
+fn stream_event_token_debug_snapshot() {
+    let event = StreamEvent::Token(TokenEvent { id: 1234, text: "hello".to_string() });
+    insta::assert_debug_snapshot!("stream_event_token", event);
+}
+
+#[test]
+fn stream_event_done_debug_snapshot() {
+    let event = StreamEvent::Done {
+        reason: StopReason::EosToken,
+        stats: GenerationStats { tokens_generated: 10, tokens_per_second: 5.0 },
+    };
+    insta::assert_debug_snapshot!("stream_event_done", event);
 }

--- a/crates/bitnet-generation/tests/snapshots/snapshot_tests__generation_stats_default_json.snap
+++ b/crates/bitnet-generation/tests/snapshots/snapshot_tests__generation_stats_default_json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-generation/tests/snapshot_tests.rs
+expression: json
+---
+{
+  "tokens_generated": 0,
+  "tokens_per_second": 0.0
+}

--- a/crates/bitnet-generation/tests/snapshots/snapshot_tests__generation_stats_with_values_json.snap
+++ b/crates/bitnet-generation/tests/snapshots/snapshot_tests__generation_stats_with_values_json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-generation/tests/snapshot_tests.rs
+expression: json
+---
+{
+  "tokens_generated": 42,
+  "tokens_per_second": 15.5
+}

--- a/crates/bitnet-generation/tests/snapshots/snapshot_tests__stream_event_done.snap
+++ b/crates/bitnet-generation/tests/snapshots/snapshot_tests__stream_event_done.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-generation/tests/snapshot_tests.rs
+expression: event
+---
+Done {
+    reason: EosToken,
+    stats: GenerationStats {
+        tokens_generated: 10,
+        tokens_per_second: 5.0,
+    },
+}

--- a/crates/bitnet-generation/tests/snapshots/snapshot_tests__stream_event_token.snap
+++ b/crates/bitnet-generation/tests/snapshots/snapshot_tests__stream_event_token.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-generation/tests/snapshot_tests.rs
+expression: event
+---
+Token(
+    TokenEvent {
+        id: 1234,
+        text: "hello",
+    },
+)


### PR DESCRIPTION
## Summary

Adds snapshot tests for key structured outputs that were missing coverage in `bitnet-generation` and `bitnet-engine-core`.

## Changes

### `bitnet-generation`
- **`GenerationStats`** JSON snapshots: default (zero values) and populated (42 tokens, 15.5 TPS)
- **`StreamEvent`** debug snapshots: `Token` variant and `Done` variant (with `EosToken` reason and stats)

### `bitnet-engine-core`
- **`GenerationStats`** JSON snapshots (re-exported from `bitnet-generation`): default and with values (64 tokens, 12.3 TPS)

## New snap files (6)
- `snapshot_tests__generation_stats_default_json.snap` (both crates)
- `snapshot_tests__generation_stats_with_values_json.snap` (both crates)
- `snapshot_tests__stream_event_token.snap` (bitnet-generation)
- `snapshot_tests__stream_event_done.snap` (bitnet-generation)

## Testing
All 8 snapshot tests in `bitnet-generation` and 7 in `bitnet-engine-core` pass.