### PR TITLE
feat(rocm): HIP compute kernels for AMD GPU inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-rocm"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-rope"
 version = "0.2.1-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
+    "crates/bitnet-rocm",          # HIP compute kernels for AMD ROCm backend",
   "crossval",
   "tests",
   "xtask",

--- a/crates/bitnet-rocm/Cargo.toml
+++ b/crates/bitnet-rocm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bitnet-rocm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "HIP compute kernels for AMD GPU inference via ROCm"
+include = [
+    "src/**",
+    "Cargo.toml",
+    "README.md",
+]
+
+[dependencies]
+
+[dev-dependencies]
+
+[features]
+default = []

--- a/crates/bitnet-rocm/src/kernels/attention.hip
+++ b/crates/bitnet-rocm/src/kernels/attention.hip
@@ -1,0 +1,124 @@
+/**
+ * HIP scaled dot-product attention kernel for AMD GPUs.
+ *
+ * Implements: Attention(Q,K,V) = softmax(Q·K^T / sqrt(d_k)) · V
+ *
+ * Single-head, row-parallel: each block computes one query row.
+ * For production multi-head attention the host dispatches per-head slices.
+ */
+
+#include <hip/hip_runtime.h>
+
+#define WARP_SIZE 64
+
+__device__ float attn_warp_reduce_max(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        val = fmaxf(val, __shfl_down(val, offset));
+    }
+    return val;
+}
+
+__device__ float attn_warp_reduce_sum(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        val += __shfl_down(val, offset);
+    }
+    return val;
+}
+
+/**
+ * Scaled dot-product attention.
+ *
+ * @param Q      Query  [seq_q,  d_k]
+ * @param K      Key    [seq_kv, d_k]
+ * @param V      Value  [seq_kv, d_v]
+ * @param output Result [seq_q,  d_v]
+ * @param seq_q  Number of query positions
+ * @param seq_kv Number of key/value positions
+ * @param d_k    Key dimension
+ * @param d_v    Value dimension
+ * @param scale  Typically 1/sqrt(d_k)
+ */
+extern "C" __global__ void scaled_dot_product_attention(
+    const float* __restrict__ Q,
+    const float* __restrict__ K,
+    const float* __restrict__ V,
+    float* __restrict__ output,
+    int seq_q, int seq_kv, int d_k, int d_v,
+    float scale
+) {
+    int q_row = hipBlockIdx_x;
+    if (q_row >= seq_q) return;
+
+    int tid = hipThreadIdx_x;
+
+    // -- Scores: Q[q_row] · K^T  (length = seq_kv) --
+    extern __shared__ float smem[];          // dynamically sized
+    float* scores = smem;                    // [seq_kv]
+
+    for (int kv = tid; kv < seq_kv; kv += hipBlockDim_x) {
+        float dot = 0.0f;
+        for (int d = 0; d < d_k; ++d) {
+            dot += Q[q_row * d_k + d] * K[kv * d_k + d];
+        }
+        scores[kv] = dot * scale;
+    }
+    __syncthreads();
+
+    // -- Numerically-stable softmax over scores --
+    float local_max = -1e30f;
+    for (int kv = tid; kv < seq_kv; kv += hipBlockDim_x) {
+        local_max = fmaxf(local_max, scores[kv]);
+    }
+
+    __shared__ float smax[64];
+    int lane = tid % WARP_SIZE;
+    int wid  = tid / WARP_SIZE;
+
+    float warp_max = attn_warp_reduce_max(local_max);
+    if (lane == 0) smax[wid] = warp_max;
+    __syncthreads();
+
+    if (tid < WARP_SIZE) {
+        float v = (tid < (hipBlockDim_x + WARP_SIZE - 1) / WARP_SIZE)
+            ? smax[tid] : -1e30f;
+        warp_max = attn_warp_reduce_max(v);
+        if (tid == 0) smax[0] = warp_max;
+    }
+    __syncthreads();
+    float row_max = smax[0];
+
+    float local_sum = 0.0f;
+    for (int kv = tid; kv < seq_kv; kv += hipBlockDim_x) {
+        float e = expf(scores[kv] - row_max);
+        scores[kv] = e;
+        local_sum += e;
+    }
+
+    __shared__ float ssum[64];
+    float warp_sum = attn_warp_reduce_sum(local_sum);
+    if (lane == 0) ssum[wid] = warp_sum;
+    __syncthreads();
+
+    if (tid < WARP_SIZE) {
+        float v = (tid < (hipBlockDim_x + WARP_SIZE - 1) / WARP_SIZE)
+            ? ssum[tid] : 0.0f;
+        warp_sum = attn_warp_reduce_sum(v);
+        if (tid == 0) ssum[0] = warp_sum;
+    }
+    __syncthreads();
+
+    float inv_sum = 1.0f / (ssum[0] + 1e-8f);
+    for (int kv = tid; kv < seq_kv; kv += hipBlockDim_x) {
+        scores[kv] *= inv_sum;
+    }
+    __syncthreads();
+
+    // -- Weighted sum: output[q_row] = scores · V --
+    for (int d = tid; d < d_v; d += hipBlockDim_x) {
+        float acc = 0.0f;
+        for (int kv = 0; kv < seq_kv; ++kv) {
+            acc += scores[kv] * V[kv * d_v + d];
+        }
+        output[q_row * d_v + d] = acc;
+    }
+}

--- a/crates/bitnet-rocm/src/kernels/elementwise.hip
+++ b/crates/bitnet-rocm/src/kernels/elementwise.hip
@@ -1,0 +1,64 @@
+/**
+ * HIP element-wise activation and arithmetic kernels for AMD GPUs.
+ *
+ * Activations: SiLU, GELU (tanh approximation)
+ * Arithmetic:  vector add, vector multiply
+ */
+
+#include <hip/hip_runtime.h>
+
+// ---------- activations ----------
+
+extern "C" __global__ void silu_forward(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    int N
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx >= N) return;
+
+    float x = input[idx];
+    float sigmoid = 1.0f / (1.0f + expf(-x));
+    output[idx] = x * sigmoid;
+}
+
+extern "C" __global__ void gelu_forward(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    int N
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx >= N) return;
+
+    float x = input[idx];
+    // GELU tanh approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+    const float SQRT_2_OVER_PI = 0.7978845608f;
+    float inner = SQRT_2_OVER_PI * (x + 0.044715f * x * x * x);
+    output[idx] = 0.5f * x * (1.0f + tanhf(inner));
+}
+
+// ---------- arithmetic ----------
+
+extern "C" __global__ void vec_add(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float* __restrict__ out,
+    int N
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx >= N) return;
+
+    out[idx] = a[idx] + b[idx];
+}
+
+extern "C" __global__ void vec_mul(
+    const float* __restrict__ a,
+    const float* __restrict__ b,
+    float* __restrict__ out,
+    int N
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx >= N) return;
+
+    out[idx] = a[idx] * b[idx];
+}

--- a/crates/bitnet-rocm/src/kernels/matmul.hip
+++ b/crates/bitnet-rocm/src/kernels/matmul.hip
@@ -1,0 +1,70 @@
+/**
+ * HIP matrix multiplication kernels for BitNet inference on AMD GPUs.
+ *
+ * Tiled matmul: C = A * B where A is int8, B is uint8 (I2S packed), C is f32.
+ * Uses shared-memory tiling with 16×16 blocks for memory coalescing.
+ */
+
+#include <hip/hip_runtime.h>
+
+#define TILE_SIZE 16
+
+extern "C" __global__ void bitnet_matmul_i2s(
+    const signed char* __restrict__ A,
+    const unsigned char* __restrict__ B,
+    float* __restrict__ C,
+    int M, int N, int K
+) {
+    int tx = hipThreadIdx_x;
+    int ty = hipThreadIdx_y;
+    int row = hipBlockIdx_y * TILE_SIZE + ty;
+    int col = hipBlockIdx_x * TILE_SIZE + tx;
+
+    __shared__ signed char As[TILE_SIZE][TILE_SIZE];
+    __shared__ unsigned char Bs[TILE_SIZE][TILE_SIZE];
+
+    float acc = 0.0f;
+
+    for (int t = 0; t < (K + TILE_SIZE - 1) / TILE_SIZE; ++t) {
+        int a_col = t * TILE_SIZE + tx;
+        int b_row = t * TILE_SIZE + ty;
+
+        As[ty][tx] = (row < M && a_col < K)
+            ? A[row * K + a_col] : 0;
+        Bs[ty][tx] = (b_row < K && col < N)
+            ? B[b_row * N + col] : 0;
+
+        __syncthreads();
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            acc += (float)As[ty][k] * (float)Bs[k][tx];
+        }
+
+        __syncthreads();
+    }
+
+    if (row < M && col < N) {
+        C[row * N + col] = acc;
+    }
+}
+
+/**
+ * Simple matmul without tiling – useful for small matrices or as fallback.
+ */
+extern "C" __global__ void bitnet_matmul_simple(
+    const float* __restrict__ A,
+    const float* __restrict__ B,
+    float* __restrict__ C,
+    int M, int N, int K
+) {
+    int row = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int col = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+
+    if (row >= M || col >= N) return;
+
+    float acc = 0.0f;
+    for (int i = 0; i < K; ++i) {
+        acc += A[row * K + i] * B[i * N + col];
+    }
+    C[row * N + col] = acc;
+}

--- a/crates/bitnet-rocm/src/kernels/mod.rs
+++ b/crates/bitnet-rocm/src/kernels/mod.rs
@@ -1,0 +1,72 @@
+//! Embedded HIP kernel sources for AMD ROCm compute.
+//!
+//! Each variant of [`HipKernelSource`] maps to a `.hip` file compiled
+//! at runtime by the ROCm HIP-RTC compiler on the target machine.
+
+/// Static kernel source strings, embedded at compile time.
+pub const MATMUL_SRC: &str = include_str!("matmul.hip");
+pub const SOFTMAX_SRC: &str = include_str!("softmax.hip");
+pub const RMSNORM_SRC: &str = include_str!("rmsnorm.hip");
+pub const ROPE_SRC: &str = include_str!("rope.hip");
+pub const ATTENTION_SRC: &str = include_str!("attention.hip");
+pub const ELEMENTWISE_SRC: &str = include_str!("elementwise.hip");
+
+/// Enumeration of available HIP kernel sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HipKernelSource {
+    /// Tiled I2S matrix multiplication.
+    Matmul,
+    /// Numerically-stable row-wise softmax.
+    Softmax,
+    /// RMS normalisation with learnable scale.
+    RmsNorm,
+    /// Rotary position embeddings (forward + table build).
+    Rope,
+    /// Scaled dot-product attention.
+    Attention,
+    /// Element-wise ops: SiLU, GELU, add, mul.
+    Elementwise,
+}
+
+impl HipKernelSource {
+    /// Returns the embedded HIP source code for the kernel.
+    #[must_use]
+    pub fn source(self) -> &'static str {
+        match self {
+            Self::Matmul => MATMUL_SRC,
+            Self::Softmax => SOFTMAX_SRC,
+            Self::RmsNorm => RMSNORM_SRC,
+            Self::Rope => ROPE_SRC,
+            Self::Attention => ATTENTION_SRC,
+            Self::Elementwise => ELEMENTWISE_SRC,
+        }
+    }
+
+    /// All kernel source variants.
+    pub const ALL: &[HipKernelSource] = &[
+        Self::Matmul,
+        Self::Softmax,
+        Self::RmsNorm,
+        Self::Rope,
+        Self::Attention,
+        Self::Elementwise,
+    ];
+}
+
+/// Convenience function returning the source for a given kernel.
+#[must_use]
+pub fn kernel_source(kernel: HipKernelSource) -> &'static str {
+    kernel.source()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_variants_return_non_empty_source() {
+        for &k in HipKernelSource::ALL {
+            assert!(!k.source().is_empty(), "{k:?} returned empty source");
+        }
+    }
+}

--- a/crates/bitnet-rocm/src/kernels/rmsnorm.hip
+++ b/crates/bitnet-rocm/src/kernels/rmsnorm.hip
@@ -1,0 +1,62 @@
+/**
+ * HIP RMS normalisation kernel for AMD GPUs.
+ *
+ * RMSNorm(x) = x / sqrt(mean(x^2) + eps) * weight
+ *
+ * Each block handles one row of the input tensor.
+ */
+
+#include <hip/hip_runtime.h>
+
+#define WARP_SIZE 64
+
+__device__ float warp_reduce_sum_rms(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        val += __shfl_down(val, offset);
+    }
+    return val;
+}
+
+extern "C" __global__ void rmsnorm_forward(
+    const float* __restrict__ input,
+    const float* __restrict__ weight,
+    float* __restrict__ output,
+    int rows, int cols, float eps
+) {
+    int row = hipBlockIdx_x;
+    if (row >= rows) return;
+
+    int tid = hipThreadIdx_x;
+
+    // Compute sum of squares
+    float sum_sq = 0.0f;
+    for (int c = tid; c < cols; c += hipBlockDim_x) {
+        float v = input[row * cols + c];
+        sum_sq += v * v;
+    }
+
+    // Block-wide reduction via shared memory
+    __shared__ float shared[64];
+    int lane = tid % WARP_SIZE;
+    int wid  = tid / WARP_SIZE;
+
+    float warp_sum = warp_reduce_sum_rms(sum_sq);
+    if (lane == 0) shared[wid] = warp_sum;
+    __syncthreads();
+
+    if (tid < WARP_SIZE) {
+        float v = (tid < (hipBlockDim_x + WARP_SIZE - 1) / WARP_SIZE)
+            ? shared[tid] : 0.0f;
+        warp_sum = warp_reduce_sum_rms(v);
+        if (tid == 0) shared[0] = warp_sum;
+    }
+    __syncthreads();
+
+    float rms = rsqrtf(shared[0] / (float)cols + eps);
+
+    // Normalise and scale
+    for (int c = tid; c < cols; c += hipBlockDim_x) {
+        output[row * cols + c] =
+            input[row * cols + c] * rms * weight[c];
+    }
+}

--- a/crates/bitnet-rocm/src/kernels/rope.hip
+++ b/crates/bitnet-rocm/src/kernels/rope.hip
@@ -1,0 +1,70 @@
+/**
+ * HIP rotary position embedding (RoPE) kernel for AMD GPUs.
+ *
+ * Applies rotation to pairs of elements (x[2i], x[2i+1]) using
+ * precomputed cos/sin tables.
+ */
+
+#include <hip/hip_runtime.h>
+
+/**
+ * In-place RoPE application.
+ *
+ * @param x         Tensor of shape [batch, seq_len, dim]  (dim is even)
+ * @param cos_table Precomputed cos values [max_seq, dim/2]
+ * @param sin_table Precomputed sin values [max_seq, dim/2]
+ * @param seq_len   Current sequence length
+ * @param dim       Hidden dimension (must be even)
+ * @param offset    Positional offset for KV-cache continuation
+ */
+extern "C" __global__ void rope_forward(
+    float* __restrict__ x,
+    const float* __restrict__ cos_table,
+    const float* __restrict__ sin_table,
+    int seq_len, int dim, int offset
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int half_dim = dim / 2;
+    int total = seq_len * half_dim;
+
+    if (idx >= total) return;
+
+    int pos = idx / half_dim;
+    int i   = idx % half_dim;
+
+    int abs_pos = pos + offset;
+
+    float cos_val = cos_table[abs_pos * half_dim + i];
+    float sin_val = sin_table[abs_pos * half_dim + i];
+
+    int base = pos * dim;
+    float x0 = x[base + 2 * i];
+    float x1 = x[base + 2 * i + 1];
+
+    x[base + 2 * i]     = x0 * cos_val - x1 * sin_val;
+    x[base + 2 * i + 1] = x0 * sin_val + x1 * cos_val;
+}
+
+/**
+ * Build cos/sin tables on-device (avoids host→device copy).
+ *
+ * theta_i = 1 / (base ^ (2i / dim))
+ */
+extern "C" __global__ void rope_build_tables(
+    float* __restrict__ cos_table,
+    float* __restrict__ sin_table,
+    int max_seq, int half_dim, float theta_base
+) {
+    int idx = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    if (idx >= max_seq * half_dim) return;
+
+    int pos = idx / half_dim;
+    int i   = idx % half_dim;
+
+    float freq = 1.0f / powf(theta_base,
+                              2.0f * (float)i / (float)(half_dim * 2));
+    float angle = (float)pos * freq;
+
+    cos_table[idx] = cosf(angle);
+    sin_table[idx] = sinf(angle);
+}

--- a/crates/bitnet-rocm/src/kernels/softmax.hip
+++ b/crates/bitnet-rocm/src/kernels/softmax.hip
@@ -1,0 +1,93 @@
+/**
+ * HIP numerically-stable softmax kernel for AMD GPUs.
+ *
+ * Two-pass algorithm:
+ *   1. Warp-reduction to find row max.
+ *   2. Subtract max, exponentiate, warp-reduction for sum, normalise.
+ */
+
+#include <hip/hip_runtime.h>
+
+#define WARP_SIZE 64
+
+/// Warp-level reduction: maximum
+__device__ float warp_reduce_max(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        val = fmaxf(val, __shfl_down(val, offset));
+    }
+    return val;
+}
+
+/// Warp-level reduction: sum
+__device__ float warp_reduce_sum(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset >>= 1) {
+        val += __shfl_down(val, offset);
+    }
+    return val;
+}
+
+/**
+ * Row-wise softmax.  Each block processes one row of length `cols`.
+ * Grid: (batch, 1, 1)   Block: (cols_padded_to_warp, 1, 1)
+ */
+extern "C" __global__ void softmax_forward(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    int rows, int cols
+) {
+    int row = hipBlockIdx_x;
+    if (row >= rows) return;
+
+    int tid = hipThreadIdx_x;
+
+    // -- Pass 1: find row max --
+    float local_max = -1e30f;
+    for (int c = tid; c < cols; c += hipBlockDim_x) {
+        local_max = fmaxf(local_max, input[row * cols + c]);
+    }
+
+    __shared__ float smax[64];
+    int lane = tid % WARP_SIZE;
+    int wid  = tid / WARP_SIZE;
+
+    float warp_max = warp_reduce_max(local_max);
+    if (lane == 0) smax[wid] = warp_max;
+    __syncthreads();
+
+    if (tid < WARP_SIZE) {
+        float v = (tid < (hipBlockDim_x + WARP_SIZE - 1) / WARP_SIZE)
+            ? smax[tid] : -1e30f;
+        warp_max = warp_reduce_max(v);
+        if (tid == 0) smax[0] = warp_max;
+    }
+    __syncthreads();
+    float row_max = smax[0];
+
+    // -- Pass 2: exp and sum --
+    float local_sum = 0.0f;
+    for (int c = tid; c < cols; c += hipBlockDim_x) {
+        float e = expf(input[row * cols + c] - row_max);
+        output[row * cols + c] = e;
+        local_sum += e;
+    }
+
+    __shared__ float ssum[64];
+    float warp_sum = warp_reduce_sum(local_sum);
+    if (lane == 0) ssum[wid] = warp_sum;
+    __syncthreads();
+
+    if (tid < WARP_SIZE) {
+        float v = (tid < (hipBlockDim_x + WARP_SIZE - 1) / WARP_SIZE)
+            ? ssum[tid] : 0.0f;
+        warp_sum = warp_reduce_sum(v);
+        if (tid == 0) ssum[0] = warp_sum;
+    }
+    __syncthreads();
+    float row_sum = ssum[0];
+
+    // -- Pass 3: normalise --
+    float inv_sum = 1.0f / (row_sum + 1e-8f);
+    for (int c = tid; c < cols; c += hipBlockDim_x) {
+        output[row * cols + c] *= inv_sum;
+    }
+}

--- a/crates/bitnet-rocm/src/lib.rs
+++ b/crates/bitnet-rocm/src/lib.rs
@@ -1,0 +1,25 @@
+//! `bitnet-rocm` — HIP compute kernels for AMD GPU inference via ROCm.
+//!
+//! This crate embeds HIP kernel source files (`.hip`) that target AMD GPUs
+//! through the ROCm platform.  The kernels cover the core operations needed
+//! for BitNet transformer inference:
+//!
+//! | Kernel        | File               | Operations                        |
+//! |---------------|--------------------|-----------------------------------|
+//! | Matrix mul    | `matmul.hip`       | Tiled I2S matmul, simple matmul   |
+//! | Softmax       | `softmax.hip`      | Numerically-stable row softmax    |
+//! | RMSNorm       | `rmsnorm.hip`      | RMS normalisation                 |
+//! | RoPE          | `rope.hip`         | Rotary position embeddings        |
+//! | Attention     | `attention.hip`    | Scaled dot-product attention      |
+//! | Element-wise  | `elementwise.hip`  | SiLU, GELU, add, mul             |
+//!
+//! # Usage
+//!
+//! ```rust
+//! use bitnet_rocm::kernels::{HipKernelSource, kernel_source};
+//!
+//! let src = kernel_source(HipKernelSource::Matmul);
+//! assert!(src.contains("__global__"));
+//! ```
+
+pub mod kernels;

--- a/crates/bitnet-rocm/tests/rocm_kernel_tests.rs
+++ b/crates/bitnet-rocm/tests/rocm_kernel_tests.rs
@@ -1,0 +1,181 @@
+//! Structure-validation tests for the ROCm HIP kernel sources.
+//!
+//! These tests verify that the embedded `.hip` files are well-formed,
+//! use the correct HIP API surface, and contain the expected kernel
+//! entry points.  They do **not** require an AMD GPU or the ROCm
+//! runtime – they operate purely on the source text.
+
+use bitnet_rocm::kernels::{
+    self, ATTENTION_SRC, ELEMENTWISE_SRC, HipKernelSource, MATMUL_SRC, RMSNORM_SRC, ROPE_SRC,
+    SOFTMAX_SRC, kernel_source,
+};
+
+// ── source embedding ────────────────────────────────────────────
+
+#[test]
+fn all_sources_are_non_empty() {
+    for &k in HipKernelSource::ALL {
+        assert!(!k.source().is_empty(), "{k:?} source is empty");
+    }
+}
+
+#[test]
+fn all_sources_are_valid_utf8() {
+    // `include_str!` guarantees UTF-8, but belt-and-suspenders:
+    for &k in HipKernelSource::ALL {
+        let src = k.source();
+        assert!(std::str::from_utf8(src.as_bytes()).is_ok(), "{k:?} source is not valid UTF-8");
+    }
+}
+
+#[test]
+fn kernel_source_fn_matches_method() {
+    for &k in HipKernelSource::ALL {
+        assert_eq!(
+            kernel_source(k),
+            k.source(),
+            "kernel_source() disagrees with .source() for {k:?}"
+        );
+    }
+}
+
+#[test]
+fn all_variants_listed_in_all_constant() {
+    assert_eq!(HipKernelSource::ALL.len(), 6, "Expected 6 kernel variants");
+}
+
+// ── HIP syntax ──────────────────────────────────────────────────
+
+#[test]
+fn all_kernels_contain_global_attribute() {
+    for &k in HipKernelSource::ALL {
+        assert!(k.source().contains("__global__"), "{k:?} missing __global__ kernel declaration");
+    }
+}
+
+#[test]
+fn all_kernels_use_hip_thread_indexing() {
+    for &k in HipKernelSource::ALL {
+        let src = k.source();
+        let has_hip_idx = src.contains("hipThreadIdx_x")
+            || src.contains("hipBlockIdx_x")
+            || src.contains("hipBlockDim_x");
+        assert!(has_hip_idx, "{k:?} missing HIP thread/block indexing macros");
+    }
+}
+
+#[test]
+fn all_kernels_include_hip_runtime() {
+    for &k in HipKernelSource::ALL {
+        assert!(
+            k.source().contains("hip/hip_runtime.h"),
+            "{k:?} missing #include <hip/hip_runtime.h>"
+        );
+    }
+}
+
+// ── shared memory & sync ────────────────────────────────────────
+
+#[test]
+fn matmul_uses_shared_memory() {
+    assert!(MATMUL_SRC.contains("__shared__"), "matmul kernel should use shared memory for tiling");
+}
+
+#[test]
+fn matmul_has_sync_barrier() {
+    assert!(
+        MATMUL_SRC.contains("__syncthreads()"),
+        "matmul kernel should synchronise after shared-memory loads"
+    );
+}
+
+#[test]
+fn softmax_uses_warp_reduction() {
+    assert!(SOFTMAX_SRC.contains("__shfl_down"), "softmax should use warp shuffle for reduction");
+}
+
+#[test]
+fn softmax_has_shared_and_sync() {
+    assert!(SOFTMAX_SRC.contains("__shared__"));
+    assert!(SOFTMAX_SRC.contains("__syncthreads()"));
+}
+
+#[test]
+fn rmsnorm_has_shared_and_sync() {
+    assert!(RMSNORM_SRC.contains("__shared__"));
+    assert!(RMSNORM_SRC.contains("__syncthreads()"));
+}
+
+#[test]
+fn attention_has_shared_and_sync() {
+    assert!(ATTENTION_SRC.contains("__shared__"));
+    assert!(ATTENTION_SRC.contains("__syncthreads()"));
+}
+
+// ── kernel entry points ─────────────────────────────────────────
+
+#[test]
+fn matmul_contains_expected_entry_points() {
+    assert!(MATMUL_SRC.contains("bitnet_matmul_i2s"));
+    assert!(MATMUL_SRC.contains("bitnet_matmul_simple"));
+}
+
+#[test]
+fn softmax_contains_entry_point() {
+    assert!(SOFTMAX_SRC.contains("softmax_forward"));
+}
+
+#[test]
+fn rmsnorm_contains_entry_point() {
+    assert!(RMSNORM_SRC.contains("rmsnorm_forward"));
+}
+
+#[test]
+fn rope_contains_entry_points() {
+    assert!(ROPE_SRC.contains("rope_forward"));
+    assert!(ROPE_SRC.contains("rope_build_tables"));
+}
+
+#[test]
+fn attention_contains_entry_point() {
+    assert!(ATTENTION_SRC.contains("scaled_dot_product_attention"));
+}
+
+#[test]
+fn elementwise_contains_all_ops() {
+    assert!(ELEMENTWISE_SRC.contains("silu_forward"));
+    assert!(ELEMENTWISE_SRC.contains("gelu_forward"));
+    assert!(ELEMENTWISE_SRC.contains("vec_add"));
+    assert!(ELEMENTWISE_SRC.contains("vec_mul"));
+}
+
+// ── numerical safety ────────────────────────────────────────────
+
+#[test]
+fn softmax_has_numerical_stability_guard() {
+    // Must subtract row-max before exp to avoid overflow
+    assert!(
+        SOFTMAX_SRC.contains("row_max") || SOFTMAX_SRC.contains("local_max"),
+        "softmax should compute row max for numerical stability"
+    );
+}
+
+#[test]
+fn rmsnorm_uses_epsilon() {
+    assert!(
+        RMSNORM_SRC.contains("eps"),
+        "rmsnorm should accept an epsilon for numerical stability"
+    );
+}
+
+// ── module-level constant re-exports ────────────────────────────
+
+#[test]
+fn constant_re_exports_match_enum() {
+    assert_eq!(kernels::MATMUL_SRC, HipKernelSource::Matmul.source());
+    assert_eq!(kernels::SOFTMAX_SRC, HipKernelSource::Softmax.source());
+    assert_eq!(kernels::RMSNORM_SRC, HipKernelSource::RmsNorm.source());
+    assert_eq!(kernels::ROPE_SRC, HipKernelSource::Rope.source());
+    assert_eq!(kernels::ATTENTION_SRC, HipKernelSource::Attention.source());
+    assert_eq!(kernels::ELEMENTWISE_SRC, HipKernelSource::Elementwise.source());
+}


### PR DESCRIPTION
## Summary
HIP compute kernels for AMD GPU inference via ROCm.

- 6 kernel implementations matching CUDA kernel suite
- HIP syntax (close to CUDA for easy porting)
- 22 structure validation tests + unit + doctest
- Foundation for ROCm backend

Part of multi-GPU support epic.