### PR TITLE
chore: workspace integration v5 — GPU microcrate wiring

### DIFF
--- a/crates/bitnet-opencl/src/runtime.rs
+++ b/crates/bitnet-opencl/src/runtime.rs
@@ -1,0 +1,9 @@
+//! OpenCL runtime: platform/device discovery via the OpenCL ICD loader.
+
+/// Placeholder for OpenCL runtime discovery.
+///
+/// Requires the `opencl-runtime` feature and a working OpenCL ICD loader.
+pub fn discover_devices() -> Vec<String> {
+    // TODO: enumerate OpenCL platforms and devices via opencl3
+    Vec::new()
+}

--- a/crates/bitnet-vulkan/src/runtime.rs
+++ b/crates/bitnet-vulkan/src/runtime.rs
@@ -1,0 +1,9 @@
+//! Vulkan runtime: device discovery via the Vulkan loader.
+
+/// Placeholder for Vulkan runtime device discovery.
+///
+/// Requires the `vulkan-runtime` feature and a working Vulkan loader.
+pub fn discover_devices() -> Vec<String> {
+    // TODO: enumerate Vulkan physical devices via ash
+    Vec::new()
+}

--- a/crates/bitnet-webgpu/src/runtime.rs
+++ b/crates/bitnet-webgpu/src/runtime.rs
@@ -1,0 +1,9 @@
+//! WebGPU runtime: adapter discovery via wgpu.
+
+/// Placeholder for WebGPU runtime adapter discovery.
+///
+/// Requires the `webgpu-runtime` feature and a working wgpu backend.
+pub fn discover_adapters() -> Vec<String> {
+    // TODO: enumerate wgpu adapters
+    Vec::new()
+}


### PR DESCRIPTION
## Summary

Workspace-level integration ensuring all GPU microcrates compile together.

### Changes

- **7 new GPU microcrates** added to workspace members:
  - \itnet-gpu-hal\ — GPU Hardware Abstraction Layer (shared traits: \GpuBackend\, \GpuBackendKind\, \GpuHalError\)
  - \itnet-opencl\ — OpenCL backend (with optional \opencl3\ dependency behind \opencl-runtime\ feature)
  - \itnet-vulkan\ — Vulkan compute backend (optional \sh\ behind \ulkan-runtime\)
  - \itnet-webgpu\ — WebGPU backend (optional \wgpu\ behind \webgpu-runtime\)
  - \itnet-metal\ — Apple Metal backend
  - \itnet-rocm\ — AMD ROCm/HIP backend
  - \itnet-level-zero\ — Intel Level Zero / oneAPI backend

- **Feature flag wiring** in root \Cargo.toml\:
  - \oneapi\ → enables \gpu\ + \itnet-level-zero/level-zero-runtime\
  - \opencl\ → enables \gpu\ + \itnet-opencl/opencl-runtime\

- **Workspace dependencies** added: \opencl3\, GPU microcrate paths

- **\default-members\ unchanged** — only core crates built by default

### Verification

- \cargo check --no-default-features --features cpu\ ✅
- \cargo clippy -p bitnet-gpu-hal ... -- -D warnings\ ✅ (all 7 crates)

Part of Intel GPU support epic.