### PR TITLE
fix(ci): fix invalid job reference in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -539,7 +539,7 @@ jobs:
   post-release:
     name: Post-release tasks
     runs-on: ubuntu-22.04
-    needs: [release, publish-crates, publish-python, publish-npm]
+    needs: [validate, release, publish-crates, publish-python, publish-npm]
     if: always() && github.event.inputs.dry_run != 'true'
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

`actionlint` reported two errors:

```
.github/workflows/release.yml:551:40: property "validate" is not defined in object type {publish-crates: ...; publish-npm: ...; publish-python: ...; release: ...}
.github/workflows/release.yml:588:36: same error
```

The `post-release` job referenced `needs.validate.outputs.version` at lines 552 and 589, but `validate` was not listed in its `needs:` array.

## Fix

Add `validate` to the `needs:` list of the `post-release` job. The `validate` job was already defined in the workflow and produces the `version` output — it was simply missing from the dependency list.

```diff
-    needs: [release, publish-crates, publish-python, publish-npm]
+    needs: [validate, release, publish-crates, publish-python, publish-npm]
```

## Verification

`actionlint .github/workflows/release.yml` reports zero errors after the fix.