### PR TITLE
ci: add ROCm/HIP CI smoke workflow

### DIFF
--- a/.github/workflows/rocm-smoke.yml
+++ b/.github/workflows/rocm-smoke.yml
@@ -1,0 +1,119 @@
+name: ROCm Smoke Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_parity:
+        description: 'Run parity receipt upload'
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Run weekly on Tuesday at 4 AM UTC (offset from GPU smoke on Monday)
+    - cron: '0 4 * * 2'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUST_LOG: warn
+
+jobs:
+  # Always-on compile check (no ROCm runtime required)
+  rocm-compile:
+    name: ROCm Compile Check
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.92.0"
+          components: rustfmt, clippy
+
+      - name: Cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ runner.os }}-rocm-compile-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-rocm-compile-
+
+      - name: Check ROCm build (no HIP runtime required)
+        run: |
+          # Compile with rocm and cpu features to validate kernel matrix
+          cargo check --locked --no-default-features --features rocm,cpu
+        env:
+          # Stub out GPU runtime detection at compile time
+          BITNET_GPU_FAKE: none
+
+  # Runtime ROCm tests — requires self-hosted ROCm runner
+  rocm-runtime:
+    name: ROCm Runtime Smoke (${{ matrix.test }})
+    runs-on: [self-hosted, linux, rocm]
+    timeout-minutes: 60
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - kernel-smoke
+          - inference-smoke
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.92.0"
+
+      - name: Cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/
+            target/
+          key: ${{ runner.os }}-rocm-runtime-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build ROCm release
+        run: cargo build --release --no-default-features --features rocm,cpu --locked
+
+      - name: ROCm kernel smoke (${{ matrix.test }})
+        if: matrix.test == 'kernel-smoke'
+        run: |
+          cargo test --locked -p bitnet-kernels \
+            --no-default-features --features rocm \
+            -- --nocapture 2>&1 | head -100
+
+      - name: ROCm inference smoke (${{ matrix.test }})
+        if: matrix.test == 'inference-smoke'
+        run: |
+          # Quick 4-token inference to validate ROCm end-to-end
+          RUST_LOG=warn cargo run --release --locked -p bitnet-cli \
+            --no-default-features --features rocm,full-cli -- run \
+            --model "${BITNET_GGUF:-models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf}" \
+            --tokenizer "${BITNET_TOKENIZER:-models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json}" \
+            --prompt "2+2=" \
+            --max-tokens 4 \
+            --temperature 0.0 \
+            --greedy 2>&1 | tail -10
+
+      - name: Upload ROCm receipts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: rocm-smoke-receipts-${{ github.run_id }}-${{ matrix.test }}
+          path: ci/inference.json
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
Adds weekly ROCm CI smoke test, mirroring the CUDA gpu-smoke workflow.

## What

- New `.github/workflows/rocm-smoke.yml` workflow
- **Compile check** on `ubuntu-22.04` (no HIP runtime needed) — validates `--features rocm,cpu` builds cleanly
- **Runtime smoke** on `[self-hosted, linux, rocm]` runners — kernel and inference tests
- Weekly schedule (Tuesday 4 AM UTC, offset from CUDA Monday)
- Manual `workflow_dispatch` trigger support
- Receipt artifact upload on completion

## Pattern

Mirrors `gpu-smoke.yml` (CUDA) structure: compile job + runtime matrix (kernel-smoke, inference-smoke).