### PR TITLE
feat(opencl): add GPU SiLU/GELU activation kernels

### DIFF
--- a/crates/bitnet-kernels/src/activation_gpu.rs
+++ b/crates/bitnet-kernels/src/activation_gpu.rs
@@ -1,0 +1,133 @@
+//! GPU-accelerated activation functions for transformer inference.
+//! Provides CPU reference implementations matching the OpenCL silu_gate.cl kernels.
+
+/// Apply SiLU (Sigmoid Linear Unit) element-wise: x * sigmoid(x).
+pub fn silu(input: &[f32]) -> Vec<f32> {
+    input.iter().map(|&x| {
+        let sig = 1.0 / (1.0 + (-x).exp());
+        x * sig
+    }).collect()
+}
+
+/// Fused SiLU-gate: silu(gate) * value.
+/// Common in LLaMA-style FFN where the up-projection splits into gate and value halves.
+///
+/// # Panics
+/// Panics if gate and value have different lengths.
+pub fn silu_gate_fused(gate: &[f32], value: &[f32]) -> Vec<f32> {
+    assert_eq!(gate.len(), value.len(), "gate/value length mismatch");
+    gate.iter().zip(value.iter()).map(|(&g, &v)| {
+        let sig = 1.0 / (1.0 + (-g).exp());
+        (g * sig) * v
+    }).collect()
+}
+
+/// GELU (Gaussian Error Linear Unit) with tanh approximation.
+pub fn gelu(input: &[f32]) -> Vec<f32> {
+    let c: f32 = (2.0f32 / std::f32::consts::PI).sqrt(); // sqrt(2/pi)
+    input.iter().map(|&x| {
+        let inner = c * (x + 0.044715 * x * x * x);
+        0.5 * x * (1.0 + inner.tanh())
+    }).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx_eq(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (&x, &y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!((x - y).abs() < tol, "index {i}: {x} vs {y} (diff {})", (x - y).abs());
+        }
+    }
+
+    #[test]
+    fn silu_zero() {
+        let out = silu(&[0.0]);
+        assert_eq!(out, vec![0.0]);
+    }
+
+    #[test]
+    fn silu_positive() {
+        let out = silu(&[1.0]);
+        // silu(1) = 1 * sigmoid(1) = 1 / (1 + e^-1) ~ 0.7311
+        approx_eq(&out, &[0.7311], 0.001);
+    }
+
+    #[test]
+    fn silu_negative() {
+        let out = silu(&[-1.0]);
+        // silu(-1) = -1 * sigmoid(-1) = -1 / (1 + e) ~ -0.2689
+        approx_eq(&out, &[-0.2689], 0.001);
+    }
+
+    #[test]
+    fn silu_batch() {
+        let out = silu(&[-2.0, -1.0, 0.0, 1.0, 2.0]);
+        assert_eq!(out.len(), 5);
+        assert!(out[2] == 0.0); // silu(0) = 0
+        assert!(out[3] > 0.0);  // silu(1) > 0
+        assert!(out[0] < 0.0);  // silu(-2) < 0
+    }
+
+    #[test]
+    fn silu_gate_fused_basic() {
+        let gate = vec![1.0, 0.0, -1.0];
+        let value = vec![2.0, 3.0, 4.0];
+        let out = silu_gate_fused(&gate, &value);
+        // silu(1)*2 ~ 1.4623, silu(0)*3 = 0, silu(-1)*4 ~ -1.0756
+        approx_eq(&out, &[1.4623, 0.0, -1.0756], 0.001);
+    }
+
+    #[test]
+    #[should_panic(expected = "gate/value length mismatch")]
+    fn silu_gate_length_mismatch() {
+        silu_gate_fused(&[1.0, 2.0], &[1.0]);
+    }
+
+    #[test]
+    fn gelu_zero() {
+        let out = gelu(&[0.0]);
+        approx_eq(&out, &[0.0], 0.001);
+    }
+
+    #[test]
+    fn gelu_positive() {
+        let out = gelu(&[1.0]);
+        // GELU(1) ~ 0.8412
+        approx_eq(&out, &[0.8412], 0.001);
+    }
+
+    #[test]
+    fn gelu_negative() {
+        let out = gelu(&[-1.0]);
+        // GELU(-1) ~ -0.1588
+        approx_eq(&out, &[-0.1588], 0.001);
+    }
+
+    #[test]
+    fn gelu_symmetry() {
+        // GELU is not symmetric, but GELU(x) + GELU(-x) ~ x for small x
+        let out_pos = gelu(&[0.5]);
+        let out_neg = gelu(&[-0.5]);
+        // GELU(0.5) ~ 0.3457, GELU(-0.5) ~ -0.1543
+        assert!(out_pos[0] > 0.0);
+        assert!(out_neg[0] < 0.0);
+        assert!(out_pos[0].abs() > out_neg[0].abs());
+    }
+
+    #[test]
+    fn silu_large_input() {
+        let out = silu(&[10.0]);
+        // sigmoid(10) ~ 1.0, so silu(10) ~ 10.0
+        approx_eq(&out, &[10.0], 0.001);
+    }
+
+    #[test]
+    fn empty_inputs() {
+        assert!(silu(&[]).is_empty());
+        assert!(gelu(&[]).is_empty());
+        assert!(silu_gate_fused(&[], &[]).is_empty());
+    }
+}

--- a/crates/bitnet-kernels/src/gpu/kernels/mod.rs
+++ b/crates/bitnet-kernels/src/gpu/kernels/mod.rs
@@ -25,6 +25,7 @@ pub const MATMUL_FP16_SRC: &str = include_str!("matmul_fp16.cl");
 
 /// INT8 matrix multiplication kernel source.
 pub const MATMUL_INT8_SRC: &str = include_str!("matmul_int8.cl");
+pub const SILU_GATE_SRC: &str = include_str!("silu_gate.cl");
 
 #[cfg(test)]
 mod tests {

--- a/crates/bitnet-kernels/src/gpu/kernels/silu_gate.cl
+++ b/crates/bitnet-kernels/src/gpu/kernels/silu_gate.cl
@@ -1,0 +1,49 @@
+// OpenCL activation kernels for GPU-accelerated transformer inference.
+// SiLU, SiLU-gate (fused), and GELU activations.
+
+/// SiLU (Sigmoid Linear Unit): output[i] = input[i] * sigmoid(input[i])
+__kernel void silu_activation(
+    __global const float* input,
+    __global float* output,
+    const uint n)
+{
+    uint gid = get_global_id(0);
+    if (gid < n) {
+        float x = input[gid];
+        float sig = 1.0f / (1.0f + exp(-x));
+        output[gid] = x * sig;
+    }
+}
+
+/// Fused SiLU-gate: output[i] = silu(gate[i]) * value[i]
+/// Common in LLaMA-style FFN: the up-projection is split into gate and value halves.
+/// gate: [n], value: [n], output: [n]
+__kernel void silu_gate_fused(
+    __global const float* gate,
+    __global const float* value,
+    __global float* output,
+    const uint n)
+{
+    uint gid = get_global_id(0);
+    if (gid < n) {
+        float g = gate[gid];
+        float sig = 1.0f / (1.0f + exp(-g));
+        output[gid] = (g * sig) * value[gid];
+    }
+}
+
+/// GELU (Gaussian Error Linear Unit) approximation using tanh.
+/// output[i] = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+__kernel void gelu_activation(
+    __global const float* input,
+    __global float* output,
+    const uint n)
+{
+    uint gid = get_global_id(0);
+    if (gid < n) {
+        float x = input[gid];
+        float c = 0.7978845608f; // sqrt(2/pi)
+        float inner = c * (x + 0.044715f * x * x * x);
+        output[gid] = 0.5f * x * (1.0f + tanh(inner));
+    }
+}

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -28,6 +28,7 @@ mod stubs;
 pub mod tl_lut;
 pub mod embedding_gpu;
 pub mod linear_gpu;
+pub mod activation_gpu;
 
 /// Kernel provider trait
 pub trait KernelProvider: Send + Sync {


### PR DESCRIPTION
## Summary

Add OpenCL activation kernels for GPU-accelerated transformer inference.

### New files
- **\silu_gate.cl\** — OpenCL kernels (\silu_activation\, \silu_gate_fused\, \gelu_activation\)
- **\ctivation_gpu.rs\** — CPU reference implementations of \silu\, \silu_gate_fused\, and \gelu\

### Changes
- Register \SILU_GATE_SRC\ kernel source in \gpu/kernels/mod.rs\
- Register \ctivation_gpu\ module in \lib.rs\

### Design
- **SiLU-gate fusion** for LLaMA-style FFN: the up-projection splits into gate + value halves, fused into one kernel for reduced memory traffic
- **GELU** uses the tanh approximation matching PyTorch/HuggingFace convention

### Tests
12 unit tests covering zero/positive/negative inputs, batched SiLU, SiLU-gate fusion, GELU symmetry properties, large inputs, empty vectors, and panic on length mismatch.

All 55 tests pass (\cargo test -p bitnet-kernels --no-default-features --features cpu --lib\).