### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-27
+
+### Highlights
+- 1200+ comprehensive tests across all microcrates (BDD, unit, property, integration, fuzz)
+- Complete microcrate SRP extraction (bitnet-sampling, bitnet-transformer, bitnet-receipts, bitnet-prompt-templates, bitnet-device-probe, bitnet-logits, bitnet-generation, bitnet-engine-core)
+- Feature lattice normalized: gpu/cuda correctly orthogonal
+- Kernel registry with capability detection
+- Modern Diataxis documentation structure
+
 ### Added
 - `test(bitnet-device-probe,bitnet-logits): add comprehensive unit tests` — 15 tests for `bitnet-device-probe` (SIMD level ordering, probe consistency, cross-probe invariants) and 26 tests for `bitnet-logits` (top-p, repetition penalty, argmax, temperature, softmax, top-k, property tests) (#929)
 - `test(bitnet-generation,bitnet-engine-core): add comprehensive unit tests` — 24 tests for `bitnet-generation` (stop criteria, streaming events, serde roundtrips, property tests) and 36 tests for `bitnet-engine-core` (session lifecycle, backend info, concurrency config, engine state, error variants, session ID uniqueness) (#928)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitnet"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags",
@@ -421,7 +421,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "insta",
  "proptest",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-cli"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-common"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-test-support",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-compat"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-crossval"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-device-probe"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-engine-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-contract"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-feature-matrix",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-matrix"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-profile-core",
  "proptest",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ffi"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-generation"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ggml-ffi"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cc",
  "libc",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-gguf"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-honest-compute"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "insta",
  "proptest",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-inference"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-kernels"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-logits"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "insta",
  "proptest",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-models"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-prompt-templates"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-tokenizers",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-py"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-quantization"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-receipts"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-rope"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "insta",
  "proptest",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-bootstrap"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-startup-contract",
  "proptest",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-context-core",
  "proptest",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags-core",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -950,21 +950,21 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-feature-matrix",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-profile-contract-core",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-runtime-context",
@@ -977,14 +977,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-profile-contract",
 ]
 
 [[package]]
 name = "bitnet-sampling"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-logits",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-server"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1051,7 +1051,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st-tools"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-validation",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st2gguf"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-startup-contract-core",
  "proptest",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-diagnostics"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-guard"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-sys"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "cc",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-test-support"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "proptest",
  "serial_test",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-policy-core",
  "proptest",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-contract"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-feature-contract",
  "bitnet-runtime-feature-flags",
@@ -1171,7 +1171,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-profile",
  "bitnet-testing-scenarios-core",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-interop"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-contract",
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-kit"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-policy",
  "insta",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-runtime"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-policy-interop",
  "insta",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-policy-runtime",
  "insta",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-profile"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-runtime-profile",
  "insta",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-scenarios-core",
  "proptest",
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-scenarios-profile-core",
  "insta",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-profile-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "bitnet-testing-profile",
  "insta",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tests"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1310,7 +1310,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tokenizers"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-trace"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "blake3",
  "candle-core",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-transformer"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-validation"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "insta",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-wasm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "migrate-gen-config"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8609,7 +8609,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8655,7 +8655,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-build-helper"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ name = "bitnet"
 readme = "README.md"
 repository = "https://github.com/microsoft/BitNet"
 rust-version.workspace = true
-version = "0.1.2"
+version = "0.2.0"
 # Disable automatic discovery of tests, benches, and examples
 # Many of these use outdated APIs and need updating
 # Note: The tests/ directory is a separate bitnet-tests workspace crate
@@ -139,19 +139,19 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/microsoft/BitNet"
 rust-version = "1.92.0"
-version = "0.1.2"
+version = "0.2.0"
 
 [dependencies]
 # Core crates - always included
-bitnet-common = { path = "crates/bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "crates/bitnet-models", version = "0.1.0" }
-bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.1.0", default-features = false }
-bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.1.0", optional = true }
+bitnet-common = { path = "crates/bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "crates/bitnet-models", version = "0.2.0" }
+bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.0", default-features = false }
+bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.0", optional = true }
 
 # Optional crates based on features
-bitnet-inference = { path = "crates/bitnet-inference", version = "0.1.0", optional = true }
-bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.1.0", optional = true }
-bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.1.0", optional = true }
+bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.0", optional = true }
+bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.0", optional = true }
+bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.0", optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
@@ -160,9 +160,9 @@ vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
 
 [dev-dependencies]
 async-trait = "0.1.89"
-bitnet-logits = { path = "crates/bitnet-logits", version = "0.1.0" }
-bitnet-rope = { path = "crates/bitnet-rope", version = "0.1.0" }
-bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.1.0" }
+bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.0" }
+bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.0" }
+bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.0" }
 bitnet-tests = { path = "tests", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 criterion = "0.7.0"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ BitNet-rs is a high-performance Rust inference engine for 1-bit BitNet LLMs.
 - **Chat templates** — raw, instruct, llama3-chat; auto-detected from GGUF metadata or tokenizer path
 - **SafeTensors → GGUF export** — `bitnet-st2gguf` preserves F16 LayerNorm weights
 
-> **v0.1.0-qna-mvp:** QK256 uses scalar kernels (~0.1 tok/s on 2B models); use `--max-tokens 4–16` for validation. AVX2 dequantization is merged; ≥3× uplift planned for v0.2.
+> **v0.2.0:** QK256 uses scalar kernels (~0.1 tok/s on 2B models); use `--max-tokens 4–16` for validation. AVX2 dequantization is merged; ≥3× uplift planned for v0.2.
 
 ## Quick Start
 

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -16,9 +16,9 @@ name = "bitnet_bdd_grid"
 path = "src/lib.rs"
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
 
 [dev-dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.1.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -23,17 +23,17 @@ name = "bitnet"
 path = "src/main.rs"
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.1.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.1.0" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.1.0" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.1.0" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.1.0" }
-bitnet-validation = { path = "../bitnet-validation", version = "0.1.0" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.1.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.0" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env", "color"] }

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -12,7 +12,7 @@ description = "Device detection and capability probing for BitNet inference"
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
 log.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-engine-core/Cargo.toml
+++ b/crates/bitnet-engine-core/Cargo.toml
@@ -12,8 +12,8 @@ description = "Orchestration contracts and session types for BitNet inference en
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.0" }
 anyhow.workspace = true
 serde.workspace = true
 

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -13,8 +13,8 @@ description = "Compact feature and BDD profile contracts for BitNet tooling"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.1.0" }
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.1.0" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared feature flag and BDD profile matrix contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.1.0" }
+bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-generation/Cargo.toml
+++ b/crates/bitnet-generation/Cargo.toml
@@ -12,7 +12,7 @@ description = "Decode-loop stopping logic and generation event types for BitNet 
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -15,19 +15,19 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.1.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.1.0" }
-bitnet-receipts = { path = "../bitnet-receipts", version = "0.1.0" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.1.0" }
-bitnet-logits = { path = "../bitnet-logits", version = "0.1.0" }
-bitnet-sampling = { path = "../bitnet-sampling", version = "0.1.0" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.1.0" }
-bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.1.0" }
-bitnet-sys = { path = "../bitnet-sys", version = "0.1.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0" }
+bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.0" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.0" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.0" }
+bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.0" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.0" }
+bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.0" }
+bitnet-sys = { path = "../bitnet-sys", version = "0.2.0", optional = true }
 anyhow.workspace = true
 futures.workspace = true
 futures-util = "0.3.31"
@@ -58,7 +58,7 @@ chrono = "0.4.42"
 serial_test = "3.2.0"
 bitnet-test-support.workspace = true
 insta.workspace = true
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.1.0" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -18,8 +18,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true
@@ -45,9 +45,9 @@ serial_test.workspace = true
 anyhow = "1.0.100"
 serde = { version = "1.0.228", features = ["derive"] }
 half = "2.7.1"
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
 proptest.workspace = true
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.1.0" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0" }
 rand = "0.9.2"
 insta.workspace = true
 rand_chacha = "0.9.0"

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -15,12 +15,12 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
-bitnet-transformer = { path = "../bitnet-transformer", version = "0.1.0" }
-bitnet-gguf = { path = "../bitnet-gguf", version = "0.1.0" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.1.0", optional = true }
-bitnet-trace = { path = "../bitnet-trace", version = "0.1.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.0" }
+bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.0" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0", optional = true }
+bitnet-trace = { path = "../bitnet-trace", version = "0.2.0", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -51,7 +51,7 @@ serial_test.workspace = true
 temp-env = "0.3.6"
 sha2 = "0.10.9"
 sysinfo = "0.37.2"
-bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.1.0" }
+bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.0" }
 bitnet-test-support.workspace = true
 insta.workspace = true
 

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.1.0" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -21,11 +21,11 @@ test = false
 bench = false
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.1.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
 
 pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
 anyhow.workspace = true
 thiserror.workspace = true
 bytemuck.workspace = true
@@ -23,7 +23,7 @@ candle-core.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.1.0", optional = true }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0", optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
@@ -33,7 +33,7 @@ serial_test = "3.1"
 rand.workspace = true
 rand_chacha = "0.9"
 insta = { workspace = true, features = ["json"] }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0", features = ["cpu"] }  # AC2: For testing re-exports
+bitnet-models = { path = "../bitnet-models", version = "0.2.0", features = ["cpu"] }  # AC2: For testing re-exports
 
 [features]
 default = []

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -16,9 +16,9 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.1.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.1.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.0" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0", optional = true }
 rustc_version_runtime = "0.3.0"
 
 [features]

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.1.0" }
+bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.1.0" }
+bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.1.0" }
-bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.1.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
+bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.1.0" }
-bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.1.0" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.1.0" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0" }
+bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.1.0" }
+bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -13,7 +13,7 @@ description = "Core runtime profile, BDD, and feature-flag contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.1.0" }
+bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Runtime profile, BDD, and feature-flagging utilities for BitNet"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.1.0" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 rand = "0.9.2"
 rand_chacha = "0.9.0"
-bitnet-logits = { path = "../bitnet-logits", version = "0.1.0" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.0" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -26,8 +26,8 @@ bitnet-inference = { path = "../bitnet-inference" }
 bitnet-kernels = { path = "../bitnet-kernels" }
 bitnet-models = { path = "../bitnet-models" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.1.0" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.1.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0" }
 chrono.workspace = true
 clap.workspace = true
 cudarc = { workspace = true, optional = true }

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }
-bitnet-validation = { path = "../bitnet-validation", version = "0.1.0" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.0" }
 walkdir = "2.5.0"
 safetensors = "0.6.2"
 half = "2.7.1"

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/main.rs"
 
 [dependencies]
 # BitNet-rs internal crates
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
 
 # Core dependencies
 anyhow.workspace = true
@@ -42,7 +42,7 @@ bytemuck.workspace = true
 half = "2.6.0"
 
 [dev-dependencies]
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
 tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.1.0" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.1.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -14,8 +14,8 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.1.0" }
-bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.1.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
+bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.2.0" }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -13,7 +13,7 @@ description = "Startup contract primitives powered by BDD grid and runtime featu
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.1.0" }
+bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.1.0" }
-bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.1.0" }
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.1.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
+bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.0" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -13,8 +13,8 @@ description = "Core policy and BDD compatibility orchestration for BitNet runtim
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.1.0" }
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.1.0" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -13,9 +13,9 @@ description = "Interoperability façade for BitNet testing policy, BDD grid, and
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.1.0" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.1.0" }
-bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.1.0" }
+bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
+bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.1.0" }
+bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.1.0" }
+bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.1.0" }
+bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -13,7 +13,7 @@ description = "Stable orchestration layer for test policy/profile resolution"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.1.0" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Testing-focused façade over BDD grid and feature-flag profile co
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.1.0" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.1.0" }
+bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.0" }
 num_cpus = "1.17.0"
 
 [dev-dependencies]

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.1.0" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0" }
 num_cpus = "1.17.0"
 
 [features]

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.1.0" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0" }
 
 [features]
 default = []

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -17,9 +17,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitnet-trace"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version = "1.92.0"
 license = "MIT OR Apache-2.0"

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.1.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.1.0" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.1.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.0" }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 anyhow.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -276,7 +276,7 @@ path = "examples/reporting_example.rs"
 async-trait = "0.1.89"
 futures-util = "0.3.31"
 tokio = { version = "1.48.0", features = ["full"] }
-bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.1.0" }
+bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.2.0" }
 bitnet-test-support = { workspace = true }
 
 # System information


### PR DESCRIPTION
Bumps all workspace crates to 0.2.0 and promotes the Unreleased changelog section.

## What's in 0.2.0

- **1200+ tests** (unit, property, integration, fuzz, BDD)
- **Complete SRP microcrate extraction** (8 new microcrates)
- **Feature lattice normalization** (gpu/cuda correctly orthogonal)
- **Modern Diataxis documentation** structure
- **Kernel registry** with capability detection and backend selection
