### PR TITLE
bench(gpu): cross-backend benchmark comparison suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,9 +843,12 @@ dependencies = [
 name = "bitnet-opencl"
 version = "0.2.0-alpha.1"
 dependencies = [
+ "criterion",
  "insta",
  "log",
  "opencl3",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
   "xtask",
   "xtask-build-helper",
   "fuzz",
+  "crates/bitnet-opencl",       # OpenCL backend & cross-backend benchmark utilities
   "tools/migrate-gen-config",   # AST migration tool for GenerationConfig
   "crates/bitnet-gpu-hal",
 ]
@@ -297,6 +298,11 @@ required-features = ["cpu", "bench"]
 
 [[bench]]
 name = "kernel_ops"
+harness = false
+required-features = ["cpu", "bench"]
+
+[[bench]]
+name = "gpu_kernels"
 harness = false
 required-features = ["cpu", "bench"]
 

--- a/benches/gpu_kernels.rs
+++ b/benches/gpu_kernels.rs
@@ -1,0 +1,275 @@
+#![cfg(feature = "bench")]
+
+//! CPU reference benchmarks for cross-backend comparison:
+//! - Matrix multiplication at multiple sizes
+//! - Softmax for various vocabulary sizes
+//! - Scaled dot-product attention at different sequence lengths
+//! - I2_S quantization roundtrip for various tensor sizes
+//! - Complete transformer layer forward pass (RMSNorm → matmul → attention)
+
+use bitnet_common::{BitNetTensor, Device, QuantizationType};
+use bitnet_kernels::KernelManager;
+use bitnet_quantization::I2SQuantizer;
+use candle_core::{DType, Device as CandleDevice, Tensor};
+use candle_nn::{Module, RmsNorm};
+use criterion::{
+    BenchmarkId, Criterion, Throughput, criterion_group, criterion_main, measurement::WallTime,
+};
+use std::hint::black_box;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_a(m: usize, k: usize) -> Vec<i8> {
+    (0..m * k).map(|i| ((i % 3) as i8) - 1).collect()
+}
+
+fn make_b(k: usize, n: usize) -> Vec<u8> {
+    (0..k * n).map(|i| (i % 256) as u8).collect()
+}
+
+fn generate_data(size: usize) -> Vec<f32> {
+    (0..size).map(|i| ((i as f32 / size as f32) * 2.0 - 1.0) * 0.95).collect()
+}
+
+// ── matmul_cpu_reference ────────────────────────────────────────────────────
+
+fn bench_matmul_cpu_reference(c: &mut Criterion) {
+    let manager = KernelManager::new();
+    let kernel = match manager.select_best() {
+        Ok(k) => k,
+        Err(_) => {
+            eprintln!("No kernel provider available – skipping matmul benchmarks");
+            return;
+        }
+    };
+
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("matmul_cpu_reference");
+
+    let sizes: &[(usize, usize, usize)] = &[(64, 64, 64), (256, 256, 256), (1024, 1024, 1024)];
+
+    for &(m, n, k) in sizes {
+        let ops = m * n * k * 2;
+        group.throughput(Throughput::Elements(ops as u64));
+
+        let a = make_a(m, k);
+        let b = make_b(k, n);
+        let mut out = vec![0.0f32; m * n];
+
+        group.bench_with_input(
+            BenchmarkId::new(kernel.name(), format!("{m}x{n}x{k}")),
+            &(m, n, k),
+            |bench, &(m, n, k)| {
+                bench.iter(|| {
+                    kernel
+                        .matmul_i2s(black_box(&a), black_box(&b), black_box(&mut out), m, n, k)
+                        .unwrap();
+                    black_box(&out);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ── softmax_cpu_reference ───────────────────────────────────────────────────
+
+fn bench_softmax_cpu_reference(c: &mut Criterion) {
+    let device = CandleDevice::Cpu;
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("softmax_cpu_reference");
+
+    let vocab_sizes: &[usize] = &[256, 32_000, 128_000];
+
+    for &vocab in vocab_sizes {
+        group.throughput(Throughput::Elements(vocab as u64));
+
+        let logits = Tensor::randn(0.0f32, 1.0, &[1, vocab], &device).unwrap();
+
+        group.bench_with_input(BenchmarkId::new("softmax", vocab), &vocab, |b, _| {
+            b.iter(|| {
+                let max = logits.max(1).unwrap();
+                let shifted = logits.broadcast_sub(&max.unsqueeze(1).unwrap()).unwrap();
+                let exp = shifted.exp().unwrap();
+                let sum = exp.sum(1).unwrap();
+                let result = exp.broadcast_div(&sum.unsqueeze(1).unwrap()).unwrap();
+                black_box(result)
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ── attention_cpu_reference ─────────────────────────────────────────────────
+
+fn bench_attention_cpu_reference(c: &mut Criterion) {
+    let device = CandleDevice::Cpu;
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("attention_cpu_reference");
+
+    // (n_heads, seq_len, head_dim)
+    let configs: &[(usize, usize, usize)] = &[(4, 128, 64), (4, 512, 64), (4, 2048, 64)];
+
+    for &(n_heads, seq_len, head_dim) in configs {
+        let elems = n_heads * seq_len * head_dim;
+        group.throughput(Throughput::Elements(elems as u64));
+
+        let q = Tensor::randn(0.0f32, 1.0, &[1, n_heads, seq_len, head_dim], &device).unwrap();
+        let k = Tensor::randn(0.0f32, 1.0, &[1, n_heads, seq_len, head_dim], &device).unwrap();
+        let v = Tensor::randn(0.0f32, 1.0, &[1, n_heads, seq_len, head_dim], &device).unwrap();
+        let k_t = k.transpose(2, 3).unwrap();
+        let scale = (head_dim as f64).sqrt().recip();
+
+        group.bench_with_input(
+            BenchmarkId::new("scaled_dot_product", format!("h{n_heads}_s{seq_len}_d{head_dim}")),
+            &seq_len,
+            |b, _| {
+                b.iter(|| {
+                    let scores = q.matmul(&k_t).unwrap();
+                    let scaled = (scores * scale).unwrap();
+                    // Softmax over last dimension
+                    let max = scaled.max(3).unwrap();
+                    let shifted = scaled.broadcast_sub(&max.unsqueeze(3).unwrap()).unwrap();
+                    let exp = shifted.exp().unwrap();
+                    let sum = exp.sum(3).unwrap();
+                    let attn_weights = exp.broadcast_div(&sum.unsqueeze(3).unwrap()).unwrap();
+                    let output = attn_weights.matmul(&v).unwrap();
+                    black_box(output)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ── quantization_cpu_reference ──────────────────────────────────────────────
+
+fn bench_quantization_cpu_reference(c: &mut Criterion) {
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("quantization_cpu_reference");
+
+    let sizes: &[usize] = &[256, 1024, 4096, 16384];
+
+    for &size in sizes {
+        let data = generate_data(size);
+        let tensor = BitNetTensor::from_slice(&data, &[size], &Device::Cpu).unwrap();
+        let quantizer = I2SQuantizer::new();
+
+        group.throughput(Throughput::Elements(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("i2s_quantize", size), &size, |b, _| {
+            b.iter(|| black_box(quantizer.quantize_tensor(&tensor).unwrap()));
+        });
+
+        group.bench_with_input(BenchmarkId::new("i2s_dequantize", size), &size, |b, _| {
+            let quantized = quantizer.quantize_tensor(&tensor).unwrap();
+            b.iter(|| black_box(quantizer.dequantize_tensor(&quantized).unwrap()));
+        });
+
+        group.bench_with_input(BenchmarkId::new("i2s_roundtrip", size), &size, |b, _| {
+            b.iter(|| {
+                let q = quantizer.quantize_tensor(&tensor).unwrap();
+                black_box(quantizer.dequantize_tensor(&q).unwrap())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+// ── full_layer_cpu_reference ────────────────────────────────────────────────
+
+fn bench_full_layer_cpu_reference(c: &mut Criterion) {
+    let device = CandleDevice::Cpu;
+    let eps = 1e-5;
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("full_layer_cpu_reference");
+
+    // (hidden_dim, n_heads, seq_len)
+    let configs: &[(usize, usize, usize)] = &[(256, 4, 64), (512, 8, 128), (1024, 8, 256)];
+
+    for &(hidden_dim, n_heads, seq_len) in configs {
+        let head_dim = hidden_dim / n_heads;
+        let elems = seq_len * hidden_dim;
+        group.throughput(Throughput::Elements(elems as u64));
+
+        let gamma = Tensor::ones(&[hidden_dim], DType::F32, &device).unwrap();
+        let norm = RmsNorm::new(gamma, eps);
+
+        let input = Tensor::randn(0.0f32, 1.0, &[1, seq_len, hidden_dim], &device).unwrap();
+        let wq = Tensor::randn(0.0f32, 0.01, &[hidden_dim, hidden_dim], &device).unwrap();
+
+        group.bench_with_input(
+            BenchmarkId::new("rmsnorm_proj_attn", format!("d{hidden_dim}_h{n_heads}_s{seq_len}")),
+            &elems,
+            |b, _| {
+                b.iter(|| {
+                    // RMSNorm
+                    let normed = norm.forward(&input).unwrap();
+                    // Linear projection (simulated Q)
+                    let q = normed.matmul(&wq.t().unwrap()).unwrap();
+                    // Reshape for multi-head attention
+                    let q = q
+                        .reshape(&[1, seq_len, n_heads, head_dim])
+                        .unwrap()
+                        .transpose(1, 2)
+                        .unwrap();
+                    // Self-attention score (Q·Qᵀ/√d)
+                    let q_t = q.transpose(2, 3).unwrap();
+                    let scale = (head_dim as f64).sqrt().recip();
+                    let scores = q.matmul(&q_t).unwrap();
+                    let scaled = (scores * scale).unwrap();
+                    black_box(scaled)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// ── kernel setup overhead ───────────────────────────────────────────────────
+
+fn bench_kernel_setup_overhead(c: &mut Criterion) {
+    let mut group: criterion::BenchmarkGroup<'_, WallTime> =
+        c.benchmark_group("kernel_setup_overhead");
+
+    group.bench_function("kernel_manager_creation", |b| {
+        b.iter(|| black_box(KernelManager::new()));
+    });
+
+    group.bench_function("kernel_selection", |b| {
+        let manager = KernelManager::new();
+        b.iter(|| black_box(manager.select_best()));
+    });
+
+    group.bench_function("buffer_allocation_4k", |b| {
+        b.iter(|| {
+            let buf: Vec<f32> = vec![0.0; 4096];
+            black_box(buf);
+        });
+    });
+
+    group.bench_function("buffer_allocation_1m", |b| {
+        b.iter(|| {
+            let buf: Vec<f32> = vec![0.0; 1_048_576];
+            black_box(buf);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_matmul_cpu_reference,
+    bench_softmax_cpu_reference,
+    bench_attention_cpu_reference,
+    bench_quantization_cpu_reference,
+    bench_full_layer_cpu_reference,
+    bench_kernel_setup_overhead,
+);
+criterion_main!(benches);

--- a/crates/bitnet-opencl/Cargo.toml
+++ b/crates/bitnet-opencl/Cargo.toml
@@ -14,13 +14,18 @@ rust-version.workspace = true
 [dependencies]
 log.workspace = true
 opencl3 = { version = "0.9", optional = true }
+serde = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 insta = { workspace = true }
+criterion = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []
 opencl-runtime = ["dep:opencl3"]
+bench = []
+cpu = []
 
 [lints]
 workspace = true

--- a/crates/bitnet-opencl/src/benchmark_utils.rs
+++ b/crates/bitnet-opencl/src/benchmark_utils.rs
@@ -1,0 +1,289 @@
+//! Cross-backend benchmark utilities: result collection, statistics,
+//! comparison tables, and human-readable report formatting.
+
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Write as _};
+use std::time::Duration;
+
+// ── BenchmarkResult ─────────────────────────────────────────────────────────
+
+/// Collected timing and throughput data from a single benchmark run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BenchmarkResult {
+    /// Human-readable name of the benchmark.
+    pub name: String,
+    /// Backend that produced these results (e.g. "cpu", "opencl", "vulkan").
+    pub backend: String,
+    /// Individual sample durations collected over N iterations.
+    pub samples: Vec<Duration>,
+    /// Total number of logical elements processed per iteration.
+    pub elements_per_iter: u64,
+    /// Peak memory usage in bytes (optional, backend-dependent).
+    pub peak_memory_bytes: Option<u64>,
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+impl BenchmarkResult {
+    /// Create a new result with the given samples.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        backend: impl Into<String>,
+        samples: Vec<Duration>,
+        elements_per_iter: u64,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            backend: backend.into(),
+            samples,
+            elements_per_iter,
+            peak_memory_bytes: None,
+        }
+    }
+
+    /// Attach optional memory usage information.
+    #[must_use]
+    pub const fn with_memory(mut self, bytes: u64) -> Self {
+        self.peak_memory_bytes = Some(bytes);
+        self
+    }
+
+    /// Number of collected samples.
+    #[must_use]
+    pub const fn count(&self) -> usize {
+        self.samples.len()
+    }
+
+    /// Arithmetic mean of sample durations.
+    #[must_use]
+    pub fn mean(&self) -> Duration {
+        if self.samples.is_empty() {
+            return Duration::ZERO;
+        }
+        let total: Duration = self.samples.iter().sum();
+        total / self.samples.len() as u32
+    }
+
+    /// Population standard deviation of sample durations.
+    #[must_use]
+    pub fn std_dev(&self) -> Duration {
+        if self.samples.len() < 2 {
+            return Duration::ZERO;
+        }
+        let mean_ns = self.mean().as_nanos() as f64;
+        let variance = self
+            .samples
+            .iter()
+            .map(|s| {
+                let diff = s.as_nanos() as f64 - mean_ns;
+                diff * diff
+            })
+            .sum::<f64>()
+            / self.samples.len() as f64;
+        Duration::from_nanos(variance.sqrt() as u64)
+    }
+
+    /// Minimum sample duration.
+    #[must_use]
+    pub fn min(&self) -> Duration {
+        self.samples.iter().copied().min().unwrap_or(Duration::ZERO)
+    }
+
+    /// Maximum sample duration.
+    #[must_use]
+    pub fn max(&self) -> Duration {
+        self.samples.iter().copied().max().unwrap_or(Duration::ZERO)
+    }
+
+    /// Percentile (0–100) of sample durations. Uses nearest-rank method.
+    #[must_use]
+    pub fn percentile(&self, p: f64) -> Duration {
+        if self.samples.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut sorted: Vec<Duration> = self.samples.clone();
+        sorted.sort();
+        let idx = ((p / 100.0) * (sorted.len() as f64 - 1.0)).round() as usize;
+        let idx = idx.min(sorted.len() - 1);
+        sorted[idx]
+    }
+
+    /// Throughput in elements per second, based on the mean duration.
+    #[must_use]
+    pub fn throughput_eps(&self) -> f64 {
+        let mean = self.mean();
+        if mean.is_zero() {
+            return 0.0;
+        }
+        self.elements_per_iter as f64 / mean.as_secs_f64()
+    }
+}
+
+// ── BenchmarkRunner ─────────────────────────────────────────────────────────
+
+/// Runs a closure N times and collects timing samples into a
+/// [`BenchmarkResult`].
+pub struct BenchmarkRunner {
+    /// Number of iterations to collect.
+    pub iterations: usize,
+    /// Number of warm-up iterations (not recorded).
+    pub warmup: usize,
+}
+
+impl Default for BenchmarkRunner {
+    fn default() -> Self {
+        Self { iterations: 100, warmup: 10 }
+    }
+}
+
+impl BenchmarkRunner {
+    /// Create a runner with explicit iteration counts.
+    #[must_use]
+    pub const fn new(iterations: usize, warmup: usize) -> Self {
+        Self { iterations, warmup }
+    }
+
+    /// Run `f` and collect timing samples.
+    pub fn run<F>(
+        &self,
+        name: impl Into<String>,
+        backend: impl Into<String>,
+        elements_per_iter: u64,
+        mut f: F,
+    ) -> BenchmarkResult
+    where
+        F: FnMut(),
+    {
+        // Warm-up phase
+        for _ in 0..self.warmup {
+            f();
+        }
+
+        // Measurement phase
+        let mut samples = Vec::with_capacity(self.iterations);
+        for _ in 0..self.iterations {
+            let start = std::time::Instant::now();
+            f();
+            samples.push(start.elapsed());
+        }
+
+        BenchmarkResult::new(name, backend, samples, elements_per_iter)
+    }
+}
+
+// ── BenchmarkComparison ─────────────────────────────────────────────────────
+
+/// Collects results from multiple backends for the same benchmark and
+/// produces a cross-backend comparison table.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BenchmarkComparison {
+    /// Label for the comparison (e.g. "matmul 256×256").
+    pub label: String,
+    /// Results from each backend being compared.
+    pub results: Vec<BenchmarkResult>,
+}
+
+#[allow(clippy::cast_precision_loss)]
+impl BenchmarkComparison {
+    /// Create a new comparison with a label.
+    #[must_use]
+    pub fn new(label: impl Into<String>) -> Self {
+        Self { label: label.into(), results: Vec::new() }
+    }
+
+    /// Add a result to this comparison.
+    pub fn add_result(&mut self, result: BenchmarkResult) {
+        self.results.push(result);
+    }
+
+    /// The fastest backend name (by mean time), or `None` if empty.
+    #[must_use]
+    pub fn fastest_backend(&self) -> Option<&str> {
+        self.results.iter().min_by_key(|r| r.mean()).map(|r| r.backend.as_str())
+    }
+
+    /// Speedup of the fastest backend relative to each other backend.
+    /// Returns `(backend, speedup_factor)` pairs.
+    #[must_use]
+    pub fn speedups(&self) -> Vec<(&str, f64)> {
+        let Some(fastest) = self.results.iter().min_by_key(|r| r.mean()) else {
+            return Vec::new();
+        };
+        let fastest_ns = fastest.mean().as_nanos() as f64;
+        if fastest_ns == 0.0 {
+            return Vec::new();
+        }
+        self.results
+            .iter()
+            .map(|r| {
+                let ratio = r.mean().as_nanos() as f64 / fastest_ns;
+                (r.backend.as_str(), ratio)
+            })
+            .collect()
+    }
+}
+
+impl fmt::Display for BenchmarkComparison {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "=== {} ===", self.label)?;
+        writeln!(
+            f,
+            "{:<12} {:>12} {:>12} {:>12} {:>12}",
+            "Backend", "Mean", "Std Dev", "P50", "Throughput"
+        )?;
+        writeln!(f, "{}", "-".repeat(64))?;
+        for r in &self.results {
+            writeln!(
+                f,
+                "{:<12} {:>12} {:>12} {:>12} {:>10.0} e/s",
+                r.backend,
+                format_duration(r.mean()),
+                format_duration(r.std_dev()),
+                format_duration(r.percentile(50.0)),
+                r.throughput_eps(),
+            )?;
+        }
+        if let Some(fastest) = self.fastest_backend() {
+            writeln!(f, "Fastest: {fastest}")?;
+        }
+        Ok(())
+    }
+}
+
+// ── format helpers ──────────────────────────────────────────────────────────
+
+/// Format a single [`BenchmarkResult`] as a human-readable report.
+#[must_use]
+pub fn format_benchmark_report(result: &BenchmarkResult) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "Benchmark: {} (backend: {})", result.name, result.backend);
+    let _ = writeln!(out, "  Samples:    {}", result.count());
+    let _ = writeln!(out, "  Mean:       {}", format_duration(result.mean()));
+    let _ = writeln!(out, "  Std Dev:    {}", format_duration(result.std_dev()));
+    let _ = writeln!(out, "  Min:        {}", format_duration(result.min()));
+    let _ = writeln!(out, "  Max:        {}", format_duration(result.max()));
+    let _ = writeln!(out, "  P50:        {}", format_duration(result.percentile(50.0)));
+    let _ = writeln!(out, "  P95:        {}", format_duration(result.percentile(95.0)));
+    let _ = writeln!(out, "  P99:        {}", format_duration(result.percentile(99.0)));
+    let _ = writeln!(out, "  Throughput: {:.2} elements/s", result.throughput_eps());
+    if let Some(mem) = result.peak_memory_bytes {
+        let _ = writeln!(out, "  Peak Mem:   {mem} bytes");
+    }
+    out
+}
+
+/// Format a `Duration` in human-friendly units.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn format_duration(d: Duration) -> String {
+    let nanos = d.as_nanos();
+    if nanos < 1_000 {
+        format!("{nanos} ns")
+    } else if nanos < 1_000_000 {
+        format!("{:.2} µs", nanos as f64 / 1_000.0)
+    } else if nanos < 1_000_000_000 {
+        format!("{:.2} ms", nanos as f64 / 1_000_000.0)
+    } else {
+        format!("{:.3} s", d.as_secs_f64())
+    }
+}

--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides safe wrappers around opencl3 types with dynamic library
 //! loading and graceful fallback when no `OpenCL` runtime is installed.
 
+pub mod benchmark_utils;
 pub mod runtime;
 
 pub use runtime::{

--- a/crates/bitnet-opencl/tests/benchmark_utils_tests.rs
+++ b/crates/bitnet-opencl/tests/benchmark_utils_tests.rs
@@ -1,0 +1,285 @@
+use bitnet_opencl::benchmark_utils::{
+    BenchmarkComparison, BenchmarkResult, BenchmarkRunner, format_benchmark_report, format_duration,
+};
+use std::time::Duration;
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+fn sample_result(
+    name: &str,
+    backend: &str,
+    durations_us: &[u64],
+    elements: u64,
+) -> BenchmarkResult {
+    let samples: Vec<Duration> = durations_us.iter().map(|&us| Duration::from_micros(us)).collect();
+    BenchmarkResult::new(name, backend, samples, elements)
+}
+
+// ── BenchmarkResult statistics ──────────────────────────────────────────────
+
+#[test]
+fn test_mean_single_sample() {
+    let r = sample_result("op", "cpu", &[100], 1);
+    assert_eq!(r.mean(), Duration::from_micros(100));
+}
+
+#[test]
+fn test_mean_multiple_samples() {
+    let r = sample_result("op", "cpu", &[100, 200, 300], 1);
+    assert_eq!(r.mean(), Duration::from_micros(200));
+}
+
+#[test]
+fn test_mean_empty() {
+    let r = BenchmarkResult::new("op", "cpu", vec![], 1);
+    assert_eq!(r.mean(), Duration::ZERO);
+}
+
+#[test]
+fn test_std_dev_identical_samples() {
+    let r = sample_result("op", "cpu", &[100, 100, 100], 1);
+    assert_eq!(r.std_dev(), Duration::ZERO);
+}
+
+#[test]
+fn test_std_dev_varied_samples() {
+    // Samples: 100, 200, 300 µs → mean 200, variance = 6666.67 µs²
+    // std_dev ≈ 81.65 µs
+    let r = sample_result("op", "cpu", &[100, 200, 300], 1);
+    let sd_us = r.std_dev().as_micros();
+    assert!(sd_us >= 80 && sd_us <= 83, "std_dev was {sd_us} µs");
+}
+
+#[test]
+fn test_std_dev_single_sample() {
+    let r = sample_result("op", "cpu", &[42], 1);
+    assert_eq!(r.std_dev(), Duration::ZERO);
+}
+
+#[test]
+fn test_min_max() {
+    let r = sample_result("op", "cpu", &[50, 100, 200, 300, 500], 1);
+    assert_eq!(r.min(), Duration::from_micros(50));
+    assert_eq!(r.max(), Duration::from_micros(500));
+}
+
+#[test]
+fn test_min_max_empty() {
+    let r = BenchmarkResult::new("op", "cpu", vec![], 1);
+    assert_eq!(r.min(), Duration::ZERO);
+    assert_eq!(r.max(), Duration::ZERO);
+}
+
+#[test]
+fn test_percentile_p50() {
+    // Sorted: 10, 20, 30, 40, 50 → P50 = index 2 = 30
+    let r = sample_result("op", "cpu", &[30, 10, 50, 20, 40], 1);
+    assert_eq!(r.percentile(50.0), Duration::from_micros(30));
+}
+
+#[test]
+fn test_percentile_p0_and_p100() {
+    let r = sample_result("op", "cpu", &[10, 20, 30, 40, 50], 1);
+    assert_eq!(r.percentile(0.0), Duration::from_micros(10));
+    assert_eq!(r.percentile(100.0), Duration::from_micros(50));
+}
+
+#[test]
+fn test_percentile_p95() {
+    let samples: Vec<u64> = (1..=100).collect();
+    let r = sample_result("op", "cpu", &samples, 1);
+    let p95 = r.percentile(95.0);
+    // Index = round(0.95 * 99) = round(94.05) = 94 → value 95 µs
+    assert_eq!(p95, Duration::from_micros(95));
+}
+
+#[test]
+fn test_percentile_empty() {
+    let r = BenchmarkResult::new("op", "cpu", vec![], 1);
+    assert_eq!(r.percentile(50.0), Duration::ZERO);
+}
+
+#[test]
+fn test_throughput_eps() {
+    // 1000 elements, mean = 1ms → 1_000_000 elements/s
+    let r = sample_result("op", "cpu", &[1000, 1000, 1000], 1000);
+    let eps = r.throughput_eps();
+    assert!((eps - 1_000_000.0).abs() < 1.0, "throughput was {eps}");
+}
+
+#[test]
+fn test_throughput_zero_mean() {
+    let r = BenchmarkResult::new("op", "cpu", vec![], 1000);
+    assert_eq!(r.throughput_eps(), 0.0);
+}
+
+#[test]
+fn test_count() {
+    let r = sample_result("op", "cpu", &[1, 2, 3, 4, 5], 1);
+    assert_eq!(r.count(), 5);
+}
+
+#[test]
+fn test_with_memory() {
+    let r = sample_result("op", "cpu", &[100], 1).with_memory(1024);
+    assert_eq!(r.peak_memory_bytes, Some(1024));
+}
+
+// ── BenchmarkRunner ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_runner_collects_correct_count() {
+    let runner = BenchmarkRunner::new(50, 5);
+    let mut counter = 0u64;
+    let result = runner.run("count_test", "cpu", 1, || {
+        counter += 1;
+    });
+    // warmup(5) + iterations(50) = 55 total calls
+    assert_eq!(counter, 55);
+    assert_eq!(result.count(), 50);
+}
+
+#[test]
+fn test_runner_default() {
+    let runner = BenchmarkRunner::default();
+    assert_eq!(runner.iterations, 100);
+    assert_eq!(runner.warmup, 10);
+}
+
+#[test]
+fn test_runner_result_name_and_backend() {
+    let runner = BenchmarkRunner::new(10, 0);
+    let result = runner.run("my_bench", "opencl", 42, || {});
+    assert_eq!(result.name, "my_bench");
+    assert_eq!(result.backend, "opencl");
+    assert_eq!(result.elements_per_iter, 42);
+}
+
+// ── format_benchmark_report ─────────────────────────────────────────────────
+
+#[test]
+fn test_report_contains_key_fields() {
+    let r = sample_result("matmul", "cpu", &[1000, 2000, 3000], 256);
+    let report = format_benchmark_report(&r);
+    assert!(report.contains("matmul"), "missing name");
+    assert!(report.contains("cpu"), "missing backend");
+    assert!(report.contains("Samples:"), "missing Samples");
+    assert!(report.contains("Mean:"), "missing Mean");
+    assert!(report.contains("Std Dev:"), "missing Std Dev");
+    assert!(report.contains("P50:"), "missing P50");
+    assert!(report.contains("Throughput:"), "missing Throughput");
+}
+
+#[test]
+fn test_report_with_memory() {
+    let r = sample_result("matmul", "cpu", &[1000], 1).with_memory(65536);
+    let report = format_benchmark_report(&r);
+    assert!(report.contains("Peak Mem:"), "missing Peak Mem");
+    assert!(report.contains("65536"), "missing memory value");
+}
+
+#[test]
+fn test_report_without_memory() {
+    let r = sample_result("matmul", "cpu", &[1000], 1);
+    let report = format_benchmark_report(&r);
+    assert!(!report.contains("Peak Mem:"), "should not have Peak Mem");
+}
+
+// ── format_duration ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_format_duration_nanos() {
+    assert_eq!(format_duration(Duration::from_nanos(42)), "42 ns");
+}
+
+#[test]
+fn test_format_duration_micros() {
+    let s = format_duration(Duration::from_micros(500));
+    assert!(s.contains("µs"), "expected µs, got {s}");
+}
+
+#[test]
+fn test_format_duration_millis() {
+    let s = format_duration(Duration::from_millis(42));
+    assert!(s.contains("ms"), "expected ms, got {s}");
+}
+
+#[test]
+fn test_format_duration_seconds() {
+    let s = format_duration(Duration::from_secs(2));
+    assert!(s.contains("s"), "expected s, got {s}");
+}
+
+// ── BenchmarkComparison ─────────────────────────────────────────────────────
+
+#[test]
+fn test_comparison_fastest_backend() {
+    let mut cmp = BenchmarkComparison::new("matmul 256");
+    cmp.add_result(sample_result("matmul", "cpu", &[200, 200], 256));
+    cmp.add_result(sample_result("matmul", "opencl", &[100, 100], 256));
+    assert_eq!(cmp.fastest_backend(), Some("opencl"));
+}
+
+#[test]
+fn test_comparison_fastest_empty() {
+    let cmp = BenchmarkComparison::new("empty");
+    assert_eq!(cmp.fastest_backend(), None);
+}
+
+#[test]
+fn test_comparison_speedups() {
+    let mut cmp = BenchmarkComparison::new("matmul 256");
+    cmp.add_result(sample_result("matmul", "cpu", &[200, 200], 256));
+    cmp.add_result(sample_result("matmul", "opencl", &[100, 100], 256));
+    let speedups = cmp.speedups();
+    assert_eq!(speedups.len(), 2);
+    // opencl is 1.0× (fastest), cpu is 2.0×
+    for (backend, factor) in &speedups {
+        match *backend {
+            "opencl" => assert!((*factor - 1.0).abs() < 0.01, "opencl factor: {factor}"),
+            "cpu" => assert!((*factor - 2.0).abs() < 0.01, "cpu factor: {factor}"),
+            other => panic!("unexpected backend: {other}"),
+        }
+    }
+}
+
+#[test]
+fn test_comparison_display() {
+    let mut cmp = BenchmarkComparison::new("softmax 32k");
+    cmp.add_result(sample_result("softmax", "cpu", &[500, 600], 32000));
+    cmp.add_result(sample_result("softmax", "opencl", &[200, 250], 32000));
+    let table = cmp.to_string();
+    assert!(table.contains("softmax 32k"), "missing label");
+    assert!(table.contains("cpu"), "missing cpu");
+    assert!(table.contains("opencl"), "missing opencl");
+    assert!(table.contains("Fastest:"), "missing Fastest line");
+}
+
+#[test]
+fn test_comparison_speedups_empty() {
+    let cmp = BenchmarkComparison::new("empty");
+    assert!(cmp.speedups().is_empty());
+}
+
+// ── Serialization round-trip ────────────────────────────────────────────────
+
+#[test]
+fn test_result_serde_roundtrip() {
+    let r = sample_result("matmul", "cpu", &[100, 200, 300], 1024).with_memory(4096);
+    let json = serde_json::to_string(&r).unwrap();
+    let restored: BenchmarkResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.name, "matmul");
+    assert_eq!(restored.backend, "cpu");
+    assert_eq!(restored.count(), 3);
+    assert_eq!(restored.peak_memory_bytes, Some(4096));
+}
+
+#[test]
+fn test_comparison_serde_roundtrip() {
+    let mut cmp = BenchmarkComparison::new("test");
+    cmp.add_result(sample_result("op", "cpu", &[100], 1));
+    let json = serde_json::to_string(&cmp).unwrap();
+    let restored: BenchmarkComparison = serde_json::from_str(&json).unwrap();
+    assert_eq!(restored.label, "test");
+    assert_eq!(restored.results.len(), 1);
+}


### PR DESCRIPTION
## Summary
Benchmark infrastructure for comparing kernel performance across CPU, OpenCL, Vulkan, and other backends.

- CPU reference benchmarks (matmul, softmax, attention, quantization, full transformer layer)
- BenchmarkRunner with statistics (mean, stddev, percentiles)
- Cross-backend comparison tables with speedup calculation
- Criterion integration with parameterized sizes
- 33 tests for statistics, formatting, serialization

Part of Intel GPU support epic.