### PR TITLE
docs: comprehensive README rewrite and test-suite docs update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,10 @@ cargo run -p xtask -- setup-cpp-auto --emit=pwsh | Invoke-Expression  # PowerShe
 
 # Trace comparison (debug cross-validation divergence)
 cargo run -p xtask -- trace-diff /tmp/rs_traces /tmp/cpp_traces
+
+# BDD grid compile coverage check
+cargo run -p xtask -- grid-check
+cargo run -p xtask -- grid-check --dry-run  # show what would be checked
 ```
 
 ## Core Architecture

--- a/docs/development/test-suite.md
+++ b/docs/development/test-suite.md
@@ -39,6 +39,10 @@ cargo test --workspace --no-default-features --features gpu
 # Skip slow tests (QK256 scalar kernels)
 BITNET_SKIP_SLOW_TESTS=1 cargo test --workspace --no-default-features --features cpu
 
+# BDD compile-coverage check (feature-matrix grid)
+cargo run -p xtask -- grid-check
+cargo run -p xtask -- grid-check --dry-run   # show what would be checked
+
 # Run including ignored tests (will encounter blocked tests)
 cargo test --workspace --no-default-features --features cpu -- --ignored --include-ignored
 ```
@@ -311,10 +315,11 @@ BitNet-rs test suite is organized into distinct categories, each addressing spec
 | **Performance Tests** | 95+ | ✅ Passing | Benchmarking, memory tracking |
 | **Integration Tests** | 110+ | 🟡 Partial | End-to-end workflows (some blocked by issues) |
 | **Slow/Ignored Tests** | 70+ | ⏸️ Skipped | QK256 scalar kernels, architecture blockers |
+| **BDD Grid Tests** | 50+ | ✅ Passing | Feature-matrix compile coverage (bitnet-bdd-grid) |
+| **Trace Tests** | 20+ | ✅ Passing | Tensor activation tracing and cross-validation (bitnet-trace) |
 
-**Total Enabled**: 3,520 tests
-**Total Skipped**: 462 tests (intentional)
-**Pass Rate**: 100%
+**Total Enabled**: 1000+ tests
+**Total Skipped**: 70+ tests (intentional `#[ignore]` scaffolding)
 
 ### Quantization Tests
 


### PR DESCRIPTION
## What changed

### README.md
- **Description**: Updated to the canonical one-liner: *BitNet-rs is a high-performance Rust inference engine for 1-bit BitNet LLMs.*
- **Features**: Trimmed from 9 bullets to 6 focused, factual bullets (removed marketing-adjacent phrasing)
- **Structure**: Split monolithic `Development` section into separate `Building` and `Testing` sections, following the Diataxis landing-page principle (README is a reference, not a tutorial)
- **Testing section**: Added `xtask grid-check`, mentions 1000+ tests, proptest/insta/fuzz/BDD grid coverage, and links to test-suite.md

### docs/development/test-suite.md
- Added **BDD Grid Tests** category row (50+, `bitnet-bdd-grid`, added in PR #905)
- Added **Trace Tests** category row (20+, `bitnet-trace`, added in PR #916)
- Updated total test count to `1000+` (previous figure was stale)
- Added `cargo run -p xtask -- grid-check` and `--dry-run` variant to standard test commands

### CLAUDE.md
- Added `xtask grid-check` and `--dry-run` to the **Essential Commands** section so contributors see it immediately

## Why
The Development section in the README mixed build and test instructions in one undifferentiated block. Separating them makes the README more scannable for users who just need to run tests. The test-suite docs were missing the BDD grid and trace test categories added in the recent test wave (PRs #901–#917).

## Not changed
- CHANGELOG.md (left for a dedicated PR)
- No test files modified
- No .rs files modified (no `cargo fmt` needed)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>