### PR TITLE
test(bitnet-common): add property-based tests

### DIFF
--- a/crates/bitnet-common/tests/common_proptests.rs
+++ b/crates/bitnet-common/tests/common_proptests.rs
@@ -14,6 +14,7 @@
 //! - `QuantizationConfig` power-of-two block-size validation
 
 use bitnet_common::{
+    BitNetConfig,
     backend_selection::{BackendRequest, BackendSelectionError, BackendStartupSummary},
     error::{
         BitNetError, InferenceError, KernelError, ModelError, QuantizationError, SecurityError,
@@ -23,7 +24,6 @@ use bitnet_common::{
     math::ceil_div,
     tensor::{ConcreteTensor, Tensor},
     types::{Device, GenerationConfig, QuantizationType},
-    BitNetConfig,
 };
 use proptest::prelude::*;
 


### PR DESCRIPTION
## Summary

Adds `crates/bitnet-common/tests/common_proptests.rs` with **39 proptest property-based tests** covering foundational types in `bitnet-common` that were not covered by the existing `property_tests.rs`.

## What's tested

| Area | Tests |
|------|-------|
| `ceil_div` invariants | coverage, minimality, identity (d=1), exact divisor, zero numerator |
| `BitNetConfig` / `ConfigBuilder` validation | valid configs pass; zero vocab/layers, odd block-size, non-positive temperature all fail; default JSON round-trip |
| Sub-error types | `ModelError`, `QuantizationError`, `KernelError`, `InferenceError`, `SecurityError` — display non-empty and contains injected field values |
| `BackendStartupSummary` | field preservation, `log_line()` format, JSON round-trip |
| `BackendRequest` | non-empty and distinct display strings |
| `Device` | JSON serialisation round-trips for all three variants |
| `SimdLevel` / `KernelBackend` | non-empty and distinct display strings |
| `SecurityLimits` | defaults non-zero; memory ≥ metadata limit |
| `ConcreteTensor::mock` | shape preserved; element count equals dimension product |
| `GenerationConfig` | JSON round-trip preserves all fields |
| `QuantizationType` | display strings are valid ASCII |

## Verification

```
cargo test --locked -p bitnet-common --no-default-features --features cpu --test common_proptests
```

All 39 tests pass in 0.74 s.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>