### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to bitnet-rs will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- `feat(bdd-grid): add Metal, Vulkan, oneAPI backend cells to BDD grid` — Three new BDD grid cells covering Metal (EndToEnd/Local), Vulkan (Minimal/PreProduction), and Intel oneAPI (Development/PreProduction) backends (#1010)
+
+### Changed
+- `ci: expand nightly fuzz schedule to all 34 fuzz targets` — Nightly CI fuzz schedule now covers all available fuzz targets (up from 7); timeboxed 5-minute runs per target (#1004)
+- `docs: update backend roadmap and architecture docs for v0.2` — Updated dual-backend roadmap and architecture documentation for post-v0.2 state (#1001)
+
+### Fixed
+- `fix(config): accept 'npu' as valid device identifier in CLI and server` — NPU device identifier (`npu`) now accepted as a valid device string in CLI and server config (#1002)
+
+### Documentation
+- `docs: add canonical CUDA GPU setup guide` — Comprehensive CUDA GPU setup guide with corrected build command examples and environment configuration (#998)
+
+## [0.2.0] - 2026-02-27
+
+### Highlights
+- 1200+ comprehensive tests across all microcrates (BDD, unit, property, integration, fuzz)
+- Complete microcrate SRP extraction (bitnet-sampling, bitnet-transformer, bitnet-receipts, bitnet-prompt-templates, bitnet-device-probe, bitnet-logits, bitnet-generation, bitnet-engine-core)
+- Feature lattice normalized: gpu/cuda correctly orthogonal
+- Kernel registry with capability detection
+- Modern Diataxis documentation structure
+
+### Added
 - `feat(kernels): implement AVX-512 kernels for TL2 quantization` — New AVX-512 optimised matrix-kernel for TL2 2-bit quantization; runtime-dispatched alongside existing AVX2 and scalar paths (#997)
 - `feat(vulkan): add initial Vulkan runtime probing and feature wiring` — Initial Vulkan backend probe and feature gate wiring; detects Vulkan ICD at runtime and exposes capability via `DeviceProbe` (#993)
 - `feat(metal): enable and wire Metal backend support across workspace` — Metal GPU backend enabled and wired across workspace feature flags; capability detection, kernel dispatch, and device-probe integration (#992)
@@ -21,31 +43,6 @@ All notable changes to bitnet-rs will be documented in this file.
 - `test: add insta snapshot tests for key serializable types` — 2 snapshot tests using `insta` crate pinning `RuntimeFeatureFlags` and related serializable types; added `INSTA_UPDATE: unseen` to CI workflow to prevent unreviewed snapshot acceptance (#938)
 - `feat(fuzz): add wave 4 fuzz targets` — 4 new fuzz targets: `engine_core_no_panic` (engine-core API panic safety), `honest_compute_no_panic` (honest-compute pipeline panic safety), `runtime_context_parse_no_panic` (runtime context parsing panic safety), `feature_activation_no_panic` (feature activation logic panic safety) (#937)
 - `test(bitnet-tokenizers,bitnet-validation): add comprehensive unit tests` — 45 tests for `bitnet-tokenizers` (TokenizerConfig defaults, BasicTokenizer construction, BOS/EOS/PAD semantics, family detection, builder profiles, property tests) and 37 tests for `bitnet-validation` (Ruleset defaults, projection RMS bounds, architecture detection, policy loading edge cases, property tests) (#934)
-
-### Changed
-- scripts: improve crates.io readiness validation with comprehensive checks (#940)
-- `chore: bump version to 0.2.0` — All crates and workspace version bumped from `0.1.x` to `0.2.0`; `CHANGELOG.md` `[Unreleased]` section promoted to `[0.2.0]` with release date (#933)
-
-### Fixed
-- `fix(device-probe): add rocm_available field to DeviceProbe` — `DeviceProbe` now includes a `rocm_available` boolean field populated by ROCm runtime detection (#995)
-- `fix(tests): gracefully skip model-dependent tests; fix AC2 attention timeout` — Model-dependent tests now gracefully skip when no GGUF is present; AC2 attention test timeout resolved (blockers #254 #260) (#981)
-- `fix(quantization): fix TL2 input quantization to stay in 2-bit domain` — TL2 input quantization clamped to valid 2-bit range; previously could produce out-of-range values corrupting matmul results (#978)
-- `ffi: preserve exact C last-error messages` — FFI layer now captures and preserves exact error strings returned by C `last_error` callbacks rather than truncating or reformatting them; improves debuggability for C/C++ consumer integrations (#941)
-
-### Documentation
-- `docs: modernize docs.rs configuration and add mdbook` — Updated `[package.metadata.docs.rs]` across crates; added mdbook setup for rendered API and user documentation (#994)
-- `docs: update changelog for PRs #931-#932` — Updated CHANGELOG.md and roadmap with 1400+ tests milestone (#935)
-
-## [0.2.0] - 2026-02-27
-
-### Highlights
-- 1200+ comprehensive tests across all microcrates (BDD, unit, property, integration, fuzz)
-- Complete microcrate SRP extraction (bitnet-sampling, bitnet-transformer, bitnet-receipts, bitnet-prompt-templates, bitnet-device-probe, bitnet-logits, bitnet-generation, bitnet-engine-core)
-- Feature lattice normalized: gpu/cuda correctly orthogonal
-- Kernel registry with capability detection
-- Modern Diataxis documentation structure
-
-### Added
 - `test(bitnet-runtime-feature-flags,bitnet-kernels): add comprehensive unit tests` — 33 tests for `bitnet-runtime-feature-flags` (feature snapshot determinism, CPU/GPU independence, JSON roundtrips, lattice implications) and 47 tests for `bitnet-kernels` (KernelManager construction, provider listing, FallbackKernel numeric correctness, dimension validation, device features API) (#932)
 - `test(integration): add multi-crate integration tests` — 69 integration tests in `tests/integration/multi_crate_tests.rs` spanning 8 microcrates (sampling, logits, device-probe, prompt-templates, generation, engine-core, GGUF, honest-compute); added 8 new path dependencies to `tests/Cargo.toml` (#931)
 - `test(bitnet-device-probe,bitnet-logits): add comprehensive unit tests` — 15 tests for `bitnet-device-probe` (SIMD level ordering, probe consistency, cross-probe invariants) and 26 tests for `bitnet-logits` (top-p, repetition penalty, argmax, temperature, softmax, top-k, property tests) (#929)
@@ -80,8 +77,16 @@ All notable changes to bitnet-rs will be documented in this file.
 - `test(bitnet-cli): add snapshot tests for CLI help output` — 8 new insta snapshot tests in `crates/bitnet-cli/tests/snapshot_tests.rs` pinning `--help` and `--version` output for all top-level subcommands; uses `assert_cmd` + `insta` for regression detection (#893)
 
 ### Documentation
+- `docs: update changelog for PRs #931-#932` — Updated CHANGELOG.md and roadmap with 1400+ tests milestone (#935)
 - `docs: comprehensive README rewrite and test-suite docs update` — README rewrite highlighting 1000+ test milestone, updated feature flag table, xtask grid-check documentation, and revised `docs/development/test-suite.md` with current test counts (#920)
 - `docs: update changelog for PRs #905-#912` — Changelog entries for server security tests, tokenizer property tests, xtask grid-check feature, E2E golden path tests, fuzz targets (sampling/receipt/template), logits property tests, and device-probe tests (#913)
+
+### Changed
+- scripts: improve crates.io readiness validation with comprehensive checks (#940)
+- `chore: bump version to 0.2.0` — All crates and workspace version bumped from `0.1.x` to `0.2.0`; `CHANGELOG.md` `[Unreleased]` section promoted to `[0.2.0]` with release date (#933)
+
+### Fixed
+- `ffi: preserve exact C last-error messages` — FFI layer now captures and preserves exact error strings returned by C `last_error` callbacks rather than truncating or reformatting them; improves debuggability for C/C++ consumer integrations (#941)
 
 ## [v0.1.3] - 2026-02-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitnet"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "insta",
  "proptest",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-cli"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-common"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-test-support",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-compat"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-crossval"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -562,7 +562,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-device-probe"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "ash",
  "bitnet-common",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-engine-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-contract"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-feature-matrix",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-matrix"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-profile-core",
  "proptest",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ffi"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-generation"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ggml-ffi"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "cc",
  "libc",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-gguf"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "insta",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-honest-compute"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "insta",
  "proptest",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-inference"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-kernels"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-logits"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "insta",
  "proptest",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-models"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-prompt-templates"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-tokenizers",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-py"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-quantization"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-receipts"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-rope"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "insta",
  "proptest",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-bootstrap"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-startup-contract",
  "proptest",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-context-core",
  "proptest",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags-core",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -964,21 +964,21 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-feature-matrix",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-profile-contract-core",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-runtime-context",
@@ -991,14 +991,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-profile-contract",
 ]
 
 [[package]]
 name = "bitnet-sampling"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-logits",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-server"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st-tools"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-validation",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st2gguf"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-startup-contract-core",
  "proptest",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
@@ -1125,7 +1125,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-diagnostics"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-guard"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-sys"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bindgen",
  "cc",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-test-support"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "proptest",
  "serial_test",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-policy-core",
  "proptest",
@@ -1174,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-contract"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-feature-contract",
  "bitnet-runtime-feature-flags",
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-profile",
  "bitnet-testing-scenarios-core",
@@ -1195,7 +1195,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-interop"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-contract",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-kit"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-policy",
  "insta",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-runtime"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-policy-interop",
  "insta",
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-tests"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-policy-runtime",
  "insta",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-profile"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-runtime-profile",
  "insta",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-scenarios-core",
  "proptest",
@@ -1249,7 +1249,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-scenarios-profile-core",
  "insta",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-profile-core"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "bitnet-testing-profile",
  "insta",
@@ -1269,7 +1269,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tests"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tokenizers"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-trace"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "blake3",
  "candle-core",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-transformer"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1397,7 +1397,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-validation"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "insta",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-wasm"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "migrate-gen-config"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-build-helper"
-version = "0.2.0"
+version = "0.2.1-dev"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ name = "bitnet"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
 rust-version.workspace = true
-version = "0.2.0"
+version = "0.2.1-dev"
 # Disable automatic discovery of tests, benches, and examples
 # Many of these use outdated APIs and need updating
 # Note: The tests/ directory is a separate bitnet-tests workspace crate
@@ -139,19 +139,19 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
 rust-version = "1.92.0"
-version = "0.2.0"
+version = "0.2.1-dev"
 
 [dependencies]
 # Core crates - always included
-bitnet-common = { path = "crates/bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "crates/bitnet-models", version = "0.2.0" }
-bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.0", default-features = false }
-bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.0", optional = true }
+bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
+bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
+bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 
 # Optional crates based on features
-bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.0", optional = true }
-bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.0", optional = true }
-bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.0", optional = true }
+bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.1-dev", optional = true }
+bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.1-dev", optional = true }
+bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.1-dev", optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
@@ -160,9 +160,9 @@ vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
 
 [dev-dependencies]
 async-trait = "0.1.89"
-bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.0" }
-bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.0" }
-bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.0" }
+bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.1-dev" }
+bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.1-dev" }
+bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.1-dev" }
 bitnet-tests = { path = "tests", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 criterion = "0.7.0"

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -16,9 +16,9 @@ name = "bitnet_bdd_grid"
 path = "src/lib.rs"
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 
 [dev-dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -23,17 +23,17 @@ name = "bitnet"
 path = "src/main.rs"
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0" }
-bitnet-validation = { path = "../bitnet-validation", version = "0.2.0" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env", "color"] }

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -12,7 +12,7 @@ description = "Device detection and capability probing for BitNet inference"
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 

--- a/crates/bitnet-engine-core/Cargo.toml
+++ b/crates/bitnet-engine-core/Cargo.toml
@@ -12,8 +12,8 @@ description = "Orchestration contracts and session types for BitNet inference en
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
 anyhow.workspace = true
 serde.workspace = true
 

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -13,8 +13,8 @@ description = "Compact feature and BDD profile contracts for BitNet tooling"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0" }
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared feature flag and BDD profile matrix contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.0" }
+bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-generation/Cargo.toml
+++ b/crates/bitnet-generation/Cargo.toml
@@ -12,7 +12,7 @@ description = "Decode-loop stopping logic and generation event types for BitNet 
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -15,19 +15,19 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0" }
-bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.0" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.2.0" }
-bitnet-logits = { path = "../bitnet-logits", version = "0.2.0" }
-bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.0" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.2.0" }
-bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.0" }
-bitnet-sys = { path = "../bitnet-sys", version = "0.2.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
+bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.1-dev" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.1-dev" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
+bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
+bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.1-dev" }
+bitnet-sys = { path = "../bitnet-sys", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true
 futures.workspace = true
 futures-util = "0.3.31"
@@ -58,7 +58,7 @@ chrono = "0.4.42"
 serial_test = "3.2.0"
 bitnet-test-support.workspace = true
 insta.workspace = true
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -18,8 +18,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true
@@ -45,9 +45,9 @@ serial_test.workspace = true
 anyhow = "1.0.100"
 serde = { version = "1.0.228", features = ["derive"] }
 half = "2.7.1"
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 proptest.workspace = true
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev" }
 rand = "0.9.2"
 insta.workspace = true
 rand_chacha = "0.9.0"

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -15,12 +15,12 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
-bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.0" }
-bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.0" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0", optional = true }
-bitnet-trace = { path = "../bitnet-trace", version = "0.2.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
+bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
+bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -51,7 +51,7 @@ serial_test.workspace = true
 temp-env = "0.3.6"
 sha2 = "0.10.9"
 sysinfo = "0.37.2"
-bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.0" }
+bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.1-dev" }
 bitnet-test-support.workspace = true
 insta.workspace = true
 

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -21,11 +21,11 @@ test = false
 bench = false
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.0" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 
 pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 anyhow.workspace = true
 thiserror.workspace = true
 bytemuck.workspace = true
@@ -23,7 +23,7 @@ candle-core.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0", optional = true }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
@@ -33,7 +33,7 @@ serial_test = "3.1"
 rand.workspace = true
 rand_chacha = "0.9"
 insta = { workspace = true, features = ["json"] }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0", features = ["cpu"] }  # AC2: For testing re-exports
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev", features = ["cpu"] }  # AC2: For testing re-exports
 
 [features]
 default = []

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -16,9 +16,9 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.0" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
 rustc_version_runtime = "0.3.0"
 
 [features]

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.0" }
+bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.0" }
+bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0" }
-bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.0" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0" }
-bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.0" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
+bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.0" }
+bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -13,7 +13,7 @@ description = "Core runtime profile, BDD, and feature-flag contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.0" }
+bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Runtime profile, BDD, and feature-flagging utilities for BitNet"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 rand = "0.9.2"
 rand_chacha = "0.9.0"
-bitnet-logits = { path = "../bitnet-logits", version = "0.2.0" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -26,8 +26,8 @@ bitnet-inference = { path = "../bitnet-inference" }
 bitnet-kernels = { path = "../bitnet-kernels" }
 bitnet-models = { path = "../bitnet-models" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true
 clap.workspace = true
 cudarc = { workspace = true, optional = true }

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }
-bitnet-validation = { path = "../bitnet-validation", version = "0.2.0" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
 walkdir = "2.5.0"
 safetensors = "0.6.2"
 half = "2.7.1"

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/main.rs"
 
 [dependencies]
 # BitNet-rs internal crates
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 
 # Core dependencies
 anyhow.workspace = true
@@ -42,7 +42,7 @@ bytemuck.workspace = true
 half = "2.6.0"
 
 [dev-dependencies]
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -14,8 +14,8 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0" }
-bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.2.0" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.2.1-dev" }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -13,7 +13,7 @@ description = "Startup contract primitives powered by BDD grid and runtime featu
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.0" }
+bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
-bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.0" }
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
+bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.1-dev" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -13,8 +13,8 @@ description = "Core policy and BDD compatibility orchestration for BitNet runtim
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0" }
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -13,9 +13,9 @@ description = "Interoperability façade for BitNet testing policy, BDD grid, and
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.0" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0" }
-bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.2.0" }
+bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
+bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.0" }
+bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.0" }
+bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.0" }
+bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -13,7 +13,7 @@ description = "Stable orchestration layer for test policy/profile resolution"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Testing-focused façade over BDD grid and feature-flag profile co
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.0" }
+bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.1-dev" }
 num_cpus = "1.17.0"
 
 [dev-dependencies]

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
 num_cpus = "1.17.0"
 
 [features]

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }
 
 [features]
 default = []

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -17,9 +17,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitnet-trace"
-version = "0.2.0"
+version = "0.2.1-dev"
 edition.workspace = true
 rust-version = "1.92.0"
 license = "MIT OR Apache-2.0"

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.0" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.2.0" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.1-dev" }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 anyhow.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -285,7 +285,7 @@ path = "examples/reporting_example.rs"
 async-trait = "0.1.89"
 futures-util = "0.3.31"
 tokio = { version = "1.48.0", features = ["full"] }
-bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.2.0" }
+bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.2.1-dev" }
 bitnet-test-support = { workspace = true }
 
 # System information


### PR DESCRIPTION
## Summary

Finalizes the v0.2.0 release by:

- **CHANGELOG**: Folds `[Unreleased]` entries (#933–#946) into `[0.2.0] - 2026-02-27`, adding `### Changed`, `### Fixed`, and additional `### Added`/`### Documentation` items to the existing release section
- **New `[Unreleased]` section**: Empty stub added above `[0.2.0]` to accumulate post-release work
- **Version bump**: `[workspace.package].version` `0.2.0` → `0.2.1-dev` across all 44 Cargo.toml files (workspace inheritance + explicit path-dep constraints)

## Verification

`cargo check --workspace --no-default-features --features cpu` passes ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>