### PR TITLE
ci(gpu): add Docker Compose GPU test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ NC := $(shell tput sgr0 2>/dev/null || echo "")
         build test-quick test-gpu test-integration gpu-smoke download-model crossval tree loc size \
         watch flame audit outdated bloat docker-run docker-gpu profile valgrind heaptrack wasm python list verbose \
         guards preflight \
+        gpu-test-build gpu-test-run gpu-test-monitor gpu-test-down gpu-test-check \
         b t r c f l d g bt bf cf cb ct fr ft q a i
 
 # Detect OS and features
@@ -374,6 +375,35 @@ docker-run: docker
 ## docker-gpu: Run with GPU support in Docker
 docker-gpu: docker
 	@docker run -it --rm --gpus all bitnet-rs:latest
+
+#############################################################################
+# GPU DOCKER TEST TARGETS
+#############################################################################
+
+## gpu-test-build: Build the Intel GPU test Docker image
+gpu-test-build:
+	@echo "$(GREEN)Building GPU test image...$(NC)"
+	@docker compose -f docker-compose.gpu-test.yml build gpu-tests
+
+## gpu-test-run: Run GPU integration tests via Docker Compose
+gpu-test-run:
+	@echo "$(GREEN)Running GPU integration tests...$(NC)"
+	@docker compose -f docker-compose.gpu-test.yml run --rm gpu-tests
+
+## gpu-test-monitor: Start the GPU monitor sidecar
+gpu-test-monitor:
+	@echo "$(GREEN)Starting GPU monitor...$(NC)"
+	@docker compose -f docker-compose.gpu-test.yml up gpu-monitor
+
+## gpu-test-down: Tear down all GPU test services
+gpu-test-down:
+	@echo "$(GREEN)Tearing down GPU test environment...$(NC)"
+	@docker compose -f docker-compose.gpu-test.yml down -v
+
+## gpu-test-check: Verify GPU is visible inside the container
+gpu-test-check:
+	@echo "$(GREEN)Checking GPU availability...$(NC)"
+	@docker compose -f docker-compose.gpu-test.yml run --rm gpu-tests clinfo --list
 
 #############################################################################
 # ADVANCED TARGETS

--- a/ci/gpu-docker/Dockerfile.gpu-test
+++ b/ci/gpu-docker/Dockerfile.gpu-test
@@ -1,0 +1,36 @@
+# Intel GPU Compute Runtime + Rust toolchain for BitNet-rs GPU tests.
+FROM ubuntu:24.04
+
+ARG RUST_VERSION=1.92.0
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install Intel Compute Runtime and OpenCL ICD loader
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    clinfo \
+    curl \
+    gcc \
+    git \
+    intel-opencl-icd \
+    libc6-dev \
+    ocl-icd-libopencl1 \
+    opencl-headers \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain ${RUST_VERSION} && \
+    . "$HOME/.cargo/env" && \
+    cargo install cargo-nextest --locked
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /workspace
+COPY . .
+
+# Pre-build dependencies so test iterations are fast
+RUN cargo build --workspace --no-default-features --features gpu 2>/dev/null || true
+
+ENTRYPOINT ["cargo"]
+CMD ["nextest", "run", "--workspace", "--no-default-features", "--features", "gpu", "-E", "test(/opencl/)", "--profile", "ci"]

--- a/ci/gpu-docker/README.md
+++ b/ci/gpu-docker/README.md
@@ -1,0 +1,79 @@
+# Intel GPU Docker Test Environment
+
+Docker Compose environment for running BitNet-rs GPU integration tests on
+Intel Arc GPUs using the Intel Compute Runtime (NEO) OpenCL driver.
+
+## Prerequisites
+
+| Requirement | Minimum | Notes |
+|---|---|---|
+| Linux host | Kernel 6.2+ | `/dev/dri` must be present |
+| Intel GPU | Arc A-series / Xe | Must support OpenCL 3.0 |
+| Docker | 24.0+ | With GPU device pass-through |
+| Docker Compose | v2.20+ | — |
+
+Install the host-side kernel driver:
+
+```bash
+# Ubuntu 22.04+
+sudo apt-get install -y intel-opencl-icd
+# Verify
+clinfo --list
+```
+
+## Quick Start
+
+```bash
+# From repository root
+docker compose -f docker-compose.gpu-test.yml up --build
+
+# Run tests only (no monitor)
+docker compose -f docker-compose.gpu-test.yml run gpu-tests
+
+# Tear down
+docker compose -f docker-compose.gpu-test.yml down -v
+```
+
+## Services
+
+### `gpu-tests`
+
+Runs the OpenCL-tagged tests in the BitNet-rs workspace using
+`cargo nextest`.  Passes through `/dev/dri` for GPU access and sets
+`BITNET_GPU_BACKEND=opencl`.
+
+Health check: `clinfo --list` verifies the OpenCL ICD loader can see
+at least one device.
+
+### `gpu-monitor`
+
+Runs `intel_gpu_top` in JSON mode (2 s sample interval) so you can
+observe GPU utilisation while the test suite runs.  Falls back
+gracefully on non-Intel hosts.
+
+## Makefile Targets
+
+The repository `Makefile` provides convenience targets:
+
+```bash
+make gpu-test-build   # Build the GPU test image
+make gpu-test-run     # Run GPU integration tests
+make gpu-test-monitor # Start the GPU monitor sidecar
+make gpu-test-down    # Tear down all GPU test services
+make gpu-test-check   # Health-check: verify GPU is visible
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `clinfo` shows 0 platforms | Install `intel-opencl-icd` on host |
+| Permission denied on `/dev/dri` | Add user to `video` + `render` groups |
+| Container starts but no GPU | Ensure `--device /dev/dri` is passed |
+| `intel_gpu_top` unavailable | Expected on non-Intel hosts; harmless |
+
+## CI Integration
+
+The GitHub Actions workflow `.github/workflows/gpu-smoke.yml` uses this
+compose file on self-hosted runners tagged `intel-gpu`.  See the workflow
+for caching and artifact upload details.

--- a/docker-compose.gpu-test.yml
+++ b/docker-compose.gpu-test.yml
@@ -1,0 +1,70 @@
+# Docker Compose GPU Test Environment for Intel GPUs
+#
+# Runs BitNet-rs integration tests on Intel Arc GPUs using the Intel
+# Compute Runtime.  Requires Linux host with /dev/dri available.
+#
+# Usage:
+#   docker compose -f docker-compose.gpu-test.yml up --build
+#   docker compose -f docker-compose.gpu-test.yml run gpu-tests
+#   docker compose -f docker-compose.gpu-test.yml down
+
+services:
+  # -----------------------------------------------------------------------
+  # GPU test runner
+  # -----------------------------------------------------------------------
+  gpu-tests:
+    build:
+      context: .
+      dockerfile: ci/gpu-docker/Dockerfile.gpu-test
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "video"
+      - "render"
+    environment:
+      - RUST_LOG=info
+      - BITNET_GPU_BACKEND=opencl
+      - OCL_ICD_VENDORS=/etc/OpenCL/vendors
+    volumes:
+      - cargo-cache:/usr/local/cargo/registry
+      - target-cache:/workspace/target
+    working_dir: /workspace
+    command: >
+      cargo nextest run --workspace --no-default-features --features gpu
+      -E 'test(/opencl/)'
+      --profile ci
+    healthcheck:
+      test: ["CMD", "clinfo", "--list"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    depends_on:
+      gpu-monitor:
+        condition: service_started
+
+  # -----------------------------------------------------------------------
+  # Intel GPU monitor (intel_gpu_top)
+  # -----------------------------------------------------------------------
+  gpu-monitor:
+    image: ubuntu:24.04
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "video"
+      - "render"
+    entrypoint: /bin/bash
+    command: >
+      -c "apt-get update -qq && apt-get install -y -qq intel-gpu-tools > /dev/null 2>&1 &&
+          echo 'GPU monitor started' &&
+          intel_gpu_top -J -s 2000 || echo 'intel_gpu_top unavailable (non-Intel host?)'"
+    healthcheck:
+      test: ["CMD-SHELL", "test -d /dev/dri"]
+      interval: 10s
+      timeout: 5s
+      retries: 2
+      start_period: 5s
+
+volumes:
+  cargo-cache:
+  target-cache:


### PR DESCRIPTION
## Summary
Add Docker Compose infrastructure for running BitNet-rs GPU integration tests on Intel Arc GPUs.

## Changes
- **docker-compose.gpu-test.yml** with `/dev/dri` passthrough for Intel GPUs
- **gpu-tests service**: Intel compute runtime + Rust 1.92.0 + cargo-nextest
- **gpu-monitor service**: `intel_gpu_top` JSON output for GPU utilisation
- **Dockerfile.gpu-test** with Ubuntu 24.04 + Intel OpenCL ICD
- **Makefile targets**: `gpu-test-{build,run,monitor,down,check}`
- **ci/gpu-docker/README.md** with prerequisites, usage, and troubleshooting

## Usage
```bash
make gpu-test-build   # Build the GPU test image
make gpu-test-run     # Run GPU integration tests
make gpu-test-check   # Verify GPU is visible
```