### PR TITLE
feat(fuzz): add gguf_header_parse fuzz target

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -161,3 +161,9 @@ name = "gguf_header_roundtrip"
 path = "fuzz_targets/gguf_header_roundtrip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "gguf_header_parse"
+path = "fuzz_targets/gguf_header_parse.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/gguf_header_parse.rs
+++ b/fuzz/fuzz_targets/gguf_header_parse.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use bitnet_gguf::{GgufValueType, check_magic, parse_header, read_version};
+use bitnet_models::GgufReader;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Low-level bitnet_gguf header helpers must never panic on arbitrary bytes.
+    let _has_magic = check_magic(data);
+    let _version = read_version(data);
+    let _header = parse_header(data);
+
+    // Exercise GgufValueType discriminant for every 4-byte aligned window.
+    let mut i = 0;
+    while i + 4 <= data.len() {
+        let discriminant = u32::from_le_bytes(data[i..i + 4].try_into().unwrap());
+        let _ = GgufValueType::from_u32(discriminant);
+        i += 4;
+    }
+
+    // Higher-level GgufReader: must not panic even on malformed input.
+    if data.len() < 16 {
+        return;
+    }
+    if let Ok(reader) = GgufReader::new(data) {
+        // Header field accessors must not panic.
+        let _ = reader.version();
+        let _ = reader.alignment();
+        let _ = reader.tensor_count();
+        let _ = reader.metadata_count();
+        let _ = reader.metadata_kv_count();
+        let _ = reader.data_offset();
+        let _ = reader.file_size();
+
+        // Validate must not panic (errors are fine).
+        let _ = reader.validate();
+    }
+});


### PR DESCRIPTION
## Summary

Adds `fuzz/fuzz_targets/gguf_header_parse.rs` — a dedicated fuzz target that exercises GGUF header parsing with arbitrary raw bytes.

## What this target does

| Layer | Functions exercised |
|-------|-------------------|
| `bitnet_gguf` (low-level) | `check_magic`, `read_version`, `parse_header` |
| `bitnet_gguf` (value type) | `GgufValueType::from_u32` over every 4-byte aligned window |
| `bitnet_models::GgufReader` (header accessors) | `version`, `alignment`, `tensor_count`, `metadata_count`, `metadata_kv_count`, `data_offset`, `file_size`, `validate` |

The invariant is simple: **no function in the header-parsing stack may panic on arbitrary input** — only return `Err`/`None`.

## How it differs from existing GGUF fuzz targets

| Target | Input | Scope |
|--------|-------|-------|
| `gguf_header` | raw `&[u8]` | `bitnet_gguf` low-level only |
| `gguf_parser` | raw `&[u8]` | `GgufReader` with metadata/tensor iteration |
| `gguf_header_roundtrip` | structured `Arbitrary` | round-trip correctness assertions |
| `gguf_kv_read` | structured `Arbitrary` | all metadata typed accessors |
| **`gguf_header_parse`** (new) | raw `&[u8]` | **both layers — low-level `bitnet_gguf` + header accessors of `GgufReader`** |

## Verification

```
cargo +nightly fuzz build gguf_header_parse --no-default-features
Finished `release` profile [optimized + debuginfo] target(s)
```

## Files changed
- `fuzz/fuzz_targets/gguf_header_parse.rs` — new fuzz target
- `fuzz/Cargo.toml` — register `[[bin]]` entry