### PR TITLE
perf(avx2): optimize QK256 GEMV hot paths with SIMD unpack and 4-wide FMA

### DIFF
--- a/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
@@ -116,19 +116,10 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
 
             // Prefetch next block's packed bytes and input vector into L1.
             if blk_idx + 1 < blocks_needed {
-                _mm_prefetch(
-                    blk.add(QK256_PACKED_BYTES) as *const i8,
-                    _MM_HINT_T0,
-                );
-                _mm_prefetch(
-                    x_ptr.add(col + QK256_BLOCK) as *const i8,
-                    _MM_HINT_T0,
-                );
+                _mm_prefetch(blk.add(QK256_PACKED_BYTES) as *const i8, _MM_HINT_T0);
+                _mm_prefetch(x_ptr.add(col + QK256_BLOCK) as *const i8, _MM_HINT_T0);
                 // Second cache-line of next input chunk (256 f32 = 1024 bytes ≈ 16 lines).
-                _mm_prefetch(
-                    x_ptr.add(col + QK256_BLOCK + 16) as *const i8,
-                    _MM_HINT_T0,
-                );
+                _mm_prefetch(x_ptr.add(col + QK256_BLOCK + 16) as *const i8, _MM_HINT_T0);
             }
 
             let mut j = 0usize;


### PR DESCRIPTION
## Summary

Optimizes the AVX2 QK256 GEMV hot path in `bitnet-quantization` by replacing scalar bit extraction with SIMD operations and improving loop structure.

## Changes

### `crates/bitnet-quantization/src/i2s_qk256_avx2.rs`

**SIMD variable-shift code extraction** — The old `decode_8_weights_avx2` built a `__m256i` via 8 scalar bit-extractions + `_mm256_setr_epi32` (compiles to a costly sequence of inserts). The new version packs both bytes into one i32 (`b0 | b1 << 16`), broadcasts it, then uses `vpsrlvd` with shifts `[0,2,4,6,16,18,20,22]` + mask `0x03` — 3 SIMD ops instead of ~16 scalar ops per 8-element group.

**4-wide accumulator bank** — Increased from 2 to 4 independent FMA accumulators. On Haswell/Skylake the FMA unit has 4–5 cycle latency; 4 independent chains keep the pipeline full.

**32-element inner loop** — Processes 8 packed bytes (32 codes → 4 FMA ops) per iteration instead of 4 bytes (16 codes → 2 FMA). Reduces loop overhead and improves µop throughput.

**Software prefetch** — Added `_mm_prefetch(..., _MM_HINT_T0)` for:
- Next block's packed bytes within a row
- Next chunk of input vector (2 cache lines)
- Next row's first cache line (in multi-row function)

**Hoisted constants** — Shift amounts, masks, and arithmetic constants moved out of the decode helper into the row function so they're loaded once per row instead of once per 8-element decode call.

### `crates/bitnet-quantization/benches/qk256_gemv.rs`

Added `bench_qk256_avx2_gemv` — Criterion benchmark comparing scalar vs AVX2 GEMV across 3 matrix sizes (256×256, 512×2048, 2K×2K). Feature-gated for x86_64.

## Testing

- All 17 QK256 tests pass (smoke, correctness, property, negatives)
- All 67 quantization lib tests pass
- Clippy clean (lib target)
- No API changes — drop-in replacement for the internal row kernel

## Benchmark

Run with:
```bash
cargo bench --bench qk256_gemv -p bitnet-quantization --no-default-features --features cpu
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AVX2 GEMV benchmark to measure quantized vector-matrix operation performance on AVX2-capable processors, providing comparative analysis against scalar implementations

* **Performance**
  * Enhanced quantized matrix multiplication through restructured loops for better parallelization, integrated memory prefetching, and optimized accumulation strategies for improved throughput

<!-- end of auto-generated comment: release notes by coderabbit.ai -->