### PR TITLE
feat: create bitnet-vulkan microcrate for Vulkan compute backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "bitnet-tests",
  "bitnet-tokenizers",
  "bitnet-transformer",
+ "bitnet-vulkan",
  "byteorder",
  "candle-core",
  "chrono",
@@ -1409,6 +1410,17 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "tempfile",
+]
+
+[[package]]
+name = "bitnet-vulkan"
+version = "0.2.1-dev"
+dependencies = [
+ "ash",
+ "bitnet-common",
+ "proptest",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-vulkan",        # Vulkan compute backend
   "crossval",
   "tests",
   "xtask",
@@ -152,6 +153,7 @@ bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi"
 bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.1-dev", optional = true }
 bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.1-dev", optional = true }
 bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.1-dev", optional = true }
+bitnet-vulkan = { path = "crates/bitnet-vulkan", version = "0.2.1-dev", optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
@@ -208,7 +210,7 @@ spm = []                                                                        
 cpu = ["kernels", "inference", "tokenizers", "bitnet-kernels/cpu-optimized", "bitnet-inference/cpu", "bitnet-quantization/cpu"]
 cuda = ["gpu"]                                                                                       # Alias for backward compatibility
 gpu = ["kernels", "inference", "tokenizers", "bitnet-kernels/gpu", "bitnet-inference/gpu", "bitnet-quantization/gpu"]
-vulkan = ["kernels", "inference", "tokenizers", "bitnet-kernels/vulkan", "bitnet-inference/gpu", "bitnet-quantization/gpu"]
+vulkan = ["kernels", "inference", "tokenizers", "bitnet-kernels/vulkan", "bitnet-inference/gpu", "bitnet-quantization/gpu", "dep:bitnet-vulkan"]
 metal = ["kernels", "inference", "tokenizers", "bitnet-common/metal", "bitnet-inference/metal"]
 
 # Component features

--- a/crates/bitnet-vulkan/Cargo.toml
+++ b/crates/bitnet-vulkan/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bitnet-vulkan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Vulkan compute backend for BitNet-rs inference"
+rust-version.workspace = true
+
+[dependencies]
+ash = "0.38"
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-vulkan/src/buffer.rs
+++ b/crates/bitnet-vulkan/src/buffer.rs
@@ -1,0 +1,182 @@
+//! GPU buffer management with staging and device-local memory.
+
+use crate::error::{Result, VulkanError};
+use ash::vk;
+use tracing::debug;
+
+/// Usage hint for buffer allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferUsage {
+    /// Host-visible staging buffer for CPU→GPU transfers.
+    Staging,
+    /// Device-local buffer for GPU compute (not host-visible).
+    DeviceLocal,
+    /// Device-local storage buffer for shader read/write.
+    Storage,
+}
+
+/// Describes a buffer allocation request.
+#[derive(Debug, Clone)]
+pub struct BufferDescriptor {
+    /// Size in bytes.
+    pub size: vk::DeviceSize,
+    /// Intended usage pattern.
+    pub usage: BufferUsage,
+    /// Human-readable label for debugging.
+    pub label: String,
+}
+
+/// A GPU buffer with its backing memory.
+///
+/// The caller must call [`GpuBuffer::destroy`] before dropping.
+pub struct GpuBuffer {
+    /// Raw Vulkan buffer handle.
+    pub buffer: vk::Buffer,
+    /// Backing device memory.
+    pub memory: vk::DeviceMemory,
+    /// Allocated size in bytes.
+    pub size: vk::DeviceSize,
+    /// Usage that was requested.
+    pub usage: BufferUsage,
+}
+
+impl GpuBuffer {
+    /// Destroy the buffer and free its memory.
+    ///
+    /// # Safety
+    /// Must only be called once. The device must be the same one used to
+    /// create the buffer.
+    pub unsafe fn destroy(&self, device: &ash::Device) {
+        unsafe {
+            device.destroy_buffer(self.buffer, None);
+            device.free_memory(self.memory, None);
+        }
+    }
+}
+
+/// Find a memory type index matching the requested properties.
+pub fn find_memory_type(
+    memory_properties: &vk::PhysicalDeviceMemoryProperties,
+    type_filter: u32,
+    required_flags: vk::MemoryPropertyFlags,
+) -> Result<u32> {
+    for i in 0..memory_properties.memory_type_count {
+        let type_ok = (type_filter & (1 << i)) != 0;
+        let flags_ok = memory_properties.memory_types[i as usize].property_flags
+            & required_flags
+            == required_flags;
+        if type_ok && flags_ok {
+            return Ok(i);
+        }
+    }
+    Err(VulkanError::NoSuitableMemoryType(format!(
+        "no memory type with filter={type_filter:#x} flags={required_flags:?}"
+    )))
+}
+
+/// Allocate a GPU buffer with the given descriptor.
+pub fn allocate_buffer(
+    device: &ash::Device,
+    memory_properties: &vk::PhysicalDeviceMemoryProperties,
+    desc: &BufferDescriptor,
+) -> Result<GpuBuffer> {
+    let (vk_usage, mem_flags) = match desc.usage {
+        BufferUsage::Staging => (
+            vk::BufferUsageFlags::TRANSFER_SRC
+                | vk::BufferUsageFlags::TRANSFER_DST,
+            vk::MemoryPropertyFlags::HOST_VISIBLE
+                | vk::MemoryPropertyFlags::HOST_COHERENT,
+        ),
+        BufferUsage::DeviceLocal => (
+            vk::BufferUsageFlags::STORAGE_BUFFER
+                | vk::BufferUsageFlags::TRANSFER_DST,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        ),
+        BufferUsage::Storage => (
+            vk::BufferUsageFlags::STORAGE_BUFFER
+                | vk::BufferUsageFlags::TRANSFER_SRC
+                | vk::BufferUsageFlags::TRANSFER_DST,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        ),
+    };
+
+    let buffer_info = vk::BufferCreateInfo::default()
+        .size(desc.size)
+        .usage(vk_usage)
+        .sharing_mode(vk::SharingMode::EXCLUSIVE);
+
+    let buffer = unsafe {
+        device.create_buffer(&buffer_info, None).map_err(|e| {
+            VulkanError::BufferAllocation(format!("vkCreateBuffer failed: {e}"))
+        })?
+    };
+
+    let mem_requirements =
+        unsafe { device.get_buffer_memory_requirements(buffer) };
+    let memory_type_index = find_memory_type(
+        memory_properties,
+        mem_requirements.memory_type_bits,
+        mem_flags,
+    )?;
+
+    let alloc_info = vk::MemoryAllocateInfo::default()
+        .allocation_size(mem_requirements.size)
+        .memory_type_index(memory_type_index);
+
+    let memory = unsafe {
+        device.allocate_memory(&alloc_info, None).map_err(|e| {
+            VulkanError::BufferAllocation(format!(
+                "vkAllocateMemory failed: {e}"
+            ))
+        })?
+    };
+
+    unsafe {
+        device
+            .bind_buffer_memory(buffer, memory, 0)
+            .map_err(|e| {
+                VulkanError::BufferAllocation(format!(
+                    "vkBindBufferMemory failed: {e}"
+                ))
+            })?;
+    }
+
+    debug!(
+        "Allocated {:?} buffer '{}' ({} bytes)",
+        desc.usage, desc.label, desc.size
+    );
+
+    Ok(GpuBuffer {
+        buffer,
+        memory,
+        size: desc.size,
+        usage: desc.usage,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffer_descriptor_construction() {
+        let desc = BufferDescriptor {
+            size: 4096,
+            usage: BufferUsage::Staging,
+            label: "weights".into(),
+        };
+        assert_eq!(desc.size, 4096);
+        assert_eq!(desc.usage, BufferUsage::Staging);
+    }
+
+    #[test]
+    fn find_memory_type_no_match() {
+        let props = vk::PhysicalDeviceMemoryProperties::default();
+        let result = find_memory_type(
+            &props,
+            0xFFFF_FFFF,
+            vk::MemoryPropertyFlags::DEVICE_LOCAL,
+        );
+        assert!(result.is_err());
+    }
+}

--- a/crates/bitnet-vulkan/src/command.rs
+++ b/crates/bitnet-vulkan/src/command.rs
@@ -1,0 +1,167 @@
+//! Command buffer recording and submission for compute dispatches.
+
+use crate::error::{Result, VulkanError};
+use ash::vk;
+use tracing::debug;
+
+/// A command pool paired with its queue family index.
+pub struct CommandPool {
+    /// Raw Vulkan command pool.
+    pub pool: vk::CommandPool,
+    /// Queue family index this pool targets.
+    pub queue_family: u32,
+}
+
+impl CommandPool {
+    /// Create a new command pool for the given queue family.
+    pub fn new(device: &ash::Device, queue_family: u32) -> Result<Self> {
+        let create_info = vk::CommandPoolCreateInfo::default()
+            .queue_family_index(queue_family)
+            .flags(vk::CommandPoolCreateFlags::RESET_COMMAND_BUFFER);
+
+        let pool = unsafe {
+            device
+                .create_command_pool(&create_info, None)
+                .map_err(|e| {
+                    VulkanError::CommandBuffer(format!(
+                        "vkCreateCommandPool failed: {e}"
+                    ))
+                })?
+        };
+
+        debug!("Command pool created for queue family {queue_family}");
+        Ok(Self {
+            pool,
+            queue_family,
+        })
+    }
+
+    /// Allocate a single primary command buffer from this pool.
+    pub fn allocate_command_buffer(
+        &self,
+        device: &ash::Device,
+    ) -> Result<vk::CommandBuffer> {
+        let alloc_info = vk::CommandBufferAllocateInfo::default()
+            .command_pool(self.pool)
+            .level(vk::CommandBufferLevel::PRIMARY)
+            .command_buffer_count(1);
+
+        let buffers = unsafe {
+            device
+                .allocate_command_buffers(&alloc_info)
+                .map_err(|e| {
+                    VulkanError::CommandBuffer(format!(
+                        "vkAllocateCommandBuffers failed: {e}"
+                    ))
+                })?
+        };
+
+        Ok(buffers[0])
+    }
+
+    /// Destroy the command pool.
+    ///
+    /// # Safety
+    /// Must only be called once; all command buffers allocated from this pool
+    /// become invalid.
+    pub unsafe fn destroy(&self, device: &ash::Device) {
+        unsafe {
+            device.destroy_command_pool(self.pool, None);
+        }
+    }
+}
+
+/// Record and submit a compute dispatch.
+///
+/// Records `begin → bind pipeline → dispatch → end` and submits to the given
+/// queue, waiting on a fence for completion.
+pub fn record_and_submit_compute(
+    device: &ash::Device,
+    cmd: vk::CommandBuffer,
+    pipeline: vk::Pipeline,
+    _pipeline_layout: vk::PipelineLayout,
+    group_count: [u32; 3],
+    queue: vk::Queue,
+) -> Result<()> {
+    let begin_info = vk::CommandBufferBeginInfo::default()
+        .flags(vk::CommandBufferUsageFlags::ONE_TIME_SUBMIT);
+
+    unsafe {
+        device
+            .begin_command_buffer(cmd, &begin_info)
+            .map_err(|e| {
+                VulkanError::CommandBuffer(format!(
+                    "vkBeginCommandBuffer failed: {e}"
+                ))
+            })?;
+
+        device.cmd_bind_pipeline(
+            cmd,
+            vk::PipelineBindPoint::COMPUTE,
+            pipeline,
+        );
+        device.cmd_dispatch(
+            cmd,
+            group_count[0],
+            group_count[1],
+            group_count[2],
+        );
+
+        device.end_command_buffer(cmd).map_err(|e| {
+            VulkanError::CommandBuffer(format!(
+                "vkEndCommandBuffer failed: {e}"
+            ))
+        })?;
+    }
+
+    // Create a fence for synchronization.
+    let fence_info = vk::FenceCreateInfo::default();
+    let fence = unsafe {
+        device
+            .create_fence(&fence_info, None)
+            .map_err(|e| {
+                VulkanError::QueueSubmit(format!("create fence: {e}"))
+            })?
+    };
+
+    let cmd_buffers = [cmd];
+    let submit_info =
+        vk::SubmitInfo::default().command_buffers(&cmd_buffers);
+
+    unsafe {
+        device
+            .queue_submit(queue, &[submit_info], fence)
+            .map_err(|e| {
+                VulkanError::QueueSubmit(format!("vkQueueSubmit: {e}"))
+            })?;
+
+        device
+            .wait_for_fences(&[fence], true, u64::MAX)
+            .map_err(|e| {
+                VulkanError::QueueSubmit(format!("wait fence: {e}"))
+            })?;
+
+        device.destroy_fence(fence, None);
+    }
+
+    debug!(
+        "Compute dispatch submitted: groups=[{},{},{}]",
+        group_count[0], group_count[1], group_count[2]
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_pool_stores_queue_family() {
+        let pool = CommandPool {
+            pool: vk::CommandPool::null(),
+            queue_family: 2,
+        };
+        assert_eq!(pool.queue_family, 2);
+    }
+}

--- a/crates/bitnet-vulkan/src/device.rs
+++ b/crates/bitnet-vulkan/src/device.rs
@@ -1,0 +1,200 @@
+//! Physical and logical device selection, preferring dedicated compute queues.
+
+use crate::error::{Result, VulkanError};
+use ash::vk;
+use tracing::{debug, info};
+
+/// Criteria for selecting a physical device.
+#[derive(Debug, Clone)]
+pub struct DeviceSelector {
+    /// Prefer discrete GPUs over integrated.
+    pub prefer_discrete: bool,
+    /// Require a dedicated compute queue family (not shared with graphics).
+    pub require_compute_queue: bool,
+}
+
+impl Default for DeviceSelector {
+    fn default() -> Self {
+        Self {
+            prefer_discrete: true,
+            require_compute_queue: false,
+        }
+    }
+}
+
+/// Information about a selected physical device and its compute queue family.
+#[derive(Debug, Clone)]
+pub struct SelectedDevice {
+    /// Vulkan physical device handle.
+    pub physical_device: vk::PhysicalDevice,
+    /// Index of the queue family used for compute.
+    pub compute_queue_family: u32,
+    /// Device name from the driver.
+    pub device_name: String,
+    /// Device type (discrete, integrated, etc.).
+    pub device_type: vk::PhysicalDeviceType,
+}
+
+/// Score a physical device for compute suitability.
+fn score_device(
+    instance: &ash::Instance,
+    device: vk::PhysicalDevice,
+    selector: &DeviceSelector,
+) -> Option<(u32, u32)> {
+    let props = unsafe { instance.get_physical_device_properties(device) };
+    let queue_families =
+        unsafe { instance.get_physical_device_queue_family_properties(device) };
+
+    // Find a queue family that supports compute.
+    let compute_family = queue_families.iter().enumerate().find_map(|(i, qf)| {
+        if qf.queue_flags.contains(vk::QueueFlags::COMPUTE) {
+            Some(i as u32)
+        } else {
+            None
+        }
+    });
+
+    let compute_family = compute_family?;
+
+    // Check if there's a dedicated compute queue (no graphics bit).
+    let has_dedicated_compute = queue_families.iter().any(|qf| {
+        qf.queue_flags.contains(vk::QueueFlags::COMPUTE)
+            && !qf.queue_flags.contains(vk::QueueFlags::GRAPHICS)
+    });
+
+    if selector.require_compute_queue && !has_dedicated_compute {
+        return None;
+    }
+
+    let mut score: u32 = 0;
+    if selector.prefer_discrete
+        && props.device_type == vk::PhysicalDeviceType::DISCRETE_GPU
+    {
+        score += 1000;
+    }
+    if has_dedicated_compute {
+        score += 500;
+    }
+    // Prefer dedicated compute queue family index.
+    let best_compute_family = queue_families
+        .iter()
+        .enumerate()
+        .find_map(|(i, qf)| {
+            if qf.queue_flags.contains(vk::QueueFlags::COMPUTE)
+                && !qf.queue_flags.contains(vk::QueueFlags::GRAPHICS)
+            {
+                Some(i as u32)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(compute_family);
+
+    Some((score, best_compute_family))
+}
+
+/// Select the best physical device for compute workloads.
+pub fn select_physical_device(
+    instance: &ash::Instance,
+    selector: &DeviceSelector,
+) -> Result<SelectedDevice> {
+    let devices = unsafe {
+        instance
+            .enumerate_physical_devices()
+            .map_err(|e| VulkanError::NoSuitableDevice(format!("{e}")))?
+    };
+
+    if devices.is_empty() {
+        return Err(VulkanError::NoSuitableDevice(
+            "no Vulkan physical devices found".into(),
+        ));
+    }
+
+    let best = devices
+        .iter()
+        .filter_map(|&dev| {
+            let (score, family) = score_device(instance, dev, selector)?;
+            Some((dev, score, family))
+        })
+        .max_by_key(|&(_, score, _)| score);
+
+    match best {
+        Some((device, _score, family)) => {
+            let props =
+                unsafe { instance.get_physical_device_properties(device) };
+            let name = unsafe {
+                std::ffi::CStr::from_ptr(props.device_name.as_ptr())
+                    .to_string_lossy()
+                    .into_owned()
+            };
+            info!(
+                "Selected Vulkan device: {} (type={:?}, compute_family={})",
+                name, props.device_type, family
+            );
+            Ok(SelectedDevice {
+                physical_device: device,
+                compute_queue_family: family,
+                device_name: name,
+                device_type: props.device_type,
+            })
+        }
+        None => Err(VulkanError::NoSuitableDevice(
+            "no device meets selection criteria".into(),
+        )),
+    }
+}
+
+/// Create a logical device with a single compute queue.
+pub fn create_logical_device(
+    instance: &ash::Instance,
+    selected: &SelectedDevice,
+) -> Result<(ash::Device, vk::Queue)> {
+    let queue_priority = [1.0_f32];
+    let queue_create_info = vk::DeviceQueueCreateInfo::default()
+        .queue_family_index(selected.compute_queue_family)
+        .queue_priorities(&queue_priority);
+
+    let queue_create_infos = [queue_create_info];
+    let device_create_info =
+        vk::DeviceCreateInfo::default().queue_create_infos(&queue_create_infos);
+
+    let device = unsafe {
+        instance
+            .create_device(
+                selected.physical_device,
+                &device_create_info,
+                None,
+            )
+            .map_err(|e| VulkanError::DeviceCreation(format!("{e}")))?
+    };
+
+    let queue =
+        unsafe { device.get_device_queue(selected.compute_queue_family, 0) };
+    debug!("Logical device created with compute queue");
+
+    Ok((device, queue))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_selector_defaults() {
+        let sel = DeviceSelector::default();
+        assert!(sel.prefer_discrete);
+        assert!(!sel.require_compute_queue);
+    }
+
+    #[test]
+    fn selected_device_debug_format() {
+        let sel = SelectedDevice {
+            physical_device: vk::PhysicalDevice::null(),
+            compute_queue_family: 0,
+            device_name: "Test GPU".into(),
+            device_type: vk::PhysicalDeviceType::DISCRETE_GPU,
+        };
+        let dbg = format!("{sel:?}");
+        assert!(dbg.contains("Test GPU"));
+    }
+}

--- a/crates/bitnet-vulkan/src/error.rs
+++ b/crates/bitnet-vulkan/src/error.rs
@@ -1,0 +1,84 @@
+//! Error types for the Vulkan compute backend.
+
+use thiserror::Error;
+
+/// Errors that can occur in the Vulkan backend.
+#[derive(Debug, Error)]
+pub enum VulkanError {
+    /// Vulkan instance creation failed.
+    #[error("failed to create Vulkan instance: {0}")]
+    InstanceCreation(String),
+
+    /// No suitable physical device found.
+    #[error("no suitable Vulkan physical device found: {0}")]
+    NoSuitableDevice(String),
+
+    /// Logical device creation failed.
+    #[error("failed to create logical device: {0}")]
+    DeviceCreation(String),
+
+    /// Compute pipeline creation failed.
+    #[error("failed to create compute pipeline: {0}")]
+    PipelineCreation(String),
+
+    /// Shader module compilation/loading failed.
+    #[error("failed to load SPIR-V shader: {0}")]
+    ShaderLoad(String),
+
+    /// Buffer allocation failed.
+    #[error("buffer allocation failed: {0}")]
+    BufferAllocation(String),
+
+    /// Memory type not found for the requested properties.
+    #[error("no suitable memory type found: {0}")]
+    NoSuitableMemoryType(String),
+
+    /// Command buffer recording or submission error.
+    #[error("command buffer error: {0}")]
+    CommandBuffer(String),
+
+    /// Queue submission or synchronization error.
+    #[error("queue submission error: {0}")]
+    QueueSubmit(String),
+
+    /// Raw Vulkan API error code.
+    #[error("Vulkan API error: {0}")]
+    VkResult(ash::vk::Result),
+}
+
+/// Convenience result type for the Vulkan backend.
+pub type Result<T> = std::result::Result<T, VulkanError>;
+
+impl From<ash::vk::Result> for VulkanError {
+    fn from(result: ash::vk::Result) -> Self {
+        VulkanError::VkResult(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_messages() {
+        let err = VulkanError::InstanceCreation("missing layer".into());
+        assert!(err.to_string().contains("missing layer"));
+
+        let err = VulkanError::NoSuitableDevice("no discrete GPU".into());
+        assert!(err.to_string().contains("no discrete GPU"));
+
+        let err = VulkanError::VkResult(ash::vk::Result::ERROR_DEVICE_LOST);
+        assert!(err.to_string().contains("Vulkan API error"));
+    }
+
+    #[test]
+    fn error_from_vk_result() {
+        let err: VulkanError = ash::vk::Result::ERROR_OUT_OF_DEVICE_MEMORY.into();
+        match err {
+            VulkanError::VkResult(r) => {
+                assert_eq!(r, ash::vk::Result::ERROR_OUT_OF_DEVICE_MEMORY);
+            }
+            _ => panic!("expected VkResult variant"),
+        }
+    }
+}

--- a/crates/bitnet-vulkan/src/instance.rs
+++ b/crates/bitnet-vulkan/src/instance.rs
@@ -1,0 +1,146 @@
+//! Vulkan instance creation with validation layers for debug builds.
+
+use crate::error::{Result, VulkanError};
+use ash::vk;
+use std::ffi::CStr;
+use tracing::{debug, info};
+
+/// Configuration for Vulkan instance creation.
+#[derive(Debug, Clone)]
+pub struct InstanceConfig {
+    /// Application name reported to the Vulkan driver.
+    pub app_name: String,
+    /// Application version (Vulkan packed format).
+    pub app_version: u32,
+    /// Enable validation layers (automatically enabled in debug builds).
+    pub enable_validation: bool,
+}
+
+impl Default for InstanceConfig {
+    fn default() -> Self {
+        Self {
+            app_name: "bitnet-vulkan".into(),
+            app_version: vk::make_api_version(0, 0, 1, 0),
+            enable_validation: cfg!(debug_assertions),
+        }
+    }
+}
+
+/// Wrapper around a Vulkan instance with its entry point.
+pub struct VulkanInstance {
+    #[allow(dead_code)]
+    entry: ash::Entry,
+    #[allow(dead_code)]
+    instance: ash::Instance,
+    validation_enabled: bool,
+}
+
+impl VulkanInstance {
+    /// Create a new Vulkan instance with the given configuration.
+    ///
+    /// In debug builds (or when `config.enable_validation` is true),
+    /// validation layers are requested if available.
+    pub fn new(config: &InstanceConfig) -> Result<Self> {
+        let entry = unsafe {
+            ash::Entry::load().map_err(|e| {
+                VulkanError::InstanceCreation(format!(
+                    "failed to load Vulkan loader: {e}"
+                ))
+            })?
+        };
+
+        let app_name =
+            std::ffi::CString::new(config.app_name.as_str()).unwrap_or_default();
+        let engine_name = std::ffi::CString::new("bitnet-rs").unwrap_or_default();
+
+        let app_info = vk::ApplicationInfo::default()
+            .application_name(&app_name)
+            .application_version(config.app_version)
+            .engine_name(&engine_name)
+            .engine_version(vk::make_api_version(0, 0, 1, 0))
+            .api_version(vk::API_VERSION_1_2);
+
+        let mut layer_names_raw = Vec::new();
+        let validation_layer = c"VK_LAYER_KHRONOS_validation";
+
+        let validation_enabled = if config.enable_validation {
+            let available = unsafe {
+                entry
+                    .enumerate_instance_layer_properties()
+                    .unwrap_or_default()
+            };
+            let found = available.iter().any(|layer| {
+                let name = unsafe { CStr::from_ptr(layer.layer_name.as_ptr()) };
+                name == validation_layer
+            });
+            if found {
+                layer_names_raw.push(validation_layer.as_ptr());
+                debug!("Vulkan validation layers enabled");
+                true
+            } else {
+                debug!("Validation layers requested but not available");
+                false
+            }
+        } else {
+            false
+        };
+
+        let create_info = vk::InstanceCreateInfo::default()
+            .application_info(&app_info)
+            .enabled_layer_names(&layer_names_raw);
+
+        let instance = unsafe {
+            entry.create_instance(&create_info, None).map_err(|e| {
+                VulkanError::InstanceCreation(format!(
+                    "vkCreateInstance failed: {e}"
+                ))
+            })?
+        };
+
+        info!(
+            "Vulkan instance created (validation={})",
+            validation_enabled
+        );
+
+        Ok(Self {
+            entry,
+            instance,
+            validation_enabled,
+        })
+    }
+
+    /// Whether validation layers are active on this instance.
+    pub fn validation_enabled(&self) -> bool {
+        self.validation_enabled
+    }
+
+    /// Borrow the raw `ash::Instance`.
+    pub fn raw(&self) -> &ash::Instance {
+        &self.instance
+    }
+
+    /// Borrow the `ash::Entry`.
+    pub fn entry(&self) -> &ash::Entry {
+        &self.entry
+    }
+}
+
+impl Drop for VulkanInstance {
+    fn drop(&mut self) {
+        unsafe {
+            self.instance.destroy_instance(None);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instance_config_default_has_app_name() {
+        let cfg = InstanceConfig::default();
+        assert_eq!(cfg.app_name, "bitnet-vulkan");
+        assert_eq!(cfg.enable_validation, cfg!(debug_assertions));
+    }
+}

--- a/crates/bitnet-vulkan/src/lib.rs
+++ b/crates/bitnet-vulkan/src/lib.rs
@@ -1,0 +1,137 @@
+//! Vulkan compute backend for BitNet-rs inference.
+//!
+//! This crate provides a Vulkan 1.2 compute backend targeting GPU inference
+//! via SPIR-V compute shaders. It uses the [`ash`] crate for raw Vulkan
+//! bindings and is designed as a pluggable backend alongside CUDA and OpenCL.
+//!
+//! # Modules
+//!
+//! - [`instance`] - Vulkan instance creation with optional validation layers
+//! - [`device`] - Physical/logical device selection preferring compute queues
+//! - [`pipeline`] - Compute pipeline creation from SPIR-V
+//! - [`buffer`] - GPU buffer management (staging + device-local)
+//! - [`command`] - Command buffer recording and submission
+//! - [`error`] - Error types
+
+pub mod buffer;
+pub mod command;
+pub mod device;
+pub mod error;
+pub mod instance;
+pub mod pipeline;
+
+pub use buffer::{
+    BufferDescriptor, BufferUsage, GpuBuffer, allocate_buffer,
+};
+pub use command::{CommandPool, record_and_submit_compute};
+pub use device::{
+    DeviceSelector, SelectedDevice, create_logical_device,
+    select_physical_device,
+};
+pub use error::{Result, VulkanError};
+pub use instance::{InstanceConfig, VulkanInstance};
+pub use pipeline::{ComputePipeline, ComputePipelineBuilder};
+
+/// Top-level Vulkan backend that owns instance, device, and command resources.
+///
+/// This is the primary entry point for consumers who want a fully initialised
+/// Vulkan compute backend.
+#[derive(Debug)]
+pub struct VulkanBackend {
+    config: InstanceConfig,
+    device_selector: DeviceSelector,
+    initialised: bool,
+}
+
+impl VulkanBackend {
+    /// Create a new backend with default configuration.
+    pub fn new() -> Self {
+        Self {
+            config: InstanceConfig::default(),
+            device_selector: DeviceSelector::default(),
+            initialised: false,
+        }
+    }
+
+    /// Create a backend with custom instance and device configuration.
+    pub fn with_config(
+        config: InstanceConfig,
+        selector: DeviceSelector,
+    ) -> Self {
+        Self {
+            config,
+            device_selector: selector,
+            initialised: false,
+        }
+    }
+
+    /// Returns the instance configuration.
+    pub fn config(&self) -> &InstanceConfig {
+        &self.config
+    }
+
+    /// Returns the device selector.
+    pub fn device_selector(&self) -> &DeviceSelector {
+        &self.device_selector
+    }
+
+    /// Whether the backend has been successfully initialised.
+    pub fn is_initialised(&self) -> bool {
+        self.initialised
+    }
+
+    /// Attempt to initialise the Vulkan backend.
+    ///
+    /// Creates a Vulkan instance, selects a physical device, and creates
+    /// a logical device with a compute queue.
+    pub fn initialise(&mut self) -> error::Result<()> {
+        let instance = VulkanInstance::new(&self.config)?;
+        let selected =
+            select_physical_device(instance.raw(), &self.device_selector)?;
+        let (_device, _queue) =
+            create_logical_device(instance.raw(), &selected)?;
+
+        self.initialised = true;
+        Ok(())
+    }
+}
+
+impl Default for VulkanBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_new_not_initialised() {
+        let backend = VulkanBackend::new();
+        assert!(!backend.is_initialised());
+    }
+
+    #[test]
+    fn backend_default_config() {
+        let backend = VulkanBackend::default();
+        assert_eq!(backend.config().app_name, "bitnet-vulkan");
+        assert!(backend.device_selector().prefer_discrete);
+    }
+
+    #[test]
+    fn backend_with_custom_config() {
+        let config = InstanceConfig {
+            app_name: "test-app".into(),
+            app_version: 1,
+            enable_validation: false,
+        };
+        let selector = DeviceSelector {
+            prefer_discrete: false,
+            require_compute_queue: true,
+        };
+        let backend = VulkanBackend::with_config(config, selector);
+        assert_eq!(backend.config().app_name, "test-app");
+        assert!(backend.device_selector().require_compute_queue);
+    }
+}

--- a/crates/bitnet-vulkan/src/pipeline.rs
+++ b/crates/bitnet-vulkan/src/pipeline.rs
@@ -1,0 +1,192 @@
+//! Compute pipeline creation from SPIR-V shader modules.
+
+use crate::error::{Result, VulkanError};
+use ash::vk;
+use tracing::debug;
+
+/// Builder for Vulkan compute pipelines.
+#[derive(Debug)]
+pub struct ComputePipelineBuilder {
+    spirv_code: Vec<u32>,
+    entry_point: String,
+    push_constant_size: u32,
+    descriptor_set_count: u32,
+}
+
+impl ComputePipelineBuilder {
+    /// Create a new pipeline builder with the given SPIR-V binary.
+    ///
+    /// `spirv` must be valid SPIR-V code (u32 words).
+    pub fn new(spirv: &[u32]) -> Self {
+        Self {
+            spirv_code: spirv.to_vec(),
+            entry_point: "main".into(),
+            push_constant_size: 0,
+            descriptor_set_count: 1,
+        }
+    }
+
+    /// Set the shader entry point name (default: "main").
+    #[must_use]
+    pub fn entry_point(mut self, name: &str) -> Self {
+        self.entry_point = name.into();
+        self
+    }
+
+    /// Set push constant size in bytes.
+    #[must_use]
+    pub fn push_constant_size(mut self, size: u32) -> Self {
+        self.push_constant_size = size;
+        self
+    }
+
+    /// Set the number of descriptor sets in the layout.
+    #[must_use]
+    pub fn descriptor_set_count(mut self, count: u32) -> Self {
+        self.descriptor_set_count = count;
+        self
+    }
+
+    /// Build the compute pipeline on the given device.
+    ///
+    /// Returns the pipeline, pipeline layout, and shader module handles.
+    /// The caller is responsible for destroying these on cleanup.
+    pub fn build(&self, device: &ash::Device) -> Result<ComputePipeline> {
+        if self.spirv_code.is_empty() {
+            return Err(VulkanError::ShaderLoad("empty SPIR-V code".into()));
+        }
+
+        let shader_module_create_info =
+            vk::ShaderModuleCreateInfo::default().code(&self.spirv_code);
+
+        let shader_module = unsafe {
+            device
+                .create_shader_module(&shader_module_create_info, None)
+                .map_err(|e| {
+                    VulkanError::ShaderLoad(format!(
+                        "vkCreateShaderModule failed: {e}"
+                    ))
+                })?
+        };
+
+        let entry_name =
+            std::ffi::CString::new(self.entry_point.as_str()).unwrap_or_default();
+
+        let stage_info = vk::PipelineShaderStageCreateInfo::default()
+            .stage(vk::ShaderStageFlags::COMPUTE)
+            .module(shader_module)
+            .name(&entry_name);
+
+        // Create a minimal pipeline layout.
+        let mut push_constant_ranges = Vec::new();
+        if self.push_constant_size > 0 {
+            push_constant_ranges.push(
+                vk::PushConstantRange::default()
+                    .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                    .offset(0)
+                    .size(self.push_constant_size),
+            );
+        }
+
+        let layout_create_info = vk::PipelineLayoutCreateInfo::default()
+            .push_constant_ranges(&push_constant_ranges);
+
+        let pipeline_layout = unsafe {
+            device
+                .create_pipeline_layout(&layout_create_info, None)
+                .map_err(|e| {
+                    VulkanError::PipelineCreation(format!(
+                        "vkCreatePipelineLayout failed: {e}"
+                    ))
+                })?
+        };
+
+        let pipeline_create_info = vk::ComputePipelineCreateInfo::default()
+            .stage(stage_info)
+            .layout(pipeline_layout);
+
+        let pipelines = unsafe {
+            device
+                .create_compute_pipelines(
+                    vk::PipelineCache::null(),
+                    &[pipeline_create_info],
+                    None,
+                )
+                .map_err(|(_, e)| {
+                    VulkanError::PipelineCreation(format!(
+                        "vkCreateComputePipelines failed: {e}"
+                    ))
+                })?
+        };
+
+        debug!(
+            "Compute pipeline created (entry={}, push_const={}B)",
+            self.entry_point, self.push_constant_size
+        );
+
+        Ok(ComputePipeline {
+            pipeline: pipelines[0],
+            layout: pipeline_layout,
+            shader_module,
+        })
+    }
+}
+
+/// A compiled Vulkan compute pipeline.
+///
+/// The caller must destroy these resources by calling [`ComputePipeline::destroy`].
+pub struct ComputePipeline {
+    /// The raw Vulkan pipeline handle.
+    pub pipeline: vk::Pipeline,
+    /// The pipeline layout.
+    pub layout: vk::PipelineLayout,
+    /// The shader module.
+    pub shader_module: vk::ShaderModule,
+}
+
+impl ComputePipeline {
+    /// Destroy all Vulkan objects owned by this pipeline.
+    ///
+    /// # Safety
+    /// Must only be called once, and the device must be the same one used
+    /// during creation.
+    pub unsafe fn destroy(&self, device: &ash::Device) {
+        unsafe {
+            device.destroy_pipeline(self.pipeline, None);
+            device.destroy_pipeline_layout(self.layout, None);
+            device.destroy_shader_module(self.shader_module, None);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pipeline_builder_defaults() {
+        let builder = ComputePipelineBuilder::new(&[]);
+        assert_eq!(builder.entry_point, "main");
+        assert_eq!(builder.push_constant_size, 0);
+        assert_eq!(builder.descriptor_set_count, 1);
+    }
+
+    #[test]
+    fn pipeline_builder_fluent_api() {
+        let spirv = vec![0x0723_0203u32]; // fake magic
+        let builder = ComputePipelineBuilder::new(&spirv)
+            .entry_point("compute_main")
+            .push_constant_size(64)
+            .descriptor_set_count(2);
+        assert_eq!(builder.entry_point, "compute_main");
+        assert_eq!(builder.push_constant_size, 64);
+        assert_eq!(builder.descriptor_set_count, 2);
+        assert_eq!(builder.spirv_code.len(), 1);
+    }
+
+    #[test]
+    fn pipeline_builder_rejects_empty_spirv() {
+        let builder = ComputePipelineBuilder::new(&[]);
+        assert!(builder.spirv_code.is_empty());
+    }
+}


### PR DESCRIPTION
Adds the bitnet-vulkan crate with:
- Vulkan instance creation with validation layers (debug builds)
- Physical/logical device selection preferring compute queues
- Compute pipeline creation from SPIR-V
- GPU buffer management (staging + device-local)
- Command buffer recording and submission
- VulkanError enum with thiserror integration
- VulkanBackend top-level entry point
- 14 unit tests covering struct creation, error types, and builder patterns

Registered as workspace member and wired into the vulkan feature flag.