### PR TITLE
test(bitnet-runtime-feature-flags,bitnet-feature-contract): add comprehensive tests

### DIFF
--- a/crates/bitnet-feature-contract/tests/contract_tests.rs
+++ b/crates/bitnet-feature-contract/tests/contract_tests.rs
@@ -1,0 +1,253 @@
+//! Comprehensive tests for `bitnet-feature-contract`.
+//!
+//! Covers `FeatureContractSnapshot` invariants, `feature_contract_snapshot` /
+//! `feature_contract_drift` semantics, and the re-exported profile/grid API
+//! from `bitnet-feature-matrix`.
+
+use bitnet_feature_contract::{
+    BitnetFeature, ExecutionEnvironment, FeatureSet, TestingScenario, active_features,
+    active_profile_for, canonical_grid, feature_contract_drift, feature_contract_snapshot,
+    feature_labels, feature_line, validate_active_profile_for,
+};
+
+// ── FeatureContractSnapshot: construction and consistency ─────────────────────
+
+#[test]
+fn snapshot_empty_inputs_is_consistent() {
+    let snap = feature_contract_snapshot([] as [&str; 0], [] as [&str; 0]);
+    assert!(snap.is_consistent(), "empty policy + empty runtime must be consistent");
+    assert!(snap.missing_from_runtime.is_empty());
+    assert!(snap.extra_from_runtime.is_empty());
+}
+
+#[test]
+fn snapshot_identical_sets_is_consistent() {
+    let snap =
+        feature_contract_snapshot(["cpu", "inference", "kernels"], ["cpu", "inference", "kernels"]);
+    assert!(snap.is_consistent(), "identical policy and runtime must be consistent");
+    assert!(snap.missing_from_runtime.is_empty());
+    assert!(snap.extra_from_runtime.is_empty());
+}
+
+#[test]
+fn snapshot_order_does_not_affect_consistency() {
+    // Consistency is set-based; insertion order must not matter.
+    let a = feature_contract_snapshot(["cpu", "gpu"], ["gpu", "cpu"]);
+    let b = feature_contract_snapshot(["gpu", "cpu"], ["cpu", "gpu"]);
+    assert!(a.is_consistent());
+    assert!(b.is_consistent());
+    assert_eq!(a.is_consistent(), b.is_consistent());
+}
+
+#[test]
+fn snapshot_missing_feature_detected() {
+    let snap = feature_contract_snapshot(["cpu", "kernels"], ["cpu"]);
+    assert!(!snap.is_consistent());
+    assert!(
+        snap.missing_from_runtime.contains(&"kernels".to_string()),
+        "expected 'kernels' in missing_from_runtime: {:?}",
+        snap.missing_from_runtime
+    );
+    assert!(snap.extra_from_runtime.is_empty(), "no extra expected");
+}
+
+#[test]
+fn snapshot_extra_feature_detected() {
+    let snap = feature_contract_snapshot(["cpu"], ["cpu", "gpu"]);
+    assert!(!snap.is_consistent());
+    assert!(
+        snap.extra_from_runtime.contains(&"gpu".to_string()),
+        "expected 'gpu' in extra_from_runtime: {:?}",
+        snap.extra_from_runtime
+    );
+    assert!(snap.missing_from_runtime.is_empty(), "no missing expected");
+}
+
+#[test]
+fn snapshot_detects_both_missing_and_extra() {
+    let snap = feature_contract_snapshot(["cpu", "kernels"], ["cpu", "inference"]);
+    assert!(!snap.is_consistent());
+    assert!(
+        snap.missing_from_runtime.contains(&"kernels".to_string()),
+        "expected 'kernels' in missing: {:?}",
+        snap.missing_from_runtime
+    );
+    assert!(
+        snap.extra_from_runtime.contains(&"inference".to_string()),
+        "expected 'inference' in extra: {:?}",
+        snap.extra_from_runtime
+    );
+}
+
+#[test]
+fn snapshot_missing_and_extra_are_disjoint() {
+    let snap = feature_contract_snapshot(["cpu", "kernels", "trace"], ["cpu", "inference", "gpu"]);
+    let missing: std::collections::BTreeSet<_> = snap.missing_from_runtime.iter().collect();
+    let extra: std::collections::BTreeSet<_> = snap.extra_from_runtime.iter().collect();
+    let overlap: Vec<_> = missing.intersection(&extra).collect();
+    assert!(overlap.is_empty(), "missing and extra must be disjoint, found overlap: {overlap:?}");
+}
+
+#[test]
+fn snapshot_preserves_input_order_for_policy() {
+    // policy_features is stored in insertion order (Vec), not sorted.
+    let snap = feature_contract_snapshot(["kernels", "cpu", "gpu"], ["kernels", "cpu", "gpu"]);
+    assert_eq!(
+        snap.policy_features,
+        vec!["kernels".to_string(), "cpu".to_string(), "gpu".to_string()],
+        "policy_features must preserve input order"
+    );
+}
+
+#[test]
+fn snapshot_preserves_input_order_for_runtime() {
+    let snap = feature_contract_snapshot(["cpu"], ["inference", "cpu", "crossval"]);
+    assert_eq!(
+        snap.runtime_features,
+        vec!["inference".to_string(), "cpu".to_string(), "crossval".to_string()],
+        "runtime_features must preserve input order"
+    );
+}
+
+#[test]
+fn snapshot_clone_and_equality() {
+    let snap = feature_contract_snapshot(["cpu", "gpu"], ["cpu"]);
+    let cloned = snap.clone();
+    assert_eq!(snap, cloned, "cloned snapshot must equal original");
+    assert!(!cloned.is_consistent());
+}
+
+// ── feature_contract_drift ────────────────────────────────────────────────────
+
+#[test]
+fn drift_returns_none_when_policy_and_runtime_match() {
+    let result = feature_contract_drift(["cpu", "inference"], ["inference", "cpu"]);
+    assert!(result.is_none(), "drift must be None when sets are equal");
+}
+
+#[test]
+fn drift_returns_some_when_policy_and_runtime_differ() {
+    let result = feature_contract_drift(["cpu", "kernels"], ["cpu"]);
+    assert!(result.is_some(), "drift must be Some when sets differ");
+    let snap = result.unwrap();
+    assert!(!snap.is_consistent());
+}
+
+#[test]
+fn drift_snapshot_contents_match_direct_snapshot() {
+    let (policy, runtime) = (vec!["cpu", "gpu", "trace"], vec!["cpu", "crossval"]);
+    let from_drift = feature_contract_drift(policy.iter().copied(), runtime.iter().copied())
+        .expect("sets differ so drift must be Some");
+    let direct = feature_contract_snapshot(policy.iter().copied(), runtime.iter().copied());
+    assert_eq!(
+        from_drift.missing_from_runtime, direct.missing_from_runtime,
+        "drift and snapshot must agree on missing"
+    );
+    assert_eq!(
+        from_drift.extra_from_runtime, direct.extra_from_runtime,
+        "drift and snapshot must agree on extra"
+    );
+}
+
+// ── Re-exported feature-matrix API ───────────────────────────────────────────
+
+#[test]
+fn active_features_returns_valid_feature_set() {
+    // active_features() is a compile-time snapshot; must always succeed.
+    let features = active_features();
+    // Cross-check: labels from FeatureSet must match feature_labels().
+    let from_set = features.labels();
+    let direct = feature_labels();
+    assert_eq!(from_set, direct, "active_features().labels() must match feature_labels()");
+}
+
+#[test]
+fn feature_line_always_has_features_prefix() {
+    let line = feature_line();
+    assert!(
+        line.starts_with("features: "),
+        "feature_line must start with 'features: ', got: {line:?}"
+    );
+}
+
+#[test]
+fn feature_labels_contains_cpu_when_compiled_with_cpu_feature() {
+    #[cfg(feature = "cpu")]
+    {
+        let labels = feature_labels();
+        assert!(
+            labels.iter().any(|l| l == "cpu"),
+            "expected 'cpu' in feature labels when --features cpu, got: {labels:?}"
+        );
+    }
+    #[cfg(not(feature = "cpu"))]
+    {} // no-op
+}
+
+#[test]
+fn canonical_grid_is_nonempty() {
+    let grid = canonical_grid();
+    // The curated grid must contain at least one row.
+    // We probe the Unit / Local pair which is always defined.
+    let rows = grid.rows_for_scenario(TestingScenario::Unit);
+    assert!(!rows.is_empty(), "canonical_grid must contain rows for Unit scenario");
+}
+
+#[test]
+fn active_profile_for_known_scenario_env_is_constructed() {
+    let profile = active_profile_for(TestingScenario::Unit, ExecutionEnvironment::Ci);
+    assert_eq!(profile.scenario, TestingScenario::Unit);
+    assert_eq!(profile.environment, ExecutionEnvironment::Ci);
+    // features are always populated (may be empty if no flags compiled in)
+    let _ = profile.features.labels(); // must not panic
+}
+
+#[test]
+fn validate_active_profile_for_unit_ci_returns_result() {
+    // validate_active_profile_for returns Some only when the grid has a cell for the
+    // given scenario/env pair.  We simply assert it does not panic and the return value
+    // is coherent.
+    let result = validate_active_profile_for(TestingScenario::Unit, ExecutionEnvironment::Ci);
+    if let Some((missing, forbidden)) = result {
+        // Both FeatureSet values must be valid (labels may be empty).
+        let _ = missing.labels();
+        let _ = forbidden.labels();
+    }
+    // None is also valid when no grid cell exists for Unit/Ci.
+}
+
+#[test]
+fn feature_set_operations_are_correct() {
+    // Verify FeatureSet works correctly when constructed manually.
+    let mut fs = FeatureSet::new();
+    assert!(fs.is_empty());
+    fs.insert(BitnetFeature::Cpu);
+    assert!(!fs.is_empty());
+    assert!(fs.contains(BitnetFeature::Cpu));
+    assert!(!fs.contains(BitnetFeature::Gpu));
+    let labels = fs.labels();
+    assert_eq!(labels, vec!["cpu".to_string()]);
+}
+
+#[test]
+fn feature_set_from_names_roundtrip() {
+    let names = ["cpu", "inference", "kernels"];
+    let fs = FeatureSet::from_names(names);
+    let labels = fs.labels();
+    for name in &names {
+        assert!(
+            labels.contains(&name.to_string()),
+            "expected '{name}' in labels from FeatureSet::from_names, got {labels:?}"
+        );
+    }
+}
+
+// ── FeatureContractSnapshot: Debug formatting ─────────────────────────────────
+
+#[test]
+fn snapshot_debug_format_is_nonempty() {
+    let snap = feature_contract_snapshot(["cpu"], ["cpu", "gpu"]);
+    let debug = format!("{snap:?}");
+    assert!(!debug.is_empty(), "Debug output must not be empty");
+    assert!(debug.contains("FeatureContractSnapshot"), "expected type name in debug: {debug}");
+}

--- a/crates/bitnet-runtime-feature-flags/tests/feature_flags_tests.rs
+++ b/crates/bitnet-runtime-feature-flags/tests/feature_flags_tests.rs
@@ -1,0 +1,368 @@
+//! Comprehensive tests for `bitnet-runtime-feature-flags`.
+//!
+//! Covers `FeatureActivation` construction, feature-lattice implications,
+//! JSON serialization of label lists, Debug formatting, and the public
+//! `active_features` / `feature_labels` / `feature_line` API.
+
+use bitnet_runtime_feature_flags::{
+    FeatureActivation, active_features, active_features_from_activation, feature_labels,
+    feature_labels_from_activation, feature_line, feature_line_from_activation,
+};
+
+// ── FeatureActivation: struct defaults ───────────────────────────────────────
+
+#[test]
+fn feature_activation_default_all_fields_false() {
+    let act = FeatureActivation::default();
+    assert!(!act.cpu);
+    assert!(!act.gpu);
+    assert!(!act.cuda);
+    assert!(!act.inference);
+    assert!(!act.kernels);
+    assert!(!act.tokenizers);
+    assert!(!act.quantization);
+    assert!(!act.cli);
+    assert!(!act.server);
+    assert!(!act.ffi);
+    assert!(!act.python);
+    assert!(!act.wasm);
+    assert!(!act.crossval);
+    assert!(!act.trace);
+    assert!(!act.iq2s_ffi);
+    assert!(!act.cpp_ffi);
+    assert!(!act.fixtures);
+    assert!(!act.reporting);
+    assert!(!act.trend);
+    assert!(!act.integration_tests);
+}
+
+#[test]
+fn feature_activation_implements_copy() {
+    let original = FeatureActivation { cpu: true, ..Default::default() };
+    let copy = original; // Copy – no move error
+    assert!(original.cpu);
+    assert!(copy.cpu);
+}
+
+#[test]
+fn feature_activation_clone_is_independent() {
+    let original = FeatureActivation { gpu: true, cuda: true, ..Default::default() };
+    let cloned = original.clone();
+    assert_eq!(original.gpu, cloned.gpu);
+    assert_eq!(original.cuda, cloned.cuda);
+    assert_eq!(original.cpu, cloned.cpu);
+}
+
+// ── Debug formatting ──────────────────────────────────────────────────────────
+
+#[test]
+fn feature_activation_debug_contains_struct_name() {
+    let act = FeatureActivation::default();
+    let debug = format!("{act:?}");
+    assert!(!debug.is_empty(), "Debug must not be empty");
+    assert!(debug.contains("FeatureActivation"), "Debug must include type name, got: {debug:?}");
+}
+
+#[test]
+fn feature_activation_debug_reflects_set_fields() {
+    let act = FeatureActivation { cpu: true, crossval: true, ..Default::default() };
+    let debug = format!("{act:?}");
+    assert!(debug.contains("cpu: true"), "expected 'cpu: true' in debug: {debug}");
+    assert!(debug.contains("crossval: true"), "expected 'crossval: true' in debug: {debug}");
+}
+
+// ── feature_line_from_activation ─────────────────────────────────────────────
+
+#[test]
+fn feature_line_default_activation_is_none() {
+    let line = feature_line_from_activation(FeatureActivation::default());
+    assert_eq!(line, "features: none");
+}
+
+#[test]
+fn feature_line_always_starts_with_features_prefix() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let line = feature_line_from_activation(act);
+    assert!(line.starts_with("features: "), "unexpected prefix: {line:?}");
+}
+
+#[test]
+fn feature_line_cpu_only_contains_cpu_label() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let line = feature_line_from_activation(act);
+    assert!(line.contains("cpu"), "expected 'cpu' in {line:?}");
+}
+
+#[test]
+fn feature_line_multiple_features_contains_each_label() {
+    let act =
+        FeatureActivation { cpu: true, quantization: true, fixtures: true, ..Default::default() };
+    let line = feature_line_from_activation(act);
+    assert!(line.contains("cpu"), "missing 'cpu' in {line:?}");
+    assert!(line.contains("quantization"), "missing 'quantization' in {line:?}");
+    assert!(line.contains("fixtures"), "missing 'fixtures' in {line:?}");
+}
+
+// ── feature_labels_from_activation ───────────────────────────────────────────
+
+#[test]
+fn feature_labels_default_is_empty() {
+    let labels = feature_labels_from_activation(FeatureActivation::default());
+    assert!(labels.is_empty(), "default activation must produce no labels, got {labels:?}");
+}
+
+#[test]
+fn cpu_activation_includes_cpu_label() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"cpu".to_string()), "expected 'cpu' in {labels:?}");
+}
+
+#[test]
+fn cpu_activation_implies_inference_label() {
+    // The feature lattice propagates cpu → Inference.
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"inference".to_string()),
+        "cpu should imply inference via lattice, got {labels:?}"
+    );
+}
+
+#[test]
+fn cpu_activation_implies_kernels_label() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"kernels".to_string()),
+        "cpu should imply kernels via lattice, got {labels:?}"
+    );
+}
+
+#[test]
+fn cpu_activation_implies_tokenizers_label() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"tokenizers".to_string()),
+        "cpu should imply tokenizers via lattice, got {labels:?}"
+    );
+}
+
+#[test]
+fn cuda_activation_implies_both_cuda_and_gpu_labels() {
+    // cuda ⟹ Gpu normalization is documented in the crate.
+    let act = FeatureActivation { cuda: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"cuda".to_string()), "expected 'cuda' in {labels:?}");
+    assert!(
+        labels.contains(&"gpu".to_string()),
+        "cuda should imply 'gpu' via normalization, got {labels:?}"
+    );
+}
+
+#[test]
+fn gpu_activation_implies_inference_and_kernels_labels() {
+    let act = FeatureActivation { gpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"gpu".to_string()), "expected 'gpu' in {labels:?}");
+    assert!(
+        labels.contains(&"inference".to_string()),
+        "gpu should imply inference via lattice, got {labels:?}"
+    );
+    assert!(
+        labels.contains(&"kernels".to_string()),
+        "gpu should imply kernels via lattice, got {labels:?}"
+    );
+}
+
+#[test]
+fn all_features_activation_yields_nonempty_labels() {
+    let act = FeatureActivation {
+        cpu: true,
+        gpu: true,
+        cuda: true,
+        inference: true,
+        kernels: true,
+        tokenizers: true,
+        quantization: true,
+        cli: true,
+        server: true,
+        ffi: true,
+        python: true,
+        wasm: true,
+        crossval: true,
+        trace: true,
+        iq2s_ffi: true,
+        cpp_ffi: true,
+        fixtures: true,
+        reporting: true,
+        trend: true,
+        integration_tests: true,
+    };
+    let labels = feature_labels_from_activation(act);
+    assert!(!labels.is_empty(), "all-true activation must produce labels");
+    for label in &labels {
+        assert!(!label.is_empty(), "each label must be non-empty");
+    }
+}
+
+#[test]
+fn labels_are_in_stable_deterministic_order() {
+    // Labels derive from a BTreeSet keyed on the enum's Ord (declaration order),
+    // so two calls with the same activation must return identical sequences.
+    let act = FeatureActivation {
+        cpu: true,
+        gpu: true,
+        cuda: true,
+        inference: true,
+        kernels: true,
+        tokenizers: true,
+        quantization: true,
+        cli: true,
+        ..Default::default()
+    };
+    let first = feature_labels_from_activation(act);
+    let second = feature_labels_from_activation(act);
+    assert_eq!(first, second, "feature labels must be deterministic across calls");
+    assert!(!first.is_empty(), "labels must not be empty for this activation");
+}
+
+// ── Consistency: FeatureSet.labels() == feature_labels_from_activation() ─────
+
+#[test]
+fn feature_set_labels_match_standalone_helper() {
+    let act =
+        FeatureActivation { cpu: true, quantization: true, trace: true, ..Default::default() };
+    let from_set = active_features_from_activation(act).labels();
+    let direct = feature_labels_from_activation(act);
+    assert_eq!(from_set, direct, "FeatureSet.labels() and helper must agree");
+}
+
+// ── FeatureActivation::to_labels ─────────────────────────────────────────────
+
+#[test]
+fn to_labels_method_matches_standalone_helper() {
+    let act = FeatureActivation { cpu: true, inference: true, ..Default::default() };
+    let via_method = act.to_labels();
+    let via_helper = feature_labels_from_activation(act);
+    assert_eq!(via_method, via_helper, "to_labels() and helper must produce identical output");
+}
+
+// ── JSON serialization round-trip ────────────────────────────────────────────
+
+#[test]
+fn labels_json_round_trip_preserves_values() {
+    let act = FeatureActivation { cpu: true, crossval: true, fixtures: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    let json = serde_json::to_string(&labels).expect("labels must serialize to JSON");
+    let round_tripped: Vec<String> =
+        serde_json::from_str(&json).expect("labels must deserialize from JSON");
+    assert_eq!(labels, round_tripped, "JSON round-trip must preserve label values");
+}
+
+#[test]
+fn empty_labels_serialize_to_json_array() {
+    let labels: Vec<String> = feature_labels_from_activation(FeatureActivation::default());
+    let json = serde_json::to_string(&labels).expect("empty labels must serialize");
+    assert_eq!(json, "[]", "empty label list must serialize as empty JSON array");
+    let deserialized: Vec<String> = serde_json::from_str(&json).unwrap();
+    assert!(deserialized.is_empty());
+}
+
+#[test]
+fn labels_serialize_to_json_array() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    let json = serde_json::to_string(&labels).expect("labels must serialize");
+    assert!(json.starts_with('['), "serialized labels must be a JSON array, got: {json:?}");
+    assert!(json.ends_with(']'), "serialized labels must end with ']', got: {json:?}");
+}
+
+// ── Public API: active_features / feature_labels / feature_line ──────────────
+
+#[test]
+fn active_features_capture_returns_valid_snapshot() {
+    // `active_features()` is the canonical "capture current flags" function.
+    let features = active_features();
+    // Labels derived from the snapshot must match `feature_labels()`.
+    let from_capture = features.labels();
+    let direct = feature_labels();
+    assert_eq!(from_capture, direct, "active_features().labels() must match feature_labels()");
+}
+
+#[test]
+fn feature_line_has_features_prefix() {
+    let line = feature_line();
+    assert!(
+        line.starts_with("features: "),
+        "feature_line must start with 'features: ', got: {line:?}"
+    );
+}
+
+#[test]
+fn feature_labels_contains_cpu_when_compiled_with_cpu_feature() {
+    #[cfg(feature = "cpu")]
+    {
+        let labels = feature_labels();
+        assert!(
+            labels.iter().any(|l| l == "cpu"),
+            "expected 'cpu' in feature labels when compiled with --features cpu, got: {labels:?}"
+        );
+    }
+    // When cpu feature is absent this test is a no-op.
+    #[cfg(not(feature = "cpu"))]
+    {
+        // Nothing to assert – just ensure the test compiles.
+    }
+}
+
+#[test]
+fn feature_line_contains_cpu_when_compiled_with_cpu_feature() {
+    #[cfg(feature = "cpu")]
+    {
+        let line = feature_line();
+        assert!(
+            line.contains("cpu"),
+            "feature_line must contain 'cpu' when compiled with --features cpu, got: {line:?}"
+        );
+    }
+    #[cfg(not(feature = "cpu"))]
+    {
+        // Nothing to assert.
+    }
+}
+
+// ── GPU / CUDA consistency (feature lattice) ──────────────────────────────────
+
+#[test]
+fn gpu_without_explicit_cuda_produces_gpu_label() {
+    // gpu=true, cuda=false → at minimum "gpu" must appear
+    let act = FeatureActivation { gpu: true, cuda: false, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"gpu".to_string()), "gpu=true must produce 'gpu' label: {labels:?}");
+}
+
+#[test]
+fn cuda_alone_produces_gpu_label_via_normalization() {
+    // cuda ⟹ gpu (normalization documented in crate)
+    let act = FeatureActivation { cuda: true, gpu: false, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"cuda".to_string()),
+        "cuda=true must produce 'cuda' label: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"gpu".to_string()),
+        "cuda=true must also produce 'gpu' via normalization: {labels:?}"
+    );
+}
+
+#[test]
+fn cpu_and_gpu_are_not_mutually_exclusive() {
+    // Both can be active simultaneously (orthogonal in the lattice).
+    let act = FeatureActivation { cpu: true, gpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"cpu".to_string()), "expected 'cpu': {labels:?}");
+    assert!(labels.contains(&"gpu".to_string()), "expected 'gpu': {labels:?}");
+}


### PR DESCRIPTION
## Summary

Add comprehensive integration test suites for two crates that previously had only property-based and snapshot tests.

### `bitnet-runtime-feature-flags` — `tests/feature_flags_tests.rs` (30 tests)

| Area | Tests |
|------|-------|
| `FeatureActivation` defaults, Copy/Clone | 3 |
| Debug formatting | 2 |
| `feature_line_from_activation` prefix & content | 4 |
| `feature_labels_from_activation` — lattice implications (cpu→inf/kern/tok, cuda→gpu, gpu→inf/kern) | 7 |
| All-features activation, nonempty labels | 2 |
| Labels determinism | 1 |
| Consistency: `FeatureSet.labels()` == helper | 1 |
| `FeatureActivation::to_labels()` vs helper | 1 |
| JSON round-trip of label lists | 3 |
| Public API (`active_features`, `feature_labels`, `feature_line`) | 3 |
| GPU/CUDA lattice orthogonality | 3 |

### `bitnet-feature-contract` — `tests/contract_tests.rs` (22 tests)

| Area | Tests |
|------|-------|
| `FeatureContractSnapshot` construction & consistency invariants | 7 |
| Disjoint / input-order-preservation / clone-equality | 3 |
| `feature_contract_drift` semantics | 3 |
| Re-exported feature-matrix API (`active_features`, `feature_labels`, `feature_line`, `canonical_grid`, `active_profile_for`, `validate_active_profile_for`) | 5 |
| `FeatureSet` operations and `from_names` | 2 |
| Debug formatting | 1 |
| `feature_labels_contains_cpu_when_compiled_with_cpu_feature` | 1 |

## Test run

```
cargo test -p bitnet-runtime-feature-flags --no-default-features --features cpu
# → 30 passed (feature_flags_tests) + 10 property + 3 snapshot = 43 total

cargo test -p bitnet-feature-contract --no-default-features --features cpu
# → 22 passed (contract_tests) + 8 property + 4 snapshot = 34 total
```

All tests pass with zero warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>