### PR TITLE
ci: expand nightly fuzz schedule to cover all 34 fuzz targets

### DIFF
--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -27,10 +27,37 @@ jobs:
           - quantization_i2s
           - quantization_tl1
           - quantization_tl2
+          - quantization_input
           - gguf_parser
+          - gguf_header
+          - gguf_header_parse
+          - gguf_header_roundtrip
+          - gguf_kv_read
+          - gguf_metadata_values
+          - gguf_writer_roundtrip
           - safetensors_parser
+          - safetensors_metadata
           - kernel_matmul
           - tokenizer_discovery
+          - tokenizer_encode
+          - tokenizer_encode_decode
+          - tokenizer_encode_no_panic
+          - transformer_config
+          - logits_transforms
+          - sampling_no_panic
+          - prompt_template_no_panic
+          - generation_stop_check
+          - generation_stop_checker
+          - receipt_json_roundtrip
+          - rope_table_gen
+          - tl_lut_helper
+          - architecture_detection
+          - feature_activation_no_panic
+          - honest_compute_no_panic
+          - engine_core_no_panic
+          - runtime_context_parse_no_panic
+          - validation_no_panic
+          - vocab_size_extraction
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Motivation

Previously only 7 of the 34 fuzz targets in `fuzz/fuzz_targets/` were running in the nightly schedule, leaving 27 targets that were never exercised in CI.

## Changes

Expand the `nightly-fuzz.yml` matrix to include all 34 fuzz targets:

**Previously scheduled (7):**
`quantization_i2s`, `quantization_tl1`, `quantization_tl2`, `gguf_parser`, `safetensors_parser`, `kernel_matmul`, `tokenizer_discovery`

**Newly added (27):**
- GGUF variants: `gguf_header`, `gguf_header_parse`, `gguf_header_roundtrip`, `gguf_kv_read`, `gguf_metadata_values`, `gguf_writer_roundtrip`
- SafeTensors: `safetensors_metadata`
- Quantization: `quantization_input`
- Tokenizer: `tokenizer_encode`, `tokenizer_encode_decode`, `tokenizer_encode_no_panic`
- Inference: `logits_transforms`, `sampling_no_panic`, `generation_stop_check`, `generation_stop_checker`
- Misc: `prompt_template_no_panic`, `receipt_json_roundtrip`, `rope_table_gen`, `tl_lut_helper`, `transformer_config`
- System: `architecture_detection`, `feature_activation_no_panic`, `honest_compute_no_panic`, `engine_core_no_panic`, `runtime_context_parse_no_panic`, `validation_no_panic`, `vocab_size_extraction`

Each target runs for 60 seconds with crash artifacts uploaded on failure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>