### PR TITLE
Accept Vulkan/OpenCL/ocl device aliases in server config and request parsing

### DIFF
--- a/crates/bitnet-server/src/config.rs
+++ b/crates/bitnet-server/src/config.rs
@@ -36,7 +36,7 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
             s if s.starts_with("gpu:") => {
                 let id_str = &s[4..];
                 let id = id_str.parse::<usize>()?;
@@ -44,6 +44,21 @@ impl FromStr for DeviceConfig {
             }
             s if s.starts_with("cuda:") => {
                 let id_str = &s[5..];
+                let id = id_str.parse::<usize>()?;
+                Ok(DeviceConfig::Gpu(id))
+            }
+            s if s.starts_with("vulkan:") => {
+                let id_str = &s[7..];
+                let id = id_str.parse::<usize>()?;
+                Ok(DeviceConfig::Gpu(id))
+            }
+            s if s.starts_with("opencl:") => {
+                let id_str = &s[7..];
+                let id = id_str.parse::<usize>()?;
+                Ok(DeviceConfig::Gpu(id))
+            }
+            s if s.starts_with("ocl:") => {
+                let id_str = &s[4..];
                 let id = id_str.parse::<usize>()?;
                 Ok(DeviceConfig::Gpu(id))
             }
@@ -500,8 +515,13 @@ mod tests {
         assert_eq!("auto".parse::<DeviceConfig>().unwrap(), DeviceConfig::Auto);
         assert_eq!("cpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Cpu);
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("vulkan".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("opencl".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
         assert_eq!("gpu:1".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(1));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
+        assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+        assert_eq!("opencl:4".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(4));
+        assert_eq!("ocl:5".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(5));
         assert!("invalid".parse::<DeviceConfig>().is_err());
     }
 


### PR DESCRIPTION
### Motivation
- Server configuration and per-request device strings should accept common GPU aliases such as `vulkan`, `opencl`, and `ocl` and map them to the GPU execution path instead of failing as unknown devices.

### Description
- Update `DeviceConfig::from_str` in `crates/bitnet-server/src/config.rs` to accept `vulkan`, `opencl`, and `ocl` as synonyms for GPU and to parse indexed forms like `vulkan:3`/`opencl:4`/`ocl:5` into `DeviceConfig::Gpu(...)`.
- Normalize and extend the request-level `parse_device` in `crates/bitnet-server/src/lib.rs` to accept the same aliases and indexed forms and return `Device::Cuda(...)` accordingly.
- Add and extend unit tests: augment `test_device_config_from_str` and add `parse_device_supports_vulkan_and_opencl_aliases` and `parse_device_supports_indexed_vulkan_and_opencl_aliases` to verify both plain and indexed aliases.
- Run `cargo fmt --all` to keep formatting consistent.

### Testing
- Ran `cargo test -p bitnet-server test_device_config_from_str` and it passed.
- Ran `cargo test -p bitnet-server parse_device_supports_vulkan_and_opencl_aliases` and `cargo test -p bitnet-server parse_device_supports_indexed_vulkan_and_opencl_aliases` and both passed.
- Ran `cargo fmt --all --check` (initially reported diffs), then `cargo fmt --all` and re-ran `cargo fmt --all --check`; formatting now passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1de4459248333aa73bf26303051fa)