### PR TITLE
docs(adr): architecture decision records for GPU backend design

### DIFF
--- a/docs/adr/ADR-001-opencl-initial-backend.md
+++ b/docs/adr/ADR-001-opencl-initial-backend.md
@@ -1,0 +1,53 @@
+# ADR-001: Use OpenCL as initial Intel GPU backend
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** bitnet-rs needs Intel Arc GPU support.  Four candidates were evaluated:
+  OpenCL (via Khronos), Level Zero (Intel oneAPI native), Vulkan compute shaders,
+  and SYCL/DPC++ (Intel's C++-based model).  The selection criteria were: driver
+  maturity on Intel Arc (A-series) and integrated Xe graphics, Rust crate ecosystem
+  quality, cross-vendor portability, and time-to-first-kernel.
+
+  Intel ships production OpenCL 3.0 drivers for both Arc discrete and integrated GPUs
+  on Windows and Linux.  The `opencl3` Rust crate provides safe, idiomatic bindings
+  with full 3.0 coverage.  Level Zero offers lower overhead but has no maintained Rust
+  bindings.  Vulkan compute is viable but requires SPIR-V toolchains and has a steeper
+  bring-up cost.  SYCL requires a C++ host compiler (icpx) and FFI bridging.
+
+- **Decision:** Use OpenCL 3.0 via the `opencl3` crate for the initial Intel GPU
+  backend (`bitnet-opencl`).  Kernel source is embedded as `.cl` files (see
+  [ADR-004](./ADR-004-kernel-compilation-strategy.md)).  The implementation targets
+  Intel Arc A-series and Xe integrated GPUs but will also work on any conformant
+  OpenCL 3.0 device (AMD, NVIDIA with `cl_nv` driver, Qualcomm Adreno).
+
+- **Consequences:**
+  - *Positive:* Cross-vendor compatibility from day one; mature driver ecosystem;
+    `opencl3` crate is well-maintained and idiomatic; same `.cl` kernels run on
+    Intel, AMD, and NVIDIA without rewrite.
+  - *Positive:* Aligns with the microcrate pattern ([ADR-002](./ADR-002-microcrate-per-backend.md)) —
+    `bitnet-opencl` can be developed and tested independently.
+  - *Negative:* Slightly lower performance ceiling than Level Zero on Intel hardware
+    (estimated 5–15% overhead for memory management and kernel dispatch).
+  - *Negative:* OpenCL lacks some modern features (e.g., cooperative groups, native
+    sub-group shuffles on all vendors) that Level Zero / Vulkan provide.
+  - *Risk:* Intel could deprecate OpenCL in favor of Level Zero long-term; mitigated
+    by the HAL abstraction ([ADR-003](./ADR-003-gpu-hal-abstraction.md)) which allows
+    swapping backends without inference code changes.
+
+## Alternatives considered
+
+- **Level Zero (oneAPI):** Lowest-latency path to Intel GPUs; no stable Rust crate;
+  would require raw FFI bindings and ongoing maintenance.  Planned as a future
+  `bitnet-level-zero` crate once Rust bindings mature.
+- **Vulkan Compute:** Portable and well-supported in Rust (`ash`, `vulkano`), but
+  requires SPIR-V pre-compilation or `glslangValidator` at build time; higher API
+  complexity for compute-only workloads (descriptor sets, pipeline barriers).
+- **SYCL/DPC++:** Best Intel optimization story; C++ only; requires FFI bridge;
+  tight coupling to Intel icpx compiler version.
+
+## How to revert
+
+Replace `bitnet-opencl` with `bitnet-level-zero` or `bitnet-vulkan`.  The HAL
+abstraction ([ADR-003](./ADR-003-gpu-hal-abstraction.md)) ensures inference code is
+backend-agnostic, so the change is confined to the backend crate and Cargo feature
+wiring.

--- a/docs/adr/ADR-002-microcrate-per-backend.md
+++ b/docs/adr/ADR-002-microcrate-per-backend.md
@@ -1,0 +1,56 @@
+# ADR-002: One microcrate per GPU backend
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** bitnet-rs follows an SRP microcrate architecture (see `bitnet-logits`,
+  `bitnet-gguf`, `bitnet-generation`, `bitnet-device-probe`, `bitnet-engine-core`).
+  GPU support requires multiple backend implementations (CUDA, OpenCL, Vulkan, ROCm,
+  Metal, WebGPU) that differ in dependencies, platform support, and build
+  requirements.  Mixing them into a single crate would create complex conditional
+  compilation, slow builds for users who only need one backend, and hard-to-isolate
+  test failures.
+
+- **Decision:** Each GPU backend lives in its own workspace crate:
+
+  | Crate              | Backend     | Primary target hardware          |
+  |--------------------|-------------|----------------------------------|
+  | `bitnet-cuda`      | CUDA        | NVIDIA GPUs (existing)           |
+  | `bitnet-opencl`    | OpenCL 3.0  | Intel Arc, AMD, cross-vendor     |
+  | `bitnet-vulkan`    | Vulkan      | Cross-platform compute           |
+  | `bitnet-rocm`      | ROCm/HIP    | AMD Radeon / Instinct            |
+  | `bitnet-metal`     | Metal       | Apple Silicon                    |
+  | `bitnet-webgpu`    | WebGPU/wgpu | Browser & portable GPU           |
+
+  All backend crates implement the common HAL traits from `bitnet-gpu-hal`
+  ([ADR-003](./ADR-003-gpu-hal-abstraction.md)) and are wired into the workspace via
+  Cargo features ([ADR-006](./ADR-006-feature-flag-design.md)).
+
+  Backend crates are excluded from `default-members` in the root `Cargo.toml` and
+  must be opted into explicitly, matching the existing pattern for wasm, Python
+  bindings, and FFI crates.
+
+- **Consequences:**
+  - *Positive:* Clean dependency isolation — `bitnet-opencl` pulls in `opencl3` but
+    never `cudarc`; `bitnet-metal` only compiles on macOS.
+  - *Positive:* Independent CI lanes — each backend can have its own test matrix
+    (e.g., `gpu-smoke.yml` for CUDA, a separate workflow for OpenCL on Intel runners).
+  - *Positive:* Users only compile the backends they need; build times stay fast.
+  - *Positive:* New backends can be added without touching existing crates.
+  - *Negative:* More crates to maintain; version alignment across backends requires
+    discipline (mitigated by workspace dependency inheritance).
+  - *Negative:* Cross-backend integration tests need a dedicated harness that
+    conditionally enables multiple features.
+
+## Alternatives considered
+
+- **Single `bitnet-gpu` crate with cfg-gated modules:** Fewer crates but entangles
+  dependencies; a CUDA build failure blocks OpenCL development; harder to
+  conditionally compile on CI runners that lack specific hardware.
+- **External plugin crates (out-of-tree):** Maximum isolation but loses workspace
+  coherence, CI integration, and version synchronization.
+
+## How to revert
+
+Merge the backend crates back into a single `bitnet-gpu` crate with
+`#[cfg(feature = "...")]` modules.  The HAL trait boundary
+([ADR-003](./ADR-003-gpu-hal-abstraction.md)) remains unchanged.

--- a/docs/adr/ADR-003-gpu-hal-abstraction.md
+++ b/docs/adr/ADR-003-gpu-hal-abstraction.md
@@ -1,0 +1,88 @@
+# ADR-003: GPU Hardware Abstraction Layer (HAL) traits
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** The existing `KernelProvider` trait in `bitnet-kernels` provides a
+  per-operation abstraction (matmul, quantize) with automatic best-provider selection
+  via `KernelManager`.  As we add non-CUDA GPU backends
+  ([ADR-001](./ADR-001-opencl-initial-backend.md),
+  [ADR-002](./ADR-002-microcrate-per-backend.md)), we need a lower-level hardware
+  abstraction that models GPU resources (devices, buffers, kernels, command queues)
+  uniformly across OpenCL, Vulkan, Level Zero, Metal, and WebGPU.
+
+  Without a shared abstraction, inference code would branch on every backend, and
+  adding a new backend would require changes throughout the stack.  The existing
+  `Device` enum (`Cpu`, `Cuda(usize)`, `Hip(usize)`, `Npu`, `Metal`) and
+  `DeviceAwareQuantizer` already demonstrate the pattern of device-polymorphic
+  dispatch.
+
+- **Decision:** Introduce a `bitnet-gpu-hal` crate defining three core traits:
+
+  ```rust
+  /// A discovered GPU device.
+  pub trait GpuDevice: Send + Sync {
+      fn name(&self) -> &str;
+      fn vendor(&self) -> GpuVendor;
+      fn memory_bytes(&self) -> u64;
+      fn create_buffer(&self, size: usize, usage: BufferUsage) -> Result<Box<dyn GpuBuffer>>;
+      fn create_kernel(&self, source: &KernelSource) -> Result<Box<dyn GpuKernel>>;
+      fn create_queue(&self) -> Result<Box<dyn GpuQueue>>;
+  }
+
+  /// A device-resident memory allocation.
+  pub trait GpuBuffer: Send + Sync {
+      fn size(&self) -> usize;
+      fn write(&self, queue: &dyn GpuQueue, data: &[u8]) -> Result<()>;
+      fn read(&self, queue: &dyn GpuQueue, data: &mut [u8]) -> Result<()>;
+  }
+
+  /// A compiled compute kernel ready for dispatch.
+  pub trait GpuKernel: Send + Sync {
+      fn dispatch(
+          &self,
+          queue: &dyn GpuQueue,
+          global_work_size: [usize; 3],
+          local_work_size: Option<[usize; 3]>,
+          args: &[KernelArg],
+      ) -> Result<()>;
+  }
+  ```
+
+  Backend crates (`bitnet-opencl`, `bitnet-vulkan`, etc.) implement these traits.
+  Higher-level code in `bitnet-kernels` and `bitnet-inference` programs against the
+  trait objects, never against backend-specific types.
+
+  A `MockGpuDevice` implementation is provided in `bitnet-gpu-hal` (behind a `mock`
+  feature) for deterministic unit testing without real hardware.
+
+- **Consequences:**
+  - *Positive:* Inference code is backend-agnostic — same `matmul_i2s` kernel launch
+    works on CUDA, OpenCL, and Vulkan through the HAL.
+  - *Positive:* `MockGpuDevice` enables full kernel-dispatch test coverage in CI
+    without GPU runners.
+  - *Positive:* New backends only need to implement the three traits; no changes to
+    inference, quantization, or model loading.
+  - *Positive:* Extends naturally from the existing `KernelProvider` / `KernelManager`
+    pattern — the HAL sits below `KernelProvider` as its implementation substrate.
+  - *Negative:* Trait-object dispatch adds a virtual call per kernel launch (~5 ns);
+    negligible compared to kernel execution time (microseconds to milliseconds).
+  - *Negative:* Lowest-common-denominator API may not expose vendor-specific
+    optimizations (e.g., CUDA cooperative groups, Metal argument buffers); backends
+    can provide escape hatches via `as_any()` downcasting when needed.
+
+## Alternatives considered
+
+- **Enum dispatch (no trait objects):** Avoids vtable overhead but requires a central
+  enum listing all backends; adding a backend changes the enum, violating
+  open/closed principle and complicating feature gating.
+- **Use `wgpu` / `wgpu-hal` directly:** Mature Rust GPU abstraction but tailored to
+  graphics pipelines; compute-only workloads require workarounds; transitive
+  dependency weight is significant (~50 crates).
+- **Thin per-backend wrappers only (no shared traits):** Simpler initially but forces
+  `#[cfg]` branches in every call site; tested by experience in the CUDA-only era.
+
+## How to revert
+
+Remove `bitnet-gpu-hal` and wire backend crates directly into `KernelManager` via
+per-backend `KernelProvider` implementations (the current CUDA pattern).  This is the
+pre-HAL status quo and remains a valid architecture for a small number of backends.

--- a/docs/adr/ADR-004-kernel-compilation-strategy.md
+++ b/docs/adr/ADR-004-kernel-compilation-strategy.md
@@ -1,0 +1,67 @@
+# ADR-004: Runtime kernel compilation with caching
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** OpenCL and Vulkan backends need compiled kernel programs.  Three
+  strategies were evaluated:
+
+  1. **Build-time compilation** — compile `.cl` → SPIR-V or binary during `cargo build`
+     via `build.rs`.
+  2. **SPIR-V pre-compilation** — ship pre-compiled SPIR-V blobs in the crate.
+  3. **Runtime compilation with caching** — embed `.cl` source, compile on first launch,
+     cache the binary for subsequent runs.
+
+  Build-time compilation requires the OpenCL SDK and/or `clang` on every developer
+  machine and CI runner, complicating the build matrix.  SPIR-V pre-compilation is
+  portable but loses device-specific optimizations and requires a SPIR-V toolchain at
+  development time.  Runtime compilation is the standard practice in GPU computing and
+  matches how NVIDIA's CUDA driver compiles PTX.
+
+- **Decision:** Embed OpenCL kernel source files via `include_str!("kernels/matmul.cl")`
+  at compile time.  At runtime:
+
+  1. Compute a cache key: `sha256(kernel_source || device_name || driver_version)`.
+  2. Look up the cache key in `$BITNET_CACHE_DIR/kernels/` (default:
+     `~/.cache/bitnet/kernels/` on Linux, `%LOCALAPPDATA%\bitnet\kernels\` on Windows).
+  3. If a cached binary exists, load it via `clCreateProgramWithBinary`.
+  4. If not, compile from source via `clBuildProgram`, store the binary, and log the
+     compilation time.
+
+  The same pattern applies to Vulkan (GLSL → SPIR-V via `shaderc` at runtime) and
+  future backends.
+
+  A `BITNET_NO_KERNEL_CACHE=1` environment variable forces recompilation (useful for
+  kernel development).
+
+- **Consequences:**
+  - *Positive:* Zero build-time dependencies on GPU SDKs — `cargo build` works on any
+    machine; only the GPU driver is needed at runtime.
+  - *Positive:* Device-specific optimizations — the OpenCL driver can apply
+    architecture-specific code generation for the exact GPU present.
+  - *Positive:* Cache makes subsequent launches near-instant; first-launch penalty is
+    typically 100–500 ms for the bitnet kernel set.
+  - *Positive:* Kernel source is auditable in the repository (no opaque blobs).
+  - *Negative:* First launch is slower (compilation overhead); mitigated by cache and
+    by a progress indicator in `bitnet-cli`.
+  - *Negative:* Cache invalidation adds complexity (driver updates change the cache
+    key, correctly triggering recompilation).
+  - *Negative:* Kernel source is visible to users (IP consideration); acceptable for
+    an open-source project.
+
+## Alternatives considered
+
+- **Build-time compilation (`build.rs`):** Guarantees cached binaries at install time
+  but requires OpenCL SDK / `clang` for every `cargo build`; breaks `cargo install`
+  on machines without the SDK.
+- **SPIR-V pre-compilation:** Portable intermediate format; loses device-specific
+  optimizations; requires `spirv-tools` or `clspv` in the build pipeline; SPIR-V
+  support varies across vendors.
+- **Hybrid (ship SPIR-V + runtime fallback):** Best of both worlds but doubles
+  maintenance; considered for a future optimization if first-launch latency becomes
+  a user complaint.
+
+## How to revert
+
+Switch to build-time compilation by adding a `build.rs` that invokes `clBuildProgram`
+(or an offline compiler) and embeds the binary via `include_bytes!`.  Remove the
+runtime cache directory logic.

--- a/docs/adr/ADR-005-cpu-fallback-strategy.md
+++ b/docs/adr/ADR-005-cpu-fallback-strategy.md
@@ -1,0 +1,62 @@
+# ADR-005: Automatic CPU fallback when GPU unavailable
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** bitnet-rs must work reliably on machines without a GPU — CI runners,
+  cloud VMs, laptops with driver issues, and WSL environments.  The existing
+  architecture already implements this pattern: `KernelManager` probes providers in
+  priority order (CUDA → AVX-512 → AVX2 → NEON → scalar fallback) and
+  `DeviceAwareQuantizer` transparently falls back from a GPU primary to a CPU
+  secondary.
+
+  With multiple GPU backends ([ADR-002](./ADR-002-microcrate-per-backend.md)) the
+  fallback surface grows: any of OpenCL, Vulkan, CUDA, ROCm, or Metal may fail to
+  initialize.  We need a consistent, predictable fallback policy.
+
+- **Decision:** GPU availability is detected at runtime, never assumed at compile time.
+  The fallback cascade is:
+
+  1. **Probe** — At startup, `bitnet-device-probe` enumerates available GPU devices
+     via each compiled backend.  Results are logged as
+     `requested=<user_pref> detected=[<backends>] selected=<chosen>` (the existing
+     `BackendStartupSummary` pattern).
+  2. **Select** — `KernelManager::select_best()` picks the highest-priority available
+     provider.  Priority: CUDA > OpenCL > Vulkan > ROCm > Metal > AVX-512 > AVX2 >
+     NEON > scalar.
+  3. **Fallback** — If no GPU provider initializes successfully, CPU SIMD kernels are
+     used.  A `warn_once!` message notifies the user: *"No GPU detected; falling back
+     to CPU (<simd_level>). Set BITNET_LOG=debug for details."*
+  4. **Strict mode** — When `BITNET_STRICT_MODE=1`, GPU fallback is still allowed
+     (it's a hardware limitation, not a configuration error), but `BITNET_GPU_FAKE`
+     is rejected.
+
+  The selected backend is recorded in inference receipts (`compute_path` field) for
+  auditability.
+
+- **Consequences:**
+  - *Positive:* `bitnet-rs` always works — users never see "GPU not found" errors
+    that block inference entirely.
+  - *Positive:* Transparent to higher layers — inference, server, and CLI code never
+    branch on device type.
+  - *Positive:* Receipts and startup logs make the selected backend auditable.
+  - *Negative:* Users may not realize they're running on CPU and report poor
+    performance; mitigated by the startup log line and `--device` CLI flag.
+  - *Negative:* Dispatch logic grows with each new backend; mitigated by the
+    `KernelProvider` trait and priority list in `KernelManager`.
+
+## Alternatives considered
+
+- **Fail-fast when GPU requested but unavailable:** Simpler but hostile UX; users
+  on headless servers would need to explicitly pass `--device cpu`.
+- **Compile-time backend selection only (`#[cfg]`):** No runtime overhead but cannot
+  adapt to the deployment environment; a single binary couldn't serve both GPU and
+  CPU machines.
+- **Environment-variable-only selection (`BITNET_DEVICE=cpu`):** Requires user
+  knowledge; bad default experience.  Still supported as an override but not
+  required.
+
+## How to revert
+
+Make GPU backends fail-fast (return `Err`) instead of falling through to CPU.  Add a
+`--device cpu` flag and require it when no GPU is present.  Remove the automatic
+probe-and-select logic from `KernelManager`.

--- a/docs/adr/ADR-006-feature-flag-design.md
+++ b/docs/adr/ADR-006-feature-flag-design.md
@@ -1,0 +1,93 @@
+# ADR-006: Feature flag structure for multi-backend
+
+- **Status:** Accepted
+- **Date:** 2025-07-14
+- **Context:** bitnet-rs already uses a feature-flag hierarchy:
+
+  ```
+  gpu  (umbrella) ─┬─ cuda
+                    ├─ vulkan
+                    └─ rocm
+  cpu               ─ kernels + SIMD auto-detection
+  metal             ─ Apple-only
+  ```
+
+  Adding OpenCL, Level Zero, WebGPU, and oneAPI backends requires extending this
+  scheme without breaking existing users or CI.  Features must be **additive** (Cargo
+  requirement) and compose cleanly for multi-backend builds (e.g.,
+  `--features cpu,opencl` for CPU primary + OpenCL acceleration).
+
+  The root `Cargo.toml` already propagates features through the workspace:
+  `gpu` enables `bitnet-kernels/gpu`, `bitnet-inference/gpu`, and
+  `bitnet-quantization/gpu`.
+
+- **Decision:** Extend the feature hierarchy as follows:
+
+  ```
+  gpu  (umbrella) ─┬─ cuda       → bitnet-cuda
+                    ├─ opencl     → bitnet-opencl     [NEW]
+                    ├─ vulkan     → bitnet-vulkan
+                    ├─ rocm       → bitnet-rocm
+                    ├─ oneapi     → bitnet-level-zero  [NEW]
+                    └─ webgpu     → bitnet-webgpu      [NEW]
+  cpu               ─ SIMD auto (AVX-512 / AVX2 / NEON / scalar)
+  metal             ─ bitnet-metal (Apple-only, not under gpu umbrella)
+  ```
+
+  Design rules:
+
+  1. **`gpu` is the umbrella** — enables all GPU backends compiled for the current
+     platform.  Users who want a single backend use the specific flag
+     (`--features opencl`).
+  2. **Backend flags are additive** — `--features cuda,opencl` compiles both; runtime
+     selection picks the best available ([ADR-005](./ADR-005-cpu-fallback-strategy.md)).
+  3. **`cpu` is always available** — it is the fallback; GPU features add acceleration
+     on top.  `cpu` is the minimal useful feature set.
+  4. **`metal` stays outside `gpu`** — Apple platforms require different CI
+     infrastructure; `metal` implies Apple-only dependencies.
+  5. **Backend crates own their dependencies** — `bitnet-opencl` declares
+     `dep:opencl3`; the root `Cargo.toml` only forwards the feature flag.
+  6. **`default = []`** — unchanged; users must opt in explicitly (matches existing
+     convention documented in CLAUDE.md).
+
+  Feature propagation through the workspace:
+
+  ```toml
+  # Root Cargo.toml (excerpt)
+  [features]
+  opencl = ["kernels", "inference", "tokenizers",
+            "bitnet-kernels/opencl", "bitnet-inference/gpu",
+            "bitnet-quantization/gpu"]
+  oneapi = ["kernels", "inference", "tokenizers",
+            "bitnet-kernels/oneapi", "bitnet-inference/gpu",
+            "bitnet-quantization/gpu"]
+  ```
+
+- **Consequences:**
+  - *Positive:* Fine-grained compilation — CI runners without CUDA can still test
+    OpenCL; WebAssembly builds enable only `webgpu`.
+  - *Positive:* Clean dependency tree — no user pulls in `cudarc` when they only
+    want OpenCL.
+  - *Positive:* Composable — `--features cpu,opencl` gives CPU fallback + OpenCL
+    acceleration in one binary.
+  - *Positive:* Backward compatible — existing `--features gpu` and `--features cuda`
+    continue to work unchanged.
+  - *Negative:* Feature matrix grows; CI must test key combinations (mitigated by
+    the `ci-core.yml` matrix strategy).
+  - *Negative:* Potential for feature-flag conflicts if two backends claim the same
+    kernel name; mitigated by the HAL trait boundary
+    ([ADR-003](./ADR-003-gpu-hal-abstraction.md)).
+
+## Alternatives considered
+
+- **Single `gpu` feature, select backend via env var:** Simpler feature surface but
+  compiles all backends unconditionally; slow builds; pulls in every GPU SDK.
+- **Separate top-level crates (not features):** Maximum isolation but users must
+  choose the right crate at dependency declaration time; loses workspace coherence.
+- **`cfg_if!` mega-crate:** One `bitnet-gpu` crate with `cfg_if!` dispatching; tested
+  in early CUDA integration and found to be fragile and hard to test in isolation.
+
+## How to revert
+
+Collapse backend-specific features into a single `gpu` feature and use runtime
+detection only.  Remove per-backend crates and move code into `bitnet-kernels/gpu/`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,14 @@
 # Architectural Decision Records
 
-- ADR-0001: [Configuration layering and clamp location](./0001-configuration-layering.md)
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](./0001-configuration-layering.md) | Configuration layering and clamp location | Accepted |
+| [001](./ADR-001-opencl-initial-backend.md) | Use OpenCL as initial Intel GPU backend | Accepted |
+| [002](./ADR-002-microcrate-per-backend.md) | One microcrate per GPU backend | Accepted |
+| [003](./ADR-003-gpu-hal-abstraction.md) | GPU Hardware Abstraction Layer (HAL) traits | Accepted |
+| [004](./ADR-004-kernel-compilation-strategy.md) | Runtime kernel compilation with caching | Accepted |
+| [005](./ADR-005-cpu-fallback-strategy.md) | Automatic CPU fallback when GPU unavailable | Accepted |
+| [006](./ADR-006-feature-flag-design.md) | Feature flag structure for multi-backend | Accepted |
 
 ## Template for new ADRs
 


### PR DESCRIPTION
## Summary
6 Architecture Decision Records documenting key GPU backend design choices.

- ADR-001: OpenCL initial backend selection rationale
- ADR-002: Microcrate-per-backend pattern
- ADR-003: GPU HAL abstraction approach
- ADR-004: Kernel compilation strategy
- ADR-005: CPU fallback design
- ADR-006: Feature flag structure

Part of Intel GPU support epic.