### PR TITLE
test(bitnet-validation,bitnet-kernel-registry): add comprehensive tests

### DIFF
--- a/crates/bitnet-common/tests/kernel_registry_tests.rs
+++ b/crates/bitnet-common/tests/kernel_registry_tests.rs
@@ -1,0 +1,508 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Comprehensive tests for `bitnet_common::kernel_registry`.
+//!
+//! Covers:
+//! - `SimdLevel` ordering, display, and copy semantics
+//! - `KernelBackend` display, GPU requirement, copy semantics
+//! - `KernelCapabilities` construction, builder methods, and capability queries
+//! - `compiled_backends()` ordering and deduplication
+//! - `best_available()` priority logic
+//! - `summary()` format invariants
+
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn cpu_only_avx2() -> KernelCapabilities {
+    KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    }
+}
+
+fn cuda_with_runtime() -> KernelCapabilities {
+    KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: true,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    }
+}
+
+fn all_backends() -> KernelCapabilities {
+    KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: true,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Avx512,
+    }
+}
+
+fn empty_caps() -> KernelCapabilities {
+    KernelCapabilities {
+        cpu_rust: false,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Scalar,
+    }
+}
+
+// ── SimdLevel ordering ────────────────────────────────────────────────────────
+
+#[test]
+fn simd_scalar_is_lowest() {
+    assert!(SimdLevel::Scalar < SimdLevel::Neon);
+    assert!(SimdLevel::Scalar < SimdLevel::Sse42);
+    assert!(SimdLevel::Scalar < SimdLevel::Avx2);
+    assert!(SimdLevel::Scalar < SimdLevel::Avx512);
+}
+
+#[test]
+fn simd_neon_between_scalar_and_sse42() {
+    assert!(SimdLevel::Neon > SimdLevel::Scalar);
+    assert!(SimdLevel::Neon < SimdLevel::Sse42);
+}
+
+#[test]
+fn simd_sse42_between_neon_and_avx2() {
+    assert!(SimdLevel::Sse42 > SimdLevel::Neon);
+    assert!(SimdLevel::Sse42 < SimdLevel::Avx2);
+}
+
+#[test]
+fn simd_avx2_between_sse42_and_avx512() {
+    assert!(SimdLevel::Avx2 > SimdLevel::Sse42);
+    assert!(SimdLevel::Avx2 < SimdLevel::Avx512);
+}
+
+#[test]
+fn simd_avx512_is_highest() {
+    assert!(SimdLevel::Avx512 > SimdLevel::Avx2);
+    assert!(SimdLevel::Avx512 > SimdLevel::Neon);
+    assert!(SimdLevel::Avx512 > SimdLevel::Scalar);
+}
+
+#[test]
+fn simd_level_total_order_is_transitive() {
+    let levels =
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512];
+    for (i, a) in levels.iter().enumerate() {
+        for (j, b) in levels.iter().enumerate() {
+            assert_eq!(i.cmp(&j), a.cmp(b), "ordering mismatch: {a:?} vs {b:?}");
+        }
+    }
+}
+
+#[test]
+fn simd_level_equality() {
+    assert_eq!(SimdLevel::Avx2, SimdLevel::Avx2);
+    assert_ne!(SimdLevel::Avx2, SimdLevel::Avx512);
+}
+
+// ── SimdLevel display ─────────────────────────────────────────────────────────
+
+#[test]
+fn simd_level_display_scalar() {
+    assert_eq!(SimdLevel::Scalar.to_string(), "scalar");
+}
+
+#[test]
+fn simd_level_display_neon() {
+    assert_eq!(SimdLevel::Neon.to_string(), "neon");
+}
+
+#[test]
+fn simd_level_display_sse42() {
+    assert_eq!(SimdLevel::Sse42.to_string(), "sse4.2");
+}
+
+#[test]
+fn simd_level_display_avx2() {
+    assert_eq!(SimdLevel::Avx2.to_string(), "avx2");
+}
+
+#[test]
+fn simd_level_display_avx512() {
+    assert_eq!(SimdLevel::Avx512.to_string(), "avx512");
+}
+
+#[test]
+fn simd_level_all_display_strings_are_distinct() {
+    let strings: Vec<String> =
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+    let unique: std::collections::HashSet<_> = strings.iter().collect();
+    assert_eq!(strings.len(), unique.len(), "duplicate display strings: {strings:?}");
+}
+
+// ── SimdLevel copy and hash semantics ─────────────────────────────────────────
+
+#[test]
+fn simd_level_is_copy() {
+    let a = SimdLevel::Avx2;
+    let b = a; // copy, not move
+    assert_eq!(a, b);
+}
+
+#[test]
+fn simd_level_is_hashable() {
+    let mut map = std::collections::HashMap::new();
+    map.insert(SimdLevel::Avx2, "avx2");
+    map.insert(SimdLevel::Avx512, "avx512");
+    assert_eq!(map[&SimdLevel::Avx2], "avx2");
+}
+
+// ── KernelBackend display ─────────────────────────────────────────────────────
+
+#[test]
+fn kernel_backend_display_cpu_rust() {
+    assert_eq!(KernelBackend::CpuRust.to_string(), "cpu-rust");
+}
+
+#[test]
+fn kernel_backend_display_cuda() {
+    assert_eq!(KernelBackend::Cuda.to_string(), "cuda");
+}
+
+#[test]
+fn kernel_backend_display_cpp_ffi() {
+    assert_eq!(KernelBackend::CppFfi.to_string(), "cpp-ffi");
+}
+
+#[test]
+fn kernel_backend_all_display_strings_are_distinct() {
+    let strings: Vec<String> = [KernelBackend::CpuRust, KernelBackend::Cuda, KernelBackend::CppFfi]
+        .iter()
+        .map(|b| b.to_string())
+        .collect();
+    let unique: std::collections::HashSet<_> = strings.iter().collect();
+    assert_eq!(strings.len(), unique.len(), "duplicate display strings: {strings:?}");
+}
+
+// ── KernelBackend::requires_gpu ───────────────────────────────────────────────
+
+#[test]
+fn cpu_rust_does_not_require_gpu() {
+    assert!(!KernelBackend::CpuRust.requires_gpu());
+}
+
+#[test]
+fn cuda_requires_gpu() {
+    assert!(KernelBackend::Cuda.requires_gpu());
+}
+
+#[test]
+fn cpp_ffi_does_not_require_gpu() {
+    assert!(!KernelBackend::CppFfi.requires_gpu());
+}
+
+// ── KernelBackend::is_compiled ────────────────────────────────────────────────
+
+#[test]
+fn cpp_ffi_is_never_compiled_from_common() {
+    // bitnet-common has no ffi feature; CppFfi always reports not compiled
+    assert!(!KernelBackend::CppFfi.is_compiled());
+}
+
+// ── KernelBackend copy and hash semantics ─────────────────────────────────────
+
+#[test]
+fn kernel_backend_is_copy() {
+    let a = KernelBackend::CpuRust;
+    let b = a; // copy, not move
+    assert_eq!(a, b);
+}
+
+#[test]
+fn kernel_backend_is_hashable() {
+    let mut set = std::collections::HashSet::new();
+    set.insert(KernelBackend::CpuRust);
+    set.insert(KernelBackend::Cuda);
+    set.insert(KernelBackend::CpuRust); // duplicate
+    assert_eq!(set.len(), 2);
+}
+
+#[test]
+fn kernel_backend_equality() {
+    assert_eq!(KernelBackend::Cuda, KernelBackend::Cuda);
+    assert_ne!(KernelBackend::Cuda, KernelBackend::CpuRust);
+}
+
+// ── KernelCapabilities: from_compile_time ─────────────────────────────────────
+
+#[test]
+fn from_compile_time_always_sets_cuda_runtime_false() {
+    let caps = KernelCapabilities::from_compile_time();
+    assert!(!caps.cuda_runtime, "cuda_runtime must be false without runtime probe");
+}
+
+#[test]
+fn from_compile_time_cpp_ffi_is_false() {
+    // bitnet-common has no ffi feature
+    let caps = KernelCapabilities::from_compile_time();
+    assert!(!caps.cpp_ffi);
+}
+
+// ── KernelCapabilities: builder methods ──────────────────────────────────────
+
+#[test]
+fn with_cuda_runtime_true_sets_flag() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    let caps = caps.with_cuda_runtime(true);
+    assert!(caps.cuda_runtime);
+}
+
+#[test]
+fn with_cuda_runtime_false_clears_flag() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: true,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    }
+    .with_cuda_runtime(false);
+    assert!(!caps.cuda_runtime);
+}
+
+#[test]
+fn with_cpp_ffi_true_sets_flag() {
+    let caps = KernelCapabilities::from_compile_time().with_cpp_ffi(true);
+    assert!(caps.cpp_ffi);
+}
+
+#[test]
+fn with_cpp_ffi_false_clears_flag() {
+    let caps = KernelCapabilities::from_compile_time().with_cpp_ffi(true).with_cpp_ffi(false);
+    assert!(!caps.cpp_ffi);
+}
+
+#[test]
+fn builder_methods_are_chainable() {
+    let caps = KernelCapabilities::from_compile_time().with_cuda_runtime(true).with_cpp_ffi(true);
+    assert!(caps.cuda_runtime);
+    assert!(caps.cpp_ffi);
+}
+
+// ── KernelCapabilities: compiled_backends ordering ───────────────────────────
+
+#[test]
+fn compiled_backends_empty_when_nothing_compiled() {
+    let caps = empty_caps();
+    assert!(caps.compiled_backends().is_empty());
+}
+
+#[test]
+fn compiled_backends_cpu_only() {
+    let caps = cpu_only_avx2();
+    let backends = caps.compiled_backends();
+    assert_eq!(backends, vec![KernelBackend::CpuRust]);
+}
+
+#[test]
+fn compiled_backends_cuda_and_cpu_no_ffi() {
+    let caps = cuda_with_runtime();
+    let backends = caps.compiled_backends();
+    // CUDA before CPU; no FFI
+    assert_eq!(backends, vec![KernelBackend::Cuda, KernelBackend::CpuRust]);
+}
+
+#[test]
+fn compiled_backends_only_ffi() {
+    let caps = KernelCapabilities {
+        cpu_rust: false,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Scalar,
+    };
+    let backends = caps.compiled_backends();
+    assert_eq!(backends, vec![KernelBackend::CppFfi]);
+}
+
+#[test]
+fn compiled_backends_all_three_in_priority_order() {
+    let caps = all_backends();
+    let backends = caps.compiled_backends();
+    assert_eq!(backends[0], KernelBackend::Cuda);
+    assert_eq!(backends[1], KernelBackend::CppFfi);
+    assert_eq!(backends[2], KernelBackend::CpuRust);
+    assert_eq!(backends.len(), 3);
+}
+
+#[test]
+fn compiled_backends_no_duplicates() {
+    let caps = all_backends();
+    let backends = caps.compiled_backends();
+    let unique: std::collections::HashSet<_> = backends.iter().collect();
+    assert_eq!(backends.len(), unique.len(), "duplicates in compiled_backends: {backends:?}");
+}
+
+#[test]
+fn compiled_backends_cuda_not_listed_when_only_runtime_missing() {
+    // cuda_compiled=true means it appears in compiled_backends (compile-time list)
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: false, // runtime not available, but compiled
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    let backends = caps.compiled_backends();
+    // CUDA is compiled so it appears in the list
+    assert!(backends.contains(&KernelBackend::Cuda));
+}
+
+// ── KernelCapabilities: best_available priority ───────────────────────────────
+
+#[test]
+fn best_available_is_none_when_nothing_compiled() {
+    assert_eq!(empty_caps().best_available(), None);
+}
+
+#[test]
+fn best_available_is_cpu_when_only_cpu() {
+    assert_eq!(cpu_only_avx2().best_available(), Some(KernelBackend::CpuRust));
+}
+
+#[test]
+fn best_available_is_cuda_when_compiled_and_runtime() {
+    assert_eq!(cuda_with_runtime().best_available(), Some(KernelBackend::Cuda));
+}
+
+#[test]
+fn best_available_is_cpu_when_cuda_compiled_but_no_runtime() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    assert_eq!(caps.best_available(), Some(KernelBackend::CpuRust));
+}
+
+#[test]
+fn best_available_is_ffi_when_no_cuda_runtime_but_ffi_present() {
+    let caps = KernelCapabilities {
+        cpu_rust: false,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Scalar,
+    };
+    assert_eq!(caps.best_available(), Some(KernelBackend::CppFfi));
+}
+
+#[test]
+fn best_available_prefers_cuda_over_ffi_and_cpu() {
+    assert_eq!(all_backends().best_available(), Some(KernelBackend::Cuda));
+}
+
+#[test]
+fn best_available_prefers_ffi_over_cpu_when_no_cuda() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Avx2,
+    };
+    assert_eq!(caps.best_available(), Some(KernelBackend::CppFfi));
+}
+
+// ── KernelCapabilities: summary format ───────────────────────────────────────
+
+#[test]
+fn summary_contains_simd_tag() {
+    let s = cpu_only_avx2().summary();
+    assert!(s.contains("simd=avx2"), "summary: {s}");
+}
+
+#[test]
+fn summary_contains_backends_tag() {
+    let s = cpu_only_avx2().summary();
+    assert!(s.contains("backends=["), "summary: {s}");
+}
+
+#[test]
+fn summary_cpu_only_has_cpu_rust_backend() {
+    let s = cpu_only_avx2().summary();
+    assert!(s.contains("cpu-rust"), "summary: {s}");
+}
+
+#[test]
+fn summary_empty_caps_has_empty_backends() {
+    let s = empty_caps().summary();
+    assert!(s.contains("backends=[]"), "summary: {s}");
+}
+
+#[test]
+fn summary_all_backends_lists_all_three() {
+    let s = all_backends().summary();
+    assert!(s.contains("cuda"), "summary: {s}");
+    assert!(s.contains("cpp-ffi"), "summary: {s}");
+    assert!(s.contains("cpu-rust"), "summary: {s}");
+}
+
+#[test]
+fn summary_reflects_simd_level_for_neon() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Neon,
+    };
+    let s = caps.summary();
+    assert!(s.contains("simd=neon"), "summary: {s}");
+}
+
+#[test]
+fn summary_reflects_simd_level_for_scalar() {
+    let s = empty_caps().summary();
+    assert!(s.contains("simd=scalar"), "summary: {s}");
+}
+
+// ── KernelCapabilities: clone semantics ──────────────────────────────────────
+
+#[test]
+fn kernel_capabilities_clone_preserves_all_fields() {
+    let original = all_backends();
+    let cloned = original.clone();
+    assert_eq!(original.cpu_rust, cloned.cpu_rust);
+    assert_eq!(original.cuda_compiled, cloned.cuda_compiled);
+    assert_eq!(original.cuda_runtime, cloned.cuda_runtime);
+    assert_eq!(original.cpp_ffi, cloned.cpp_ffi);
+    assert_eq!(original.simd_level, cloned.simd_level);
+}
+
+#[test]
+fn kernel_capabilities_clone_is_independent() {
+    let original = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    let cloned = original.clone();
+    // Both should have identical fields; clone does not alias original
+    assert_eq!(original.cpu_rust, cloned.cpu_rust);
+    // Verify cloned summary matches original summary (structural equality)
+    assert_eq!(original.summary(), cloned.summary());
+}

--- a/crates/bitnet-validation/tests/validation_tests.rs
+++ b/crates/bitnet-validation/tests/validation_tests.rs
@@ -1,0 +1,528 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Comprehensive integration tests for `bitnet-validation`.
+//!
+//! Covers:
+//! - LayerNorm name detection (`is_ln_gamma`)
+//! - Ruleset construction and threshold checks
+//! - Architecture detection via `detect_rules`
+//! - Policy gate selection and YAML loading
+//! - Edge cases for `Ruleset::default()` (no-rules fallback)
+
+use bitnet_validation::{
+    Ruleset, detect_rules, is_ln_gamma, load_policy, rules_bitnet_b158_f16, rules_bitnet_b158_i2s,
+    rules_generic,
+};
+use tempfile::NamedTempFile;
+
+// ── is_ln_gamma name detection ───────────────────────────────────────────────
+
+#[test]
+fn is_ln_gamma_attn_norm() {
+    assert!(is_ln_gamma("blk.0.attn_norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_ffn_norm() {
+    assert!(is_ln_gamma("blk.7.ffn_norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_ffn_layernorm() {
+    assert!(is_ln_gamma("blk.3.ffn_layernorm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_rms_norm() {
+    assert!(is_ln_gamma("blk.0.rms_norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_input_layernorm() {
+    assert!(is_ln_gamma("model.layers.5.input_layernorm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_post_attention_layernorm() {
+    assert!(is_ln_gamma("model.layers.2.post_attention_layernorm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_final_norm() {
+    assert!(is_ln_gamma("final_norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_final_layernorm() {
+    assert!(is_ln_gamma("model.final_layernorm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_bare_norm_weight() {
+    assert!(is_ln_gamma("model.norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_deep_block_path() {
+    assert!(is_ln_gamma("transformer.layers.31.attn_norm.weight"));
+}
+
+#[test]
+fn is_ln_gamma_rejects_projection_weight() {
+    assert!(!is_ln_gamma("blk.0.attn_q.weight"));
+    assert!(!is_ln_gamma("blk.0.ffn_up.weight"));
+    assert!(!is_ln_gamma("blk.0.ffn_down.weight"));
+    assert!(!is_ln_gamma("blk.0.attn_v.weight"));
+}
+
+#[test]
+fn is_ln_gamma_rejects_output_weight() {
+    assert!(!is_ln_gamma("output.weight"));
+}
+
+#[test]
+fn is_ln_gamma_rejects_token_embedding() {
+    assert!(!is_ln_gamma("token_embd.weight"));
+}
+
+#[test]
+fn is_ln_gamma_rejects_missing_weight_suffix() {
+    assert!(!is_ln_gamma("blk.0.attn_norm"));
+    assert!(!is_ln_gamma("blk.0.attn_norm.bias"));
+}
+
+#[test]
+fn is_ln_gamma_rejects_empty_string() {
+    assert!(!is_ln_gamma(""));
+}
+
+#[test]
+fn is_ln_gamma_is_deterministic() {
+    let name = "blk.10.ffn_norm.weight";
+    assert_eq!(is_ln_gamma(name), is_ln_gamma(name));
+}
+
+// ── Architecture detection ───────────────────────────────────────────────────
+
+#[test]
+fn detect_rules_bitnet_f16_gives_f16_ruleset() {
+    let r = detect_rules("bitnet", 1);
+    assert_eq!(r.name, "bitnet-b1.58:f16");
+}
+
+#[test]
+fn detect_rules_bitnet_quantized_gives_i2s_ruleset() {
+    let r = detect_rules("bitnet", 2);
+    assert_eq!(r.name, "bitnet-b1.58:i2_s");
+}
+
+#[test]
+fn detect_rules_b158_in_arch_gives_bitnet_ruleset() {
+    let r = detect_rules("b1.58-llama", 1);
+    assert_eq!(r.name, "bitnet-b1.58:f16");
+}
+
+#[test]
+fn detect_rules_case_insensitive_bitnet_upper() {
+    let r = detect_rules("BITNET", 1);
+    assert_eq!(r.name, "bitnet-b1.58:f16");
+}
+
+#[test]
+fn detect_rules_case_insensitive_mixed() {
+    let r = detect_rules("BitNet-b1.58", 0);
+    assert_eq!(r.name, "bitnet-b1.58:i2_s");
+}
+
+#[test]
+fn detect_rules_llama_gives_generic() {
+    let r = detect_rules("llama", 0);
+    assert_eq!(r.name, "generic");
+}
+
+#[test]
+fn detect_rules_unknown_arch_gives_generic() {
+    let r = detect_rules("mistral", 1);
+    assert_eq!(r.name, "generic");
+}
+
+#[test]
+fn detect_rules_empty_arch_gives_generic() {
+    let r = detect_rules("", 0);
+    assert_eq!(r.name, "generic");
+}
+
+#[test]
+fn detect_rules_never_returns_empty_name() {
+    for arch in ["bitnet", "llama", "gpt", "mistral", "", "unknown"] {
+        for ft in [0u32, 1, 2, 10] {
+            let r = detect_rules(arch, ft);
+            assert!(!r.name.is_empty(), "empty name for arch={arch:?} ft={ft}");
+        }
+    }
+}
+
+// ── F16 ruleset thresholds ────────────────────────────────────────────────────
+
+#[test]
+fn f16_ruleset_name_is_correct() {
+    assert_eq!(rules_bitnet_b158_f16().name, "bitnet-b1.58:f16");
+}
+
+#[test]
+fn f16_check_ln_attn_norm_accepts_valid_rms() {
+    let r = rules_bitnet_b158_f16();
+    // attn_norm falls through to ".*norm\.weight$" catch-all: min=0.50, max=2.0
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.8));
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.5));
+    assert!(r.check_ln("blk.0.attn_norm.weight", 2.0));
+}
+
+#[test]
+fn f16_check_ln_attn_norm_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.49));
+}
+
+#[test]
+fn f16_check_ln_ffn_layernorm_accepts_low_rms() {
+    // ffn_layernorm has min=0.05 in F16 ruleset
+    let r = rules_bitnet_b158_f16();
+    assert!(r.check_ln("blk.0.ffn_layernorm.weight", 0.07));
+}
+
+#[test]
+fn f16_check_ln_ffn_layernorm_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_ln("blk.0.ffn_layernorm.weight", 0.01));
+}
+
+#[test]
+fn f16_check_ln_post_attention_layernorm_accepts_valid() {
+    let r = rules_bitnet_b158_f16();
+    assert!(r.check_ln("model.layers.0.post_attention_layernorm.weight", 0.5));
+}
+
+#[test]
+fn f16_check_ln_post_attention_layernorm_rejects_too_low() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_ln("model.layers.0.post_attention_layernorm.weight", 0.1));
+}
+
+#[test]
+fn f16_check_ln_input_layernorm_accepts_valid() {
+    let r = rules_bitnet_b158_f16();
+    assert!(r.check_ln("model.layers.3.input_layernorm.weight", 0.6));
+}
+
+#[test]
+fn f16_check_ln_final_norm_accepts_valid() {
+    let r = rules_bitnet_b158_f16();
+    assert!(r.check_ln("final_norm.weight", 1.0));
+}
+
+#[test]
+fn f16_check_ln_unrecognized_name_falls_back_to_generic_envelope() {
+    let r = rules_bitnet_b158_f16();
+    // Name does not end in "norm.weight" → fallback generic: 0.50..=2.0
+    assert!(r.check_ln("blk.0.attn_q.weight", 0.9));
+    assert!(!r.check_ln("blk.0.attn_q.weight", 2.5));
+    assert!(!r.check_ln("blk.0.attn_q.weight", 0.1));
+}
+
+#[test]
+fn f16_check_proj_rms_accepts_in_range() {
+    let r = rules_bitnet_b158_f16();
+    assert!(r.check_proj_rms(0.01)); // exactly at min
+    assert!(r.check_proj_rms(0.40)); // exactly at max
+    assert!(r.check_proj_rms(0.15)); // mid-range
+}
+
+#[test]
+fn f16_check_proj_rms_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_proj_rms(0.009));
+    assert!(!r.check_proj_rms(0.0));
+}
+
+#[test]
+fn f16_check_proj_rms_rejects_above_max() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_proj_rms(0.401));
+    assert!(!r.check_proj_rms(1.0));
+}
+
+// ── I2_S ruleset thresholds ───────────────────────────────────────────────────
+
+#[test]
+fn i2s_ruleset_name_is_correct() {
+    assert_eq!(rules_bitnet_b158_i2s().name, "bitnet-b1.58:i2_s");
+}
+
+#[test]
+fn i2s_check_ln_attn_norm_accepts_very_low_rms() {
+    // I2_S attn_norm has min=0.01 (looser after quantization)
+    let r = rules_bitnet_b158_i2s();
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.01));
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.015));
+}
+
+#[test]
+fn i2s_check_ln_attn_norm_rejects_below_min() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.005));
+}
+
+#[test]
+fn i2s_check_ln_ffn_norm_accepts_valid() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(r.check_ln("blk.2.ffn_norm.weight", 0.6));
+}
+
+#[test]
+fn i2s_check_ln_ffn_norm_rejects_below_min() {
+    // I2_S ffn_norm has min=0.50
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_ln("blk.2.ffn_norm.weight", 0.1));
+}
+
+#[test]
+fn i2s_check_proj_rms_accepts_very_low_rms() {
+    // I2_S proj_weight_rms_min=0.002 (much lower than F16's 0.01)
+    let r = rules_bitnet_b158_i2s();
+    assert!(r.check_proj_rms(0.002));
+    assert!(r.check_proj_rms(0.01));
+    assert!(r.check_proj_rms(0.15));
+}
+
+#[test]
+fn i2s_check_proj_rms_rejects_too_low() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_proj_rms(0.001));
+}
+
+#[test]
+fn i2s_check_proj_rms_rejects_too_high() {
+    // I2_S proj_weight_rms_max=0.20
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_proj_rms(0.21));
+}
+
+// ── Generic ruleset ───────────────────────────────────────────────────────────
+
+#[test]
+fn generic_ruleset_name_is_correct() {
+    assert_eq!(rules_generic().name, "generic");
+}
+
+#[test]
+fn generic_check_ln_accepts_near_one() {
+    let r = rules_generic();
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.90));
+    assert!(r.check_ln("blk.0.attn_norm.weight", 1.00));
+    assert!(r.check_ln("blk.0.attn_norm.weight", 1.10));
+}
+
+#[test]
+fn generic_check_ln_rejects_far_from_one() {
+    let r = rules_generic();
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.5));
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 1.5));
+}
+
+#[test]
+fn generic_check_proj_rms_no_bounds_accepts_any_value() {
+    let r = rules_generic();
+    // Generic ruleset has no proj thresholds
+    assert!(r.proj_weight_rms_min.is_none());
+    assert!(r.proj_weight_rms_max.is_none());
+    assert!(r.check_proj_rms(0.0));
+    assert!(r.check_proj_rms(1.0));
+    assert!(r.check_proj_rms(100.0));
+    assert!(r.check_proj_rms(f32::MAX));
+}
+
+// ── Ruleset::default() (empty ruleset) ───────────────────────────────────────
+
+#[test]
+fn default_ruleset_has_no_ln_rules() {
+    let r = Ruleset::default();
+    assert!(r.ln.is_empty());
+}
+
+#[test]
+fn default_ruleset_check_ln_uses_generic_fallback_envelope() {
+    let r = Ruleset::default();
+    // No patterns → fallback generic envelope: 0.50..=2.0
+    assert!(r.check_ln("any_name.weight", 0.5));
+    assert!(r.check_ln("any_name.weight", 1.5));
+    assert!(!r.check_ln("any_name.weight", 0.4));
+    assert!(!r.check_ln("any_name.weight", 2.1));
+}
+
+#[test]
+fn default_ruleset_check_proj_rms_no_bounds_accepts_any() {
+    let r = Ruleset::default();
+    assert!(r.proj_weight_rms_min.is_none());
+    assert!(r.proj_weight_rms_max.is_none());
+    assert!(r.check_proj_rms(0.0));
+    assert!(r.check_proj_rms(999.0));
+}
+
+// ── Policy loading ────────────────────────────────────────────────────────────
+
+#[test]
+fn load_policy_valid_yaml_with_ln_and_proj_bounds() {
+    let yaml = r#"
+version: 1
+rules:
+  my-arch:f16:
+    name: "my-arch-f16-ruleset"
+    ln:
+      - pattern: ".*norm\\.weight$"
+        min: 0.4
+        max: 1.8
+    proj_weight_rms_min: 0.02
+    proj_weight_rms_max: 0.35
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "my-arch:f16").unwrap();
+    assert_eq!(r.name, "my-arch-f16-ruleset");
+    assert_eq!(r.ln.len(), 1);
+    assert!(r.check_ln("blk.0.attn_norm.weight", 1.0));
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.1));
+    assert!(r.check_proj_rms(0.20));
+    assert!(!r.check_proj_rms(0.01));
+    assert!(!r.check_proj_rms(0.40));
+}
+
+#[test]
+fn load_policy_name_defaults_to_policy_colon_key_when_absent() {
+    let yaml = r#"
+version: 1
+rules:
+  unnamed-key:
+    ln: []
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "unnamed-key").unwrap();
+    assert_eq!(r.name, "policy:unnamed-key");
+}
+
+#[test]
+fn load_policy_missing_key_returns_error() {
+    let yaml = "version: 1\nrules:\n  present:\n    ln: []\n";
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    assert!(load_policy(tmp.path(), "absent").is_err());
+}
+
+#[test]
+fn load_policy_missing_key_error_mentions_key() {
+    let yaml = "version: 1\nrules:\n  x:\n    ln: []\n";
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let err = load_policy(tmp.path(), "missing-key").unwrap_err();
+    assert!(err.to_string().contains("missing-key"), "error: {err}");
+}
+
+#[test]
+fn load_policy_invalid_yaml_returns_error() {
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "not: valid: yaml: [[[").unwrap();
+    assert!(load_policy(tmp.path(), "any-key").is_err());
+}
+
+#[test]
+fn load_policy_invalid_regex_pattern_returns_error() {
+    let yaml = r#"
+version: 1
+rules:
+  bad-regex:
+    ln:
+      - pattern: "["
+        min: 0.5
+        max: 2.0
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    assert!(load_policy(tmp.path(), "bad-regex").is_err());
+}
+
+#[test]
+fn load_policy_no_proj_bounds_check_proj_accepts_any() {
+    let yaml = r#"
+version: 1
+rules:
+  no-proj:
+    ln:
+      - pattern: ".*norm\\.weight$"
+        min: 0.5
+        max: 2.0
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "no-proj").unwrap();
+    assert!(r.proj_weight_rms_min.is_none());
+    assert!(r.proj_weight_rms_max.is_none());
+    assert!(r.check_proj_rms(0.0));
+    assert!(r.check_proj_rms(1000.0));
+}
+
+#[test]
+fn load_policy_file_not_found_returns_error() {
+    let result = load_policy(std::path::Path::new("/nonexistent/path/policy.yml"), "key");
+    assert!(result.is_err());
+}
+
+#[test]
+fn load_policy_multiple_ln_rules_first_matching_pattern_wins() {
+    let yaml = r#"
+version: 1
+rules:
+  multi:
+    ln:
+      - pattern: "attn_norm\\.weight$"
+        min: 0.5
+        max: 1.5
+      - pattern: ".*norm\\.weight$"
+        min: 0.1
+        max: 3.0
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "multi").unwrap();
+    // attn_norm matches first rule (min=0.5, max=1.5)
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.8));
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.2)); // below first rule's min
+    // ffn_norm falls through to second rule (min=0.1, max=3.0)
+    assert!(r.check_ln("blk.0.ffn_norm.weight", 0.2));
+}
+
+// ── Ruleset cloneability and immutability ─────────────────────────────────────
+
+#[test]
+fn rulesets_can_be_cloned_independently() {
+    let a = rules_bitnet_b158_f16();
+    let b = a.clone();
+    assert_eq!(a.name, b.name);
+    assert_eq!(a.ln.len(), b.ln.len());
+    assert_eq!(a.proj_weight_rms_min, b.proj_weight_rms_min);
+    assert_eq!(a.proj_weight_rms_max, b.proj_weight_rms_max);
+}
+
+#[test]
+fn builtin_rulesets_have_ln_rules() {
+    assert!(!rules_bitnet_b158_f16().ln.is_empty());
+    assert!(!rules_bitnet_b158_i2s().ln.is_empty());
+    assert!(!rules_generic().ln.is_empty());
+}
+
+#[test]
+fn detect_rules_returns_same_ruleset_on_repeated_calls() {
+    let r1 = detect_rules("bitnet", 1);
+    let r2 = detect_rules("bitnet", 1);
+    assert_eq!(r1.name, r2.name);
+    assert_eq!(r1.ln.len(), r2.ln.len());
+}


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for `bitnet-validation` and `bitnet_common::kernel_registry`.

### `crates/bitnet-validation/tests/validation_tests.rs` (65 tests)

- **`is_ln_gamma` name detection**: all 9 known LayerNorm keyword patterns (attn_norm, ffn_norm, ffn_layernorm, rms_norm, input_layernorm, post_attention_layernorm, final_norm, final_layernorm, norm), plus rejection cases (projection weights, embeddings, missing .weight suffix, empty string)
- **Architecture detection** via `detect_rules`: bitnet/b1.58 case-insensitive dispatch, F16 (file_type=1) vs I2_S (file_type!=1) ruleset selection, unknown/generic fallback, never-empty-name invariant
- **F16 ruleset thresholds**: per-pattern envelopes (ffn_layernorm low-min=0.05, post_attention_layernorm, input_layernorm, final_norm), proj_rms bounds (0.01–0.40), fallback generic envelope for unrecognized names
- **I2_S ruleset thresholds**: relaxed attn_norm min (0.01), ffn_norm min, proj_rms bounds (0.002–0.20)
- **Generic ruleset**: near-1.0 gamma envelope (0.80–1.20), unbounded proj_rms
- **`Ruleset::default()`** fallback behavior (generic 0.50–2.0 envelope, no proj bounds)
- **Policy loading**: valid YAML with name/ln/proj_bounds, name defaulting to `policy:{key}`, missing key error (mentions key in message), invalid YAML, invalid regex pattern, missing proj bounds, multi-rule first-match semantics, file-not-found
- **Clone independence** and **repeatability** invariants

### `crates/bitnet-common/tests/kernel_registry_tests.rs` (56 tests)

- **`SimdLevel` ordering**: full total-order coverage (Scalar < Neon < Sse42 < Avx2 < Avx512), pairwise and transitivity checks, display strings, all-distinct invariant, Copy/Hash semantics
- **`KernelBackend`**: display strings (cpu-rust/cuda/cpp-ffi), `requires_gpu` contract (only Cuda=true), `is_compiled` (CppFfi always false from bitnet-common), Copy/Hash/Eq semantics
- **`KernelCapabilities::from_compile_time`**: cuda_runtime always false, cpp_ffi always false
- **Builder methods**: `with_cuda_runtime`, `with_cpp_ffi`, method chaining
- **`compiled_backends()`**: empty caps, cpu-only, cuda+cpu (no ffi), ffi-only, all-three (CUDA→FFI→CPU priority order), no-duplicates, cuda-compiled presence vs runtime distinction
- **`best_available()`**: None on empty, CPU fallback, CUDA priority over FFI/CPU, cuda-compiled-but-no-runtime falls back, FFI preferred over CPU when no CUDA
- **`summary()`**: simd= tag, backends=[] format, all-three listing, NEON/scalar SIMD levels
- **Clone**: field preservation and structural equality

## Test results

```
cargo test -p bitnet-validation        → 65 passed; 0 failed
cargo test -p bitnet-common --test kernel_registry_tests → 56 passed; 0 failed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>