### PR TITLE
feat(receipts): extend receipt schema with OpenCL device info and timing

### DIFF
--- a/crates/bitnet-inference/src/lib.rs
+++ b/crates/bitnet-inference/src/lib.rs
@@ -55,7 +55,8 @@ pub use production_engine::{
 pub use prompt_template::{ChatRole, ChatTurn, PromptTemplate, TemplateType};
 pub use receipts::{
     AccuracyMetric, AccuracyTestResults, CrossValidation, DeterminismTestResults, InferenceReceipt,
-    KVCacheTestResults, ModelInfo, PerformanceBaseline, RECEIPT_SCHEMA_VERSION, TestResults,
+    KVCacheTestResults, ModelInfo, OpenClDeviceInfo, OpenClTiming, PerformanceBaseline,
+    RECEIPT_SCHEMA_VERSION, TestResults,
 };
 // Re-export CorrectionRecord from bitnet-common for convenience
 pub use bitnet_common::CorrectionRecord;


### PR DESCRIPTION
Extends receipt schema with OpenClDeviceInfo, OpenClTiming structs and backend_type field for Intel Arc GPU inference. Includes validation, builder methods, xtask support, and 7 new tests.