### PR TITLE
chore: prepare v0.2.0-alpha.1 multi-GPU release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitnet"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-bdd-grid-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "proptest",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-cli"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-common"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-test-support",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-compat"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-crossval"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-device-probe"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "ash",
  "bitnet-common",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-engine-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -590,7 +590,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-contract"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-feature-matrix",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-feature-matrix"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-profile-core",
  "insta",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ffi"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-generation"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-common",
  "insta",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-ggml-ffi"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "cc",
  "libc",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-gguf"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-honest-compute"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "proptest",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-inference"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-kernels"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bindgen",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-logits"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "proptest",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-models"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-prompt-templates"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-tokenizers",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-py"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-quantization"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-receipts"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -909,7 +909,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-rope"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "proptest",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-bootstrap"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-startup-contract",
  "proptest",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-context-core",
  "proptest",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-context-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid-core",
  "bitnet-runtime-feature-flags-core",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-feature-flags-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid-core",
  "insta",
@@ -967,21 +967,21 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-feature-matrix",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-profile-contract-core",
 ]
 
 [[package]]
 name = "bitnet-runtime-profile-contract-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-bdd-grid",
  "bitnet-runtime-context",
@@ -994,14 +994,14 @@ dependencies = [
 
 [[package]]
 name = "bitnet-runtime-profile-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-profile-contract",
 ]
 
 [[package]]
 name = "bitnet-sampling"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-logits",
@@ -1014,7 +1014,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-server"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1068,7 +1068,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st-tools"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-validation",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-st2gguf"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-startup-contract-core",
  "proptest",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-runtime-profile",
@@ -1128,7 +1128,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-diagnostics"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-startup-contract-guard"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-runtime-bootstrap",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-sys"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-test-support"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "proptest",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-policy-core",
  "proptest",
@@ -1178,7 +1178,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-contract"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-feature-contract",
  "bitnet-runtime-feature-flags",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-profile",
  "bitnet-testing-scenarios-core",
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-interop"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-feature-flags",
  "bitnet-testing-policy-contract",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-kit"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-policy",
  "insta",
@@ -1218,7 +1218,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-runtime"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-policy-interop",
  "insta",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-policy-tests"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-policy-runtime",
  "insta",
@@ -1236,7 +1236,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-profile"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-runtime-profile",
  "insta",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-scenarios-core",
  "proptest",
@@ -1253,7 +1253,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-scenarios-profile-core",
  "insta",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-testing-scenarios-profile-core"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bitnet-testing-profile",
  "insta",
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tests"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-tokenizers"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-trace"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blake3",
  "candle-core",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-transformer"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-validation"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "insta",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-wasm"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "bitnet-common",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "migrate-gen-config"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8638,7 +8638,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -8684,7 +8684,7 @@ dependencies = [
 
 [[package]]
 name = "xtask-build-helper"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ name = "bitnet"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
 rust-version.workspace = true
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 # Disable automatic discovery of tests, benches, and examples
 # Many of these use outdated APIs and need updating
 # Note: The tests/ directory is a separate bitnet-tests workspace crate
@@ -139,20 +139,20 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
 rust-version = "1.92.0"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 
 [dependencies]
 # Core crates - always included
-bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
-bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
-bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "crates/bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "crates/bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.0-alpha.1", default-features = false }
+bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.0-alpha.1", optional = true }
 
 # Optional crates based on features
-bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.1-dev", optional = true }
-bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.1-dev", optional = true }
-bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.1-dev", optional = true }
-bitnet-device-probe = { path = "crates/bitnet-device-probe", version = "0.2.1-dev", optional = true }
+bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.0-alpha.1", optional = true }
+bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.0-alpha.1", optional = true }
+bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.0-alpha.1", optional = true }
+bitnet-device-probe = { path = "crates/bitnet-device-probe", version = "0.2.0-alpha.1", optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
@@ -161,10 +161,10 @@ vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
 
 [dev-dependencies]
 async-trait = "0.1.89"
-bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.1-dev" }
-bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.1-dev" }
-bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.1-dev" }
-bitnet-tests = { path = "tests", version = "0.2.1-dev", package = "bitnet-tests", default-features = false }
+bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.0-alpha.1" }
+bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.0-alpha.1" }
+bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.0-alpha.1" }
+bitnet-tests = { path = "tests", version = "0.2.0-alpha.1", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 candle-nn = { version = "0.9.1", default-features = false }
 criterion = "0.7.0"
@@ -374,7 +374,7 @@ serial_test = "3.2.0"
 temp-env = "0.3.6"
 tracing-test = "0.2.6"
 rand = "0.9.2"
-bitnet-test-support = { path = "crates/bitnet-test-support", version = "0.2.1-dev" }
+bitnet-test-support = { path = "crates/bitnet-test-support", version = "0.2.0-alpha.1" }
 
 # HTTP client for examples
 reqwest = { version = "0.12.24", features = ["json"] }

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -16,9 +16,9 @@ name = "bitnet_bdd_grid"
 path = "src/lib.rs"
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0-alpha.1" }
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -23,17 +23,17 @@ name = "bitnet"
 path = "src/main.rs"
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
-bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0-alpha.1" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0-alpha.1" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0-alpha.1" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.0-alpha.1" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0-alpha.1", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive", "env", "color"] }

--- a/crates/bitnet-compat/Cargo.toml
+++ b/crates/bitnet-compat/Cargo.toml
@@ -8,9 +8,9 @@ description = "Compatibility layer for drop-in llama.cpp replacement"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1", optional = true }
 anyhow = "1.0.100"
 tracing = "0.1.41"
 serde_json.workspace = true

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -12,7 +12,7 @@ description = "Device detection and capability probing for BitNet inference"
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 

--- a/crates/bitnet-engine-core/Cargo.toml
+++ b/crates/bitnet-engine-core/Cargo.toml
@@ -12,8 +12,8 @@ description = "Orchestration contracts and session types for BitNet inference en
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.0-alpha.1" }
 anyhow.workspace = true
 serde.workspace = true
 

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -13,8 +13,8 @@ description = "Compact feature and BDD profile contracts for BitNet tooling"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0-alpha.1" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -13,7 +13,7 @@ description = "Shared feature flag and BDD profile matrix contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.1-dev" }
+bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-ffi/Cargo.toml
+++ b/crates/bitnet-ffi/Cargo.toml
@@ -16,11 +16,11 @@ name = "bitnet_ffi"
 crate-type = ["rlib", "cdylib", "staticlib"]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-compat = { path = "../bitnet-compat", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-compat = { path = "../bitnet-compat", version = "0.2.0-alpha.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -37,7 +37,7 @@ cudarc = { workspace = true, optional = true }
 cbindgen = "0.29.0"
 
 [dev-dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
 tempfile.workspace = true
 proptest = { workspace = true }
 

--- a/crates/bitnet-generation/Cargo.toml
+++ b/crates/bitnet-generation/Cargo.toml
@@ -12,7 +12,7 @@ description = "Decode-loop stopping logic and generation event types for BitNet 
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -15,19 +15,19 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
-bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
-bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.1-dev" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.2.1-dev" }
-bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
-bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
-bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
-bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.1-dev" }
-bitnet-sys = { path = "../bitnet-sys", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.0-alpha.1" }
+bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.0-alpha.1" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.0-alpha.1" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.0-alpha.1" }
+bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.0-alpha.1" }
+bitnet-generation = { path = "../bitnet-generation", version = "0.2.0-alpha.1" }
+bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.0-alpha.1" }
+bitnet-sys = { path = "../bitnet-sys", version = "0.2.0-alpha.1", optional = true }
 anyhow.workspace = true
 futures.workspace = true
 futures-util = "0.3.31"
@@ -58,7 +58,7 @@ chrono = "0.4.42"
 serial_test = "3.2.0"
 bitnet-test-support.workspace = true
 insta.workspace = true
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -18,8 +18,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.0-alpha.1" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true
@@ -45,13 +45,13 @@ serial_test.workspace = true
 anyhow = "1.0.100"
 serde = { version = "1.0.228", features = ["derive"] }
 half = "2.7.1"
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
 proptest.workspace = true
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0-alpha.1" }
 rand = "0.9.2"
 insta.workspace = true
 rand_chacha = "0.9.0"
-bitnet-tests = { path = "../../tests", version = "0.2.1-dev" }
+bitnet-tests = { path = "../../tests", version = "0.2.0-alpha.1" }
 bitnet-test-support.workspace = true
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -15,12 +15,12 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
-bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
-bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
-bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
-bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.0-alpha.1" }
+bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.0-alpha.1" }
+bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.0-alpha.1", optional = true }
+bitnet-trace = { path = "../bitnet-trace", version = "0.2.0-alpha.1", optional = true }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
@@ -51,7 +51,7 @@ serial_test.workspace = true
 temp-env = "0.3.6"
 sha2 = "0.10.9"
 sysinfo = "0.37.2"
-bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.1-dev" }
+bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.0-alpha.1" }
 bitnet-test-support.workspace = true
 insta.workspace = true
 

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 anyhow = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -21,11 +21,11 @@ test = false
 bench = false
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
 
 pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py312"] }
 pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime"] }

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -15,7 +15,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
 anyhow.workspace = true
 thiserror.workspace = true
 bytemuck.workspace = true
@@ -23,7 +23,7 @@ candle-core.workspace = true
 rayon.workspace = true
 serde.workspace = true
 tracing.workspace = true
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1", optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
@@ -33,7 +33,7 @@ serial_test = "3.1"
 rand.workspace = true
 rand_chacha = "0.9"
 insta = { workspace = true, features = ["json"] }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev", features = ["cpu"] }  # AC2: For testing re-exports
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1", features = ["cpu"] }  # AC2: For testing re-exports
 
 [features]
 default = []

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -16,9 +16,9 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1", optional = true }
 rustc_version_runtime = "0.3.0"
 
 [features]

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.1-dev" }
+bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.1-dev" }
+bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -16,8 +16,8 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
-bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }
+bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
+bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
-bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.1-dev" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
+bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.0-alpha.1" }
+bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.0-alpha.1" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.1-dev" }
+bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -13,7 +13,7 @@ description = "Core runtime profile, BDD, and feature-flag contracts"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.1-dev" }
+bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Runtime profile, BDD, and feature-flagging utilities for BitNet"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
+bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -16,7 +16,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 rand = "0.9.2"
 rand_chacha = "0.9.0"
-bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
+bitnet-logits = { path = "../bitnet-logits", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -21,13 +21,13 @@ anyhow.workspace = true
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
-bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0-alpha.1" }
+bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.0-alpha.1" }
 chrono.workspace = true
 clap.workspace = true
 cudarc = { workspace = true, optional = true }

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -11,7 +11,7 @@ description = "SafeTensors utilities for BitNet: LN inspection and LN-preserving
 [dependencies]
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }
-bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
+bitnet-validation = { path = "../bitnet-validation", version = "0.2.0-alpha.1" }
 walkdir = "2.5.0"
 safetensors = "0.6.2"
 half = "2.7.1"

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/main.rs"
 
 [dependencies]
 # BitNet-rs internal crates
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
 
 # Core dependencies
 anyhow.workspace = true
@@ -42,7 +42,7 @@ bytemuck.workspace = true
 half = "2.6.0"
 
 [dev-dependencies]
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
 tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -14,7 +14,7 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -14,8 +14,8 @@ include = ["src/**", "Cargo.toml"]
 
 [dependencies]
 anyhow.workspace = true
-bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
-bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.2.1-dev" }
+bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.0-alpha.1" }
+bitnet-startup-contract-diagnostics = { path = "../bitnet-startup-contract-diagnostics", version = "0.2.0-alpha.1" }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -13,7 +13,7 @@ description = "Startup contract primitives powered by BDD grid and runtime featu
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.1-dev" }
+bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0.17"
 # Build-time dependencies for generating bindings
 bindgen = { version = "0.72.1", optional = true }
 cc = { version = "1.2.41", optional = true }
-xtask-build-helper = { path = "../../xtask-build-helper", version = "0.2.1-dev" }
+xtask-build-helper = { path = "../../xtask-build-helper", version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -16,9 +16,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
-bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.1-dev" }
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.1-dev" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0-alpha.1" }
+bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.0-alpha.1" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -13,8 +13,8 @@ description = "Core policy and BDD compatibility orchestration for BitNet runtim
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0-alpha.1" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -13,9 +13,9 @@ description = "Interoperability façade for BitNet testing policy, BDD grid, and
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.1-dev" }
-bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
-bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.2.1-dev" }
+bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.0-alpha.1" }
+bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.0-alpha.1" }
+bitnet-testing-policy-kit = { path = "../bitnet-testing-policy-kit", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.1-dev" }
+bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
+bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.1-dev" }
+bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -13,7 +13,7 @@ description = "Stable orchestration layer for test policy/profile resolution"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.1-dev" }
+bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -13,7 +13,7 @@ description = "Testing-focused façade over BDD grid and feature-flag profile co
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }
+bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.1-dev" }
+bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.0-alpha.1" }
 num_cpus = "1.17.0"
 
 [dev-dependencies]

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
+bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.0-alpha.1" }
 num_cpus = "1.17.0"
 
 [features]

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 ]
 
 [dependencies]
-bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }
+bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.0-alpha.1" }
 
 [features]
 default = []

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -17,9 +17,9 @@ include = [
 ]
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }
@@ -61,7 +61,7 @@ tokio = { workspace = true, features = ["full"] }
 tempfile = "3.23.0"
 temp-env = "0.3.6"
 serial_test.workspace = true
-bitnet-tests = { path = "../../tests", version = "0.2.1-dev" }
+bitnet-tests = { path = "../../tests", version = "0.2.0-alpha.1" }
 bitnet-test-support.workspace = true
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitnet-trace"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 rust-version = "1.92.0"
 license = "MIT OR Apache-2.0"

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
-bitnet-rope = { path = "../bitnet-rope", version = "0.2.1-dev" }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-rope = { path = "../bitnet-rope", version = "0.2.0-alpha.1" }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
 anyhow.workspace = true

--- a/crates/bitnet-wasm/Cargo.toml
+++ b/crates/bitnet-wasm/Cargo.toml
@@ -17,13 +17,13 @@ crate-type = ["cdylib", "rlib"]
 futures-util = "0.3.31"
 # getrandom for WASM compatibility
 getrandom = { version = "0.3.3", features = ["wasm_js"] }
-bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
-bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", features = ["cpu"], optional = true }
+bitnet-common = { path = "../bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.0-alpha.1", features = ["cpu"], optional = true }
 # Keep inference optional to avoid pulling tokio/mio on wasm by default.
-bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev", optional = true, default-features = false }
-bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-inference = { path = "../bitnet-inference", version = "0.2.0-alpha.1", optional = true, default-features = false }
+bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.0-alpha.1" }
 
 # WebAssembly specific dependencies
 wasm-bindgen = { workspace = true, features = ["serde-serialize"] }

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -36,14 +36,14 @@ toml.workspace = true
 bindgen = { version = "0.72.1", optional = true }
 cc = { version = "1.2.46", optional = true }
 # bitnet-sys is needed for bitnet.cpp cross-validation (enabled via bitnet-ffi)
-bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.1-dev", optional = true }
+bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.0-alpha.1", optional = true }
 
 # Internal crates for testing
-bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev" }
-bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
-bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", features = ["spm"] }
-bitnet-ggml-ffi = { path = "../crates/bitnet-ggml-ffi", version = "0.2.1-dev" }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.0-alpha.1", features = ["spm"] }
+bitnet-ggml-ffi = { path = "../crates/bitnet-ggml-ffi", version = "0.2.0-alpha.1" }
 scopeguard = "1.2.0"
 dirs = "6.0.0"
 humantime = "2.3.0"
@@ -56,7 +56,7 @@ console = "0.16.1"  # For colored error messages in token parity
 criterion = { version = "0.7.0", features = ["html_reports"] }
 tempfile = "3.23.0"
 rand = "0.9.2"
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.0-alpha.1" }
 half = "2.7.1"
 serial_test = "3.2.0"
 

--- a/docs/GPU_MIGRATION_GUIDE.md
+++ b/docs/GPU_MIGRATION_GUIDE.md
@@ -1,0 +1,41 @@
+# Migration Guide: v0.1.x → v0.2.0
+
+## Device Enum Changes
+
+The `Device` enum in `bitnet-common` has new variants. If you match on `Device`,
+add wildcard arms:
+
+```rust
+match device {
+    Device::Cpu => { /* ... */ }
+    Device::Cuda(id) => { /* ... */ }
+    Device::Metal => { /* ... */ }
+    // New in v0.2.0:
+    Device::OpenCL(id) => { /* ... */ }
+    Device::Vulkan(id) => { /* ... */ }
+    Device::Rocm(id) => { /* ... */ }
+    _ => { /* future-proof */ }
+}
+```
+
+## Feature Flags
+
+New feature flags available:
+- `oneapi` — Intel GPU (OpenCL) support
+- `vulkan` — Vulkan compute backend (experimental)
+- `rocm` — AMD ROCm/HIP backend (experimental)
+- `webgpu` — WebGPU/WGSL backend (experimental)
+
+Existing flags (`cpu`, `gpu`, `full-cli`) are unchanged.
+
+## CLI Changes
+
+New `--device` options: `opencl`, `vulkan`, `rocm`, `auto`
+
+```bash
+# Auto-detect best device (default)
+bitnet-cli run --device auto --model model.gguf
+
+# Force OpenCL
+bitnet-cli run --device opencl --model model.gguf
+```

--- a/docs/RELEASE_NOTES_v0.2.0.md
+++ b/docs/RELEASE_NOTES_v0.2.0.md
@@ -1,0 +1,55 @@
+# BitNet-rs v0.2.0-alpha.1 Release Notes
+
+## Multi-GPU Backend Support
+
+This release introduces comprehensive multi-GPU backend support for BitNet-rs,
+enabling inference on Intel Arc, AMD ROCm, Apple Metal, and WebGPU devices in
+addition to the existing NVIDIA CUDA and CPU backends.
+
+### New Features
+
+#### GPU Backends
+- **Intel Arc (OpenCL)**: Full inference support via `--features oneapi`
+  - 20+ OpenCL compute kernels (matmul, attention, softmax, RoPE, etc.)
+  - Flash Attention with O(N) memory
+  - Ternary matmul optimization for 1-bit weights
+  - Fused LayerNorm+Linear kernel
+- **Vulkan**: Cross-vendor GPU compute via `--features vulkan` (experimental)
+- **AMD ROCm**: HIP-based kernels via `--features rocm` (experimental)
+- **Apple Metal**: MSL compute kernels via `--features metal` (experimental)
+- **WebGPU**: Browser-compatible WGSL kernels via `--features webgpu` (experimental)
+
+#### GPU Infrastructure
+- Unified Hardware Abstraction Layer (bitnet-gpu-hal)
+- Runtime backend discovery and selection
+- GPU memory estimation and planning
+- Kernel fusion and optimization passes
+- Flash Attention, PagedAttention KV cache
+- Multi-device scheduling and load balancing
+
+#### Server Features
+- Smart request routing to GPU backends
+- Model registry with GPU affinity
+- WebSocket streaming for real-time token output
+- Canary deployment for GPU backends
+- GPU-aware rate limiting
+
+#### Testing & CI
+- Mock GPU backend for CI testing without hardware
+- Property tests for all kernel operations
+- Cross-backend numerical validation
+- Benchmark regression detection
+- Feature flag compile matrix
+
+### Breaking Changes
+- `Device` enum now includes `OpenCL(usize)`, `Vulkan(usize)`, `Rocm(usize)` variants
+- `KernelBackend` enum expanded with new variants
+
+### Known Limitations
+- GPU backends are experimental; CPU and CUDA remain the recommended production paths
+- QK256 GPU kernels are scalar-only (no SIMD vectorization on GPU)
+- Real hardware testing is limited to NVIDIA CUDA; other backends tested via mock only
+- WebGPU and ROCm backends have minimal kernel coverage
+
+### Migration Guide
+See `docs/GPU_MIGRATION_GUIDE.md` for details on upgrading from v0.1.x.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,24 +13,24 @@ libfuzzer-sys = "0.4.10"
 serde_json = "1.0.145"
 safetensors = "0.6.2"
 tempfile = "3"
-bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.1-dev" }
-bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
-bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
-bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.1-dev" }
-bitnet-st2gguf = { path = "../crates/bitnet-st2gguf", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.1-dev" }
-bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.1-dev" }
-bitnet-rope = { path = "../crates/bitnet-rope", version = "0.2.1-dev" }
-bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.1-dev" }
-bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.1-dev" }
-bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.1-dev" }
-bitnet-validation = { path = "../crates/bitnet-validation", version = "0.2.1-dev" }
-bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.1-dev" }
-bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.1-dev" }
-bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core", version = "0.2.1-dev" }
-bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }
+bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.0-alpha.1" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.0-alpha.1" }
+bitnet-st2gguf = { path = "../crates/bitnet-st2gguf", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.0-alpha.1" }
+bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.0-alpha.1" }
+bitnet-rope = { path = "../crates/bitnet-rope", version = "0.2.0-alpha.1" }
+bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.0-alpha.1" }
+bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.0-alpha.1" }
+bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.0-alpha.1" }
+bitnet-validation = { path = "../crates/bitnet-validation", version = "0.2.0-alpha.1" }
+bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.0-alpha.1" }
+bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.0-alpha.1" }
+bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
+bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core", version = "0.2.0-alpha.1" }
 candle-core = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -285,7 +285,7 @@ path = "examples/reporting_example.rs"
 async-trait = "0.1.89"
 futures-util = "0.3.31"
 tokio = { version = "1.48.0", features = ["full"] }
-bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.2.1-dev" }
+bitnet-testing-policy-tests = { path = "../crates/bitnet-testing-policy-tests", version = "0.2.0-alpha.1" }
 bitnet-test-support = { workspace = true }
 
 # System information
@@ -357,24 +357,24 @@ cargo_metadata = "0.23.1"
 filetime = "0.2.26"
 
 # bitnet-rs crates for cross-validation
-bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
-bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, features = ["cpu", "rt-tokio"] }
-bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
-bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.1-dev" }
-bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev" }
-bitnet-compat = { path = "../crates/bitnet-compat", version = "0.2.1-dev" }
-bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.1-dev" }
-bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.1-dev" }
-bitnet-device-probe = { path = "../crates/bitnet-device-probe", version = "0.2.1-dev" }
-bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.1-dev" }
-bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.1-dev" }
-bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.1-dev" }
-bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.1-dev" }
-bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.1-dev" }
-bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.1-dev" }
-bitnet = { path = "../", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
-bitnet-crossval = { path = "../crossval", version = "0.2.1-dev", package = "bitnet-crossval" }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.0-alpha.1", default-features = false, features = ["cpu", "rt-tokio"] }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.0-alpha.1" }
+bitnet-quantization = { path = "../crates/bitnet-quantization", version = "0.2.0-alpha.1" }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.0-alpha.1" }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.0-alpha.1" }
+bitnet-compat = { path = "../crates/bitnet-compat", version = "0.2.0-alpha.1" }
+bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.0-alpha.1" }
+bitnet-sampling = { path = "../crates/bitnet-sampling", version = "0.2.0-alpha.1" }
+bitnet-device-probe = { path = "../crates/bitnet-device-probe", version = "0.2.0-alpha.1" }
+bitnet-logits = { path = "../crates/bitnet-logits", version = "0.2.0-alpha.1" }
+bitnet-generation = { path = "../crates/bitnet-generation", version = "0.2.0-alpha.1" }
+bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.0-alpha.1" }
+bitnet-gguf = { path = "../crates/bitnet-gguf", version = "0.2.0-alpha.1" }
+bitnet-prompt-templates = { path = "../crates/bitnet-prompt-templates", version = "0.2.0-alpha.1" }
+bitnet-receipts = { path = "../crates/bitnet-receipts", version = "0.2.0-alpha.1" }
+bitnet = { path = "../", version = "0.2.0-alpha.1", default-features = false, features = ["cpu"] }
+bitnet-crossval = { path = "../crossval", version = "0.2.0-alpha.1", package = "bitnet-crossval" }
 
 # Additional dependencies for fixtures
 bincode = "2.0.1"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -25,19 +25,19 @@ toml = "0.9.8"
 httpdate = "1.0.3"
 tempfile = "3.23.0"
 chrono = "0.4.42"
-bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
-bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
-bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev", default-features = false }
-bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", default-features = false, features = ["spm"] }
-bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, optional = true }
-bitnet = { path = "..", version = "0.2.1-dev", default-features = false, features = ["cpu"], optional = true }
+bitnet-models = { path = "../crates/bitnet-models", version = "0.2.0-alpha.1", default-features = false, features = ["cpu"] }
+bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.0-alpha.1", default-features = false, features = ["cpu"] }
+bitnet-common = { path = "../crates/bitnet-common", version = "0.2.0-alpha.1", default-features = false }
+bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.0-alpha.1", default-features = false, features = ["spm"] }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.0-alpha.1", default-features = false, optional = true }
+bitnet = { path = "..", version = "0.2.0-alpha.1", default-features = false, features = ["cpu"], optional = true }
 tokio = { version = "1.48.0", features = ["rt"], optional = true }
 futures = { version = "0.3.31", optional = true }
 regex = "1.12.2"
-xtask-build-helper = { path = "../xtask-build-helper", version = "0.2.1-dev" }
-bitnet-crossval = { path = "../crossval", version = "0.2.1-dev", default-features = false, optional = true }
-bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.1-dev", default-features = false, optional = true }
-bitnet-bdd-grid = { path = "../crates/bitnet-bdd-grid", version = "0.2.1-dev" }
+xtask-build-helper = { path = "../xtask-build-helper", version = "0.2.0-alpha.1" }
+bitnet-crossval = { path = "../crossval", version = "0.2.0-alpha.1", default-features = false, optional = true }
+bitnet-sys = { path = "../crates/bitnet-sys", version = "0.2.0-alpha.1", default-features = false, optional = true }
+bitnet-bdd-grid = { path = "../crates/bitnet-bdd-grid", version = "0.2.0-alpha.1" }
 scopeguard = "1.2.0"
 thiserror = "2.0.17"
 


### PR DESCRIPTION
Version bump, release notes, migration guide. Documents all new GPU backends, features, breaking changes.