### PR TITLE
fix(ci): fix invalid expression syntax in workflow files

### DIFF
--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -86,15 +86,8 @@ jobs:
             os: macos-latest  # M1 Mac
             target: aarch64-apple-darwin
 
-    # Skip platforms based on filter; only run on schedule or manual dispatch
-    if: |
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (
-        github.event.inputs.platform_filter == 'all' ||
-        github.event.inputs.platform_filter == '' ||
-        github.event.inputs.platform_filter == null ||
-        (github.event.inputs.platform_filter == 'linux' && startsWith(matrix.platform, 'linux')) ||
-        (github.event.inputs.platform_filter == 'macos' && startsWith(matrix.platform, 'macos'))
-      )
+    # Only run on schedule or manual dispatch
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -208,7 +208,7 @@ jobs:
             // Add performance metrics if available
             comment += '### Performance\n';
             comment += 'Model: ${{ matrix.model.name }}\n';
-            comment += 'Examples tested: ${{ github.event.inputs.num_examples || "10" }}\n';
+            comment += `Examples tested: ${{ github.event.inputs.num_examples || '10' }}\n`;
 
             // Post comment
             github.rest.issues.createComment({


### PR DESCRIPTION
## Summary

Fixes two workflow files that were silently failing with 0 jobs due to invalid GitHub Actions expression syntax.

### Root causes

**`property-tests.yml` (line 211):**
Double-quoted string literal inside a `${{ }}` expression:
```yaml
# INVALID - double quotes not allowed in GitHub Actions expressions
comment += 'Examples tested: ${{ github.event.inputs.num_examples || "10" }}\n';
```
Fixed to use single quotes and a JS template literal:
```yaml
comment += `Examples tested: ${{ github.event.inputs.num_examples || '10' }}\n`;
```

**`performance-tracking.yml` (line 95):**
`matrix` context used in a job-level `if:` condition where it is not available (only available inside steps):
```yaml
# INVALID - matrix context not available at job level
(github.event.inputs.platform_filter == 'linux' && startsWith(matrix.platform, 'linux'))
```
Fixed by simplifying the job-level condition to only check the event type.

### Validation
Both files pass `actionlint` validation after this fix.

### Effect
Both `property-tests.yml` and `performance-tracking.yml` were showing "This run likely failed because of a workflow file issue" with 0 jobs and 0 seconds duration on every push. This fix allows the `cargo-tests` smoke jobs (added in #879) to actually run.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflows for testing and performance tracking processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->