### PR TITLE
feat(opencl): GPU-accelerated quantized inference for 1.58-bit BitNet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "log",
  "opencl3",
  "serial_test",
+ "rand 0.9.2",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bitnet-opencl/Cargo.toml
+++ b/crates/bitnet-opencl/Cargo.toml
@@ -20,6 +20,7 @@ opencl3 = { version = "0.9", optional = true }
 [dev-dependencies]
 env_logger = "0.11.8"
 serial_test.workspace = true
+rand = "0.9.2"
 
 [features]
 default = []
@@ -30,3 +31,7 @@ cuda = []
 
 [lints]
 workspace = true
+
+[[test]]
+name = "quantized_ops_tests"
+path = "tests/quantized_ops_tests.rs"

--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -4,6 +4,9 @@
 //! including context pooling, local memory optimizations, prefetch
 //! pipelines, KV cache, paged attention, and multi-backend GPU dispatch
 //! with automatic selection.
+//! pipelines, KV cache, paged attention, and CPU reference implementations
+//! with OpenCL kernel sources for I2_S dequantization, QK256 block
+//! dequantization, and ternary matrix multiply.
 
 pub mod backend_dispatcher;
 pub mod backend_registry;
@@ -16,3 +19,5 @@ pub use backend_dispatcher::{
     DispatchLog, DispatchStrategy, Operation,
 };
 pub use backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
+pub mod quantized_kernels;
+pub mod quantized_ops;

--- a/crates/bitnet-opencl/src/quantized_kernels.rs
+++ b/crates/bitnet-opencl/src/quantized_kernels.rs
@@ -1,0 +1,216 @@
+//! `OpenCL` kernel source strings for quantized inference operations.
+//!
+//! Each kernel is embedded as a `const &str` so the crate remains
+//! self-contained (no external `.cl` files needed at runtime).
+
+// ── I2_S dequantization ──────────────────────────────────────────────────────
+
+/// `OpenCL` kernel for `I2_S` dequantization.
+///
+/// **Workgroup**: 256 work-items (one per output element group).
+/// **Memory**: No local memory; reads from global `packed` buffer.
+///
+/// Each work-item unpacks one byte (4 weights) and writes 4 consecutive
+/// output floats.
+///
+/// Args (via `clSetKernelArg`):
+///   0: `__global const uchar *packed` — `I2_S` packed weight bytes
+///   1: `__global float *output`       — dequantized f32 output
+///   2: `float scale`                  — per-tensor scale factor
+///   3: `uint n_bytes`                 — number of packed bytes
+pub const DEQUANTIZE_I2S_CL: &str = r"
+__kernel void dequantize_i2s(
+    __global const uchar *packed,
+    __global float *output,
+    const float scale,
+    const uint n_bytes)
+{
+    uint gid = get_global_id(0);
+    if (gid >= n_bytes) return;
+
+    uchar byte = packed[gid];
+    uint base = gid * 4;
+
+    // 2-bit decode: 00->0, 01->+1, 10->-1, 11->0(reserved)
+    for (int i = 0; i < 4; i++) {
+        uchar code = (byte >> (i * 2)) & 0x3;
+        float w = (code == 1) ? 1.0f : ((code == 2) ? -1.0f : 0.0f);
+        output[base + i] = w * scale;
+    }
+}
+";
+
+/// Recommended workgroup size for [`DEQUANTIZE_I2S_CL`].
+pub const DEQUANTIZE_I2S_WORKGROUP: usize = 256;
+
+// ── Ternary matrix multiply ──────────────────────────────────────────────────
+
+/// `OpenCL` kernel for ternary matrix-vector multiply.
+///
+/// **Workgroup**: 256 work-items (one per output row tile).
+/// **Memory**: No local memory; row-parallel reduction.
+///
+/// Each work-item computes one output row by iterating over packed weight
+/// bytes and accumulating dot products.
+///
+/// Args:
+///   0: `__global const uchar *weights` — packed ternary weights
+///   1: `__global const float *input`   — input vector
+///   2: `__global float *output`        — output vector
+///   3: `float scale`                   — scale factor
+///   4: `uint rows`
+///   5: `uint cols`
+///   6: `uint cols_packed`              — `cols.div_ceil(4)`
+pub const TERNARY_MATMUL_CL: &str = r"
+__kernel void ternary_matmul(
+    __global const uchar *weights,
+    __global const float *input,
+    __global float *output,
+    const float scale,
+    const uint rows,
+    const uint cols,
+    const uint cols_packed)
+{
+    uint row = get_global_id(0);
+    if (row >= rows) return;
+
+    float acc = 0.0f;
+    uint row_offset = row * cols_packed;
+
+    for (uint byte_idx = 0; byte_idx < cols_packed; byte_idx++) {
+        uchar byte = weights[row_offset + byte_idx];
+        uint base_col = byte_idx * 4;
+
+        for (int sub = 0; sub < 4; sub++) {
+            uint col = base_col + sub;
+            if (col >= cols) break;
+            uchar code = (byte >> (sub * 2)) & 0x3;
+            float w = (code == 1) ? 1.0f : ((code == 2) ? -1.0f : 0.0f);
+            acc += w * input[col];
+        }
+    }
+
+    output[row] = acc * scale;
+}
+";
+
+/// Recommended workgroup size for [`TERNARY_MATMUL_CL`].
+pub const TERNARY_MATMUL_WORKGROUP: usize = 256;
+
+/// Minimum global memory required (bytes) for the ternary matmul kernel,
+/// given matrix dimensions.
+pub const fn ternary_matmul_mem_bytes(rows: usize, cols: usize) -> usize {
+    let cols_packed = cols.div_ceil(4);
+    // weights + input + output
+    rows * cols_packed + cols * 4 + rows * 4
+}
+
+// ── QK256 block dequantization ───────────────────────────────────────────────
+
+/// `OpenCL` kernel for QK256 block dequantization.
+///
+/// **Workgroup**: 256 work-items (one per block).
+/// **Memory**: No local memory.
+///
+/// Each work-item dequantizes one 66-byte QK256 block into 256 floats.
+///
+/// Args:
+///   0: `__global const uchar *blocks` — packed QK256 blocks (66 bytes each)
+///   1: `__global float *output`       — dequantized output
+///   2: `uint n_blocks`
+pub const QK256_DEQUANT_CL: &str = r"
+__kernel void qk256_dequant(
+    __global const uchar *blocks,
+    __global float *output,
+    const uint n_blocks)
+{
+    uint bid = get_global_id(0);
+    if (bid >= n_blocks) return;
+
+    // 66 bytes per block: 2-byte f16 scale + 64 bytes of 2-bit weights
+    uint block_offset = bid * 66;
+    uchar lo = blocks[block_offset];
+    uchar hi = blocks[block_offset + 1];
+
+    // f16 -> f32 conversion
+    ushort f16_bits = (ushort)lo | ((ushort)hi << 8);
+    uint sign  = (f16_bits >> 15) & 1;
+    uint exp   = (f16_bits >> 10) & 0x1F;
+    uint frac  = f16_bits & 0x3FF;
+    float scale;
+    if (exp == 0) {
+        scale = (float)frac * (1.0f / 16777216.0f);
+        if (sign) scale = -scale;
+    } else if (exp == 0x1F) {
+        scale = 0.0f;
+    } else {
+        uint f32_bits = (sign << 31) | ((exp + 112) << 23) | (frac << 13);
+        scale = as_float(f32_bits);
+    }
+
+    uint out_base = bid * 256;
+    for (uint i = 0; i < 64; i++) {
+        uchar byte = blocks[block_offset + 2 + i];
+        for (int j = 0; j < 4; j++) {
+            uchar code = (byte >> (j * 2)) & 0x3;
+            float w = (code == 1) ? 1.0f : ((code == 2) ? -1.0f : 0.0f);
+            output[out_base + i * 4 + j] = w * scale;
+        }
+    }
+}
+";
+
+/// Recommended workgroup size for [`QK256_DEQUANT_CL`].
+pub const QK256_DEQUANT_WORKGROUP: usize = 256;
+
+/// Returns all kernel sources paired with their entry-point names.
+///
+/// Useful for batch compilation into an `OpenCL` program.
+pub fn all_kernel_sources() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("dequantize_i2s", DEQUANTIZE_I2S_CL),
+        ("ternary_matmul", TERNARY_MATMUL_CL),
+        ("qk256_dequant", QK256_DEQUANT_CL),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kernel_sources_non_empty() {
+        assert!(!DEQUANTIZE_I2S_CL.is_empty());
+        assert!(!TERNARY_MATMUL_CL.is_empty());
+        assert!(!QK256_DEQUANT_CL.is_empty());
+    }
+
+    #[test]
+    fn kernel_sources_contain_entry_points() {
+        assert!(DEQUANTIZE_I2S_CL.contains("dequantize_i2s"));
+        assert!(TERNARY_MATMUL_CL.contains("ternary_matmul"));
+        assert!(QK256_DEQUANT_CL.contains("qk256_dequant"));
+    }
+
+    #[test]
+    fn all_kernel_sources_complete() {
+        let sources = all_kernel_sources();
+        assert_eq!(sources.len(), 3);
+    }
+
+    #[test]
+    fn ternary_matmul_mem_estimate() {
+        // 128×64 matrix
+        let mem = ternary_matmul_mem_bytes(128, 64);
+        let cols_packed = (64 + 3) / 4; // 16
+        let expected = 128 * cols_packed + 64 * 4 + 128 * 4;
+        assert_eq!(mem, expected);
+    }
+
+    #[test]
+    fn workgroup_sizes_are_power_of_two() {
+        assert!(DEQUANTIZE_I2S_WORKGROUP.is_power_of_two());
+        assert!(TERNARY_MATMUL_WORKGROUP.is_power_of_two());
+        assert!(QK256_DEQUANT_WORKGROUP.is_power_of_two());
+    }
+}

--- a/crates/bitnet-opencl/src/quantized_ops.rs
+++ b/crates/bitnet-opencl/src/quantized_ops.rs
@@ -1,0 +1,251 @@
+//! CPU reference implementations for 1.58-bit (ternary) quantized inference.
+//!
+//! Provides pack/unpack utilities for `I2_S` format (2 bits per weight) and
+//! QK256 block dequantization, plus ternary matmul/matvec operations.
+
+// ── I2_S format ──────────────────────────────────────────────────────────────
+//
+// Each weight is encoded as 2 bits:
+//   0b00 → 0, 0b01 → +1, 0b10 → -1, 0b11 → reserved (treated as 0)
+//
+// Weights are packed LSB-first: 4 weights per byte.
+
+/// Map a 2-bit code to its ternary value.
+#[inline]
+const fn i2s_decode(code: u8) -> f32 {
+    match code & 0b11 {
+        0b01 => 1.0,
+        0b10 => -1.0,
+        _ => 0.0, // 0b00 = zero, 0b11 = reserved → zero
+    }
+}
+
+/// Unpack `I2_S` packed bytes to `f32` values and apply `scale`.
+///
+/// Each byte holds 4 weights (2 bits each, LSB-first).
+/// Returns `packed.len() * 4` elements.
+pub fn dequantize_i2s(packed: &[u8], scale: f32) -> Vec<f32> {
+    let mut out = Vec::with_capacity(packed.len() * 4);
+    for &byte in packed {
+        for shift in (0..8).step_by(2) {
+            out.push(i2s_decode(byte >> shift) * scale);
+        }
+    }
+    out
+}
+
+// ── QK256 format ─────────────────────────────────────────────────────────────
+//
+// A QK256 block encodes 256 ternary weights:
+//   - First 2 bytes: f16 scale factor (little-endian IEEE 754 half)
+//   - Next 64 bytes: 256 weights × 2 bits = 512 bits = 64 bytes
+//
+// Total block size: 66 bytes.
+
+/// Expected byte size of a single QK256 block.
+pub const QK256_BLOCK_SIZE: usize = 66;
+
+/// Number of weights per QK256 block.
+pub const QK256_WEIGHTS_PER_BLOCK: usize = 256;
+
+/// Decode an f16 value from two little-endian bytes.
+#[inline]
+#[allow(clippy::cast_precision_loss)]
+fn f16_to_f32(lo: u8, hi: u8) -> f32 {
+    let bits = u16::from_le_bytes([lo, hi]);
+    let sign = u32::from((bits >> 15) & 1);
+    let exp = u32::from((bits >> 10) & 0x1F);
+    let frac = u32::from(bits & 0x3FF);
+
+    if exp == 0 {
+        // Subnormal or zero
+        let val = (frac as f32) * (1.0 / 16_777_216.0); // 2^-24
+        if sign == 1 { -val } else { val }
+    } else if exp == 0x1F {
+        0.0 // Inf / NaN → treat as 0 for safety
+    } else {
+        let f32_exp = exp + 112; // rebias: -15 + 127
+        let f32_bits = (sign << 31) | (f32_exp << 23) | (frac << 13);
+        f32::from_bits(f32_bits)
+    }
+}
+
+/// Dequantize a single QK256 block (66 bytes) into 256 `f32` values.
+///
+/// Returns an empty vec if the block is too short.
+pub fn dequantize_qk256(block: &[u8]) -> Vec<f32> {
+    if block.len() < QK256_BLOCK_SIZE {
+        return Vec::new();
+    }
+
+    let scale = f16_to_f32(block[0], block[1]);
+    let weight_bytes = &block[2..QK256_BLOCK_SIZE];
+
+    let mut out = Vec::with_capacity(QK256_WEIGHTS_PER_BLOCK);
+    for &byte in weight_bytes {
+        for shift in (0..8).step_by(2) {
+            out.push(i2s_decode(byte >> shift) * scale);
+        }
+    }
+    out
+}
+
+// ── Pack utilities ───────────────────────────────────────────────────────────
+
+/// Map a ternary value to its 2-bit `I2_S` code.
+///
+/// Rounds: negative → `0b10`, positive → `0b01`, otherwise → `0b00`.
+#[inline]
+fn i2s_encode(val: f32) -> u8 {
+    if val > 0.5 {
+        0b01
+    } else if val < -0.5 {
+        0b10
+    } else {
+        0b00
+    }
+}
+
+/// Pack ternary values (-1, 0, +1) into `I2_S` bytes, 4 weights per byte.
+///
+/// Input length is rounded up to a multiple of 4 (padding with zeros).
+pub fn pack_i2s(values: &[f32]) -> Vec<u8> {
+    let n_bytes = values.len().div_ceil(4);
+    let mut packed = vec![0u8; n_bytes];
+    for (i, &v) in values.iter().enumerate() {
+        let byte_idx = i / 4;
+        let bit_offset = (i % 4) * 2;
+        packed[byte_idx] |= i2s_encode(v) << bit_offset;
+    }
+    packed
+}
+
+// ── Ternary MatMul ───────────────────────────────────────────────────────────
+
+/// Matrix-vector multiply with packed ternary weights.
+///
+/// `weights_packed` contains `rows * cols_packed` bytes, where
+/// `cols_packed = cols.div_ceil(4)`. Each byte holds 4 ternary weights.
+/// `input` has length `cols`.
+///
+/// Returns a vector of length `rows`, each element scaled by `scale`.
+pub fn ternary_matvec(
+    weights_packed: &[u8],
+    input: &[f32],
+    scale: f32,
+    rows: usize,
+    cols: usize,
+) -> Vec<f32> {
+    let cols_packed = cols.div_ceil(4);
+    assert!(
+        weights_packed.len() >= rows * cols_packed,
+        "weights buffer too small: need {} bytes, got {}",
+        rows * cols_packed,
+        weights_packed.len(),
+    );
+
+    let mut output = vec![0.0f32; rows];
+
+    for (row, out_val) in output.iter_mut().enumerate() {
+        let row_start = row * cols_packed;
+        let mut acc = 0.0f32;
+
+        for (byte_idx, &byte) in
+            weights_packed[row_start..row_start + cols_packed].iter().enumerate()
+        {
+            let base_col = byte_idx * 4;
+            for sub in 0..4 {
+                let col = base_col + sub;
+                if col >= cols {
+                    break;
+                }
+                let w = i2s_decode(byte >> (sub * 2));
+                acc += w * input[col];
+            }
+        }
+
+        *out_val = acc * scale;
+    }
+
+    output
+}
+
+/// Matrix-matrix multiply with packed ternary weights (batch of vectors).
+///
+/// `input` is a row-major `[batch_size * cols]` matrix.
+/// Returns a row-major `[batch_size * rows]` matrix.
+pub fn ternary_matmul(
+    weights_packed: &[u8],
+    input: &[f32],
+    scale: f32,
+    rows: usize,
+    cols: usize,
+    batch_size: usize,
+) -> Vec<f32> {
+    assert_eq!(
+        input.len(),
+        batch_size * cols,
+        "input length mismatch: expected {}, got {}",
+        batch_size * cols,
+        input.len(),
+    );
+
+    let mut output = Vec::with_capacity(batch_size * rows);
+
+    for b in 0..batch_size {
+        let batch_input = &input[b * cols..(b + 1) * cols];
+        let row_out = ternary_matvec(weights_packed, batch_input, scale, rows, cols);
+        output.extend_from_slice(&row_out);
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn i2s_decode_values() {
+        assert_eq!(i2s_decode(0b00), 0.0);
+        assert_eq!(i2s_decode(0b01), 1.0);
+        assert_eq!(i2s_decode(0b10), -1.0);
+        assert_eq!(i2s_decode(0b11), 0.0); // reserved
+    }
+
+    #[test]
+    fn pack_unpack_roundtrip() {
+        let values = vec![1.0, -1.0, 0.0, 1.0, -1.0, 0.0, 0.0, 1.0];
+        let packed = pack_i2s(&values);
+        let unpacked = dequantize_i2s(&packed, 1.0);
+        assert_eq!(&unpacked[..values.len()], &values[..]);
+    }
+
+    #[test]
+    fn dequantize_i2s_with_scale() {
+        // byte: 0b10_00_01_01 = weights [+1, +1, 0, -1]
+        let packed = vec![0b10_00_01_01u8];
+        let result = dequantize_i2s(&packed, 2.5);
+        assert_eq!(result, vec![2.5, 2.5, 0.0, -2.5]);
+    }
+
+    #[test]
+    fn f16_to_f32_one() {
+        // f16 for 1.0: sign=0, exp=15, frac=0 → bits = 0x3C00
+        let val = f16_to_f32(0x00, 0x3C);
+        assert!((val - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn f16_to_f32_negative_two() {
+        // f16 for -2.0: sign=1, exp=16, frac=0 → bits = 0xC000
+        let val = f16_to_f32(0x00, 0xC0);
+        assert!((val - (-2.0)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn dequantize_qk256_too_short() {
+        let result = dequantize_qk256(&[0u8; 10]);
+        assert!(result.is_empty());
+    }
+}

--- a/crates/bitnet-opencl/tests/quantized_ops_tests.rs
+++ b/crates/bitnet-opencl/tests/quantized_ops_tests.rs
@@ -1,0 +1,341 @@
+//! Tests for quantized inference operations.
+//!
+//! Covers I2_S/QK256 dequantization, ternary matmul/matvec, packing,
+//! scale factors, round-trips, and edge cases.
+
+use bitnet_opencl::quantized_kernels;
+use bitnet_opencl::quantized_ops;
+
+// ── I2_S dequantization ──────────────────────────────────────────────────────
+
+#[test]
+fn i2s_dequant_known_bytes() {
+    // byte 0b10_00_01_01 → [+1, +1, 0, -1]
+    let packed = vec![0b10_00_01_01u8];
+    let result = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(result, vec![1.0, 1.0, 0.0, -1.0]);
+}
+
+#[test]
+fn i2s_dequant_all_zeros() {
+    let packed = vec![0x00u8; 4];
+    let result = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert!(result.iter().all(|&v| v == 0.0));
+    assert_eq!(result.len(), 16);
+}
+
+#[test]
+fn i2s_dequant_all_plus_one() {
+    // 0b01_01_01_01 = 0x55 → [+1,+1,+1,+1]
+    let packed = vec![0x55u8; 3];
+    let result = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(result.len(), 12);
+    assert!(result.iter().all(|&v| v == 1.0));
+}
+
+#[test]
+fn i2s_dequant_all_minus_one() {
+    // 0b10_10_10_10 = 0xAA → [-1,-1,-1,-1]
+    let packed = vec![0xAAu8; 2];
+    let result = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(result.len(), 8);
+    assert!(result.iter().all(|&v| v == -1.0));
+}
+
+#[test]
+fn i2s_dequant_scale_applied() {
+    let packed = vec![0x55u8]; // all +1
+    let result = quantized_ops::dequantize_i2s(&packed, 3.0);
+    assert_eq!(result, vec![3.0, 3.0, 3.0, 3.0]);
+}
+
+#[test]
+fn i2s_dequant_negative_scale() {
+    let packed = vec![0x55u8]; // all +1
+    let result = quantized_ops::dequantize_i2s(&packed, -2.0);
+    assert_eq!(result, vec![-2.0, -2.0, -2.0, -2.0]);
+}
+
+#[test]
+fn i2s_dequant_zero_scale() {
+    let packed = vec![0x55u8, 0xAAu8];
+    let result = quantized_ops::dequantize_i2s(&packed, 0.0);
+    assert!(result.iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn i2s_dequant_reserved_bits() {
+    // 0b11 → treated as 0
+    let packed = vec![0xFFu8]; // 0b11_11_11_11 → [0,0,0,0]
+    let result = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(result, vec![0.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn i2s_dequant_mixed_pattern() {
+    // 0b00_10_01_00 = weights [0, +1, -1, 0] packed LSB-first
+    let byte = 0b00_10_01_00u8;
+    let result = quantized_ops::dequantize_i2s(&[byte], 1.0);
+    assert_eq!(result, vec![0.0, 1.0, -1.0, 0.0]);
+}
+
+#[test]
+fn i2s_dequant_empty_input() {
+    let result = quantized_ops::dequantize_i2s(&[], 1.0);
+    assert!(result.is_empty());
+}
+
+// ── QK256 dequantization ─────────────────────────────────────────────────────
+
+#[test]
+fn qk256_dequant_too_short() {
+    let result = quantized_ops::dequantize_qk256(&[0u8; 65]);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn qk256_dequant_all_zeros() {
+    let block = vec![0u8; quantized_ops::QK256_BLOCK_SIZE];
+    let result = quantized_ops::dequantize_qk256(&block);
+    assert_eq!(result.len(), 256);
+    assert!(result.iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn qk256_dequant_scale_one_all_plus() {
+    let mut block = vec![0u8; quantized_ops::QK256_BLOCK_SIZE];
+    // f16 1.0 = 0x3C00 (little-endian: [0x00, 0x3C])
+    block[0] = 0x00;
+    block[1] = 0x3C;
+    // Fill weight bytes with all +1: 0x55
+    for b in &mut block[2..] {
+        *b = 0x55;
+    }
+    let result = quantized_ops::dequantize_qk256(&block);
+    assert_eq!(result.len(), 256);
+    for &v in &result {
+        assert!((v - 1.0).abs() < 1e-3, "expected ~1.0, got {v}");
+    }
+}
+
+#[test]
+fn qk256_dequant_negative_scale() {
+    let mut block = vec![0u8; quantized_ops::QK256_BLOCK_SIZE];
+    // f16 -2.0 = 0xC000 (little-endian: [0x00, 0xC0])
+    block[0] = 0x00;
+    block[1] = 0xC0;
+    // all +1 weights
+    for b in &mut block[2..] {
+        *b = 0x55;
+    }
+    let result = quantized_ops::dequantize_qk256(&block);
+    for &v in &result {
+        assert!((v - (-2.0)).abs() < 1e-3, "expected ~-2.0, got {v}");
+    }
+}
+
+#[test]
+fn qk256_dequant_output_count() {
+    let block = vec![0u8; quantized_ops::QK256_BLOCK_SIZE];
+    let result = quantized_ops::dequantize_qk256(&block);
+    assert_eq!(result.len(), quantized_ops::QK256_WEIGHTS_PER_BLOCK);
+}
+
+// ── Pack / unpack round-trip ─────────────────────────────────────────────────
+
+#[test]
+fn pack_unpack_roundtrip_simple() {
+    let original = vec![1.0, -1.0, 0.0, 1.0];
+    let packed = quantized_ops::pack_i2s(&original);
+    let unpacked = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(&unpacked[..original.len()], &original[..]);
+}
+
+#[test]
+fn pack_unpack_roundtrip_longer() {
+    let original = vec![1.0, 0.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0, 1.0, 1.0, -1.0, 0.0];
+    let packed = quantized_ops::pack_i2s(&original);
+    let unpacked = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(&unpacked[..original.len()], &original[..]);
+}
+
+#[test]
+fn pack_unpack_roundtrip_non_multiple_of_4() {
+    // 5 elements → 2 packed bytes, unpacked → 8 elements (padded)
+    let original = vec![1.0, -1.0, 0.0, 1.0, -1.0];
+    let packed = quantized_ops::pack_i2s(&original);
+    assert_eq!(packed.len(), 2);
+    let unpacked = quantized_ops::dequantize_i2s(&packed, 1.0);
+    assert_eq!(unpacked.len(), 8);
+    assert_eq!(&unpacked[..5], &original[..]);
+    // padding should be zero
+    assert_eq!(unpacked[5], 0.0);
+    assert_eq!(unpacked[6], 0.0);
+    assert_eq!(unpacked[7], 0.0);
+}
+
+#[test]
+fn pack_empty() {
+    let packed = quantized_ops::pack_i2s(&[]);
+    assert!(packed.is_empty());
+}
+
+// ── Ternary matvec ───────────────────────────────────────────────────────────
+
+#[test]
+fn matvec_identity_like() {
+    // 4×4 "identity" in ternary: diagonal +1, rest 0
+    let mut weights = vec![0.0f32; 16];
+    for i in 0..4 {
+        weights[i * 4 + i] = 1.0;
+    }
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 4, 4);
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn matvec_all_zero_weights() {
+    let packed = vec![0x00u8; 4]; // 4×4, cols_packed=1
+    let input = vec![5.0, 6.0, 7.0, 8.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 4, 4);
+    assert_eq!(output, vec![0.0, 0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn matvec_all_plus_one_weights() {
+    // 2×4 matrix, all +1
+    let weights = vec![1.0f32; 8];
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 2, 4);
+    let sum: f32 = input.iter().sum();
+    assert_eq!(output, vec![sum, sum]);
+}
+
+#[test]
+fn matvec_all_minus_one_weights() {
+    let weights = vec![-1.0f32; 8];
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 2, 4);
+    let neg_sum: f32 = -input.iter().sum::<f32>();
+    assert_eq!(output, vec![neg_sum, neg_sum]);
+}
+
+#[test]
+fn matvec_scale_factor() {
+    let weights = vec![1.0f32; 4]; // 1×4
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![1.0, 1.0, 1.0, 1.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 2.5, 1, 4);
+    assert!((output[0] - 10.0).abs() < 1e-6); // 4 * 2.5
+}
+
+#[test]
+fn matvec_mixed_weights() {
+    // 1×4 weights: [+1, -1, +1, 0]
+    let weights = vec![1.0, -1.0, 1.0, 0.0];
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![3.0, 5.0, 7.0, 11.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 1, 4);
+    // 3 - 5 + 7 + 0 = 5
+    assert!((output[0] - 5.0).abs() < 1e-6);
+}
+
+// ── Ternary matmul (batched) ─────────────────────────────────────────────────
+
+#[test]
+fn matmul_batch_of_two() {
+    let weights = vec![1.0f32; 8]; // 2×4
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![
+        1.0, 2.0, 3.0, 4.0, // batch 0
+        5.0, 6.0, 7.0, 8.0, // batch 1
+    ];
+    let output = quantized_ops::ternary_matmul(&packed, &input, 1.0, 2, 4, 2);
+    assert_eq!(output.len(), 4); // 2 batches × 2 rows
+    assert!((output[0] - 10.0).abs() < 1e-6); // sum batch0
+    assert!((output[1] - 10.0).abs() < 1e-6);
+    assert!((output[2] - 26.0).abs() < 1e-6); // sum batch1
+    assert!((output[3] - 26.0).abs() < 1e-6);
+}
+
+#[test]
+fn matmul_single_element() {
+    // 1×1 matrix with +1 weight
+    let packed = quantized_ops::pack_i2s(&[1.0]);
+    let input = vec![42.0];
+    let output = quantized_ops::ternary_matmul(&packed, &input, 1.0, 1, 1, 1);
+    assert_eq!(output.len(), 1);
+    assert!((output[0] - 42.0).abs() < 1e-6);
+}
+
+// ── Edge cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn i2s_dequant_single_byte() {
+    let result = quantized_ops::dequantize_i2s(&[0x55], 1.0);
+    assert_eq!(result.len(), 4);
+}
+
+#[test]
+fn matvec_256_boundary() {
+    // 1×256 weights, all +1
+    let weights = vec![1.0f32; 256];
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![1.0f32; 256];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 1, 256);
+    assert!((output[0] - 256.0).abs() < 1e-3);
+}
+
+#[test]
+fn matvec_cols_not_multiple_of_4() {
+    // 1×5 weights: [+1, +1, +1, +1, +1]
+    let weights = vec![1.0f32; 5];
+    let packed = quantized_ops::pack_i2s(&weights);
+    let input = vec![2.0, 3.0, 4.0, 5.0, 6.0];
+    let output = quantized_ops::ternary_matvec(&packed, &input, 1.0, 1, 5);
+    // 2+3+4+5+6 = 20
+    assert!((output[0] - 20.0).abs() < 1e-6);
+}
+
+// ── Kernel source validation ─────────────────────────────────────────────────
+
+#[test]
+fn kernel_sources_have_kernel_keyword() {
+    assert!(quantized_kernels::DEQUANTIZE_I2S_CL.contains("__kernel"));
+    assert!(quantized_kernels::TERNARY_MATMUL_CL.contains("__kernel"));
+    assert!(quantized_kernels::QK256_DEQUANT_CL.contains("__kernel"));
+}
+
+#[test]
+fn kernel_all_sources_returns_three() {
+    let sources = quantized_kernels::all_kernel_sources();
+    assert_eq!(sources.len(), 3);
+    for (name, src) in &sources {
+        assert!(!name.is_empty());
+        assert!(src.contains(name), "kernel source should contain '{name}'");
+    }
+}
+
+#[test]
+fn kernel_workgroup_sizes_positive() {
+    assert!(quantized_kernels::DEQUANTIZE_I2S_WORKGROUP > 0);
+    assert!(quantized_kernels::TERNARY_MATMUL_WORKGROUP > 0);
+    assert!(quantized_kernels::QK256_DEQUANT_WORKGROUP > 0);
+}
+
+#[test]
+fn kernel_mem_estimate_scales_with_size() {
+    let small = quantized_kernels::ternary_matmul_mem_bytes(16, 16);
+    let large = quantized_kernels::ternary_matmul_mem_bytes(256, 256);
+    assert!(large > small);
+}
+
+#[test]
+fn qk256_block_size_constant() {
+    assert_eq!(quantized_ops::QK256_BLOCK_SIZE, 66);
+    assert_eq!(quantized_ops::QK256_WEIGHTS_PER_BLOCK, 256);
+}


### PR DESCRIPTION
## Summary
Quantized inference operations for BitNet 1.58-bit models.

- I2_S and QK256 dequantization
- Ternary matmul/matvec for packed weights
- CPU reference implementations for validation
- OpenCL kernel sources for GPU acceleration

Part of Intel GPU support epic.