### PR TITLE
feat(fuzz): add wave 3 fuzz targets (gguf-writer, tokenizer, validation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,11 +633,14 @@ dependencies = [
  "bitnet-receipts",
  "bitnet-rope",
  "bitnet-sampling",
+ "bitnet-st2gguf",
  "bitnet-tokenizers",
+ "bitnet-validation",
  "candle-core",
  "libfuzzer-sys",
  "safetensors 0.6.2",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,11 +12,13 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4.10"
 serde_json = "1.0.145"
 safetensors = "0.6.2"
+tempfile = "3"
 bitnet-quantization = { path = "../crates/bitnet-quantization" }
 bitnet-models = { path = "../crates/bitnet-models" }
 bitnet-kernels = { path = "../crates/bitnet-kernels" }
 bitnet-common = { path = "../crates/bitnet-common" }
 bitnet-gguf = { path = "../crates/bitnet-gguf" }
+bitnet-st2gguf = { path = "../crates/bitnet-st2gguf" }
 bitnet-tokenizers = { path = "../crates/bitnet-tokenizers" }
 bitnet-logits = { path = "../crates/bitnet-logits" }
 bitnet-generation = { path = "../crates/bitnet-generation" }
@@ -24,6 +26,7 @@ bitnet-rope = { path = "../crates/bitnet-rope" }
 bitnet-sampling = { path = "../crates/bitnet-sampling" }
 bitnet-receipts = { path = "../crates/bitnet-receipts" }
 bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates" }
+bitnet-validation = { path = "../crates/bitnet-validation" }
 candle-core = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 
@@ -186,5 +189,23 @@ doc = false
 [[bin]]
 name = "prompt_template_no_panic"
 path = "fuzz_targets/prompt_template_no_panic.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gguf_writer_roundtrip"
+path = "fuzz_targets/gguf_writer_roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "tokenizer_encode_no_panic"
+path = "fuzz_targets/tokenizer_encode_no_panic.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "validation_no_panic"
+path = "fuzz_targets/validation_no_panic.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/gguf_writer_roundtrip.rs
+++ b/fuzz/fuzz_targets/gguf_writer_roundtrip.rs
@@ -1,0 +1,73 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_gguf::parse_header;
+use bitnet_st2gguf::writer::{GgufWriter, MetadataValue};
+use libfuzzer_sys::fuzz_target;
+
+/// Structured input driving the GgufWriter → GgufReader round-trip.
+#[derive(Arbitrary, Debug)]
+struct WriterInput {
+    /// Used as the `general.name` metadata string.
+    model_name: String,
+    /// Written as a u32 context-length entry.
+    context_length: u32,
+    /// An optional extra string metadata entry.
+    extra_value: String,
+    include_extra: bool,
+    /// An optional bool metadata entry.
+    flag_value: bool,
+    include_flag: bool,
+}
+
+fuzz_target!(|input: WriterInput| {
+    // Cap string sizes to keep individual runs fast.
+    if input.model_name.len() > 128 || input.extra_value.len() > 256 {
+        return;
+    }
+
+    // Build a minimal GGUF using GgufWriter.
+    let mut writer = GgufWriter::new();
+    writer.add_metadata("general.name", MetadataValue::String(input.model_name.clone()));
+    writer.add_metadata("llama.context_length", MetadataValue::U32(input.context_length));
+
+    let mut expected_kv: u64 = 2;
+    if input.include_extra {
+        writer.add_metadata("extra.value", MetadataValue::String(input.extra_value.clone()));
+        expected_kv += 1;
+    }
+    if input.include_flag {
+        writer.add_metadata("general.quantized", MetadataValue::Bool(input.flag_value));
+        expected_kv += 1;
+    }
+
+    // Write to a temporary file; skip if the OS refuses (e.g. disk full).
+    let tmp = match tempfile::NamedTempFile::new() {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    let path = tmp.path().to_path_buf();
+    if writer.write_to_file(&path).is_err() {
+        return;
+    }
+
+    // Read back the raw bytes and parse the header.
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+
+    let info = match parse_header(&bytes) {
+        Ok(h) => h,
+        Err(e) => panic!("parse_header failed on GgufWriter output: {e}"),
+    };
+
+    // Invariants: GgufWriter always produces v3 and the count we wrote.
+    assert_eq!(info.version, 3, "GgufWriter must produce GGUF v3");
+    assert_eq!(
+        info.metadata_count,
+        expected_kv,
+        "metadata_count {actual} != expected {expected_kv}",
+        actual = info.metadata_count,
+    );
+});

--- a/fuzz/fuzz_targets/tokenizer_encode_no_panic.rs
+++ b/fuzz/fuzz_targets/tokenizer_encode_no_panic.rs
@@ -1,0 +1,49 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_tokenizers::{BasicTokenizer, Tokenizer};
+use libfuzzer_sys::fuzz_target;
+
+/// Structured UTF-8 input that lets the fuzzer generate valid Unicode strings
+/// directly rather than filtering arbitrary byte slices.
+#[derive(Arbitrary, Debug)]
+struct EncodeInput {
+    text: String,
+    add_bos: bool,
+    add_special: bool,
+    /// Additional token IDs to decode (arbitrary, may be out-of-range).
+    decode_ids: Vec<u32>,
+}
+
+fuzz_target!(|input: EncodeInput| {
+    // Cap text length to keep individual runs bounded.
+    if input.text.len() > 4096 {
+        return;
+    }
+
+    let tok = BasicTokenizer::new();
+    let vocab_size = tok.vocab_size();
+
+    // Primary encode path must not panic.
+    if let Ok(tokens) = tok.encode(&input.text, input.add_bos, input.add_special) {
+        // Every returned token ID must be within [0, vocab_size).
+        for &id in &tokens {
+            assert!(
+                (id as usize) < vocab_size,
+                "encode returned out-of-range token id {id} for vocab_size {vocab_size}",
+            );
+        }
+        // Round-trip decode must not panic.
+        let _ = tok.decode(&tokens);
+    }
+
+    // All flag combinations must not panic.
+    let _ = tok.encode(&input.text, true, true);
+    let _ = tok.encode(&input.text, true, false);
+    let _ = tok.encode(&input.text, false, true);
+    let _ = tok.encode(&input.text, false, false);
+
+    // Decoding arbitrary (possibly out-of-range) IDs must not panic.
+    let ids: Vec<u32> = input.decode_ids.into_iter().take(512).collect();
+    let _ = tok.decode(&ids);
+});

--- a/fuzz/fuzz_targets/validation_no_panic.rs
+++ b/fuzz/fuzz_targets/validation_no_panic.rs
@@ -1,0 +1,56 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_validation::{
+    is_ln_gamma,
+    rules::{detect_rules, rules_bitnet_b158_f16, rules_bitnet_b158_i2s, rules_generic},
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Structured input exercising the validation layer with arbitrary
+/// tensor names and RMS statistics.
+#[derive(Arbitrary, Debug)]
+struct ValidationInput {
+    /// Simulates the GGUF `general.architecture` metadata value.
+    arch: String,
+    /// Simulates the GGUF `general.file_type` metadata value.
+    file_type: u32,
+    /// Arbitrary tensor name (e.g. "blk.0.attn_norm.weight").
+    tensor_name: String,
+    /// Arbitrary RMS statistic (may be NaN, ±inf, negative).
+    rms: f32,
+    /// A second RMS for projection weight checks.
+    proj_rms: f32,
+}
+
+fuzz_target!(|input: ValidationInput| {
+    // Cap string lengths to keep individual runs fast.
+    if input.arch.len() > 64 || input.tensor_name.len() > 256 {
+        return;
+    }
+
+    // detect_rules must not panic on arbitrary arch + file_type.
+    let ruleset = detect_rules(&input.arch, input.file_type);
+
+    // check_ln must not panic; returning false for out-of-envelope is fine.
+    let _ = ruleset.check_ln(&input.tensor_name, input.rms);
+
+    // check_proj_rms must not panic on arbitrary (possibly non-finite) RMS.
+    let _ = ruleset.check_proj_rms(input.proj_rms);
+
+    // is_ln_gamma must not panic on arbitrary tensor name.
+    let _ = is_ln_gamma(&input.tensor_name);
+
+    // Built-in rulesets must also not panic.
+    let f16 = rules_bitnet_b158_f16();
+    let _ = f16.check_ln(&input.tensor_name, input.rms);
+    let _ = f16.check_proj_rms(input.proj_rms);
+
+    let i2s = rules_bitnet_b158_i2s();
+    let _ = i2s.check_ln(&input.tensor_name, input.rms);
+    let _ = i2s.check_proj_rms(input.proj_rms);
+
+    let generic = rules_generic();
+    let _ = generic.check_ln(&input.tensor_name, input.rms);
+    let _ = generic.check_proj_rms(input.proj_rms);
+});


### PR DESCRIPTION
## Summary

Adds three new fuzz targets to `fuzz/fuzz_targets/`:

### 1. `gguf_writer_roundtrip`
Exercises the **GgufWriter → GgufReader round-trip**. Uses `Arbitrary` to generate structured inputs (model name, context length, optional metadata entries), writes a minimal GGUF via `GgufWriter::write_to_file`, then parses it back with `bitnet_gguf::parse_header`. Asserts GGUF v3 version and exact metadata count invariants.

### 2. `tokenizer_encode_no_panic`
Focuses on the **no-panic contract** of `BasicTokenizer::encode`. Uses `Arbitrary` to derive proper UTF-8 `String` inputs (letting the fuzzer generate valid Unicode directly), exercises all `(add_bos, add_special)` flag combinations, and asserts every returned token ID is within `[0, vocab_size)`.

### 3. `validation_no_panic`
Exercises the **bitnet-validation layer** with arbitrary arch strings, tensor names, and RMS floats (including NaN and ±∞). Calls `detect_rules`, `check_ln`, `check_proj_rms`, `is_ln_gamma`, and all three built-in rulesets (`f16`, `i2s`, `generic`). Asserts no panics regardless of input.

## Changes
- 3 new fuzz target `.rs` files  
- 3 new `[[bin]]` entries in `fuzz/Cargo.toml`  
- Added `bitnet-st2gguf`, `bitnet-validation`, and `tempfile` deps to `fuzz/Cargo.toml`  
- Updated `Cargo.lock`

## Build test
All 3 targets compile cleanly:
```
cd fuzz && cargo +nightly build --no-default-features
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 19s
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>