### PR TITLE
fix(ci): pass PR branch refs through env to prevent script injection

### DIFF
--- a/.github/workflows/pr-size-guard.yml
+++ b/.github/workflows/pr-size-guard.yml
@@ -33,10 +33,11 @@ jobs:
 
     - name: Get PR Size Information
       id: pr-size
+      env:
+        BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+        HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
       run: |
-        # Get the base branch (usually main)
-        BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
-        HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+        # Get the base branch (usually main) from env to avoid script injection
 
         # Get diff statistics
         ADDITIONS=$(git diff --numstat origin/$BASE_BRANCH...HEAD | awk '{sum += $1} END {print sum}')


### PR DESCRIPTION
## Summary

Fixes a GitHub Actions security warning reported by `actionlint`:

> `github.event.pull_request.head.ref` is potentially untrusted. avoid using it directly in inline scripts. instead, pass it through an environment variable.

### Before
```yaml
run: |
  BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
  HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
```

### After
```yaml
env:
  BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
  HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
run: |
  # uses $BASE_BRANCH and $HEAD_BRANCH from env
```

Branch ref names are user-controlled (e.g., a branch named `$(evil command)`) and should not be interpolated directly into shell scripts.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>