### PR TITLE
feat(vulkan): GLSL compute shaders for Vulkan GPU inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,6 +1487,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-vulkan"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-warn-once"
 version = "0.2.1-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ members = [
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
     "crates/bitnet-rocm",          # HIP compute kernels for AMD ROCm backend",
+  "crates/bitnet-vulkan",        # Vulkan GLSL compute shaders for GPU inference
   "crossval",
   "tests",
   "tests-new",

--- a/crates/bitnet-vulkan/Cargo.toml
+++ b/crates/bitnet-vulkan/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "bitnet-vulkan"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Vulkan GLSL compute shaders for BitNet GPU inference"
+rust-version.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+
+[features]
+default = []
+cpu = []
+gpu = ["cuda"]
+cuda = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-vulkan/src/kernels/attention.comp
+++ b/crates/bitnet-vulkan/src/kernels/attention.comp
@@ -1,0 +1,114 @@
+#version 450
+// Scaled dot-product attention compute shader
+// attn = softmax(Q * K^T / sqrt(d_k)) * V
+// Single-head variant; dispatch one workgroup per query row.
+
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint seq_len;   // sequence / KV length
+    uint head_dim;  // dimension per head
+    float scale;    // 1.0 / sqrt(head_dim)
+} params;
+
+layout(set = 0, binding = 0) readonly buffer Query {
+    float data[];
+} q_buf;
+
+layout(set = 0, binding = 1) readonly buffer Key {
+    float data[];
+} k_buf;
+
+layout(set = 0, binding = 2) readonly buffer Value {
+    float data[];
+} v_buf;
+
+layout(set = 0, binding = 3) writeonly buffer Output {
+    float data[];
+} out_buf;
+
+shared float shared_scores[256];
+shared float shared_max[256];
+shared float shared_sum[256];
+
+void main() {
+    uint q_row = gl_WorkGroupID.x;
+    uint tid = gl_LocalInvocationID.x;
+    uint wgSize = gl_WorkGroupSize.x;
+
+    // --- Phase 1: compute QK^T scores ---
+    // Each thread handles a subset of K rows
+    float local_max = -1.0 / 0.0;
+    for (uint k_row = tid; k_row < params.seq_len; k_row += wgSize) {
+        float dot = 0.0;
+        for (uint d = 0; d < params.head_dim; d++) {
+            dot += q_buf.data[q_row * params.head_dim + d]
+                 * k_buf.data[k_row * params.head_dim + d];
+        }
+        float score = dot * params.scale;
+        shared_scores[k_row % wgSize] = score;
+        local_max = max(local_max, score);
+    }
+
+    // Reduce max across workgroup via subgroups
+    local_max = subgroupMax(local_max);
+    shared_max[gl_SubgroupID] = local_max;
+    barrier();
+    memoryBarrierShared();
+
+    if (tid < gl_NumSubgroups) {
+        local_max = shared_max[tid];
+    } else {
+        local_max = -1.0 / 0.0;
+    }
+    local_max = subgroupMax(local_max);
+    float row_max = subgroupBroadcastFirst(local_max);
+    barrier();
+
+    // --- Phase 2: numerically stable softmax ---
+    float local_sum = 0.0;
+    for (uint k_row = tid; k_row < params.seq_len; k_row += wgSize) {
+        // Recompute score (avoids large shared memory for long seqs)
+        float dot = 0.0;
+        for (uint d = 0; d < params.head_dim; d++) {
+            dot += q_buf.data[q_row * params.head_dim + d]
+                 * k_buf.data[k_row * params.head_dim + d];
+        }
+        float score = dot * params.scale;
+        float w = exp(score - row_max);
+        local_sum += w;
+    }
+
+    local_sum = subgroupAdd(local_sum);
+    shared_sum[gl_SubgroupID] = local_sum;
+    barrier();
+    memoryBarrierShared();
+
+    if (tid < gl_NumSubgroups) {
+        local_sum = shared_sum[tid];
+    } else {
+        local_sum = 0.0;
+    }
+    local_sum = subgroupAdd(local_sum);
+    float sum_exp = subgroupBroadcastFirst(local_sum);
+    float inv_sum = 1.0 / sum_exp;
+    barrier();
+
+    // --- Phase 3: weighted sum over V ---
+    for (uint d = tid; d < params.head_dim; d += wgSize) {
+        float acc = 0.0;
+        for (uint k_row = 0; k_row < params.seq_len; k_row++) {
+            // Recompute attention weight for this k_row
+            float dot = 0.0;
+            for (uint dd = 0; dd < params.head_dim; dd++) {
+                dot += q_buf.data[q_row * params.head_dim + dd]
+                     * k_buf.data[k_row * params.head_dim + dd];
+            }
+            float w = exp(dot * params.scale - row_max) * inv_sum;
+            acc += w * v_buf.data[k_row * params.head_dim + d];
+        }
+        out_buf.data[q_row * params.head_dim + d] = acc;
+    }
+}

--- a/crates/bitnet-vulkan/src/kernels/elementwise.comp
+++ b/crates/bitnet-vulkan/src/kernels/elementwise.comp
@@ -1,0 +1,66 @@
+#version 450
+// Element-wise operations compute shader
+// Supports: SiLU, GELU, Add, Mul via push-constant op selector
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+// Op codes
+const uint OP_SILU = 0;
+const uint OP_GELU = 1;
+const uint OP_ADD  = 2;
+const uint OP_MUL  = 3;
+
+layout(push_constant) uniform PushConstants {
+    uint N;      // number of elements
+    uint op;     // operation selector (see OP_ constants above)
+} params;
+
+layout(set = 0, binding = 0) readonly buffer InputA {
+    float data[];
+} a_buf;
+
+// Second input used for binary ops (add, mul); unused for unary ops
+layout(set = 0, binding = 1) readonly buffer InputB {
+    float data[];
+} b_buf;
+
+layout(set = 0, binding = 2) writeonly buffer Output {
+    float data[];
+} out_buf;
+
+// SiLU(x) = x * sigmoid(x)
+float silu(float x) {
+    return x / (1.0 + exp(-x));
+}
+
+// GELU(x) ≈ 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x^3)))
+float gelu(float x) {
+    const float SQRT_2_OVER_PI = 0.7978845608;
+    const float COEFF = 0.044715;
+    float x3 = x * x * x;
+    float inner = SQRT_2_OVER_PI * (x + COEFF * x3);
+    return 0.5 * x * (1.0 + tanh(inner));
+}
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+
+    if (idx >= params.N) return;
+
+    float val_a = a_buf.data[idx];
+
+    float result;
+    if (params.op == OP_SILU) {
+        result = silu(val_a);
+    } else if (params.op == OP_GELU) {
+        result = gelu(val_a);
+    } else if (params.op == OP_ADD) {
+        result = val_a + b_buf.data[idx];
+    } else if (params.op == OP_MUL) {
+        result = val_a * b_buf.data[idx];
+    } else {
+        result = val_a; // passthrough for unknown ops
+    }
+
+    out_buf.data[idx] = result;
+}

--- a/crates/bitnet-vulkan/src/kernels/matmul.comp
+++ b/crates/bitnet-vulkan/src/kernels/matmul.comp
@@ -1,0 +1,73 @@
+#version 450
+// Tiled matrix multiplication compute shader
+// C = A * B where A is [M, K], B is [K, N], C is [M, N]
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint M; // rows of A / C
+    uint N; // cols of B / C
+    uint K; // cols of A / rows of B
+} params;
+
+layout(set = 0, binding = 0) readonly buffer InputA {
+    float data[];
+} a;
+
+layout(set = 0, binding = 1) readonly buffer InputB {
+    float data[];
+} b;
+
+layout(set = 0, binding = 2) writeonly buffer Output {
+    float data[];
+} c;
+
+const uint TILE_SIZE = 16;
+
+shared float tileA[TILE_SIZE][TILE_SIZE];
+shared float tileB[TILE_SIZE][TILE_SIZE];
+
+void main() {
+    uint row = gl_GlobalInvocationID.y;
+    uint col = gl_GlobalInvocationID.x;
+
+    uint localRow = gl_LocalInvocationID.y;
+    uint localCol = gl_LocalInvocationID.x;
+
+    float acc = 0.0;
+
+    uint numTiles = (params.K + TILE_SIZE - 1) / TILE_SIZE;
+
+    for (uint t = 0; t < numTiles; t++) {
+        // Load tile of A into shared memory
+        uint aCol = t * TILE_SIZE + localCol;
+        if (row < params.M && aCol < params.K) {
+            tileA[localRow][localCol] = a.data[row * params.K + aCol];
+        } else {
+            tileA[localRow][localCol] = 0.0;
+        }
+
+        // Load tile of B into shared memory
+        uint bRow = t * TILE_SIZE + localRow;
+        if (bRow < params.K && col < params.N) {
+            tileB[localRow][localCol] = b.data[bRow * params.N + col];
+        } else {
+            tileB[localRow][localCol] = 0.0;
+        }
+
+        barrier();
+        memoryBarrierShared();
+
+        // Accumulate dot product for this tile
+        for (uint k = 0; k < TILE_SIZE; k++) {
+            acc += tileA[localRow][k] * tileB[k][localCol];
+        }
+
+        barrier();
+    }
+
+    // Write result
+    if (row < params.M && col < params.N) {
+        c.data[row * params.N + col] = acc;
+    }
+}

--- a/crates/bitnet-vulkan/src/kernels/mod.rs
+++ b/crates/bitnet-vulkan/src/kernels/mod.rs
@@ -1,0 +1,62 @@
+//! Vulkan GLSL compute shader sources for GPU inference kernels.
+//!
+//! Each variant of [`VulkanShaderSource`] maps to a `.comp` GLSL file
+//! embedded at compile time via [`include_str!`].
+
+/// Enumerates the available Vulkan compute shaders.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VulkanShaderSource {
+    /// Tiled matrix multiplication with shared memory.
+    Matmul,
+    /// Numerically stable softmax with subgroup reduction.
+    Softmax,
+    /// RMS normalization with subgroup ops.
+    RmsNorm,
+    /// Rotary position embeddings.
+    Rope,
+    /// Scaled dot-product attention.
+    Attention,
+    /// Element-wise ops: `SiLU`, GELU, add, mul.
+    Elementwise,
+}
+
+impl VulkanShaderSource {
+    /// All shader variants in declaration order.
+    pub const ALL: &[Self] = &[
+        Self::Matmul,
+        Self::Softmax,
+        Self::RmsNorm,
+        Self::Rope,
+        Self::Attention,
+        Self::Elementwise,
+    ];
+
+    /// Returns the raw GLSL source code for this shader.
+    pub const fn glsl_source(&self) -> &'static str {
+        match self {
+            Self::Matmul => include_str!("matmul.comp"),
+            Self::Softmax => include_str!("softmax.comp"),
+            Self::RmsNorm => include_str!("rmsnorm.comp"),
+            Self::Rope => include_str!("rope.comp"),
+            Self::Attention => include_str!("attention.comp"),
+            Self::Elementwise => include_str!("elementwise.comp"),
+        }
+    }
+
+    /// The SPIR-V entry point name (always `"main"` per Vulkan convention).
+    pub const fn entry_point(&self) -> &'static str {
+        "main"
+    }
+
+    /// A human-readable name for logging / diagnostics.
+    pub const fn name(&self) -> &'static str {
+        match self {
+            Self::Matmul => "matmul",
+            Self::Softmax => "softmax",
+            Self::RmsNorm => "rmsnorm",
+            Self::Rope => "rope",
+            Self::Attention => "attention",
+            Self::Elementwise => "elementwise",
+        }
+    }
+}

--- a/crates/bitnet-vulkan/src/kernels/rmsnorm.comp
+++ b/crates/bitnet-vulkan/src/kernels/rmsnorm.comp
@@ -1,0 +1,67 @@
+#version 450
+// RMS normalization compute shader
+// out[i] = (x[i] / rms) * weight[i]
+// where rms = sqrt(mean(x^2) + eps)
+
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint N;     // vector dimension
+    float eps;  // numerical stability epsilon
+} params;
+
+layout(set = 0, binding = 0) readonly buffer Input {
+    float data[];
+} input_buf;
+
+layout(set = 0, binding = 1) readonly buffer Weight {
+    float data[];
+} weight_buf;
+
+layout(set = 0, binding = 2) writeonly buffer Output {
+    float data[];
+} output_buf;
+
+shared float shared_sq_sum[256];
+
+void main() {
+    uint row = gl_WorkGroupID.x;
+    uint tid = gl_LocalInvocationID.x;
+    uint wgSize = gl_WorkGroupSize.x;
+
+    uint row_offset = row * params.N;
+
+    // Phase 1: compute sum of squares
+    float local_sq_sum = 0.0;
+    for (uint i = tid; i < params.N; i += wgSize) {
+        float val = input_buf.data[row_offset + i];
+        local_sq_sum += val * val;
+    }
+
+    // Subgroup reduction
+    local_sq_sum = subgroupAdd(local_sq_sum);
+    shared_sq_sum[gl_SubgroupID] = local_sq_sum;
+    barrier();
+    memoryBarrierShared();
+
+    // Cross-subgroup reduction
+    if (tid < gl_NumSubgroups) {
+        local_sq_sum = shared_sq_sum[tid];
+    } else {
+        local_sq_sum = 0.0;
+    }
+    local_sq_sum = subgroupAdd(local_sq_sum);
+    float total_sq_sum = subgroupBroadcastFirst(local_sq_sum);
+    barrier();
+
+    // Phase 2: compute RMS and normalize
+    float rms = sqrt(total_sq_sum / float(params.N) + params.eps);
+    float inv_rms = 1.0 / rms;
+
+    for (uint i = tid; i < params.N; i += wgSize) {
+        output_buf.data[row_offset + i] =
+            input_buf.data[row_offset + i] * inv_rms * weight_buf.data[i];
+    }
+}

--- a/crates/bitnet-vulkan/src/kernels/rope.comp
+++ b/crates/bitnet-vulkan/src/kernels/rope.comp
@@ -1,0 +1,54 @@
+#version 450
+// Rotary Position Embedding (RoPE) compute shader
+// Applies rotation in pairs: (x0, x1) -> (x0*cos - x1*sin, x0*sin + x1*cos)
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint seq_len;   // sequence length
+    uint head_dim;  // dimension per attention head (must be even)
+    uint num_heads; // number of attention heads
+    float theta;    // RoPE base frequency (typically 10000.0)
+} params;
+
+layout(set = 0, binding = 0) buffer InOut {
+    float data[];
+} io_buf;
+
+layout(set = 0, binding = 1) readonly buffer Positions {
+    uint data[];
+} pos_buf;
+
+void main() {
+    uint idx = gl_GlobalInvocationID.x;
+
+    uint half_dim = params.head_dim / 2;
+    uint total_pairs = params.seq_len * params.num_heads * half_dim;
+
+    if (idx >= total_pairs) return;
+
+    // Decompose index into (seq_pos, head, pair_idx)
+    uint pair_idx = idx % half_dim;
+    uint remainder = idx / half_dim;
+    uint head = remainder % params.num_heads;
+    uint seq_idx = remainder / params.num_heads;
+
+    uint pos = pos_buf.data[seq_idx];
+
+    // Compute rotation angle: pos * theta^(-2*pair_idx / head_dim)
+    float freq = pow(params.theta, -float(2 * pair_idx) / float(params.head_dim));
+    float angle = float(pos) * freq;
+    float cos_val = cos(angle);
+    float sin_val = sin(angle);
+
+    // Locate the pair in the flat buffer
+    uint base = (seq_idx * params.num_heads + head) * params.head_dim;
+    uint i0 = base + pair_idx;
+    uint i1 = base + pair_idx + half_dim;
+
+    float x0 = io_buf.data[i0];
+    float x1 = io_buf.data[i1];
+
+    io_buf.data[i0] = x0 * cos_val - x1 * sin_val;
+    io_buf.data[i1] = x0 * sin_val + x1 * cos_val;
+}

--- a/crates/bitnet-vulkan/src/kernels/softmax.comp
+++ b/crates/bitnet-vulkan/src/kernels/softmax.comp
@@ -1,0 +1,83 @@
+#version 450
+// Numerically stable softmax compute shader
+// Operates on rows of length N: out[i] = exp(in[i] - max) / sum(exp(in[j] - max))
+
+#extension GL_KHR_shader_subgroup_arithmetic : enable
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PushConstants {
+    uint N;         // row length
+    uint num_rows;  // number of rows
+} params;
+
+layout(set = 0, binding = 0) readonly buffer Input {
+    float data[];
+} input_buf;
+
+layout(set = 0, binding = 1) writeonly buffer Output {
+    float data[];
+} output_buf;
+
+shared float shared_max[256];
+shared float shared_sum[256];
+
+void main() {
+    uint row = gl_WorkGroupID.x;
+    uint tid = gl_LocalInvocationID.x;
+    uint wgSize = gl_WorkGroupSize.x;
+
+    if (row >= params.num_rows) return;
+
+    uint row_offset = row * params.N;
+
+    // Phase 1: find row maximum (numerically stable)
+    float local_max = -1.0 / 0.0; // -inf
+    for (uint i = tid; i < params.N; i += wgSize) {
+        local_max = max(local_max, input_buf.data[row_offset + i]);
+    }
+
+    // Subgroup reduction for max
+    local_max = subgroupMax(local_max);
+    shared_max[gl_SubgroupID] = local_max;
+    barrier();
+    memoryBarrierShared();
+
+    // Final reduction across subgroups
+    if (tid < gl_NumSubgroups) {
+        local_max = shared_max[tid];
+    } else {
+        local_max = -1.0 / 0.0;
+    }
+    local_max = subgroupMax(local_max);
+    float row_max = subgroupBroadcastFirst(local_max);
+    barrier();
+
+    // Phase 2: compute sum of exp(x - max)
+    float local_sum = 0.0;
+    for (uint i = tid; i < params.N; i += wgSize) {
+        local_sum += exp(input_buf.data[row_offset + i] - row_max);
+    }
+
+    // Subgroup reduction for sum
+    local_sum = subgroupAdd(local_sum);
+    shared_sum[gl_SubgroupID] = local_sum;
+    barrier();
+    memoryBarrierShared();
+
+    if (tid < gl_NumSubgroups) {
+        local_sum = shared_sum[tid];
+    } else {
+        local_sum = 0.0;
+    }
+    local_sum = subgroupAdd(local_sum);
+    float row_sum = subgroupBroadcastFirst(local_sum);
+    barrier();
+
+    // Phase 3: write normalized output
+    float inv_sum = 1.0 / row_sum;
+    for (uint i = tid; i < params.N; i += wgSize) {
+        output_buf.data[row_offset + i] =
+            exp(input_buf.data[row_offset + i] - row_max) * inv_sum;
+    }
+}

--- a/crates/bitnet-vulkan/src/lib.rs
+++ b/crates/bitnet-vulkan/src/lib.rs
@@ -1,0 +1,11 @@
+//! Vulkan GLSL compute shaders for `BitNet` GPU inference.
+//!
+//! This crate provides embedded GLSL compute shader sources for the
+//! core neural-network operations needed by the `BitNet` inference engine:
+//! matrix multiplication, softmax, RMS normalization, rotary position
+//! embeddings, scaled dot-product attention, and element-wise activations.
+//!
+//! Shaders target Vulkan 1.0 (`#version 450`) and use tiled shared-memory
+//! algorithms and subgroup operations where applicable.
+
+pub mod kernels;

--- a/crates/bitnet-vulkan/tests/vulkan_shader_tests.rs
+++ b/crates/bitnet-vulkan/tests/vulkan_shader_tests.rs
@@ -1,0 +1,242 @@
+//! Structural validation tests for Vulkan GLSL compute shaders.
+
+use bitnet_vulkan::kernels::VulkanShaderSource;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+fn all_shaders() -> &'static [VulkanShaderSource] {
+    VulkanShaderSource::ALL
+}
+
+// ---------------------------------------------------------------------------
+// Basic source validity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_sources_non_empty() {
+    for shader in all_shaders() {
+        assert!(!shader.glsl_source().is_empty(), "{} shader source is empty", shader.name());
+    }
+}
+
+#[test]
+fn all_sources_valid_utf8() {
+    // include_str! guarantees UTF-8, but verify we can round-trip.
+    for shader in all_shaders() {
+        let src = shader.glsl_source();
+        assert!(
+            std::str::from_utf8(src.as_bytes()).is_ok(),
+            "{} source is not valid UTF-8",
+            shader.name()
+        );
+    }
+}
+
+#[test]
+fn all_sources_contain_version_450() {
+    for shader in all_shaders() {
+        assert!(
+            shader.glsl_source().contains("#version 450"),
+            "{} missing #version 450 directive",
+            shader.name()
+        );
+    }
+}
+
+#[test]
+fn all_entry_points_are_main() {
+    for shader in all_shaders() {
+        assert_eq!(shader.entry_point(), "main", "{} entry point is not \"main\"", shader.name());
+    }
+}
+
+#[test]
+fn all_sources_have_void_main() {
+    for shader in all_shaders() {
+        assert!(
+            shader.glsl_source().contains("void main()"),
+            "{} missing void main() definition",
+            shader.name()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layout declarations
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_sources_have_local_size() {
+    for shader in all_shaders() {
+        assert!(
+            shader.glsl_source().contains("local_size_x"),
+            "{} missing layout(local_size_x ...) declaration",
+            shader.name()
+        );
+    }
+}
+
+#[test]
+fn all_sources_have_buffer_bindings() {
+    for shader in all_shaders() {
+        assert!(
+            shader.glsl_source().contains("binding"),
+            "{} missing buffer binding declaration",
+            shader.name()
+        );
+    }
+}
+
+#[test]
+fn all_sources_have_push_constants_or_buffer() {
+    for shader in all_shaders() {
+        let src = shader.glsl_source();
+        let has_push = src.contains("push_constant");
+        let has_buffer = src.contains("buffer");
+        assert!(
+            has_push || has_buffer,
+            "{} missing push_constant or buffer declaration",
+            shader.name()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-shader content checks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matmul_has_shared_memory() {
+    let src = VulkanShaderSource::Matmul.glsl_source();
+    assert!(src.contains("shared float"), "matmul missing shared memory");
+}
+
+#[test]
+fn matmul_has_barrier() {
+    let src = VulkanShaderSource::Matmul.glsl_source();
+    assert!(src.contains("barrier()"), "matmul missing barrier()");
+}
+
+#[test]
+fn matmul_has_tile_size() {
+    let src = VulkanShaderSource::Matmul.glsl_source();
+    assert!(src.contains("TILE_SIZE"), "matmul missing TILE_SIZE constant");
+}
+
+#[test]
+fn softmax_has_subgroup_extension() {
+    let src = VulkanShaderSource::Softmax.glsl_source();
+    assert!(
+        src.contains("GL_KHR_shader_subgroup_arithmetic"),
+        "softmax missing subgroup extension"
+    );
+}
+
+#[test]
+fn softmax_has_exp() {
+    let src = VulkanShaderSource::Softmax.glsl_source();
+    assert!(src.contains("exp("), "softmax missing exp() call");
+}
+
+#[test]
+fn rmsnorm_has_sqrt() {
+    let src = VulkanShaderSource::RmsNorm.glsl_source();
+    assert!(src.contains("sqrt("), "rmsnorm missing sqrt()");
+}
+
+#[test]
+fn rmsnorm_has_epsilon() {
+    let src = VulkanShaderSource::RmsNorm.glsl_source();
+    assert!(src.contains("eps"), "rmsnorm missing epsilon parameter");
+}
+
+#[test]
+fn rope_has_cos_sin() {
+    let src = VulkanShaderSource::Rope.glsl_source();
+    assert!(src.contains("cos("), "rope missing cos()");
+    assert!(src.contains("sin("), "rope missing sin()");
+}
+
+#[test]
+fn rope_has_theta() {
+    let src = VulkanShaderSource::Rope.glsl_source();
+    assert!(src.contains("theta"), "rope missing theta parameter");
+}
+
+#[test]
+fn attention_has_scale() {
+    let src = VulkanShaderSource::Attention.glsl_source();
+    assert!(src.contains("scale"), "attention missing scale parameter");
+}
+
+#[test]
+fn attention_has_qkv_buffers() {
+    let src = VulkanShaderSource::Attention.glsl_source();
+    assert!(src.contains("Query"), "attention missing Query buffer");
+    assert!(src.contains("Key"), "attention missing Key buffer");
+    assert!(src.contains("Value"), "attention missing Value buffer");
+}
+
+#[test]
+fn elementwise_has_silu() {
+    let src = VulkanShaderSource::Elementwise.glsl_source();
+    assert!(src.contains("silu"), "elementwise missing SiLU");
+}
+
+#[test]
+fn elementwise_has_gelu() {
+    let src = VulkanShaderSource::Elementwise.glsl_source();
+    assert!(src.contains("gelu"), "elementwise missing GELU");
+}
+
+#[test]
+fn elementwise_has_binary_ops() {
+    let src = VulkanShaderSource::Elementwise.glsl_source();
+    assert!(src.contains("OP_ADD"), "elementwise missing add op");
+    assert!(src.contains("OP_MUL"), "elementwise missing mul op");
+}
+
+// ---------------------------------------------------------------------------
+// Enum coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_variant_count_is_six() {
+    assert_eq!(VulkanShaderSource::ALL.len(), 6);
+}
+
+#[test]
+fn all_names_unique() {
+    let names: Vec<&str> = all_shaders().iter().map(|s| s.name()).collect();
+    let mut deduped = names.clone();
+    deduped.sort();
+    deduped.dedup();
+    assert_eq!(names.len(), deduped.len(), "duplicate shader names");
+}
+
+#[test]
+fn shader_debug_impl() {
+    // Ensure Debug is derived and doesn't panic.
+    let dbg = format!("{:?}", VulkanShaderSource::Matmul);
+    assert!(!dbg.is_empty());
+}
+
+#[test]
+fn shader_clone_eq() {
+    let a = VulkanShaderSource::Softmax;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn push_constants_present_in_all() {
+    for shader in all_shaders() {
+        assert!(
+            shader.glsl_source().contains("push_constant"),
+            "{} missing push_constant uniform block",
+            shader.name()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
GLSL compute shaders for Vulkan GPU inference.

- 6 .comp shader files matching the full kernel suite
- Vulkan 1.0 compatible, tiled/subgroup optimized
- 27 structure validation tests

Part of multi-GPU support epic.