### PR TITLE
cli: wire i2_s qk256 tensors in mock loader fallback

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -975,7 +975,7 @@ async fn run_simple_generation(
                     packed.resize(expected_bytes, 0);
                 }
 
-                let raw_tensor = Tensor::from_raw_buffer(
+                let raw_tensor = candle_core::Tensor::from_raw_buffer(
                     &packed,
                     DType::U8,
                     &[qk256.rows, qk256.row_stride_bytes],


### PR DESCRIPTION
### Motivation
- Ensure that when the CLI falls back to the mock GGUF loader (via `--allow-mock`), raw I2_S QK256 quantized tensors parsed by the GGUF loader are preserved and passed into model construction so QK256-backed models work in mock mode.
- Guard against malformed/unaligned QK256 byte buffers by normalizing sizes at runtime to avoid runtime shape errors when constructing raw U8 tensors.

### Description
- Replaced the empty `raw_tensors` placeholder in the mock-loader fallback with an iteration over `load_result.i2s_qk256` that converts each `I2SQk256NoScale` into a runtime raw U8 tensor keyed as `"{name}.qk256_qs"`.
- Construct raw tensors using `Tensor::from_raw_buffer(&packed, DType::U8, &[rows, row_stride_bytes], &candle_core::Device::Cpu)` so the transformer path can consume QK256 raw weights.
- Added a warning and normalization step that resizes the packed byte buffer to `rows * row_stride_bytes` when the stored length differs from the expected size to avoid malformed tensor shapes.
- Kept the rest of the fallback flow unchanged and pass the populated `raw_tensors` map into `BitNetModel::from_gguf`.

### Testing
- Ran `cargo test -p bitnet-cli --no-default-features --features full-cli --lib` and all unit tests in the crate passed (`29 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1de0023c08333916905d32381318c)