### PR TITLE
chore: prepare v0.1.3 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+## [v0.1.3] - 2026-02-27
+
+Test coverage expansion wave 2: property tests across 10+ crates, new fuzz targets, BDD-style kernel tests, CLI snapshot tests, CI hardening, and integration tests for quantization, device-probe, logits, transformer, and tokenizer.
+
 ### Added
 - `test(bitnet-receipts): add property-based tests for receipt validation` — 5 new property tests (20 total) covering validation gate invariants in `crates/bitnet-receipts/tests/`; raises receipt proptest coverage (#891)
 - `test(bitnet-sampling): add comprehensive property-based tests` — 14 new property tests for sampling invariants in `crates/bitnet-sampling/tests/`; covers temperature, top-k/p, repetition penalty, and greedy determinism (#890)

--- a/docs/releases/v0.1.3.md
+++ b/docs/releases/v0.1.3.md
@@ -1,0 +1,101 @@
+# v0.1.3 Release Notes
+
+**Released**: 2026-02-27
+
+## Overview
+
+v0.1.3 is a test coverage and CI hardening release. It continues the property-test expansion
+begun in v0.1.2, adding hundreds of new tests across over ten crates, two new fuzz targets,
+BDD-style kernel tests, and CLI snapshot tests. CI workflows were tightened to prevent injection
+attacks and eliminate false-green builds.
+
+## Highlights
+
+### Test Coverage Expansion
+
+Property-based tests (proptest) were added or expanded in:
+
+- **bitnet-receipts** — 20 total property tests covering validation gate invariants
+- **bitnet-sampling** — 14 new property tests for temperature, top-k/p, repetition penalty,
+  and greedy determinism
+- **bitnet-kernels** — 30 BDD-style kernel tests across 7 sections validating dispatch,
+  capability registry, and SIMD selection
+- **bitnet-common** — 39 property tests across `Device`, `Config`, errors, and math invariants
+- **bitnet-gguf** — 103 total property tests (up from 83)
+- **bitnet-transformer** — 8 property tests for RoPE and KV-cache invariants
+- **bitnet-inference** — 20 property tests covering `SamplingConfig`, `GenerationConfig`,
+  stop tokens, and receipt schema invariants
+- **bitnet-models** — 10 property tests for config roundtrip, shape invariants, quantization
+  type parsing, and flavor detection
+- **bitnet-tokenizers** — expanded from 7 to 18 property tests
+- **bitnet-server / bitnet-ffi** — batch/concurrency/security config invariants and C API
+  round-trips
+- **bitnet-engine-core** — 6 property tests for clone, field, and seed invariants
+- **bitnet-generation** — 6 property tests for stopping invariants
+- **bitnet-logits** — 4 property tests for logits invariants
+
+### New Fuzz Targets
+
+- **`gguf_header_parse`** — exercises GGUF header parsing paths for robustness
+- **`generation_stop_checker`** — exercises `check_stop` covering stop-token, stop-sequence,
+  max-tokens, and combined stopping criteria
+
+The fuzz suite now includes 10+ targets with a scheduled nightly CI job (2 AM UTC, 60 s per
+target) that uploads crash artifacts automatically.
+
+### Integration Tests
+
+- **bitnet-quantization** — 10 integration tests for I2S, TL1, and TL2 roundtrip accuracy
+- **bitnet-device-probe** — `SimdLevel` ordering and `probe_device` smoke tests
+- **bitnet-logits** — softmax, top-k, temperature, and argmax invariants
+- **CPU E2E golden path** — extended with 6 always-on tests (stop token, receipt kernel IDs,
+  schema version, max-tokens boundary)
+
+### CLI Snapshot Tests
+
+Insta snapshot tests were added to pin:
+- CLI help output for regression detection
+- `StopReason` display variants and `GenerationStats` fields
+- Receipt schema version string
+
+### CI Hardening
+
+- **`pr-size-guard.yml`** — PR branch refs are now passed via environment variables instead
+  of being interpolated into shell commands, eliminating a script-injection vector (#885)
+- **`property-tests.yml` / `performance-tracking.yml`** — added push/PR triggers and a
+  `cargo-tests` smoke job so these workflows gate correctly on PRs (#879)
+- **Fuzz CI** — `--force` added to `cargo install cargo-fuzz` to prevent failures when the
+  binary is already cached; build timeout raised to 60 minutes (#872, #840)
+- **Grid-check timeout** raised to 20 minutes; duplicate `cargo check` calls removed (#859)
+- **Nightly fuzz run** workflow added (#844)
+
+### Reduced Ignored Tests
+
+Ignored test count reduced from 433 → 423 (−10) by enabling tests that were no longer blocked
+by outstanding issues (#847).
+
+### New SRP Microcrates
+
+- **`bitnet-device-probe`** — exports `SimdLevel`, `CpuProbe`, `DeviceProbe`, `probe_device()`
+- **`bitnet-logits`** — named unit tests for softmax, top-k, temperature, and argmax invariants
+
+## Bug Fixes
+
+- **Server rate-limiter memory leak** — `ConcurrencyManager::cleanup_rate_limiters` now
+  properly removes idle entries (#810)
+- **WASM clipboard UX** — copy-to-clipboard button added for generated text in the browser
+  example (#809)
+
+## Performance
+
+- **`apply_top_p` optimization** — skip zero-probability tokens before sorting, reducing
+  unnecessary work in nucleus sampling (#811)
+- **Numerical accuracy integration tests** for `bitnet-quantization` added (I2S dequantize,
+  TL1 LUT, TL2 symmetry, round-trip accuracy, QK256 block size, zero vector) (#838)
+
+## Upgrading
+
+No API changes. No `Cargo.toml` version bumps are required beyond updating your dependency on
+`bitnet-rs` crates to `0.1.3`.
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the full list of changes.


### PR DESCRIPTION
## Summary

Prepares the v0.1.3 release documentation.

### Changes

- **CHANGELOG.md** — moves `[Unreleased]` content to `[v0.1.3] - 2026-02-27` and adds a fresh empty `[Unreleased]` section at the top
- **docs/releases/v0.1.3.md** — new release summary covering all v0.1.3 highlights

### Highlights documented

- Property-based tests across 10+ crates (bitnet-receipts, bitnet-sampling, bitnet-kernels, bitnet-common, bitnet-gguf, bitnet-transformer, bitnet-inference, bitnet-models, bitnet-tokenizers, bitnet-server, bitnet-ffi, bitnet-engine-core, bitnet-generation, bitnet-logits)
- New fuzz targets: `gguf_header_parse`, `generation_stop_checker` (10+ total fuzz targets)
- BDD-style kernel tests (30 tests across 7 sections)
- CLI snapshot tests (insta)
- CI hardening: pr-size-guard script injection fix, property-tests/performance-tracking trigger fix, fuzz build improvements
- Integration tests: quantization roundtrip, device-probe, logits, CPU E2E golden path
- New SRP microcrates: bitnet-device-probe, bitnet-logits
- Ignored test count reduced: 433 → 423

### What this PR does NOT do

- Does **not** bump version numbers in any `Cargo.toml` — that is a separate step
- Does **not** create a git tag — tag will be created after merge

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>