### PR TITLE
Improve Node-friendly WASM FFI Type Bindings

### DIFF
--- a/crates/bitnet-wasm/pkg/bitnet_wasm.d.ts
+++ b/crates/bitnet-wasm/pkg/bitnet_wasm.d.ts
@@ -13,13 +13,30 @@ export interface InitOutput {
 }
 
 /**
+ * Node/browser-friendly module initialization input.
+ *
+ * In Node.js this supports file paths and Buffer/typed array payloads.
+ * In browsers this supports Request/Response/URL-based loading.
+ */
+export type InitInput =
+  | string
+  | URL
+  | BufferSource
+  | WebAssembly.Module
+  | Response
+  | Request;
+
+/**
+ * Runtime-neutral readable stream type for browser and Node.js.
+ */
+export type BitNetReadableStream = ReadableStream<Uint8Array>;
+
+/**
  * Initialize the WebAssembly module
  * @param module_or_path - WebAssembly module or path to .wasm file
  * @returns Promise that resolves to the initialized module
  */
 export default function init(module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;
-
-export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;
 
 /**
  * Configuration for WASM model loading
@@ -254,7 +271,7 @@ export class WasmGenerationStream {
    * Convert to ReadableStream
    * @returns ReadableStream for use with Streams API
    */
-  to_readable_stream(): ReadableStream<Uint8Array>;
+  to_readable_stream(): BitNetReadableStream;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Make the generated WebAssembly TypeScript declarations more ergonomic for Node.js consumers while keeping browser compatibility so the WASM package can be initialized from file paths/Buffer inputs and expose a runtime-neutral stream type.

### Description
- Updated `crates/bitnet-wasm/pkg/bitnet_wasm.d.ts` to expand `InitInput` to include `string` (file paths) and to document Node/browser-friendly inputs, and added a `BitNetReadableStream` alias used by `to_readable_stream()` for clearer cross-runtime streaming semantics.

### Testing
- Ran a TypeScript declaration check with `npx -y -p typescript@5.4.5 tsc --noEmit --lib es2018,dom bitnet_wasm.d.ts`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ded40a64833386d7f75f56cf6424)