### PR TITLE
docs: update changelog and roadmap for PRs #879-#882

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to bitnet-rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `test(server,ffi): add property-based tests to bitnet-server and bitnet-ffi` — additional property tests for `bitnet-server` (batch/concurrency/security config invariants) and `bitnet-ffi` (C API round-trips); further raises proptest coverage across both crates (#880)
 - `test(tokenizers): expand tokenizer_proptests.rs to 18 property tests` — expanded from 7 to 18 property tests covering edge cases in encode/decode round-trips, special-token handling, vocab-size bounds, and determinism invariants in `crates/bitnet-tokenizers/tests/tokenizer_proptests.rs` (#874)
 - `test(device-probe,logits): add integration tests` — integration tests for `bitnet-device-probe` (SimdLevel ordering, `probe_device` smoke test) and `bitnet-logits` (softmax, top-k, temperature, argmax invariants) (#876)
 - `test(snapshot): add snapshot tests wave 2 for generation and engine-core` — insta snapshot tests pinning `StopReason` display variants, `GenerationStats` fields, and receipt schema version string for regression detection (#877)
@@ -32,6 +33,7 @@ All notable changes to bitnet-rs will be documented in this file.
 - `test: expand proptest coverage for compat, templates, and feature-flag crates` — 18 new proptests across bitnet-compat, bitnet-templates, and bitnet-runtime-feature-flags (#841)
 
 ### Fixed
+- `fix(ci): fix property-tests and performance-tracking workflows` — added push/PR triggers and a `cargo-tests` smoke job to the property-tests and performance-tracking CI workflows so they gate correctly on PRs (#879)
 - `fix(ci): add --force to cargo install cargo-fuzz` — prevents fuzz CI failures when the `cargo-fuzz` binary is already present in the runner cache (#872)
 - `fix(server): implement rate limiter cleanup to prevent memory leak` — `ConcurrencyManager::cleanup_rate_limiters` now properly cleans up idle entries to prevent unbounded memory growth (#810)
 

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,6 +1,6 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#877.
+> **Last updated**: reflects implementation state after PRs #608–#880.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
 
 ---
@@ -147,6 +147,8 @@
 | feat(fuzz): safetensors parser fuzz targets — `safetensors_metadata.rs` (header path) and `safetensors_parser.rs` (full parse); `fuzz/Cargo.toml` updated | `fuzz/fuzz_targets/safetensors_metadata.rs`, `fuzz/fuzz_targets/safetensors_parser.rs` | #813 |
 | test(bdd): 5 new BDD grid cells (Unit/Ci, Integration/Ci, Performance/Local, Development/Local, Smoke/Ci); snapshot count 8→13 | `crates/bitnet-bdd-grid/src/lib.rs` | #814 |
 | test(proptest): 31 property + unit tests for `bitnet-ffi` — BitNetCConfig/BitNetCInferenceConfig round-trips, BitNetCError display, MemoryStats arithmetic, thread-local error state | `crates/bitnet-ffi/tests/property_tests.rs` | #815 |
+| CI workflow fixes: push/PR triggers and `cargo-tests` smoke job added to property-tests and performance-tracking workflows | `.github/workflows/property-tests.yml`, `.github/workflows/performance-tracking.yml` | #879 |
+| Additional property tests for `bitnet-server` (batch/concurrency/security config invariants) and `bitnet-ffi` (C API round-trips) | `crates/bitnet-server/tests/`, `crates/bitnet-ffi/tests/` | #880 |
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect recently merged PRs and note upcoming work.

### Changes

**`CHANGELOG.md`** — added to `[Unreleased]` section:
- **`### Added`**: PR #880 — `test(server,ffi)` property-based tests for `bitnet-server` and `bitnet-ffi`
- **`### Fixed`**: PR #879 — `fix(ci)` property-tests and performance-tracking workflow fixes (push/PR triggers + `cargo-tests` smoke job)

**`docs/reference/dual-backend-roadmap.md`**:
- Updated `Last updated` marker from `#608–#877` → `#608–#880`
- Added implementation table rows for PR #879 (CI workflow fixes) and PR #880 (additional property tests)

### Related PRs
- Merged: #879, #880
- Pending (not yet documented): #881 (CI expression syntax fix), #882 (env-var guards replacing `#[ignore]`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>