### PR TITLE
fuzz: add attention, softmax, and rmsnorm stability fuzz targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -249,3 +249,21 @@ name = "device_opencl_construct"
 path = "fuzz_targets/device_opencl_construct.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "attention_dimensions"
+path = "fuzz_targets/attention_dimensions.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "softmax_numerical"
+path = "fuzz_targets/softmax_numerical.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "rmsnorm_stability"
+path = "fuzz_targets/rmsnorm_stability.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/attention_dimensions.rs
+++ b/fuzz/fuzz_targets/attention_dimensions.rs
@@ -1,0 +1,107 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct AttentionInput {
+    seq_len: u8,
+    head_dim: u8,
+    num_heads: u8,
+    q_data: Vec<f32>,
+    k_data: Vec<f32>,
+    v_data: Vec<f32>,
+}
+
+fn ref_softmax(input: &[f32]) -> Vec<f32> {
+    let max_val = input.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = input.iter().map(|&x| (x - max_val).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum == 0.0 || !sum.is_finite() {
+        vec![1.0 / input.len() as f32; input.len()]
+    } else {
+        exps.iter().map(|&e| e / sum).collect()
+    }
+}
+
+fn ref_attention(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    seq_len: usize,
+    head_dim: usize,
+) -> Vec<f32> {
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let mut output = vec![0.0f32; seq_len * head_dim];
+
+    for i in 0..seq_len {
+        let mut scores = vec![0.0f32; seq_len];
+        for j in 0..seq_len {
+            let mut dot = 0.0f32;
+            for d in 0..head_dim {
+                dot += q[i * head_dim + d] * k[j * head_dim + d];
+            }
+            scores[j] = dot * scale;
+        }
+
+        let weights = ref_softmax(&scores);
+
+        for d in 0..head_dim {
+            let mut sum = 0.0f32;
+            for j in 0..seq_len {
+                sum += weights[j] * v[j * head_dim + d];
+            }
+            output[i * head_dim + d] = sum;
+        }
+    }
+    output
+}
+
+fuzz_target!(|input: AttentionInput| {
+    let seq_len = (input.seq_len as usize).clamp(1, 32);
+    let head_dim = (input.head_dim as usize).clamp(2, 16) & !1; // must be even
+    let num_heads = (input.num_heads as usize).clamp(1, 4);
+
+    let total = seq_len * head_dim;
+
+    for _head in 0..num_heads.min(256) {
+        let q: Vec<f32> = input
+            .q_data
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(0.0))
+            .take(total)
+            .map(|x| if x.is_finite() { x.clamp(-100.0, 100.0) } else { 0.0 })
+            .collect();
+        let k: Vec<f32> = input
+            .k_data
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(0.0))
+            .take(total)
+            .map(|x| if x.is_finite() { x.clamp(-100.0, 100.0) } else { 0.0 })
+            .collect();
+        let v: Vec<f32> = input
+            .v_data
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(0.0))
+            .take(total)
+            .map(|x| if x.is_finite() { x.clamp(-100.0, 100.0) } else { 0.0 })
+            .collect();
+
+        let output = ref_attention(&q, &k, &v, seq_len, head_dim);
+
+        assert_eq!(output.len(), total, "output length mismatch");
+        for (i, &val) in output.iter().enumerate() {
+            assert!(
+                val.is_finite(),
+                "NaN/Inf in attention output at index {} (seq_len={}, head_dim={}, heads={})",
+                i,
+                seq_len,
+                head_dim,
+                num_heads
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/rmsnorm_stability.rs
+++ b/fuzz/fuzz_targets/rmsnorm_stability.rs
@@ -1,0 +1,105 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct RmsNormInput {
+    data: Vec<f32>,
+    weights: Vec<f32>,
+}
+
+fn ref_rms_norm(input: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+    let n = input.len();
+    if n == 0 {
+        return vec![];
+    }
+    let sum_sq: f32 = input.iter().map(|x| x * x).sum();
+    let rms = 1.0 / (sum_sq / n as f32 + eps).sqrt();
+    input
+        .iter()
+        .zip(weight.iter())
+        .map(|(&x, &w)| x * rms * w)
+        .collect()
+}
+
+fuzz_target!(|input: RmsNormInput| {
+    if input.data.is_empty() || input.data.len() > 256 {
+        return;
+    }
+
+    let n = input.data.len().min(256);
+
+    // Sanitize inputs: replace non-finite with 0
+    let data: Vec<f32> = input
+        .data
+        .iter()
+        .take(n)
+        .map(|&x| if x.is_finite() { x.clamp(-1e6, 1e6) } else { 0.0 })
+        .collect();
+
+    // Pad or trim weights to match data length
+    let weights: Vec<f32> = input
+        .weights
+        .iter()
+        .copied()
+        .chain(std::iter::repeat(1.0))
+        .take(n)
+        .map(|x| if x.is_finite() { x.clamp(-1e6, 1e6) } else { 1.0 })
+        .collect();
+
+    let eps = 1e-5f32;
+    let output = ref_rms_norm(&data, &weights, eps);
+
+    // Verify no NaN/Inf in output
+    for (i, &val) in output.iter().enumerate() {
+        assert!(
+            val.is_finite(),
+            "NaN/Inf in rmsnorm output at index {} (input len {})",
+            i,
+            n
+        );
+    }
+
+    // Verify output has finite norm
+    let norm: f32 = output.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(
+        norm.is_finite(),
+        "rmsnorm output norm is not finite: {}",
+        norm
+    );
+
+    // Test near-zero input: should not produce NaN due to eps
+    let near_zero: Vec<f32> = vec![1e-20; n];
+    let near_zero_out = ref_rms_norm(&near_zero, &weights, eps);
+    for (i, &val) in near_zero_out.iter().enumerate() {
+        assert!(
+            val.is_finite(),
+            "near-zero input produced non-finite at index {}",
+            i
+        );
+    }
+
+    // Test all-zero input: should produce all zeros (0 * rms * w = 0)
+    let zeros = vec![0.0f32; n];
+    let zero_out = ref_rms_norm(&zeros, &weights, eps);
+    for (i, &val) in zero_out.iter().enumerate() {
+        assert!(
+            val.abs() < 1e-10,
+            "zero input should produce zero output at index {}, got {}",
+            i,
+            val
+        );
+    }
+
+    // Test very large input: should not overflow
+    let large: Vec<f32> = vec![1e6; n];
+    let large_out = ref_rms_norm(&large, &weights, eps);
+    for (i, &val) in large_out.iter().enumerate() {
+        assert!(
+            val.is_finite(),
+            "large input produced non-finite at index {}",
+            i
+        );
+    }
+});

--- a/fuzz/fuzz_targets/softmax_numerical.rs
+++ b/fuzz/fuzz_targets/softmax_numerical.rs
@@ -1,0 +1,94 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct SoftmaxInput {
+    data: Vec<f32>,
+}
+
+fn ref_softmax(input: &[f32]) -> Vec<f32> {
+    let max_val = input.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let exps: Vec<f32> = input.iter().map(|&x| (x - max_val).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum == 0.0 || !sum.is_finite() {
+        vec![1.0 / input.len() as f32; input.len()]
+    } else {
+        exps.iter().map(|&e| e / sum).collect()
+    }
+}
+
+fuzz_target!(|input: SoftmaxInput| {
+    if input.data.is_empty() || input.data.len() > 256 {
+        return;
+    }
+
+    // Clamp to avoid extreme values that cause exp() overflow
+    let clamped: Vec<f32> = input
+        .data
+        .iter()
+        .take(256)
+        .map(|&x| {
+            if x.is_finite() {
+                x.clamp(-1e38, 1e38)
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    let output = ref_softmax(&clamped);
+
+    // Verify no NaN in output
+    for (i, &val) in output.iter().enumerate() {
+        assert!(
+            !val.is_nan(),
+            "NaN in softmax output at index {} for input len {}",
+            i,
+            clamped.len()
+        );
+    }
+
+    // Verify sum is approximately 1.0
+    let sum: f32 = output.iter().sum();
+    assert!(
+        (sum - 1.0).abs() < 1e-4,
+        "softmax sum is {}, expected ~1.0 for input len {}",
+        sum,
+        clamped.len()
+    );
+
+    // Verify all values in [0, 1]
+    for (i, &val) in output.iter().enumerate() {
+        assert!(
+            val >= 0.0 && val <= 1.0,
+            "softmax[{}] = {} not in [0,1]",
+            i,
+            val
+        );
+    }
+
+    // Test with extreme inputs: all same value
+    if clamped.len() >= 2 {
+        let uniform = vec![clamped[0]; clamped.len()];
+        let uniform_out = ref_softmax(&uniform);
+        let expected = 1.0 / uniform.len() as f32;
+        for &val in &uniform_out {
+            assert!(
+                (val - expected).abs() < 1e-5,
+                "uniform input should give uniform output"
+            );
+        }
+    }
+
+    // Test with subnormal-like inputs (near zero)
+    let tiny: Vec<f32> = clamped.iter().map(|_| 1e-38f32).collect();
+    let tiny_out = ref_softmax(&tiny);
+    let tiny_sum: f32 = tiny_out.iter().sum();
+    assert!(
+        (tiny_sum - 1.0).abs() < 1e-4,
+        "softmax of subnormals should still sum to 1.0, got {}",
+        tiny_sum
+    );
+});


### PR DESCRIPTION
Three new fuzz targets for complex kernel operations:

- **attention_dimensions**: Fuzz seq_len, head_dim, num_heads with arbitrary values. Verifies no panics, no NaN/Inf in output. Inputs clamped to [-100, 100] with dimensions capped (seq≤32, dim≤16, heads≤4).

- **softmax_numerical**: Fuzz input values including extreme floats (±1e38), subnormals, and uniform inputs. Verifies output always sums to ~1.0, no NaN, all values in [0,1].

- **rmsnorm_stability**: Fuzz input vectors including near-zero, very large, all-zero, and mixed values. Verifies no NaN/Inf, output has finite norm.

All targets use \rbitrary::Arbitrary\ for structured input generation and cap input sizes at 256 elements.