### PR TITLE
test(bitnet-tokenizers,bitnet-validation): add extended tests

### DIFF
--- a/crates/bitnet-tokenizers/tests/tokenizer_extended_tests.rs
+++ b/crates/bitnet-tokenizers/tests/tokenizer_extended_tests.rs
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Extended tests for `bitnet-tokenizers`.
+//!
+//! Covers areas complementing `tokenizer_comprehensive_tests.rs`:
+//! - `TokenizerConfig` construction, field assignment, serde round-trip
+//! - `BasicTokenizer` construction variants and default equivalence
+//! - Encoding / decoding special-token semantics (BOS/EOS/PAD)
+//! - `token_to_piece` for byte and high-ID tokens
+//! - `get_family_name` heuristic
+//! - `real_vocab_size` default delegation
+//! - Legacy shim methods
+//! - `MockTokenizer::with_special_tokens` and `token_to_id`
+//! - `TokenizerBuilder::from_pretrained` built-in profiles
+//! - `TokenizerBuilder::from_file` / `from_path` error paths
+//! - Property tests: BOS/EOS opt-in, token_to_piece consistency
+
+use bitnet_tokenizers::{
+    BasicTokenizer, MockTokenizer, Tokenizer, TokenizerBuilder, TokenizerConfig, TokenizerFileKind,
+    from_path,
+};
+use proptest::prelude::*;
+use std::path::Path;
+
+// ── TokenizerConfig defaults and construction ────────────────────────────────
+
+#[test]
+fn config_new_has_empty_model_type() {
+    let cfg = TokenizerConfig::new();
+    assert_eq!(cfg.model_type, "");
+}
+
+#[test]
+fn config_default_has_zero_vocab_size() {
+    let cfg = TokenizerConfig::default();
+    assert_eq!(cfg.vocab_size, 0);
+}
+
+#[test]
+fn config_default_booleans_are_false() {
+    let cfg = TokenizerConfig::default();
+    assert!(!cfg.add_bos);
+    assert!(!cfg.add_eos);
+    assert!(!cfg.add_space_prefix);
+    assert!(!cfg.byte_fallback);
+}
+
+#[test]
+fn config_default_option_fields_are_none() {
+    let cfg = TokenizerConfig::default();
+    assert!(cfg.bos_token_id.is_none());
+    assert!(cfg.eos_token_id.is_none());
+    assert!(cfg.pad_token_id.is_none());
+    assert!(cfg.unk_token_id.is_none());
+    assert!(cfg.vocabulary.is_none());
+    assert!(cfg.bpe_merges.is_none());
+    assert!(cfg.pre_tokenizer.is_none());
+}
+
+#[test]
+fn config_field_assignment_roundtrip() {
+    let mut cfg = TokenizerConfig::new();
+    cfg.model_type = "llama".into();
+    cfg.vocab_size = 32_000;
+    cfg.bos_token_id = Some(1);
+    cfg.eos_token_id = Some(2);
+    cfg.pad_token_id = Some(0);
+    cfg.add_bos = true;
+
+    assert_eq!(cfg.model_type, "llama");
+    assert_eq!(cfg.vocab_size, 32_000);
+    assert_eq!(cfg.bos_token_id, Some(1));
+    assert_eq!(cfg.eos_token_id, Some(2));
+    assert_eq!(cfg.pad_token_id, Some(0));
+    assert!(cfg.add_bos);
+}
+
+#[test]
+fn config_serde_roundtrip_preserves_fields() {
+    let mut cfg = TokenizerConfig::new();
+    cfg.model_type = "gpt2".into();
+    cfg.vocab_size = 50_257;
+    cfg.eos_token_id = Some(50_256);
+
+    let json = serde_json::to_string(&cfg).expect("serialize");
+    let back: TokenizerConfig = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(back.model_type, cfg.model_type);
+    assert_eq!(back.vocab_size, cfg.vocab_size);
+    assert_eq!(back.eos_token_id, cfg.eos_token_id);
+}
+
+// ── BasicTokenizer construction ───────────────────────────────────────────────
+
+#[test]
+fn basic_tokenizer_default_equals_new() {
+    let a = BasicTokenizer::new();
+    let b = BasicTokenizer::default();
+    assert_eq!(a.vocab_size(), b.vocab_size());
+    assert_eq!(a.eos_token_id(), b.eos_token_id());
+    assert_eq!(a.bos_token_id(), b.bos_token_id());
+    assert_eq!(a.pad_token_id(), b.pad_token_id());
+}
+
+#[test]
+fn basic_tokenizer_new_gpt2_defaults() {
+    let tok = BasicTokenizer::new();
+    assert_eq!(tok.vocab_size(), 50_257);
+    assert_eq!(tok.eos_token_id(), Some(50_256));
+    assert!(tok.bos_token_id().is_none());
+    assert!(tok.pad_token_id().is_none());
+}
+
+#[test]
+fn basic_tokenizer_with_config_all_fields() {
+    let tok = BasicTokenizer::with_config(1_000, Some(1), Some(2), Some(0));
+    assert_eq!(tok.vocab_size(), 1_000);
+    assert_eq!(tok.bos_token_id(), Some(1));
+    assert_eq!(tok.eos_token_id(), Some(2));
+    assert_eq!(tok.pad_token_id(), Some(0));
+}
+
+// ── Encoding semantics ────────────────────────────────────────────────────────
+
+#[test]
+fn encode_add_bos_is_noop_when_bos_token_id_is_none() {
+    let tok = BasicTokenizer::new(); // bos_token_id = None
+    let without_bos = tok.encode("hi", false, false).unwrap();
+    let with_bos_flag = tok.encode("hi", true, false).unwrap();
+    assert_eq!(
+        without_bos, with_bos_flag,
+        "add_bos=true must be a no-op when bos_token_id is None"
+    );
+}
+
+#[test]
+fn encode_bos_prepended_when_configured() {
+    let tok = BasicTokenizer::with_config(50_257, Some(99), Some(50_256), None);
+    let tokens = tok.encode("A", true, false).unwrap();
+    assert_eq!(tokens[0], 99, "BOS token must be first");
+}
+
+#[test]
+fn encode_eos_appended_when_add_special_true() {
+    let tok = BasicTokenizer::new();
+    let tokens = tok.encode("A", false, true).unwrap();
+    assert!(tokens.contains(&50_256), "EOS must appear when add_special=true");
+}
+
+#[test]
+fn encode_eos_absent_when_add_special_false() {
+    let tok = BasicTokenizer::new();
+    let tokens = tok.encode("A", false, false).unwrap();
+    assert!(!tokens.contains(&50_256), "EOS must be absent when add_special=false");
+}
+
+#[test]
+fn encode_small_vocab_rejects_large_bytes() {
+    let tok = BasicTokenizer::with_config(10, None, None, None);
+    // 'A' = 65, which exceeds vocab_size=10
+    let result = tok.encode("A", false, false);
+    assert!(result.is_err(), "byte >= vocab_size must be an error");
+}
+
+#[test]
+fn encode_single_byte_produces_correct_id() {
+    let tok = BasicTokenizer::new();
+    let tokens = tok.encode("A", false, false).unwrap();
+    assert_eq!(tokens, vec![65u32], "'A' (0x41=65) should map to token ID 65");
+}
+
+// ── Decoding semantics ────────────────────────────────────────────────────────
+
+#[test]
+fn decode_eos_token_is_skipped() {
+    let tok = BasicTokenizer::new(); // eos = 50256
+    let decoded = tok.decode(&[50_256]).unwrap();
+    assert!(decoded.is_empty(), "lone EOS must decode to empty string");
+}
+
+#[test]
+fn decode_bos_token_is_skipped() {
+    let tok = BasicTokenizer::with_config(50_257, Some(1), Some(2), None);
+    let decoded = tok.decode(&[1]).unwrap();
+    assert!(decoded.is_empty(), "lone BOS must decode to empty string");
+}
+
+#[test]
+fn decode_pad_token_is_skipped() {
+    let tok = BasicTokenizer::with_config(50_257, None, None, Some(0));
+    // PAD = 0; byte 0 would normally decode but as a special token it is skipped
+    let decoded = tok.decode(&[0]).unwrap();
+    assert!(decoded.is_empty(), "lone PAD must decode to empty string");
+}
+
+#[test]
+fn decode_high_non_special_id_dropped() {
+    let tok = BasicTokenizer::new();
+    // ID 300 is not a special token and is ≥ 256 (no byte mapping)
+    let decoded = tok.decode(&[300]).unwrap();
+    assert!(decoded.is_empty(), "non-special high IDs (≥256) must be silently dropped");
+}
+
+#[test]
+fn decode_ascii_byte_sequence_is_correct() {
+    let tok = BasicTokenizer::new();
+    // 'h'=104, 'i'=105
+    let decoded = tok.decode(&[104, 105]).unwrap();
+    assert_eq!(decoded, "hi");
+}
+
+// ── token_to_piece ────────────────────────────────────────────────────────────
+
+#[test]
+fn token_to_piece_printable_ascii_matches_char() {
+    let tok = BasicTokenizer::new();
+    let piece = tok.token_to_piece(65).unwrap(); // 'A'
+    assert_eq!(piece, "A");
+}
+
+#[test]
+fn token_to_piece_high_id_uses_angle_bracket_format() {
+    let tok = BasicTokenizer::new();
+    let piece = tok.token_to_piece(9_999).unwrap();
+    assert_eq!(piece, "<token_9999>");
+}
+
+#[test]
+fn token_to_piece_byte_zero_is_some() {
+    let tok = BasicTokenizer::new();
+    assert!(tok.token_to_piece(0).is_some());
+}
+
+// ── real_vocab_size default ───────────────────────────────────────────────────
+
+#[test]
+fn real_vocab_size_equals_vocab_size_for_basic_tokenizer() {
+    let tok = BasicTokenizer::new();
+    assert_eq!(
+        tok.real_vocab_size(),
+        tok.vocab_size(),
+        "BasicTokenizer must delegate real_vocab_size to vocab_size"
+    );
+}
+
+// ── get_family_name ───────────────────────────────────────────────────────────
+
+#[test]
+fn basic_tokenizer_family_name_is_unknown() {
+    let tok = BasicTokenizer::new();
+    assert_eq!(
+        tok.get_family_name(),
+        "unknown",
+        "BasicTokenizer has no special token mappings so family should be 'unknown'"
+    );
+}
+
+#[test]
+fn mock_tokenizer_with_eot_id_is_llama3_family() {
+    let tok = MockTokenizer::with_special_tokens(&[("<|eot_id|>", 128_009)]);
+    assert_eq!(tok.get_family_name(), "llama3");
+}
+
+#[test]
+fn mock_tokenizer_with_start_header_id_is_llama3_family() {
+    let tok = MockTokenizer::with_special_tokens(&[("<|start_header_id|>", 128_006)]);
+    assert_eq!(tok.get_family_name(), "llama3");
+}
+
+#[test]
+fn mock_tokenizer_with_inst_token_is_mistral_family() {
+    let tok = MockTokenizer::with_special_tokens(&[("[INST]", 3)]);
+    assert_eq!(tok.get_family_name(), "mistral-instruct");
+}
+
+// ── Legacy shims ──────────────────────────────────────────────────────────────
+
+#[test]
+fn encode_legacy_matches_encode_with_same_semantics() {
+    let tok = BasicTokenizer::new();
+    // encode_legacy(text, add_special) → encode(text, /*add_bos=*/true, add_special)
+    let via_legacy = tok.encode_legacy("abc", false).unwrap();
+    let via_direct = tok.encode("abc", true, false).unwrap();
+    assert_eq!(via_legacy, via_direct);
+}
+
+#[test]
+fn decode_legacy_matches_decode() {
+    let tok = BasicTokenizer::new();
+    let tokens = tok.encode("hello", false, false).unwrap();
+    let via_legacy = tok.decode_legacy(&tokens, true).unwrap();
+    let via_direct = tok.decode(&tokens).unwrap();
+    assert_eq!(via_legacy, via_direct);
+}
+
+// ── MockTokenizer::token_to_id ────────────────────────────────────────────────
+
+#[test]
+fn mock_tokenizer_token_to_id_returns_mapped_value() {
+    let tok = MockTokenizer::with_special_tokens(&[("<|end|>", 32_000)]);
+    assert_eq!(tok.token_to_id("<|end|>"), Some(32_000));
+}
+
+#[test]
+fn mock_tokenizer_token_to_id_returns_none_for_unmapped() {
+    let tok = MockTokenizer::new();
+    assert!(tok.token_to_id("<|eot_id|>").is_none());
+}
+
+// ── TokenizerBuilder::from_pretrained profiles ───────────────────────────────
+
+#[test]
+fn builder_from_pretrained_gpt2_has_correct_vocab() {
+    let tok = TokenizerBuilder::from_pretrained("gpt2").unwrap();
+    assert_eq!(tok.vocab_size(), 50_257);
+    assert_eq!(tok.eos_token_id(), Some(50_256));
+}
+
+#[test]
+fn builder_from_pretrained_bert_has_cls_sep_tokens() {
+    let tok = TokenizerBuilder::from_pretrained("bert").unwrap();
+    assert_eq!(tok.vocab_size(), 30_522);
+    assert_eq!(tok.bos_token_id(), Some(101)); // [CLS]
+    assert_eq!(tok.eos_token_id(), Some(102)); // [SEP]
+    assert_eq!(tok.pad_token_id(), Some(0));
+}
+
+#[test]
+fn builder_from_pretrained_tiny_has_small_vocab() {
+    let tok = TokenizerBuilder::from_pretrained("tiny").unwrap();
+    assert_eq!(tok.vocab_size(), 1_000);
+}
+
+#[test]
+fn builder_from_pretrained_unknown_falls_back_to_gpt2_defaults() {
+    let tok = TokenizerBuilder::from_pretrained("completely_unknown_xyz").unwrap();
+    assert_eq!(tok.vocab_size(), 50_257);
+}
+
+// ── from_path / from_file error handling ─────────────────────────────────────
+
+#[test]
+fn from_path_unsupported_extension_errors() {
+    let result = from_path(Path::new("model.safetensors"));
+    assert!(result.is_err(), "unsupported extension must return Err");
+}
+
+#[test]
+fn from_path_bin_extension_errors() {
+    let result = from_path(Path::new("tokenizer.bin"));
+    assert!(result.is_err(), "'.bin' extension is unsupported and must return Err");
+}
+
+#[test]
+fn from_path_no_extension_errors() {
+    let result = from_path(Path::new("/tmp/tokenizer_no_ext"));
+    assert!(result.is_err(), "missing extension must return Err");
+}
+
+#[test]
+fn from_file_nonexistent_json_errors() {
+    let result = TokenizerBuilder::from_file(Path::new("/nonexistent/path/tokenizer.json"));
+    assert!(result.is_err(), "nonexistent file must return Err");
+}
+
+// ── Property tests ────────────────────────────────────────────────────────────
+
+proptest! {
+    /// token_to_piece for IDs 0–127 returns a non-empty string (printable ASCII or control escape).
+    #[test]
+    fn prop_token_to_piece_always_some_in_byte_range(id in 0u32..256u32) {
+        let tok = BasicTokenizer::new();
+        prop_assert!(tok.token_to_piece(id).is_some());
+    }
+
+    /// For IDs ≥ 256 that are not special tokens, token_to_piece returns the <token_N> format.
+    #[test]
+    fn prop_token_to_piece_high_id_format(id in 300u32..10_000u32) {
+        let tok = BasicTokenizer::new();
+        let piece = tok.token_to_piece(id).unwrap();
+        prop_assert!(
+            piece.starts_with("<token_") && piece.ends_with('>'),
+            "expected <token_N> format for id={}, got {:?}",
+            id, piece
+        );
+    }
+
+    /// real_vocab_size always equals vocab_size for BasicTokenizer.
+    #[test]
+    fn prop_real_vocab_size_equals_vocab_size(vs in 1usize..200_000usize) {
+        let tok = BasicTokenizer::with_config(vs, None, None, None);
+        prop_assert_eq!(tok.real_vocab_size(), tok.vocab_size());
+    }
+
+    /// Encode of a single printable ASCII character produces exactly one token.
+    #[test]
+    fn prop_single_ascii_byte_encodes_to_one_token(c in b'!'..=b'~') {
+        let tok = BasicTokenizer::new();
+        let s = String::from_utf8(vec![c]).unwrap();
+        let tokens = tok.encode(&s, false, false).unwrap();
+        prop_assert_eq!(tokens.len(), 1);
+        prop_assert_eq!(tokens[0], c as u32);
+    }
+
+    /// decode(encode(text, false, false)) == text for printable ASCII.
+    #[test]
+    fn prop_encode_decode_roundtrip_no_special(text in "[!-~]{1,80}") {
+        let tok = BasicTokenizer::new();
+        let tokens = tok.encode(&text, false, false).unwrap();
+        let decoded = tok.decode(&tokens).unwrap();
+        prop_assert_eq!(decoded, text);
+    }
+}

--- a/crates/bitnet-validation/tests/validation_extended_tests.rs
+++ b/crates/bitnet-validation/tests/validation_extended_tests.rs
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Extended tests for `bitnet-validation`.
+//!
+//! Complements `validation_tests.rs` with coverage of:
+//! - `Ruleset::default()` / no-rules fallback envelope
+//! - `Ruleset::check_proj_rms` when proj bounds are `None` (generic ruleset)
+//! - `rules_bitnet_b158_i2s` pattern-specific checks
+//! - `rules_bitnet_b158_f16` per-pattern boundary values
+//! - `detect_rules` edge inputs (empty arch, numeric, mixed-case variants)
+//! - `load_policy` with invalid regex, empty ln list, multiple keys
+//! - `Ruleset::check_ln` fallback envelope when no pattern matches
+//! - Property tests for I2S attn_norm, generic reject, proj_rms consistency
+
+use bitnet_validation::{
+    Ruleset, detect_rules, is_ln_gamma, load_policy, rules_bitnet_b158_f16, rules_bitnet_b158_i2s,
+    rules_generic,
+};
+use proptest::prelude::*;
+use tempfile::NamedTempFile;
+
+// ── Ruleset::default() – no rules, uses fallback envelope ────────────────────
+
+#[test]
+fn default_ruleset_accepts_value_in_fallback_envelope() {
+    let r = Ruleset::default();
+    // No rules → fallback is (0.50..=2.0)
+    assert!(
+        r.check_ln("blk.0.attn_norm.weight", 1.0),
+        "default Ruleset must accept 1.0 via fallback envelope"
+    );
+}
+
+#[test]
+fn default_ruleset_rejects_value_below_fallback_envelope() {
+    let r = Ruleset::default();
+    // Value 0.1 is below the generic fallback lower bound (0.50)
+    assert!(
+        !r.check_ln("blk.0.attn_norm.weight", 0.1),
+        "default Ruleset must reject 0.1 (below fallback min 0.50)"
+    );
+}
+
+#[test]
+fn default_ruleset_rejects_value_above_fallback_envelope() {
+    let r = Ruleset::default();
+    assert!(
+        !r.check_ln("blk.0.attn_norm.weight", 2.5),
+        "default Ruleset must reject 2.5 (above fallback max 2.0)"
+    );
+}
+
+#[test]
+fn default_ruleset_check_proj_rms_with_no_bounds_always_true() {
+    let r = Ruleset::default(); // proj bounds are None
+    // When no proj bounds are set, any finite value should pass
+    assert!(r.check_proj_rms(0.0));
+    assert!(r.check_proj_rms(0.001));
+    assert!(r.check_proj_rms(1_000.0));
+}
+
+// ── Generic ruleset: proj_rms has None bounds → always passes ────────────────
+
+#[test]
+fn generic_ruleset_check_proj_rms_unbounded() {
+    let r = rules_generic();
+    // Generic ruleset does not constrain proj_rms
+    assert!(r.check_proj_rms(0.0));
+    assert!(r.check_proj_rms(100.0));
+    assert!(r.check_proj_rms(1e-6));
+}
+
+// ── rules_bitnet_b158_i2s pattern-specific checks ────────────────────────────
+
+#[test]
+fn i2s_attn_norm_accepts_very_low_rms() {
+    let r = rules_bitnet_b158_i2s();
+    // attn_norm in I2S: min=0.01, so 0.015 must pass
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.015));
+}
+
+#[test]
+fn i2s_attn_norm_accepts_min_boundary() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(r.check_ln("blk.0.attn_norm.weight", 0.01));
+}
+
+#[test]
+fn i2s_attn_norm_rejects_below_min() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.005));
+}
+
+#[test]
+fn i2s_ffn_norm_accepts_mid_range() {
+    let r = rules_bitnet_b158_i2s();
+    // ffn_norm in I2S: min=0.50, max=2.0
+    assert!(r.check_ln("blk.3.ffn_norm.weight", 1.0));
+}
+
+#[test]
+fn i2s_ffn_norm_rejects_below_min() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_ln("blk.3.ffn_norm.weight", 0.3));
+}
+
+#[test]
+fn i2s_proj_rms_accepts_valid_range() {
+    let r = rules_bitnet_b158_i2s();
+    // I2S: proj_weight_rms_min=0.002, proj_weight_rms_max=0.20
+    assert!(r.check_proj_rms(0.05));
+}
+
+#[test]
+fn i2s_proj_rms_rejects_below_min() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_proj_rms(0.001));
+}
+
+#[test]
+fn i2s_proj_rms_rejects_above_max() {
+    let r = rules_bitnet_b158_i2s();
+    assert!(!r.check_proj_rms(0.25));
+}
+
+// ── rules_bitnet_b158_f16 per-pattern boundary values ────────────────────────
+
+#[test]
+fn f16_ffn_layernorm_accepts_low_rms_at_boundary() {
+    let r = rules_bitnet_b158_f16();
+    // ffn_layernorm in F16: min=0.05
+    assert!(r.check_ln("blk.2.ffn_layernorm.weight", 0.05));
+}
+
+#[test]
+fn f16_ffn_layernorm_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_ln("blk.2.ffn_layernorm.weight", 0.04));
+}
+
+#[test]
+fn f16_post_attention_layernorm_accepts_at_min() {
+    let r = rules_bitnet_b158_f16();
+    // post_attention_layernorm: min=0.25
+    assert!(r.check_ln("blk.0.post_attention_layernorm.weight", 0.25));
+}
+
+#[test]
+fn f16_post_attention_layernorm_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    assert!(!r.check_ln("blk.0.post_attention_layernorm.weight", 0.20));
+}
+
+#[test]
+fn f16_input_layernorm_rejects_below_min() {
+    let r = rules_bitnet_b158_f16();
+    // input_layernorm: min=0.35
+    assert!(!r.check_ln("model.layers.0.input_layernorm.weight", 0.30));
+}
+
+// ── detect_rules edge inputs ──────────────────────────────────────────────────
+
+#[test]
+fn detect_rules_empty_arch_gives_generic() {
+    let r = detect_rules("", 1);
+    assert_eq!(r.name, "generic");
+}
+
+#[test]
+fn detect_rules_numeric_only_arch_gives_generic() {
+    let r = detect_rules("123", 0);
+    assert_eq!(r.name, "generic");
+}
+
+#[test]
+fn detect_rules_bitnet_file_type_zero_gives_i2s() {
+    // file_type != 1 → treat as quantized (I2S)
+    let r = detect_rules("bitnet", 0);
+    assert_eq!(r.name, "bitnet-b1.58:i2_s");
+}
+
+#[test]
+fn detect_rules_b158_substring_detected() {
+    let r = detect_rules("b1.58-2B", 1);
+    assert_eq!(r.name, "bitnet-b1.58:f16");
+}
+
+#[test]
+fn detect_rules_llama_arch_gives_generic() {
+    let r = detect_rules("llama", 1);
+    assert_eq!(r.name, "generic");
+}
+
+// ── Ruleset::check_ln fallback when no pattern matches ───────────────────────
+
+#[test]
+fn f16_ruleset_fallback_accepts_non_norm_name_within_range() {
+    let r = rules_bitnet_b158_f16();
+    // A name that matches the broad ".*norm.weight$" catch-all (min=0.50)
+    // Let's use something that would fall through to the final catch-all
+    assert!(r.check_ln("model.norm.weight", 0.8));
+}
+
+#[test]
+fn f16_ruleset_fallback_rejects_non_matching_name_out_of_range() {
+    let r = rules_bitnet_b158_f16();
+    // "output.weight" does not match any rule in f16 → generic fallback (0.50..=2.0)
+    // Below 0.50 should be rejected by the fallback
+    assert!(!r.check_ln("output.weight", 0.1));
+}
+
+// ── load_policy edge cases ────────────────────────────────────────────────────
+
+#[test]
+fn load_policy_invalid_yaml_returns_error() {
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "this is not: valid: yaml: [").unwrap();
+    let result = load_policy(tmp.path(), "any-key");
+    assert!(result.is_err(), "invalid YAML must return Err");
+}
+
+#[test]
+fn load_policy_invalid_regex_in_pattern_returns_error() {
+    let yaml = r#"
+version: 1
+rules:
+  bad-regex-key:
+    name: "bad-regex"
+    ln:
+      - pattern: "["
+        min: 0.5
+        max: 2.0
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let result = load_policy(tmp.path(), "bad-regex-key");
+    assert!(result.is_err(), "invalid regex in policy must return Err");
+}
+
+#[test]
+fn load_policy_empty_ln_list_succeeds() {
+    let yaml = r#"
+version: 1
+rules:
+  empty-ln:
+    name: "empty"
+    ln: []
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "empty-ln").unwrap();
+    assert_eq!(r.name, "empty");
+    assert!(r.ln.is_empty());
+}
+
+#[test]
+fn load_policy_empty_ln_falls_back_to_generic_envelope() {
+    let yaml = r#"
+version: 1
+rules:
+  empty-ln:
+    ln: []
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "empty-ln").unwrap();
+    // No rules → fallback accepts values in 0.50..=2.0
+    assert!(r.check_ln("blk.0.attn_norm.weight", 1.0));
+    assert!(!r.check_ln("blk.0.attn_norm.weight", 0.1));
+}
+
+#[test]
+fn load_policy_multiple_keys_access_correct_one() {
+    let yaml = r#"
+version: 1
+rules:
+  key-a:
+    name: "ruleset-a"
+    ln:
+      - pattern: ".*norm\\.weight$"
+        min: 0.5
+        max: 2.0
+  key-b:
+    name: "ruleset-b"
+    ln:
+      - pattern: ".*norm\\.weight$"
+        min: 0.8
+        max: 1.2
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+
+    let ra = load_policy(tmp.path(), "key-a").unwrap();
+    let rb = load_policy(tmp.path(), "key-b").unwrap();
+
+    assert_eq!(ra.name, "ruleset-a");
+    assert_eq!(rb.name, "ruleset-b");
+
+    // key-a accepts 0.6, key-b rejects it (min=0.8)
+    assert!(ra.check_ln("blk.0.attn_norm.weight", 0.6));
+    assert!(!rb.check_ln("blk.0.attn_norm.weight", 0.6));
+}
+
+#[test]
+fn load_policy_proj_bounds_are_loaded() {
+    let yaml = r#"
+version: 1
+rules:
+  proj-test:
+    ln: []
+    proj_weight_rms_min: 0.05
+    proj_weight_rms_max: 0.30
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "proj-test").unwrap();
+    assert!(r.check_proj_rms(0.10));
+    assert!(!r.check_proj_rms(0.01));
+    assert!(!r.check_proj_rms(0.40));
+}
+
+#[test]
+fn load_policy_default_name_is_policy_key() {
+    let yaml = r#"
+version: 1
+rules:
+  my-arch:
+    ln: []
+"#;
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), yaml).unwrap();
+    let r = load_policy(tmp.path(), "my-arch").unwrap();
+    assert_eq!(r.name, "policy:my-arch");
+}
+
+// ── Property tests ────────────────────────────────────────────────────────────
+
+proptest! {
+    /// I2S attn_norm accepts any RMS in [0.01, 2.0].
+    #[test]
+    fn prop_i2s_attn_norm_accepts_valid_range(rms in 0.01f32..=2.0) {
+        let r = rules_bitnet_b158_i2s();
+        prop_assert!(
+            r.check_ln("blk.0.attn_norm.weight", rms),
+            "I2S attn_norm should accept rms={}", rms
+        );
+    }
+
+    /// Generic ruleset check_proj_rms with no bounds always returns true.
+    #[test]
+    fn prop_generic_proj_rms_always_true(rms in 0.0f32..=1_000.0) {
+        let r = rules_generic();
+        prop_assert!(
+            r.check_proj_rms(rms),
+            "generic ruleset has no proj bounds so check_proj_rms must always return true"
+        );
+    }
+
+    /// F16 check_proj_rms is exactly [0.01, 0.40].
+    #[test]
+    fn prop_f16_proj_rms_consistent_with_bounds(rms in 0.0f32..=1.0) {
+        let r = rules_bitnet_b158_f16();
+        let accepted = r.check_proj_rms(rms);
+        let expected = (0.01f32..=0.40f32).contains(&rms);
+        prop_assert_eq!(
+            accepted, expected,
+            "f16 proj_rms={}: expected={} got={}", rms, expected, accepted
+        );
+    }
+
+    /// detect_rules is deterministic: two calls with same inputs return rulesets with same name.
+    #[test]
+    fn prop_detect_rules_is_deterministic(
+        arch in "[a-zA-Z0-9._-]{0,20}",
+        file_type in 0u32..=10,
+    ) {
+        let r1 = detect_rules(&arch, file_type);
+        let r2 = detect_rules(&arch, file_type);
+        prop_assert_eq!(r1.name, r2.name);
+    }
+
+    /// is_ln_gamma is consistent with check_ln in that names identified as LN weights
+    /// are subject to the ruleset's LN checks (not silently bypassed).
+    #[test]
+    fn prop_is_ln_gamma_consistent_with_ruleset_check(
+        keyword in prop_oneof![
+            Just("attn_norm"),
+            Just("ffn_norm"),
+            Just("ffn_layernorm"),
+            Just("input_layernorm"),
+        ],
+        block in 0u32..32,
+    ) {
+        let name = format!("blk.{}.{}.weight", block, keyword);
+        let is_ln = is_ln_gamma(&name);
+        // If is_ln_gamma identifies it as a LayerNorm weight, the name must have ".weight" suffix
+        prop_assert!(is_ln, "known LN keyword {:?} must be recognised by is_ln_gamma", keyword);
+    }
+}


### PR DESCRIPTION
Adds comprehensive unit and property tests for bitnet-tokenizers and bitnet-validation.

## Changes

### `crates/bitnet-tokenizers/tests/tokenizer_extended_tests.rs` (45 tests)
- `TokenizerConfig` defaults, field assignment, serde round-trip
- `BasicTokenizer` construction variants (`new`, `default`, `with_config`)
- BOS/EOS/PAD encoding opt-in semantics (no-op when token ID is None)
- Decoding skips BOS/EOS/PAD and drops high non-special IDs
- `token_to_piece` for byte-range IDs and high-ID `<token_N>` format
- `get_family_name` heuristic for llama3, mistral-instruct, unknown families
- `real_vocab_size` default delegation to `vocab_size`
- Legacy shim consistency (`encode_legacy`, `decode_legacy`)
- `MockTokenizer::with_special_tokens` and `token_to_id`
- `TokenizerBuilder::from_pretrained` built-in profiles (gpt2, bert, tiny)
- `from_path` / `from_file` error paths (unsupported extension, nonexistent file)
- Property tests: token_to_piece always Some in byte range, high-ID format, encode→decode round-trip

### `crates/bitnet-validation/tests/validation_extended_tests.rs` (37 tests)
- `Ruleset::default()` fallback envelope (0.50–2.0) accept/reject
- `check_proj_rms` with `None` bounds (generic ruleset) always passes
- I2S ruleset: `attn_norm` at low values (0.01), `ffn_norm` boundaries, proj bounds
- F16 ruleset: `ffn_layernorm` (min 0.05), `post_attention_layernorm` (min 0.25) boundaries
- `detect_rules` edge inputs: empty arch, numeric arch, file_type=0 for bitnet
- `load_policy` with invalid YAML, invalid regex, empty ln list, multiple keys
- Policy proj_weight_rms bounds loaded correctly; default name uses `policy:<key>`
- Property tests: I2S attn_norm [0.01,2.0], generic proj_rms unbounded, F16 proj bounds, determinism