### PR TITLE
test(bitnet-cli): add snapshot tests for CLI help output

### DIFF
--- a/crates/bitnet-cli/tests/cli_snapshot_tests.rs
+++ b/crates/bitnet-cli/tests/cli_snapshot_tests.rs
@@ -1,0 +1,100 @@
+//! Snapshot tests for the `bitnet` binary's CLI output.
+//!
+//! Captures `--help` text for the top-level command and each major subcommand,
+//! plus error messages for invalid arguments.  Any accidental renaming of flags,
+//! addition/removal of subcommands, or changed defaults will cause a diff.
+//!
+//! # Regenerating snapshots
+//!
+//! ```bash
+//! INSTA_UPDATE=unseen cargo test --locked -p bitnet-cli \
+//!   --no-default-features --features cpu,full-cli \
+//!   --test cli_snapshot_tests
+//! ```
+
+#![cfg(feature = "full-cli")]
+
+use assert_cmd::cargo::cargo_bin_cmd;
+use insta::assert_snapshot;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Run `bitnet <args>` and return its stdout as a `String`.
+/// Panics if the process exits with a non-zero code.
+fn bitnet_stdout(args: &[&str]) -> String {
+    let output = cargo_bin_cmd!("bitnet").args(args).output().expect("failed to spawn bitnet");
+    String::from_utf8(output.stdout).expect("stdout is not valid UTF-8")
+}
+
+/// Run `bitnet <args>` and return its stderr as a `String`.
+/// Panics if the process exits with a zero code (we expect failure here).
+fn bitnet_stderr_failure(args: &[&str]) -> String {
+    let output = cargo_bin_cmd!("bitnet").args(args).output().expect("failed to spawn bitnet");
+    assert!(!output.status.success(), "expected bitnet {:?} to fail, but it succeeded", args);
+    String::from_utf8(output.stderr).expect("stderr is not valid UTF-8")
+}
+
+// ---------------------------------------------------------------------------
+// Top-level help
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cli_help() {
+    let help = bitnet_stdout(&["--help"]);
+    assert_snapshot!("cli_help", help);
+}
+
+// ---------------------------------------------------------------------------
+// Subcommand help
+// ---------------------------------------------------------------------------
+
+#[test]
+fn run_help() {
+    let help = bitnet_stdout(&["run", "--help"]);
+    assert_snapshot!("run_help", help);
+}
+
+#[test]
+fn chat_help() {
+    let help = bitnet_stdout(&["chat", "--help"]);
+    assert_snapshot!("chat_help", help);
+}
+
+#[test]
+fn inspect_help() {
+    let help = bitnet_stdout(&["inspect", "--help"]);
+    assert_snapshot!("inspect_help", help);
+}
+
+#[test]
+fn compat_check_help() {
+    let help = bitnet_stdout(&["compat-check", "--help"]);
+    assert_snapshot!("compat_check_help", help);
+}
+
+// ---------------------------------------------------------------------------
+// Error output for invalid / missing arguments
+// ---------------------------------------------------------------------------
+
+#[test]
+fn run_missing_required_args_error() {
+    // `run` needs at least --model and --prompt; omitting them should fail.
+    let err = bitnet_stderr_failure(&["run"]);
+    assert_snapshot!("run_missing_required_args_error", err);
+}
+
+#[test]
+fn compat_check_missing_path_error() {
+    // `compat-check` requires a positional <PATH>; omitting it should fail.
+    let err = bitnet_stderr_failure(&["compat-check"]);
+    assert_snapshot!("compat_check_missing_path_error", err);
+}
+
+#[test]
+fn unknown_subcommand_error() {
+    // An unrecognised subcommand should fail with a helpful error.
+    let err = bitnet_stderr_failure(&["this-does-not-exist"]);
+    assert_snapshot!("unknown_subcommand_error", err);
+}

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
@@ -1,0 +1,166 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: help
+---
+Interactive chat mode (streaming)
+
+# Examples
+
+Auto-detect chat template: bitnet chat --model model.gguf --tokenizer tokenizer.json
+
+LLaMA-3 chat with system prompt: bitnet chat --model model.gguf --prompt-template llama3-chat \ --system-prompt "You are a helpful coding assistant"
+
+Creative chat with nucleus sampling: bitnet chat --model model.gguf --temperature 0.8 --top-p 0.95
+
+Usage: bitnet chat [OPTIONS]
+
+Options:
+  -c, --config <PATH>
+          Configuration file path
+
+  -m, --model <PATH>
+          Path to the model file
+
+      --model-format <FORMAT>
+          Model format (auto, gguf, safetensors)
+          
+          [default: auto]
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
+
+  -p, --prompt <TEXT>
+          Input prompt (if not provided, interactive mode is used)
+
+      --input-file <PATH>
+          Input file containing prompts (one per line)
+
+  -o, --output <PATH>
+          Output file for results
+
+  -d, --device <DEVICE>
+          Device to use for inference (cpu, cuda, auto)
+
+  -q, --quantization <TYPE>
+          Quantization type (i2s, tl1, tl2, auto)
+
+      --max-tokens <N>
+          Maximum number of tokens to generate (aliases: --max-new-tokens, --n-predict)
+          
+          [default: 512]
+          [aliases: --max-new-tokens, --n-predict]
+
+      --temperature <TEMP>
+          Temperature for sampling (0.0 = greedy, higher = more random)
+          
+          [default: 0.7]
+
+      --top-k <K>
+          Top-k sampling parameter
+
+      --top-p <P>
+          Top-p (nucleus) sampling parameter
+
+      --repetition-penalty <PENALTY>
+          Repetition penalty
+          
+          [default: 1.1]
+
+      --seed <SEED>
+          Random seed for reproducible generation
+
+      --greedy
+          Enable greedy decoding (temperature=0, top_p=1, top_k=0)
+
+      --deterministic
+          Force deterministic execution (single-threaded, deterministic ops)
+
+      --threads <N>
+          Number of threads to use (default: all cores)
+
+      --stream
+          Enable streaming output
+
+      --batch-size <SIZE>
+          Batch size for processing multiple prompts
+          
+          [default: 1]
+
+      --workers <N>
+          Number of parallel workers for batch processing
+
+  -i, --interactive
+          Enable interactive mode
+
+      --metrics
+          Show performance metrics
+
+  -v, --verbose
+          Enable verbose output
+
+      --format <FORMAT>
+          Output format (text, json, jsonl)
+          
+          [default: text]
+
+      --system-prompt <TEXT>
+          System prompt for chat models
+
+      --chat-template <TEMPLATE>
+          Chat template to use (deprecated - use --prompt-template)
+
+      --prompt-template <TEMPLATE>
+          Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
+          
+          [default: auto]
+
+      --tokenizer <PATH>
+          Path to tokenizer.json (HF) or tokenizer.model (SPM)
+
+      --no-bos
+          Disable BOS insertion
+
+      --no-eos
+          Disable EOS insertion
+
+      --stop <SEQ>
+          Stop sequences (aliases: --stop-sequence, --stop_sequences)
+          
+          [aliases: --stop-sequence, --stop_sequences]
+
+      --stop-id <ID>
+          Stop token IDs (numeric token IDs to stop generation)
+
+      --stop-string-window <N>
+          Window size for tail-based stop string matching (default: 64) Only decode the last N tokens when checking stop sequences
+          
+          [default: 64]
+
+      --timeout <SECONDS>
+          Timeout for inference (in seconds)
+
+      --dump-logits <N>
+          Dump top-k logits for first N decode steps (for testing)
+
+      --logits-topk <K>
+          Number of top logits to dump per step
+          
+          [default: 10]
+
+      --chat-history-limit <N>
+          Chat history limit (number of turns to keep in context)
+
+      --emit-receipt-dir <DIR>
+          Directory to emit per-turn receipts in chat mode
+
+      --receipt-path <PATH>
+          Path for the primary inference receipt (default: ci/inference.json)
+
+      --qa
+          Q&A mode: bundle Q&A-friendly defaults (auto template, temp=0.7, top-p=0.95, top-k=50) Individual parameters can still be overridden (e.g., --qa --temperature 0.5)
+
+      --strict-loader
+          Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1) Preferred for CI/parity testing. Unset to allow minimal loader fallback (reduced features)
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
@@ -1,0 +1,95 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: help
+---
+BitNet-rs CLI — one-shot generation and chat with strict receipts
+
+QUICK EXAMPLES:
+
+  # Deterministic math sanity check (validates model correctness)
+  RUST_LOG=warn bitnet run --model model.gguf --tokenizer tokenizer.json \
+    --prompt "Answer with a single digit: 2+2=" --max-tokens 1 --temperature 0.0 --greedy
+
+  # General Q&A with instruct template
+  RUST_LOG=warn bitnet run --model model.gguf --tokenizer tokenizer.json \
+    --prompt "What is 2+2?" --max-tokens 16 --temperature 0.0 --greedy
+
+  # Creative completion (nucleus sampling)
+  RUST_LOG=warn bitnet run --model model.gguf --tokenizer tokenizer.json \
+    --prompt "Explain photosynthesis" --max-tokens 128 --temperature 0.7 --top-p 0.95
+
+  # Interactive chat (auto-detects template, clean output)
+  RUST_LOG=warn bitnet chat --model model.gguf --tokenizer tokenizer.json
+
+LOGGING:
+  Set RUST_LOG=warn (default: info) to reduce log noise and focus on generated text.
+  Options: error, warn, info, debug, trace
+
+PERFORMANCE:
+  For best CPU throughput, build with:
+    RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C lto=thin" \
+      cargo build --release --features cpu
+
+  Run with:
+    RAYON_NUM_THREADS=$(nproc) RUST_LOG=warn bitnet run ...
+
+  QK256 Models (I2_S quantization):
+    - Without AVX2: ~0.1 tok/s (scalar kernels, ~10s per token)
+    - With AVX2: ~1.2× faster (optimized kernels)
+    - For quick validation: use --max-tokens 4-16
+    - SIMD optimizations (≥3× faster) coming in v0.2.0
+
+
+Usage: bitnet [OPTIONS] [COMMAND]
+
+Commands:
+  run           Run simple text generation
+  tokenize      Tokenize text and output token IDs as JSON
+  score         Calculate perplexity score for a model
+  inference     Run inference on a model
+  chat          Interactive chat mode (streaming)
+  convert       Convert between model formats
+  benchmark     Benchmark model performance
+  serve         Start inference server
+  config        Manage configuration
+  info          Show system information
+  inspect       Inspect model metadata and diagnostics
+  compat-check  Check GGUF file compatibility using header validation
+  help          Print this message or the help of the given subcommand(s)
+
+Options:
+  -c, --config <PATH>
+          Configuration file path
+
+  -d, --device <DEVICE>
+          Device to use (cpu, cuda, auto)
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
+
+      --threads <N>
+          Number of CPU threads
+
+      --batch-size <SIZE>
+          Batch size for processing
+
+      --completions <SHELL>
+          Generate shell completions
+          
+          [possible values: bash, elvish, fish, powershell, zsh]
+
+      --save-config <PATH>
+          Write the effective configuration to a file and exit
+
+      --interface-version
+          Print CLI interface version and exit
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+CLI Interface Version: 1.0.0
+Docs: https://docs.rs/bitnet
+Issues: https://github.com/EffortlessMetrics/BitNet-rs/issues

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: help
+---
+Check GGUF file compatibility using header validation
+
+Usage: bitnet compat-check [OPTIONS] <PATH>
+
+Arguments:
+  <PATH>  Path to .gguf file
+
+Options:
+  -c, --config <PATH>        Configuration file path
+      --json                 Output JSON
+  -d, --device <DEVICE>      Device to use (cpu, cuda, auto)
+      --strict               Fail on unsupported version or suspicious counts
+      --log-level <LEVEL>    Log level (trace, debug, info, warn, error)
+      --show-kv              Show key-value metadata (limit with --kv-limit)
+      --kv-limit <KV_LIMIT>  Limit number of KV pairs to show (default: 20) [default: 20]
+      --threads <N>          Number of CPU threads
+      --batch-size <SIZE>    Batch size for processing
+  -h, --help                 Print help

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_missing_path_error.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_missing_path_error.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: err
+---
+error: the following required arguments were not provided:
+  <PATH>
+
+Usage: bitnet compat-check <PATH>
+
+For more information, try '--help'.

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: help
+---
+Inspect model metadata and diagnostics
+
+Usage: bitnet inspect [OPTIONS] <MODEL>
+
+Arguments:
+  <MODEL>  Model file path
+
+Options:
+  -c, --config <PATH>            Configuration file path
+      --ln-stats                 Compute and display LayerNorm gamma statistics
+  -d, --device <DEVICE>          Device to use (cpu, cuda, auto)
+      --gate <GATE>              Gate behavior: none|auto|policy [default: auto]
+      --log-level <LEVEL>        Log level (trace, debug, info, warn, error)
+      --policy <POLICY>          Policy file (YAML) for custom validation rules
+      --policy-key <POLICY_KEY>  Policy key (architecture ID) for rules lookup
+      --threads <N>              Number of CPU threads
+      --batch-size <SIZE>        Batch size for processing
+      --json                     Output format as JSON
+  -h, --help                     Print help

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
@@ -1,0 +1,135 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: help
+---
+Run simple text generation
+
+# Examples
+
+Auto-detect template for Q&A (recommended): bitnet run --model model.gguf --prompt "Who wrote Pride and Prejudice?"
+
+Instruct template (explicit Q&A format): bitnet run --model model.gguf --prompt-template instruct \ --prompt "What is 2+2?" --max-tokens 16
+
+LLaMA-3 chat format with system prompt: bitnet run --model model.gguf --prompt-template llama3-chat \ --system-prompt "You are a helpful assistant" \ --prompt "Explain photosynthesis" --max-tokens 128
+
+Deterministic Q&A with greedy decoding: bitnet run --model model.gguf --prompt "Test question" \ --temperature 0.0 --greedy --seed 42
+
+Raw completion (no Q&A formatting): bitnet run --model model.gguf --prompt-template raw \ --prompt "2+2=" --max-tokens 16
+
+Usage: bitnet run [OPTIONS] --model <MODEL> --prompt <PROMPT>
+
+Options:
+  -c, --config <PATH>
+          Configuration file path
+
+  -m, --model <MODEL>
+          Model file path
+
+  -d, --device <DEVICE>
+          Device to use (cpu, cuda, auto)
+
+      --tokenizer <TOKENIZER>
+          Tokenizer file path (optional, will look for sibling file if not provided)
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
+
+  -p, --prompt <PROMPT>
+          Input prompt
+
+      --max-new-tokens <MAX_NEW_TOKENS>
+          Maximum new tokens to generate (aliases: --max-tokens, --n-predict)
+          
+          [default: 32]
+          [aliases: --max-tokens, --n-predict]
+
+      --batch-size <SIZE>
+          Batch size for processing
+
+      --temperature <TEMPERATURE>
+          Temperature for sampling (0 = greedy)
+          
+          [default: 1]
+
+      --top-k <TOP_K>
+          Top-k sampling (0 = disabled)
+          
+          [default: 0]
+
+      --top-p <TOP_P>
+          Top-p (nucleus) sampling
+          
+          [default: 1]
+
+      --repetition-penalty <REPETITION_PENALTY>
+          Repetition penalty
+          
+          [default: 1.1]
+
+      --seed <SEED>
+          Random seed for reproducibility
+
+      --allow-mock
+          Allow falling back to mock loader if real loader fails Also toggled by env BITNET_ALLOW_MOCK=1
+          
+          [env: BITNET_ALLOW_MOCK=]
+
+      --strict-mapping
+          Strict mapping mode: fail if any tensors are unmapped
+
+      --strict-tokenizer
+          Strict tokenizer mode: fail if no real tokenizer available
+
+      --strict-loader
+          Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)
+
+      --json-out <JSON_OUT>
+          Output JSON results to file
+
+      --dump-ids
+          Dump token IDs to stdout
+
+      --bos
+          Insert BOS token at start of prompt
+
+      --greedy
+          Use greedy decoding (overrides temperature)
+
+      --deterministic
+          Enable deterministic mode (single-threaded)
+
+      --threads <THREADS>
+          Number of threads to use (0 = all cores)
+          
+          [default: 0]
+
+      --prompt-template <TEMPLATE>
+          Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
+          
+          [default: auto]
+
+      --system-prompt <TEXT>
+          System prompt for chat models
+
+      --stop <SEQ>
+          Stop sequences (can be repeated for multiple sequences)
+
+      --stop-id <ID>
+          Stop token IDs (numeric token IDs, can be repeated)
+
+      --dump-logit-steps <DUMP_LOGIT_STEPS>
+          Dump logit steps during generation (max steps)
+
+      --logits-topk <K>
+          Top-k tokens to include in logit dump
+          
+          [default: 10]
+
+      --assert-greedy
+          Assert greedy argmax invariant when dumping logits
+
+      --no-warnings
+          Suppress performance warnings
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_missing_required_args_error.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_missing_required_args_error.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: err
+---
+error: the following required arguments were not provided:
+  --model <MODEL>
+  --prompt <PROMPT>
+
+Usage: bitnet run --model <MODEL> --prompt <PROMPT>
+
+For more information, try '--help'.

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__unknown_subcommand_error.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__unknown_subcommand_error.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
+expression: err
+---
+error: unrecognized subcommand 'this-does-not-exist'
+
+Usage: bitnet [OPTIONS] [COMMAND]
+
+For more information, try '--help'.


### PR DESCRIPTION
## Summary

Adds `crates/bitnet-cli/tests/cli_snapshot_tests.rs` with 8 **insta snapshot tests** that pin the deterministic CLI output of the `bitnet` binary.

## Tests added

| Test | What it pins |
|---|---|
| `cli_help` | `bitnet --help` top-level output |
| `run_help` | `bitnet run --help` subcommand output |
| `chat_help` | `bitnet chat --help` subcommand output |
| `inspect_help` | `bitnet inspect --help` subcommand output |
| `compat_check_help` | `bitnet compat-check --help` subcommand output |
| `run_missing_required_args_error` | stderr when `run` omits required args |
| `compat_check_missing_path_error` | stderr when `compat-check` omits the path |
| `unknown_subcommand_error` | stderr for an unrecognised subcommand |

All snapshots are committed alongside the test file under `tests/snapshots/`.

## How it works

- All tests are gated on `#[cfg(feature = "full-cli")]` consistent with the crate convention.
- To regenerate snapshots after an intentional CLI change:
  ```bash
  INSTA_UPDATE=unseen cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_snapshot_tests
  ```

## Testing

```
running 8 tests
test cli_help ... ok
test run_missing_required_args_error ... ok
test compat_check_missing_path_error ... ok
test run_help ... ok
test inspect_help ... ok
test compat_check_help ... ok
test unknown_subcommand_error ... ok
test chat_help ... ok

test result: ok. 8 passed; 0 failed; 0 ignored
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>