### PR TITLE
docs: add Architecture Decision Records for GPU backends

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -17,3 +17,27 @@ BitNet-rs subsystems.
 | [ADR-002](decisions/ADR-002-manual-branch-protection.md) | Manual Branch Protection |
 | [ADR-003](decisions/ADR-003-receipt-schema-stability.md) | Receipt Schema Stability |
 | [ADR-004](decisions/ADR-004-deterministic-baseline-tolerance.md) | Deterministic Baseline Tolerance |
+# Architecture Decision Records
+This directory contains Architecture Decision Records (ADRs) for the
+BitNet-rs project.  Each ADR captures the context, decision, rationale,
+and consequences of a significant architectural choice.
+## Index
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](decisions/ADR-001-production-model-baseline.md) | Production Model for CPU Baseline | Accepted | 2025-10-15 |
+| [ADR-002](decisions/ADR-002-manual-branch-protection.md) | Manual Branch Protection | Accepted | 2025-10-15 |
+| [ADR-003](decisions/ADR-003-receipt-schema-stability.md) | Receipt Schema Stability | Accepted | 2025-10-15 |
+| [ADR-004](decisions/ADR-004-deterministic-baseline-tolerance.md) | Deterministic Baseline Tolerance | Accepted | 2025-10-15 |
+| [ADR-005](decisions/ADR-005-opencl-first-backend.md) | OpenCL-First GPU Backend | Accepted | 2025-06-24 |
+| [ADR-006](decisions/ADR-006-dynamic-gpu-linking.md) | Dynamic GPU Library Linking | Accepted | 2025-06-24 |
+| [ADR-007](decisions/ADR-007-microcrate-per-backend.md) | Microcrate per GPU Backend | Accepted | 2025-06-24 |
+| [ADR-008](decisions/ADR-008-kernel-embedding-strategy.md) | Kernel Embedding Strategy | Accepted | 2025-06-24 |
+| [ADR-009](decisions/ADR-009-cpu-reference-testing.md) | CPU Reference Testing for GPU Kernels | Accepted | 2025-06-24 |
+## Template
+New ADRs should follow the structure in any of the existing records:
+1. **Status** — Proposed → Accepted → Deprecated / Superseded
+2. **Context** — What problem are we solving?
+3. **Decision** — What did we decide?
+4. **Rationale** — Why this option over others?
+5. **Consequences** — Positive and negative impacts
+6. **Alternatives Considered** — What else was evaluated?

--- a/docs/architecture/decisions/ADR-005-opencl-first-backend.md
+++ b/docs/architecture/decisions/ADR-005-opencl-first-backend.md
@@ -1,0 +1,117 @@
+# ADR-005: OpenCL-First GPU Backend
+
+**Status**: ACCEPTED
+**Date**: 2025-06-24
+**Context**: Intel Arc GPU support for BitNet-rs inference
+
+---
+
+## Context
+
+BitNet-rs needs Intel Arc A-series GPU support for accelerated 1-bit LLM
+inference.  Multiple compute APIs are available on Intel hardware:
+
+| API | Rust Ecosystem | Intel ICD | Maturity |
+|-----|---------------|-----------|----------|
+| OpenCL 3.0 | `opencl3` crate (stable) | Shipped in driver | Production |
+| Vulkan Compute | `ash` / `vulkano` | Shipped in driver | Production |
+| Level-Zero (oneAPI) | Minimal bindings | Separate install | Emerging |
+| SYCL (via DPC++) | No native Rust crate | oneAPI toolkit | C++ only |
+
+### Constraints
+
+- Must compile without GPU libraries installed (dynamic linking only)
+- Must coexist with the existing CUDA backend
+- Must support Intel Arc A770/A750 (Xe-HPG, 32 EUs / 512 cores)
+- Must be testable on CI runners without GPU hardware
+
+---
+
+## Decision
+
+**Use OpenCL 3.0 as the first Intel GPU backend.**
+
+Vulkan Compute and Level-Zero are deferred to follow-up milestones.
+
+---
+
+## Rationale
+
+### 1. Mature Rust Crate
+The `opencl3` crate provides safe, well-maintained bindings with buffer
+management, kernel compilation, and command-queue abstractions.  It has
+>600k total downloads and is actively maintained.
+
+### 2. Intel ICD Ships in the Driver
+Intel's OpenCL ICD (`intel-opencl-icd`) is bundled with the standard GPU
+driver on Windows and Linux.  No additional SDK install is required at
+runtime, reducing user friction.
+
+### 3. Simpler Programming Model
+OpenCL's buffer + kernel + queue model maps cleanly onto the existing
+`KernelProvider` trait.  A single `.cl` source file per kernel is easy to
+review, embed via `include_str!`, and compile at runtime.
+
+### 4. Cross-Vendor Portability
+The same OpenCL kernels can run on NVIDIA (via pocl or vendor ICD), AMD
+(via ROCm ICD), and Intel GPUs, giving users a fallback when CUDA is
+unavailable.
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Fast time-to-prototype — working matmul kernel in <1 week
+- ✅ No build-time GPU dependency (dynamic linking)
+- ✅ Reusable across Intel, AMD, and NVIDIA hardware
+- ✅ Well-understood debugging tools (`clinfo`, `oclgrind`)
+
+### Negative
+- ⚠️ Slightly lower peak throughput compared to Level-Zero (no
+  direct GPU memory mapping, higher dispatch overhead)
+- ⚠️ OpenCL 3.0 feature support varies by vendor — need runtime feature
+  queries for subgroups, fp16, etc.
+- ⚠️ No SPIR-V pre-compilation in OpenCL 1.2 fallback — must compile from
+  source on first launch
+
+### Mitigations
+1. **SPIR-V Cache**: Pre-compile kernels to SPIR-V and cache the binary in
+   `$XDG_CACHE_HOME/bitnet/kernels/` for subsequent launches.
+2. **Feature Probing**: Use `CL_DEVICE_EXTENSIONS` to query subgroup and
+   fp16 support at device enumeration time.
+3. **Level-Zero Upgrade Path**: The `KernelProvider` trait is
+   backend-agnostic — a Level-Zero provider can replace OpenCL without
+   changing upper layers.
+
+---
+
+## Alternatives Considered
+
+### Vulkan Compute
+**Deferred**: Higher API complexity (descriptor sets, pipeline layouts,
+memory barriers).  Better suited for graphics-adjacent workloads.  Will be
+evaluated for v0.3.
+
+### Level-Zero
+**Deferred**: Requires separate oneAPI toolkit installation.  Rust
+bindings are immature.  Best reserved for when sub-microsecond dispatch
+latency matters.
+
+### SYCL via DPC++
+**Rejected**: No native Rust integration.  Would require FFI to a C++
+runtime, conflicting with the project's pure-Rust philosophy.
+
+---
+
+## References
+
+- Intel OpenCL ICD: https://github.com/intel/compute-runtime
+- `opencl3` crate: https://crates.io/crates/opencl3
+- BitNet-rs KernelProvider trait: `crates/bitnet-kernels/src/lib.rs`
+
+---
+
+## Changelog
+
+- **2025-06-24**: Initial decision for Intel Arc GPU support

--- a/docs/architecture/decisions/ADR-006-dynamic-gpu-linking.md
+++ b/docs/architecture/decisions/ADR-006-dynamic-gpu-linking.md
@@ -1,0 +1,103 @@
+# ADR-006: Dynamic GPU Library Linking
+
+**Status**: ACCEPTED
+**Date**: 2025-06-24
+**Context**: GPU backend compilation and distribution strategy
+
+---
+
+## Context
+
+BitNet-rs must compile on machines **without** GPU libraries installed
+(CI runners, developer laptops, ARM devices).  At the same time, users
+with a GPU driver should get hardware acceleration automatically.
+
+Two linking strategies exist:
+
+| Strategy | Compile Requirement | Runtime Requirement | Error Mode |
+|----------|-------------------|-------------------|------------|
+| Static / build-time | GPU SDK headers + libs | GPU driver | Linker error if SDK absent |
+| Dynamic / runtime | None | GPU driver (optional) | Graceful runtime fallback |
+
+---
+
+## Decision
+
+**Use dynamic library loading (dlopen / LoadLibrary) for all GPU backends.**
+
+GPU libraries (OpenCL ICD, CUDA runtime, Vulkan loader) are loaded at
+runtime via the platform's dynamic linker.  If loading fails, the backend
+reports "unavailable" and the `KernelManager` falls back to CPU.
+
+---
+
+## Rationale
+
+### 1. Compile Everywhere
+A single `cargo build --features cpu,gpu` produces the same binary whether
+the build machine has GPU libraries or not.  This simplifies CI (no GPU
+SDK in the build container) and distribution (one binary for GPU and
+non-GPU machines).
+
+### 2. Graceful Degradation
+Users who install BitNet-rs on a headless server or a Raspberry Pi get
+CPU inference automatically.  The absence of `libOpenCL.so` or
+`nvcuda.dll` is a soft warning, not a hard error.
+
+### 3. Multi-Backend Coexistence
+The same binary can probe for CUDA, OpenCL, and Vulkan at startup,
+selecting the best available backend.  This is impossible with static
+linking when only one SDK is installed.
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Single binary for all platforms (CPU + optional GPU)
+- ✅ No GPU SDK required at build time
+- ✅ CI can test GPU code paths (compile check) without GPU hardware
+- ✅ Users get automatic CPU fallback
+
+### Negative
+- ⚠️ Runtime errors instead of link-time errors — a missing function
+  pointer is detected at first kernel launch, not at compile time
+- ⚠️ Slightly more complex initialisation code (symbol resolution,
+  version checks)
+- ⚠️ Harder to diagnose "driver too old" issues versus "driver missing"
+
+### Mitigations
+1. **Startup Diagnostics**: `BackendStartupSummary` logs
+   `requested=X detected=[…] selected=Y` at launch.
+2. **Feature Probing**: Each backend crate exposes a
+   `gpu_available_runtime()` function that performs a full health check
+   (load library → query devices → verify compute capability).
+3. **Strict Mode**: `BITNET_STRICT_MODE=1` escalates a missing GPU to an
+   error instead of a silent fallback.
+
+---
+
+## Alternatives Considered
+
+### Static Linking Against GPU SDKs
+**Rejected**: Would require CUDA Toolkit and Intel oneAPI SDK in every CI
+job and on every developer machine.  Breaks the "compile everywhere" goal.
+
+### Optional Crate Features Without Dynamic Loading
+**Rejected**: Cargo features select code at compile time, but the linked
+library must still be present.  Dynamic loading is the only way to defer
+the requirement to runtime.
+
+---
+
+## References
+
+- `bitnet_kernels::device_features::{gpu_compiled, gpu_available_runtime}`
+- `BackendStartupSummary` in `bitnet-inference/src/backend.rs`
+- `KernelManager::select_best()` fallback logic
+
+---
+
+## Changelog
+
+- **2025-06-24**: Initial decision

--- a/docs/architecture/decisions/ADR-007-microcrate-per-backend.md
+++ b/docs/architecture/decisions/ADR-007-microcrate-per-backend.md
@@ -1,0 +1,115 @@
+# ADR-007: Microcrate per GPU Backend
+
+**Status**: ACCEPTED
+**Date**: 2025-06-24
+**Context**: Workspace organisation for multi-GPU-backend support
+
+---
+
+## Context
+
+BitNet-rs targets multiple GPU backends: CUDA (NVIDIA), OpenCL (Intel /
+AMD), Vulkan (cross-vendor), and potentially Metal (Apple).  Each backend
+has distinct dependencies, build requirements, and feature-flag surfaces.
+
+Two workspace structures were considered:
+
+### Option A: Single `bitnet-kernels` Crate
+All backends live under `crates/bitnet-kernels/src/gpu/{cuda,opencl,vulkan}/`.
+Feature flags gate each sub-module.
+
+### Option B: Separate Microcrate per Backend
+Each backend gets its own crate:
+```
+crates/bitnet-kernels/          (core trait + CPU fallback)
+crates/bitnet-gpu-cuda/         (NVIDIA CUDA)
+crates/bitnet-gpu-opencl/       (Intel/AMD OpenCL)
+crates/bitnet-gpu-vulkan/       (Vulkan compute)
+```
+
+---
+
+## Decision
+
+**Option B — one microcrate per GPU backend.**
+
+Each backend is a standalone workspace member that depends on
+`bitnet-common` for shared types and implements the `KernelProvider` trait
+from `bitnet-kernels`.
+
+---
+
+## Rationale
+
+### 1. Single Responsibility
+Each crate owns exactly one backend.  Its `Cargo.toml` declares only the
+dependencies needed for that backend (e.g., `opencl3` for OpenCL,
+`cudarc` for CUDA).  No conditional `dep:` gymnastics.
+
+### 2. Independent Compilation
+`cargo check -p bitnet-gpu-opencl` compiles only OpenCL code.  Developers
+working on one backend are not slowed by changes to another.  CI can
+parallelise backend checks across matrix jobs.
+
+### 3. Clear Dependency Graph
+The workspace dependency graph makes it obvious which crates pull in GPU
+SDKs.  Auditing `Cargo.lock` for unexpected native dependencies is
+straightforward.
+
+### 4. Testability
+Each backend crate can have its own integration tests, property tests, and
+snapshot tests without polluting the core kernel test suite.
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Minimal compile scope per backend
+- ✅ Clean `Cargo.toml` per crate (no conditional deps)
+- ✅ Parallel CI matrix across backends
+- ✅ Easy to add new backends (copy template, implement trait)
+
+### Negative
+- ⚠️ More crates to maintain (one per backend + the core trait crate)
+- ⚠️ Inter-crate coordination for shared kernel utilities (solved by
+  `bitnet-common` and `bitnet-kernels` as the trait host)
+- ⚠️ Version bumps touch more `Cargo.toml` files (mitigated by
+  `workspace.version`)
+
+### Mitigations
+1. **Workspace Version**: All backend crates inherit
+   `version.workspace = true` to keep versions in sync.
+2. **Shared Utilities**: Common GPU helpers (memory pool, profiling,
+   error mapping) live in `bitnet-kernels` under a `gpu-common` module
+   that backends can depend on.
+3. **Template**: A `crates/bitnet-gpu-template/` skeleton accelerates
+   new backend creation.
+
+---
+
+## Alternatives Considered
+
+### Single Mega-Crate (Option A)
+**Rejected**: Feature-flag complexity grows quadratically with backends.
+Conditional `dep:` attributes make `Cargo.toml` hard to audit.  A
+compile-time error in one backend blocks `cargo check` for all.
+
+### Runtime Plugin System
+**Deferred**: A `libloading`-based plugin architecture is more flexible
+but introduces ABI stability requirements.  May be revisited for
+third-party backend contributions.
+
+---
+
+## References
+
+- Workspace members: `Cargo.toml` `[workspace]` section
+- `KernelProvider` trait: `crates/bitnet-kernels/src/lib.rs`
+- SRP microcrate pattern: `bitnet-logits`, `bitnet-gguf`, `bitnet-device-probe`
+
+---
+
+## Changelog
+
+- **2025-06-24**: Initial decision

--- a/docs/architecture/decisions/ADR-008-kernel-embedding-strategy.md
+++ b/docs/architecture/decisions/ADR-008-kernel-embedding-strategy.md
@@ -1,0 +1,114 @@
+# ADR-008: Kernel Embedding Strategy
+
+**Status**: ACCEPTED
+**Date**: 2025-06-24
+**Context**: How GPU kernel source code is shipped and compiled
+
+---
+
+## Context
+
+GPU kernels (OpenCL `.cl`, Vulkan `.glsl` / SPIR-V, CUDA `.cu`) must be
+available at runtime for compilation or dispatch.  Three strategies exist:
+
+| Strategy | Ship Format | First-Launch Cost | Cross-Platform |
+|----------|-----------|------------------|---------------|
+| Embed source (`include_str!`) | Text in binary | Compile on first use | ✅ |
+| Pre-compile to SPIR-V / PTX | Binary blob in binary | Near-zero | Partial |
+| External files | Separate `.cl` / `.spv` files | Compile on first use | ✅ |
+
+---
+
+## Decision
+
+**Embed kernel source via `include_str!` and compile at runtime.**
+
+Each kernel is stored as a `.cl` (or `.glsl`) file in the backend crate's
+`csrc/` directory and embedded into the Rust binary at compile time.
+Runtime compilation produces device-specific binaries that are cached to
+disk.
+
+---
+
+## Rationale
+
+### 1. Simplicity
+No external build tools (SPIR-V compiler, `clang`, `glslc`) required at
+build time.  The Rust toolchain is sufficient — `include_str!` is a
+built-in macro.
+
+### 2. Cross-Platform by Default
+OpenCL source compiles to the target device's ISA at runtime.  A single
+binary works on Intel, AMD, and NVIDIA GPUs without separate builds per
+vendor.
+
+### 3. No Distribution Complexity
+The kernel source is baked into the executable.  There are no separate
+`.cl` files to package, no `KERNEL_DIR` environment variable to configure,
+and no risk of version mismatch between binary and kernel files.
+
+### 4. Developer Experience
+Kernel authors edit a `.cl` file and re-run `cargo build` — the updated
+source is embedded automatically.  No separate compilation step.
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Zero external build dependencies for GPU kernels
+- ✅ Single-file distribution (binary includes all kernels)
+- ✅ Runtime compilation targets the exact device present
+- ✅ Easy to inspect embedded kernels (`strings binary | grep __kernel`)
+
+### Negative
+- ⚠️ First-launch latency: OpenCL runtime compilation takes 50–500 ms per
+  kernel depending on driver and kernel complexity
+- ⚠️ No compile-time validation of kernel syntax — errors surface at
+  runtime
+- ⚠️ Binary size increases slightly (kernel sources are small — typically
+  <10 KB per kernel)
+
+### Mitigations
+1. **SPIR-V Pre-Compilation Cache**: After first runtime compilation, the
+   compiled binary is cached in
+   `$XDG_CACHE_HOME/bitnet/kernels/<hash>.bin`.  Subsequent launches load
+   the cached binary directly, reducing startup to <1 ms per kernel.
+2. **Build-Script Validation** (optional): A `build.rs` step can invoke
+   `clang -cl-std=CL3.0 -fsyntax-only` to catch syntax errors at build
+   time on machines with the OpenCL SDK installed.
+3. **SPIR-V Embedding** (future): For performance-critical deployments,
+   SPIR-V blobs can be pre-compiled and embedded alongside the source as
+   a fast-path.  The runtime tries the SPIR-V blob first, falling back to
+   source compilation if the blob is incompatible.
+
+---
+
+## Alternatives Considered
+
+### Pre-Compile to SPIR-V at Build Time
+**Deferred**: Requires `spirv-tools` or `clang` in the build environment.
+Breaks the "no GPU SDK at build time" principle (ADR-006).  Will be
+offered as an opt-in `build.rs` step for release builds.
+
+### Ship External Kernel Files
+**Rejected**: Adds deployment complexity (file paths, packaging, version
+skew).  Contradicts the single-binary distribution goal.
+
+### Ahead-of-Time PTX for CUDA
+**Not applicable**: The CUDA backend uses `cudarc` which already handles
+JIT compilation from PTX.  This ADR focuses on OpenCL and Vulkan.
+
+---
+
+## References
+
+- `include_str!` usage: `crates/bitnet-kernels/src/gpu/opencl/kernels/`
+- Kernel cache implementation: `crates/bitnet-kernels/src/gpu/kernel_cache.rs`
+- ADR-006: Dynamic GPU Library Linking
+
+---
+
+## Changelog
+
+- **2025-06-24**: Initial decision

--- a/docs/architecture/decisions/ADR-009-cpu-reference-testing.md
+++ b/docs/architecture/decisions/ADR-009-cpu-reference-testing.md
@@ -1,0 +1,151 @@
+# ADR-009: CPU Reference Testing for Every GPU Kernel
+
+**Status**: ACCEPTED
+**Date**: 2025-06-24
+**Context**: Testing strategy for GPU kernel correctness
+
+---
+
+## Context
+
+GPU kernels are notoriously difficult to debug.  Differences in floating-
+point rounding, driver versions, and hardware errata can produce subtly
+wrong results that are invisible in unit tests but corrupt model output.
+
+BitNet-rs needs a testing strategy that:
+
+1. Works **without** GPU hardware (CI runners, developer laptops)
+2. Catches numerical drift across driver or hardware changes
+3. Validates correctness, not just "doesn't crash"
+
+---
+
+## Decision
+
+**Every GPU kernel must have a corresponding CPU reference implementation
+used for cross-validation testing.**
+
+The CPU reference is a simple, readable, scalar implementation of the same
+mathematical operation.  It is the single source of truth for expected
+output.
+
+---
+
+## Rationale
+
+### 1. Test Without Hardware
+CPU reference tests run on any machine.  CI can validate kernel
+correctness on standard ubuntu-22.04 runners without GPU instances,
+keeping CI costs low.
+
+### 2. Cross-Validate GPU Output
+When GPU hardware is available (local dev, GPU CI lane), the test
+harness runs both the GPU kernel and the CPU reference on the same
+input, then asserts the outputs match within a configurable tolerance
+(`correlation > 0.999`, `max_relative_error < 1e-3`).
+
+### 3. Regression Detection
+CPU reference outputs are pinned as insta snapshots (see ADR for snapshot
+testing).  Any change to the reference implementation or its inputs
+is caught immediately, preventing "drift by a thousand commits."
+
+### 4. Documentation by Example
+The CPU reference serves as executable documentation of what the kernel
+**should** compute.  New contributors can read the scalar code without
+understanding OpenCL, CUDA, or Vulkan.
+
+---
+
+## Consequences
+
+### Positive
+- ✅ Kernel correctness tested on every PR (no GPU required)
+- ✅ GPU vs CPU cross-validation when hardware is available
+- ✅ Snapshot-pinned reference outputs catch silent drift
+- ✅ CPU reference doubles as documentation
+- ✅ Property tests can use the CPU reference as an oracle
+
+### Negative
+- ⚠️ Dual maintenance: kernel logic exists in both GPU and CPU code.
+  Changes to the kernel algorithm must be mirrored in the reference.
+- ⚠️ CPU reference may mask GPU-specific bugs that only appear with
+  GPU-specific input patterns (e.g., warp divergence, bank conflicts).
+- ⚠️ Tolerance thresholds must be carefully tuned per kernel to avoid
+  false positives (too tight) or false negatives (too loose).
+
+### Mitigations
+1. **Property Tests**: Use `proptest` to generate random inputs and
+   verify invariants (e.g., softmax sums to 1.0, matmul is associative)
+   against the CPU reference.
+2. **Golden Output Tests**: Pin a small set of known-good outputs per
+   kernel to catch both GPU and CPU regressions.
+3. **Tolerance Registry**: A per-kernel tolerance table in
+   `crates/bitnet-kernels/tests/support/` defines acceptable error
+   bounds, reviewed and updated when algorithms change.
+4. **GPU-Only Stress Tests**: Separate `#[ignore]` tests exercise
+   GPU-specific patterns (large work-groups, shared memory, subgroup
+   operations) that the CPU reference cannot cover.
+
+---
+
+## Implementation
+
+Each kernel follows this test structure:
+
+```rust
+/// CPU reference: simple scalar implementation
+fn cpu_matmul_reference(a: &[f32], b: &[f32], m: usize, n: usize, k: usize) -> Vec<f32> {
+    // Triple-loop matmul — clear, correct, slow
+    ...
+}
+
+#[test]
+fn matmul_cpu_reference_correctness() {
+    let a = deterministic_input(m * k, seed);
+    let b = deterministic_input(k * n, seed + 1);
+    let expected = cpu_matmul_reference(&a, &b, m, n, k);
+    insta::assert_debug_snapshot!(expected);
+}
+
+#[test]
+#[cfg(feature = "gpu")]
+#[ignore = "Requires GPU hardware"]
+fn matmul_gpu_matches_cpu_reference() {
+    let a = deterministic_input(m * k, seed);
+    let b = deterministic_input(k * n, seed + 1);
+    let expected = cpu_matmul_reference(&a, &b, m, n, k);
+    let actual = gpu_matmul(&a, &b, m, n, k);
+    assert_correlation(&expected, &actual, 0.999);
+}
+```
+
+---
+
+## Alternatives Considered
+
+### Test GPU Kernels Only on GPU Hardware
+**Rejected**: Would require GPU CI runners for every PR.  Expensive and
+fragile (driver updates break tests).
+
+### Use Third-Party Math Libraries as Reference
+**Rejected**: Adds large dependencies (`ndarray`, `faer`).  The scalar
+CPU reference is trivial to implement and has zero dependencies.
+
+### Compare Against C++ Reference (bitnet.cpp)
+**Complementary**: The `crossval` crate already validates end-to-end
+against bitnet.cpp.  CPU reference testing validates individual kernels
+at a finer granularity.
+
+---
+
+## References
+
+- Snapshot regression tests: `crates/bitnet-kernels/tests/gpu_snapshot_regression.rs`
+- Cross-validation framework: `crossval/`
+- `KernelProvider` trait: `crates/bitnet-kernels/src/lib.rs`
+
+---
+
+## Changelog
+
+- **2025-06-24**: Initial decision


### PR DESCRIPTION
Add five ADRs for GPU architecture decisions: ADR-005 OpenCL-first backend, ADR-006 dynamic GPU linking, ADR-007 microcrate per backend, ADR-008 kernel embedding strategy, ADR-009 CPU reference testing. Also adds docs/architecture/README.md indexing all 9 ADRs.