### PR TITLE
fix(bitnet-engine-core): make new/state/allows const fn to satisfy clippy

### DIFF
--- a/crates/bitnet-engine-core/src/lib.rs
+++ b/crates/bitnet-engine-core/src/lib.rs
@@ -312,12 +312,12 @@ impl Default for EngineStateTracker {
 
 impl EngineStateTracker {
     /// Create a new tracker in the [`EngineState::Idle`] state.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self { state: EngineState::Idle }
     }
 
     /// Return a reference to the current state.
-    pub fn state(&self) -> &EngineState {
+    pub const fn state(&self) -> &EngineState {
         &self.state
     }
 
@@ -383,7 +383,7 @@ impl ConcurrencyConfig {
     /// assert!(cfg.allows(3));
     /// assert!(!cfg.allows(4));
     /// ```
-    pub fn allows(&self, active: usize) -> bool {
+    pub const fn allows(&self, active: usize) -> bool {
         active < self.max_concurrent
     }
 }


### PR DESCRIPTION
## Problem

The `clippy::missing_const_for_fn` lint (with `-D warnings`) fails when trivial getter methods could be `const fn` but are not. This was causing the "Build full" step in `test-framework.yml` to fail for any PR that triggers that workflow.

## Changes

- `EngineStateTracker::new()` → `const fn`
- `EngineStateTracker::state()` → `const fn`
- `ConcurrencyConfig::allows()` → `const fn`

All three methods have no heap allocation or trait calls that would prevent being `const`.

## Fix for

- Unblocks PR #947, PR #949, and any other PR that triggers the test-framework workflow.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>