### PR TITLE
ffi: preserve exact C last-error messages

### DIFF
--- a/crates/bitnet-ffi/src/c_api.rs
+++ b/crates/bitnet-ffi/src/c_api.rs
@@ -454,7 +454,9 @@ pub unsafe extern "C" fn bitnet_inference_with_config(
 pub extern "C" fn bitnet_get_last_error() -> *const c_char {
     match get_last_error() {
         Some(error) => {
-            let error_msg = format!("{}\0", error);
+            // CString adds the trailing null terminator; keep the payload free of '\0'
+            // so callers receive the original error message instead of a fallback string.
+            let error_msg = error.to_string().replace('\0', "\\0");
             // Store in thread-local storage to ensure lifetime
             thread_local! {
                 static ERROR_MSG: std::cell::RefCell<Option<CString>> = const { std::cell::RefCell::new(None) };

--- a/crates/bitnet-ffi/tests/c_api_tests.rs
+++ b/crates/bitnet-ffi/tests/c_api_tests.rs
@@ -106,6 +106,7 @@ fn test_error_handling() {
     let error_msg = error_str.to_str().expect("Invalid UTF-8 in error message");
     assert!(!error_msg.is_empty());
     assert!(error_msg.contains("null"), "Error should mention null pointer");
+    assert_eq!(error_msg, "Invalid argument: path cannot be null");
 
     // Test error clearing
     bitnet_clear_last_error();


### PR DESCRIPTION
### Motivation
- Ensure C callers receive the original, actionable error text instead of a generic fallback when retrieving the last error over the FFI boundary. 
- Previously, appending a manual NUL to the Rust string caused `CString::new` to fail and lose the real error content.

### Description
- Replace `format!("{}\0", error)` with a sanitized string built via `error.to_string().replace('\0', "\\0")` so `CString::new` succeeds while embedded NULs are defensively escaped. 
- Keep storing the `CString` in thread-local storage to preserve the pointer lifetime returned to C callers. 
- Strengthen the C API integration test to assert the exact error message when calling `bitnet_model_load(NULL)`.

### Testing
- Ran the C API integration test with `cargo test -p bitnet-ffi --features "integration-tests ffi-tests" --test c_api_tests test_error_handling -- --nocapture` and it passed (`test_error_handling ... ok`).
- The `bitnet-ffi` test build and related tests compiled successfully during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1dedcf34c8333a696ea629efafabf)