### PR TITLE
Prepare the workspace for crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,7 @@ async-trait = "0.1.89"
 bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.1-dev" }
 bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.1-dev" }
 bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.1-dev" }
-bitnet-tests = { path = "tests", package = "bitnet-tests", default-features = false }
+bitnet-tests = { path = "tests", version = "0.2.1-dev", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 criterion = "0.7.0"
 ctor = "0.6.1"
@@ -360,7 +360,7 @@ serial_test = "3.2.0"
 temp-env = "0.3.6"
 tracing-test = "0.2.6"
 rand = "0.9.2"
-bitnet-test-support = { path = "crates/bitnet-test-support" }
+bitnet-test-support = { path = "crates/bitnet-test-support", version = "0.2.1-dev" }
 
 # HTTP client for examples
 reqwest = { version = "0.12.24", features = ["json"] }

--- a/crates/bitnet-common/tests/snapshots/snapshot_tests__kernel_capabilities_cpu_avx2.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_tests__kernel_capabilities_cpu_avx2.snap
@@ -6,6 +6,8 @@ KernelCapabilities {
     cpu_rust: true,
     cuda_compiled: false,
     cuda_runtime: false,
+    oneapi_compiled: false,
+    oneapi_runtime: false,
     cpp_ffi: false,
     simd_level: Avx2,
 }

--- a/crates/bitnet-compat/Cargo.toml
+++ b/crates/bitnet-compat/Cargo.toml
@@ -6,12 +6,11 @@ rust-version.workspace = true
 authors = ["BitNet Contributors"]
 description = "Compatibility layer for drop-in llama.cpp replacement"
 license = "MIT OR Apache-2.0"
-publish = false
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common" }
-bitnet-models = { path = "../bitnet-models" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev", optional = true }
 anyhow = "1.0.100"
 tracing = "0.1.41"
 serde_json.workspace = true

--- a/crates/bitnet-ffi/Cargo.toml
+++ b/crates/bitnet-ffi/Cargo.toml
@@ -16,11 +16,11 @@ name = "bitnet_ffi"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common" }
-bitnet-models = { path = "../bitnet-models" }
-bitnet-inference = { path = "../bitnet-inference" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers" }
-bitnet-compat = { path = "../bitnet-compat" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-compat = { path = "../bitnet-compat", version = "0.2.1-dev" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -37,7 +37,7 @@ cudarc = { workspace = true, optional = true }
 cbindgen = "0.29.0"
 
 [dev-dependencies]
-bitnet-common = { path = "../bitnet-common" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 tempfile.workspace = true
 proptest = { workspace = true }
 

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -51,7 +51,7 @@ bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev" }
 rand = "0.9.2"
 insta.workspace = true
 rand_chacha = "0.9.0"
-bitnet-tests = { path = "../../tests" }
+bitnet-tests = { path = "../../tests", version = "0.2.1-dev" }
 bitnet-test-support.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_supported_without_gpu.snap.new
+++ b/crates/bitnet-runtime-profile-contract-core/tests/snapshots/snapshot_tests__active_profile_unit_local_supported_without_gpu.snap.new
@@ -1,6 +1,0 @@
----
-source: crates/bitnet-runtime-profile-contract-core/tests/snapshot_tests.rs
-assertion_line: 40
-expression: labels
----
-[]

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -21,11 +21,11 @@ anyhow.workspace = true
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
-bitnet-common = { path = "../bitnet-common" }
-bitnet-inference = { path = "../bitnet-inference" }
-bitnet-kernels = { path = "../bitnet-kernels" }
-bitnet-models = { path = "../bitnet-models" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "SafeTensors utilities for BitNet: LN inspection and LN-preserving merge"
-publish = false
 
 [dependencies]
 anyhow = "1.0.100"

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0.17"
 # Build-time dependencies for generating bindings
 bindgen = { version = "0.72.1", optional = true }
 cc = { version = "1.2.41", optional = true }
-xtask-build-helper = { path = "../../xtask-build-helper" }
+xtask-build-helper = { path = "../../xtask-build-helper", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-test-support/Cargo.toml
+++ b/crates/bitnet-test-support/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
 description = "Shared test infrastructure for BitNet-rs: EnvGuard/EnvScope, model-path gating, RNG seeds"
-publish = false
+publish = true
 
 [dependencies]
 # No runtime deps — this crate is intentionally minimal

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { workspace = true, features = ["full"] }
 tempfile = "3.23.0"
 temp-env = "0.3.6"
 serial_test.workspace = true
-bitnet-tests = { path = "../../tests" }
+bitnet-tests = { path = "../../tests", version = "0.2.1-dev" }
 bitnet-test-support.workspace = true
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-wasm/Cargo.toml
+++ b/crates/bitnet-wasm/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib", "rlib"]
 futures-util = "0.3.31"
 # getrandom for WASM compatibility
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
-bitnet-common = { path = "../bitnet-common" }
-bitnet-models = { path = "../bitnet-models" }
-bitnet-quantization = { path = "../bitnet-quantization" }
-bitnet-kernels = { path = "../bitnet-kernels", features = ["cpu"], optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", features = ["cpu"], optional = true }
 # Keep inference optional to avoid pulling tokio/mio on wasm by default.
-bitnet-inference = { path = "../bitnet-inference", optional = true, default-features = false }
-bitnet-tokenizers = { path = "../bitnet-tokenizers" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev", optional = true, default-features = false }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 
 # WebAssembly specific dependencies
 wasm-bindgen = { workspace = true, features = ["serde-serialize"] }

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -36,14 +36,14 @@ toml.workspace = true
 bindgen = { version = "0.72.1", optional = true }
 cc = { version = "1.2.46", optional = true }
 # bitnet-sys is needed for bitnet.cpp cross-validation (enabled via bitnet-ffi)
-bitnet-sys = { path = "../crates/bitnet-sys", optional = true }
+bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.1-dev", optional = true }
 
 # Internal crates for testing
-bitnet-inference = { path = "../crates/bitnet-inference" }
-bitnet-models = { path = "../crates/bitnet-models" }
-bitnet-common = { path = "../crates/bitnet-common" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", features = ["spm"] }
-bitnet-ggml-ffi = { path = "../crates/bitnet-ggml-ffi" }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev" }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", features = ["spm"] }
+bitnet-ggml-ffi = { path = "../crates/bitnet-ggml-ffi", version = "0.2.1-dev" }
 scopeguard = "1.2.0"
 dirs = "6.0.0"
 humantime = "2.3.0"
@@ -56,7 +56,7 @@ console = "0.16.1"  # For colored error messages in token parity
 criterion = { version = "0.7.0", features = ["html_reports"] }
 tempfile = "3.23.0"
 rand = "0.9.2"
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
 half = "2.7.1"
 serial_test = "3.2.0"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,24 +13,24 @@ libfuzzer-sys = "0.4.10"
 serde_json = "1.0.145"
 safetensors = "0.6.2"
 tempfile = "3"
-bitnet-quantization = { path = "../crates/bitnet-quantization" }
-bitnet-models = { path = "../crates/bitnet-models" }
-bitnet-kernels = { path = "../crates/bitnet-kernels" }
-bitnet-common = { path = "../crates/bitnet-common" }
-bitnet-gguf = { path = "../crates/bitnet-gguf" }
-bitnet-st2gguf = { path = "../crates/bitnet-st2gguf" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers" }
-bitnet-logits = { path = "../crates/bitnet-logits" }
-bitnet-generation = { path = "../crates/bitnet-generation" }
-bitnet-rope = { path = "../crates/bitnet-rope" }
-bitnet-sampling = { path = "../crates/bitnet-sampling" }
-bitnet-receipts = { path = "../crates/bitnet-receipts" }
-bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates" }
-bitnet-validation = { path = "../crates/bitnet-validation" }
-bitnet-engine-core = { path = "../crates/bitnet-engine-core" }
-bitnet-honest-compute = { path = "../crates/bitnet-honest-compute" }
-bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core" }
-bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core" }
+bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.1-dev" }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
+bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.1-dev" }
+bitnet-st2gguf = { path = "../crates/bitnet-st2gguf", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.1-dev" }
+bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.1-dev" }
+bitnet-rope = { path = "../crates/bitnet-rope", version = "0.2.1-dev" }
+bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.1-dev" }
+bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.1-dev" }
+bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.1-dev" }
+bitnet-validation = { path = "../crates/bitnet-validation", version = "0.2.1-dev" }
+bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.1-dev" }
+bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.1-dev" }
+bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }
 candle-core = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -357,24 +357,24 @@ cargo_metadata = "0.23.1"
 filetime = "0.2.26"
 
 # bitnet-rs crates for cross-validation
-bitnet-common = { path = "../crates/bitnet-common" }
-bitnet-inference = { path = "../crates/bitnet-inference", default-features = false, features = ["cpu", "rt-tokio"] }
-bitnet-models = { path = "../crates/bitnet-models" }
-bitnet-quantization = { path = "../crates/bitnet-quantization" }
-bitnet-kernels = { path = "../crates/bitnet-kernels" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers" }
-bitnet-compat = { path = "../crates/bitnet-compat" }
-bitnet-honest-compute = { path = "../crates/bitnet-honest-compute" }
-bitnet-sampling = { path = "../crates/bitnet-sampling" }
-bitnet-device-probe = { path = "../crates/bitnet-device-probe" }
-bitnet-logits = { path = "../crates/bitnet-logits" }
-bitnet-generation = { path = "../crates/bitnet-generation" }
-bitnet-engine-core = { path = "../crates/bitnet-engine-core" }
-bitnet-gguf = { path = "../crates/bitnet-gguf" }
-bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates" }
-bitnet-receipts = { path = "../crates/bitnet-receipts" }
-bitnet = { path = "../", default-features = false, features = ["cpu"] }
-bitnet-crossval = { path = "../crossval", package = "bitnet-crossval" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, features = ["cpu", "rt-tokio"] }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-compat = { path = "../crates/bitnet-compat", version = "0.2.1-dev" }
+bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.1-dev" }
+bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.1-dev" }
+bitnet-device-probe = { path = "../crates/bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.1-dev" }
+bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.1-dev" }
+bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.1-dev" }
+bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.1-dev" }
+bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.1-dev" }
+bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.1-dev" }
+bitnet = { path = "../", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
+bitnet-crossval = { path = "../crossval", version = "0.2.1-dev", package = "bitnet-crossval" }
 
 # Additional dependencies for fixtures
 bincode = "2.0.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,19 +25,19 @@ toml = "0.9.8"
 httpdate = "1.0.3"
 tempfile = "3.23.0"
 chrono = "0.4.42"
-bitnet-models = { path = "../crates/bitnet-models", default-features = false, features = ["cpu"] }
-bitnet-kernels = { path = "../crates/bitnet-kernels", default-features = false, features = ["cpu"] }
-bitnet-common = { path = "../crates/bitnet-common", default-features = false }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", default-features = false, features = ["spm"] }
-bitnet-inference = { path = "../crates/bitnet-inference", default-features = false, optional = true }
-bitnet = { path = "..", default-features = false, features = ["cpu"], optional = true }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev", default-features = false }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", default-features = false, features = ["spm"] }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, optional = true }
+bitnet = { path = "..", version = "0.2.1-dev", default-features = false, features = ["cpu"], optional = true }
 tokio = { version = "1.48.0", features = ["rt"], optional = true }
 futures = { version = "0.3.31", optional = true }
 regex = "1.12.2"
-xtask-build-helper = { path = "../xtask-build-helper" }
-bitnet-crossval = { path = "../crossval", default-features = false, optional = true }
-bitnet-sys = { path = "../crates/bitnet-sys", default-features = false, optional = true }
-bitnet-bdd-grid = { path = "../crates/bitnet-bdd-grid" }
+xtask-build-helper = { path = "../xtask-build-helper", version = "0.2.1-dev" }
+bitnet-crossval = { path = "../crossval", version = "0.2.1-dev", default-features = false, optional = true }
+bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.1-dev", default-features = false, optional = true }
+bitnet-bdd-grid = { path = "../crates/bitnet-bdd-grid", version = "0.2.1-dev" }
 scopeguard = "1.2.0"
 thiserror = "2.0.17"
 
@@ -55,4 +55,4 @@ assert_cmd = "2.1.1"
 predicates = "3.1.3"
 serial_test = "3.2.0"
 temp-env = "0.3.6"
-bitnet-test-support = { path = "../crates/bitnet-test-support" }
+bitnet-test-support.workspace = true


### PR DESCRIPTION
- Update path dependencies across all crates to include the required `version = "0.2.1-dev"` specification, which is required for `cargo publish`.
- Ensure workspace internal dependencies like `bitnet-test-support` do not have `publish = false`, making them available to other published crates.
- Refresh an outdated `insta` snapshot test in `bitnet-common` to successfully pass the verification pipeline.

---
*PR created automatically by Jules for task [9420358292589389217](https://jules.google.com/task/9420358292589389217) started by @EffortlessSteven*