### PR TITLE
docs: add Intel Arc GPU setup guide

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -177,6 +177,7 @@ While not breaking compatibility, we guarantee:
 - NVIDIA GPUs with compute capability 6.0+ (Pascal architecture, GTX 10 series and newer)
 - CUDA 11.0+ toolkit for compilation
 - Minimum 4GB VRAM for inference
+- Intel Arc A-series GPUs (A770, A750, A580) via OpenCL (`--features oneapi`); see [Intel GPU Setup](docs/INTEL_GPU_SETUP.md)
 
 ### Operating System Support
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Organised by [Diátaxis](https://diataxis.fr/):
 | [**Explanation**](docs/explanation/) | Architecture, quantization formats, dual-backend cross-val, feature flags |
 | [**Reference**](docs/reference/) | CLI flags, environment variables, API, quantization support |
 
-Key guides: [Quickstart](docs/quickstart.md) · [Environment variables](docs/environment-variables.md) · [GPU setup](docs/GPU_SETUP.md) · [C++ cross-validation](docs/howto/cpp-setup.md) · [Quantization support](docs/reference/quantization-support.md) · [Validation gates](docs/reference/validation-gates.md) · [Honest-compute receipts](docs/howto/receipt-verification.md) · [QK256 usage](docs/howto/use-qk256-models.md) · [macOS 26 Apple Silicon roadmap](docs/reference/macos-26-apple-silicon-roadmap.md)
+Key guides: [Quickstart](docs/quickstart.md) · [Environment variables](docs/environment-variables.md) · [GPU setup](docs/GPU_SETUP.md) · [Intel GPU setup](docs/INTEL_GPU_SETUP.md) · [C++ cross-validation](docs/howto/cpp-setup.md) · [Quantization support](docs/reference/quantization-support.md) · [Validation gates](docs/reference/validation-gates.md) · [Honest-compute receipts](docs/howto/receipt-verification.md) · [QK256 usage](docs/howto/use-qk256-models.md) · [macOS 26 Apple Silicon roadmap](docs/reference/macos-26-apple-silicon-roadmap.md)
 
 ## Building
 

--- a/docs/INTEL_GPU_SETUP.md
+++ b/docs/INTEL_GPU_SETUP.md
@@ -1,0 +1,177 @@
+# Intel Arc GPU Setup Guide
+
+## Overview
+
+BitNet-rs supports Intel Arc GPUs (A770, A750, etc.) via OpenCL through Intel's Compute Runtime.
+This guide covers environment setup, driver installation, and configuration for Intel GPU inference.
+
+## Requirements
+
+### Hardware
+- Intel Arc A-series GPU (A770, A750, A580, etc.)
+- PCIe 4.0 x16 slot (recommended)
+- 8GB+ VRAM for 2B parameter models
+
+### Software
+- Linux kernel ≥ 6.2 (i915 driver with Arc support)
+- Ubuntu 22.04/24.04, Fedora 37+, or equivalent
+- Intel Compute Runtime (OpenCL 3.0 + Level Zero 1.3)
+
+## Installation
+
+### Step 1: Verify Kernel Support
+
+```bash
+uname -r  # Should be ≥ 6.2
+dmesg | grep i915  # Should show GuC/HuC loaded
+lspci | grep -i vga  # Should show Intel Arc device
+```
+
+### Step 2: Install Intel GPU Drivers
+
+#### Ubuntu 22.04/24.04
+
+```bash
+# Add Intel GPU repository
+wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+  | sudo gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+  https://repositories.intel.com/gpu/ubuntu jammy unified" \
+  | sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+
+sudo apt-get update
+
+# Install compute runtime packages
+sudo apt-get install -y \
+  libze-intel-gpu1 \
+  libze1 \
+  intel-opencl-icd \
+  clinfo \
+  intel-gpu-tools
+```
+
+#### Fedora 37+
+
+```bash
+sudo dnf install -y \
+  intel-opencl \
+  level-zero \
+  clinfo \
+  intel-gpu-tools
+```
+
+### Step 3: Verify Installation
+
+```bash
+# Check OpenCL devices
+clinfo | grep -i intel
+
+# Check GPU utilization tool
+intel_gpu_top  # Should show your Arc device
+
+# Optional: Check Vulkan
+vulkaninfo | grep -i intel
+```
+
+### Step 4: User Permissions
+
+Add your user to the `render` and `video` groups:
+
+```bash
+sudo usermod -aG render,video $USER
+# Log out and back in for changes to take effect
+```
+
+## Building BitNet-rs with Intel GPU Support
+
+```bash
+# Build with OneAPI/OpenCL support
+cargo build --release --no-default-features --features oneapi
+
+# Build with both CPU and Intel GPU
+cargo build --release --no-default-features --features cpu,oneapi
+
+# Build optimized for native CPU + Intel GPU
+RUSTFLAGS="-C target-cpu=native -C opt-level=3" \
+  cargo build --release --no-default-features --features cpu,oneapi
+```
+
+## Running Inference
+
+```bash
+# Auto-detect device (prefers GPU if available)
+cargo run -p bitnet-cli --no-default-features --features oneapi,full-cli -- run \
+  --model models/model.gguf \
+  --tokenizer models/tokenizer.json \
+  --prompt "Hello world" \
+  --max-tokens 32
+
+# Force OpenCL device
+cargo run -p bitnet-cli --no-default-features --features oneapi,full-cli -- run \
+  --model models/model.gguf \
+  --tokenizer models/tokenizer.json \
+  --device opencl \
+  --prompt "Hello world" \
+  --max-tokens 32
+```
+
+## Environment Variables
+
+| Variable | Values | Description |
+|----------|--------|-------------|
+| `BITNET_GPU_FAKE` | `oneapi`, `none` | Override GPU detection for testing |
+| `BITNET_STRICT_MODE` | `1` | Force real hardware detection |
+| `RUST_LOG` | `info`, `debug` | Control log verbosity |
+
+## Profiling
+
+### intel_gpu_top
+```bash
+# Monitor GPU utilization during inference
+sudo intel_gpu_top
+```
+
+### OpenCL Event Timing
+BitNet-rs uses OpenCL event profiling internally when `RUST_LOG=debug` is set.
+
+## Troubleshooting
+
+### "No OpenCL devices found"
+1. Check driver installation: `clinfo`
+2. Check permissions: user must be in `render` and `video` groups
+3. Check kernel module: `lsmod | grep i915`
+4. Check firmware: `dmesg | grep -i guc`
+
+### "OpenCL kernel compilation failed"
+1. Ensure `intel-opencl-icd` is installed
+2. Try updating Intel Compute Runtime to latest version
+3. Check `RUST_LOG=debug` output for OpenCL compiler errors
+
+### Performance Issues
+1. Use `intel_gpu_top` to check GPU utilization
+2. Ensure PCIe link is x16 (check `lspci -vv`)
+3. Try adjusting work-group sizes (advanced)
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│         BitNet Inference Engine      │
+├─────────┬───────────┬───────────────┤
+│ CPU     │ CUDA      │ OpenCL        │
+│ (SIMD)  │ (NVIDIA)  │ (Intel Arc)   │
+├─────────┴───────────┴───────────────┤
+│        KernelProvider Trait          │
+├─────────┬───────────┬───────────────┤
+│ AVX2/   │ cudarc    │ opencl3       │
+│ AVX-512 │ (PTX)     │ (.cl kernels) │
+└─────────┴───────────┴───────────────┘
+```
+
+## Known Limitations (MVP)
+
+- OpenCL backend is initial implementation; performance tuning ongoing
+- Level Zero backend planned for future optimization
+- Vulkan compute path planned as alternative
+- Some operations may fall back to CPU during early development

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
 - [CPU Kernel Architecture](cpu-kernel-architecture.md)
 - [GPU Kernel Architecture](gpu-kernel-architecture.md)
 - [CUDA Configuration Guide](cuda-configuration-guide.md)
+- [Intel Arc GPU Setup](INTEL_GPU_SETUP.md)
 
 ## Miscellaneous
 - [GGUF Inspection](gguf-inspection.md)


### PR DESCRIPTION
## Summary
Create comprehensive documentation for Intel GPU setup and usage.

## Changes
- Create `docs/INTEL_GPU_SETUP.md` with driver installation, build, and usage instructions
- Update README.md with Intel GPU support mention
- Update COMPATIBILITY.md with Intel Arc hardware

Part of Intel Arc GPU support epic.
