### PR TITLE
test(bitnet-st2gguf,bitnet-server): add extended tests

### DIFF
--- a/crates/bitnet-server/tests/server_extended_tests.rs
+++ b/crates/bitnet-server/tests/server_extended_tests.rs
@@ -1,0 +1,315 @@
+//! Extended integration tests for `bitnet-server`.
+//!
+//! Coverage (all NEW — not duplicated from server_security_tests.rs,
+//! property_tests.rs, or health_endpoints_integration.rs):
+//!
+//! - BatchEngine: new, get_stats (initial zeros), get_health (initially healthy)
+//! - BatchRequest: unique IDs across instances, priority assignment
+//! - ConcurrencyManager: initial stats/health, request admission, global rate-limit rejection
+//! - InferenceResponse / ErrorResponse: JSON serialization and field presence
+//! - EnhancedInferenceResponse: flattened base fields accessible in JSON
+//! - /health/live: HTTP 200 status, Content-Type header, JSON "status" field
+
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::Value as Json;
+use tower::ServiceExt;
+
+use bitnet_inference::GenerationConfig;
+use bitnet_server::{
+    EnhancedInferenceResponse, ErrorResponse, InferenceResponse,
+    batch_engine::{BatchEngine, BatchEngineConfig, BatchRequest, RequestPriority},
+    concurrency::{ConcurrencyConfig, ConcurrencyManager, RequestAdmission, RequestMetadata},
+    monitoring::{
+        MonitoringConfig,
+        health::{HealthChecker, create_health_routes},
+        metrics::MetricsCollector,
+    },
+};
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn make_metadata(ip: &str) -> RequestMetadata {
+    RequestMetadata {
+        id: uuid::Uuid::new_v4().to_string(),
+        client_ip: ip.parse::<IpAddr>().unwrap(),
+        user_agent: None,
+        start_time: Instant::now(),
+        priority: RequestPriority::Normal,
+    }
+}
+
+// ── BatchEngine ───────────────────────────────────────────────────────────────
+
+/// BatchEngine::new with default config should not panic.
+#[tokio::test]
+async fn test_batch_engine_new_creates_instance() {
+    let _engine = BatchEngine::new(BatchEngineConfig::default());
+}
+
+/// A freshly-created BatchEngine has queue_depth = 0.
+#[tokio::test]
+async fn test_batch_engine_initial_stats_zero_queue_depth() {
+    let engine = BatchEngine::new(BatchEngineConfig::default());
+    let stats = engine.get_stats().await;
+    assert_eq!(stats.queue_depth, 0, "fresh engine must have empty queue");
+}
+
+/// A freshly-created BatchEngine has zero processed requests and batches.
+#[tokio::test]
+async fn test_batch_engine_initial_stats_zero_processed() {
+    let engine = BatchEngine::new(BatchEngineConfig::default());
+    let stats = engine.get_stats().await;
+    assert_eq!(stats.total_requests_processed, 0);
+    assert_eq!(stats.total_batches_processed, 0);
+}
+
+/// A freshly-created BatchEngine reports healthy with no issues.
+#[tokio::test]
+async fn test_batch_engine_initial_health_healthy() {
+    let engine = BatchEngine::new(BatchEngineConfig::default());
+    let health = engine.get_health().await;
+    assert!(health.healthy, "fresh engine must report healthy");
+    assert!(health.issues.is_empty(), "fresh engine must have no issues: {:?}", health.issues);
+}
+
+// ── BatchRequest ──────────────────────────────────────────────────────────────
+
+/// Two independently-created BatchRequests must have distinct IDs.
+#[test]
+fn test_batch_request_ids_are_unique() {
+    let r1 = BatchRequest::new("hello".to_string(), GenerationConfig::default());
+    let r2 = BatchRequest::new("hello".to_string(), GenerationConfig::default());
+    assert_ne!(r1.id, r2.id, "batch request IDs must be unique per request");
+}
+
+/// with_priority stores the Critical priority level correctly.
+#[test]
+fn test_batch_request_priority_critical() {
+    let req = BatchRequest::new("test".to_string(), GenerationConfig::default())
+        .with_priority(RequestPriority::Critical);
+    assert_eq!(req.priority, RequestPriority::Critical);
+}
+
+/// A newly-created BatchRequest has Normal priority by default.
+#[test]
+fn test_batch_request_default_priority_is_normal() {
+    let req = BatchRequest::new("test".to_string(), GenerationConfig::default());
+    assert_eq!(req.priority, RequestPriority::Normal, "default priority must be Normal");
+}
+
+// ── ConcurrencyManager ────────────────────────────────────────────────────────
+
+/// ConcurrencyManager::new with default config should not panic.
+#[tokio::test]
+async fn test_concurrency_manager_new_with_config() {
+    let _mgr = ConcurrencyManager::new(ConcurrencyConfig::default());
+}
+
+/// A fresh ConcurrencyManager has zero active requests and zero total requests.
+#[tokio::test]
+async fn test_concurrency_manager_initial_stats_zeros() {
+    let mgr = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let stats = mgr.get_stats().await;
+    assert_eq!(stats.active_requests, 0, "no active requests on a fresh manager");
+    assert_eq!(stats.total_requests, 0, "no total requests on a fresh manager");
+    assert_eq!(stats.rejected_requests, 0, "no rejections on a fresh manager");
+}
+
+/// A fresh ConcurrencyManager is healthy and not overloaded.
+#[tokio::test]
+async fn test_concurrency_manager_initial_health_not_overloaded() {
+    let mgr = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let health = mgr.get_health().await;
+    assert!(health.healthy, "fresh manager must report healthy");
+    // current_load should be 0.0 with no active requests
+    assert_eq!(health.current_load, 0.0, "load must be 0.0 when no requests active");
+}
+
+/// The first request to a manager with plenty of capacity must be Admitted.
+#[tokio::test]
+async fn test_concurrency_manager_admits_first_request() {
+    let config = ConcurrencyConfig {
+        global_rate_limit: Some(1000),
+        per_ip_rate_limit: None,
+        circuit_breaker_enabled: false,
+        ..ConcurrencyConfig::default()
+    };
+    let mgr = ConcurrencyManager::new(config);
+    let meta = make_metadata("127.0.0.1");
+
+    let decision = mgr.should_admit_request(&meta).await.unwrap();
+    assert!(
+        matches!(decision, RequestAdmission::Admitted),
+        "first request must be Admitted when capacity is available"
+    );
+}
+
+/// After exhausting a global rate limit of 1, subsequent requests are Rejected.
+#[tokio::test]
+async fn test_concurrency_manager_rejects_after_rate_limit_exhausted() {
+    let config = ConcurrencyConfig {
+        global_rate_limit: Some(1), // only 1 token
+        per_ip_rate_limit: None,
+        circuit_breaker_enabled: false,
+        ..ConcurrencyConfig::default()
+    };
+    let mgr = ConcurrencyManager::new(config);
+    let meta = make_metadata("10.0.0.1");
+
+    // First request consumes the single token.
+    let first = mgr.should_admit_request(&meta).await.unwrap();
+    assert!(matches!(first, RequestAdmission::Admitted), "first must be admitted");
+
+    // Second request finds no tokens remaining.
+    let second = mgr.should_admit_request(&meta).await.unwrap();
+    assert!(
+        matches!(second, RequestAdmission::Rejected { .. }),
+        "second request must be Rejected once the global rate limit token is consumed"
+    );
+}
+
+// ── JSON serialization ────────────────────────────────────────────────────────
+
+/// InferenceResponse serializes to JSON with a "text" field.
+#[test]
+fn test_inference_response_json_has_text_field() {
+    let resp = InferenceResponse {
+        text: "Hello, world!".to_string(),
+        tokens_generated: 3,
+        inference_time_ms: 50,
+        tokens_per_second: 60.0,
+    };
+    let json: Json = serde_json::to_value(&resp).unwrap();
+    assert_eq!(json["text"], "Hello, world!");
+}
+
+/// InferenceResponse serializes tokens_per_second as a JSON number.
+#[test]
+fn test_inference_response_tokens_per_second_in_json() {
+    let resp = InferenceResponse {
+        text: String::new(),
+        tokens_generated: 10,
+        inference_time_ms: 200,
+        tokens_per_second: 50.0,
+    };
+    let json: Json = serde_json::to_value(&resp).unwrap();
+    // JSON numbers from f64 may not compare exactly; check it's numeric and close.
+    let tps = json["tokens_per_second"].as_f64().expect("tokens_per_second must be a number");
+    assert!((tps - 50.0).abs() < 1e-6);
+}
+
+/// ErrorResponse serializes with the required "error" and "error_code" fields.
+#[test]
+fn test_error_response_json_has_required_fields() {
+    let resp = ErrorResponse {
+        error: "model not found".to_string(),
+        error_code: "ERR_MODEL_404".to_string(),
+        request_id: None,
+        details: None,
+    };
+    let json: Json = serde_json::to_value(&resp).unwrap();
+    assert_eq!(json["error"], "model not found");
+    assert_eq!(json["error_code"], "ERR_MODEL_404");
+}
+
+/// Optional fields in ErrorResponse serialize as null when None.
+#[test]
+fn test_error_response_none_fields_serialize_as_null() {
+    let resp = ErrorResponse {
+        error: "oops".to_string(),
+        error_code: "E_OOPS".to_string(),
+        request_id: None,
+        details: None,
+    };
+    let json: Json = serde_json::to_value(&resp).unwrap();
+    assert!(json["request_id"].is_null(), "None request_id must serialize as JSON null");
+    assert!(json["details"].is_null(), "None details must serialize as JSON null");
+}
+
+/// EnhancedInferenceResponse: the flattened "text" field from InferenceResponse appears in JSON.
+#[test]
+fn test_enhanced_response_flattened_text_field() {
+    let resp = EnhancedInferenceResponse {
+        base: InferenceResponse {
+            text: "42".to_string(),
+            tokens_generated: 1,
+            inference_time_ms: 10,
+            tokens_per_second: 100.0,
+        },
+        device_used: "cpu".to_string(),
+        quantization_type: "f16".to_string(),
+        batch_id: None,
+        batch_size: None,
+        queue_time_ms: 0,
+    };
+    let json: Json = serde_json::to_value(&resp).unwrap();
+    // Flattened base fields should appear at the top level.
+    assert_eq!(json["text"], "42", "flattened 'text' from base must appear in JSON");
+    assert_eq!(json["device_used"], "cpu");
+}
+
+// ── /health/live endpoint ─────────────────────────────────────────────────────
+
+/// /health/live returns a valid HTTP status code (200 when healthy, 503 when degraded).
+#[tokio::test]
+async fn test_health_live_returns_valid_status() {
+    let config = MonitoringConfig::default();
+    let metrics = Arc::new(MetricsCollector::new(&config).unwrap());
+    let checker = Arc::new(HealthChecker::new(metrics));
+    let app = create_health_routes(checker);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/health/live").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let status = resp.status();
+    assert!(
+        status == StatusCode::OK || status == StatusCode::SERVICE_UNAVAILABLE,
+        "/health/live must return 200 (healthy) or 503 (degraded/unhealthy), got {status}"
+    );
+}
+
+/// /health/live response includes a Content-Type that contains "application/json".
+#[tokio::test]
+async fn test_health_live_content_type_is_json() {
+    let config = MonitoringConfig::default();
+    let metrics = Arc::new(MetricsCollector::new(&config).unwrap());
+    let checker = Arc::new(HealthChecker::new(metrics));
+    let app = create_health_routes(checker);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/health/live").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let ct = resp.headers().get("content-type").and_then(|v| v.to_str().ok()).unwrap_or("");
+    assert!(
+        ct.contains("application/json"),
+        "/health/live Content-Type must include 'application/json', got: {ct}"
+    );
+}
+
+/// /health/live response body is valid JSON with a "status" field.
+#[tokio::test]
+async fn test_health_live_json_has_status_field() {
+    let config = MonitoringConfig::default();
+    let metrics = Arc::new(MetricsCollector::new(&config).unwrap());
+    let checker = Arc::new(HealthChecker::new(metrics));
+    let app = create_health_routes(checker);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/health/live").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Json = serde_json::from_slice(&body).expect("/health/live body must be valid JSON");
+    assert!(json.get("status").is_some(), "liveness response must have a 'status' field");
+}

--- a/crates/bitnet-st2gguf/tests/st2gguf_tests.rs
+++ b/crates/bitnet-st2gguf/tests/st2gguf_tests.rs
@@ -1,0 +1,389 @@
+//! Integration tests for `bitnet-st2gguf`.
+//!
+//! Coverage:
+//! - GgufWriter: output file creation, GGUF magic, header fields, tensor storage
+//! - TensorEntry and TensorDType: field access and type codes
+//! - LayerNorm detection: GGUF blk-style, rms_norm, attention_norm variants
+//! - count_layernorm_tensors: edge cases
+//! - CLI binary: --help exits 0, nonexistent --input path exits non-zero
+//! - Property test: blk-style ffn_norm always detected as LayerNorm
+
+use std::fs;
+
+use bitnet_st2gguf::{
+    layernorm::{count_layernorm_tensors, is_layernorm_tensor},
+    writer::{GgufWriter, MetadataValue, TensorDType, TensorEntry},
+};
+use proptest::prelude::*;
+use tempfile::TempDir;
+
+// ── GgufWriter file-creation tests ──────────────────────────────────────────
+
+/// Writing a GGUF file creates the output path on disk.
+#[test]
+fn test_writer_creates_output_file() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("model.gguf");
+
+    let writer = GgufWriter::new();
+    writer.write_to_file(&out).unwrap();
+
+    assert!(out.exists(), "output file must be created on disk");
+}
+
+/// The first four bytes of every GGUF file must be the magic b"GGUF".
+#[test]
+fn test_writer_output_starts_with_gguf_magic() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("model.gguf");
+
+    GgufWriter::new().write_to_file(&out).unwrap();
+
+    let data = fs::read(&out).unwrap();
+    assert!(data.len() >= 4, "output must have at least 4 bytes");
+    assert_eq!(&data[0..4], b"GGUF", "first 4 bytes must be the GGUF magic");
+}
+
+/// The GGUF version field (bytes 4–7) must equal 3.
+#[test]
+fn test_writer_header_version_is_3() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("model.gguf");
+
+    GgufWriter::new().write_to_file(&out).unwrap();
+
+    let data = fs::read(&out).unwrap();
+    assert!(data.len() >= 8);
+    let version = u32::from_le_bytes(data[4..8].try_into().unwrap());
+    assert_eq!(version, 3, "GGUF version must be 3");
+}
+
+/// The tensor-count field (bytes 8–15) reflects the actual number of tensors added.
+#[test]
+fn test_writer_header_tensor_count() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("model.gguf");
+
+    let mut writer = GgufWriter::new();
+    writer.add_tensor(TensorEntry::new(
+        "a".to_string(),
+        vec![4],
+        TensorDType::F16,
+        vec![0u8; 8], // 4 × 2 bytes
+    ));
+    writer.add_tensor(TensorEntry::new("b".to_string(), vec![2], TensorDType::F16, vec![0u8; 4]));
+    writer.write_to_file(&out).unwrap();
+
+    let data = fs::read(&out).unwrap();
+    assert!(data.len() >= 16);
+    let tensor_count = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    assert_eq!(tensor_count, 2, "header tensor_count must equal the number added");
+}
+
+/// The KV-count field (bytes 16–23) reflects the number of metadata entries.
+#[test]
+fn test_writer_header_kv_count() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("model.gguf");
+
+    let mut writer = GgufWriter::new();
+    writer.add_metadata("key.one", MetadataValue::U32(1));
+    writer.add_metadata("key.two", MetadataValue::U32(2));
+    writer.add_metadata("key.three", MetadataValue::U32(3));
+    writer.write_to_file(&out).unwrap();
+
+    let data = fs::read(&out).unwrap();
+    assert!(data.len() >= 24);
+    let kv_count = u64::from_le_bytes(data[16..24].try_into().unwrap());
+    assert_eq!(kv_count, 3, "header kv_count must equal the number of metadata entries");
+}
+
+/// A writer with zero tensors still produces a valid non-empty GGUF file.
+#[test]
+fn test_writer_output_non_empty_with_no_tensors() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("empty.gguf");
+
+    GgufWriter::new().write_to_file(&out).unwrap();
+
+    let len = fs::metadata(&out).unwrap().len();
+    assert!(len > 0, "GGUF file must be non-empty even with no tensors");
+}
+
+/// Three tensors added are all reflected in the header tensor count.
+#[test]
+fn test_writer_multiple_tensors_all_stored() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("multi.gguf");
+
+    let mut writer = GgufWriter::new();
+    for i in 0u32..3 {
+        writer.add_tensor(TensorEntry::new(
+            format!("layer.{i}.weight"),
+            vec![2],
+            TensorDType::F16,
+            vec![0u8; 4],
+        ));
+    }
+    writer.write_to_file(&out).unwrap();
+
+    let data = fs::read(&out).unwrap();
+    let tensor_count = u64::from_le_bytes(data[8..16].try_into().unwrap());
+    assert_eq!(tensor_count, 3);
+}
+
+/// A tensor with 1024 bytes of data can be written without error.
+#[test]
+fn test_writer_tensor_with_large_data() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("large.gguf");
+
+    let mut writer = GgufWriter::new();
+    writer.add_tensor(TensorEntry::new(
+        "embed.weight".to_string(),
+        vec![512], // 512 F16 elements
+        TensorDType::F16,
+        vec![0u8; 1024], // 512 × 2 bytes
+    ));
+    // Should not panic or return Err
+    writer.write_to_file(&out).unwrap();
+
+    assert!(out.exists());
+}
+
+/// The output file size is greater than the fixed header size (36 bytes) when
+/// metadata is present.
+#[test]
+fn test_writer_output_file_size_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("sized.gguf");
+
+    let mut writer = GgufWriter::new();
+    writer.add_metadata("general.architecture", MetadataValue::String("test".to_string()));
+    writer.write_to_file(&out).unwrap();
+
+    let len = fs::metadata(&out).unwrap().len();
+    // Header (36 bytes) + KV for "general.architecture" + alignment padding
+    assert!(len >= 36, "file must be at least as large as the GGUF header");
+}
+
+// ── TensorEntry and TensorDType ──────────────────────────────────────────────
+
+/// TensorEntry stores and exposes the name field.
+#[test]
+fn test_tensor_entry_name_accessible() {
+    let entry =
+        TensorEntry::new("my.tensor.weight".to_string(), vec![4, 4], TensorDType::F16, vec![0; 32]);
+    assert_eq!(entry.name, "my.tensor.weight");
+}
+
+/// TensorEntry stores and exposes the shape field.
+#[test]
+fn test_tensor_entry_shape_accessible() {
+    let entry = TensorEntry::new("x".to_string(), vec![3, 5, 7], TensorDType::F32, vec![0; 420]);
+    assert_eq!(entry.shape, vec![3, 5, 7]);
+}
+
+/// TensorEntry stores and exposes the data bytes.
+#[test]
+fn test_tensor_entry_data_length_matches() {
+    let data = vec![42u8; 64];
+    let entry = TensorEntry::new("t".to_string(), vec![32], TensorDType::F16, data.clone());
+    assert_eq!(entry.data.len(), 64);
+}
+
+/// TensorDType::F16 and TensorDType::F32 have different GGUF type codes.
+#[test]
+fn test_tensor_dtype_codes_differ() {
+    assert_ne!(
+        TensorDType::F16.as_gguf_type(),
+        TensorDType::F32.as_gguf_type(),
+        "F16 and F32 must have distinct GGUF type codes"
+    );
+}
+
+/// TensorDType::F16 has GGUF type code 1 (standard GGUF spec).
+#[test]
+fn test_tensor_dtype_f16_code_is_1() {
+    assert_eq!(TensorDType::F16.as_gguf_type(), 1);
+}
+
+/// TensorDType::F32 has GGUF type code 0 (standard GGUF spec).
+#[test]
+fn test_tensor_dtype_f32_code_is_0() {
+    assert_eq!(TensorDType::F32.as_gguf_type(), 0);
+}
+
+/// TensorDType::F16 element size is 2 bytes.
+#[test]
+fn test_tensor_dtype_f16_element_size_is_2() {
+    assert_eq!(TensorDType::F16.element_size(), 2);
+}
+
+/// TensorDType::F32 element size is 4 bytes.
+#[test]
+fn test_tensor_dtype_f32_element_size_is_4() {
+    assert_eq!(TensorDType::F32.element_size(), 4);
+}
+
+// ── LayerNorm detection: additional patterns ─────────────────────────────────
+
+/// GGUF-style blk prefix: `blk.0.attn_norm.weight` must be detected as LayerNorm.
+#[test]
+fn test_layernorm_gguf_blk_style_attn_norm() {
+    assert!(
+        is_layernorm_tensor("blk.0.attn_norm.weight"),
+        "blk-style attn_norm must be a LayerNorm tensor"
+    );
+}
+
+/// GGUF-style blk prefix: `blk.5.ffn_norm.weight` must be detected as LayerNorm.
+#[test]
+fn test_layernorm_gguf_blk_style_ffn_norm() {
+    assert!(
+        is_layernorm_tensor("blk.5.ffn_norm.weight"),
+        "blk-style ffn_norm must be a LayerNorm tensor"
+    );
+}
+
+/// `rms_norm.weight` suffix pattern must be detected as LayerNorm.
+#[test]
+fn test_layernorm_rms_norm_variant() {
+    assert!(
+        is_layernorm_tensor("blk.3.rms_norm.weight"),
+        ".rms_norm.weight suffix must be a LayerNorm tensor"
+    );
+}
+
+/// `attention_norm.weight` (LLaMA-style) must be detected as LayerNorm.
+#[test]
+fn test_layernorm_attention_norm_variant() {
+    assert!(
+        is_layernorm_tensor("blk.2.attention_norm.weight"),
+        ".attention_norm.weight suffix must be a LayerNorm tensor"
+    );
+}
+
+/// `.norm.weight` generic suffix must be detected as LayerNorm.
+#[test]
+fn test_layernorm_norm_weight_suffix() {
+    assert!(
+        is_layernorm_tensor("model.layers.0.norm.weight"),
+        ".norm.weight suffix must be detected as LayerNorm"
+    );
+}
+
+/// `token_embd.weight` is not a LayerNorm tensor.
+#[test]
+fn test_non_layernorm_token_embd() {
+    assert!(
+        !is_layernorm_tensor("token_embd.weight"),
+        "token_embd.weight must NOT be a LayerNorm tensor"
+    );
+}
+
+/// `blk.0.attn_output.weight` (a projection) is not a LayerNorm tensor.
+#[test]
+fn test_non_layernorm_attn_output_projection() {
+    assert!(
+        !is_layernorm_tensor("blk.0.attn_output.weight"),
+        "attention projection weights must NOT be LayerNorm"
+    );
+}
+
+// ── count_layernorm_tensors ───────────────────────────────────────────────────
+
+/// An empty slice produces a count of zero.
+#[test]
+fn test_count_empty_slice_is_zero() {
+    assert_eq!(count_layernorm_tensors([].iter().copied()), 0);
+}
+
+/// When every name in the list is a LayerNorm tensor, count equals the list length.
+#[test]
+fn test_count_all_match_equals_len() {
+    let names = [
+        "blk.0.attn_norm.weight",
+        "blk.0.ffn_norm.weight",
+        "blk.1.attn_norm.weight",
+        "blk.1.ffn_norm.weight",
+    ];
+    assert_eq!(count_layernorm_tensors(names.iter().copied()), names.len());
+}
+
+/// A mixed list counts only the LayerNorm names.
+#[test]
+fn test_count_partial_match() {
+    let names = [
+        "blk.0.attn_norm.weight", // LN
+        "blk.0.attn_q.weight",    // projection, not LN
+        "blk.0.ffn_norm.weight",  // LN
+        "token_embd.weight",      // embedding, not LN
+    ];
+    assert_eq!(count_layernorm_tensors(names.iter().copied()), 2);
+}
+
+// ── CLI binary tests ─────────────────────────────────────────────────────────
+
+/// `st2gguf --help` exits with status 0.
+#[test]
+fn test_cli_help_exits_zero() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_st2gguf"))
+        .arg("--help")
+        .output()
+        .expect("failed to run st2gguf binary");
+    assert!(output.status.success(), "--help must exit 0, got {:?}", output.status.code());
+}
+
+/// Running with a nonexistent --input path exits with a non-zero status.
+#[test]
+fn test_cli_nonexistent_input_file_exits_nonzero() {
+    let dir = TempDir::new().unwrap();
+    let out = dir.path().join("out.gguf");
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_st2gguf"))
+        .args([
+            "--input",
+            "/definitely/does/not/exist/model.safetensors",
+            "--output",
+            out.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to run st2gguf binary");
+
+    assert!(!output.status.success(), "nonexistent input path must cause a non-zero exit code");
+}
+
+// ── Property tests ────────────────────────────────────────────────────────────
+
+proptest! {
+    /// blk.{n}.ffn_norm.weight always matches the LayerNorm predicate, regardless of layer index.
+    #[test]
+    fn prop_blk_style_ffn_norm_always_layernorm(layer in 0usize..256) {
+        let name = format!("blk.{layer}.ffn_norm.weight");
+        prop_assert!(
+            is_layernorm_tensor(&name),
+            "{name} must always be detected as a LayerNorm tensor"
+        );
+    }
+
+    /// blk.{n}.attn_norm.weight always matches regardless of layer index.
+    #[test]
+    fn prop_blk_style_attn_norm_always_layernorm(layer in 0usize..256) {
+        let name = format!("blk.{layer}.attn_norm.weight");
+        prop_assert!(
+            is_layernorm_tensor(&name),
+            "{name} must always be detected as a LayerNorm tensor"
+        );
+    }
+
+    /// blk.{n}.attn_q.weight is never a LayerNorm tensor.
+    #[test]
+    fn prop_projection_weight_never_layernorm(layer in 0usize..256) {
+        let name = format!("blk.{layer}.attn_q.weight");
+        prop_assert!(
+            !is_layernorm_tensor(&name),
+            "{name} is a projection weight and must NOT match LayerNorm"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for two crates:

### `crates/bitnet-st2gguf/tests/st2gguf_tests.rs` (26 tests)

**GgufWriter file creation:**
- Output file created on disk
- GGUF magic bytes (`b"GGUF"`) at offset 0
- Header version = 3
- Tensor count in header matches added tensors
- KV count in header matches metadata entries
- Non-empty output even with no tensors; correct file size

**TensorEntry / TensorDType:**
- Name, shape, data fields accessible
- F16 GGUF type code = 1, F32 = 0 (spec-compliant)
- F16 element size = 2, F32 = 4

**LayerNorm detection (new patterns not in existing tests):**
- GGUF blk-style: `blk.0.attn_norm.weight`, `blk.5.ffn_norm.weight`
- RMS-norm: `blk.3.rms_norm.weight`
- Attention-norm: `blk.2.attention_norm.weight`
- Generic: `model.layers.0.norm.weight`
- Negative: `token_embd.weight`, `blk.0.attn_output.weight`

**`count_layernorm_tensors`:** empty=0, all-match, partial-match

**CLI binary tests:**
- `--help` exits with code 0
- Nonexistent `--input` path exits non-zero

**Property tests (proptest):**
- `blk.{n}.ffn_norm.weight` always matches for any layer index
- `blk.{n}.attn_norm.weight` always matches for any layer index
- `blk.{n}.attn_q.weight` never matches (projection, not LN)

---

### `crates/bitnet-server/tests/server_extended_tests.rs` (20 tests)

**BatchEngine:**
- `new()` with default config does not panic
- Initial `get_stats()`: queue\_depth=0, total\_requests=0
- Initial `get_health()`: healthy=true, issues=[]

**BatchRequest:**
- Two independently-created requests have distinct UUIDs
- `with_priority(Critical)` stores Critical priority
- Default priority is Normal

**ConcurrencyManager:**
- `new()` with default config does not panic
- Initial stats: active\_requests=0, total\_requests=0, rejected=0
- Initial health: healthy=true, current\_load=0.0
- First request admitted when capacity available
- Second request rejected after global rate-limit token exhausted (token bucket `capacity=1`)

**JSON serialization:**
- `InferenceResponse`: `text` and `tokens_per_second` fields in JSON
- `ErrorResponse`: required fields present; `None` optional fields serialize as `null`
- `EnhancedInferenceResponse`: flattened `base` fields appear at top level

**`/health/live` endpoint:**
- Returns valid HTTP status (200 healthy / 503 degraded)
- `Content-Type: application/json`
- Body is valid JSON with a `status` field

---

## Test results

```
cargo test -p bitnet-st2gguf --no-default-features
test result: ok. 32 passed; 0 failed

cargo test -p bitnet-server --no-default-features --features cpu --test server_extended_tests
test result: ok. 20 passed; 0 failed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>