### PR TITLE
fix(snapshot): update kernel provider count 2→3 after Metal backend

### DIFF
--- a/crates/bitnet-kernels/tests/snapshots/snapshot_tests__kernel_manager_has_at_least_one_provider.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_tests__kernel_manager_has_at_least_one_provider.snap
@@ -2,4 +2,4 @@
 source: crates/bitnet-kernels/tests/snapshot_tests.rs
 expression: "format!(\"count={} has_providers={}\", providers.len(), !providers.is_empty())"
 ---
-count=2 has_providers=true
+count=3 has_providers=true


### PR DESCRIPTION
Updates snapshot after Metal backend was added in #992, increasing provider count from 2 to 3.