### PR TITLE
test: remove #[ignore] from 10 self-skipping tests

### DIFF
--- a/crates/bitnet-cli/tests/help_text_snapshot.rs
+++ b/crates/bitnet-cli/tests/help_text_snapshot.rs
@@ -149,9 +149,8 @@ fn test_help_footer_has_docs_and_issues_links() -> Result<()> {
 }
 
 #[test]
-#[ignore = "Manual inspection: Run with --ignored to see current help text"]
 fn test_print_current_help_text() -> Result<()> {
-    // This test is ignored by default but can be run manually to inspect help text
+    // Prints current help text; useful during development for manual review.
     let mut cmd = TestCli::command();
     let help = format!("{}", cmd.render_help());
 

--- a/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
+++ b/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
@@ -24,7 +24,6 @@ use std::path::Path;
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_tokenizer_from_huggingface() {
     let download_info = TokenizerDownloadInfo {
         repo: "meta-llama/Llama-2-7b-hf".to_string(),
@@ -57,7 +56,6 @@ async fn ac4_download_tokenizer_from_huggingface() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_tokenizer_download_caching() {
     use std::time::Instant;
 
@@ -99,7 +97,6 @@ async fn ac4_tokenizer_download_caching() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_verification() {
     let download_info = TokenizerDownloadInfo {
         repo: "meta-llama/Llama-2-7b-hf".to_string(),
@@ -162,7 +159,6 @@ async fn ac4_network_failure_handling() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test with retry simulation"]
 async fn ac4_download_retry_logic() {
     let download_info = TokenizerDownloadInfo {
         repo: "meta-llama/Llama-2-7b-hf".to_string(),
@@ -230,7 +226,6 @@ async fn ac4_bitnet_download_infrastructure_integration() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_multiple_tokenizer_files() {
     let download_info = TokenizerDownloadInfo {
         repo: "1bitLLM/bitnet_b1_58-large".to_string(),
@@ -261,7 +256,6 @@ async fn ac4_download_multiple_tokenizer_files() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_progress_monitoring() {
     use std::time::Duration;
     use tokio::time::timeout;
@@ -329,7 +323,6 @@ async fn ac4_offline_mode_handling() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_concurrent_downloads() {
     use tokio::task;
 
@@ -380,7 +373,6 @@ async fn ac4_concurrent_downloads() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_with_vocab_validation() {
     let download_info = TokenizerDownloadInfo {
         repo: "meta-llama/Llama-2-7b-hf".to_string(),
@@ -461,7 +453,6 @@ async fn ac4_discovery_download_integration() {
 // AC:ID AC4
 #[tokio::test]
 #[cfg(feature = "cpu")]
-#[ignore = "Network-dependent test"]
 async fn ac4_download_error_recovery() {
     let problematic_downloads = [
         ("nonexistent/repo", "Repository not found"),


### PR DESCRIPTION
## Summary

Removes `#[ignore]` from 10 tests that already self-skip gracefully when
their dependencies are unavailable, making them invisible to the normal
test run for no reason.

## Changes

### `crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs` (9 tests)

All 9 async download tests had `#[ignore = "Network-dependent test"]`.
Each test calls `SmartTokenizerDownload::download_tokenizer()` which, when the
`downloads` cargo feature is disabled (the default), immediately returns
`Err("Download feature not enabled. Build with --features downloads")`.
network access, no hang, no panic.

| Test | Self-skip mechanism |
|------|---------------------|

### `crates/bitnet-cli/tests/help_text_snapshot.rs` (1 test)

`test_print_current_help_text` had `#[ignore = "Manual inspection: Run with --ignored to see current help text"]`.
The test renders the CLI help text and prints it — zero assertions — so it
always passes.

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| `#[ignore]` count | 238 | 228 |
| Tests enabled | +10 |  |

## Verification

```
cargo test -p bitnet-tokenizers --no-default-features --features cpu \
  --test test_ac4_smart_download_integration
# 14 passed; 0 failed; 0 ignored

cargo test -p bitnet-cli --no-default-features --features cpu,full-cli \
  --test help_text_snapshot -- test_print_current_help_text
# 1 passed; 0 failed; 0 ignored
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>