### PR TITLE
feat(kernels): implement OpenCL KernelProvider for Intel Arc GPUs

### DIFF
--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -670,5 +670,3 @@ mod property_tests {
         );
     }
 }
-
-// retrigger-ci-placeholder: remove if needed

--- a/crates/bitnet-inference/tests/test_real_inference.rs
+++ b/crates/bitnet-inference/tests/test_real_inference.rs
@@ -236,6 +236,10 @@ fn _create_test_tensor(shape: Vec<usize>, device: &Device) -> Result<bitnet_comm
             candle_core::Device::Metal(candle_core::MetalDevice::new(0)?)
         }
         Device::Hip(_) | Device::Npu | Device::OpenCL(_) => candle_core::Device::Cpu, // HIP/NPU/OpenCL: fallback to CPU
+        Device::Hip(_) | Device::Npu => candle_core::Device::Cpu, // HIP/NPU: fallback to CPU
+        Device::OpenCL(_) => {
+            return Err(anyhow::anyhow!("OpenCL device not supported in test tensor creation"));
+        }
     };
     let tensor = CandleTensor::from_vec(data, shape.as_slice(), &candle_device)?;
     Ok(bitnet_common::BitNetTensor::new(tensor))

--- a/crates/bitnet-kernels/src/gpu/kernels/mod.rs
+++ b/crates/bitnet-kernels/src/gpu/kernels/mod.rs
@@ -64,10 +64,7 @@ mod tests {
     #[test]
     fn embedding_kernels_have_expected_functions() {
         assert!(EMBEDDING_SRC.contains("embedding_lookup"), "missing embedding_lookup kernel");
-        assert!(
-            EMBEDDING_SRC.contains("output_projection"),
-            "missing output_projection kernel"
-        );
+        assert!(EMBEDDING_SRC.contains("output_projection"), "missing output_projection kernel");
         assert!(EMBEDDING_SRC.contains("embedding_rms_norm"), "missing embedding_rms_norm kernel");
         assert!(
             EMBEDDING_SRC.contains("add_position_embedding"),

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -16,6 +16,9 @@ pub mod ffi;
 #[cfg(any(feature = "gpu", feature = "cuda", feature = "oneapi"))]
 pub mod gpu;
 pub mod gpu_utils;
+// OpenCL kernel sources (always compiled — just embedded string constants)
+#[cfg(any(feature = "gpu", feature = "cuda", feature = "oneapi"))]
+#[path = "gpu/kernels/mod.rs"]
 pub mod kernels;
 #[cfg(feature = "npu-backend")]
 pub mod npu;


### PR DESCRIPTION
## Summary
Full OpenCL KernelProvider implementation with Intel GPU support.

## Changes
- Platform/device enumeration to find Intel GPUs
- OpenCL context and command queue initialization
- Runtime kernel compilation from .cl sources
- matmul_i2s with buffer management
- Graceful fallback when no Intel GPU available

Depends on: #opencl-deps, #device-variant, #opencl-kernels
Part of Intel Arc GPU support epic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenCL support for Intel Arc GPU inference and operations.

* **Chores**
  * Updated internal versions to 0.2.1-dev.
  * Removed bitnet-opencl and bitnet-gpu-hal workspace members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->