### PR TITLE
Improve CUDA device detection path

### DIFF
--- a/crates/bitnet-kernels/src/gpu/cuda.rs
+++ b/crates/bitnet-kernels/src/gpu/cuda.rs
@@ -436,23 +436,18 @@ impl KernelProvider for CudaKernel {
 
 /// Check if CUDA is available on the system
 pub fn is_cuda_available() -> bool {
-    // Try to create a CUDA context
-    CudaContext::new(0).is_ok()
+    cuda_device_count() > 0
 }
 
 /// Get the number of available CUDA devices
 pub fn cuda_device_count() -> usize {
-    // Try to create contexts for different device IDs to count devices
-    let mut count = 0;
-    for device_id in 0..16 {
-        // Check up to 16 devices
-        if CudaContext::new(device_id).is_ok() {
-            count += 1;
-        } else {
-            break; // Stop at first failure
+    match CudaContext::device_count() {
+        Ok(count) => count.max(0) as usize,
+        Err(e) => {
+            log::debug!("CUDA device count query failed: {:?}", e);
+            0
         }
     }
-    count
 }
 
 /// List all available CUDA devices with their information


### PR DESCRIPTION
### Motivation
- Previous CUDA availability probing repeatedly created `CudaContext` instances (looping up to a fixed upper bound), which is heavier and can give misleading early termination behavior.
- Querying the runtime for device count is simpler and more accurate for determining CUDA availability and avoids unnecessary context initialization.

### Description
- Updated `is_cuda_available()` to return `cuda_device_count() > 0` instead of attempting `CudaContext::new(0)` directly.
- Rewrote `cuda_device_count()` to call `CudaContext::device_count()` and return a safe `usize`, with debug logging on failure and a fallback to `0` devices.
- Adjusted related code paths to rely on the normalized device-count helper (file: `crates/bitnet-kernels/src/gpu/cuda.rs`).

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/bitnet-target cargo check -p bitnet-kernels --lib --no-default-features`, which completed successfully.
- Ran `rustfmt crates/bitnet-kernels/src/gpu/cuda.rs` to format the updated file successfully.
- Committed the change with message `Improve CUDA device detection path`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1de11e06c8333bbef79d6cc548ccc)