### PR TITLE
test(bitnet-compat,bitnet-sys): add comprehensive tests

### DIFF
--- a/crates/bitnet-compat/tests/compat_tests.rs
+++ b/crates/bitnet-compat/tests/compat_tests.rs
@@ -1,0 +1,459 @@
+//! Comprehensive tests for `bitnet-compat` crate.
+//!
+//! Exercises `GgufCompatibilityFixer`: diagnose, export_fixed, verify_idempotent,
+//! print_report, and the companion stamp-file contract.
+
+use bitnet_compat::GgufCompatibilityFixer;
+use bitnet_models::formats::gguf::GgufReader;
+use std::fs;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Minimal syntactically-valid GGUF v3 blob: magic + version + two zero counts.
+fn minimal_gguf_v3() -> Vec<u8> {
+    let mut data = Vec::with_capacity(24);
+    data.extend_from_slice(b"GGUF");
+    data.extend_from_slice(&3u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes()); // tensor_count
+    data.extend_from_slice(&0u64.to_le_bytes()); // metadata_kv_count
+    data
+}
+
+fn write_temp(dir: &TempDir, name: &str, bytes: &[u8]) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    fs::write(&path, bytes).expect("write temp file");
+    path
+}
+
+// ---------------------------------------------------------------------------
+// diagnose() — error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diagnose_nonexistent_path_returns_err() {
+    let result = GgufCompatibilityFixer::diagnose("/nonexistent/no/such/file.gguf");
+    assert!(result.is_err(), "diagnose on missing path must return Err");
+}
+
+#[test]
+fn diagnose_empty_path_returns_err() {
+    let result = GgufCompatibilityFixer::diagnose("");
+    assert!(result.is_err(), "diagnose on empty path must return Err");
+}
+
+#[test]
+fn diagnose_invalid_magic_returns_err() {
+    let dir = TempDir::new().unwrap();
+    // 24 bytes that do NOT start with "GGUF"
+    let bad: Vec<u8> = b"NOTG-not-gguf-magic-12345678".to_vec();
+    let path = write_temp(&dir, "bad_magic.gguf", &bad);
+    let result = GgufCompatibilityFixer::diagnose(&path);
+    assert!(result.is_err(), "diagnose on non-GGUF magic must return Err");
+}
+
+#[test]
+fn diagnose_truncated_file_returns_err() {
+    let dir = TempDir::new().unwrap();
+    // Only 3 bytes — too short for any valid GGUF
+    let path = write_temp(&dir, "trunc.gguf", b"GGU");
+    let result = GgufCompatibilityFixer::diagnose(&path);
+    assert!(result.is_err(), "diagnose on truncated file must return Err");
+}
+
+// ---------------------------------------------------------------------------
+// diagnose() — Ok path on minimal GGUF
+// ---------------------------------------------------------------------------
+
+#[test]
+fn diagnose_minimal_gguf_returns_ok() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let result = GgufCompatibilityFixer::diagnose(&path);
+    assert!(result.is_ok(), "diagnose on minimal GGUF must succeed: {:?}", result.err());
+}
+
+#[test]
+fn diagnose_minimal_gguf_reports_missing_bos() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert!(
+        issues.iter().any(|i| i.contains("BOS")),
+        "should report missing BOS token; got: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn diagnose_minimal_gguf_reports_missing_eos() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert!(
+        issues.iter().any(|i| i.contains("EOS")),
+        "should report missing EOS token; got: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn diagnose_minimal_gguf_reports_missing_vocabulary() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert!(
+        issues.iter().any(|i| i.to_lowercase().contains("vocab")),
+        "should report missing vocabulary; got: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn diagnose_minimal_gguf_has_at_least_three_issues() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert!(
+        issues.len() >= 3,
+        "minimal GGUF should have ≥3 issues (BOS, EOS, vocab); got: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn diagnose_all_issue_strings_are_nonempty() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    for issue in &issues {
+        assert!(!issue.trim().is_empty(), "every issue string must be non-empty");
+    }
+}
+
+#[test]
+fn diagnose_all_issue_strings_are_single_line() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "minimal.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    for issue in &issues {
+        assert!(
+            !issue.contains('\n') && !issue.contains('\r'),
+            "issue string must be single-line; got: {:?}",
+            issue
+        );
+    }
+}
+
+#[test]
+fn diagnose_is_deterministic_across_two_calls() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "det.gguf", &minimal_gguf_v3());
+    let first = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    let second = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert_eq!(first, second, "diagnose must return identical issues on repeated calls");
+}
+
+#[test]
+fn diagnose_issue_count_is_bounded() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "bounded.gguf", &minimal_gguf_v3());
+    let issues = GgufCompatibilityFixer::diagnose(&path).unwrap();
+    assert!(issues.len() <= 20, "issue count must be ≤ 20; got {}", issues.len());
+}
+
+// ---------------------------------------------------------------------------
+// export_fixed() — error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_fixed_same_src_dst_returns_err() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "same.gguf", &minimal_gguf_v3());
+    let result = GgufCompatibilityFixer::export_fixed(&path, &path);
+    assert!(result.is_err(), "export_fixed with identical src and dst must return Err");
+}
+
+#[test]
+fn export_fixed_nonexistent_src_returns_err() {
+    let dir = TempDir::new().unwrap();
+    let dst = dir.path().join("out.gguf");
+    let src = std::path::Path::new("/no/such/file.gguf");
+    let result = GgufCompatibilityFixer::export_fixed(src, &dst);
+    assert!(result.is_err(), "export_fixed with nonexistent src must return Err");
+}
+
+// ---------------------------------------------------------------------------
+// export_fixed() — output correctness
+// ---------------------------------------------------------------------------
+
+#[test]
+fn export_fixed_creates_output_file() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    assert!(!dst.exists(), "dst must not exist before export_fixed");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    assert!(dst.exists(), "export_fixed must create the output file");
+}
+
+#[test]
+fn export_fixed_output_is_parseable_by_gguf_reader() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let out = fs::read(&dst).unwrap();
+    let result = GgufReader::new(&out);
+    assert!(result.is_ok(), "exported GGUF must be parseable: {:?}", result.err());
+}
+
+#[test]
+fn export_fixed_sets_compat_fixed_flag() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let out = fs::read(&dst).unwrap();
+    let reader = GgufReader::new(&out).unwrap();
+    assert_eq!(
+        reader.get_bool_metadata("bitnet.compat.fixed"),
+        Some(true),
+        "export_fixed must set bitnet.compat.fixed=true"
+    );
+}
+
+#[test]
+fn export_fixed_adds_bos_token_id_one() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let out = fs::read(&dst).unwrap();
+    let reader = GgufReader::new(&out).unwrap();
+    assert_eq!(
+        reader.get_u32_metadata("tokenizer.ggml.bos_token_id"),
+        Some(1),
+        "export_fixed must set bos_token_id=1 for a minimal GGUF"
+    );
+}
+
+#[test]
+fn export_fixed_adds_eos_token_id_two() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let out = fs::read(&dst).unwrap();
+    let reader = GgufReader::new(&out).unwrap();
+    assert_eq!(
+        reader.get_u32_metadata("tokenizer.ggml.eos_token_id"),
+        Some(2),
+        "export_fixed must set eos_token_id=2 for a minimal GGUF"
+    );
+}
+
+#[test]
+fn export_fixed_adds_vocab_size_metadata() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let out = fs::read(&dst).unwrap();
+    let reader = GgufReader::new(&out).unwrap();
+    assert!(
+        reader.get_u32_metadata("tokenizer.ggml.vocab_size").is_some(),
+        "export_fixed must add tokenizer.ggml.vocab_size metadata"
+    );
+}
+
+#[test]
+fn export_fixed_output_is_larger_than_source() {
+    // A fixed GGUF must be larger than the bare minimal source because it adds metadata.
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    let src_len = fs::metadata(&src).unwrap().len();
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let dst_len = fs::metadata(&dst).unwrap().len();
+    assert!(
+        dst_len > src_len,
+        "fixed GGUF must be larger than source; src={src_len}, dst={dst_len}"
+    );
+}
+
+#[test]
+fn export_fixed_does_not_increase_issue_count() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    let before = GgufCompatibilityFixer::diagnose(&src).unwrap().len();
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let after = GgufCompatibilityFixer::diagnose(&dst).unwrap().len();
+    assert!(
+        after <= before,
+        "export_fixed must not increase issues: before={before}, after={after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// verify_idempotent()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn verify_idempotent_false_for_unfixed_minimal() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "unfixed.gguf", &minimal_gguf_v3());
+    let result = GgufCompatibilityFixer::verify_idempotent(&path);
+    assert!(result.is_ok(), "verify_idempotent must not error on valid GGUF");
+    assert!(!result.unwrap(), "unfixed minimal GGUF must not be considered idempotent");
+}
+
+#[test]
+fn verify_idempotent_true_after_export_fixed() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("fixed.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let result = GgufCompatibilityFixer::verify_idempotent(&dst);
+    assert!(result.is_ok(), "verify_idempotent must not error on fixed GGUF");
+    assert!(result.unwrap(), "export_fixed output must pass idempotency check");
+}
+
+#[test]
+fn verify_idempotent_err_for_nonexistent_path() {
+    let result = GgufCompatibilityFixer::verify_idempotent("/no/such/file.gguf");
+    assert!(result.is_err(), "verify_idempotent must return Err for nonexistent path");
+}
+
+// ---------------------------------------------------------------------------
+// print_report()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn print_report_ok_on_valid_minimal_gguf() {
+    let dir = TempDir::new().unwrap();
+    let path = write_temp(&dir, "report.gguf", &minimal_gguf_v3());
+    let result = GgufCompatibilityFixer::print_report(&path);
+    assert!(result.is_ok(), "print_report must succeed on valid GGUF: {:?}", result.err());
+}
+
+#[test]
+fn print_report_err_on_nonexistent_path() {
+    let result = GgufCompatibilityFixer::print_report("/no/such/file.gguf");
+    assert!(result.is_err(), "print_report must return Err for nonexistent path");
+}
+
+#[test]
+fn print_report_ok_on_fixed_gguf() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("fixed.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let result = GgufCompatibilityFixer::print_report(&dst);
+    assert!(result.is_ok(), "print_report must succeed on a fixed GGUF");
+}
+
+// ---------------------------------------------------------------------------
+// Stamp file — content invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stamp_file_exists_after_export_fixed() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let stamp = dst.with_extension("gguf.compat.json");
+    assert!(stamp.exists(), "stamp file must be created at {:?}", stamp);
+}
+
+#[test]
+fn stamp_file_is_valid_json() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let stamp = dst.with_extension("gguf.compat.json");
+    let content = fs::read_to_string(&stamp).unwrap();
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&content);
+    assert!(parsed.is_ok(), "stamp file must be valid JSON; content:\n{content}");
+}
+
+#[test]
+fn stamp_json_has_timestamp_field() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let content = fs::read_to_string(dst.with_extension("gguf.compat.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let ts = json.get("timestamp").and_then(|v| v.as_str());
+    assert!(ts.is_some(), "stamp must have a non-null 'timestamp' string field");
+    assert!(!ts.unwrap().is_empty(), "timestamp must not be empty");
+}
+
+#[test]
+fn stamp_json_has_version_field_with_semver() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let content = fs::read_to_string(dst.with_extension("gguf.compat.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let ver = json.get("version").and_then(|v| v.as_str()).expect("stamp must have 'version'");
+    let parts: Vec<&str> = ver.split('.').collect();
+    assert!(parts.len() >= 3, "version must have ≥3 dot-separated parts; got: {ver}");
+    for part in &parts[..3] {
+        let numeric = part.split('-').next().unwrap_or(part);
+        assert!(
+            numeric.chars().all(|c| c.is_ascii_digit()),
+            "semver component {numeric:?} is not numeric in {ver:?}"
+        );
+    }
+}
+
+#[test]
+fn stamp_json_has_fixes_applied_array() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let content = fs::read_to_string(dst.with_extension("gguf.compat.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let fixes = json.get("fixes_applied");
+    assert!(fixes.is_some(), "stamp must have 'fixes_applied' field");
+    assert!(fixes.unwrap().is_array(), "'fixes_applied' must be a JSON array");
+}
+
+#[test]
+fn stamp_fixes_applied_nonempty_for_minimal_gguf() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let content = fs::read_to_string(dst.with_extension("gguf.compat.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let fixes = json["fixes_applied"].as_array().unwrap();
+    assert!(
+        !fixes.is_empty(),
+        "fixes_applied must be non-empty for a minimal GGUF that needed patches"
+    );
+}
+
+#[test]
+fn stamp_fixes_applied_entries_are_nonempty_strings() {
+    let dir = TempDir::new().unwrap();
+    let src = write_temp(&dir, "src.gguf", &minimal_gguf_v3());
+    let dst = dir.path().join("dst.gguf");
+    GgufCompatibilityFixer::export_fixed(&src, &dst).unwrap();
+    let content = fs::read_to_string(dst.with_extension("gguf.compat.json")).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+    let fixes = json["fixes_applied"].as_array().unwrap();
+    for fix in fixes {
+        let s = fix.as_str().expect("each fix entry must be a string");
+        assert!(!s.trim().is_empty(), "fix entry string must not be empty");
+    }
+}

--- a/crates/bitnet-sys/tests/sys_tests.rs
+++ b/crates/bitnet-sys/tests/sys_tests.rs
@@ -1,0 +1,336 @@
+//! Comprehensive unit tests for `bitnet-sys` crate.
+//!
+//! Covers `CompileTimeLibCapabilities` (always available) and the disabled-stub
+//! module (available when `ffi` feature is **not** enabled).
+
+use bitnet_sys::CompileTimeLibCapabilities;
+
+// ---------------------------------------------------------------------------
+// CompileTimeLibCapabilities — field constructor variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn caps_all_false_fields() {
+    let caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    assert!(!caps.available);
+    assert!(!caps.has_cuda);
+    assert!(!caps.has_bitnet_shim);
+}
+
+#[test]
+fn caps_available_only() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: false };
+    assert!(caps.available);
+    assert!(!caps.has_cuda);
+    assert!(!caps.has_bitnet_shim);
+}
+
+#[test]
+fn caps_available_and_cuda() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: false };
+    assert!(caps.available);
+    assert!(caps.has_cuda);
+    assert!(!caps.has_bitnet_shim);
+}
+
+#[test]
+fn caps_available_and_shim() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: true };
+    assert!(caps.available);
+    assert!(!caps.has_cuda);
+    assert!(caps.has_bitnet_shim);
+}
+
+#[test]
+fn caps_all_true_fields() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: true };
+    assert!(caps.available);
+    assert!(caps.has_cuda);
+    assert!(caps.has_bitnet_shim);
+}
+
+// ---------------------------------------------------------------------------
+// CompileTimeLibCapabilities — summary() exact format
+// ---------------------------------------------------------------------------
+
+#[test]
+fn summary_all_false_exact() {
+    let caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    assert_eq!(caps.summary(), "cpp=unavailable cuda=no shim=no");
+}
+
+#[test]
+fn summary_all_true_exact() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: true };
+    assert_eq!(caps.summary(), "cpp=available cuda=yes shim=yes");
+}
+
+#[test]
+fn summary_available_no_cuda_shim_yes_exact() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: true };
+    assert_eq!(caps.summary(), "cpp=available cuda=no shim=yes");
+}
+
+#[test]
+fn summary_available_cuda_yes_shim_no_exact() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: false };
+    assert_eq!(caps.summary(), "cpp=available cuda=yes shim=no");
+}
+
+#[test]
+fn summary_contains_cpp_key() {
+    for available in [false, true] {
+        let caps =
+            CompileTimeLibCapabilities { available, has_cuda: false, has_bitnet_shim: false };
+        assert!(caps.summary().contains("cpp="), "summary must contain 'cpp='");
+    }
+}
+
+#[test]
+fn summary_contains_cuda_key() {
+    for has_cuda in [false, true] {
+        let caps = CompileTimeLibCapabilities { available: true, has_cuda, has_bitnet_shim: false };
+        assert!(caps.summary().contains("cuda="), "summary must contain 'cuda='");
+    }
+}
+
+#[test]
+fn summary_contains_shim_key() {
+    for has_bitnet_shim in [false, true] {
+        let caps = CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim };
+        assert!(caps.summary().contains("shim="), "summary must contain 'shim='");
+    }
+}
+
+#[test]
+fn summary_cuda_token_reflects_field() {
+    let yes_caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: false };
+    assert!(yes_caps.summary().contains("cuda=yes"), "has_cuda=true must produce cuda=yes");
+
+    let no_caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    assert!(no_caps.summary().contains("cuda=no"), "has_cuda=false must produce cuda=no");
+}
+
+#[test]
+fn summary_shim_token_reflects_field() {
+    let yes_caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: true };
+    assert!(yes_caps.summary().contains("shim=yes"), "has_bitnet_shim=true must produce shim=yes");
+
+    let no_caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    assert!(no_caps.summary().contains("shim=no"), "has_bitnet_shim=false must produce shim=no");
+}
+
+#[test]
+fn summary_is_deterministic() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: true };
+    assert_eq!(caps.summary(), caps.summary());
+}
+
+#[test]
+fn summary_is_nonempty_for_all_combinations() {
+    for available in [false, true] {
+        for has_cuda in [false, true] {
+            for has_bitnet_shim in [false, true] {
+                let caps = CompileTimeLibCapabilities { available, has_cuda, has_bitnet_shim };
+                assert!(!caps.summary().is_empty(), "summary must never be empty");
+            }
+        }
+    }
+}
+
+#[test]
+fn summary_length_is_bounded() {
+    for available in [false, true] {
+        for has_cuda in [false, true] {
+            for has_bitnet_shim in [false, true] {
+                let caps = CompileTimeLibCapabilities { available, has_cuda, has_bitnet_shim };
+                let s = caps.summary();
+                assert!(s.len() < 128, "summary must be short; got len={}: {s}", s.len());
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Clone and PartialEq
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clone_produces_equal_struct() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: true };
+    let cloned = caps.clone();
+    assert_eq!(caps, cloned, "clone must equal original");
+}
+
+#[test]
+fn equality_distinguishes_different_structs() {
+    let a = CompileTimeLibCapabilities { available: true, has_cuda: true, has_bitnet_shim: false };
+    let b = CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: false };
+    assert_ne!(a, b, "structs with different has_cuda must not be equal");
+}
+
+#[test]
+fn equality_is_reflexive() {
+    let caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    assert_eq!(caps, caps.clone(), "caps must equal a clone of itself");
+}
+
+// ---------------------------------------------------------------------------
+// Debug formatting
+// ---------------------------------------------------------------------------
+
+#[test]
+fn debug_format_is_nonempty() {
+    let caps =
+        CompileTimeLibCapabilities { available: true, has_cuda: false, has_bitnet_shim: false };
+    assert!(!format!("{caps:?}").is_empty(), "Debug output must not be empty");
+}
+
+#[test]
+fn debug_format_contains_field_names() {
+    let caps =
+        CompileTimeLibCapabilities { available: false, has_cuda: false, has_bitnet_shim: false };
+    let debug = format!("{caps:?}");
+    assert!(debug.contains("available"), "Debug must mention 'available': {debug}");
+    assert!(debug.contains("has_cuda"), "Debug must mention 'has_cuda': {debug}");
+    assert!(debug.contains("has_bitnet_shim"), "Debug must mention 'has_bitnet_shim': {debug}");
+}
+
+// ---------------------------------------------------------------------------
+// from_compile_time() — structural invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn from_compile_time_has_cuda_implies_available() {
+    let caps = CompileTimeLibCapabilities::from_compile_time();
+    if caps.has_cuda {
+        assert!(caps.available, "has_cuda must imply available at build time");
+    }
+}
+
+#[test]
+fn from_compile_time_has_shim_implies_available() {
+    let caps = CompileTimeLibCapabilities::from_compile_time();
+    if caps.has_bitnet_shim {
+        assert!(caps.available, "has_bitnet_shim must imply available at build time");
+    }
+}
+
+#[test]
+fn from_compile_time_summary_contains_all_keys() {
+    let s = CompileTimeLibCapabilities::from_compile_time().summary();
+    assert!(s.contains("cpp="), "runtime summary must contain 'cpp=': {s}");
+    assert!(s.contains("cuda="), "runtime summary must contain 'cuda=': {s}");
+    assert!(s.contains("shim="), "runtime summary must contain 'shim=': {s}");
+}
+
+#[test]
+fn from_compile_time_is_deterministic() {
+    let a = CompileTimeLibCapabilities::from_compile_time();
+    let b = CompileTimeLibCapabilities::from_compile_time();
+    assert_eq!(a, b, "from_compile_time must be deterministic");
+}
+
+// ---------------------------------------------------------------------------
+// Disabled stubs — only compiled when `ffi` feature is not enabled
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "ffi"))]
+mod disabled_stub_tests {
+    use bitnet_sys::disabled;
+
+    #[test]
+    fn stub_is_available_returns_false() {
+        assert!(!disabled::is_available(), "stub is_available() must return false");
+    }
+
+    #[test]
+    fn stub_version_returns_err() {
+        assert!(disabled::version().is_err(), "stub version() must return Err");
+    }
+
+    #[test]
+    fn stub_initialize_returns_err() {
+        assert!(disabled::initialize().is_err(), "stub initialize() must return Err");
+    }
+
+    #[test]
+    fn stub_load_model_returns_err() {
+        assert!(
+            disabled::load_model("/any/path.gguf").is_err(),
+            "stub load_model() must return Err"
+        );
+    }
+
+    #[test]
+    fn stub_cleanup_returns_err() {
+        assert!(disabled::cleanup().is_err(), "stub cleanup() must return Err");
+    }
+
+    #[test]
+    fn stub_generate_returns_err() {
+        let mut handle = disabled::ModelHandle;
+        assert!(
+            disabled::generate(&mut handle, "hello", 1).is_err(),
+            "stub generate() must return Err"
+        );
+    }
+
+    #[test]
+    fn stub_generate_with_zero_tokens_returns_err() {
+        let mut handle = disabled::ModelHandle;
+        // Even with max_tokens=0, the stub must return Err (not panic).
+        assert!(
+            disabled::generate(&mut handle, "", 0).is_err(),
+            "stub generate() with empty prompt/zero tokens must return Err"
+        );
+    }
+
+    #[test]
+    fn disabled_error_message_is_informative() {
+        let err = disabled::version().unwrap_err();
+        let msg = err.to_string();
+        assert!(!msg.is_empty(), "error message must not be empty");
+        // The message should help the user understand what to do.
+        assert!(
+            msg.to_lowercase().contains("ffi")
+                || msg.to_lowercase().contains("bitnet")
+                || msg.to_lowercase().contains("bindings"),
+            "error message should guide the user; got: {msg}"
+        );
+    }
+
+    #[test]
+    fn stub_version_error_is_displayable() {
+        let err = disabled::version().unwrap_err();
+        // Ensure Display impl works and doesn't panic.
+        let _ = format!("{err}");
+        let _ = format!("{err:?}");
+    }
+
+    #[test]
+    fn stub_load_model_error_is_displayable() {
+        let result = disabled::load_model("irrelevant.gguf");
+        assert!(result.is_err());
+        // Extract error via match since ModelHandle doesn't impl Debug
+        if let Err(e) = result {
+            let _ = format!("{e}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for `bitnet-compat` and `bitnet-sys` crates.

### `crates/bitnet-compat/tests/compat_tests.rs` — 36 tests

- **`diagnose()` error handling**: nonexistent path, empty path, invalid magic bytes, truncated file
- **`diagnose()` issue detection**: BOS, EOS, vocab missing on minimal GGUF; at-least-3-issues assertion
- **Issue string invariants**: nonempty, single-line, deterministic across calls, count ≤ 20
- **`export_fixed()` errors**: same src/dst path, nonexistent src
- **`export_fixed()` output**: creates file, GgufReader-parseable, sets `bitnet.compat.fixed=true`, `bos_token_id=1`, `eos_token_id=2`, adds `vocab_size`; output is larger than source; does not increase issue count
- **`verify_idempotent()`**: false for unfixed GGUF, true after `export_fixed`, Err for missing path
- **`print_report()`**: Ok on valid GGUF, Err on nonexistent, Ok on fixed GGUF
- **Stamp JSON**: file exists, is valid JSON, has `timestamp`/`version`/`fixes_applied` fields, version follows semver X.Y.Z, fix entries are nonempty strings

### `crates/bitnet-sys/tests/sys_tests.rs` — 36 tests

- **`CompileTimeLibCapabilities` constructors**: all five meaningful field combinations
- **`summary()` exact format**: pinned strings for each combination, reflection of `has_cuda` and `has_bitnet_shim` fields
- **`summary()` invariants**: key presence, determinism, nonempty, length < 128
- **`Clone` + `PartialEq`**: clone equality, field-level inequality, reflexivity
- **`Debug`**: nonempty output, field names present
- **`from_compile_time()`**: `has_cuda` ⇒ `available`, `has_bitnet_shim` ⇒ `available`, summary validity, determinism
- **Disabled stubs** (`cfg(not(feature = "ffi"))`): all six stubs (`is_available`, `version`, `initialize`, `load_model`, `generate`, `cleanup`) return the expected error; error messages are displayable and informative

### Test counts
| Crate | New tests |
|---|---|
| bitnet-compat | 36 |
| bitnet-sys | 36 |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>