### PR TITLE
test(bitnet-cli,bitnet-gguf): add extended tests

### DIFF
--- a/crates/bitnet-cli/tests/cli_extended_tests.rs
+++ b/crates/bitnet-cli/tests/cli_extended_tests.rs
@@ -1,0 +1,574 @@
+//! Extended tests for `bitnet-cli`.
+//!
+//! Covers areas not exercised by the existing test files:
+//!   - `InferenceCommand` default field values
+//!   - `PromptTemplate` / `TemplateType` parsing: case-insensitive variants, underscore alias
+//!   - `TemplateType::detect()` from GGUF metadata and tokenizer name
+//!   - `TemplateType` methods: `Display`, `default_stop_sequences`, `should_add_bos`,
+//!     `parse_special`, `apply`
+//!   - `CliConfig` validation (invalid device / log-level / format / zero batch-size)
+//!   - `ConfigBuilder` fluent API
+//!   - `InferenceCommand` specific optional fields (`--top-p`, `--stop-string-window`)
+//!   - Property test: top-p values in [0,1] stored correctly
+
+// ── InferenceCommand tests require the full-cli feature ─────────────────────
+
+#[cfg(feature = "full-cli")]
+use bitnet_cli::commands::InferenceCommand;
+#[cfg(feature = "full-cli")]
+use clap::Parser;
+
+use bitnet_cli::config::{CliConfig, ConfigBuilder};
+use bitnet_inference::TemplateType;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "full-cli")]
+#[derive(Parser)]
+struct TestCli {
+    #[command(flatten)]
+    cmd: InferenceCommand,
+}
+
+#[cfg(feature = "full-cli")]
+fn parse_args(args: &[&str]) -> Result<InferenceCommand, clap::Error> {
+    TestCli::try_parse_from(args).map(|c| c.cmd)
+}
+
+// ============================================================================
+// 1. InferenceCommand default field values
+// ============================================================================
+
+#[cfg(feature = "full-cli")]
+mod inference_defaults {
+    use super::*;
+
+    /// Default temperature is 0.7.
+    #[test]
+    fn test_default_temperature_is_0_7() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(
+            (cmd.temperature - 0.7).abs() < 1e-6,
+            "expected temperature=0.7, got {}",
+            cmd.temperature
+        );
+    }
+
+    /// Default max_tokens is 512.
+    #[test]
+    fn test_default_max_tokens_is_512() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert_eq!(cmd.max_tokens, 512);
+    }
+
+    /// Default repetition_penalty is 1.1.
+    #[test]
+    fn test_default_repetition_penalty_is_1_1() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(
+            (cmd.repetition_penalty - 1.1).abs() < 1e-6,
+            "expected repetition_penalty=1.1, got {}",
+            cmd.repetition_penalty
+        );
+    }
+
+    /// Default stop_string_window is 64.
+    #[test]
+    fn test_default_stop_string_window_is_64() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert_eq!(cmd.stop_string_window, 64);
+    }
+
+    /// Default prompt_template is "auto".
+    #[test]
+    fn test_default_prompt_template_is_auto() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert_eq!(cmd.prompt_template, "auto");
+    }
+
+    /// Default format is "text".
+    #[test]
+    fn test_default_format_is_text() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert_eq!(cmd.format, "text");
+    }
+
+    /// Default batch_size is 1.
+    #[test]
+    fn test_default_batch_size_is_1() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert_eq!(cmd.batch_size, 1);
+    }
+
+    /// Default greedy is false.
+    #[test]
+    fn test_default_greedy_is_false() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(!cmd.greedy, "greedy must default to false");
+    }
+
+    /// Default no_bos is false.
+    #[test]
+    fn test_default_no_bos_is_false() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(!cmd.no_bos, "no_bos must default to false");
+    }
+
+    /// Default no_eos is false.
+    #[test]
+    fn test_default_no_eos_is_false() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(!cmd.no_eos, "no_eos must default to false");
+    }
+
+    /// top_k is absent (None) by default.
+    #[test]
+    fn test_default_top_k_is_none() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(cmd.top_k.is_none(), "top_k must default to None");
+    }
+
+    /// top_p is absent (None) by default.
+    #[test]
+    fn test_default_top_p_is_none() {
+        let cmd = parse_args(&["bitnet"]).expect("empty args must parse");
+        assert!(cmd.top_p.is_none(), "top_p must default to None");
+    }
+}
+
+// ============================================================================
+// 2. PromptTemplate flag parsing: case-insensitive and underscore alias
+// ============================================================================
+
+#[cfg(feature = "full-cli")]
+mod prompt_template_parsing {
+    use super::*;
+
+    /// "RAW" (uppercase) is stored verbatim and parses to TemplateType::Raw.
+    #[test]
+    fn test_prompt_template_case_insensitive_raw() {
+        let cmd = parse_args(&["bitnet", "--prompt-template", "RAW"]).expect("should parse");
+        let tpl: TemplateType =
+            cmd.prompt_template.parse().expect("RAW should parse to TemplateType");
+        assert_eq!(tpl, TemplateType::Raw);
+    }
+
+    /// "INSTRUCT" (uppercase) parses to TemplateType::Instruct.
+    #[test]
+    fn test_prompt_template_case_insensitive_instruct() {
+        let cmd = parse_args(&["bitnet", "--prompt-template", "INSTRUCT"]).expect("should parse");
+        let tpl: TemplateType =
+            cmd.prompt_template.parse().expect("INSTRUCT should parse to TemplateType");
+        assert_eq!(tpl, TemplateType::Instruct);
+    }
+
+    /// "LLAMA3-CHAT" (uppercase) parses to TemplateType::Llama3Chat.
+    #[test]
+    fn test_prompt_template_case_insensitive_llama3_chat() {
+        let cmd =
+            parse_args(&["bitnet", "--prompt-template", "LLAMA3-CHAT"]).expect("should parse");
+        let tpl: TemplateType =
+            cmd.prompt_template.parse().expect("LLAMA3-CHAT should parse to TemplateType");
+        assert_eq!(tpl, TemplateType::Llama3Chat);
+    }
+
+    /// "llama3_chat" (underscore variant) parses to TemplateType::Llama3Chat.
+    #[test]
+    fn test_prompt_template_underscore_variant() {
+        let cmd =
+            parse_args(&["bitnet", "--prompt-template", "llama3_chat"]).expect("should parse");
+        let tpl: TemplateType =
+            cmd.prompt_template.parse().expect("llama3_chat should parse to TemplateType");
+        assert_eq!(tpl, TemplateType::Llama3Chat);
+    }
+
+    /// An empty string stored as prompt_template fails TemplateType::from_str.
+    #[test]
+    fn test_empty_prompt_template_fails_parse() {
+        let result: Result<TemplateType, _> = "".parse();
+        assert!(result.is_err(), "empty string must fail TemplateType::from_str");
+    }
+
+    /// Parsing all three canonical names succeeds and returns the right variant.
+    #[test]
+    fn test_all_canonical_template_names_parse() {
+        let cases = [
+            ("raw", TemplateType::Raw),
+            ("instruct", TemplateType::Instruct),
+            ("llama3-chat", TemplateType::Llama3Chat),
+        ];
+        for (name, expected) in &cases {
+            let got: TemplateType = name.parse().unwrap_or_else(|e| {
+                panic!("'{name}' should parse to TemplateType: {e}");
+            });
+            assert_eq!(&got, expected, "wrong variant for '{name}'");
+        }
+    }
+}
+
+// ============================================================================
+// 3. TemplateType::detect()
+// ============================================================================
+
+mod template_detect {
+    use super::*;
+
+    /// LLaMA-3 jinja template is detected as Llama3Chat.
+    #[test]
+    fn test_detect_llama3_from_jinja() {
+        let jinja = "{% if <|start_header_id|> %}...{% endif %} <|eot_id|>".to_string();
+        let result = TemplateType::detect(None, Some(&jinja));
+        assert_eq!(result, TemplateType::Llama3Chat);
+    }
+
+    /// Instruct-style jinja template is detected as Instruct.
+    #[test]
+    fn test_detect_instruct_from_jinja() {
+        let jinja = "{% for message in messages %}{{ message.content }}{% endfor %}".to_string();
+        let result = TemplateType::detect(None, Some(&jinja));
+        assert_eq!(result, TemplateType::Instruct);
+    }
+
+    /// Tokenizer name containing "llama3" → Llama3Chat.
+    #[test]
+    fn test_detect_llama3_from_tokenizer_name() {
+        let result = TemplateType::detect(Some("llama3-tokenizer"), None);
+        assert_eq!(result, TemplateType::Llama3Chat);
+    }
+
+    /// Tokenizer name containing "instruct" → Instruct.
+    #[test]
+    fn test_detect_instruct_from_tokenizer_name() {
+        let result = TemplateType::detect(Some("mistral-instruct-v0.2"), None);
+        assert_eq!(result, TemplateType::Instruct);
+    }
+
+    /// No hints at all → Raw (fallback).
+    #[test]
+    fn test_detect_raw_fallback() {
+        let result = TemplateType::detect(None, None);
+        assert_eq!(result, TemplateType::Raw);
+    }
+
+    /// GGUF metadata takes priority over tokenizer name.
+    #[test]
+    fn test_detect_gguf_metadata_wins_over_tokenizer_name() {
+        // Jinja says LLaMA-3, tokenizer name says "instruct" — jinja wins.
+        let jinja = "<|start_header_id|>user<|end_header_id|>\n{msg}<|eot_id|>".to_string();
+        let result = TemplateType::detect(Some("generic-instruct"), Some(&jinja));
+        assert_eq!(result, TemplateType::Llama3Chat, "GGUF metadata must override tokenizer name");
+    }
+}
+
+// ============================================================================
+// 4. TemplateType methods
+// ============================================================================
+
+mod template_methods {
+    use super::*;
+
+    /// Display for all three variants matches the canonical string.
+    #[test]
+    fn test_template_display() {
+        assert_eq!(TemplateType::Raw.to_string(), "raw");
+        assert_eq!(TemplateType::Instruct.to_string(), "instruct");
+        assert_eq!(TemplateType::Llama3Chat.to_string(), "llama3-chat");
+    }
+
+    /// Raw template has no default stop sequences.
+    #[test]
+    fn test_raw_default_stop_sequences_empty() {
+        assert!(
+            TemplateType::Raw.default_stop_sequences().is_empty(),
+            "Raw must have no default stop sequences"
+        );
+    }
+
+    /// Instruct template has at least one default stop sequence.
+    #[test]
+    fn test_instruct_default_stop_sequences_nonempty() {
+        let stops = TemplateType::Instruct.default_stop_sequences();
+        assert!(!stops.is_empty(), "Instruct must have at least one default stop sequence");
+    }
+
+    /// LLaMA-3 template stop sequences include "<|eot_id|>".
+    #[test]
+    fn test_llama3_default_stop_sequences_include_eot() {
+        let stops = TemplateType::Llama3Chat.default_stop_sequences();
+        assert!(
+            stops.iter().any(|s| s.contains("<|eot_id|>")),
+            "Llama3Chat default stops must include <|eot_id|>"
+        );
+    }
+
+    /// Raw and Instruct should_add_bos returns true; Llama3Chat returns false.
+    #[test]
+    fn test_should_add_bos() {
+        assert!(TemplateType::Raw.should_add_bos(), "Raw must add BOS");
+        assert!(TemplateType::Instruct.should_add_bos(), "Instruct must add BOS");
+        assert!(!TemplateType::Llama3Chat.should_add_bos(), "Llama3Chat must NOT add BOS");
+    }
+
+    /// Only Llama3Chat enables parse_special.
+    #[test]
+    fn test_parse_special_only_llama3() {
+        assert!(!TemplateType::Raw.parse_special(), "Raw must not parse_special");
+        assert!(!TemplateType::Instruct.parse_special(), "Instruct must not parse_special");
+        assert!(TemplateType::Llama3Chat.parse_special(), "Llama3Chat must parse_special");
+    }
+
+    /// Raw template apply() returns the user text unchanged.
+    #[test]
+    fn test_apply_raw_passthrough() {
+        let text = "What is 2+2?";
+        assert_eq!(TemplateType::Raw.apply(text, None), text);
+    }
+
+    /// Instruct template apply() wraps the text with Q:/A: markers.
+    #[test]
+    fn test_apply_instruct_wraps_prompt() {
+        let formatted = TemplateType::Instruct.apply("What is 2+2?", None);
+        assert!(formatted.contains("Q:"), "Instruct template must add Q: prefix; got: {formatted}");
+        assert!(formatted.contains("A:"), "Instruct template must add A: suffix; got: {formatted}");
+    }
+
+    /// LLaMA-3 template apply() wraps the text with special tokens.
+    #[test]
+    fn test_apply_llama3_wraps_with_special_tokens() {
+        let formatted = TemplateType::Llama3Chat.apply("Hello", None);
+        assert!(
+            formatted.contains("<|begin_of_text|>"),
+            "Llama3Chat must start with <|begin_of_text|>"
+        );
+        assert!(
+            formatted.contains("<|start_header_id|>"),
+            "Llama3Chat must contain <|start_header_id|>"
+        );
+    }
+
+    /// Instruct template apply() with a system prompt includes "System:" prefix.
+    #[test]
+    fn test_apply_instruct_with_system_prompt() {
+        let formatted = TemplateType::Instruct.apply("Hello", Some("You are a helpful assistant"));
+        assert!(
+            formatted.contains("System:"),
+            "Instruct+system must add 'System:' prefix; got: {formatted}"
+        );
+    }
+
+    /// TemplateType Clone copies the same variant.
+    #[test]
+    fn test_template_type_clone() {
+        let original = TemplateType::Llama3Chat;
+        let cloned = original;
+        assert_eq!(original, cloned);
+    }
+}
+
+// ============================================================================
+// 5. CliConfig validation
+// ============================================================================
+
+mod cli_config_validation {
+    use super::*;
+
+    /// Default CliConfig is valid.
+    #[test]
+    fn test_cli_config_default_is_valid() {
+        let cfg = CliConfig::default();
+        assert!(cfg.validate().is_ok(), "default CliConfig must be valid");
+    }
+
+    /// Default device is "auto".
+    #[test]
+    fn test_cli_config_default_device_is_auto() {
+        let cfg = CliConfig::default();
+        assert_eq!(cfg.default_device, "auto");
+    }
+
+    /// Invalid device string fails validate().
+    #[test]
+    fn test_cli_config_invalid_device_fails() {
+        let mut cfg = CliConfig::default();
+        cfg.default_device = "invalid-device".to_string();
+        assert!(cfg.validate().is_err(), "invalid device must fail validate()");
+    }
+
+    /// Invalid log level string fails validate().
+    #[test]
+    fn test_cli_config_invalid_log_level_fails() {
+        let mut cfg = CliConfig::default();
+        cfg.logging.level = "verbose".to_string(); // not a valid level
+        assert!(cfg.validate().is_err(), "invalid log level must fail validate()");
+    }
+
+    /// Invalid log format string fails validate().
+    #[test]
+    fn test_cli_config_invalid_log_format_fails() {
+        let mut cfg = CliConfig::default();
+        cfg.logging.format = "xml".to_string(); // not pretty/json/compact
+        assert!(cfg.validate().is_err(), "invalid log format must fail validate()");
+    }
+
+    /// Zero batch size fails validate().
+    #[test]
+    fn test_cli_config_zero_batch_size_fails() {
+        let mut cfg = CliConfig::default();
+        cfg.performance.batch_size = 0;
+        assert!(cfg.validate().is_err(), "batch_size=0 must fail validate()");
+    }
+
+    /// Valid device strings all pass.
+    #[test]
+    fn test_cli_config_all_valid_devices() {
+        for device in &["cpu", "cuda", "auto"] {
+            let mut cfg = CliConfig::default();
+            cfg.default_device = device.to_string();
+            assert!(cfg.validate().is_ok(), "device={device} must be valid");
+        }
+    }
+
+    /// Valid log levels all pass.
+    #[test]
+    fn test_cli_config_all_valid_log_levels() {
+        for level in &["trace", "debug", "info", "warn", "error"] {
+            let mut cfg = CliConfig::default();
+            cfg.logging.level = level.to_string();
+            assert!(cfg.validate().is_ok(), "log level={level} must be valid");
+        }
+    }
+}
+
+// ============================================================================
+// 6. ConfigBuilder fluent API
+// ============================================================================
+
+mod config_builder {
+    use super::*;
+
+    /// ConfigBuilder::new().build() returns a valid default config.
+    #[test]
+    fn test_config_builder_new_builds_valid_config() {
+        let cfg = ConfigBuilder::new().build().expect("default ConfigBuilder must build");
+        assert!(cfg.validate().is_ok(), "newly built config must be valid");
+    }
+
+    /// ConfigBuilder::device() overrides the default device.
+    #[test]
+    fn test_config_builder_device_override() {
+        let cfg =
+            ConfigBuilder::new().device(Some("cpu".to_string())).build().expect("should build");
+        assert_eq!(cfg.default_device, "cpu");
+    }
+
+    /// ConfigBuilder::cpu_threads() sets thread count.
+    #[test]
+    fn test_config_builder_cpu_threads() {
+        let cfg = ConfigBuilder::new().cpu_threads(Some(4)).build().expect("should build");
+        assert_eq!(cfg.performance.cpu_threads, Some(4));
+    }
+
+    /// ConfigBuilder with invalid device fails at build.
+    #[test]
+    fn test_config_builder_invalid_device_fails() {
+        let result = ConfigBuilder::new().device(Some("npu".to_string())).build();
+        assert!(result.is_err(), "ConfigBuilder with invalid device must fail to build");
+    }
+}
+
+// ============================================================================
+// 7. Specific InferenceCommand optional fields
+// ============================================================================
+
+#[cfg(feature = "full-cli")]
+mod inference_optional_fields {
+    use super::*;
+
+    /// --top-p 0.5 is stored as Some(0.5).
+    #[test]
+    fn test_top_p_stored_as_some() {
+        let cmd = parse_args(&["bitnet", "--top-p", "0.5"]).expect("should parse");
+        assert_eq!(cmd.top_p, Some(0.5f32));
+    }
+
+    /// --top-p 1.0 is stored as Some(1.0).
+    #[test]
+    fn test_top_p_one_stored_as_some() {
+        let cmd = parse_args(&["bitnet", "--top-p", "1.0"]).expect("should parse");
+        assert_eq!(cmd.top_p, Some(1.0f32));
+    }
+
+    /// --top-k 50 is stored as Some(50).
+    #[test]
+    fn test_top_k_50_stored_as_some() {
+        let cmd = parse_args(&["bitnet", "--top-k", "50"]).expect("should parse");
+        assert_eq!(cmd.top_k, Some(50usize));
+    }
+
+    /// --stop-string-window 128 overrides the default.
+    #[test]
+    fn test_stop_string_window_overridden() {
+        let cmd = parse_args(&["bitnet", "--stop-string-window", "128"]).expect("should parse");
+        assert_eq!(cmd.stop_string_window, 128);
+    }
+
+    /// --stop and --stop-id can be combined in a single invocation.
+    #[test]
+    fn test_stop_and_stop_id_combined() {
+        let cmd =
+            parse_args(&["bitnet", "--stop", "</s>", "--stop-id", "2"]).expect("should parse");
+        assert!(cmd.stop.contains(&"</s>".to_string()), "stop sequences must contain </s>");
+        assert!(cmd.stop_id.contains(&2u32), "stop_id must contain 2");
+    }
+
+    /// --temperature 0.0 together with --greedy stores both correctly.
+    #[test]
+    fn test_zero_temperature_and_greedy_together() {
+        let cmd =
+            parse_args(&["bitnet", "--temperature", "0.0", "--greedy"]).expect("should parse");
+        assert!(cmd.greedy, "greedy must be true");
+        assert_eq!(cmd.temperature, 0.0f32);
+    }
+}
+
+// ============================================================================
+// 8. Property tests
+// ============================================================================
+
+#[cfg(feature = "full-cli")]
+mod property_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// top_p values in [0.0, 1.0] (expressed as integer hundredths) are stored as Some(p).
+        #[test]
+        fn prop_top_p_range_0_to_1_stored_as_some(
+            hundredths in 0u32..=100u32,
+        ) {
+            let p = hundredths as f32 / 100.0;
+            let p_str = format!("{p:.2}");
+            let cmd = parse_args(&["bitnet", "--top-p", &p_str]).expect("should parse");
+            let stored = cmd.top_p.expect("--top-p must yield Some");
+            // Allow 1e-4 tolerance for f32 string round-trip.
+            prop_assert!((stored - p).abs() < 1e-4, "stored top_p {stored} must be ~{p}");
+        }
+
+        /// Positive max_tokens values are always accepted by all three aliases.
+        #[test]
+        fn prop_all_three_max_tokens_aliases_accept_same_value(
+            n in 1usize..=2048usize,
+        ) {
+            let n_str = n.to_string();
+            let primary = parse_args(&["bitnet", "--max-tokens", &n_str])
+                .expect("--max-tokens must accept positive n");
+            let alias1 = parse_args(&["bitnet", "--max-new-tokens", &n_str])
+                .expect("--max-new-tokens must accept positive n");
+            let alias2 = parse_args(&["bitnet", "--n-predict", &n_str])
+                .expect("--n-predict must accept positive n");
+            prop_assert_eq!(primary.max_tokens, n);
+            prop_assert_eq!(alias1.max_tokens, n);
+            prop_assert_eq!(alias2.max_tokens, n);
+        }
+    }
+}

--- a/crates/bitnet-gguf/tests/gguf_extended_tests.rs
+++ b/crates/bitnet-gguf/tests/gguf_extended_tests.rs
@@ -1,0 +1,436 @@
+//! Extended tests for `bitnet-gguf`.
+//!
+//! Covers gaps not addressed by the existing suites:
+//!   - `GgufValue::Uint8` (0, 255, mid-range) stored verbatim
+//!   - `GgufValue::Uint32` stored verbatim
+//!   - `GgufValue::Float32` stored with bit-identical precision
+//!   - `GgufMetadataKv` with Float32 / Int32 values
+//!   - `GgufMetadataKv` key with dot-separated segments preserved
+//!   - v3 header with exactly 24 bytes (no alignment field) → defaults to 32
+//!   - `read_version` returns `Some(3)` for a v3 header
+//!   - `parse_header` v3 with alignment = 32 (preserved exactly)
+//!   - `parse_header` v3 with alignment = 65536 (large power-of-two, preserved)
+//!   - `TensorInfo` offset field and dtype field preserved
+//!   - `TensorInfo` with multiple dims stored in order
+//!   - `GgufValue::Array` with Bool elements
+//!   - `GgufFileInfo` Debug output contains "version"
+//!   - `GGUF_MAGIC`, `GGUF_VERSION_MIN`, `GGUF_VERSION_MAX` constant assertions
+//!   - `GgufValueType` specific discriminants: Bool=7, String=8, Array=9
+//!   - Property tests: `GgufValue::Uint8` and `GgufValue::Uint32` round-trips
+//!   - Property test: arbitrary ASCII tensor names stored verbatim
+
+use bitnet_gguf::{
+    GGUF_MAGIC, GGUF_VERSION_MAX, GGUF_VERSION_MIN, GgufFileInfo, GgufMetadataKv, GgufValue,
+    GgufValueType, TensorInfo, check_magic, parse_header, read_version,
+};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn v2_header(tensor_count: u64, metadata_count: u64) -> Vec<u8> {
+    let mut d = Vec::with_capacity(24);
+    d.extend_from_slice(b"GGUF");
+    d.extend_from_slice(&2u32.to_le_bytes());
+    d.extend_from_slice(&tensor_count.to_le_bytes());
+    d.extend_from_slice(&metadata_count.to_le_bytes());
+    d
+}
+
+fn v3_header(tensor_count: u64, metadata_count: u64, alignment: u32) -> Vec<u8> {
+    let mut d = Vec::with_capacity(28);
+    d.extend_from_slice(b"GGUF");
+    d.extend_from_slice(&3u32.to_le_bytes());
+    d.extend_from_slice(&tensor_count.to_le_bytes());
+    d.extend_from_slice(&metadata_count.to_le_bytes());
+    d.extend_from_slice(&alignment.to_le_bytes());
+    d
+}
+
+// ---------------------------------------------------------------------------
+// 1. GgufValue::Uint8 unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_uint8_zero_stored() {
+    let GgufValue::Uint8(v) = GgufValue::Uint8(0) else { panic!("wrong variant") };
+    assert_eq!(v, 0u8);
+}
+
+#[test]
+fn gguf_value_uint8_max_stored() {
+    let GgufValue::Uint8(v) = GgufValue::Uint8(255) else { panic!("wrong variant") };
+    assert_eq!(v, 255u8);
+}
+
+#[test]
+fn gguf_value_uint8_mid_value_stored() {
+    let GgufValue::Uint8(v) = GgufValue::Uint8(128) else { panic!("wrong variant") };
+    assert_eq!(v, 128u8);
+}
+
+// ---------------------------------------------------------------------------
+// 2. GgufValue::Uint32 unit test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_uint32_stored() {
+    let GgufValue::Uint32(v) = GgufValue::Uint32(42) else { panic!("wrong variant") };
+    assert_eq!(v, 42u32);
+}
+
+#[test]
+fn gguf_value_uint32_max_stored() {
+    let GgufValue::Uint32(v) = GgufValue::Uint32(u32::MAX) else { panic!("wrong variant") };
+    assert_eq!(v, u32::MAX);
+}
+
+// ---------------------------------------------------------------------------
+// 3. GgufValue::Float32 unit test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_float32_pi_stored() {
+    let pi = std::f32::consts::PI;
+    let GgufValue::Float32(v) = GgufValue::Float32(pi) else { panic!("wrong variant") };
+    // Exact bit-identity (no conversions involved).
+    assert_eq!(v.to_bits(), pi.to_bits());
+}
+
+#[test]
+fn gguf_value_float32_zero_stored() {
+    let GgufValue::Float32(v) = GgufValue::Float32(0.0f32) else { panic!("wrong variant") };
+    assert_eq!(v, 0.0f32);
+}
+
+// ---------------------------------------------------------------------------
+// 4. GgufValue::Bool unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_bool_true_stored() {
+    let GgufValue::Bool(v) = GgufValue::Bool(true) else { panic!("wrong variant") };
+    assert!(v);
+}
+
+#[test]
+fn gguf_value_bool_false_stored() {
+    let GgufValue::Bool(v) = GgufValue::Bool(false) else { panic!("wrong variant") };
+    assert!(!v);
+}
+
+// ---------------------------------------------------------------------------
+// 5. GgufMetadataKv with various value types
+// ---------------------------------------------------------------------------
+
+#[test]
+fn metadata_kv_float32_value_stored() {
+    let kv =
+        GgufMetadataKv { key: "general.temperature".to_string(), value: GgufValue::Float32(0.7) };
+    let GgufValue::Float32(v) = &kv.value else { panic!("expected Float32") };
+    assert!((v - 0.7f32).abs() < 1e-6, "Float32 metadata value must be preserved");
+}
+
+#[test]
+fn metadata_kv_int32_value_stored() {
+    let kv =
+        GgufMetadataKv { key: "general.context_length".to_string(), value: GgufValue::Int32(-1) };
+    let GgufValue::Int32(v) = &kv.value else { panic!("expected Int32") };
+    assert_eq!(*v, -1i32);
+}
+
+/// Dot-separated key (GGUF convention: "general.architecture") is preserved.
+#[test]
+fn metadata_kv_dot_separated_key_preserved() {
+    let key = "general.architecture";
+    let kv = GgufMetadataKv { key: key.to_string(), value: GgufValue::String("bitnet".into()) };
+    assert_eq!(&kv.key, key, "dot-separated key must be preserved verbatim");
+}
+
+/// Nested dot key with multiple segments is preserved.
+#[test]
+fn metadata_kv_nested_dot_key_preserved() {
+    let key = "llama.attention.head_count";
+    let kv = GgufMetadataKv { key: key.to_string(), value: GgufValue::Uint32(32) };
+    assert_eq!(&kv.key, key);
+}
+
+// ---------------------------------------------------------------------------
+// 6. v3 header with exactly 24 bytes (no alignment field) → default 32
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_header_v3_no_alignment_field_defaults_to_32() {
+    // Build a header that looks like v3 but has only 24 bytes (no alignment u32 at [24..28]).
+    let mut d = v2_header(0, 0);
+    d[4..8].copy_from_slice(&3u32.to_le_bytes()); // set version=3
+    assert_eq!(d.len(), 24, "must be exactly 24 bytes");
+    let info = parse_header(&d).expect("v3 with 24 bytes must parse (no alignment byte)");
+    assert_eq!(info.version, 3);
+    assert_eq!(info.alignment, 32, "missing alignment field must fall back to 32");
+}
+
+// ---------------------------------------------------------------------------
+// 7. read_version for v3
+// ---------------------------------------------------------------------------
+
+#[test]
+fn read_version_v3() {
+    let d = v3_header(5, 10, 32);
+    let version = read_version(&d).expect("read_version must succeed for a v3 header");
+    assert_eq!(version, 3u32);
+}
+
+#[test]
+fn read_version_v2_agrees_with_parse_header() {
+    let d = v2_header(3, 5);
+    let version = read_version(&d).expect("read_version must succeed");
+    let info = parse_header(&d).expect("parse_header must succeed");
+    assert_eq!(version, info.version, "read_version and parse_header must agree on version");
+}
+
+// ---------------------------------------------------------------------------
+// 8. parse_header v3 with alignment = 32 and alignment = 65536
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_header_v3_alignment_32_preserved() {
+    let d = v3_header(0, 0, 32);
+    let info = parse_header(&d).expect("v3 with alignment=32 must parse");
+    assert_eq!(info.alignment, 32, "alignment=32 (power-of-two) must be preserved");
+}
+
+#[test]
+fn parse_header_v3_alignment_65536_preserved() {
+    let d = v3_header(0, 0, 65536);
+    let info = parse_header(&d).expect("v3 with alignment=65536 must parse");
+    assert_eq!(info.alignment, 65536, "alignment=65536 (2^16) must be preserved");
+}
+
+#[test]
+fn parse_header_v3_alignment_u32_max_falls_back_to_32() {
+    // u32::MAX is not a power of two.
+    let d = v3_header(0, 0, u32::MAX);
+    let info = parse_header(&d).expect("v3 with alignment=u32::MAX must still parse");
+    assert_eq!(info.alignment, 32, "u32::MAX alignment must fall back to 32");
+}
+
+// ---------------------------------------------------------------------------
+// 9. TensorInfo: offset, dtype, dims ordering
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tensor_info_offset_max_preserved() {
+    let info = TensorInfo {
+        name: "weight".to_string(),
+        n_dims: 1,
+        dims: vec![1024],
+        dtype: 0,
+        offset: u64::MAX,
+    };
+    assert_eq!(info.offset, u64::MAX, "offset u64::MAX must be preserved in TensorInfo");
+}
+
+#[test]
+fn tensor_info_dtype_preserved() {
+    let info =
+        TensorInfo { name: "bias".to_string(), n_dims: 1, dims: vec![512], dtype: 7, offset: 0 };
+    assert_eq!(info.dtype, 7u32, "dtype must be preserved verbatim in TensorInfo");
+}
+
+#[test]
+fn tensor_info_dims_order_preserved() {
+    let dims = vec![32u64, 128, 256, 4096];
+    let info = TensorInfo {
+        name: "hidden".to_string(),
+        n_dims: dims.len() as u32,
+        dims: dims.clone(),
+        dtype: 0,
+        offset: 0,
+    };
+    assert_eq!(info.dims, dims, "dims must be stored in the original order");
+}
+
+// ---------------------------------------------------------------------------
+// 10. GgufValue::Array with Bool elements
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_array_bool_elements_preserved() {
+    let elems = vec![GgufValue::Bool(true), GgufValue::Bool(false), GgufValue::Bool(true)];
+    let arr = GgufValue::Array(GgufValueType::Bool, elems);
+    let GgufValue::Array(elem_type, stored) = arr else { panic!("expected Array") };
+    assert_eq!(elem_type, GgufValueType::Bool);
+    assert_eq!(stored.len(), 3);
+    let bools: Vec<bool> = stored
+        .iter()
+        .map(|v| match v {
+            GgufValue::Bool(b) => *b,
+            _ => panic!("expected Bool element"),
+        })
+        .collect();
+    assert_eq!(bools, vec![true, false, true]);
+}
+
+// ---------------------------------------------------------------------------
+// 11. GgufFileInfo Debug output smoke test
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_file_info_debug_contains_version() {
+    let info = GgufFileInfo { version: 2, tensor_count: 5, metadata_count: 3, alignment: 32 };
+    let debug = format!("{info:?}");
+    assert!(
+        debug.contains("version"),
+        "GgufFileInfo Debug output must contain 'version'; got: {debug}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12. Constants assertions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_magic_constant_is_gguf() {
+    assert_eq!(&GGUF_MAGIC, b"GGUF", "GGUF_MAGIC must be exactly b\"GGUF\"");
+}
+
+#[test]
+fn gguf_version_min_is_2() {
+    assert_eq!(GGUF_VERSION_MIN, 2u32, "GGUF_VERSION_MIN must be 2");
+}
+
+#[test]
+fn gguf_version_max_is_3() {
+    assert_eq!(GGUF_VERSION_MAX, 3u32, "GGUF_VERSION_MAX must be 3");
+}
+
+// ---------------------------------------------------------------------------
+// 13. GgufValueType specific discriminant values
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gguf_value_type_bool_discriminant_is_7() {
+    assert_eq!(GgufValueType::Bool as u32, 7u32);
+    assert_eq!(GgufValueType::from_u32(7), Some(GgufValueType::Bool));
+}
+
+#[test]
+fn gguf_value_type_string_discriminant_is_8() {
+    assert_eq!(GgufValueType::String as u32, 8u32);
+    assert_eq!(GgufValueType::from_u32(8), Some(GgufValueType::String));
+}
+
+#[test]
+fn gguf_value_type_array_discriminant_is_9() {
+    assert_eq!(GgufValueType::Array as u32, 9u32);
+    assert_eq!(GgufValueType::from_u32(9), Some(GgufValueType::Array));
+}
+
+#[test]
+fn gguf_value_type_float32_discriminant_is_6() {
+    assert_eq!(GgufValueType::Float32 as u32, 6u32);
+    assert_eq!(GgufValueType::from_u32(6), Some(GgufValueType::Float32));
+}
+
+#[test]
+fn gguf_value_type_uint32_discriminant_is_4() {
+    assert_eq!(GgufValueType::Uint32 as u32, 4u32);
+    assert_eq!(GgufValueType::from_u32(4), Some(GgufValueType::Uint32));
+}
+
+// ---------------------------------------------------------------------------
+// 14. check_magic edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn check_magic_exact_four_bytes_gguf() {
+    assert!(check_magic(b"GGUF"), "exactly b\"GGUF\" must pass check_magic");
+}
+
+#[test]
+fn check_magic_with_trailing_zeros() {
+    let mut d = vec![0u8; 32];
+    d[..4].copy_from_slice(b"GGUF");
+    assert!(check_magic(&d), "GGUF followed by zeros must pass check_magic");
+}
+
+#[test]
+fn check_magic_ggml_fails() {
+    assert!(!check_magic(b"GGML"), "GGML must not pass check_magic");
+}
+
+// ---------------------------------------------------------------------------
+// 15. Property tests
+// ---------------------------------------------------------------------------
+
+proptest! {
+    /// GgufValue::Uint8 stores any u8 value verbatim (proptest).
+    #[test]
+    fn prop_gguf_value_uint8_round_trip(v in any::<u8>()) {
+        let GgufValue::Uint8(stored) = GgufValue::Uint8(v) else {
+            panic!("unexpected variant");
+        };
+        prop_assert_eq!(stored, v);
+    }
+
+    /// GgufValue::Uint32 stores any u32 value verbatim (proptest).
+    #[test]
+    fn prop_gguf_value_uint32_round_trip(v in any::<u32>()) {
+        let GgufValue::Uint32(stored) = GgufValue::Uint32(v) else {
+            panic!("unexpected variant");
+        };
+        prop_assert_eq!(stored, v);
+    }
+
+    /// Arbitrary printable ASCII tensor names are stored verbatim in TensorInfo.
+    #[test]
+    fn prop_tensor_info_ascii_name_stored_verbatim(
+        name in "[a-zA-Z][a-zA-Z0-9_./]{0,63}",
+    ) {
+        let info = TensorInfo {
+            name: name.clone(),
+            n_dims: 0,
+            dims: vec![],
+            dtype: 0,
+            offset: 0,
+        };
+        prop_assert_eq!(&info.name, &name, "tensor name must be stored verbatim");
+    }
+
+    /// GgufValue::Array with Uint32 elements preserves every element value.
+    #[test]
+    fn prop_gguf_value_array_uint32_elements_preserved(
+        values in prop::collection::vec(any::<u32>(), 0..=32),
+    ) {
+        let elems: Vec<GgufValue> = values.iter().map(|&v| GgufValue::Uint32(v)).collect();
+        let expected = values.clone();
+        let arr = GgufValue::Array(GgufValueType::Uint32, elems);
+        let GgufValue::Array(_, stored) = arr else { panic!("expected Array") };
+        prop_assert_eq!(stored.len(), expected.len());
+        for (i, (sv, &ev)) in stored.iter().zip(expected.iter()).enumerate() {
+            let GgufValue::Uint32(x) = sv else {
+                prop_assert!(false, "element {i} is not Uint32");
+                return Ok(());
+            };
+            prop_assert_eq!(*x, ev);
+        }
+    }
+
+    /// valid v3 headers with various tensor/metadata counts always parse.
+    #[test]
+    fn prop_v3_header_with_any_counts_parses(
+        tensor_count in 0u64..1_000_000u64,
+        metadata_count in 0u64..1_000_000u64,
+        exp in 0u32..=16u32,
+    ) {
+        let alignment = 1u32 << exp;
+        let d = v3_header(tensor_count, metadata_count, alignment);
+        let info = parse_header(&d).expect("v3 header with valid counts must parse");
+        prop_assert_eq!(info.version, 3);
+        prop_assert_eq!(info.tensor_count, tensor_count);
+        prop_assert_eq!(info.metadata_count, metadata_count);
+        prop_assert_eq!(info.alignment, alignment);
+    }
+}


### PR DESCRIPTION
## Summary

Adds **55 new tests** for `bitnet-cli` and **40 new tests** for `bitnet-gguf`, covering areas not exercised by existing suites.

### `crates/bitnet-cli/tests/cli_extended_tests.rs` (55 tests)

| Category | Tests |
|---|---|
| `InferenceCommand` defaults | temperature=0.7, max_tokens=512, repetition_penalty=1.1, stop_string_window=64, format, prompt_template, batch_size, greedy, no_bos, no_eos, top_k/top_p=None |
| `PromptTemplate` parsing | Case-insensitive RAW/INSTRUCT/LLAMA3-CHAT, underscore variant `llama3_chat`, empty string rejects, all canonical names |
| `TemplateType::detect()` | LLaMA-3 jinja, instruct jinja, tokenizer name heuristics, raw fallback, GGUF metadata priority |
| `TemplateType` methods | `Display`, `default_stop_sequences`, `should_add_bos`, `parse_special`, `apply` (raw passthrough, instruct Q:/A:, llama3 special tokens) |
| `CliConfig` validation | Default valid, invalid device/log-level/format, zero batch-size, all valid values |
| `ConfigBuilder` | Fluent API: new, device override, cpu_threads, invalid device fails |
| Optional `InferenceCommand` fields | `--top-p`, `--top-k`, `--stop-string-window`, `--stop` + `--stop-id` combined, `--temperature 0.0 --greedy` |
| Property tests | top_p \[0,1\] stored as Some; all 3 max-tokens aliases accept same value |

### `crates/bitnet-gguf/tests/gguf_extended_tests.rs` (40 tests)

| Category | Tests |
|---|---|
| `GgufValue` unit tests | Uint8 (0/128/255), Uint32 (42/MAX), Float32 (π, 0.0), Bool (true/false) |
| `GgufMetadataKv` | Float32 value, Int32 value, dot-separated keys (`general.architecture`, `llama.attention.head_count`) |
| Header parsing | v3 with 24 bytes → alignment=32, v3 alignment=32/65536 preserved, u32::MAX alignment falls back to 32 |
| `read_version` | v3 returns Some(3); agrees with `parse_header` |
| `TensorInfo` | offset=u64::MAX, dtype preserved, dims order preserved |
| `GgufValue::Array` | Bool elements preserved |
| Debug smoke | `GgufFileInfo` Debug output contains "version" |
| Constants | GGUF_MAGIC=b"GGUF", VERSION_MIN=2, VERSION_MAX=3 |
| `GgufValueType` discriminants | Bool=7, String=8, Array=9, Float32=6, Uint32=4 |
| `check_magic` edge cases | Exact 4 bytes, trailing zeros, GGML fails |
| Property tests | Uint8/Uint32 round-trips, ASCII tensor names verbatim, Array elements, v3 header arbitrary counts |

## Test Results

All **55 + 40 = 95 new tests pass** with `--no-default-features --features cpu,full-cli`. No regressions in the full test suite.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>