### PR TITLE
Improve GPU probe performance with runtime cache

### DIFF
--- a/crates/bitnet-kernels/tests/gpu_info_mock.rs
+++ b/crates/bitnet-kernels/tests/gpu_info_mock.rs
@@ -20,6 +20,7 @@ fn test_gpu_info_mocked_scenarios() {
         let mut scope = EnvScope::new();
         scope.set("PATH", dir.path().to_str().unwrap());
         scope.remove("BITNET_GPU_FAKE");
+        scope.set("BITNET_GPU_CACHE", "0");
 
         let info = get_gpu_info();
         assert!(!info.any_available());
@@ -40,6 +41,7 @@ fn test_gpu_info_mocked_scenarios() {
         let mut scope = EnvScope::new();
         scope.set("PATH", &format!("{}:{}", dir.path().display(), original_path));
         scope.remove("BITNET_GPU_FAKE");
+        scope.set("BITNET_GPU_CACHE", "0");
 
         let info = get_gpu_info();
         assert!(info.cuda);


### PR DESCRIPTION
### Motivation
- Repeated runtime probes (`nvidia-smi`, `rocm-smi`, `nvcc`) are expensive and spawn processes on each call to `get_gpu_info()`, so we need a one-time cache for real hardware detection.
- Tests and tooling rely on the `BITNET_GPU_FAKE` override and some test scenarios require dynamic re-probing, so fake overrides must remain uncached and a bypass is needed.

### Description
- Add a `OnceLock<GpuInfo>` runtime cache (`REAL_GPU_INFO_CACHE`) and move real detection into a new helper `detect_real_gpu_info()` so real hardware probing runs once per process.
- Respect `BITNET_GPU_FAKE` as before and keep fake selection uncached to preserve deterministic test overrides.
- Add `BITNET_GPU_CACHE=0` escape hatch that forces immediate re-detection (bypassing the cache) for tests or environments that must mutate PATH/device visibility.
- Update `crates/bitnet-kernels/tests/gpu_info_mock.rs` to set `BITNET_GPU_CACHE=0` in mocked scenarios so tests remain independent of the cache.

### Testing
- Ran `cargo fmt --all -- --check`, which succeeded.
- Attempted to run `cargo test -p bitnet-kernels --test gpu_info_mock`, but the targeted test run did not complete in this environment due to the large compile graph (incomplete/timeout).
- Some targeted test invocations were attempted during validation but were interrupted by the heavy build; the modified `gpu_info_mock` test was updated to explicitly disable caching to make it deterministic when run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1de23ea6083338fa934aee1c57c22)