### PR TITLE
Fix NPU device parsing in CLI and Server configs

### DIFF
--- a/crates/bitnet-cli/src/config.rs
+++ b/crates/bitnet-cli/src/config.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 pub struct CliConfig {
     /// Default model path
     pub default_model: Option<PathBuf>,
-    /// Default device (cpu, cuda, auto)
+    /// Default device (cpu, cuda, npu, auto)
     pub default_device: String,
     /// Default quantization type
     pub default_quantization: Option<String>,
@@ -135,9 +135,9 @@ impl CliConfig {
     pub fn validate(&self) -> Result<()> {
         // Validate device
         match self.default_device.as_str() {
-            "cpu" | "cuda" | "auto" => {}
+            "cpu" | "cuda" | "npu" | "auto" => {}
             _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, auto",
+                "Invalid device: {}. Must be one of: cpu, cuda, npu, auto",
                 self.default_device
             ),
         }

--- a/crates/bitnet-cli/tests/cli_extended_tests.rs
+++ b/crates/bitnet-cli/tests/cli_extended_tests.rs
@@ -471,7 +471,7 @@ mod config_builder {
     /// ConfigBuilder with invalid device fails at build.
     #[test]
     fn test_config_builder_invalid_device_fails() {
-        let result = ConfigBuilder::new().device(Some("npu".to_string())).build();
+        let result = ConfigBuilder::new().device(Some("invalid-device".to_string())).build();
         assert!(result.is_err(), "ConfigBuilder with invalid device must fail to build");
     }
 }

--- a/crates/bitnet-server/src/config.rs
+++ b/crates/bitnet-server/src/config.rs
@@ -36,7 +36,7 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
             s if s.starts_with("gpu:") => {
                 let id_str = &s[4..];
                 let id = id_str.parse::<usize>()?;


### PR DESCRIPTION
Fixed an issue where "npu" was not being accepted as a valid target device. The string literal is now accepted as a valid device identifier in `crates/bitnet-cli/src/config.rs` and `crates/bitnet-server/src/config.rs`. Tests and warnings were additionally updated and verified.

---
*PR created automatically by Jules for task [13465370420272700611](https://jules.google.com/task/13465370420272700611) started by @EffortlessSteven*