### PR TITLE
docs: add canonical CUDA GPU setup guide and fix GPU build command examples

### DIFF
--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -1,0 +1,103 @@
+# GPU Setup (CUDA 12.x)
+
+This guide is the canonical setup for running BitNet-rs with the `gpu` feature.
+
+> **Status:** CUDA inference is implemented, but full GPU receipt-validation parity is still in progress.
+
+## Requirements
+
+- NVIDIA GPU with CUDA support
+- NVIDIA driver compatible with your CUDA toolkit
+- CUDA Toolkit **12.x** (12.0+ minimum)
+- Rust toolchain matching project MSRV (see `rust-toolchain.toml`)
+
+## 1) Install CUDA Toolkit
+
+Install CUDA 12.x using NVIDIA packages for your OS.
+
+After installation, ensure toolkit binaries and shared libraries are discoverable:
+
+```bash
+export CUDA_HOME=/usr/local/cuda
+export PATH="$CUDA_HOME/bin:$PATH"
+export LD_LIBRARY_PATH="$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}"
+```
+
+Verify the environment:
+
+```bash
+nvcc --version
+nvidia-smi
+```
+
+## 2) Build with GPU support
+
+Use explicit feature selection (default features are intentionally empty):
+
+```bash
+cargo build --no-default-features --features gpu
+```
+
+Run GPU tests where hardware is available:
+
+```bash
+cargo test --workspace --no-default-features --features gpu
+```
+
+If you only need compilation validation in non-GPU environments:
+
+```bash
+cargo check --workspace --no-default-features --features gpu,cpu
+```
+
+## 3) Runtime notes
+
+- Prefer `gpu` feature in new code.
+- `cuda` is a compatibility alias for `gpu`.
+- Use unified cfg predicates for GPU code paths:
+
+```rust
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+```
+
+## 4) CI recommendations
+
+For reliable CUDA validation in CI:
+
+1. Keep a compile-only GPU job (works without GPU hardware).
+2. Add a runtime GPU smoke job on self-hosted NVIDIA runners.
+3. Test at least one CUDA 12.x version used in production.
+
+The repository already includes a dedicated workflow at `.github/workflows/gpu-smoke.yml`.
+
+## Troubleshooting
+
+### Linker cannot find CUDA libraries
+
+Symptoms include missing `-lcuda`, `-lnvrtc`, `-lcublas`, or `-lcurand`.
+
+- Confirm `$CUDA_HOME/lib64` exists.
+- Export `LD_LIBRARY_PATH` to include CUDA `lib64`.
+- Re-run with verbose build output:
+
+```bash
+cargo build -vv --no-default-features --features gpu
+```
+
+### No CUDA device found at runtime
+
+- Ensure NVIDIA driver is loaded (`nvidia-smi`).
+- Confirm the process can access `/dev/nvidia*` devices.
+- In containers, pass GPU devices/runtime correctly (e.g. NVIDIA Container Toolkit).
+
+### GPU tests are flaky in CI
+
+- Serialize GPU integration tests if they share device-global state.
+- Reduce parallelism (`-- --test-threads=1`) for smoke checks.
+- Split compile-only and runtime GPU jobs.
+
+## Related docs
+
+- `docs/development/gpu-setup-guide.md` (extended examples)
+- `docs/howto/receipt-verification.md`
+- `docs/reference/validation-gates.md`

--- a/docs/development/gpu-setup-guide.md
+++ b/docs/development/gpu-setup-guide.md
@@ -67,19 +67,19 @@ Device 0: NVIDIA GeForce RTX 4080
 ### Basic CUDA Build
 ```bash
 # Build with CUDA support
-cargo build --no-default-features --release --no-default-features --features gpu
+cargo build --release --no-default-features --features gpu
 
 # Run tests to verify GPU functionality
-cargo test --no-default-features --workspace --no-default-features --features gpu
+cargo test --workspace --no-default-features --features gpu
 ```
 
 ### Advanced GPU Features
 ```bash
 # Build with all GPU optimizations
-cargo build --no-default-features --release --no-default-features --features "cuda,mixed-precision"
+cargo build --release --no-default-features --features "cuda,mixed-precision"
 
 # Build with validation framework for debugging
-cargo build --no-default-features --release --no-default-features --features "cuda,gpu-validation"
+cargo build --release --no-default-features --features "cuda,gpu-validation"
 ```
 
 ## Usage Examples
@@ -359,7 +359,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # Copy source and build with GPU support
 COPY . /app
 WORKDIR /app
-RUN cargo build --no-default-features --release --no-default-features --features gpu
+RUN cargo build --release --no-default-features --features gpu
 
 # Run with GPU access
 CMD ["./target/release/bitnet-server", "--gpu", "0"]


### PR DESCRIPTION
### Motivation
- Provide a single, canonical CUDA (CUDA 12.x) setup and troubleshooting guide and make the documented build/test commands for the `gpu` feature correct and copy-pasteable, while calling out that GPU receipt-validation parity is still pending.

### Description
- Add `docs/GPU_SETUP.md` with requirements, install/verify steps, build/test commands (`cargo build --no-default-features --features gpu`, `cargo test --workspace --no-default-features --features gpu`), CI recommendations, and troubleshooting, and clean up duplicated `--no-default-features` flags in `docs/development/gpu-setup-guide.md` so examples and Dockerfile commands use the corrected form.

### Testing
- Ran `cargo check -p bitnet-kernels --no-default-features` which completed successfully, validating compilation for the kernels crate with default features disabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a21287c2d083338b49140c4364b328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GPU setup documentation for BitNet-rs with detailed coverage of system requirements, CUDA toolkit installation, environment configuration, build and test procedures, and extensive troubleshooting guidance for common GPU-related issues.
  * Refined existing GPU setup guide with improved command formatting and optimized argument organization for better clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->