### PR TITLE
fix(config): accept 'npu' as valid device identifier in CLI and server

### DIFF
--- a/crates/bitnet-cli/src/config.rs
+++ b/crates/bitnet-cli/src/config.rs
@@ -135,9 +135,9 @@ impl CliConfig {
     pub fn validate(&self) -> Result<()> {
         // Validate device
         match self.default_device.as_str() {
-            "cpu" | "cuda" | "gpu" | "vulkan" | "opencl" | "ocl" | "auto" => {}
+            "cpu" | "cuda" | "gpu" | "vulkan" | "opencl" | "ocl" | "npu" | "auto" => {}
             _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, auto",
+                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, auto",
                 self.default_device
             ),
         }

--- a/crates/bitnet-cli/tests/cli_extended_tests.rs
+++ b/crates/bitnet-cli/tests/cli_extended_tests.rs
@@ -471,7 +471,7 @@ mod config_builder {
     /// ConfigBuilder with invalid device fails at build.
     #[test]
     fn test_config_builder_invalid_device_fails() {
-        let result = ConfigBuilder::new().device(Some("npu".to_string())).build();
+        let result = ConfigBuilder::new().device(Some("invalid-device".to_string())).build();
         assert!(result.is_err(), "ConfigBuilder with invalid device must fail to build");
     }
 }

--- a/crates/bitnet-server/src/config.rs
+++ b/crates/bitnet-server/src/config.rs
@@ -36,7 +36,7 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
             s if s.starts_with("gpu:") => {
                 let id_str = &s[4..];
                 let id = id_str.parse::<usize>()?;


### PR DESCRIPTION
Adds 'npu' as an accepted device identifier in both CLI and server configuration, so that users can specify NPU as their target device alongside the existing cpu/cuda/gpu/vulkan/opencl/ocl options.

## Changes
- `crates/bitnet-cli/src/config.rs`: Add 'npu' to device validation match arm
- `crates/bitnet-server/src/config.rs`: Add 'npu' to `DeviceConfig::from_str` parsing
- `crates/bitnet-cli/tests/cli_extended_tests.rs`: Update invalid-device test to use 'invalid-device' instead of 'npu'

Closes #999

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NPU (Neural Processing Unit) device support to the CLI and server configurations, allowing users to specify NPU as a valid device option alongside existing CPU, CUDA, GPU, Vulkan, and OpenCL options.

* **Tests**
  * Updated device validation tests to properly validate NPU as a recognized device option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->