### PR TITLE
ci: complete fuzz target matrices in fuzz-nightly and fuzz-ci workflows

### DIFF
--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -69,17 +69,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Complete list of fuzz targets — must match fuzz/Cargo.toml [[bin]] entries.
+        # When adding a new fuzz target, add it here AND in fuzz-nightly.yml matrix.
         target:
+          # Quantization
           - quantization_i2s
+          - quantization_input
           - quantization_tl1
           - quantization_tl2
-          - gguf_parser
+          # GGUF parsing
           - gguf_header
+          - gguf_header_parse
+          - gguf_header_roundtrip
+          - gguf_kv_read
+          - gguf_metadata_values
+          - gguf_parser
+          - gguf_writer_roundtrip
+          # SafeTensors
+          - safetensors_metadata
           - safetensors_parser
-          - tokenizer_discovery
+          # Kernels & compute
           - kernel_matmul
           - tl_lut_helper
+          # Tokenizer
+          - tokenizer_discovery
+          - tokenizer_encode
+          - tokenizer_encode_decode
+          - tokenizer_encode_no_panic
+          # Inference & generation
+          - generation_stop_check
+          - generation_stop_checker
+          - logits_transforms
+          - prompt_template_no_panic
+          - rope_table_gen
+          - sampling_no_panic
+          - transformer_config
+          # Validation & runtime
           - architecture_detection
+          - engine_core_no_panic
+          - feature_activation_no_panic
+          - honest_compute_no_panic
+          - receipt_json_roundtrip
+          - runtime_context_parse_no_panic
+          - validation_no_panic
           - vocab_size_extraction
     steps:
       - name: Checkout

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -19,17 +19,50 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Complete list of fuzz targets — must match fuzz/Cargo.toml [[bin]] entries.
+        # When adding a new fuzz target, add it here AND in fuzz-ci.yml fuzz-run matrix.
         target:
+          # Quantization
           - quantization_i2s
+          - quantization_input
           - quantization_tl1
           - quantization_tl2
-          - gguf_parser
-          - safetensors_parser
-          - tokenizer_discovery
-          - kernel_matmul
-          - quantization_input
-          - transformer_config
+          # GGUF parsing
+          - gguf_header
+          - gguf_header_parse
+          - gguf_header_roundtrip
           - gguf_kv_read
+          - gguf_metadata_values
+          - gguf_parser
+          - gguf_writer_roundtrip
+          # SafeTensors
+          - safetensors_metadata
+          - safetensors_parser
+          # Kernels & compute
+          - kernel_matmul
+          - tl_lut_helper
+          # Tokenizer
+          - tokenizer_discovery
+          - tokenizer_encode
+          - tokenizer_encode_decode
+          - tokenizer_encode_no_panic
+          # Inference & generation
+          - generation_stop_check
+          - generation_stop_checker
+          - logits_transforms
+          - prompt_template_no_panic
+          - rope_table_gen
+          - sampling_no_panic
+          - transformer_config
+          # Validation & runtime
+          - architecture_detection
+          - engine_core_no_panic
+          - feature_activation_no_panic
+          - honest_compute_no_panic
+          - receipt_json_roundtrip
+          - runtime_context_parse_no_panic
+          - validation_no_panic
+          - vocab_size_extraction
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4


### PR DESCRIPTION
## Summary

Both `fuzz-nightly.yml` (10 targets) and `fuzz-ci.yml` fuzz-run job (11 targets) were missing the majority of fuzz targets that exist in `fuzz/Cargo.toml` and are already listed in `nightly-fuzz.yml`.

## Changes

- **`fuzz-nightly.yml`**: Updated from 10 → 34 fuzz targets (added 24 missing targets)
- **`fuzz-ci.yml`**: Updated fuzz-run matrix from 11 → 34 fuzz targets (added 23 missing targets)
- Organized targets by category (quantization, GGUF, SafeTensors, kernels, tokenizer, inference, validation) with comments
- Added cross-reference comments so new targets get added to all workflows

## Targets added

```
engine_core_no_panic, feature_activation_no_panic, generation_stop_check,
generation_stop_checker, gguf_header_parse, gguf_header_roundtrip,
gguf_metadata_values, gguf_writer_roundtrip, honest_compute_no_panic,
logits_transforms, prompt_template_no_panic, receipt_json_roundtrip,
rope_table_gen, runtime_context_parse_no_panic, safetensors_metadata,
sampling_no_panic, tokenizer_encode, tokenizer_encode_decode,
tokenizer_encode_no_panic, validation_no_panic
```
(plus others that were in one workflow but not the other)

## Verification

- All 3 fuzz workflows now have identical 34-target coverage matching `fuzz/Cargo.toml`
- YAML syntax validated with `yaml.safe_load()`
- No functional changes to workflow steps or configuration