### PR TITLE
feat(opencl): add FP16/INT8 mixed-precision kernel variants

### DIFF
--- a/crates/bitnet-kernels/src/gpu/kernels/matmul_fp16.cl
+++ b/crates/bitnet-kernels/src/gpu/kernels/matmul_fp16.cl
@@ -1,0 +1,58 @@
+/// FP16 matrix multiplication kernel for Intel Arc GPUs.
+///
+/// Uses cl_khr_fp16 extension for half-precision computation.
+/// Accumulates in FP32, stores FP16 intermediates for 2x throughput.
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__kernel void matmul_i2s_fp16(
+    __global const half* A,
+    __global const uchar* B,
+    __global float* C,
+    const uint M,
+    const uint N,
+    const uint K
+) {
+    const uint row = get_global_id(0);
+    const uint col = get_global_id(1);
+    if (row >= M || col >= N) return;
+
+    float acc = 0.0f;
+    const uint k_packed = K / 4;
+
+    for (uint kb = 0; kb < k_packed; kb++) {
+        uchar packed = B[kb * N + col];
+        uint base_k = kb * 4;
+        for (uint sub = 0; sub < 4; sub++) {
+            int bits = (packed >> (sub * 2)) & 0x3;
+            float w;
+            if (bits == 0x1) w = 1.0f;
+            else if (bits == 0x3) w = -1.0f;
+            else w = 0.0f;
+            float a_val = vload_half(0, &A[row * K + base_k + sub]);
+            acc += a_val * w;
+        }
+    }
+    C[row * N + col] = acc;
+}
+
+__kernel void matmul_fp16_full(
+    __global const half* A,
+    __global const half* B,
+    __global half* C,
+    const uint M,
+    const uint N,
+    const uint K
+) {
+    const uint row = get_global_id(0);
+    const uint col = get_global_id(1);
+    if (row >= M || col >= N) return;
+
+    float acc = 0.0f;
+    for (uint k = 0; k < K; k++) {
+        float a_val = vload_half(0, &A[row * K + k]);
+        float b_val = vload_half(0, &B[k * N + col]);
+        acc += a_val * b_val;
+    }
+    vstore_half(acc, 0, &C[row * N + col]);
+}

--- a/crates/bitnet-kernels/src/gpu/kernels/matmul_int8.cl
+++ b/crates/bitnet-kernels/src/gpu/kernels/matmul_int8.cl
@@ -1,0 +1,46 @@
+/// INT8 matrix multiplication kernel.
+/// INT8 weight x FP16 activation -> FP32 accumulate.
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+__kernel void matmul_int8_fp16(
+    __global const half* A,
+    __global const char* B,
+    __global float* C,
+    const uint M,
+    const uint N,
+    const uint K
+) {
+    const uint row = get_global_id(0);
+    const uint col = get_global_id(1);
+    if (row >= M || col >= N) return;
+
+    float acc = 0.0f;
+    for (uint k = 0; k < K; k++) {
+        float a_val = vload_half(0, &A[row * K + k]);
+        float b_val = (float)B[k * N + col];
+        acc += a_val * b_val;
+    }
+    C[row * N + col] = acc;
+}
+
+__kernel void matmul_int8_int8(
+    __global const char* A,
+    __global const char* B,
+    __global float* C,
+    const uint M,
+    const uint N,
+    const uint K,
+    const float scale_a,
+    const float scale_b
+) {
+    const uint row = get_global_id(0);
+    const uint col = get_global_id(1);
+    if (row >= M || col >= N) return;
+
+    int acc = 0;
+    for (uint k = 0; k < K; k++) {
+        acc += (int)A[row * K + k] * (int)B[k * N + col];
+    }
+    C[row * N + col] = (float)acc * scale_a * scale_b;
+}

--- a/crates/bitnet-kernels/src/gpu/kernels/mod.rs
+++ b/crates/bitnet-kernels/src/gpu/kernels/mod.rs
@@ -19,6 +19,12 @@ pub const MATMUL_I2S_TILED_SRC: &str = include_str!("matmul_i2s_tiled.cl");
 /// KV cache management kernels source.
 pub const KV_CACHE_SRC: &str = include_str!("kv_cache.cl");
 
+/// FP16 matrix multiplication kernel source (cl_khr_fp16).
+pub const MATMUL_FP16_SRC: &str = include_str!("matmul_fp16.cl");
+
+/// INT8 matrix multiplication kernel source.
+pub const MATMUL_INT8_SRC: &str = include_str!("matmul_int8.cl");
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,10 +34,12 @@ mod tests {
         assert!(!MATMUL_I2S_SRC.is_empty(), "matmul_i2s.cl should not be empty");
         assert!(!QUANTIZE_I2S_SRC.is_empty(), "quantize_i2s.cl should not be empty");
         assert!(!ELEMENTWISE_SRC.is_empty(), "elementwise.cl should not be empty");
-        assert!(
+assert!(
             !MATMUL_I2S_TILED_SRC.is_empty(),
             "matmul_i2s_tiled.cl should not be empty"
         );
+assert!(!MATMUL_FP16_SRC.is_empty(), "matmul_fp16.cl should not be empty");
+        assert!(!MATMUL_INT8_SRC.is_empty(), "matmul_int8.cl should not be empty");
     }
 
     #[test]
@@ -39,10 +47,12 @@ mod tests {
         assert!(MATMUL_I2S_SRC.contains("__kernel"), "matmul_i2s.cl missing __kernel");
         assert!(QUANTIZE_I2S_SRC.contains("__kernel"), "quantize_i2s.cl missing __kernel");
         assert!(ELEMENTWISE_SRC.contains("__kernel"), "elementwise.cl missing __kernel");
-        assert!(
+assert!(
             MATMUL_I2S_TILED_SRC.contains("__kernel"),
             "matmul_i2s_tiled.cl missing __kernel"
         );
+assert!(MATMUL_FP16_SRC.contains("__kernel"), "matmul_fp16.cl missing __kernel");
+        assert!(MATMUL_INT8_SRC.contains("__kernel"), "matmul_int8.cl missing __kernel");
     }
 
     #[test]

--- a/crates/bitnet-kernels/src/gpu/opencl_mixed_precision.rs
+++ b/crates/bitnet-kernels/src/gpu/opencl_mixed_precision.rs
@@ -1,0 +1,192 @@
+//! OpenCL mixed-precision support for Intel Arc GPUs.
+//!
+//! Selects optimal precision mode based on device capabilities.
+//! Controlled via `BITNET_PRECISION` env var: fp16|int8|fp32|auto.
+
+use std::fmt;
+
+/// Precision mode for GPU compute kernels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenClPrecisionMode {
+    /// Full FP32 precision (default, most compatible)
+    FP32,
+    /// Half precision FP16 (requires cl_khr_fp16)
+    FP16,
+    /// INT8 quantized (requires integer dot product support)
+    INT8,
+    /// Mixed: FP16 activations + ternary weights -> FP32 accumulate
+    Mixed,
+    /// Auto-detect best precision from device capabilities
+    Auto,
+}
+
+impl fmt::Display for OpenClPrecisionMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FP32 => write!(f, "fp32"),
+            Self::FP16 => write!(f, "fp16"),
+            Self::INT8 => write!(f, "int8"),
+            Self::Mixed => write!(f, "mixed"),
+            Self::Auto => write!(f, "auto"),
+        }
+    }
+}
+
+impl OpenClPrecisionMode {
+    /// Parse from string (env var value).
+    pub fn from_str_loose(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "fp32" => Some(Self::FP32),
+            "fp16" => Some(Self::FP16),
+            "int8" => Some(Self::INT8),
+            "mixed" => Some(Self::Mixed),
+            "auto" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+
+    /// Read from `BITNET_PRECISION` env var, defaulting to Auto.
+    pub fn from_env() -> Self {
+        std::env::var("BITNET_PRECISION")
+            .ok()
+            .and_then(|v| Self::from_str_loose(&v))
+            .unwrap_or(Self::Auto)
+    }
+}
+
+/// Device capabilities relevant to precision selection.
+#[derive(Debug, Clone)]
+pub struct OpenClDeviceCaps {
+    /// Device supports cl_khr_fp16
+    pub has_fp16: bool,
+    /// Device supports cl_khr_int8
+    pub has_int8: bool,
+    /// Device name for logging
+    pub device_name: String,
+}
+
+/// Select the best precision mode for the given device capabilities.
+pub fn select_opencl_precision(
+    caps: &OpenClDeviceCaps,
+    requested: OpenClPrecisionMode,
+) -> OpenClPrecisionMode {
+    match requested {
+        OpenClPrecisionMode::Auto => {
+            if caps.has_fp16 {
+                OpenClPrecisionMode::Mixed
+            } else {
+                OpenClPrecisionMode::FP32
+            }
+        }
+        OpenClPrecisionMode::FP16 if !caps.has_fp16 => {
+            log::warn!(
+                "FP16 requested but cl_khr_fp16 not supported on {}; falling back to FP32",
+                caps.device_name
+            );
+            OpenClPrecisionMode::FP32
+        }
+        OpenClPrecisionMode::INT8 if !caps.has_int8 => {
+            log::warn!(
+                "INT8 requested but not supported on {}; falling back to FP32",
+                caps.device_name
+            );
+            OpenClPrecisionMode::FP32
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn arc_caps() -> OpenClDeviceCaps {
+        OpenClDeviceCaps {
+            has_fp16: true,
+            has_int8: true,
+            device_name: "Intel Arc A770".into(),
+        }
+    }
+
+    fn basic_caps() -> OpenClDeviceCaps {
+        OpenClDeviceCaps {
+            has_fp16: false,
+            has_int8: false,
+            device_name: "Basic GPU".into(),
+        }
+    }
+
+    #[test]
+    fn test_auto_selects_mixed_when_fp16_available() {
+        let mode = select_opencl_precision(&arc_caps(), OpenClPrecisionMode::Auto);
+        assert_eq!(mode, OpenClPrecisionMode::Mixed);
+    }
+
+    #[test]
+    fn test_auto_selects_fp32_when_no_fp16() {
+        let mode = select_opencl_precision(&basic_caps(), OpenClPrecisionMode::Auto);
+        assert_eq!(mode, OpenClPrecisionMode::FP32);
+    }
+
+    #[test]
+    fn test_fp16_fallback_when_unsupported() {
+        let mode = select_opencl_precision(&basic_caps(), OpenClPrecisionMode::FP16);
+        assert_eq!(mode, OpenClPrecisionMode::FP32);
+    }
+
+    #[test]
+    fn test_int8_fallback_when_unsupported() {
+        let mode = select_opencl_precision(&basic_caps(), OpenClPrecisionMode::INT8);
+        assert_eq!(mode, OpenClPrecisionMode::FP32);
+    }
+
+    #[test]
+    fn test_explicit_fp32_always_works() {
+        let mode = select_opencl_precision(&basic_caps(), OpenClPrecisionMode::FP32);
+        assert_eq!(mode, OpenClPrecisionMode::FP32);
+    }
+
+    #[test]
+    fn test_explicit_fp16_when_supported() {
+        let mode = select_opencl_precision(&arc_caps(), OpenClPrecisionMode::FP16);
+        assert_eq!(mode, OpenClPrecisionMode::FP16);
+    }
+
+    #[test]
+    fn test_explicit_int8_when_supported() {
+        let mode = select_opencl_precision(&arc_caps(), OpenClPrecisionMode::INT8);
+        assert_eq!(mode, OpenClPrecisionMode::INT8);
+    }
+
+    #[test]
+    fn test_parse_precision_mode() {
+        assert_eq!(OpenClPrecisionMode::from_str_loose("fp16"), Some(OpenClPrecisionMode::FP16));
+        assert_eq!(OpenClPrecisionMode::from_str_loose("FP32"), Some(OpenClPrecisionMode::FP32));
+        assert_eq!(OpenClPrecisionMode::from_str_loose("INT8"), Some(OpenClPrecisionMode::INT8));
+        assert_eq!(OpenClPrecisionMode::from_str_loose("auto"), Some(OpenClPrecisionMode::Auto));
+        assert_eq!(OpenClPrecisionMode::from_str_loose("invalid"), None);
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(format!("{}", OpenClPrecisionMode::FP16), "fp16");
+        assert_eq!(format!("{}", OpenClPrecisionMode::Mixed), "mixed");
+    }
+
+    #[test]
+    #[serial(bitnet_env)]
+    fn test_from_env_default_is_auto() {
+        temp_env::with_var("BITNET_PRECISION", None::<&str>, || {
+            assert_eq!(OpenClPrecisionMode::from_env(), OpenClPrecisionMode::Auto);
+        });
+    }
+
+    #[test]
+    #[serial(bitnet_env)]
+    fn test_from_env_fp16() {
+        temp_env::with_var("BITNET_PRECISION", Some("fp16"), || {
+            assert_eq!(OpenClPrecisionMode::from_env(), OpenClPrecisionMode::FP16);
+        });
+    }
+}

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -15,6 +15,9 @@ pub mod kernels;
 // Persistent OpenCL kernel cache (filesystem only — no GPU deps)
 #[path = "gpu/kernel_cache.rs"]
 pub mod kernel_cache;
+// OpenCL mixed-precision selection (no GPU deps)
+#[path = "gpu/opencl_mixed_precision.rs"]
+pub mod opencl_mixed_precision;
 #[cfg(any(feature = "gpu", feature = "cuda", feature = "oneapi"))]
 pub mod gpu;
 pub mod gpu_utils;


### PR DESCRIPTION
Add FP16 and INT8 OpenCL kernel variants for Intel Arc GPUs with auto-detection.