### PR TITLE
feat(metal): Metal Shading Language compute kernels for Apple Silicon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-metal"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-models"
 version = "0.2.1-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
+  "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
   "crossval",
   "tests",
   "xtask",

--- a/crates/bitnet-metal/Cargo.toml
+++ b/crates/bitnet-metal/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bitnet-metal"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Metal Shading Language compute kernels for Apple Silicon GPU inference"
+rust-version.workspace = true
+
+[dependencies]
+# Pure embedded shader sources – no runtime deps required.
+
+[dev-dependencies]
+
+[features]
+default = []
+cpu = []
+gpu = ["cuda"]
+cuda = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-metal/src/kernels/attention.metal
+++ b/crates/bitnet-metal/src/kernels/attention.metal
@@ -1,0 +1,98 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// Scaled dot-product attention with optional causal mask.
+/// Q: [batch, heads, seq_q, head_dim]   - query
+/// K: [batch, heads, seq_k, head_dim]   - key
+/// V: [batch, heads, seq_k, head_dim]   - value
+/// output: [batch, heads, seq_q, head_dim]
+///
+/// attention_dims: (batch, heads, seq_q, seq_k)
+/// head_dim passed separately in buffer(5)
+/// causal: if non-zero, applies causal mask
+constant uint ATTN_THREADGROUP_SIZE = 256;
+
+kernel void attention_scores(
+    device const float* q [[buffer(0)]],
+    device const float* k [[buffer(1)]],
+    device float* scores [[buffer(2)]],
+    constant uint4& attention_dims [[buffer(3)]],
+    constant uint& head_dim [[buffer(4)]],
+    constant uint& causal [[buffer(5)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    const uint batch = gid.z / attention_dims.y;
+    const uint head = gid.z % attention_dims.y;
+    const uint q_pos = gid.y;
+    const uint k_pos = gid.x;
+
+    const uint n_batch = attention_dims.x;
+    const uint n_heads = attention_dims.y;
+    const uint seq_q = attention_dims.z;
+    const uint seq_k = attention_dims.w;
+
+    if (batch >= n_batch || head >= n_heads ||
+        q_pos >= seq_q || k_pos >= seq_k) {
+        return;
+    }
+
+    // Causal mask: future positions get -inf
+    if (causal != 0 && k_pos > q_pos) {
+        const uint score_idx = ((batch * n_heads + head) * seq_q + q_pos) * seq_k + k_pos;
+        scores[score_idx] = -INFINITY;
+        return;
+    }
+
+    const float scale = rsqrt(float(head_dim));
+
+    // Compute dot product Q[q_pos] · K[k_pos]
+    const uint q_offset = ((batch * n_heads + head) * seq_q + q_pos) * head_dim;
+    const uint k_offset = ((batch * n_heads + head) * seq_k + k_pos) * head_dim;
+
+    float dot = 0.0f;
+    for (uint i = 0; i < head_dim; i++) {
+        dot += q[q_offset + i] * k[k_offset + i];
+    }
+
+    const uint score_idx = ((batch * n_heads + head) * seq_q + q_pos) * seq_k + k_pos;
+    scores[score_idx] = dot * scale;
+}
+
+/// Attention weighted sum: output = softmax(scores) @ V
+/// scores: [batch, heads, seq_q, seq_k] (already softmaxed)
+/// V: [batch, heads, seq_k, head_dim]
+/// output: [batch, heads, seq_q, head_dim]
+kernel void attention_weighted_sum(
+    device const float* scores [[buffer(0)]],
+    device const float* v [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint4& attention_dims [[buffer(3)]],
+    constant uint& head_dim [[buffer(4)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    const uint batch = gid.z / attention_dims.y;
+    const uint head = gid.z % attention_dims.y;
+    const uint q_pos = gid.y;
+    const uint d = gid.x;
+
+    const uint n_batch = attention_dims.x;
+    const uint n_heads = attention_dims.y;
+    const uint seq_q = attention_dims.z;
+    const uint seq_k = attention_dims.w;
+
+    if (batch >= n_batch || head >= n_heads ||
+        q_pos >= seq_q || d >= head_dim) {
+        return;
+    }
+
+    float sum = 0.0f;
+    const uint score_offset = ((batch * n_heads + head) * seq_q + q_pos) * seq_k;
+    const uint v_base = (batch * n_heads + head) * seq_k;
+
+    for (uint k = 0; k < seq_k; k++) {
+        sum += scores[score_offset + k] * v[(v_base + k) * head_dim + d];
+    }
+
+    const uint out_idx = ((batch * n_heads + head) * seq_q + q_pos) * head_dim + d;
+    output[out_idx] = sum;
+}

--- a/crates/bitnet-metal/src/kernels/elementwise.metal
+++ b/crates/bitnet-metal/src/kernels/elementwise.metal
@@ -1,0 +1,80 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// Element-wise addition: output = a + b
+kernel void add(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    output[gid] = a[gid] + b[gid];
+}
+
+/// Element-wise multiplication: output = a * b
+kernel void mul(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    output[gid] = a[gid] * b[gid];
+}
+
+/// SiLU (Swish) activation: output = x * sigmoid(x)
+kernel void silu(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    const float x = input[gid];
+    output[gid] = x / (1.0f + exp(-x));
+}
+
+/// GELU activation (approximate): output = 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+kernel void gelu(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint& count [[buffer(2)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    const float x = input[gid];
+    const float sqrt_2_over_pi = 0.7978845608f;
+    const float coeff = 0.044715f;
+    const float inner = sqrt_2_over_pi * (x + coeff * x * x * x);
+    output[gid] = 0.5f * x * (1.0f + tanh(inner));
+}
+
+/// Fused SiLU-gated multiplication: output = silu(gate) * up
+/// Common in LLM feed-forward blocks (gate projection × up projection).
+kernel void silu_mul(
+    device const float* gate [[buffer(0)]],
+    device const float* up [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    const float g = gate[gid];
+    const float silu_g = g / (1.0f + exp(-g));
+    output[gid] = silu_g * up[gid];
+}
+
+/// Scalar multiply: output = input * scalar
+kernel void scalar_mul(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant float& scalar [[buffer(2)]],
+    constant uint& count [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= count) { return; }
+    output[gid] = input[gid] * scalar;
+}

--- a/crates/bitnet-metal/src/kernels/matmul.metal
+++ b/crates/bitnet-metal/src/kernels/matmul.metal
@@ -1,0 +1,86 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// Matrix multiplication: C = A * B
+/// dims.x = M (rows of A), dims.y = N (cols of B), dims.z = K (cols of A / rows of B)
+kernel void matmul(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* c [[buffer(2)]],
+    constant uint3& dims [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    const uint M = dims.x;
+    const uint N = dims.y;
+    const uint K = dims.z;
+
+    const uint row = gid.y;
+    const uint col = gid.x;
+
+    if (row >= M || col >= N) {
+        return;
+    }
+
+    float sum = 0.0f;
+    for (uint i = 0; i < K; i++) {
+        sum += a[row * K + i] * b[i * N + col];
+    }
+    c[row * N + col] = sum;
+}
+
+/// Tiled matrix multiplication using threadgroup shared memory.
+/// TILE_SIZE must match the threadgroup dimensions (e.g., 16×16).
+constant uint TILE_SIZE = 16;
+
+kernel void matmul_tiled(
+    device const float* a [[buffer(0)]],
+    device const float* b [[buffer(1)]],
+    device float* c [[buffer(2)]],
+    constant uint3& dims [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]],
+    uint2 tid [[thread_position_in_threadgroup]],
+    uint2 tgid [[threadgroup_position_in_grid]]
+) {
+    const uint M = dims.x;
+    const uint N = dims.y;
+    const uint K = dims.z;
+
+    threadgroup float a_tile[16 * 16];
+    threadgroup float b_tile[16 * 16];
+
+    const uint row = tgid.y * TILE_SIZE + tid.y;
+    const uint col = tgid.x * TILE_SIZE + tid.x;
+
+    float sum = 0.0f;
+    const uint num_tiles = (K + TILE_SIZE - 1) / TILE_SIZE;
+
+    for (uint t = 0; t < num_tiles; t++) {
+        // Load tile from A
+        const uint a_col = t * TILE_SIZE + tid.x;
+        if (row < M && a_col < K) {
+            a_tile[tid.y * TILE_SIZE + tid.x] = a[row * K + a_col];
+        } else {
+            a_tile[tid.y * TILE_SIZE + tid.x] = 0.0f;
+        }
+
+        // Load tile from B
+        const uint b_row = t * TILE_SIZE + tid.y;
+        if (b_row < K && col < N) {
+            b_tile[tid.y * TILE_SIZE + tid.x] = b[b_row * N + col];
+        } else {
+            b_tile[tid.y * TILE_SIZE + tid.x] = 0.0f;
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint i = 0; i < TILE_SIZE; i++) {
+            sum += a_tile[tid.y * TILE_SIZE + i] * b_tile[i * TILE_SIZE + tid.x];
+        }
+
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (row < M && col < N) {
+        c[row * N + col] = sum;
+    }
+}

--- a/crates/bitnet-metal/src/kernels/mod.rs
+++ b/crates/bitnet-metal/src/kernels/mod.rs
@@ -1,0 +1,69 @@
+//! Embedded Metal Shading Language (MSL) kernel sources for Apple Silicon.
+//!
+//! Each kernel is embedded at compile time via `include_str!` for portable
+//! distribution without runtime file dependencies.
+
+/// Identifies a Metal compute kernel source file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MetalKernelSource {
+    /// Matrix multiplication (naive + tiled variants).
+    Matmul,
+    /// Numerically stable softmax with threadgroup reduction.
+    Softmax,
+    /// RMS normalization with threadgroup reduction.
+    RmsNorm,
+    /// Rotary position embeddings (`RoPE`) + table builder.
+    Rope,
+    /// Scaled dot-product attention with optional causal mask.
+    Attention,
+    /// Element-wise ops: add, mul, `SiLU`, GELU, `silu_mul`, `scalar_mul`.
+    Elementwise,
+}
+
+impl MetalKernelSource {
+    /// Returns all kernel source variants.
+    pub const ALL: &[Self] = &[
+        Self::Matmul,
+        Self::Softmax,
+        Self::RmsNorm,
+        Self::Rope,
+        Self::Attention,
+        Self::Elementwise,
+    ];
+}
+
+/// Returns the embedded MSL source code for the given kernel.
+pub const fn kernel_source(kernel: MetalKernelSource) -> &'static str {
+    match kernel {
+        MetalKernelSource::Matmul => {
+            include_str!("matmul.metal")
+        }
+        MetalKernelSource::Softmax => {
+            include_str!("softmax.metal")
+        }
+        MetalKernelSource::RmsNorm => {
+            include_str!("rmsnorm.metal")
+        }
+        MetalKernelSource::Rope => {
+            include_str!("rope.metal")
+        }
+        MetalKernelSource::Attention => {
+            include_str!("attention.metal")
+        }
+        MetalKernelSource::Elementwise => {
+            include_str!("elementwise.metal")
+        }
+    }
+}
+
+/// Returns the primary kernel function name(s) for each source.
+pub const fn kernel_function_names(kernel: MetalKernelSource) -> &'static [&'static str] {
+    match kernel {
+        MetalKernelSource::Matmul => &["matmul", "matmul_tiled"],
+        MetalKernelSource::Softmax => &["softmax"],
+        MetalKernelSource::RmsNorm => &["rmsnorm"],
+        MetalKernelSource::Rope => &["rope", "rope_build_tables"],
+        MetalKernelSource::Attention => &["attention_scores", "attention_weighted_sum"],
+        MetalKernelSource::Elementwise => &["add", "mul", "silu", "gelu", "silu_mul", "scalar_mul"],
+    }
+}

--- a/crates/bitnet-metal/src/kernels/rmsnorm.metal
+++ b/crates/bitnet-metal/src/kernels/rmsnorm.metal
@@ -1,0 +1,53 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// RMS normalization: output = (input / rms) * weight
+/// where rms = sqrt(mean(input^2) + eps)
+/// dims.x = batch size, dims.y = hidden dimension
+constant uint RMSNORM_THREADGROUP_SIZE = 256;
+
+kernel void rmsnorm(
+    device const float* input [[buffer(0)]],
+    device const float* weight [[buffer(1)]],
+    device float* output [[buffer(2)]],
+    constant uint2& dims [[buffer(3)]],
+    constant float& eps [[buffer(4)]],
+    uint2 gid [[thread_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]]
+) {
+    const uint batch = gid.y;
+    const uint hidden_dim = dims.y;
+
+    if (batch >= dims.x) {
+        return;
+    }
+
+    const uint row_offset = batch * hidden_dim;
+
+    threadgroup float shared_data[256];
+
+    // Phase 1: Compute sum of squares via threadgroup reduction
+    float local_sum_sq = 0.0f;
+    for (uint i = tid; i < hidden_dim; i += tg_size) {
+        const float val = input[row_offset + i];
+        local_sum_sq += val * val;
+    }
+    shared_data[tid] = local_sum_sq;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = tg_size / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            shared_data[tid] += shared_data[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const float rms = rsqrt(shared_data[0] / float(hidden_dim) + eps);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase 2: Normalize and scale
+    for (uint i = tid; i < hidden_dim; i += tg_size) {
+        output[row_offset + i] = input[row_offset + i] * rms * weight[i];
+    }
+}

--- a/crates/bitnet-metal/src/kernels/rope.metal
+++ b/crates/bitnet-metal/src/kernels/rope.metal
@@ -1,0 +1,70 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// Rotary Position Embeddings (RoPE).
+/// Applies rotation to pairs of elements in the input tensor.
+/// dims.x = batch_size, dims.y = seq_len, dims.z = head_dim
+/// The head_dim is expected to be even (pairs of elements are rotated).
+kernel void rope(
+    device float* input [[buffer(0)]],
+    device const float* cos_table [[buffer(1)]],
+    device const float* sin_table [[buffer(2)]],
+    constant uint3& dims [[buffer(3)]],
+    constant uint& position_offset [[buffer(4)]],
+    uint3 gid [[thread_position_in_grid]]
+) {
+    const uint batch = gid.z;
+    const uint seq_pos = gid.y;
+    const uint pair_idx = gid.x;
+
+    const uint batch_size = dims.x;
+    const uint seq_len = dims.y;
+    const uint head_dim = dims.z;
+    const uint half_dim = head_dim / 2;
+
+    if (batch >= batch_size || seq_pos >= seq_len || pair_idx >= half_dim) {
+        return;
+    }
+
+    const uint pos = position_offset + seq_pos;
+    const uint cos_sin_idx = pos * half_dim + pair_idx;
+    const float cos_val = cos_table[cos_sin_idx];
+    const float sin_val = sin_table[cos_sin_idx];
+
+    const uint base_idx = batch * seq_len * head_dim + seq_pos * head_dim;
+    const uint idx_re = base_idx + pair_idx;
+    const uint idx_im = base_idx + pair_idx + half_dim;
+
+    const float x_re = input[idx_re];
+    const float x_im = input[idx_im];
+
+    // Apply rotation: [cos, -sin; sin, cos] * [x_re, x_im]
+    input[idx_re] = x_re * cos_val - x_im * sin_val;
+    input[idx_im] = x_re * sin_val + x_im * cos_val;
+}
+
+/// Build cos/sin frequency tables for RoPE.
+/// dims.x = max_seq_len, dims.y = half_head_dim
+kernel void rope_build_tables(
+    device float* cos_table [[buffer(0)]],
+    device float* sin_table [[buffer(1)]],
+    constant uint2& dims [[buffer(2)]],
+    constant float& theta_base [[buffer(3)]],
+    uint2 gid [[thread_position_in_grid]]
+) {
+    const uint pos = gid.y;
+    const uint dim_idx = gid.x;
+    const uint max_seq_len = dims.x;
+    const uint half_dim = dims.y;
+
+    if (pos >= max_seq_len || dim_idx >= half_dim) {
+        return;
+    }
+
+    const float freq = 1.0f / pow(theta_base, float(2 * dim_idx) / float(2 * half_dim));
+    const float angle = float(pos) * freq;
+
+    const uint idx = pos * half_dim + dim_idx;
+    cos_table[idx] = cos(angle);
+    sin_table[idx] = sin(angle);
+}

--- a/crates/bitnet-metal/src/kernels/softmax.metal
+++ b/crates/bitnet-metal/src/kernels/softmax.metal
@@ -1,0 +1,67 @@
+#include <metal_stdlib>
+using namespace metal;
+
+/// Numerically stable softmax over the last dimension.
+/// dims.x = batch size, dims.y = sequence length (number of elements per row).
+/// Uses threadgroup reduction for max and sum computation.
+constant uint SOFTMAX_THREADGROUP_SIZE = 256;
+
+kernel void softmax(
+    device const float* input [[buffer(0)]],
+    device float* output [[buffer(1)]],
+    constant uint2& dims [[buffer(2)]],
+    uint2 gid [[thread_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint tg_size [[threads_per_threadgroup]]
+) {
+    const uint batch = gid.y;
+    const uint seq_len = dims.y;
+
+    if (batch >= dims.x) {
+        return;
+    }
+
+    const uint row_offset = batch * seq_len;
+
+    threadgroup float shared_data[256];
+
+    // Phase 1: Find max value via threadgroup reduction
+    float local_max = -INFINITY;
+    for (uint i = tid; i < seq_len; i += tg_size) {
+        local_max = max(local_max, input[row_offset + i]);
+    }
+    shared_data[tid] = local_max;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = tg_size / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            shared_data[tid] = max(shared_data[tid], shared_data[tid + stride]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float row_max = shared_data[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase 2: Compute sum of exp(x - max) via threadgroup reduction
+    float local_sum = 0.0f;
+    for (uint i = tid; i < seq_len; i += tg_size) {
+        local_sum += exp(input[row_offset + i] - row_max);
+    }
+    shared_data[tid] = local_sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = tg_size / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            shared_data[tid] += shared_data[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+    const float row_sum = shared_data[0];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // Phase 3: Normalize
+    const float inv_sum = 1.0f / row_sum;
+    for (uint i = tid; i < seq_len; i += tg_size) {
+        output[row_offset + i] = exp(input[row_offset + i] - row_max) * inv_sum;
+    }
+}

--- a/crates/bitnet-metal/src/lib.rs
+++ b/crates/bitnet-metal/src/lib.rs
@@ -1,0 +1,17 @@
+//! Metal Shading Language (MSL) compute kernels for Apple Silicon GPU inference.
+//!
+//! This crate provides embedded MSL kernel sources for core neural network
+//! operations. Kernels are compiled at runtime by the Metal framework on macOS.
+//!
+//! # Kernels
+//!
+//! - **matmul** — matrix multiplication (naive + tiled)
+//! - **softmax** — numerically stable softmax with threadgroup reduction
+//! - **rmsnorm** — RMS normalization with threadgroup reduction
+//! - **rope** — rotary position embeddings + frequency table builder
+//! - **attention** — scaled dot-product attention with causal mask
+//! - **elementwise** — `SiLU`, GELU, add, mul, `silu_mul`, `scalar_mul`
+
+pub mod kernels;
+
+pub use kernels::{MetalKernelSource, kernel_function_names, kernel_source};

--- a/crates/bitnet-metal/tests/metal_kernel_tests.rs
+++ b/crates/bitnet-metal/tests/metal_kernel_tests.rs
@@ -1,0 +1,219 @@
+use bitnet_metal::{MetalKernelSource, kernel_function_names, kernel_source};
+
+// ── Source embedding tests ──────────────────────────────────────────
+
+#[test]
+fn all_kernel_sources_non_empty() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        assert!(!src.is_empty(), "Kernel source for {kernel:?} should not be empty");
+    }
+}
+
+#[test]
+fn all_kernel_sources_valid_utf8() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        // include_str! guarantees UTF-8, but verify no null bytes
+        assert!(!src.contains('\0'), "Kernel source for {kernel:?} contains null bytes");
+    }
+}
+
+#[test]
+fn all_kernels_include_metal_stdlib() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        assert!(
+            src.contains("#include <metal_stdlib>"),
+            "Kernel {kernel:?} should include metal_stdlib"
+        );
+    }
+}
+
+#[test]
+fn all_kernels_use_metal_namespace() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        assert!(
+            src.contains("using namespace metal;"),
+            "Kernel {kernel:?} should use metal namespace"
+        );
+    }
+}
+
+// ── Kernel function name tests ──────────────────────────────────────
+
+#[test]
+fn all_kernel_functions_declared_in_source() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        for name in kernel_function_names(*kernel) {
+            let pattern = format!("kernel void {name}(");
+            assert!(src.contains(&pattern), "Kernel {kernel:?} should contain function '{name}'");
+        }
+    }
+}
+
+#[test]
+fn matmul_has_expected_functions() {
+    let names = kernel_function_names(MetalKernelSource::Matmul);
+    assert!(names.contains(&"matmul"));
+    assert!(names.contains(&"matmul_tiled"));
+}
+
+#[test]
+fn softmax_has_expected_function() {
+    let names = kernel_function_names(MetalKernelSource::Softmax);
+    assert!(names.contains(&"softmax"));
+}
+
+#[test]
+fn rmsnorm_has_expected_function() {
+    let names = kernel_function_names(MetalKernelSource::RmsNorm);
+    assert!(names.contains(&"rmsnorm"));
+}
+
+#[test]
+fn rope_has_expected_functions() {
+    let names = kernel_function_names(MetalKernelSource::Rope);
+    assert!(names.contains(&"rope"));
+    assert!(names.contains(&"rope_build_tables"));
+}
+
+#[test]
+fn attention_has_expected_functions() {
+    let names = kernel_function_names(MetalKernelSource::Attention);
+    assert!(names.contains(&"attention_scores"));
+    assert!(names.contains(&"attention_weighted_sum"));
+}
+
+#[test]
+fn elementwise_has_expected_functions() {
+    let names = kernel_function_names(MetalKernelSource::Elementwise);
+    assert!(names.contains(&"add"));
+    assert!(names.contains(&"mul"));
+    assert!(names.contains(&"silu"));
+    assert!(names.contains(&"gelu"));
+    assert!(names.contains(&"silu_mul"));
+    assert!(names.contains(&"scalar_mul"));
+}
+
+// ── Buffer binding tests ────────────────────────────────────────────
+
+#[test]
+fn all_kernels_have_sequential_buffer_bindings() {
+    for kernel in MetalKernelSource::ALL {
+        let src = kernel_source(*kernel);
+        for name in kernel_function_names(*kernel) {
+            // Extract the function signature for this kernel
+            let fn_start = format!("kernel void {name}(");
+            let start = src.find(&fn_start).unwrap_or_else(|| {
+                panic!("Function {name} not found in {kernel:?}");
+            });
+            // Find the closing paren of the parameter list
+            let rest = &src[start..];
+            let body_start = rest.find('{').unwrap_or(rest.len());
+            let signature = &rest[..body_start];
+
+            // Collect buffer indices
+            let mut indices: Vec<u32> = Vec::new();
+            for part in signature.split("[[buffer(") {
+                if let Some(end) = part.find(")]]") {
+                    if let Ok(idx) = part[..end].parse::<u32>() {
+                        indices.push(idx);
+                    }
+                }
+            }
+
+            assert!(
+                !indices.is_empty(),
+                "Function {name} in {kernel:?} should have buffer bindings"
+            );
+
+            // Verify sequential starting from 0
+            for (i, idx) in indices.iter().enumerate() {
+                assert_eq!(
+                    *idx, i as u32,
+                    "Buffer binding {i} in {name} ({kernel:?}) should be \
+                     {i}, got {idx}"
+                );
+            }
+        }
+    }
+}
+
+// ── Threadgroup / barrier tests ─────────────────────────────────────
+
+#[test]
+fn reduction_kernels_use_threadgroup_barrier() {
+    let reduction_kernels = [MetalKernelSource::Softmax, MetalKernelSource::RmsNorm];
+    for kernel in &reduction_kernels {
+        let src = kernel_source(*kernel);
+        assert!(
+            src.contains("threadgroup_barrier"),
+            "Reduction kernel {kernel:?} should use threadgroup_barrier"
+        );
+    }
+}
+
+#[test]
+fn tiled_matmul_uses_threadgroup_memory() {
+    let src = kernel_source(MetalKernelSource::Matmul);
+    assert!(src.contains("threadgroup float"), "Tiled matmul should use threadgroup shared memory");
+    assert!(src.contains("threadgroup_barrier"), "Tiled matmul should use threadgroup barriers");
+}
+
+#[test]
+fn softmax_uses_threadgroup_reduction() {
+    let src = kernel_source(MetalKernelSource::Softmax);
+    assert!(src.contains("threadgroup float"));
+    assert!(src.contains("threadgroup_barrier"));
+    // Verify numerical stability (subtracts max)
+    assert!(src.contains("row_max"), "Softmax should subtract max for numerical stability");
+}
+
+// ── Kernel-specific structure tests ─────────────────────────────────
+
+#[test]
+fn attention_supports_causal_mask() {
+    let src = kernel_source(MetalKernelSource::Attention);
+    assert!(src.contains("causal"), "Attention kernel should support causal masking");
+    assert!(src.contains("-INFINITY"), "Causal mask should use -INFINITY for masked positions");
+}
+
+#[test]
+fn rope_applies_rotation() {
+    let src = kernel_source(MetalKernelSource::Rope);
+    assert!(
+        src.contains("cos_val") && src.contains("sin_val"),
+        "RoPE should apply rotation with cos/sin"
+    );
+}
+
+#[test]
+fn elementwise_silu_uses_sigmoid() {
+    let src = kernel_source(MetalKernelSource::Elementwise);
+    // SiLU = x * sigmoid(x) = x / (1 + exp(-x))
+    assert!(
+        src.contains("exp(-x)") || src.contains("exp(- x)"),
+        "SiLU should use sigmoid (exp(-x))"
+    );
+}
+
+#[test]
+fn all_enum_variants_covered() {
+    assert_eq!(MetalKernelSource::ALL.len(), 6, "Should have exactly 6 kernel sources");
+}
+
+// ── Metal-on-device test (requires macOS with Metal) ────────────────
+
+#[test]
+#[ignore = "requires macOS with Metal GPU - run manually on Apple Silicon"]
+fn compile_all_kernels_on_metal_device() {
+    // This test would compile each MSL source via the Metal framework.
+    // Requires metal-rs or objc bindings on macOS.
+    for kernel in MetalKernelSource::ALL {
+        let _src = kernel_source(*kernel);
+        // TODO: MTLDevice::newLibraryWithSource(src, ...)
+    }
+}


### PR DESCRIPTION
## Summary
MSL compute shaders for Apple Silicon GPU inference.

- 6 kernel implementations (matmul, softmax, rmsnorm, rope, attention, elementwise)
- Embedded via \include_str!\ for portable distribution
- 19 structure validation tests (+ 1 ignored device test)
- Foundation for Metal backend

### Kernels
| Kernel | Functions | Features |
|--------|-----------|----------|
| matmul | \matmul\, \matmul_tiled\ | Naive + tiled with threadgroup shared memory |
| softmax | \softmax\ | Numerically stable with threadgroup reduction |
| rmsnorm | \msnorm\ | Threadgroup reduction, epsilon parameter |
| rope | \ope\, \ope_build_tables\ | Rotary position embeddings + frequency tables |
| attention | \ttention_scores\, \ttention_weighted_sum\ | Scaled dot-product with causal mask |
| elementwise | \dd\, \mul\, \silu\, \gelu\, \silu_mul\, \scalar_mul\ | Fused SiLU-gate, GELU approximate |

Part of multi-GPU support epic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GPU acceleration support for Apple Silicon devices
  * Introduced optimized compute kernels for core ML operations, enabling faster neural network inference on Mac devices with M-series chips
  * Support for efficient tensor computations and transformations required for inference execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->