### PR TITLE
Improve TL1 lookup indexing correctness

### DIFF
--- a/crates/bitnet-quantization/src/tl1.rs
+++ b/crates/bitnet-quantization/src/tl1.rs
@@ -97,8 +97,8 @@ impl LookupTable {
 
     /// Quantize a value using the lookup table
     pub fn quantize(&self, value: f32) -> i8 {
-        let index = ((value / self.scale + 128.0).round() as usize).clamp(0, 255);
-        self.forward[index]
+        let index = (value / self.scale + 128.0).round() as i32;
+        self.forward[index.clamp(0, 255) as usize]
     }
 
     /// Dequantize a value using the lookup table
@@ -457,10 +457,10 @@ impl TL1Quantizer {
 
                 // Use lookup table for each element
                 let mut result = [0i8; 4];
-                for j in 0..4 {
-                    let idx = vgetq_lane_u32::<0>(indices).min(255) as usize;
-                    result[j] = lookup_table.forward[idx];
-                }
+                result[0] = lookup_table.forward[vgetq_lane_u32::<0>(indices).min(255) as usize];
+                result[1] = lookup_table.forward[vgetq_lane_u32::<1>(indices).min(255) as usize];
+                result[2] = lookup_table.forward[vgetq_lane_u32::<2>(indices).min(255) as usize];
+                result[3] = lookup_table.forward[vgetq_lane_u32::<3>(indices).min(255) as usize];
 
                 // Store results
                 std::ptr::copy_nonoverlapping(result.as_ptr(), output.as_mut_ptr().add(i * 4), 4);


### PR DESCRIPTION
### Motivation
- Fix incorrect indexing and SIMD lane handling in TL1 table-lookup quantization that could produce wrong LUT indices for negative-scaled values and reuse the same SIMD lane for all outputs in the NEON path.

### Description
- Change `LookupTable::quantize` to compute the intermediate index as a signed `i32` and clamp in signed space before converting to `usize` to avoid negative-to-usize wrap/incorrect indexing (`crates/bitnet-quantization/src/tl1.rs`).
- Fix AArch64 NEON block quantization in `quantize_neon_block` to read each SIMD lane (`vgetq_lane_u32::<0..3>`) instead of repeatedly reading lane 0, ensuring each of the 4 packed elements maps to the correct LUT entry.
- Keep existing API and TL1 behavior unchanged besides correcting the indexing and lane extraction logic.

### Testing
- Ran `cargo test -p bitnet-quantization tl1 -- --nocapture` and all TL1-related unit and integration tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1dea43cd48333aeeb3915d3dc4f1b)