### PR TITLE
test(bitnet-inference,bitnet-models): add extended engine and model tests

### DIFF
--- a/crates/bitnet-inference/tests/inference_engine_tests.rs
+++ b/crates/bitnet-inference/tests/inference_engine_tests.rs
@@ -1,0 +1,493 @@
+//! Extended tests for `bitnet-inference` public API.
+//!
+//! Focuses on areas not covered by `inference_integration_tests.rs`:
+//! - Additional `SamplingConfig` / `SamplingStrategy` edge cases
+//! - `GenerationConfig` builder methods not yet exercised
+//! - `InferenceReceipt` builder/validate variants
+//! - `ModelInfo`, `TestResults`, `AccuracyMetric` construction
+//!
+//! Run with:
+//!   `cargo test --locked -p bitnet-inference --no-default-features --features cpu \
+//!    -- inference_engine_tests`
+#![cfg(feature = "cpu")]
+
+use bitnet_common::CorrectionRecord;
+use bitnet_inference::receipts::{
+    AccuracyMetric, AccuracyTestResults, InferenceReceipt, ModelInfo, ParityMetadata,
+    PerformanceBaseline, RECEIPT_SCHEMA_VERSION, TestResults,
+};
+use bitnet_inference::{GenerationConfig, InferenceConfig, SamplingConfig, SamplingStrategy};
+use bitnet_sampling::greedy_sample;
+
+// ---------------------------------------------------------------------------
+// SamplingConfig – construction variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sampling_config_greedy_temperature_zero() {
+    let cfg = SamplingConfig { temperature: 0.0, seed: Some(0), ..Default::default() };
+    assert_eq!(cfg.temperature, 0.0);
+    assert_eq!(cfg.seed, Some(0));
+}
+
+#[test]
+fn sampling_config_top_k_one_is_deterministic() {
+    let cfg = SamplingConfig { top_k: 1, temperature: 1.0, seed: Some(7), ..Default::default() };
+    assert_eq!(cfg.top_k, 1);
+}
+
+#[test]
+fn sampling_config_top_p_half() {
+    let cfg = SamplingConfig { top_p: 0.5, ..Default::default() };
+    assert!(cfg.top_p > 0.0 && cfg.top_p < 1.0);
+}
+
+#[test]
+fn sampling_config_high_repetition_penalty() {
+    let cfg = SamplingConfig { repetition_penalty: 2.0, ..Default::default() };
+    assert!(cfg.repetition_penalty > 1.0);
+}
+
+#[test]
+fn sampling_config_seed_none_by_default() {
+    let cfg = SamplingConfig::default();
+    assert!(cfg.seed.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// SamplingStrategy – additional behaviour
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sampling_strategy_valid_index_high_temperature() {
+    let cfg = SamplingConfig { temperature: 10.0, seed: Some(123), ..Default::default() };
+    let mut strategy = SamplingStrategy::new(cfg);
+    let logits = vec![0.1_f32, 0.3, 0.6];
+    let token = strategy.sample(&logits, &[]).unwrap();
+    assert!((token as usize) < logits.len());
+}
+
+#[test]
+fn sampling_strategy_large_vocab_stays_in_range() {
+    let cfg = SamplingConfig { temperature: 0.7, seed: Some(42), ..Default::default() };
+    let mut strategy = SamplingStrategy::new(cfg);
+    let logits: Vec<f32> = (0..32000).map(|i| i as f32 / 32000.0).collect();
+    let token = strategy.sample(&logits, &[]).unwrap();
+    assert!((token as usize) < logits.len());
+}
+
+#[test]
+fn sampling_strategy_update_config_changes_temperature() {
+    let initial = SamplingConfig { temperature: 0.0, seed: Some(1), ..Default::default() };
+    let mut strategy = SamplingStrategy::new(initial);
+    let new_cfg = SamplingConfig { temperature: 0.8, seed: Some(1), ..Default::default() };
+    strategy.update_config(new_cfg.clone());
+    // Verify updated config is reflected (strategy returns valid index).
+    let logits = vec![0.2_f32, 0.5, 0.3];
+    let token = strategy.sample(&logits, &[]).unwrap();
+    assert!((token as usize) < logits.len());
+}
+
+#[test]
+fn sampling_strategy_update_config_new_seed_accepted() {
+    let initial = SamplingConfig { temperature: 0.5, seed: Some(10), ..Default::default() };
+    let mut strategy = SamplingStrategy::new(initial);
+    // Changing the seed re-seeds the RNG; the method must not panic.
+    let new_cfg = SamplingConfig { temperature: 0.5, seed: Some(99), ..Default::default() };
+    strategy.update_config(new_cfg);
+    let logits = vec![1.0_f32, 2.0, 3.0];
+    assert!(strategy.sample(&logits, &[]).is_ok());
+}
+
+#[test]
+fn sampling_strategy_reset_allows_reuse() {
+    let cfg = SamplingConfig { repetition_penalty: 1.5, seed: Some(5), ..Default::default() };
+    let mut strategy = SamplingStrategy::new(cfg);
+    let logits = vec![1.0_f32; 8];
+    // Sample multiple tokens to build internal counts.
+    for _ in 0..4 {
+        strategy.sample(&logits, &[]).unwrap();
+    }
+    // After reset the state should be clean and further sampling should succeed.
+    strategy.reset();
+    assert!(strategy.sample(&logits, &[]).is_ok());
+}
+
+// ---------------------------------------------------------------------------
+// greedy_sample – tie-breaking
+// ---------------------------------------------------------------------------
+
+#[test]
+fn greedy_sample_tie_breaking_returns_lowest_index() {
+    let logits = vec![1.0_f32, 1.0, 0.5];
+    assert_eq!(greedy_sample(&logits).unwrap(), 0, "ties must break to lowest index");
+}
+
+#[test]
+fn greedy_sample_single_element() {
+    let logits = vec![42.0_f32];
+    assert_eq!(greedy_sample(&logits).unwrap(), 0);
+}
+
+#[test]
+fn greedy_sample_empty_returns_error() {
+    let result = greedy_sample(&[]);
+    assert!(result.is_err());
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig – builder methods not yet exercised
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_balanced_preset() {
+    let cfg = GenerationConfig::balanced();
+    assert_eq!(cfg.temperature, 0.7);
+    assert_eq!(cfg.top_k, 50);
+    assert_eq!(cfg.top_p, 0.9);
+    assert!(cfg.repetition_penalty > 1.0, "balanced preset penalises repetition");
+}
+
+#[test]
+fn generation_config_with_stop_string_window() {
+    let cfg = GenerationConfig::default().with_stop_string_window(128);
+    assert_eq!(cfg.stop_string_window, 128);
+}
+
+#[test]
+fn generation_config_with_eos_token_id() {
+    let cfg = GenerationConfig::default().with_eos_token_id(Some(2));
+    assert_eq!(cfg.eos_token_id, Some(2));
+    let cfg_none = GenerationConfig::default().with_eos_token_id(None);
+    assert!(cfg_none.eos_token_id.is_none());
+}
+
+#[test]
+fn generation_config_with_add_bos_true() {
+    let cfg = GenerationConfig::default().with_add_bos(true);
+    assert!(cfg.add_bos);
+}
+
+#[test]
+fn generation_config_with_add_bos_false_default() {
+    let cfg = GenerationConfig::default();
+    assert!(!cfg.add_bos, "add_bos must be false by default");
+}
+
+#[test]
+fn generation_config_with_skip_special_tokens_false() {
+    let cfg = GenerationConfig::default().with_skip_special_tokens(false);
+    assert!(!cfg.skip_special_tokens);
+}
+
+#[test]
+fn generation_config_validation_rejects_top_p_zero() {
+    let cfg = GenerationConfig::default().with_top_p(0.0);
+    assert!(cfg.validate().is_err(), "top_p = 0.0 must be rejected");
+}
+
+#[test]
+fn generation_config_validation_rejects_top_p_above_one() {
+    let cfg = GenerationConfig::default().with_top_p(1.1);
+    assert!(cfg.validate().is_err(), "top_p = 1.1 must be rejected");
+}
+
+#[test]
+fn generation_config_multiple_stop_sequences_order_preserved() {
+    let cfg = GenerationConfig::default()
+        .with_stop_sequence("</s>".to_string())
+        .with_stop_sequence("\n\nQ:".to_string())
+        .with_stop_sequence("<|eot_id|>".to_string());
+    assert_eq!(cfg.stop_sequences.len(), 3);
+    assert_eq!(cfg.stop_sequences[0], "</s>");
+    assert_eq!(cfg.stop_sequences[1], "\n\nQ:");
+    assert_eq!(cfg.stop_sequences[2], "<|eot_id|>");
+}
+
+#[test]
+fn generation_config_rebuild_stop_token_set_needed_after_direct_mutation() {
+    let mut cfg = GenerationConfig::default();
+    // Direct mutation – HashSet is NOT updated yet.
+    cfg.stop_token_ids = vec![128009];
+    assert!(!cfg.is_stop_token(128009), "HashSet out of sync before rebuild");
+    cfg.rebuild_stop_token_set();
+    assert!(cfg.is_stop_token(128009), "HashSet synced after rebuild");
+}
+
+// ---------------------------------------------------------------------------
+// InferenceConfig – edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inference_config_memory_efficient_preset() {
+    let cfg = InferenceConfig::memory_efficient();
+    assert_eq!(cfg.max_context_length, 1024);
+    assert_eq!(cfg.batch_size, 1);
+    assert_eq!(cfg.memory_pool_size, 1024 * 1024 * 256);
+}
+
+// ---------------------------------------------------------------------------
+// InferenceReceipt – additional builder / validator coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn receipt_generate_basic_is_real() {
+    let r = InferenceReceipt::generate(
+        "cpu",
+        vec!["i2s_gemv".to_string(), "rope_apply".to_string()],
+        None,
+    )
+    .unwrap();
+    assert_eq!(r.compute_path, "real");
+    assert_eq!(r.schema_version, RECEIPT_SCHEMA_VERSION);
+}
+
+#[test]
+fn receipt_validate_kernel_ids_rejects_empty_string() {
+    let r = InferenceReceipt::generate("cpu", vec!["".to_string()], None).unwrap();
+    assert!(r.validate_kernel_ids().is_err(), "empty kernel id must fail validation");
+}
+
+#[test]
+fn receipt_validate_kernel_ids_rejects_oversized_id() {
+    let long_id = "a".repeat(129);
+    let r = InferenceReceipt::generate("cpu", vec![long_id], None).unwrap();
+    assert!(r.validate_kernel_ids().is_err(), "kernel id > 128 chars must fail");
+}
+
+#[test]
+fn receipt_validate_kernel_ids_accepts_exactly_128_chars() {
+    let ok_id = "b".repeat(128);
+    let r = InferenceReceipt::generate("cpu", vec![ok_id], None).unwrap();
+    assert!(r.validate_kernel_ids().is_ok(), "128-char kernel id must pass");
+}
+
+#[test]
+fn receipt_with_parity_sets_parity_field() {
+    let parity = ParityMetadata {
+        cpp_available: true,
+        cosine_similarity: Some(0.9999),
+        exact_match_rate: Some(1.0),
+        status: "ok".to_string(),
+    };
+    let r = InferenceReceipt::generate("cpu", vec!["i2s_gemv".to_string()], None)
+        .unwrap()
+        .with_parity(parity.clone());
+    let p = r.parity.as_ref().unwrap();
+    assert!(p.cpp_available);
+    assert_eq!(p.status, "ok");
+    assert!((p.cosine_similarity.unwrap() - 0.9999).abs() < 1e-6);
+}
+
+#[test]
+fn receipt_with_corrections_sets_corrections_field() {
+    let correction = CorrectionRecord {
+        layer: "model.layers.0.input_layernorm.weight".to_string(),
+        correction_type: "ln_gamma_rescale_rms".to_string(),
+        rms_before: Some(0.01),
+        rms_after: Some(1.0),
+        factor: Some(100.0),
+        policy_fingerprint: "test-policy".to_string(),
+        metadata: None,
+    };
+    let r = InferenceReceipt::generate("cpu", vec!["i2s_gemv".to_string()], None)
+        .unwrap()
+        .with_corrections(vec![correction]);
+    assert_eq!(r.corrections.len(), 1);
+    assert_eq!(r.corrections[0].correction_type, "ln_gamma_rescale_rms");
+}
+
+#[test]
+fn receipt_parity_rust_only_status() {
+    let parity = ParityMetadata {
+        cpp_available: false,
+        cosine_similarity: None,
+        exact_match_rate: None,
+        status: "rust_only".to_string(),
+    };
+    let r = InferenceReceipt::generate("cpu", vec!["i2s_gemv".to_string()], None)
+        .unwrap()
+        .with_parity(parity);
+    assert_eq!(r.parity.as_ref().unwrap().status, "rust_only");
+    assert!(!r.parity.as_ref().unwrap().cpp_available);
+}
+
+// ---------------------------------------------------------------------------
+// ModelInfo – field coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_info_all_optional_fields_populated() {
+    let info = ModelInfo {
+        model_path: Some("/models/model.gguf".to_string()),
+        quantization_type: Some("I2_S".to_string()),
+        layers: Some(32),
+        hidden_size: Some(4096),
+        num_attention_heads: Some(32),
+        num_key_value_heads: Some(8),
+        vocab_size: Some(32000),
+        sha256: Some("abc123".to_string()),
+        effective_correction_digest: None,
+    };
+    assert_eq!(info.layers, Some(32));
+    assert_eq!(info.hidden_size, Some(4096));
+    assert_eq!(info.vocab_size, Some(32000));
+    assert_eq!(info.quantization_type.as_deref(), Some("I2_S"));
+}
+
+#[test]
+fn model_info_default_all_none() {
+    let info = ModelInfo::default();
+    assert!(info.model_path.is_none());
+    assert!(info.quantization_type.is_none());
+    assert!(info.layers.is_none());
+    assert!(info.vocab_size.is_none());
+}
+
+#[test]
+fn receipt_with_model_info_round_trips_via_json() {
+    let info = ModelInfo {
+        model_path: Some("model.gguf".to_string()),
+        vocab_size: Some(32000),
+        ..Default::default()
+    };
+    let r = InferenceReceipt::generate("cpu", vec!["i2s_gemv".to_string()], None)
+        .unwrap()
+        .with_model_info(info);
+
+    let json = r.to_json_string().unwrap();
+    assert!(json.contains("model.gguf"));
+    assert!(json.contains("32000"));
+}
+
+// ---------------------------------------------------------------------------
+// TestResults – field relationships
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_results_passed_plus_failed_le_total() {
+    let tr = TestResults {
+        total_tests: 10,
+        passed: 8,
+        failed: 2,
+        skipped: None,
+        accuracy_tests: None,
+        determinism_tests: None,
+        kv_cache_tests: None,
+    };
+    assert_eq!(tr.passed + tr.failed, tr.total_tests);
+}
+
+#[test]
+fn test_results_with_skipped() {
+    let tr = TestResults {
+        total_tests: 12,
+        passed: 10,
+        failed: 0,
+        skipped: Some(2),
+        accuracy_tests: None,
+        determinism_tests: None,
+        kv_cache_tests: None,
+    };
+    let skipped = tr.skipped.unwrap_or(0);
+    assert_eq!(tr.passed + tr.failed + skipped, tr.total_tests);
+}
+
+// ---------------------------------------------------------------------------
+// AccuracyMetric
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accuracy_metric_passed_when_mse_under_tolerance() {
+    let m = AccuracyMetric { mse: 0.001, tolerance: 0.01, passed: true };
+    assert!(m.passed);
+    assert!(m.mse < m.tolerance);
+}
+
+#[test]
+fn accuracy_metric_failed_when_mse_exceeds_tolerance() {
+    let m = AccuracyMetric { mse: 0.05, tolerance: 0.01, passed: false };
+    assert!(!m.passed);
+    assert!(m.mse > m.tolerance);
+}
+
+#[test]
+fn accuracy_test_results_all_kernels() {
+    let tr = AccuracyTestResults {
+        i2s_accuracy: Some(AccuracyMetric { mse: 0.001, tolerance: 0.01, passed: true }),
+        tl1_accuracy: Some(AccuracyMetric { mse: 0.002, tolerance: 0.01, passed: true }),
+        tl2_accuracy: Some(AccuracyMetric { mse: 0.003, tolerance: 0.01, passed: true }),
+    };
+    assert!(tr.i2s_accuracy.as_ref().unwrap().passed);
+    assert!(tr.tl1_accuracy.as_ref().unwrap().passed);
+    assert!(tr.tl2_accuracy.as_ref().unwrap().passed);
+}
+
+// ---------------------------------------------------------------------------
+// PerformanceBaseline – optional fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn performance_baseline_all_fields_set() {
+    let pb = PerformanceBaseline {
+        tokens_generated: Some(100),
+        total_time_ms: Some(5000),
+        tokens_per_second: Some(20.0),
+        first_token_latency_ms: Some(100),
+        average_token_latency_ms: Some(50),
+        memory_usage_mb: Some(512),
+        cache_efficiency: None,
+    };
+    assert_eq!(pb.tokens_generated, Some(100));
+    assert_eq!(pb.tokens_per_second, Some(20.0));
+}
+
+#[test]
+fn performance_baseline_default_all_none() {
+    let pb = PerformanceBaseline::default();
+    assert!(pb.tokens_generated.is_none());
+    assert!(pb.tokens_per_second.is_none());
+    assert!(pb.memory_usage_mb.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// proptest – sampling properties
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod sampling_proptests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// SamplingStrategy with a seed always returns valid indices.
+        #[test]
+        fn strategy_seeded_valid_index(
+            logits in prop::collection::vec(-20f32..=20f32, 2..=256),
+            seed in 0u64..u64::MAX,
+            temperature in 0.0f32..=2.0f32,
+        ) {
+            let cfg = SamplingConfig { temperature, seed: Some(seed), top_k: 0, top_p: 1.0, repetition_penalty: 1.0 };
+            let mut strategy = SamplingStrategy::new(cfg);
+            let token = strategy.sample(&logits, &[]).unwrap();
+            prop_assert!((token as usize) < logits.len());
+        }
+
+        /// GenerationConfig builder chain never panics for valid inputs.
+        #[test]
+        fn gen_config_builder_never_panics(
+            max_tokens in 1u32..512,
+            temp in 0.0f32..=2.0f32,
+            top_k in 0u32..100,
+            window in 1usize..=256,
+        ) {
+            let cfg = GenerationConfig::default()
+                .with_max_tokens(max_tokens)
+                .with_temperature(temp)
+                .with_top_k(top_k)
+                .with_stop_string_window(window);
+            prop_assert_eq!(cfg.max_new_tokens, max_tokens);
+            prop_assert_eq!(cfg.temperature, temp);
+        }
+    }
+}

--- a/crates/bitnet-models/tests/model_loading_extended_tests.rs
+++ b/crates/bitnet-models/tests/model_loading_extended_tests.rs
@@ -1,0 +1,439 @@
+//! Extended tests for `bitnet-models` core types.
+//!
+//! Targets areas not covered by `comprehensive_tests.rs` (gated on
+//! `integration-tests`) or `model_proptests.rs`:
+//!
+//! - `ModelMetadata` construction variants (quantization types, fingerprint,
+//!   large context length)
+//! - `QuantizationType` Display, serde round-trip, Copy, equality
+//! - `BitNetConfig` / `ModelConfig` default field values and serialization
+//! - `LoadConfig` defaults and clone
+//! - `ProductionLoadConfig` defaults and strict-validation flag
+//! - `ProductionModelLoader` construction, memory requirements, device config
+//! - `ModelLoader` extension behaviour (unknown extension, bad path)
+//! - Memory-estimation sanity for known configs
+//!
+//! Run with:
+//!   `cargo test --locked -p bitnet-models --no-default-features --features cpu \
+//!    -- model_loading_extended_tests`
+#![cfg(feature = "cpu")]
+
+use bitnet_common::{BitNetConfig, Device, ModelMetadata, QuantizationType};
+use bitnet_models::{
+    loader::{LoadConfig, ModelLoader},
+    production_loader::{ProductionLoadConfig, ProductionModelLoader},
+};
+
+// ---------------------------------------------------------------------------
+// ModelMetadata – construction variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_metadata_no_quantization() {
+    let m = ModelMetadata {
+        name: "base".to_string(),
+        version: "0.1".to_string(),
+        architecture: "llama".to_string(),
+        vocab_size: 32000,
+        context_length: 4096,
+        quantization: None,
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    assert!(m.quantization.is_none());
+    assert_eq!(m.vocab_size, 32000);
+}
+
+#[test]
+fn model_metadata_i2s_quantization() {
+    let m = ModelMetadata {
+        name: "bitnet".to_string(),
+        version: "1.0".to_string(),
+        architecture: "bitnet".to_string(),
+        vocab_size: 32000,
+        context_length: 2048,
+        quantization: Some(QuantizationType::I2S),
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    assert_eq!(m.quantization, Some(QuantizationType::I2S));
+}
+
+#[test]
+fn model_metadata_tl1_quantization() {
+    let m = ModelMetadata {
+        name: "bitnet-tl1".to_string(),
+        version: "1.0".to_string(),
+        architecture: "bitnet".to_string(),
+        vocab_size: 32000,
+        context_length: 2048,
+        quantization: Some(QuantizationType::TL1),
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    assert_eq!(m.quantization, Some(QuantizationType::TL1));
+}
+
+#[test]
+fn model_metadata_tl2_quantization() {
+    let m = ModelMetadata {
+        name: "bitnet-tl2".to_string(),
+        version: "1.0".to_string(),
+        architecture: "bitnet".to_string(),
+        vocab_size: 32000,
+        context_length: 2048,
+        quantization: Some(QuantizationType::TL2),
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    assert_eq!(m.quantization, Some(QuantizationType::TL2));
+}
+
+#[test]
+fn model_metadata_with_fingerprint() {
+    let m = ModelMetadata {
+        name: "model-sha".to_string(),
+        version: "1.0".to_string(),
+        architecture: "bitnet".to_string(),
+        vocab_size: 32000,
+        context_length: 2048,
+        quantization: Some(QuantizationType::I2S),
+        fingerprint: Some("sha256-deadbeef".to_string()),
+        corrections_applied: None,
+    };
+    assert_eq!(m.fingerprint.as_deref(), Some("sha256-deadbeef"));
+}
+
+#[test]
+fn model_metadata_large_context_length() {
+    let m = ModelMetadata {
+        name: "long-ctx".to_string(),
+        version: "1.0".to_string(),
+        architecture: "llama".to_string(),
+        vocab_size: 128256,
+        context_length: 131_072,
+        quantization: None,
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    assert_eq!(m.context_length, 131_072);
+    assert_eq!(m.vocab_size, 128256);
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationType – Display, serde, Copy, equality
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantization_type_i2s_display() {
+    assert_eq!(format!("{}", QuantizationType::I2S), "I2_S");
+}
+
+#[test]
+fn quantization_type_tl1_display() {
+    assert_eq!(format!("{}", QuantizationType::TL1), "TL1");
+}
+
+#[test]
+fn quantization_type_tl2_display() {
+    assert_eq!(format!("{}", QuantizationType::TL2), "TL2");
+}
+
+#[test]
+fn quantization_type_all_variants_distinct() {
+    assert_ne!(QuantizationType::I2S, QuantizationType::TL1);
+    assert_ne!(QuantizationType::TL1, QuantizationType::TL2);
+    assert_ne!(QuantizationType::I2S, QuantizationType::TL2);
+}
+
+#[test]
+fn quantization_type_copy() {
+    let original = QuantizationType::I2S;
+    let copy = original;
+    assert_eq!(original, copy);
+}
+
+#[test]
+fn quantization_type_serde_roundtrip_json() {
+    for qt in [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2] {
+        let json = serde_json::to_string(&qt).unwrap();
+        let back: QuantizationType = serde_json::from_str(&json).unwrap();
+        assert_eq!(qt, back, "serde round-trip failed for {:?}", qt);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BitNetConfig / ModelConfig – default field values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bitnet_config_default_vocab_size() {
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.vocab_size, 32000);
+}
+
+#[test]
+fn bitnet_config_default_hidden_size() {
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.hidden_size, 4096);
+}
+
+#[test]
+fn bitnet_config_default_num_layers() {
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.num_layers, 32);
+}
+
+#[test]
+fn bitnet_config_default_num_heads() {
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.num_heads, 32);
+}
+
+#[test]
+fn bitnet_config_default_max_position_embeddings() {
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.max_position_embeddings, 2048);
+}
+
+#[test]
+fn bitnet_config_default_num_key_value_heads_is_zero() {
+    // 0 means "use num_heads" (MHA default)
+    let cfg = BitNetConfig::default();
+    assert_eq!(cfg.model.num_key_value_heads, 0);
+}
+
+#[test]
+fn bitnet_config_default_intermediate_size() {
+    let cfg = BitNetConfig::default();
+    assert!(cfg.model.intermediate_size > 0);
+}
+
+#[test]
+fn bitnet_config_serde_roundtrip_json() {
+    let original = BitNetConfig::default();
+    let json = serde_json::to_string(&original).unwrap();
+    let restored: BitNetConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(original.model.vocab_size, restored.model.vocab_size);
+    assert_eq!(original.model.hidden_size, restored.model.hidden_size);
+    assert_eq!(original.model.num_layers, restored.model.num_layers);
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig – default and clone
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_config_default_use_mmap_true() {
+    let cfg = LoadConfig::default();
+    assert!(cfg.use_mmap);
+}
+
+#[test]
+fn load_config_default_validate_checksums_true() {
+    let cfg = LoadConfig::default();
+    assert!(cfg.validate_checksums);
+}
+
+#[test]
+fn load_config_default_no_progress_callback() {
+    let cfg = LoadConfig::default();
+    assert!(cfg.progress_callback.is_none());
+}
+
+#[test]
+fn load_config_clone_is_independent() {
+    let original = LoadConfig::default();
+    let mut cloned = original.clone();
+    cloned.use_mmap = false;
+    // Original should be unchanged.
+    assert!(LoadConfig::default().use_mmap);
+    assert!(!cloned.use_mmap);
+}
+
+// ---------------------------------------------------------------------------
+// ProductionLoadConfig – defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn production_load_config_default_strict_validation() {
+    let cfg = ProductionLoadConfig::default();
+    assert!(cfg.strict_validation);
+}
+
+#[test]
+fn production_load_config_default_target_device_is_cpu() {
+    let cfg = ProductionLoadConfig::default();
+    assert_eq!(cfg.target_device, Device::Cpu);
+}
+
+#[test]
+fn production_load_config_default_validate_tensor_alignment() {
+    let cfg = ProductionLoadConfig::default();
+    assert!(cfg.validate_tensor_alignment);
+}
+
+#[test]
+fn production_load_config_default_max_model_size_is_set() {
+    let cfg = ProductionLoadConfig::default();
+    let max = cfg.max_model_size_bytes.expect("max_model_size_bytes should be set");
+    // Default is 32 GiB.
+    assert_eq!(max, 32 * 1024 * 1024 * 1024);
+}
+
+#[test]
+fn production_load_config_profile_memory_false_by_default() {
+    let cfg = ProductionLoadConfig::default();
+    assert!(!cfg.profile_memory);
+}
+
+// ---------------------------------------------------------------------------
+// ProductionModelLoader – construction / memory / device config
+// ---------------------------------------------------------------------------
+
+#[test]
+fn production_model_loader_new_enables_validation() {
+    let loader = ProductionModelLoader::new();
+    assert!(loader.validation_enabled);
+}
+
+#[test]
+fn production_model_loader_strict_sets_flags() {
+    let loader = ProductionModelLoader::new_with_strict_validation();
+    assert!(loader.config.strict_validation);
+    assert!(loader.config.validate_tensor_alignment);
+}
+
+#[test]
+fn production_model_loader_memory_requirements_cpu() {
+    let loader = ProductionModelLoader::new();
+    let req = loader.get_memory_requirements("cpu");
+    assert!(req.total_mb > 0, "total_mb must be positive");
+    assert!(req.cpu_memory_mb > 0, "cpu_memory_mb must be positive");
+    assert!(req.gpu_memory_mb.is_none(), "no GPU memory for cpu device");
+}
+
+#[test]
+fn production_model_loader_memory_requirements_gpu() {
+    let loader = ProductionModelLoader::new();
+    let req = loader.get_memory_requirements("gpu");
+    assert!(req.total_mb > 0);
+    assert!(req.gpu_memory_mb.is_some(), "GPU memory must be set for gpu device");
+}
+
+#[test]
+fn production_model_loader_optimal_device_config_has_strategy() {
+    let loader = ProductionModelLoader::new();
+    let dc = loader.get_optimal_device_config();
+    assert!(dc.strategy.is_some());
+    assert!(dc.recommended_batch_size >= 1);
+}
+
+#[test]
+fn production_model_loader_cpu_threads_at_least_one() {
+    let loader = ProductionModelLoader::new();
+    let dc = loader.get_optimal_device_config();
+    let threads = dc.cpu_threads.expect("cpu_threads should be Some");
+    assert!(threads >= 1);
+}
+
+// ---------------------------------------------------------------------------
+// ModelLoader – available formats and error on missing path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_loader_available_formats_includes_gguf() {
+    let loader = ModelLoader::new(Device::Cpu);
+    let formats = loader.available_formats();
+    assert!(formats.contains(&"GGUF"), "GGUF must be a known format");
+}
+
+#[test]
+fn model_loader_available_formats_includes_safetensors() {
+    let loader = ModelLoader::new(Device::Cpu);
+    let formats = loader.available_formats();
+    assert!(formats.contains(&"SafeTensors"), "SafeTensors must be a known format");
+}
+
+#[test]
+fn model_loader_load_nonexistent_path_returns_err() {
+    let loader = ModelLoader::new(Device::Cpu);
+    let result = loader.load("/nonexistent/path/model.gguf");
+    assert!(result.is_err(), "loading a non-existent file must fail");
+}
+
+// ---------------------------------------------------------------------------
+// Memory estimation – bytes-per-param sanity for known configs
+// ---------------------------------------------------------------------------
+
+/// Sanity-check that I2_S 2B-param model fits within 1.5 GiB.
+/// 2-bit quant: 2 billion params × 0.25 bytes/param ≈ 500 MB.
+#[test]
+fn memory_estimation_i2s_2b_model_under_1_5_gib() {
+    const PARAMS_2B: u64 = 2_000_000_000;
+    const BITS_PER_PARAM_I2S: u64 = 2;
+    let bytes = PARAMS_2B * BITS_PER_PARAM_I2S / 8;
+    let mib = bytes / (1024 * 1024);
+    assert!(mib < 1536, "I2_S 2B model should be < 1.5 GiB, got {} MiB", mib);
+}
+
+/// F16 weights for LayerNorm at the same scale are tiny compared to the model.
+#[test]
+fn memory_estimation_layernorm_f16_weights_small() {
+    // Typical BitNet 2B: 32 layers × hidden_size=4096 × 2 bytes = ~256 KiB
+    const LAYERS: u64 = 32;
+    const HIDDEN: u64 = 4096;
+    const BYTES_PER_F16: u64 = 2;
+    let ln_bytes = LAYERS * HIDDEN * BYTES_PER_F16;
+    let ln_kb = ln_bytes / 1024;
+    assert!(ln_kb < 512, "LayerNorm weights should be < 512 KiB, got {} KiB", ln_kb);
+}
+
+// ---------------------------------------------------------------------------
+// proptest – QuantizationType round-trips and ModelMetadata invariants
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod model_proptests_ext {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// ModelMetadata with any valid vocab_size preserves the value.
+        #[test]
+        fn model_metadata_vocab_size_roundtrip(vocab_size in 1usize..=200_000) {
+            let m = ModelMetadata {
+                name: "test".to_string(),
+                version: "1.0".to_string(),
+                architecture: "bitnet".to_string(),
+                vocab_size,
+                context_length: 2048,
+                quantization: None,
+                fingerprint: None,
+                corrections_applied: None,
+            };
+            prop_assert_eq!(m.vocab_size, vocab_size);
+        }
+
+        /// BitNetConfig serde round-trip preserves vocab_size for arbitrary values.
+        #[test]
+        fn bitnet_config_vocab_size_roundtrip(vocab_size in 1usize..=256_000) {
+            let mut cfg = BitNetConfig::default();
+            cfg.model.vocab_size = vocab_size;
+            let json = serde_json::to_string(&cfg).unwrap();
+            let back: BitNetConfig = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(back.model.vocab_size, vocab_size);
+        }
+
+        /// ProductionLoadConfig never loses its max_model_size_bytes field on clone.
+        #[test]
+        fn production_load_config_max_size_survives_clone(
+            size_gib in 1u64..=128,
+        ) {
+            let mut cfg = ProductionLoadConfig::default();
+            cfg.max_model_size_bytes = Some(size_gib * 1024 * 1024 * 1024);
+            let cloned = cfg.clone();
+            prop_assert_eq!(cloned.max_model_size_bytes, Some(size_gib * 1024 * 1024 * 1024));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds 86 new unit/property tests (43 per crate) targeting public APIs not covered by existing test suites.

### `crates/bitnet-inference/tests/inference_engine_tests.rs` (43 tests)

**SamplingConfig / SamplingStrategy**
- Construction variants: greedy (temp=0), top-k=1, top-p=0.5, high repetition penalty, no-seed default
- Edge cases: high-temperature still returns valid index, large-vocab (32k) bounds check, `update_config` changes temperature / re-seeds RNG, `reset` then reuse
- `greedy_sample` tie-breaking returns lowest index; empty slice returns `Err`

**GenerationConfig builders (not previously exercised)**
- `with_stop_string_window`, `with_eos_token_id`, `with_add_bos`, `with_skip_special_tokens`
- `balanced()` preset field values
- Multiple stop sequences preserve insertion order
- `rebuild_stop_token_set` required after direct Vec mutation
- Validation rejects `top_p = 0.0` and `top_p = 1.1`

**InferenceConfig**
- `memory_efficient()` preset

**InferenceReceipt**
- `generate(backend, kernels, None)` sets `compute_path = "real"`
- `validate_kernel_ids()`: rejects empty string, rejects 129-char ID, accepts exactly 128-char ID
- Builders: `with_parity`, `with_corrections`, `with_model_info` + JSON round-trip

**Supporting types**
- `ModelInfo` all-fields populated and all-None default
- `TestResults` passed + failed = total, skipped field
- `AccuracyMetric` pass/fail, `AccuracyTestResults` all three kernels
- `PerformanceBaseline` all-fields and default

**proptest suites**
- Seeded `SamplingStrategy` always returns index in bounds
- `GenerationConfig` builder chain never panics for valid inputs

---

### `crates/bitnet-models/tests/model_loading_extended_tests.rs` (43 tests)

**ModelMetadata**
- Variants: no quantization, I2S, TL1, TL2, with fingerprint, 131 072 context length, 128 256 vocab size

**QuantizationType**
- I2S / TL1 / TL2 `Display`, all variants distinct, `Copy`, serde JSON round-trip

**BitNetConfig / ModelConfig defaults**
- `vocab_size=32000`, `hidden_size=4096`, `num_layers=32`, `num_heads=32`, `max_position_embeddings=2048`, `num_key_value_heads=0` (MHA default), `intermediate_size > 0`, JSON serde round-trip

**LoadConfig**
- `use_mmap=true`, `validate_checksums=true`, no progress callback, clone independence

**ProductionLoadConfig**
- `strict_validation=true`, `target_device=Cpu`, `validate_tensor_alignment=true`, 32 GiB max size, `profile_memory=false`

**ProductionModelLoader**
- Construction (`new` / `new_with_strict_validation`), memory requirements CPU/GPU, optimal device config, cpu_threads ≥ 1

**ModelLoader**
- `available_formats()` includes GGUF and SafeTensors
- `load()` returns `Err` for a non-existent path

**Memory-estimation sanity**
- I2_S 2B model < 1.5 GiB; LayerNorm F16 weights < 512 KiB

**proptest suites**
- `ModelMetadata` preserves arbitrary `vocab_size`
- `BitNetConfig` serde round-trip preserves `vocab_size`
- `ProductionLoadConfig` `max_model_size_bytes` survives clone

## Test results

All non-ignored tests pass:
```
bitnet-inference (inference_engine_tests): 43 passed; 0 failed
bitnet-models (model_loading_extended_tests): 43 passed; 0 failed
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>