### PR TITLE
feat(opencl): SPIR-V compilation pipeline for GPU kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "opencl3",
  "rand 0.9.2",
  "serial_test",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bitnet-opencl/Cargo.toml
+++ b/crates/bitnet-opencl/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 log.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 opencl3 = { version = "0.9", optional = true }
 

--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -7,6 +7,7 @@
 //! pipelines, KV cache, paged attention, and CPU reference implementations
 //! with OpenCL kernel sources for I2_S dequantization, QK256 block
 //! dequantization, and ternary matrix multiply.
+//! pipelines, KV cache, paged attention, SPIR-V compilation, and kernel registry.
 
 pub mod backend_dispatcher;
 pub mod backend_registry;
@@ -21,3 +22,12 @@ pub use backend_dispatcher::{
 pub use backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
 pub mod quantized_kernels;
 pub mod quantized_ops;
+pub mod spirv;
+pub mod spirv_kernels;
+
+// Re-exports for convenience.
+pub use spirv::{
+    CompileOptions, CompilerBackend, OptimizationLevel, SPIRV_MAGIC, SpirVCache, SpirVCompiler,
+    SpirVError, SpirVModule, SpirVValidator,
+};
+pub use spirv_kernels::{KernelSource, SpirvKernelRegistry};

--- a/crates/bitnet-opencl/src/spirv.rs
+++ b/crates/bitnet-opencl/src/spirv.rs
@@ -1,0 +1,461 @@
+//! SPIR-V compilation pipeline for `OpenCL` kernels.
+//!
+//! Provides offline compilation of `.cl` kernel sources to SPIR-V binary,
+//! with runtime detection of available compilers (`clang`, `ocloc`) and
+//! automatic fallback to embedding raw `.cl` source for runtime compilation.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::Command;
+use std::sync::Mutex;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/// Errors that can occur during SPIR-V compilation or validation.
+#[derive(Debug, thiserror::Error)]
+pub enum SpirVError {
+    /// The SPIR-V binary failed validation.
+    #[error("SPIR-V validation failed: {0}")]
+    ValidationFailed(String),
+
+    /// Compilation of `.cl` source to SPIR-V failed.
+    #[error("SPIR-V compilation failed: {0}")]
+    CompilationFailed(String),
+
+    /// An I/O error occurred (e.g. reading/writing cache files).
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// No supported compiler was found on the system.
+    #[error("no SPIR-V compiler available")]
+    NoCompilerAvailable,
+}
+
+// ── Compile options ──────────────────────────────────────────────────────────
+
+/// Optimization level for SPIR-V compilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OptimizationLevel {
+    /// No optimization (`-O0`).
+    None,
+    /// Basic optimization (`-O1`).
+    Basic,
+    /// Full optimization (`-O2`).
+    Full,
+}
+
+impl OptimizationLevel {
+    const fn as_flag(self) -> &'static str {
+        match self {
+            Self::None => "-O0",
+            Self::Basic => "-O1",
+            Self::Full => "-O2",
+        }
+    }
+}
+
+/// Options controlling SPIR-V compilation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompileOptions {
+    /// Target device hint (informational; not all compilers use this).
+    pub target_device: Option<String>,
+    /// Optimisation level for the SPIR-V compiler.
+    pub optimization_level: OptimizationLevel,
+    /// Preprocessor defines passed to the compiler (`-D`).
+    pub defines: Vec<(String, String)>,
+}
+
+impl Default for CompileOptions {
+    fn default() -> Self {
+        Self {
+            target_device: None,
+            optimization_level: OptimizationLevel::Full,
+            defines: Vec::new(),
+        }
+    }
+}
+
+// ── Compiler backend detection ───────────────────────────────────────────────
+
+/// Which compiler backend is available on this system.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompilerBackend {
+    /// LLVM/Clang with SPIR-V target support.
+    Clang,
+    /// Intel Graphics Offline Compiler.
+    Ocloc,
+}
+
+/// Probe the system for a usable SPIR-V compiler.
+///
+/// Checks `clang` first, then `ocloc`. Returns `None` when neither is found.
+pub fn detect_compiler() -> Option<CompilerBackend> {
+    if probe_clang() {
+        Some(CompilerBackend::Clang)
+    } else if probe_ocloc() {
+        Some(CompilerBackend::Ocloc)
+    } else {
+        None
+    }
+}
+
+fn probe_clang() -> bool {
+    Command::new("clang")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn probe_ocloc() -> bool {
+    Command::new("ocloc")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+// ── SPIR-V module ────────────────────────────────────────────────────────────
+
+/// A compiled SPIR-V module together with its metadata.
+#[derive(Debug, Clone)]
+pub struct SpirVModule {
+    /// Raw SPIR-V binary (little-endian words).
+    pub bytecode: Vec<u8>,
+    /// Hex-encoded SHA-256 of the *source* that produced this module.
+    pub source_hash: String,
+    /// The compiler backend that produced this module (if any).
+    pub compiler: Option<CompilerBackend>,
+}
+
+// ── SPIR-V compiler ──────────────────────────────────────────────────────────
+
+/// Offline compiler that turns `OpenCL` C source into SPIR-V binary.
+///
+/// When no system compiler is detected the caller should fall back to
+/// passing the raw `.cl` source to the `OpenCL` runtime for JIT compilation.
+pub struct SpirVCompiler {
+    backend: Option<CompilerBackend>,
+}
+
+impl SpirVCompiler {
+    /// Create a new compiler, auto-detecting available backends.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { backend: detect_compiler() }
+    }
+
+    /// Create a compiler with an explicit backend (useful for testing).
+    #[must_use]
+    pub const fn with_backend(backend: Option<CompilerBackend>) -> Self {
+        Self { backend }
+    }
+
+    /// Returns the detected backend, if any.
+    #[must_use]
+    pub const fn backend(&self) -> Option<CompilerBackend> {
+        self.backend
+    }
+
+    /// Compile `OpenCL` C `source` to SPIR-V.
+    ///
+    /// Returns [`SpirVError::NoCompilerAvailable`] when no backend is
+    /// detected. The caller should fall back to runtime `.cl` compilation.
+    pub fn compile_to_spirv(
+        &self,
+        source: &str,
+        options: &CompileOptions,
+    ) -> Result<SpirVModule, SpirVError> {
+        let backend = self.backend.ok_or(SpirVError::NoCompilerAvailable)?;
+
+        let hash = source_hash(source, options);
+        let bytecode = invoke_compiler(backend, source, options)?;
+
+        // Sanity-check the output before handing it back.
+        SpirVValidator::validate_bytes(&bytecode)?;
+
+        Ok(SpirVModule { bytecode, source_hash: hash, compiler: Some(backend) })
+    }
+}
+
+impl Default for SpirVCompiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Invoke the actual compiler process and return raw SPIR-V bytes.
+fn invoke_compiler(
+    backend: CompilerBackend,
+    source: &str,
+    options: &CompileOptions,
+) -> Result<Vec<u8>, SpirVError> {
+    let dir = tempfile::tempdir().map_err(SpirVError::Io)?;
+
+    let src_path = dir.path().join("kernel.cl");
+    let out_path = dir.path().join("kernel.spv");
+    std::fs::write(&src_path, source)?;
+
+    let status = match backend {
+        CompilerBackend::Clang => build_clang_command(&src_path, &out_path, options)
+            .status()
+            .map_err(|e| SpirVError::CompilationFailed(format!("failed to launch clang: {e}")))?,
+        CompilerBackend::Ocloc => build_ocloc_command(&src_path, &out_path, options)
+            .status()
+            .map_err(|e| SpirVError::CompilationFailed(format!("failed to launch ocloc: {e}")))?,
+    };
+
+    if !status.success() {
+        return Err(SpirVError::CompilationFailed(format!("{backend:?} exited with {status}")));
+    }
+
+    let mut buf = Vec::new();
+    std::fs::File::open(&out_path)?.read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn build_clang_command(
+    src: &std::path::Path,
+    out: &std::path::Path,
+    opts: &CompileOptions,
+) -> Command {
+    let mut cmd = Command::new("clang");
+    cmd.args([
+        "-cc1",
+        "-triple",
+        "spir64-unknown-unknown",
+        "-emit-spirv",
+        opts.optimization_level.as_flag(),
+        "-o",
+    ]);
+    cmd.arg(out);
+    for (k, v) in &opts.defines {
+        cmd.arg(format!("-D{k}={v}"));
+    }
+    cmd.arg(src);
+    cmd
+}
+
+fn build_ocloc_command(
+    src: &std::path::Path,
+    out: &std::path::Path,
+    opts: &CompileOptions,
+) -> Command {
+    let mut cmd = Command::new("ocloc");
+    cmd.args(["compile", "-file"]);
+    cmd.arg(src);
+    cmd.args(["-spirv_input", "-output"]);
+    cmd.arg(out);
+    if let Some(dev) = &opts.target_device {
+        cmd.args(["-device", dev]);
+    }
+    for (k, v) in &opts.defines {
+        cmd.arg(format!("-D{k}={v}"));
+    }
+    cmd
+}
+
+// ── SPIR-V validator ─────────────────────────────────────────────────────────
+
+/// SPIR-V magic number (first four bytes, little-endian).
+pub const SPIRV_MAGIC: u32 = 0x0723_0203;
+
+/// Lightweight SPIR-V binary validator.
+///
+/// Performs structural checks only – it does **not** run the full Khronos
+/// `spirv-val` tool.
+pub struct SpirVValidator;
+
+impl SpirVValidator {
+    /// Validate raw SPIR-V `bytes`.
+    ///
+    /// Checks:
+    /// 1. Minimum length (20 bytes = 5 words for the header).
+    /// 2. Magic number matches [`SPIRV_MAGIC`].
+    /// 3. Version word is a known SPIR-V version (1.0 – 1.6).
+    pub fn validate_bytes(bytes: &[u8]) -> Result<(), SpirVError> {
+        Self::check_length(bytes)?;
+        Self::check_magic(bytes)?;
+        Self::check_version(bytes)?;
+        Ok(())
+    }
+
+    /// Validate the magic number only.
+    pub fn check_magic(bytes: &[u8]) -> Result<(), SpirVError> {
+        if bytes.len() < 4 {
+            return Err(SpirVError::ValidationFailed("too short for magic number".into()));
+        }
+        let magic = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        if magic != SPIRV_MAGIC {
+            return Err(SpirVError::ValidationFailed(format!(
+                "bad magic: expected 0x{SPIRV_MAGIC:08X}, got 0x{magic:08X}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate minimum length (5 header words = 20 bytes).
+    pub fn check_length(bytes: &[u8]) -> Result<(), SpirVError> {
+        if bytes.len() < 20 {
+            return Err(SpirVError::ValidationFailed(format!(
+                "SPIR-V binary too short: {} bytes (minimum 20)",
+                bytes.len()
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate the version word (second 32-bit word).
+    pub fn check_version(bytes: &[u8]) -> Result<(), SpirVError> {
+        if bytes.len() < 8 {
+            return Err(SpirVError::ValidationFailed("too short for version word".into()));
+        }
+        let version = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        // SPIR-V versions: major in bits 23:16, minor in bits 15:8.
+        let major = (version >> 16) & 0xFF;
+        let minor = (version >> 8) & 0xFF;
+        if major != 1 || minor > 6 {
+            return Err(SpirVError::ValidationFailed(format!(
+                "unsupported SPIR-V version {major}.{minor}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Check whether the binary *might* contain a given SPIR-V capability.
+    ///
+    /// This is a best-effort scan – it searches for `OpCapability`
+    /// instructions (opcode 17) whose operand matches `capability_id`.
+    pub fn has_capability(bytes: &[u8], capability_id: u32) -> bool {
+        // OpCapability = opcode 17, word count 2.
+        // Encoded as: (2 << 16) | 17 = 0x0002_0011.
+        let op_capability: u32 = (2 << 16) | 17;
+        // Walk word-aligned through the binary after the 5-word header.
+        if bytes.len() < 24 {
+            return false;
+        }
+        let mut offset = 20; // skip header
+        while offset + 8 <= bytes.len() {
+            let word = u32::from_le_bytes([
+                bytes[offset],
+                bytes[offset + 1],
+                bytes[offset + 2],
+                bytes[offset + 3],
+            ]);
+            if word == op_capability {
+                let operand = u32::from_le_bytes([
+                    bytes[offset + 4],
+                    bytes[offset + 5],
+                    bytes[offset + 6],
+                    bytes[offset + 7],
+                ]);
+                if operand == capability_id {
+                    return true;
+                }
+            }
+            // Advance by word-count (upper 16 bits).
+            let wc = (word >> 16) as usize;
+            if wc == 0 {
+                break;
+            }
+            offset += wc * 4;
+        }
+        false
+    }
+}
+
+// ── SPIR-V cache ─────────────────────────────────────────────────────────────
+
+/// Thread-safe in-memory cache for compiled SPIR-V modules, keyed by a hash
+/// of the source text and compile options.
+pub struct SpirVCache {
+    entries: Mutex<HashMap<String, SpirVModule>>,
+}
+
+impl SpirVCache {
+    /// Create a new empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { entries: Mutex::new(HashMap::new()) }
+    }
+
+    /// Look up a cached module by its source hash.
+    pub fn get(&self, hash: &str) -> Option<SpirVModule> {
+        self.entries.lock().expect("spirv cache lock poisoned").get(hash).cloned()
+    }
+
+    /// Store a compiled module in the cache.
+    pub fn insert(&self, module: SpirVModule) {
+        self.entries
+            .lock()
+            .expect("spirv cache lock poisoned")
+            .insert(module.source_hash.clone(), module);
+    }
+
+    /// Number of entries currently in the cache.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.lock().expect("spirv cache lock poisoned").len()
+    }
+
+    /// Returns `true` if the cache is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Remove all entries from the cache.
+    pub fn clear(&self) {
+        self.entries.lock().expect("spirv cache lock poisoned").clear();
+    }
+}
+
+impl Default for SpirVCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Source hashing ───────────────────────────────────────────────────────────
+
+/// Compute a deterministic hash of the source + options, suitable for
+/// cache keys. Uses a simple `DefaultHasher`-based approach (not
+/// cryptographic, but fast and collision-resistant enough for caching).
+pub fn source_hash(source: &str, options: &CompileOptions) -> String {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    source.hash(&mut hasher);
+    options.optimization_level.hash(&mut hasher);
+    options.target_device.hash(&mut hasher);
+    for (k, v) in &options.defines {
+        k.hash(&mut hasher);
+        v.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a minimal valid SPIR-V binary (header only) for testing.
+///
+/// This is **not** a useful module – it exists solely for unit tests that
+/// need bytes passing the validator.
+#[must_use]
+pub fn build_test_spirv(version_major: u8, version_minor: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(20);
+    // Word 0: magic
+    buf.extend_from_slice(&SPIRV_MAGIC.to_le_bytes());
+    // Word 1: version (major.minor.0)
+    let version_word = (u32::from(version_major) << 16) | (u32::from(version_minor) << 8);
+    buf.extend_from_slice(&version_word.to_le_bytes());
+    // Word 2: generator magic (0 = unknown)
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    // Word 3: bound (IDs upper bound; 1 is minimum valid)
+    buf.extend_from_slice(&1u32.to_le_bytes());
+    // Word 4: reserved (must be 0)
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    buf
+}

--- a/crates/bitnet-opencl/src/spirv_kernels/mod.rs
+++ b/crates/bitnet-opencl/src/spirv_kernels/mod.rs
@@ -1,0 +1,129 @@
+//! SPIR-V kernel registry.
+//!
+//! Maps kernel names to their source representation — either an embedded
+//! `.cl` source string (for runtime / JIT compilation) or pre-compiled
+//! SPIR-V bytes.
+
+use std::collections::HashMap;
+
+// ── Kernel source representation ─────────────────────────────────────────────
+
+/// How a kernel's code is stored in the registry.
+#[derive(Debug, Clone)]
+pub enum KernelSource {
+    /// Raw `OpenCL` C source (`.cl`), used when no offline compiler was
+    /// available at build time.
+    ClSource(String),
+    /// Pre-compiled SPIR-V binary.
+    SpirV(Vec<u8>),
+}
+
+// ── Registry ─────────────────────────────────────────────────────────────────
+
+/// Registry mapping kernel names to their [`KernelSource`].
+///
+/// Populated at startup from either embedded `.cl` sources or, when a
+/// `build_spirv` step has run, from the resulting `.spv` blobs.
+#[derive(Debug, Clone)]
+pub struct SpirvKernelRegistry {
+    kernels: HashMap<String, KernelSource>,
+}
+
+impl SpirvKernelRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { kernels: HashMap::new() }
+    }
+
+    /// Register a kernel under `name`.
+    pub fn register(&mut self, name: impl Into<String>, source: KernelSource) {
+        self.kernels.insert(name.into(), source);
+    }
+
+    /// Look up a kernel by name.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&KernelSource> {
+        self.kernels.get(name)
+    }
+
+    /// Number of kernels in the registry.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.kernels.len()
+    }
+
+    /// Returns `true` if the registry contains no kernels.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.kernels.is_empty()
+    }
+
+    /// Iterate over all registered kernel names.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.kernels.keys().map(String::as_str)
+    }
+
+    /// Build a default registry pre-loaded with the built-in `.cl`
+    /// kernel sources shipped with this crate.
+    #[must_use]
+    pub fn with_builtin_kernels() -> Self {
+        let mut reg = Self::new();
+        // Placeholder: real kernels would be included here via
+        // `include_str!()` once the `.cl` files exist.
+        reg.register("matmul_i2", KernelSource::ClSource(MATMUL_I2_CL.into()));
+        reg.register("dequant_i2s", KernelSource::ClSource(DEQUANT_I2S_CL.into()));
+        reg
+    }
+}
+
+impl Default for SpirvKernelRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Embedded kernel sources (stubs) ──────────────────────────────────────────
+
+/// Stub `.cl` source for the `matmul_i2` kernel.
+const MATMUL_I2_CL: &str = "\
+__kernel void matmul_i2(
+    __global const uchar* A,
+    __global const float* B,
+    __global float* C,
+    const int M,
+    const int N,
+    const int K)
+{
+    int row = get_global_id(0);
+    int col = get_global_id(1);
+    if (row < M && col < N) {
+        float sum = 0.0f;
+        for (int k = 0; k < K; ++k) {
+            sum += (float)A[row * K + k] * B[k * N + col];
+        }
+        C[row * N + col] = sum;
+    }
+}
+";
+
+/// Stub `.cl` source for the `dequant_i2s` kernel.
+const DEQUANT_I2S_CL: &str = "\
+__kernel void dequant_i2s(
+    __global const uchar* packed,
+    __global float* output,
+    const float scale,
+    const int n)
+{
+    int gid = get_global_id(0);
+    if (gid < n) {
+        int byte_idx = gid / 4;
+        int bit_off  = (gid % 4) * 2;
+        int val = (packed[byte_idx] >> bit_off) & 0x3;
+        float dequant = (val == 0) ? -1.0f :
+                        (val == 1) ?  0.0f :
+                                      1.0f;
+        output[gid] = dequant * scale;
+    }
+}
+";

--- a/crates/bitnet-opencl/tests/spirv_tests.rs
+++ b/crates/bitnet-opencl/tests/spirv_tests.rs
@@ -1,0 +1,291 @@
+//! Tests for the SPIR-V compilation pipeline.
+
+use bitnet_opencl::spirv::{
+    CompileOptions, OptimizationLevel, SPIRV_MAGIC, SpirVCache, SpirVCompiler, SpirVError,
+    SpirVModule, SpirVValidator, build_test_spirv, source_hash,
+};
+use bitnet_opencl::spirv_kernels::{KernelSource, SpirvKernelRegistry};
+
+// ── Magic number validation ──────────────────────────────────────────────────
+
+#[test]
+fn magic_number_constant_matches_spec() {
+    assert_eq!(SPIRV_MAGIC, 0x0723_0203);
+}
+
+#[test]
+fn valid_spirv_passes_magic_check() {
+    let spv = build_test_spirv(1, 0);
+    assert!(SpirVValidator::check_magic(&spv).is_ok());
+}
+
+#[test]
+fn invalid_magic_rejected() {
+    let mut spv = build_test_spirv(1, 0);
+    // Corrupt the magic number.
+    spv[0] = 0xFF;
+    assert!(SpirVValidator::check_magic(&spv).is_err());
+}
+
+#[test]
+fn empty_bytes_rejected() {
+    assert!(SpirVValidator::validate_bytes(&[]).is_err());
+}
+
+#[test]
+fn too_short_bytes_rejected() {
+    // 19 bytes is one short of the minimum 20-byte header.
+    let bytes = vec![0u8; 19];
+    assert!(SpirVValidator::validate_bytes(&bytes).is_err());
+}
+
+// ── Version validation ───────────────────────────────────────────────────────
+
+#[test]
+fn version_1_0_accepted() {
+    let spv = build_test_spirv(1, 0);
+    assert!(SpirVValidator::validate_bytes(&spv).is_ok());
+}
+
+#[test]
+fn version_1_5_accepted() {
+    let spv = build_test_spirv(1, 5);
+    assert!(SpirVValidator::validate_bytes(&spv).is_ok());
+}
+
+#[test]
+fn version_1_6_accepted() {
+    let spv = build_test_spirv(1, 6);
+    assert!(SpirVValidator::validate_bytes(&spv).is_ok());
+}
+
+#[test]
+fn version_2_0_rejected() {
+    let spv = build_test_spirv(2, 0);
+    let err = SpirVValidator::validate_bytes(&spv).unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("unsupported"), "unexpected error: {msg}");
+}
+
+#[test]
+fn version_1_7_rejected() {
+    let spv = build_test_spirv(1, 7);
+    let err = SpirVValidator::validate_bytes(&spv).unwrap_err();
+    assert!(err.to_string().contains("unsupported"));
+}
+
+// ── Full validation on valid binary ──────────────────────────────────────────
+
+#[test]
+fn full_validation_passes_for_valid_binary() {
+    let spv = build_test_spirv(1, 3);
+    assert!(SpirVValidator::validate_bytes(&spv).is_ok());
+}
+
+#[test]
+fn all_zeroes_rejected() {
+    let bytes = vec![0u8; 20];
+    assert!(SpirVValidator::validate_bytes(&bytes).is_err());
+}
+
+// ── Capability checking ──────────────────────────────────────────────────────
+
+#[test]
+fn capability_check_on_minimal_binary_returns_false() {
+    let spv = build_test_spirv(1, 5);
+    // Minimal header has no capability instructions.
+    assert!(!SpirVValidator::has_capability(&spv, 1));
+}
+
+#[test]
+fn capability_check_finds_embedded_capability() {
+    let mut spv = build_test_spirv(1, 5);
+    // Append an OpCapability instruction: word-count 2, opcode 17 →
+    // header word = (2 << 16) | 17 = 0x0002_0011
+    let op_cap: u32 = (2 << 16) | 17;
+    spv.extend_from_slice(&op_cap.to_le_bytes());
+    // Operand: capability ID 22 (Image1D).
+    spv.extend_from_slice(&22u32.to_le_bytes());
+    assert!(SpirVValidator::has_capability(&spv, 22));
+    assert!(!SpirVValidator::has_capability(&spv, 99));
+}
+
+// ── Compiler detection ───────────────────────────────────────────────────────
+
+#[test]
+fn compiler_with_no_backend_returns_error() {
+    let compiler = SpirVCompiler::with_backend(None);
+    assert!(compiler.backend().is_none());
+    let err =
+        compiler.compile_to_spirv("__kernel void f(){}", &CompileOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, SpirVError::NoCompilerAvailable),
+        "expected NoCompilerAvailable, got {err:?}"
+    );
+}
+
+#[test]
+#[ignore = "requires clang with SPIR-V target - run manually"]
+fn clang_backend_compiles_trivial_kernel() {
+    use bitnet_opencl::CompilerBackend;
+    let compiler = SpirVCompiler::with_backend(Some(CompilerBackend::Clang));
+    let module = compiler
+        .compile_to_spirv("__kernel void noop() {}", &CompileOptions::default())
+        .expect("clang compilation failed");
+    assert!(!module.bytecode.is_empty());
+    assert!(SpirVValidator::validate_bytes(&module.bytecode).is_ok());
+}
+
+#[test]
+#[ignore = "requires Intel ocloc - run manually"]
+fn ocloc_backend_compiles_trivial_kernel() {
+    use bitnet_opencl::CompilerBackend;
+    let compiler = SpirVCompiler::with_backend(Some(CompilerBackend::Ocloc));
+    let module = compiler
+        .compile_to_spirv("__kernel void noop() {}", &CompileOptions::default())
+        .expect("ocloc compilation failed");
+    assert!(!module.bytecode.is_empty());
+}
+
+// ── Cache ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn cache_stores_and_retrieves() {
+    let cache = SpirVCache::new();
+    assert!(cache.is_empty());
+
+    let module = SpirVModule {
+        bytecode: build_test_spirv(1, 5),
+        source_hash: "abc123".into(),
+        compiler: None,
+    };
+    cache.insert(module.clone());
+    assert_eq!(cache.len(), 1);
+
+    let hit = cache.get("abc123").expect("cache miss");
+    assert_eq!(hit.bytecode, module.bytecode);
+}
+
+#[test]
+fn cache_miss_returns_none() {
+    let cache = SpirVCache::new();
+    assert!(cache.get("nonexistent").is_none());
+}
+
+#[test]
+fn source_hash_changes_invalidate_cache() {
+    let opts = CompileOptions::default();
+    let hash_a = source_hash("kernel void a(){}", &opts);
+    let hash_b = source_hash("kernel void b(){}", &opts);
+    assert_ne!(hash_a, hash_b, "different sources must hash differently");
+
+    // Simulate: cache only contains hash_a.
+    let cache = SpirVCache::new();
+    cache.insert(SpirVModule {
+        bytecode: build_test_spirv(1, 5),
+        source_hash: hash_a.clone(),
+        compiler: None,
+    });
+    assert!(cache.get(&hash_a).is_some());
+    assert!(cache.get(&hash_b).is_none());
+}
+
+#[test]
+fn compile_options_affect_hash() {
+    let src = "__kernel void f(){}";
+    let opts_o0 =
+        CompileOptions { optimization_level: OptimizationLevel::None, ..CompileOptions::default() };
+    let opts_o2 =
+        CompileOptions { optimization_level: OptimizationLevel::Full, ..CompileOptions::default() };
+    assert_ne!(
+        source_hash(src, &opts_o0),
+        source_hash(src, &opts_o2),
+        "different options must produce different hashes"
+    );
+}
+
+#[test]
+fn cache_clear_removes_all_entries() {
+    let cache = SpirVCache::new();
+    cache.insert(SpirVModule {
+        bytecode: build_test_spirv(1, 5),
+        source_hash: "h1".into(),
+        compiler: None,
+    });
+    cache.insert(SpirVModule {
+        bytecode: build_test_spirv(1, 3),
+        source_hash: "h2".into(),
+        compiler: None,
+    });
+    assert_eq!(cache.len(), 2);
+    cache.clear();
+    assert!(cache.is_empty());
+}
+
+// ── Kernel registry ──────────────────────────────────────────────────────────
+
+#[test]
+fn registry_starts_empty() {
+    let reg = SpirvKernelRegistry::new();
+    assert!(reg.is_empty());
+    assert_eq!(reg.len(), 0);
+}
+
+#[test]
+fn registry_registers_and_retrieves_cl_source() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("test_kernel", KernelSource::ClSource("src".into()));
+    assert_eq!(reg.len(), 1);
+    let src = reg.get("test_kernel").expect("registry miss");
+    assert!(matches!(src, KernelSource::ClSource(s) if s == "src"));
+}
+
+#[test]
+fn registry_registers_spirv_binary() {
+    let mut reg = SpirvKernelRegistry::new();
+    let spv = build_test_spirv(1, 5);
+    reg.register("kern", KernelSource::SpirV(spv.clone()));
+    let entry = reg.get("kern").expect("registry miss");
+    assert!(matches!(entry, KernelSource::SpirV(b) if b == &spv));
+}
+
+#[test]
+fn builtin_registry_has_expected_kernels() {
+    let reg = SpirvKernelRegistry::with_builtin_kernels();
+    assert!(reg.get("matmul_i2").is_some());
+    assert!(reg.get("dequant_i2s").is_some());
+    assert!(reg.get("nonexistent").is_none());
+}
+
+#[test]
+fn registry_names_iterator() {
+    let reg = SpirvKernelRegistry::with_builtin_kernels();
+    let names: Vec<&str> = reg.names().collect();
+    assert!(names.contains(&"matmul_i2"));
+    assert!(names.contains(&"dequant_i2s"));
+}
+
+// ── Fallback behaviour ───────────────────────────────────────────────────────
+
+#[test]
+fn fallback_to_cl_source_when_no_compiler() {
+    // When no compiler is available, callers should use ClSource directly.
+    let compiler = SpirVCompiler::with_backend(None);
+    let result = compiler.compile_to_spirv("__kernel void f(){}", &CompileOptions::default());
+    assert!(matches!(result, Err(SpirVError::NoCompilerAvailable)));
+
+    // The registry still provides the .cl source for runtime JIT.
+    let reg = SpirvKernelRegistry::with_builtin_kernels();
+    let src = reg.get("matmul_i2").unwrap();
+    assert!(matches!(src, KernelSource::ClSource(_)), "should fall back to .cl source");
+}
+
+// ── Build test helper ────────────────────────────────────────────────────────
+
+#[test]
+fn build_test_spirv_produces_valid_binary() {
+    for minor in 0..=6 {
+        let spv = build_test_spirv(1, minor);
+        assert!(SpirVValidator::validate_bytes(&spv).is_ok(), "v1.{minor} should be valid");
+    }
+}


### PR DESCRIPTION
## Summary
SPIR-V compilation infrastructure for GPU kernel deployment.

- SpirVCompiler with clang/ocloc auto-detection
- SPIR-V binary validation (magic, version, capability checks)
- Source-hash keyed caching
- SpirvKernelRegistry for kernel source management
- Fallback to runtime .cl compilation when no compiler available
- 27 tests (2 ignored with justification for requiring external tools)

Part of Intel GPU support epic.