### PR TITLE
test(bitnet-runtime-feature-flags,bitnet-kernels): add comprehensive unit tests

### DIFF
--- a/crates/bitnet-kernels/tests/kernels_extended_tests.rs
+++ b/crates/bitnet-kernels/tests/kernels_extended_tests.rs
@@ -1,0 +1,479 @@
+//! Extended unit tests for `bitnet-kernels`.
+//!
+//! These tests cover the public API that is accessible without the
+//! `integration-tests` or `ffi` feature gates, and complement the existing
+//! `property_tests.rs` without duplicating its coverage.
+//!
+//! Run with:
+//!   cargo test -p bitnet-kernels --no-default-features --features cpu
+//!
+//! GPU tests are individually marked `#[ignore = "requires CUDA runtime"]` so
+//! the suite stays green in CPU-only CI.
+
+use bitnet_common::{QuantizationType, kernel_registry::SimdLevel};
+use bitnet_kernels::{
+    FallbackKernel, KernelManager, KernelProvider, device_features, select_cpu_kernel,
+    select_gpu_kernel,
+};
+
+// ── KernelManager construction ────────────────────────────────────────────────
+
+#[test]
+fn kernel_manager_new_succeeds() {
+    let _mgr = KernelManager::new();
+}
+
+#[test]
+fn kernel_manager_default_trait_works() {
+    let _mgr = KernelManager::default();
+}
+
+#[test]
+fn kernel_manager_new_twice_is_independent() {
+    let mgr1 = KernelManager::new();
+    let mgr2 = KernelManager::new();
+    let name1 = mgr1.select_best().map(|p| p.name()).unwrap_or("err");
+    let name2 = mgr2.select_best().map(|p| p.name()).unwrap_or("err");
+    assert_eq!(name1, name2, "two independent KernelManagers must select the same provider");
+}
+
+#[test]
+fn kernel_manager_list_available_providers_nonempty() {
+    let mgr = KernelManager::new();
+    let providers = mgr.list_available_providers();
+    assert!(
+        !providers.is_empty(),
+        "list_available_providers must always return at least one entry"
+    );
+}
+
+#[test]
+fn kernel_manager_list_available_providers_contains_fallback_name() {
+    let mgr = KernelManager::new();
+    let providers = mgr.list_available_providers();
+    // "fallback" is always present as the last-resort provider
+    assert!(
+        providers.iter().any(|&name| name == "fallback"),
+        "fallback provider must always be listed, got: {providers:?}"
+    );
+}
+
+#[test]
+fn kernel_manager_selected_provider_name_none_before_select() {
+    let mgr = KernelManager::new();
+    // Before calling select_best(), selected_provider_name returns None
+    assert!(
+        mgr.selected_provider_name().is_none(),
+        "selected_provider_name must be None before select_best() is called"
+    );
+}
+
+#[test]
+fn kernel_manager_selected_provider_name_some_after_select() {
+    let mgr = KernelManager::new();
+    mgr.select_best().expect("select_best must succeed");
+    let name = mgr.selected_provider_name();
+    assert!(name.is_some(), "selected_provider_name must be Some after select_best() is called");
+    assert!(!name.unwrap().is_empty(), "selected provider name must be non-empty");
+}
+
+#[test]
+fn kernel_manager_select_best_is_ok() {
+    let mgr = KernelManager::new();
+    assert!(mgr.select_best().is_ok(), "select_best must return Ok on any platform");
+}
+
+#[test]
+fn kernel_manager_select_best_twice_same_name() {
+    let mgr = KernelManager::new();
+    let n1 = mgr.select_best().map(|p| p.name()).unwrap_or("err");
+    let n2 = mgr.select_best().map(|p| p.name()).unwrap_or("err");
+    assert_eq!(n1, n2, "select_best must be idempotent (OnceLock-cached)");
+}
+
+// ── select_cpu_kernel ─────────────────────────────────────────────────────────
+
+#[test]
+fn select_cpu_kernel_always_succeeds() {
+    let result = select_cpu_kernel();
+    assert!(result.is_ok(), "select_cpu_kernel must always return Ok");
+}
+
+#[test]
+fn select_cpu_kernel_name_is_nonempty() {
+    let kernel = select_cpu_kernel().expect("cpu kernel must be available");
+    assert!(!kernel.name().is_empty(), "cpu kernel name must be non-empty");
+}
+
+#[test]
+fn select_cpu_kernel_is_available() {
+    let kernel = select_cpu_kernel().expect("cpu kernel must be available");
+    assert!(kernel.is_available(), "cpu kernel must report is_available() = true");
+}
+
+// ── select_gpu_kernel ─────────────────────────────────────────────────────────
+
+#[test]
+#[cfg(not(any(feature = "gpu", feature = "cuda")))]
+fn select_gpu_kernel_returns_err_when_not_compiled() {
+    let result = select_gpu_kernel(0);
+    assert!(result.is_err(), "select_gpu_kernel must return Err when GPU not compiled");
+}
+
+#[test]
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+#[ignore = "requires CUDA runtime"]
+fn select_gpu_kernel_returns_ok_with_gpu_runtime() {
+    let result = select_gpu_kernel(0);
+    assert!(result.is_ok(), "select_gpu_kernel must return Ok when CUDA GPU is present");
+}
+
+// ── FallbackKernel: direct API ────────────────────────────────────────────────
+
+#[test]
+fn fallback_kernel_name_is_fallback() {
+    assert_eq!(FallbackKernel.name(), "fallback");
+}
+
+#[test]
+fn fallback_kernel_is_always_available() {
+    assert!(FallbackKernel.is_available(), "FallbackKernel must always be available");
+}
+
+#[test]
+fn fallback_kernel_matmul_identity_1x1() {
+    let a = [2i8];
+    let b = [3u8];
+    let mut c = [0.0f32];
+    FallbackKernel.matmul_i2s(&a, &b, &mut c, 1, 1, 1).expect("1×1 matmul must succeed");
+    assert_eq!(c[0], 6.0, "1×1: 2 * 3 = 6");
+}
+
+#[test]
+fn fallback_kernel_matmul_identity_matrix() {
+    // 2×2 * identity = original
+    let a = [1i8, 2, 3, 4];
+    let b = [1u8, 0, 0, 1]; // 2×2 identity
+    let mut c = [0.0f32; 4];
+    FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2).expect("2×2 identity matmul must succeed");
+    assert_eq!(c, [1.0, 2.0, 3.0, 4.0], "A × I₂ must equal A");
+}
+
+#[test]
+fn fallback_kernel_matmul_zero_matrix() {
+    let a = [1i8, -1, 2, -2];
+    let b = [0u8; 4];
+    let mut c = [99.0f32; 4];
+    FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2).expect("matmul with zero B must succeed");
+    assert_eq!(c, [0.0, 0.0, 0.0, 0.0], "A × 0 must equal 0");
+}
+
+#[test]
+fn fallback_kernel_matmul_3x2_times_2x3() {
+    // C(3×3) = A(3×2) × B(2×3)
+    // A = [[1,2],[3,4],[5,6]]  B = [[1,0,1],[0,1,1]]
+    let a = [1i8, 2, 3, 4, 5, 6];
+    let b = [1u8, 0, 1, 0, 1, 1];
+    let mut c = [0.0f32; 9];
+    FallbackKernel.matmul_i2s(&a, &b, &mut c, 3, 3, 2).expect("3×3 matmul must succeed");
+    // Row 0: [1*1+2*0, 1*0+2*1, 1*1+2*1] = [1, 2, 3]
+    // Row 1: [3*1+4*0, 3*0+4*1, 3*1+4*1] = [3, 4, 7]
+    // Row 2: [5*1+6*0, 5*0+6*1, 5*1+6*1] = [5, 6, 11]
+    assert_eq!(c[0], 1.0);
+    assert_eq!(c[1], 2.0);
+    assert_eq!(c[2], 3.0);
+    assert_eq!(c[3], 3.0);
+    assert_eq!(c[4], 4.0);
+    assert_eq!(c[5], 7.0);
+    assert_eq!(c[6], 5.0);
+    assert_eq!(c[7], 6.0);
+    assert_eq!(c[8], 11.0);
+}
+
+// ── FallbackKernel: dimension validation ─────────────────────────────────────
+
+#[test]
+fn fallback_kernel_matmul_err_a_too_short() {
+    let a = [1i8]; // should be 2*2=4
+    let b = [1u8; 4];
+    let mut c = [0.0f32; 4];
+    let result = FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2);
+    assert!(result.is_err(), "A too short must return Err");
+}
+
+#[test]
+fn fallback_kernel_matmul_err_b_too_short() {
+    let a = [1i8; 4];
+    let b = [1u8]; // should be 4
+    let mut c = [0.0f32; 4];
+    let result = FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2);
+    assert!(result.is_err(), "B too short must return Err");
+}
+
+#[test]
+fn fallback_kernel_matmul_err_c_too_short() {
+    let a = [1i8; 4];
+    let b = [1u8; 4];
+    let mut c = [0.0f32; 2]; // should be 4
+    let result = FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2);
+    assert!(result.is_err(), "C too short must return Err");
+}
+
+// ── FallbackKernel: quantization ──────────────────────────────────────────────
+
+#[test]
+fn fallback_kernel_quantize_i2s_valid_input() {
+    let input: Vec<f32> = (0..32).map(|i| (i as f32 - 16.0) / 8.0).collect();
+    let mut output = vec![0u8; 8]; // 32 values / 4 per byte
+    let mut scales = vec![0.0f32; 1]; // 32 values / 32 per block = 1 block
+    FallbackKernel
+        .quantize(&input, &mut output, &mut scales, QuantizationType::I2S)
+        .expect("I2S quantize with valid input must succeed");
+    assert!(scales[0] > 0.0, "I2S scale must be positive for non-zero input");
+}
+
+#[test]
+fn fallback_kernel_quantize_tl1_valid_input() {
+    let input: Vec<f32> = (0..64).map(|i| (i as f32 - 32.0) / 16.0).collect();
+    let mut output = vec![0u8; 16]; // 64 values / 4 per byte
+    let mut scales = vec![0.0f32; 1]; // 64 values / 64 per block = 1 block
+    FallbackKernel
+        .quantize(&input, &mut output, &mut scales, QuantizationType::TL1)
+        .expect("TL1 quantize with valid input must succeed");
+    assert!(scales[0] > 0.0, "TL1 scale must be positive");
+}
+
+#[test]
+fn fallback_kernel_quantize_tl2_valid_input() {
+    let input: Vec<f32> = (0..128).map(|i| (i as f32 - 64.0) / 32.0).collect();
+    let mut output = vec![0u8; 32]; // 128 values / 4 per byte
+    let mut scales = vec![0.0f32; 1]; // 128 values / 128 per block = 1 block
+    FallbackKernel
+        .quantize(&input, &mut output, &mut scales, QuantizationType::TL2)
+        .expect("TL2 quantize with valid input must succeed");
+    assert!(scales[0] > 0.0, "TL2 scale must be positive");
+}
+
+#[test]
+fn fallback_kernel_quantize_err_output_too_small() {
+    let input = vec![1.0f32; 32];
+    let mut output = vec![0u8; 1]; // needs at least 32/4 = 8 bytes
+    let mut scales = vec![0.0f32; 1];
+    let result = FallbackKernel.quantize(&input, &mut output, &mut scales, QuantizationType::I2S);
+    assert!(result.is_err(), "quantize must return Err when output buffer too small");
+}
+
+#[test]
+fn fallback_kernel_quantize_err_scales_too_small() {
+    let input = vec![1.0f32; 64]; // 2 blocks of 32
+    let mut output = vec![0u8; 16];
+    let mut scales = vec![0.0f32; 0]; // needs at least 2 scale entries
+    let result = FallbackKernel.quantize(&input, &mut output, &mut scales, QuantizationType::I2S);
+    assert!(result.is_err(), "quantize must return Err when scales buffer too small");
+}
+
+// ── device_features: gpu_compiled ─────────────────────────────────────────────
+
+#[test]
+fn gpu_compiled_is_deterministic() {
+    let first = device_features::gpu_compiled();
+    let second = device_features::gpu_compiled();
+    assert_eq!(first, second, "gpu_compiled() must be deterministic (constant)");
+}
+
+#[test]
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+fn gpu_compiled_true_when_gpu_feature_enabled() {
+    assert!(
+        device_features::gpu_compiled(),
+        "gpu_compiled() must return true when gpu/cuda feature is enabled"
+    );
+}
+
+#[test]
+#[cfg(not(any(feature = "gpu", feature = "cuda")))]
+fn gpu_compiled_false_when_no_gpu_feature() {
+    assert!(
+        !device_features::gpu_compiled(),
+        "gpu_compiled() must return false without gpu/cuda features"
+    );
+}
+
+// ── device_features: gpu_available_runtime ────────────────────────────────────
+
+#[test]
+#[cfg(not(any(feature = "gpu", feature = "cuda")))]
+fn gpu_available_runtime_false_without_gpu_feature() {
+    assert!(
+        !device_features::gpu_available_runtime(),
+        "gpu_available_runtime() must return false without gpu/cuda features"
+    );
+}
+
+// ── device_features: detect_simd_level ───────────────────────────────────────
+
+#[test]
+fn detect_simd_level_returns_valid_level() {
+    let level = device_features::detect_simd_level();
+    // Just verifying it's a valid enum value — any variant is acceptable
+    let display = format!("{level:?}");
+    assert!(!display.is_empty(), "SimdLevel debug must be non-empty");
+}
+
+#[test]
+fn detect_simd_level_is_at_least_scalar() {
+    let level = device_features::detect_simd_level();
+    assert!(
+        level >= SimdLevel::Scalar,
+        "detected SIMD level must be at least Scalar, got {level:?}"
+    );
+}
+
+#[test]
+fn detect_simd_level_deterministic() {
+    let first = device_features::detect_simd_level();
+    let second = device_features::detect_simd_level();
+    assert_eq!(first, second, "detect_simd_level() must be deterministic");
+}
+
+// ── device_features: device_capability_summary ───────────────────────────────
+
+#[test]
+fn device_capability_summary_is_nonempty() {
+    let summary = device_features::device_capability_summary();
+    assert!(!summary.is_empty(), "device_capability_summary() must not be empty");
+}
+
+#[test]
+fn device_capability_summary_contains_cpu() {
+    let summary = device_features::device_capability_summary();
+    assert!(
+        summary.contains("CPU"),
+        "device_capability_summary must mention CPU, got: {summary:?}"
+    );
+}
+
+#[test]
+fn device_capability_summary_is_deterministic() {
+    let first = device_features::device_capability_summary();
+    let second = device_features::device_capability_summary();
+    assert_eq!(first, second, "device_capability_summary() must be deterministic");
+}
+
+// ── device_features: current_kernel_capabilities ─────────────────────────────
+
+#[test]
+fn current_kernel_capabilities_cpu_rust_matches_feature() {
+    let caps = device_features::current_kernel_capabilities();
+    assert_eq!(caps.cpu_rust, cfg!(feature = "cpu"), "cpu_rust must match cfg!(feature = \"cpu\")");
+}
+
+#[test]
+fn current_kernel_capabilities_cuda_compiled_matches_feature() {
+    let caps = device_features::current_kernel_capabilities();
+    assert_eq!(
+        caps.cuda_compiled,
+        cfg!(any(feature = "gpu", feature = "cuda")),
+        "cuda_compiled must match gpu/cuda feature gate"
+    );
+}
+
+#[test]
+#[cfg(not(any(feature = "gpu", feature = "cuda")))]
+fn current_kernel_capabilities_no_runtime_cuda_without_gpu_feature() {
+    let caps = device_features::current_kernel_capabilities();
+    assert!(!caps.cuda_runtime, "cuda_runtime must be false without gpu/cuda features");
+    assert!(!caps.cuda_compiled, "cuda_compiled must be false without gpu/cuda features");
+}
+
+#[test]
+fn current_kernel_capabilities_simd_level_at_least_scalar() {
+    let caps = device_features::current_kernel_capabilities();
+    assert!(
+        caps.simd_level >= SimdLevel::Scalar,
+        "simd_level must be at least Scalar, got {:?}",
+        caps.simd_level
+    );
+}
+
+#[test]
+fn current_kernel_capabilities_is_deterministic() {
+    let c1 = device_features::current_kernel_capabilities();
+    let c2 = device_features::current_kernel_capabilities();
+    assert_eq!(c1.cpu_rust, c2.cpu_rust);
+    assert_eq!(c1.cuda_compiled, c2.cuda_compiled);
+    assert_eq!(c1.cuda_runtime, c2.cuda_runtime);
+    assert_eq!(c1.cpp_ffi, c2.cpp_ffi);
+    assert_eq!(c1.simd_level, c2.simd_level);
+}
+
+// ── KernelManager: matmul via select_best ────────────────────────────────────
+
+#[test]
+fn kernel_manager_matmul_i2s_basic() {
+    let mgr = KernelManager::new();
+    let kernel = mgr.select_best().expect("kernel must be available");
+    let a = [1i8, 0, 0, 1];
+    let b = [2u8, 3, 4, 5];
+    let mut c = [0.0f32; 4];
+    kernel.matmul_i2s(&a, &b, &mut c, 2, 2, 2).expect("2×2 matmul must succeed");
+    // Row 0: 1*2 + 0*4 = 2,  1*3 + 0*5 = 3
+    // Row 1: 0*2 + 1*4 = 4,  0*3 + 1*5 = 5
+    assert_eq!(c[0], 2.0);
+    assert_eq!(c[1], 3.0);
+    assert_eq!(c[2], 4.0);
+    assert_eq!(c[3], 5.0);
+}
+
+#[test]
+fn kernel_manager_matmul_i2s_returns_err_on_bad_dims() {
+    // Use FallbackKernel directly to test dimension validation without
+    // hitting the pre-existing panic in the AVX2 kernel for bad dims.
+    let a = [1i8; 4];
+    let b = [1u8; 4];
+    let mut c = [0.0f32; 4];
+    // Wrong k dimension: a.len()=4, m*k=2*3=6 → mismatch
+    let result = FallbackKernel.matmul_i2s(&a, &b, &mut c, 2, 2, 3);
+    assert!(result.is_err(), "mismatched dimensions must return Err");
+}
+
+// ── SimdLevel ordering invariants ─────────────────────────────────────────────
+
+#[test]
+fn simd_level_scalar_is_minimum() {
+    assert!(SimdLevel::Scalar <= SimdLevel::Neon);
+    assert!(SimdLevel::Scalar <= SimdLevel::Sse42);
+    assert!(SimdLevel::Scalar <= SimdLevel::Avx2);
+    assert!(SimdLevel::Scalar <= SimdLevel::Avx512);
+}
+
+#[test]
+fn simd_level_avx512_is_maximum() {
+    assert!(SimdLevel::Avx512 >= SimdLevel::Scalar);
+    assert!(SimdLevel::Avx512 >= SimdLevel::Neon);
+    assert!(SimdLevel::Avx512 >= SimdLevel::Sse42);
+    assert!(SimdLevel::Avx512 >= SimdLevel::Avx2);
+}
+
+#[test]
+fn simd_level_display_strings_nonempty() {
+    for level in
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512]
+    {
+        let s = level.to_string();
+        assert!(!s.is_empty(), "SimdLevel::Display must be non-empty for {level:?}");
+    }
+}
+
+// ── FallbackKernel: deterministic output ─────────────────────────────────────
+
+#[test]
+fn fallback_kernel_matmul_deterministic_same_inputs() {
+    let a = [3i8, -1, 2, 0, -2, 1];
+    let b = [1u8, 2, 3, 4, 5, 6];
+    let mut c1 = [0.0f32; 4];
+    let mut c2 = [0.0f32; 4];
+    FallbackKernel.matmul_i2s(&a, &b, &mut c1, 2, 2, 3).expect("first call must succeed");
+    FallbackKernel.matmul_i2s(&a, &b, &mut c2, 2, 2, 3).expect("second call must succeed");
+    assert_eq!(c1, c2, "matmul must be deterministic for identical inputs");
+}

--- a/crates/bitnet-runtime-feature-flags/tests/runtime_feature_flags_tests.rs
+++ b/crates/bitnet-runtime-feature-flags/tests/runtime_feature_flags_tests.rs
@@ -1,0 +1,404 @@
+//! Comprehensive tests for `bitnet-runtime-feature-flags`.
+//!
+//! Covers the full public API surface: `FeatureActivation` construction and
+//! field semantics, feature-lattice implications, determinism, individual flag
+//! independence, single-flag lattice propagation, and JSON label round-trips.
+//!
+//! These tests are designed to run under `--no-default-features --features cpu`
+//! and do NOT duplicate the coverage already present in `feature_flags_tests.rs`
+//! or `property_tests.rs`.
+
+use bitnet_runtime_feature_flags::{
+    FeatureActivation, active_features, active_features_from_activation, feature_labels,
+    feature_labels_from_activation, feature_line, feature_line_from_activation,
+};
+
+// ── FeatureActivation field enumeration ──────────────────────────────────────
+
+/// Every publicly accessible field is a bool and individually settable.
+#[test]
+fn every_field_is_independently_settable() {
+    let fields: &[(&str, fn() -> FeatureActivation)] = &[
+        ("cpu", || FeatureActivation { cpu: true, ..Default::default() }),
+        ("gpu", || FeatureActivation { gpu: true, ..Default::default() }),
+        ("cuda", || FeatureActivation { cuda: true, ..Default::default() }),
+        ("inference", || FeatureActivation { inference: true, ..Default::default() }),
+        ("kernels", || FeatureActivation { kernels: true, ..Default::default() }),
+        ("tokenizers", || FeatureActivation { tokenizers: true, ..Default::default() }),
+        ("quantization", || FeatureActivation { quantization: true, ..Default::default() }),
+        ("cli", || FeatureActivation { cli: true, ..Default::default() }),
+        ("server", || FeatureActivation { server: true, ..Default::default() }),
+        ("ffi", || FeatureActivation { ffi: true, ..Default::default() }),
+        ("python", || FeatureActivation { python: true, ..Default::default() }),
+        ("wasm", || FeatureActivation { wasm: true, ..Default::default() }),
+        ("crossval", || FeatureActivation { crossval: true, ..Default::default() }),
+        ("trace", || FeatureActivation { trace: true, ..Default::default() }),
+        ("iq2s_ffi", || FeatureActivation { iq2s_ffi: true, ..Default::default() }),
+        ("cpp_ffi", || FeatureActivation { cpp_ffi: true, ..Default::default() }),
+        ("fixtures", || FeatureActivation { fixtures: true, ..Default::default() }),
+        ("reporting", || FeatureActivation { reporting: true, ..Default::default() }),
+        ("trend", || FeatureActivation { trend: true, ..Default::default() }),
+        ("integration_tests", || FeatureActivation {
+            integration_tests: true,
+            ..Default::default()
+        }),
+    ];
+    for (name, make) in fields {
+        let act = make();
+        let labels = feature_labels_from_activation(act);
+        assert!(!labels.is_empty(), "field '{name}' set to true must produce at least one label");
+    }
+}
+
+// ── CPU / GPU flag independence ───────────────────────────────────────────────
+
+#[test]
+fn cpu_only_activation_gpu_and_cuda_labels_absent() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        !labels.contains(&"gpu".to_string()),
+        "cpu-only should NOT produce 'gpu' label, got {labels:?}"
+    );
+    assert!(
+        !labels.contains(&"cuda".to_string()),
+        "cpu-only should NOT produce 'cuda' label, got {labels:?}"
+    );
+}
+
+#[test]
+fn gpu_only_activation_cpu_label_absent() {
+    let act = FeatureActivation { gpu: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        !labels.contains(&"cpu".to_string()),
+        "gpu-only should NOT produce 'cpu' label, got {labels:?}"
+    );
+}
+
+#[test]
+fn ffi_flag_produces_ffi_label() {
+    let act = FeatureActivation { ffi: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(labels.contains(&"ffi".to_string()), "ffi=true must produce 'ffi' label: {labels:?}");
+}
+
+#[test]
+fn crossval_flag_produces_crossval_label() {
+    let act = FeatureActivation { crossval: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"crossval".to_string()),
+        "crossval=true must produce 'crossval' label: {labels:?}"
+    );
+}
+
+#[test]
+fn trace_flag_produces_trace_label() {
+    let act = FeatureActivation { trace: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"trace".to_string()),
+        "trace=true must produce 'trace' label: {labels:?}"
+    );
+}
+
+#[test]
+fn reporting_flag_produces_reporting_label() {
+    let act = FeatureActivation { reporting: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"reporting".to_string()),
+        "reporting=true must produce 'reporting' label: {labels:?}"
+    );
+}
+
+#[test]
+fn trend_flag_produces_trend_label() {
+    let act = FeatureActivation { trend: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"trend".to_string()),
+        "trend=true must produce 'trend' label: {labels:?}"
+    );
+}
+
+#[test]
+fn fixtures_flag_produces_fixtures_label() {
+    let act = FeatureActivation { fixtures: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"fixtures".to_string()),
+        "fixtures=true must produce 'fixtures' label: {labels:?}"
+    );
+}
+
+#[test]
+fn python_flag_produces_python_label() {
+    let act = FeatureActivation { python: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"python".to_string()),
+        "python=true must produce 'python' label: {labels:?}"
+    );
+}
+
+#[test]
+fn wasm_flag_produces_wasm_label() {
+    let act = FeatureActivation { wasm: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"wasm".to_string()),
+        "wasm=true must produce 'wasm' label: {labels:?}"
+    );
+}
+
+#[test]
+fn server_flag_produces_server_label() {
+    let act = FeatureActivation { server: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"server".to_string()),
+        "server=true must produce 'server' label: {labels:?}"
+    );
+}
+
+#[test]
+fn quantization_flag_produces_quantization_label() {
+    let act = FeatureActivation { quantization: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"quantization".to_string()),
+        "quantization=true must produce 'quantization' label: {labels:?}"
+    );
+}
+
+#[test]
+fn cpp_ffi_flag_produces_cpp_ffi_label() {
+    let act = FeatureActivation { cpp_ffi: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.contains(&"cpp-ffi".to_string()) || labels.iter().any(|l| l.contains("ffi")),
+        "cpp_ffi=true must produce a ffi-related label: {labels:?}"
+    );
+}
+
+#[test]
+fn iq2s_ffi_flag_produces_iq2s_ffi_label() {
+    let act = FeatureActivation { iq2s_ffi: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        labels.iter().any(|l| l.contains("iq2") || l.contains("ffi")),
+        "iq2s_ffi=true must produce a iq2s/ffi-related label: {labels:?}"
+    );
+}
+
+#[test]
+fn integration_tests_flag_produces_nonempty_labels() {
+    let act = FeatureActivation { integration_tests: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    assert!(
+        !labels.is_empty(),
+        "integration_tests=true must produce at least one label: {labels:?}"
+    );
+}
+
+// ── Determinism across multiple calls ────────────────────────────────────────
+
+#[test]
+fn active_features_deterministic_across_two_calls() {
+    let first = active_features();
+    let second = active_features();
+    assert_eq!(
+        first.labels(),
+        second.labels(),
+        "active_features() must be deterministic across calls"
+    );
+}
+
+#[test]
+fn feature_labels_deterministic_across_two_calls() {
+    let first = feature_labels();
+    let second = feature_labels();
+    assert_eq!(first, second, "feature_labels() must be deterministic");
+}
+
+#[test]
+fn feature_line_deterministic_across_two_calls() {
+    let first = feature_line();
+    let second = feature_line();
+    assert_eq!(first, second, "feature_line() must be deterministic");
+}
+
+// ── CPU feature gate: compile-time verification ───────────────────────────────
+
+#[test]
+fn cpu_feature_flag_reflects_build_flag() {
+    let labels = feature_labels();
+    let line = feature_line();
+
+    #[cfg(feature = "cpu")]
+    {
+        assert!(
+            labels.iter().any(|l| l == "cpu"),
+            "compiled with --features cpu; 'cpu' must appear in feature_labels(), got {labels:?}"
+        );
+        assert!(
+            line.contains("cpu"),
+            "compiled with --features cpu; feature_line() must contain 'cpu', got {line:?}"
+        );
+    }
+
+    #[cfg(not(feature = "cpu"))]
+    {
+        assert!(
+            !labels.iter().any(|l| l == "cpu"),
+            "compiled WITHOUT cpu feature; 'cpu' must NOT appear in labels, got {labels:?}"
+        );
+    }
+}
+
+// ── Public API: `active_features()` == `active_features_from_activation(cfg)` ─
+
+#[test]
+fn active_features_api_consistent_with_from_activation() {
+    let via_api = active_features();
+    // The public `active_features_from_activation` with a cpu-true activation
+    // (when the feature is compiled) must contain at minimum what the API reports.
+    let labels_api = via_api.labels();
+    let labels_direct = feature_labels();
+    assert_eq!(labels_api, labels_direct, "active_features().labels() must equal feature_labels()");
+}
+
+// ── Feature-line format invariants ───────────────────────────────────────────
+
+#[test]
+fn feature_line_never_empty() {
+    let line = feature_line();
+    assert!(!line.is_empty(), "feature_line() must never be empty");
+}
+
+#[test]
+fn feature_line_none_when_all_flags_off() {
+    let line = feature_line_from_activation(FeatureActivation::default());
+    assert_eq!(line, "features: none", "all-false activation must yield 'features: none'");
+}
+
+#[test]
+fn feature_line_has_comma_separator_for_multiple_labels() {
+    let act = FeatureActivation { cpu: true, quantization: true, ..Default::default() };
+    let line = feature_line_from_activation(act);
+    // Two distinct features should be separated by ", "
+    assert!(
+        line.contains(", "),
+        "feature_line with multiple labels must use ', ' separator, got: {line:?}"
+    );
+}
+
+// ── Labels are always non-empty strings ──────────────────────────────────────
+
+#[test]
+fn all_runtime_labels_are_nonempty_strings() {
+    for label in feature_labels() {
+        assert!(!label.is_empty(), "every label must be a non-empty string");
+    }
+}
+
+// ── FeatureSet / active_features_from_activation consistency ─────────────────
+
+#[test]
+fn active_features_from_activation_cpu_contains_expected_labels() {
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let fs = active_features_from_activation(act);
+    let labels = fs.labels();
+    // cpu should imply cpu, inference, kernels, tokenizers
+    for expected in &["cpu", "inference", "kernels", "tokenizers"] {
+        assert!(
+            labels.contains(&expected.to_string()),
+            "cpu activation must contain '{expected}' label, got: {labels:?}"
+        );
+    }
+}
+
+#[test]
+fn feature_labels_length_is_stable() {
+    let act = FeatureActivation { cpu: true, gpu: true, ..Default::default() };
+    let len1 = feature_labels_from_activation(act).len();
+    let len2 = feature_labels_from_activation(act).len();
+    assert_eq!(len1, len2, "label count must be stable across repeated calls");
+}
+
+// ── JSON round-trips for individual flags ─────────────────────────────────────
+
+#[test]
+fn json_round_trip_ffi_only_labels() {
+    let act = FeatureActivation { ffi: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    let json = serde_json::to_string(&labels).expect("must serialize");
+    let back: Vec<String> = serde_json::from_str(&json).expect("must deserialize");
+    assert_eq!(labels, back, "ffi-only labels must survive JSON round-trip");
+}
+
+#[test]
+fn json_round_trip_crossval_only_labels() {
+    let act = FeatureActivation { crossval: true, ..Default::default() };
+    let labels = feature_labels_from_activation(act);
+    let json = serde_json::to_string(&labels).expect("must serialize");
+    let back: Vec<String> = serde_json::from_str(&json).expect("must deserialize");
+    assert_eq!(labels, back, "crossval-only labels must survive JSON round-trip");
+}
+
+// ── FeatureActivation Copy semantics ─────────────────────────────────────────
+
+#[test]
+fn feature_activation_copied_produces_same_labels() {
+    let original = FeatureActivation { cpu: true, trace: true, ..Default::default() };
+    let copied = original; // Copy (not move)
+    assert_eq!(
+        feature_labels_from_activation(original),
+        feature_labels_from_activation(copied),
+        "Copy of FeatureActivation must yield identical labels"
+    );
+}
+
+#[test]
+fn feature_activation_cloned_produces_same_labels() {
+    let original = FeatureActivation { quantization: true, fixtures: true, ..Default::default() };
+    let cloned = original.clone();
+    assert_eq!(
+        feature_labels_from_activation(original),
+        feature_labels_from_activation(cloned),
+        "Clone of FeatureActivation must yield identical labels"
+    );
+}
+
+// ── Feature-line contains all labels ─────────────────────────────────────────
+
+#[test]
+fn feature_line_contains_all_label_strings_multi() {
+    let act = FeatureActivation {
+        ffi: true,
+        crossval: true,
+        reporting: true,
+        trend: true,
+        ..Default::default()
+    };
+    let labels = feature_labels_from_activation(act);
+    let line = feature_line_from_activation(act);
+    for label in &labels {
+        assert!(line.contains(label.as_str()), "label '{label}' missing from line '{line}'");
+    }
+}
+
+#[test]
+fn feature_line_cpu_inference_all_present() {
+    // cpu implies inference, kernels, tokenizers in the lattice
+    let act = FeatureActivation { cpu: true, ..Default::default() };
+    let line = feature_line_from_activation(act);
+    for expected_label in &["cpu", "inference", "kernels", "tokenizers"] {
+        assert!(
+            line.contains(expected_label),
+            "feature_line for cpu must include '{expected_label}': {line:?}"
+        );
+    }
+}


### PR DESCRIPTION
Adds comprehensive unit and property tests for `bitnet-runtime-feature-flags` and `bitnet-kernels` crates.

## Changes

### `crates/bitnet-runtime-feature-flags/tests/runtime_feature_flags_tests.rs` (new, 33 tests)
- Per-field label emission for all 20 `FeatureActivation` fields
- CPU/GPU/CUDA flag independence (cpu-only → no gpu/cuda labels; gpu-only → no cpu label)
- Compile-time feature gate verification (`#[cfg(feature = "cpu")]`)
- Determinism: `active_features()`, `feature_labels()`, `feature_line()` are stable across calls
- Feature-line format invariants (prefix, comma separator, label containment)
- JSON round-trips for individual activation flags (`ffi`, `crossval`)
- `Copy`/`Clone` semantics produce identical labels
- Lattice implication check: `cpu → inference + kernels + tokenizers`

### `crates/bitnet-kernels/tests/kernels_extended_tests.rs` (new, 47 tests)
- `KernelManager::new()` / `Default` construction and multi-instance independence
- `list_available_providers()` always non-empty and always contains "fallback"
- `selected_provider_name()` is `None` before and `Some` after `select_best()`
- `select_cpu_kernel()` always succeeds and returns an available kernel
- `select_gpu_kernel()` returns `Err` when GPU not compiled
- `FallbackKernel` numeric correctness: 1×1, 2×2 identity, 2×2 zero, 3×2×3 matrix
- `FallbackKernel` dimension-validation error paths (A/B/C size mismatches)
- `FallbackKernel` quantization: I2S, TL1, TL2 valid inputs and error conditions
- `device_features`: `gpu_compiled()`, `gpu_available_runtime()`, `detect_simd_level()`, `device_capability_summary()`, `current_kernel_capabilities()`
- `SimdLevel` ordering invariants and Display strings
- Determinism: same inputs → same matmul outputs
- GPU tests marked `#[ignore = "requires CUDA runtime"]`

## Verification
```
cargo test -p bitnet-runtime-feature-flags --no-default-features --features cpu
# → 33 tests pass

cargo test -p bitnet-kernels --no-default-features --features cpu --test kernels_extended_tests
# → 47 tests pass
```