### PR TITLE
docs: update changelog and roadmap for PRs #913-#922

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to bitnet-rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `test(bitnet-st2gguf,bitnet-server): add extended tests` — 26 extended tests for bitnet-st2gguf (conversion pipeline, quantization type handling, error variants) and 20 tests for bitnet-server (batch engine config, CORS, security middleware) (#922)
+- `test(bitnet-transformer,bitnet-honest-compute): add comprehensive tests` — 29 tests for bitnet-transformer (RoPE invariants, KVCache shape/seq-len properties) and 37 tests for bitnet-honest-compute (ComputeMode gating, receipt validation, honest-compute enforcement) (#921)
+- `test(bitnet-bdd-grid,bitnet-testing-policy): add comprehensive grid and policy tests` — 36 tests for bitnet-bdd-grid (grid rows/columns, cell lookup, scenario validation) and 28 tests for bitnet-testing-policy (PolicyDiagnostics coherence, GridCompatibility invariants) (#917)
+- `feat(fuzz): add wave 3 fuzz targets` — 3 new fuzz targets: `gguf_writer_roundtrip` (GGUF writer round-trip safety), `tokenizer_encode_no_panic` (tokenizer encode panic safety), `validation_no_panic` (validation pipeline panic safety) (#919)
+- `test(bitnet-trace): add 20+ comprehensive tests` — 20+ tests covering TraceSink and TraceComparison APIs, JSON round-trips, hash invariants, rms calculations, and decode-step tracing (#916)
+- `test(bitnet-validation,bitnet-kernel-registry): add comprehensive tests` — 65 tests for bitnet-validation (LayerNorm bounds, error messages, policy keys, gate modes, RMS validation) and 56 tests for bitnet-kernel-registry (kernel dispatch, capability registry, SIMD selection behaviour) (#915)
+- `test(bitnet-quantization): add 25+ extended integration and property tests` — 25+ extended integration and property tests covering I2_S, TL1, TL2, and QK256 roundtrip accuracy, block-size invariants, and edge-case inputs (#914)
 - `test(bitnet-device-probe): add 25+ comprehensive tests` — SIMD level detection ordering, GPU probe validation, DeviceCapabilities construction/equality, and property tests for probe determinism and capability invariants (#912)
 - `test(bitnet-runtime-feature-flags,bitnet-feature-contract): add comprehensive tests` — RuntimeFeatureFlags snapshot tests, CPU-always-true invariant, CUDA/GPU orthogonality, and JSON round-trips for feature-flag and feature-contract crates (#911)
 - `test: reduce ignored test count by converting to env-var guards (wave 2)` — 13 fewer ignored tests (1043→1030); `tokenization_smoke` converted to `CROSSVAL_GGUF` opt-in; AC3/AC6 acceptance tests gated on `BITNET_RUN_SLOW_TESTS` env-var (#910)
@@ -23,6 +30,10 @@ All notable changes to bitnet-rs will be documented in this file.
 - `test(bitnet-models): add 15 property-based tests for model loading` — 15 new proptests in `crates/bitnet-models/tests/model_load_proptests.rs` covering `ModelConfig` round-trips, tensor-shape invariants, quantization-type parsing edge cases, and QK256 vs BitNet32-F16 flavor disambiguation (#895)
 - `test(bitnet-inference): add 77 integration tests that run without a real model` — 77 new no-model integration tests in `crates/bitnet-inference/tests/` exercising `ProductionInferenceEngine` construction, `SamplingStrategy` configuration paths, `GenerationStream` lifecycle, and error-handling branches without requiring a GGUF file (#894)
 - `test(bitnet-cli): add snapshot tests for CLI help output` — 8 new insta snapshot tests in `crates/bitnet-cli/tests/snapshot_tests.rs` pinning `--help` and `--version` output for all top-level subcommands; uses `assert_cmd` + `insta` for regression detection (#893)
+
+### Documentation
+- `docs: comprehensive README rewrite and test-suite docs update` — README rewrite highlighting 1000+ test milestone, updated feature flag table, xtask grid-check documentation, and revised `docs/development/test-suite.md` with current test counts (#920)
+- `docs: update changelog for PRs #905-#912` — Changelog entries for server security tests, tokenizer property tests, xtask grid-check feature, E2E golden path tests, fuzz targets (sampling/receipt/template), logits property tests, and device-probe tests (#913)
 
 ## [v0.1.3] - 2026-02-27
 

--- a/docs/reference/dual-backend-roadmap.md
+++ b/docs/reference/dual-backend-roadmap.md
@@ -1,9 +1,12 @@
 # Dual-Backend Support Implementation Roadmap
 
-> **Last updated**: reflects implementation state after PRs #608–#907.
+> **Last updated**: reflects implementation state after PRs #608–#922.
 > Items marked ✅ are **done**; items marked 🔲 are **planned**.
-> **Recent wave (PRs #886–#907)**: ~200+ new tests added across server security, tokenizers,
-> logits, E2E golden path, fuzz targets, and active test unblocking.
+> **Recent wave (PRs #908–#922)**: 1000+ tests milestone reached; Phase 6 SRP microcrate extractions
+> complete (bitnet-device-probe, bitnet-logits, bitnet-generation, bitnet-sampling, bitnet-transformer,
+> bitnet-engine-core, bitnet-gguf); wave 3 fuzz targets added; comprehensive tests for
+> bitnet-validation, bitnet-kernel-registry, bitnet-trace, bitnet-bdd-grid, bitnet-testing-policy,
+> bitnet-transformer, bitnet-honest-compute, bitnet-st2gguf, and bitnet-server.
 
 ---
 
@@ -23,6 +26,8 @@
 | `bitnet-generation` SRP microcrate | `crates/bitnet-generation/` | #629 |
 | `bitnet-engine-core` SRP microcrate | `crates/bitnet-engine-core/` | #629 |
 | `bitnet-gguf` SRP microcrate | `crates/bitnet-gguf/` | #629 |
+| `bitnet-sampling` SRP microcrate: Phase 6 extraction ✅ DONE | `crates/bitnet-sampling/` | #629 |
+| `bitnet-transformer` SRP microcrate: Phase 6 extraction ✅ DONE | `crates/bitnet-transformer/` | #629 |
 | `KernelBackend`, `KernelCapabilities`, `SimdLevel` types | `crates/bitnet-common/src/kernel_registry.rs` | #611 |
 | CodeRabbit path exclusions (archive, reports) | `.coderabbit.yaml` | #611 |
 | GPU smoke workflow (compile-only PR lane) | `.github/workflows/gpu-smoke.yml` | #611 |
@@ -158,6 +163,28 @@
 | `xtask grid-check [--dry-run]` BDD compile-coverage gate: 18 cells including cpu, cpu+full-cli, cpu+crossval, cpu+gpu | `xtask/src/grid_check.rs` | #905 |
 | 45 comprehensive tokenizer property-based tests: 40 proptest + 5 integration covering encode/decode round-trips, vocab consistency, Unicode safety, config JSON round-trip, auto-discovery, batch encoding | `crates/bitnet-tokenizers/tests/` | #906 |
 | 43 server security & middleware tests: 7 CORS, 5 security header, 9 request validation, 4 model path, 3 config/auth, 4 IP extraction, 8 property, 1 health endpoint; uses `tower::ServiceExt::oneshot` | `crates/bitnet-server/tests/` | #907 |
+| 72 comprehensive tests for `bitnet-compat` (diagnose/export/verify/stamp paths) and `bitnet-sys` (CompileTimeLibCapabilities, disabled-feature stubs) | `crates/bitnet-compat/tests/`, `crates/bitnet-sys/tests/` | #909 |
+| 13 fewer ignored tests: `tokenization_smoke` converted to `CROSSVAL_GGUF` opt-in; AC3/AC6 acceptance tests gated on `BITNET_RUN_SLOW_TESTS` (1043→1030 ignored) | workspace | #910 |
+| Comprehensive tests for `bitnet-runtime-feature-flags` (RuntimeFeatureFlags snapshots, CPU-always-true invariant, CUDA/GPU orthogonality, JSON round-trips) and `bitnet-feature-contract` | `crates/bitnet-runtime-feature-flags/tests/`, `crates/bitnet-feature-contract/tests/` | #911 |
+| 25+ comprehensive tests for `bitnet-device-probe`: SIMD level detection ordering, GPU probe validation, DeviceCapabilities construction/equality, probe determinism and capability invariants | `crates/bitnet-device-probe/tests/` | #912 |
+| 25+ extended integration and property tests for `bitnet-quantization`: I2_S, TL1, TL2, QK256 roundtrip accuracy, block-size invariants, edge-case inputs | `crates/bitnet-quantization/tests/` | #914 |
+| 65 tests for `bitnet-validation` (LayerNorm bounds, policy keys, gate modes, RMS validation) and 56 tests for `bitnet-kernel-registry` (kernel dispatch, capability registry, SIMD selection) | `crates/bitnet-validation/tests/`, `crates/bitnet-kernel-registry/tests/` | #915 |
+| 20+ comprehensive tests for `bitnet-trace`: TraceSink and TraceComparison APIs, JSON round-trips, hash invariants, decode-step tracing | `crates/bitnet-trace/tests/` | #916 |
+| 36 tests for `bitnet-bdd-grid` (grid rows/columns, cell lookup, scenario validation) and 28 tests for `bitnet-testing-policy` (PolicyDiagnostics, GridCompatibility invariants) | `crates/bitnet-bdd-grid/tests/`, `crates/bitnet-testing-policy/tests/` | #917 |
+| Wave 3 fuzz targets: `gguf_writer_roundtrip`, `tokenizer_encode_no_panic`, `validation_no_panic` | `fuzz/fuzz_targets/` | #919 |
+| **1000+ tests milestone** ✅: comprehensive README rewrite, updated `docs/development/test-suite.md` with current counts and xtask grid-check docs | `README.md`, `docs/development/test-suite.md` | #920 |
+| 29 tests for `bitnet-transformer` (RoPE invariants, KVCache shape/seq-len properties) and 37 tests for `bitnet-honest-compute` (ComputeMode gating, receipt validation, honest-compute enforcement) | `crates/bitnet-transformer/tests/`, `crates/bitnet-honest-compute/tests/` | #921 |
+| 26 extended tests for `bitnet-st2gguf` (conversion pipeline, quantization type handling, error variants) and 20 tests for `bitnet-server` (batch engine config, CORS, security middleware) | `crates/bitnet-st2gguf/tests/`, `crates/bitnet-server/tests/` | #922 |
+
+### ✅ Phase 7: Test Coverage (DONE — 1000+ tests)
+
+All Phase 7 test coverage targets have been met:
+- **1000+ total tests** across workspace (snapshot, property, integration, fuzz, E2E)
+- **Phase 6 SRP microcrates**: bitnet-device-probe, bitnet-logits, bitnet-generation,
+  bitnet-sampling, bitnet-transformer, bitnet-engine-core, bitnet-gguf — all ✅ DONE
+- **Fuzz coverage**: 18+ fuzz targets across GGUF, tokenizer, quantization, generation,
+  validation, receipts, and transformer paths
+- **Wave 3 fuzz targets**: gguf_writer_roundtrip, tokenizer_encode_no_panic, validation_no_panic
 
 ### 🔲 What's Planned
 


### PR DESCRIPTION
## Summary

Updates `CHANGELOG.md` and `docs/reference/dual-backend-roadmap.md` to reflect recently merged PRs #913–#922.

## CHANGELOG.md — `[Unreleased]` additions

### Added
- **#914** `test(bitnet-quantization)`: 25+ extended integration and property tests (I2_S, TL1, TL2, QK256 roundtrip accuracy)
- **#915** `test(bitnet-validation,bitnet-kernel-registry)`: 65 + 56 comprehensive tests
- **#916** `test(bitnet-trace)`: 20+ tests covering TraceSink and TraceComparison APIs
- **#917** `test(bitnet-bdd-grid,bitnet-testing-policy)`: 36 + 28 comprehensive tests
- **#919** `feat(fuzz)`: wave 3 fuzz targets — gguf_writer_roundtrip, tokenizer_encode_no_panic, validation_no_panic
- **#921** `test(bitnet-transformer,bitnet-honest-compute)`: 29 + 37 comprehensive tests
- **#922** `test(bitnet-st2gguf,bitnet-server)`: 26 + 20 extended tests

### Documentation (new subsection)
- **#913** `docs`: changelog batch update for PRs #905-#912
- **#920** `docs`: comprehensive README rewrite + test-suite docs (1000+ test milestone)

## dual-backend-roadmap.md updates

- Bumped "Last updated" header to PRs #608–#922
- Added Phase 7 test coverage section: **1000+ tests milestone ✅ DONE**
- Marked all Phase 6 SRP microcrate extractions ✅ DONE — added `bitnet-sampling` and `bitnet-transformer` alongside the five already listed
- Added What's Implemented table rows for PRs #909–#922

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive README rewrite with updated guidance
  * Enhanced test suite and coverage documentation 
  * Updated development roadmap reflecting Phase 6 SRP microcrate completion milestones and 1000+ test achievement
  * Introduced Phase 7 test coverage roadmap with detailed implementation status across multiple components and planned enhancements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->