### PR TITLE
feat(server): WebSocket streaming for GPU inference

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -15,7 +15,9 @@ pub mod health;
 pub mod model_manager;
 pub mod monitoring;
 pub mod security;
+pub mod sse;
 pub mod streaming;
+pub mod websocket;
 
 use anyhow::Result;
 use axum::{

--- a/crates/bitnet-server/src/sse.rs
+++ b/crates/bitnet-server/src/sse.rs
@@ -1,0 +1,126 @@
+//! Server-Sent Events (SSE) fallback for streaming inference.
+//!
+//! When a client does not support WebSocket, the server can fall back
+//! to SSE for token-by-token delivery.
+
+use crate::websocket::WsMessage;
+
+/// SSE event for token streaming.
+#[derive(Debug, Clone)]
+pub struct SseToken {
+    /// Optional event id for resumable streams.
+    pub id: Option<String>,
+    /// SSE event type (e.g. `"token"`, `"metadata"`, `"error"`).
+    pub event: String,
+    /// JSON-encoded event payload.
+    pub data: String,
+    /// Retry interval hint for the client (milliseconds).
+    pub retry: Option<u64>,
+}
+
+/// SSE stream configuration.
+pub struct SseConfig {
+    /// Default retry interval hint sent to clients (milliseconds).
+    pub retry_ms: u64,
+    /// Interval for SSE keep-alive comments (seconds).
+    pub keep_alive_secs: u64,
+}
+
+impl Default for SseConfig {
+    fn default() -> Self {
+        Self { retry_ms: 3000, keep_alive_secs: 15 }
+    }
+}
+
+/// Format a [`WsMessage`] as a standards-compliant SSE event string.
+///
+/// The returned string includes the trailing double-newline required by
+/// the SSE specification.
+pub fn format_sse_event(msg: &WsMessage) -> String {
+    match msg {
+        WsMessage::Token { .. } => {
+            let data = serde_json::to_string(msg).unwrap_or_default();
+            format!("event: token\ndata: {data}\n\n")
+        }
+        WsMessage::Metadata { .. } => {
+            let data = serde_json::to_string(msg).unwrap_or_default();
+            format!("event: metadata\ndata: {data}\n\n")
+        }
+        WsMessage::Error { .. } => {
+            let data = serde_json::to_string(msg).unwrap_or_default();
+            format!("event: error\ndata: {data}\n\n")
+        }
+        WsMessage::Ping => "event: ping\ndata: \n\n".to_string(),
+        WsMessage::Pong => "event: pong\ndata: \n\n".to_string(),
+        WsMessage::Request { .. } => {
+            // Requests are client→server; formatting as SSE is
+            // atypical but supported for debugging.
+            let data = serde_json::to_string(msg).unwrap_or_default();
+            format!("event: request\ndata: {data}\n\n")
+        }
+    }
+}
+
+/// Build an [`SseToken`] from a [`WsMessage`] with optional id and
+/// retry hint.
+pub fn build_sse_token(msg: &WsMessage, id: Option<String>, retry: Option<u64>) -> SseToken {
+    let (event, data) = match msg {
+        WsMessage::Token { .. } => {
+            ("token".to_string(), serde_json::to_string(msg).unwrap_or_default())
+        }
+        WsMessage::Metadata { .. } => {
+            ("metadata".to_string(), serde_json::to_string(msg).unwrap_or_default())
+        }
+        WsMessage::Error { .. } => {
+            ("error".to_string(), serde_json::to_string(msg).unwrap_or_default())
+        }
+        WsMessage::Ping => ("ping".to_string(), String::new()),
+        WsMessage::Pong => ("pong".to_string(), String::new()),
+        WsMessage::Request { .. } => {
+            ("request".to_string(), serde_json::to_string(msg).unwrap_or_default())
+        }
+    };
+    SseToken { id, event, data, retry }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_config_defaults_are_sane() {
+        let cfg = SseConfig::default();
+        assert_eq!(cfg.retry_ms, 3000);
+        assert_eq!(cfg.keep_alive_secs, 15);
+    }
+
+    #[test]
+    fn format_token_event() {
+        let msg = WsMessage::Token {
+            text: "hello".into(),
+            token_id: 42,
+            logprob: None,
+            finish_reason: None,
+        };
+        let sse = format_sse_event(&msg);
+        assert!(sse.starts_with("event: token\n"));
+        assert!(sse.contains("\"token_id\":42"));
+        assert!(sse.ends_with("\n\n"));
+    }
+
+    #[test]
+    fn format_ping_event() {
+        let sse = format_sse_event(&WsMessage::Ping);
+        assert_eq!(sse, "event: ping\ndata: \n\n");
+    }
+
+    #[test]
+    fn build_sse_token_captures_fields() {
+        let msg = WsMessage::Error { message: "oops".into(), code: 500 };
+        let tok = build_sse_token(&msg, Some("id-1".into()), Some(5000));
+        assert_eq!(tok.event, "error");
+        assert_eq!(tok.id.as_deref(), Some("id-1"));
+        assert_eq!(tok.retry, Some(5000));
+        assert!(tok.data.contains("oops"));
+    }
+}

--- a/crates/bitnet-server/src/websocket.rs
+++ b/crates/bitnet-server/src/websocket.rs
@@ -1,0 +1,184 @@
+//! WebSocket streaming endpoint for GPU inference.
+//!
+//! Provides real-time token-by-token output via WebSocket connections.
+//! Falls back to Server-Sent Events (SSE) for clients that don't
+//! support WebSocket.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// WebSocket message types for inference streaming.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum WsMessage {
+    /// Client sends inference request.
+    #[serde(rename = "request")]
+    Request {
+        prompt: String,
+        max_tokens: Option<usize>,
+        temperature: Option<f32>,
+        top_k: Option<usize>,
+        top_p: Option<f32>,
+        stream: Option<bool>,
+    },
+    /// Server sends a generated token.
+    #[serde(rename = "token")]
+    Token { text: String, token_id: u32, logprob: Option<f32>, finish_reason: Option<String> },
+    /// Server sends generation metadata.
+    #[serde(rename = "metadata")]
+    Metadata {
+        model: String,
+        backend: String,
+        tokens_per_second: f64,
+        total_tokens: usize,
+        prompt_tokens: usize,
+    },
+    /// Server sends error.
+    #[serde(rename = "error")]
+    Error { message: String, code: u32 },
+    /// Ping for keepalive.
+    #[serde(rename = "ping")]
+    Ping,
+    /// Pong for keepalive.
+    #[serde(rename = "pong")]
+    Pong,
+}
+
+/// Configuration for WebSocket streaming.
+pub struct WsConfig {
+    /// Maximum number of concurrent WebSocket connections.
+    pub max_connections: usize,
+    /// Idle timeout before disconnecting (seconds).
+    pub idle_timeout_secs: u64,
+    /// Maximum incoming message size in bytes.
+    pub max_message_size: usize,
+    /// Interval between heartbeat pings (seconds).
+    pub heartbeat_interval_secs: u64,
+    /// Maximum queued messages before applying backpressure.
+    pub backpressure_limit: usize,
+}
+
+impl Default for WsConfig {
+    fn default() -> Self {
+        Self {
+            max_connections: 100,
+            idle_timeout_secs: 300,
+            max_message_size: 64 * 1024,
+            heartbeat_interval_secs: 30,
+            backpressure_limit: 1024,
+        }
+    }
+}
+
+/// Manages active WebSocket connections.
+pub struct WsConnectionManager {
+    config: WsConfig,
+    active_connections: Arc<AtomicUsize>,
+}
+
+impl WsConnectionManager {
+    /// Create a new connection manager with the given configuration.
+    pub fn new(config: WsConfig) -> Self {
+        Self { config, active_connections: Arc::new(AtomicUsize::new(0)) }
+    }
+
+    /// Return the number of active connections.
+    pub fn active_count(&self) -> usize {
+        self.active_connections.load(Ordering::Relaxed)
+    }
+
+    /// Return `true` when the manager can accept another connection.
+    pub fn can_accept(&self) -> bool {
+        self.active_count() < self.config.max_connections
+    }
+
+    /// Register a new connection. Returns `false` if at capacity.
+    pub fn register(&self) -> bool {
+        let prev =
+            self.active_connections.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |cur| {
+                if cur < self.config.max_connections { Some(cur + 1) } else { None }
+            });
+        prev.is_ok()
+    }
+
+    /// Unregister a connection (on disconnect).
+    pub fn unregister(&self) {
+        self.active_connections.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    /// Return the configured maximum number of connections.
+    pub fn max_connections(&self) -> usize {
+        self.config.max_connections
+    }
+
+    /// Return the configured backpressure limit.
+    pub fn backpressure_limit(&self) -> usize {
+        self.config.backpressure_limit
+    }
+
+    /// Return the configured idle timeout in seconds.
+    pub fn idle_timeout_secs(&self) -> u64 {
+        self.config.idle_timeout_secs
+    }
+
+    /// Return the configured heartbeat interval in seconds.
+    pub fn heartbeat_interval_secs(&self) -> u64 {
+        self.config.heartbeat_interval_secs
+    }
+
+    /// Return the configured max message size in bytes.
+    pub fn max_message_size(&self) -> usize {
+        self.config.max_message_size
+    }
+}
+
+/// Check whether the queued message count exceeds the backpressure
+/// threshold.
+pub fn should_apply_backpressure(queued: usize, limit: usize) -> bool {
+    queued >= limit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ws_config_defaults_are_sane() {
+        let cfg = WsConfig::default();
+        assert_eq!(cfg.max_connections, 100);
+        assert_eq!(cfg.idle_timeout_secs, 300);
+        assert_eq!(cfg.max_message_size, 64 * 1024);
+        assert_eq!(cfg.heartbeat_interval_secs, 30);
+        assert_eq!(cfg.backpressure_limit, 1024);
+    }
+
+    #[test]
+    fn connection_manager_starts_at_zero() {
+        let mgr = WsConnectionManager::new(WsConfig::default());
+        assert_eq!(mgr.active_count(), 0);
+        assert!(mgr.can_accept());
+    }
+
+    #[test]
+    fn register_and_unregister_adjusts_count() {
+        let mgr = WsConnectionManager::new(WsConfig { max_connections: 2, ..WsConfig::default() });
+        assert!(mgr.register());
+        assert_eq!(mgr.active_count(), 1);
+        assert!(mgr.register());
+        assert_eq!(mgr.active_count(), 2);
+        assert!(!mgr.register()); // at capacity
+        assert!(!mgr.can_accept());
+
+        mgr.unregister();
+        assert_eq!(mgr.active_count(), 1);
+        assert!(mgr.can_accept());
+    }
+
+    #[test]
+    fn backpressure_applies_at_limit() {
+        assert!(!should_apply_backpressure(0, 10));
+        assert!(!should_apply_backpressure(9, 10));
+        assert!(should_apply_backpressure(10, 10));
+        assert!(should_apply_backpressure(11, 10));
+    }
+}

--- a/crates/bitnet-server/tests/websocket_tests.rs
+++ b/crates/bitnet-server/tests/websocket_tests.rs
@@ -1,0 +1,299 @@
+//! Integration tests for WebSocket streaming and SSE fallback modules.
+
+use bitnet_server::sse::{SseConfig, build_sse_token, format_sse_event};
+use bitnet_server::websocket::{
+    WsConfig, WsConnectionManager, WsMessage, should_apply_backpressure,
+};
+
+// ── WsMessage serialization round-trips ─────────────────────────────
+
+#[test]
+fn round_trip_request_message() {
+    let msg = WsMessage::Request {
+        prompt: "Explain gravity".into(),
+        max_tokens: Some(64),
+        temperature: Some(0.7),
+        top_k: Some(50),
+        top_p: Some(0.9),
+        stream: Some(true),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+    if let WsMessage::Request { prompt, max_tokens, .. } = decoded {
+        assert_eq!(prompt, "Explain gravity");
+        assert_eq!(max_tokens, Some(64));
+    } else {
+        panic!("expected Request variant");
+    }
+}
+
+#[test]
+fn round_trip_token_message() {
+    let msg = WsMessage::Token {
+        text: "hello".into(),
+        token_id: 42,
+        logprob: Some(-1.5),
+        finish_reason: None,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+    if let WsMessage::Token { text, token_id, logprob, finish_reason } = decoded {
+        assert_eq!(text, "hello");
+        assert_eq!(token_id, 42);
+        assert!((logprob.unwrap() - (-1.5)).abs() < f32::EPSILON);
+        assert!(finish_reason.is_none());
+    } else {
+        panic!("expected Token variant");
+    }
+}
+
+#[test]
+fn round_trip_metadata_message() {
+    let msg = WsMessage::Metadata {
+        model: "bitnet-2B".into(),
+        backend: "cuda".into(),
+        tokens_per_second: 12.5,
+        total_tokens: 100,
+        prompt_tokens: 10,
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+    if let WsMessage::Metadata { model, backend, tokens_per_second, total_tokens, prompt_tokens } =
+        decoded
+    {
+        assert_eq!(model, "bitnet-2B");
+        assert_eq!(backend, "cuda");
+        assert!((tokens_per_second - 12.5).abs() < f64::EPSILON);
+        assert_eq!(total_tokens, 100);
+        assert_eq!(prompt_tokens, 10);
+    } else {
+        panic!("expected Metadata variant");
+    }
+}
+
+#[test]
+fn round_trip_error_message() {
+    let msg = WsMessage::Error { message: "out of memory".into(), code: 503 };
+    let json = serde_json::to_string(&msg).unwrap();
+    let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+    if let WsMessage::Error { message, code } = decoded {
+        assert_eq!(message, "out of memory");
+        assert_eq!(code, 503);
+    } else {
+        panic!("expected Error variant");
+    }
+}
+
+#[test]
+fn round_trip_ping_pong() {
+    for msg in [WsMessage::Ping, WsMessage::Pong] {
+        let json = serde_json::to_string(&msg).unwrap();
+        let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+        // Verify the tag survives the round-trip.
+        let re_json = serde_json::to_string(&decoded).unwrap();
+        assert_eq!(json, re_json);
+    }
+}
+
+// ── WsConfig defaults ───────────────────────────────────────────────
+
+#[test]
+fn ws_config_default_values() {
+    let cfg = WsConfig::default();
+    assert_eq!(cfg.max_connections, 100);
+    assert_eq!(cfg.idle_timeout_secs, 300);
+    assert_eq!(cfg.max_message_size, 64 * 1024);
+    assert_eq!(cfg.heartbeat_interval_secs, 30);
+    assert_eq!(cfg.backpressure_limit, 1024);
+}
+
+// ── Connection manager limits ───────────────────────────────────────
+
+#[test]
+fn connection_manager_respects_capacity() {
+    let mgr = WsConnectionManager::new(WsConfig { max_connections: 3, ..WsConfig::default() });
+    assert!(mgr.can_accept());
+    assert!(mgr.register());
+    assert!(mgr.register());
+    assert!(mgr.register());
+    assert!(!mgr.can_accept());
+    assert!(!mgr.register());
+
+    mgr.unregister();
+    assert!(mgr.can_accept());
+    assert!(mgr.register());
+}
+
+#[test]
+fn connection_manager_accessors() {
+    let mgr = WsConnectionManager::new(WsConfig {
+        max_connections: 10,
+        idle_timeout_secs: 120,
+        max_message_size: 8192,
+        heartbeat_interval_secs: 15,
+        backpressure_limit: 512,
+    });
+    assert_eq!(mgr.max_connections(), 10);
+    assert_eq!(mgr.idle_timeout_secs(), 120);
+    assert_eq!(mgr.max_message_size(), 8192);
+    assert_eq!(mgr.heartbeat_interval_secs(), 15);
+    assert_eq!(mgr.backpressure_limit(), 512);
+}
+
+// ── Backpressure ────────────────────────────────────────────────────
+
+#[test]
+fn backpressure_boundary() {
+    assert!(!should_apply_backpressure(0, 1));
+    assert!(should_apply_backpressure(1, 1));
+    assert!(!should_apply_backpressure(1023, 1024));
+    assert!(should_apply_backpressure(1024, 1024));
+    assert!(should_apply_backpressure(2000, 1024));
+}
+
+// ── SSE event formatting ────────────────────────────────────────────
+
+#[test]
+fn sse_format_token_event() {
+    let msg = WsMessage::Token {
+        text: "world".into(),
+        token_id: 7,
+        logprob: None,
+        finish_reason: Some("stop".into()),
+    };
+    let sse = format_sse_event(&msg);
+    assert!(sse.starts_with("event: token\n"));
+    assert!(sse.contains("\"token_id\":7"));
+    assert!(sse.contains("\"finish_reason\":\"stop\""));
+    assert!(sse.ends_with("\n\n"));
+}
+
+#[test]
+fn sse_format_metadata_event() {
+    let msg = WsMessage::Metadata {
+        model: "m".into(),
+        backend: "cpu".into(),
+        tokens_per_second: 1.0,
+        total_tokens: 1,
+        prompt_tokens: 0,
+    };
+    let sse = format_sse_event(&msg);
+    assert!(sse.starts_with("event: metadata\n"));
+    assert!(sse.ends_with("\n\n"));
+}
+
+#[test]
+fn sse_format_error_event() {
+    let msg = WsMessage::Error { message: "bad".into(), code: 400 };
+    let sse = format_sse_event(&msg);
+    assert!(sse.starts_with("event: error\n"));
+    assert!(sse.contains("\"code\":400"));
+}
+
+#[test]
+fn sse_format_ping_pong_events() {
+    assert_eq!(format_sse_event(&WsMessage::Ping), "event: ping\ndata: \n\n");
+    assert_eq!(format_sse_event(&WsMessage::Pong), "event: pong\ndata: \n\n");
+}
+
+// ── SseConfig defaults ──────────────────────────────────────────────
+
+#[test]
+fn sse_config_defaults() {
+    let cfg = SseConfig::default();
+    assert_eq!(cfg.retry_ms, 3000);
+    assert_eq!(cfg.keep_alive_secs, 15);
+}
+
+// ── build_sse_token ─────────────────────────────────────────────────
+
+#[test]
+fn build_sse_token_with_id_and_retry() {
+    let msg =
+        WsMessage::Token { text: "hi".into(), token_id: 1, logprob: None, finish_reason: None };
+    let tok = build_sse_token(&msg, Some("ev-1".into()), Some(2000));
+    assert_eq!(tok.event, "token");
+    assert_eq!(tok.id.as_deref(), Some("ev-1"));
+    assert_eq!(tok.retry, Some(2000));
+    assert!(tok.data.contains("\"text\":\"hi\""));
+}
+
+#[test]
+fn build_sse_token_no_optional_fields() {
+    let msg = WsMessage::Ping;
+    let tok = build_sse_token(&msg, None, None);
+    assert_eq!(tok.event, "ping");
+    assert!(tok.id.is_none());
+    assert!(tok.retry.is_none());
+}
+
+// ── Message type variant coverage ───────────────────────────────────
+
+#[test]
+fn all_message_variants_serialize() {
+    let variants: Vec<WsMessage> = vec![
+        WsMessage::Request {
+            prompt: "x".into(),
+            max_tokens: None,
+            temperature: None,
+            top_k: None,
+            top_p: None,
+            stream: None,
+        },
+        WsMessage::Token { text: "t".into(), token_id: 0, logprob: None, finish_reason: None },
+        WsMessage::Metadata {
+            model: "m".into(),
+            backend: "b".into(),
+            tokens_per_second: 0.0,
+            total_tokens: 0,
+            prompt_tokens: 0,
+        },
+        WsMessage::Error { message: "e".into(), code: 0 },
+        WsMessage::Ping,
+        WsMessage::Pong,
+    ];
+    for v in &variants {
+        let json = serde_json::to_string(v).unwrap();
+        let _: WsMessage = serde_json::from_str(&json).unwrap();
+    }
+}
+
+// ── Property tests for WsMessage serialization ─────────────────────
+
+mod prop {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_ws_message() -> impl Strategy<Value = WsMessage> {
+        prop_oneof![
+            (
+                ".*",
+                proptest::option::of(0usize..4096),
+                proptest::option::of(0.0f32..2.0),
+                proptest::option::of(0usize..200),
+                proptest::option::of(0.0f32..1.0),
+                proptest::option::of(proptest::bool::ANY),
+            )
+                .prop_map(|(prompt, max_tokens, temperature, top_k, top_p, stream)| {
+                    WsMessage::Request { prompt, max_tokens, temperature, top_k, top_p, stream }
+                }),
+            (".*", 0u32..100_000, proptest::option::of(-10.0f32..0.0f32)).prop_map(
+                |(text, token_id, logprob)| {
+                    WsMessage::Token { text, token_id, logprob, finish_reason: None }
+                }
+            ),
+            Just(WsMessage::Ping),
+            Just(WsMessage::Pong),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn ws_message_round_trip(msg in arb_ws_message()) {
+            let json = serde_json::to_string(&msg).unwrap();
+            let decoded: WsMessage = serde_json::from_str(&json).unwrap();
+            let re_json = serde_json::to_string(&decoded).unwrap();
+            prop_assert_eq!(json, re_json);
+        }
+    }
+}


### PR DESCRIPTION
Real-time token-by-token streaming via WebSocket with SSE fallback.

## Changes

- **\websocket.rs\**: \WsMessage\ enum (request/token/metadata/error/ping/pong), \WsConfig\, \WsConnectionManager\ with atomic connection tracking, backpressure support
- **\sse.rs\**: SSE fallback with \ormat_sse_event\, \uild_sse_token\, \SseConfig\, \SseToken\
- **\lib.rs\**: Expose \websocket\ and \sse\ modules
- **\websocket_tests.rs\**: 18 integration tests including serialization round-trips, connection manager limits, SSE formatting, and proptest property tests

## Testing

- 18 integration tests + 8 unit tests all passing
- 108 total lib tests pass (no regressions)
- \cargo clippy\ clean for bitnet-server