### PR TITLE
docs: clarify BitNet.cpp vs llama.cpp cross-validation relationship

### DIFF
--- a/docs/explanation/dual-backend-crossval.md
+++ b/docs/explanation/dual-backend-crossval.md
@@ -28,6 +28,26 @@ BitNet-rs must support multiple model types with different C++ reference impleme
    - Generally compatible with llama.cpp
    - Default to llama.cpp unless explicitly overridden
 
+## bitnet.cpp vs llama.cpp: Relationship in BitNet-rs
+
+BitNet-rs treats `bitnet.cpp` and `llama.cpp` as **two distinct C++ cross-validation lanes**, but they are not symmetric dependencies:
+
+- `llama.cpp` is a standalone upstream inference engine.
+- `bitnet.cpp` is BitNet-focused and, in practice, vendors/depends on `llama.cpp` + `ggml` internals for shared runtime plumbing.
+
+In local builds this shows up as:
+
+- **Full lane available**: BitNet.cpp artifacts are found **and** embedded llama/ggml artifacts are found.
+- **Fallback lane available**: standalone llama.cpp artifacts are found, while BitNet.cpp artifacts are missing.
+
+This is why BitNet-rs labels availability as “full BitNet lane” vs “llama fallback lane” during detection and preflight diagnostics.
+
+### Practical interpretation
+
+- BitNet.cpp carries llama.cpp as part of its build graph.
+- llama.cpp does **not** require BitNet.cpp.
+- For cross-validation, BitNet-rs can still run useful checks with llama.cpp even when the BitNet lane is unavailable.
+
 ## Architecture
 
 ### Component Structure


### PR DESCRIPTION
### Motivation

- Clarify the operational relationship between the two C++ reference backends used for cross-validation so contributors and users understand availability semantics. 
- Reduce confusion about dependency directionality by explicitly documenting when the repository treats `bitnet.cpp` as the “full” lane and `llama.cpp` as a fallback lane. 

### Description

- Added a new section to `docs/explanation/dual-backend-crossval.md` entitled "bitnet.cpp vs llama.cpp: Relationship in BitNet-rs" that explains the asymmetric dependency relationship. 
- Documented the two detection outcomes used by the project as “Full lane available” (BitNet + embedded `llama/ggml`) and “Fallback lane available” (standalone `llama.cpp` present). 
- Included a concise "Practical interpretation" summary that states `bitnet.cpp` vendors/depends on `llama.cpp` plumbing while `llama.cpp` remains standalone and usable for parity checks. 

### Testing

- Verified the modified file changes via a local diff inspection of `docs/explanation/dual-backend-crossval.md` and confirmed the new section is present and readable. 
- Confirmed repository status and that the change is a docs-only modification with no code runtime changes. 
- Inspected the updated file content with line-numbered output to ensure formatting and placement within the document are correct.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2393889a08333b0f9bade70aa1207)