### PR TITLE
fuzz: add wave 4 fuzz targets (7 new targets)

### DIFF
--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -124,6 +124,14 @@ jobs:
           # Token & model boundary testing
           - tensor_shape_validate
           - token_id_bounds
+          # Wave 4: GPU HAL, server, CLI, metadata, quantization, attention, cache
+          - gpu_hal_types
+          - server_request_parse
+          - cli_config_parse
+          - gguf_metadata_validate
+          - quantization_config_validate
+          - attention_mask_gen
+          - kv_cache_eviction
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -58,6 +58,14 @@ jobs:
           - runtime_context_parse_no_panic
           - validation_no_panic
           - vocab_size_extraction
+          # Wave 4
+          - gpu_hal_types
+          - server_request_parse
+          - cli_config_parse
+          - gguf_metadata_validate
+          - quantization_config_validate
+          - attention_mask_gen
+          - kv_cache_eviction
 
     steps:
       - name: Checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "vergen",
@@ -484,7 +484,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -506,7 +506,7 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -559,7 +559,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -636,11 +636,13 @@ version = "0.0.0"
 dependencies = [
  "arbitrary",
  "bitnet-bdd-grid-core",
+ "bitnet-cli",
  "bitnet-common",
  "bitnet-engine-core",
  "bitnet-generation",
  "bitnet-gguf",
  "bitnet-honest-compute",
+ "bitnet-inference",
  "bitnet-kernels",
  "bitnet-logits",
  "bitnet-models",
@@ -650,6 +652,7 @@ dependencies = [
  "bitnet-rope",
  "bitnet-runtime-feature-flags-core",
  "bitnet-sampling",
+ "bitnet-server",
  "bitnet-st2gguf",
  "bitnet-tokenizers",
  "bitnet-validation",
@@ -658,6 +661,7 @@ dependencies = [
  "safetensors 0.6.2",
  "serde_json",
  "tempfile",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -692,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-gpu-hal"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "proptest",
 ]
@@ -838,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "bitnet-opencl"
-version = "0.2.1-dev"
+version = "0.2.0-alpha.1"
 dependencies = [
  "insta",
  "log",
@@ -1069,7 +1073,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tonic",
  "tower",
  "tower-http",
@@ -1344,7 +1348,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "walkdir",
@@ -1689,7 +1693,7 @@ dependencies = [
  "serde_json",
  "syn",
  "tempfile",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -5785,7 +5789,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -6787,6 +6791,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -7415,17 +7428,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7439,12 +7473,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -7457,6 +7505,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8722,7 +8776,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
  "which",
  "xtask-build-helper",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,8 +31,12 @@ bitnet-engine-core = { path = "../crates/bitnet-engine-core", version = "0.2.0-a
 bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.0-alpha.1" }
 bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core", version = "0.2.0-alpha.1" }
 bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core", version = "0.2.0-alpha.1" }
+bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.0-alpha.1" }
+bitnet-server = { path = "../crates/bitnet-server", version = "0.2.0-alpha.1" }
+bitnet-cli = { path = "../crates/bitnet-cli", version = "0.2.0-alpha.1" }
 candle-core = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
+toml = "0.8"
 
 [[bin]]
 name = "quantization_i2s"
@@ -295,5 +299,47 @@ doc = false
 [[bin]]
 name = "token_id_bounds"
 path = "fuzz_targets/token_id_bounds.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gpu_hal_types"
+path = "fuzz_targets/gpu_hal_types.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "server_request_parse"
+path = "fuzz_targets/server_request_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "cli_config_parse"
+path = "fuzz_targets/cli_config_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gguf_metadata_validate"
+path = "fuzz_targets/gguf_metadata_validate.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "quantization_config_validate"
+path = "fuzz_targets/quantization_config_validate.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "attention_mask_gen"
+path = "fuzz_targets/attention_mask_gen.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "kv_cache_eviction"
+path = "fuzz_targets/kv_cache_eviction.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/attention_mask_gen.rs
+++ b/fuzz/fuzz_targets/attention_mask_gen.rs
@@ -1,0 +1,93 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MaskInput {
+    seq_len: u16,
+    pad_positions: Vec<u16>,
+    batch_size: u8,
+}
+
+fuzz_target!(|input: MaskInput| {
+    // Cap seq_len to prevent OOM (seq_len^2 allocation).
+    let seq_len = (input.seq_len as usize % 512) + 1;
+
+    // build causal mask: lower-triangular with -inf above diagonal.
+    let mask = build_causal_mask(seq_len);
+    assert_eq!(mask.len(), seq_len * seq_len);
+
+    // Verify causal property: mask[i][j] == -inf iff j > i.
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            let val = mask[i * seq_len + j];
+            if j > i {
+                assert!(val < -1e8, "Future position ({i},{j}) should be masked");
+            } else {
+                assert_eq!(val, 0.0, "Past/current position ({i},{j}) should be unmasked");
+            }
+        }
+    }
+
+    // Build padding mask from arbitrary pad positions.
+    let pad_positions: Vec<usize> =
+        input.pad_positions.iter().take(64).map(|&p| p as usize % seq_len).collect();
+    let pad_mask = build_padding_mask(seq_len, &pad_positions);
+    assert_eq!(pad_mask.len(), seq_len);
+
+    // Verify padded positions are masked.
+    for &pos in &pad_positions {
+        assert!(pad_mask[pos] < -1e8, "Padded position {pos} should be masked");
+    }
+
+    // Combined causal + padding mask.
+    let combined = combine_masks(&mask, &pad_mask, seq_len);
+    assert_eq!(combined.len(), seq_len * seq_len);
+
+    // Batch dimension: multiple sequences.
+    let batch = (input.batch_size as usize % 4) + 1;
+    let batched: Vec<Vec<f32>> = (0..batch).map(|_| build_causal_mask(seq_len)).collect();
+    assert_eq!(batched.len(), batch);
+    for b in &batched {
+        assert_eq!(b.len(), seq_len * seq_len);
+    }
+
+    // Edge: seq_len == 1
+    let single = build_causal_mask(1);
+    assert_eq!(single, vec![0.0f32]);
+});
+
+fn build_causal_mask(seq_len: usize) -> Vec<f32> {
+    let mut mask = vec![0.0f32; seq_len * seq_len];
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            if j > i {
+                mask[i * seq_len + j] = -1e9;
+            }
+        }
+    }
+    mask
+}
+
+fn build_padding_mask(seq_len: usize, pad_positions: &[usize]) -> Vec<f32> {
+    let mut mask = vec![0.0f32; seq_len];
+    for &pos in pad_positions {
+        if pos < seq_len {
+            mask[pos] = -1e9;
+        }
+    }
+    mask
+}
+
+fn combine_masks(causal: &[f32], padding: &[f32], seq_len: usize) -> Vec<f32> {
+    let mut combined = causal.to_vec();
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            if padding[j] < -1e8 {
+                combined[i * seq_len + j] = -1e9;
+            }
+        }
+    }
+    combined
+}

--- a/fuzz/fuzz_targets/cli_config_parse.rs
+++ b/fuzz/fuzz_targets/cli_config_parse.rs
@@ -1,0 +1,80 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct CliConfigInput {
+    raw_json: Vec<u8>,
+    raw_toml: Vec<u8>,
+    device: Vec<u8>,
+    level: Vec<u8>,
+    format: Vec<u8>,
+    cpu_threads: Option<u32>,
+    batch_size: u32,
+    memory_opt: bool,
+    timestamps: bool,
+}
+
+fuzz_target!(|input: CliConfigInput| {
+    // Fuzz CliConfig deserialization from arbitrary JSON.
+    if let Ok(s) = std::str::from_utf8(&input.raw_json) {
+        if s.len() <= 4096 {
+            let _ = serde_json::from_str::<bitnet_cli::config::CliConfig>(s);
+        }
+    }
+
+    // Fuzz CliConfig deserialization from arbitrary TOML.
+    if let Ok(s) = std::str::from_utf8(&input.raw_toml) {
+        if s.len() <= 4096 {
+            // TOML parsing (via serde) must never panic.
+            let _ = toml::from_str::<bitnet_cli::config::CliConfig>(s);
+        }
+    }
+
+    // Construct structured JSON from arbitrary fields.
+    let device = std::str::from_utf8(&input.device).unwrap_or("auto");
+    let level = std::str::from_utf8(&input.level).unwrap_or("info");
+    let format = std::str::from_utf8(&input.format).unwrap_or("pretty");
+
+    let obj = serde_json::json!({
+        "default_device": device,
+        "logging": {
+            "level": level,
+            "format": format,
+            "timestamps": input.timestamps,
+        },
+        "performance": {
+            "cpu_threads": input.cpu_threads,
+            "batch_size": input.batch_size,
+            "memory_optimization": input.memory_opt,
+        }
+    });
+
+    let _ = serde_json::from_value::<bitnet_cli::config::CliConfig>(obj);
+
+    // Edge: zero batch size, huge thread count.
+    let edge = serde_json::json!({
+        "default_device": "cpu",
+        "logging": { "level": "error", "format": "json", "timestamps": false },
+        "performance": {
+            "cpu_threads": u64::MAX,
+            "batch_size": 0,
+            "memory_optimization": true,
+        }
+    });
+    let _ = serde_json::from_value::<bitnet_cli::config::CliConfig>(edge);
+
+    // Also test build_cli() doesn't panic on arbitrary args.
+    let cli = bitnet_cli::build_cli();
+    let args: Vec<String> = input
+        .raw_json
+        .chunks(8)
+        .take(16)
+        .filter_map(|chunk| std::str::from_utf8(chunk).ok())
+        .map(|s| s.to_string())
+        .collect();
+    let mut full_args = vec!["bitnet".to_string()];
+    full_args.extend(args);
+    let _ = cli.try_get_matches_from(full_args);
+});

--- a/fuzz/fuzz_targets/gguf_metadata_validate.rs
+++ b/fuzz/fuzz_targets/gguf_metadata_validate.rs
@@ -1,0 +1,136 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_gguf::{check_magic, parse_header, read_version};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MetadataInput {
+    kv_count: u8,
+    entries: Vec<KvEntry>,
+    trailing: Vec<u8>,
+}
+
+#[derive(Arbitrary, Debug)]
+struct KvEntry {
+    key: Vec<u8>,
+    value_type: u8,
+    str_val: Vec<u8>,
+    int_val: u64,
+    float_val: f32,
+    bool_val: bool,
+    array_len: u8,
+}
+
+fuzz_target!(|input: MetadataInput| {
+    if input.trailing.len() > 512 {
+        return;
+    }
+
+    let kv_count = (input.kv_count as u64).min(16);
+    let entries: Vec<&KvEntry> = input.entries.iter().take(kv_count as usize).collect();
+
+    let buf = build_gguf_with_metadata(kv_count, &entries, &input.trailing);
+
+    // Low-level primitives must never panic on crafted metadata.
+    let _ = check_magic(&buf);
+    let _ = read_version(&buf);
+    let _ = parse_header(&buf);
+
+    // GgufReader must handle arbitrary metadata kv pairs.
+    if buf.len() >= 16 {
+        if let Ok(reader) = bitnet_models::GgufReader::new(&buf) {
+            let _ = reader.metadata_kv_count();
+            let _ = reader.tensor_count();
+            let _ = reader.validate();
+
+            // Iterate metadata by index — must never panic.
+            let count = reader.metadata_kv_count();
+            let _ = reader.metadata_count();
+            let _ = count;
+
+            // Lookup by arbitrary key — must never panic.
+            for e in &entries {
+                if let Ok(key) = std::str::from_utf8(&e.key) {
+                    let _ = reader.get_string_metadata(key);
+                    let _ = reader.get_u32_metadata(key);
+                    let _ = reader.get_i32_metadata(key);
+                    let _ = reader.get_f32_metadata(key);
+                    let _ = reader.get_bool_metadata(key);
+                }
+            }
+
+            // Architecture-specific lookups.
+            let _ = reader.get_string_metadata("general.architecture");
+            let _ = reader.get_string_metadata("general.name");
+            let _ = reader.get_u32_metadata("general.file_type");
+            let _ = reader.get_u32_metadata("llama.context_length");
+            let _ = reader.get_u32_metadata("llama.embedding_length");
+            let _ = reader.get_u32_metadata("llama.block_count");
+        }
+    }
+
+    // Also test sub-slices.
+    for end in [16, 24, 48, buf.len().min(256), buf.len()] {
+        if end <= buf.len() {
+            let _ = parse_header(&buf[..end]);
+        }
+    }
+});
+
+fn build_gguf_with_metadata(kv_count: u64, entries: &[&KvEntry], trailing: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::new();
+
+    // GGUF magic + version 3
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&3u32.to_le_bytes());
+    // tensor_count = 0
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    // metadata_kv_count
+    buf.extend_from_slice(&kv_count.to_le_bytes());
+
+    // Write metadata kv entries
+    for e in entries {
+        let key_len = e.key.len().min(128);
+        // key: u64 length + bytes
+        buf.extend_from_slice(&(key_len as u64).to_le_bytes());
+        buf.extend_from_slice(&e.key[..key_len]);
+
+        // value_type: GGUF types 0-12
+        let vtype = e.value_type % 13;
+        buf.extend_from_slice(&(vtype as u32).to_le_bytes());
+
+        match vtype {
+            0 => buf.push(e.bool_val as u8), // UINT8
+            1 => buf.push(e.int_val as u8),  // INT8
+            2 => buf.extend_from_slice(&(e.int_val as u16).to_le_bytes()), // UINT16
+            3 => buf.extend_from_slice(&(e.int_val as i16).to_le_bytes()), // INT16
+            4 => buf.extend_from_slice(&(e.int_val as u32).to_le_bytes()), // UINT32
+            5 => buf.extend_from_slice(&(e.int_val as i32).to_le_bytes()), // INT32
+            6 => buf.extend_from_slice(&e.float_val.to_le_bytes()), // FLOAT32
+            7 => buf.push(e.bool_val as u8), // BOOL
+            8 => {
+                // STRING
+                let s_len = e.str_val.len().min(128);
+                buf.extend_from_slice(&(s_len as u64).to_le_bytes());
+                buf.extend_from_slice(&e.str_val[..s_len]);
+            }
+            9 => {
+                // ARRAY — write small array of UINT32
+                let arr_len = (e.array_len as u64).min(8);
+                buf.extend_from_slice(&4u32.to_le_bytes()); // element type UINT32
+                buf.extend_from_slice(&arr_len.to_le_bytes());
+                for i in 0..arr_len {
+                    buf.extend_from_slice(&(i as u32).to_le_bytes());
+                }
+            }
+            10 => buf.extend_from_slice(&e.int_val.to_le_bytes()), // UINT64
+            11 => buf.extend_from_slice(&(e.int_val as i64).to_le_bytes()), // INT64
+            12 => buf.extend_from_slice(&(e.float_val as f64).to_le_bytes()), // FLOAT64
+            _ => {}
+        }
+    }
+
+    buf.extend_from_slice(trailing);
+    buf
+}

--- a/fuzz/fuzz_targets/gpu_hal_types.rs
+++ b/fuzz/fuzz_targets/gpu_hal_types.rs
@@ -1,0 +1,83 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::{KernelBackend, KernelCapabilities, SimdLevel};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct HalInput {
+    cpu_rust: bool,
+    cuda_compiled: bool,
+    cuda_runtime: bool,
+    hip_compiled: bool,
+    hip_runtime: bool,
+    oneapi_compiled: bool,
+    oneapi_runtime: bool,
+    cpp_ffi: bool,
+    simd_idx: u8,
+    backend_idx: u8,
+}
+
+fuzz_target!(|input: HalInput| {
+    let simd_levels =
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512];
+    let simd = simd_levels[input.simd_idx as usize % simd_levels.len()];
+
+    let backends = [
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::CppFfi,
+    ];
+    let backend = backends[input.backend_idx as usize % backends.len()];
+
+    // KernelBackend methods must never panic.
+    let _ = backend.requires_gpu();
+    let _ = backend.is_compiled();
+    let _ = format!("{backend}");
+
+    // SimdLevel Display and ordering must never panic.
+    let _ = format!("{simd}");
+    let _ = simd.cmp(&SimdLevel::Avx2);
+
+    // Build KernelCapabilities from arbitrary flags.
+    let caps = KernelCapabilities {
+        cpu_rust: input.cpu_rust,
+        cuda_compiled: input.cuda_compiled,
+        cuda_runtime: input.cuda_runtime,
+        hip_compiled: input.hip_compiled,
+        hip_runtime: input.hip_runtime,
+        oneapi_compiled: input.oneapi_compiled,
+        oneapi_runtime: input.oneapi_runtime,
+        cpp_ffi: input.cpp_ffi,
+        simd_level: simd,
+    };
+
+    // All capability queries must never panic.
+    let compiled = caps.compiled_backends();
+    let _ = caps.best_available();
+    let _ = format!("{caps:?}");
+    let _ = compiled.len();
+
+    // Builder chain methods must never panic.
+    let chained = KernelCapabilities::from_compile_time()
+        .with_cuda_runtime(input.cuda_runtime)
+        .with_hip_runtime(input.hip_runtime)
+        .with_oneapi_runtime(input.oneapi_runtime)
+        .with_cpp_ffi(input.cpp_ffi);
+    let _ = chained.compiled_backends();
+    let _ = chained.best_available();
+    let _ = chained.summary();
+
+    // Verify requires_gpu consistency for all backends.
+    for b in &backends {
+        let needs_gpu = b.requires_gpu();
+        if needs_gpu {
+            assert!(
+                matches!(b, KernelBackend::Cuda | KernelBackend::Hip | KernelBackend::OneApi),
+                "requires_gpu mismatch for {b:?}",
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/kv_cache_eviction.rs
+++ b/fuzz/fuzz_targets/kv_cache_eviction.rs
@@ -1,0 +1,92 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_inference::cache::{CacheConfig, EvictionPolicy, KVCache};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct CacheInput {
+    max_size_bytes: u32,
+    max_seq_len: u16,
+    enable_compression: bool,
+    eviction_idx: u8,
+    block_size: u16,
+    ops: Vec<CacheOp>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum CacheOp {
+    Store { layer: u8, position: u16, kv_len: u8 },
+    Get { layer: u8, position: u16 },
+    Contains { layer: u8, position: u16 },
+    ClearLayer { layer: u8 },
+    ClearAll,
+    Stats,
+}
+
+fuzz_target!(|input: CacheInput| {
+    let policies = [EvictionPolicy::LRU, EvictionPolicy::FIFO, EvictionPolicy::LFU];
+    let policy = policies[input.eviction_idx as usize % policies.len()];
+
+    // Bound sizes to prevent OOM.
+    let max_size = ((input.max_size_bytes as usize) % (4 * 1024 * 1024)).max(1024);
+    let block_size = ((input.block_size as usize) % 256).max(1);
+
+    let config = CacheConfig {
+        max_size_bytes: max_size,
+        max_sequence_length: (input.max_seq_len as usize % 1024).max(1),
+        enable_compression: input.enable_compression,
+        eviction_policy: policy,
+        block_size,
+    };
+
+    let mut cache = match KVCache::new(config) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Execute operations capped at 256 to prevent timeout.
+    for op in input.ops.iter().take(256) {
+        match op {
+            CacheOp::Store { layer, position, kv_len } => {
+                let l = *layer as usize % 32;
+                let p = *position as usize;
+                let len = (*kv_len as usize % 64).max(1);
+                let key = vec![0.5f32; len];
+                let value = vec![-0.5f32; len];
+                let _ = cache.store(l, p, key, value);
+            }
+            CacheOp::Get { layer, position } => {
+                let l = *layer as usize % 32;
+                let p = *position as usize;
+                let _ = cache.get(l, p);
+            }
+            CacheOp::Contains { layer, position } => {
+                let l = *layer as usize % 32;
+                let p = *position as usize;
+                let _ = cache.contains(l, p);
+            }
+            CacheOp::ClearLayer { layer } => {
+                let l = *layer as usize % 32;
+                cache.clear_layer(l);
+            }
+            CacheOp::ClearAll => {
+                cache.clear();
+            }
+            CacheOp::Stats => {
+                let stats = cache.stats();
+                let _ = format!("{stats:?}");
+                let _ = cache.size();
+                let _ = cache.usage_percent();
+            }
+        }
+    }
+
+    // After all ops, stats must not panic.
+    let _ = cache.stats();
+    let _ = cache.size();
+    let _ = cache.usage_percent();
+
+    // Verify invariants.
+    assert!(cache.usage_percent() <= 100.1, "Usage cannot exceed 100%");
+});

--- a/fuzz/fuzz_targets/quantization_config_validate.rs
+++ b/fuzz/fuzz_targets/quantization_config_validate.rs
@@ -1,0 +1,79 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::{BitNetConfig, ModelConfig, ModelFormat, QuantizationConfig, QuantizationType};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct QuantConfigInput {
+    block_size: u32,
+    precision: f32,
+    quant_type_idx: u8,
+    vocab_size: u32,
+    hidden_size: u32,
+    num_heads: u16,
+    num_layers: u16,
+    scale_factors: Vec<f32>,
+}
+
+fuzz_target!(|input: QuantConfigInput| {
+    let quant_types = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    let qt = quant_types[input.quant_type_idx as usize % quant_types.len()];
+
+    // QuantizationConfig construction and serde must never panic.
+    let qc = QuantizationConfig {
+        quantization_type: qt,
+        block_size: input.block_size as usize,
+        precision: input.precision,
+    };
+    let _ = format!("{qc:?}");
+
+    // Serde round-trip on QuantizationConfig must not panic.
+    if let Ok(json) = serde_json::to_string(&qc) {
+        let _ = serde_json::from_str::<QuantizationConfig>(&json);
+    }
+
+    // BitNetConfig builder with quantization must not panic.
+    let result = BitNetConfig::builder()
+        .vocab_size(input.vocab_size as usize)
+        .hidden_size(input.hidden_size as usize)
+        .num_heads(input.num_heads as usize)
+        .num_layers(input.num_layers as usize)
+        .build();
+
+    if let Ok(config) = result {
+        let _ = config.validate();
+    }
+
+    // ModelConfig with extreme values must not panic on serde.
+    let mc = ModelConfig {
+        vocab_size: input.vocab_size as usize,
+        hidden_size: input.hidden_size as usize,
+        num_layers: input.num_layers as usize,
+        num_heads: input.num_heads as usize,
+        num_key_value_heads: input.num_heads as usize,
+        intermediate_size: (input.hidden_size as usize).saturating_mul(4),
+        max_position_embeddings: 2048,
+        format: ModelFormat::Gguf,
+        ..Default::default()
+    };
+    if let Ok(json) = serde_json::to_string(&mc) {
+        let _ = serde_json::from_str::<ModelConfig>(&json);
+    }
+
+    // Validate scale factors don't cause panics (NaN, inf, zero, negative).
+    for &s in input.scale_factors.iter().take(256) {
+        let clamped = if s.is_finite() { s } else { 0.0 };
+        let _ = clamped.abs();
+        // Division by scale: must not panic even with zero.
+        if clamped != 0.0 {
+            let _ = 1.0f32 / clamped;
+        }
+    }
+
+    // Block size edge cases: zero, 1, powers of 2, odd values.
+    for bs in [0usize, 1, 2, 31, 32, 33, 63, 64, 128, 255, 256, 512, usize::MAX] {
+        let edge_qc = QuantizationConfig { quantization_type: qt, block_size: bs, precision: 1.0 };
+        let _ = format!("{edge_qc:?}");
+    }
+});

--- a/fuzz/fuzz_targets/server_request_parse.rs
+++ b/fuzz/fuzz_targets/server_request_parse.rs
@@ -1,0 +1,90 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct RequestInput {
+    raw_json: Vec<u8>,
+    prompt: Vec<u8>,
+    max_tokens: Option<u32>,
+    temperature: Option<f32>,
+    top_p: Option<f32>,
+    top_k: Option<u32>,
+    repetition_penalty: Option<f32>,
+    priority: Option<Vec<u8>>,
+    device_pref: Option<Vec<u8>>,
+    timeout_ms: Option<u64>,
+    model_path: Vec<u8>,
+}
+
+fuzz_target!(|input: RequestInput| {
+    // Fuzz InferenceRequest deserialization from arbitrary JSON.
+    if let Ok(s) = std::str::from_utf8(&input.raw_json) {
+        if s.len() <= 4096 {
+            let _ = serde_json::from_str::<bitnet_server::InferenceRequest>(s);
+            let _ = serde_json::from_str::<bitnet_server::EnhancedInferenceRequest>(s);
+            let _ = serde_json::from_str::<bitnet_server::ModelLoadRequest>(s);
+        }
+    }
+
+    // Construct valid-ish JSON from structured input and parse.
+    let prompt = std::str::from_utf8(&input.prompt).unwrap_or("test");
+    let model_path = std::str::from_utf8(&input.model_path).unwrap_or("/tmp/model.gguf");
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("prompt".into(), serde_json::Value::String(prompt.to_string()));
+    if let Some(mt) = input.max_tokens {
+        obj.insert("max_tokens".into(), serde_json::json!(mt));
+    }
+    if let Some(t) = input.temperature {
+        if t.is_finite() {
+            obj.insert("temperature".into(), serde_json::json!(t));
+        }
+    }
+    if let Some(p) = input.top_p {
+        if p.is_finite() {
+            obj.insert("top_p".into(), serde_json::json!(p));
+        }
+    }
+    if let Some(k) = input.top_k {
+        obj.insert("top_k".into(), serde_json::json!(k));
+    }
+    if let Some(rp) = input.repetition_penalty {
+        if rp.is_finite() {
+            obj.insert("repetition_penalty".into(), serde_json::json!(rp));
+        }
+    }
+
+    let json_str = serde_json::Value::Object(obj.clone()).to_string();
+    let _ = serde_json::from_str::<bitnet_server::InferenceRequest>(&json_str);
+
+    // Add enhanced fields and parse as EnhancedInferenceRequest.
+    if let Some(ref p) = input.priority {
+        if let Ok(ps) = std::str::from_utf8(p) {
+            obj.insert("priority".into(), serde_json::Value::String(ps.to_string()));
+        }
+    }
+    if let Some(ref dp) = input.device_pref {
+        if let Ok(ds) = std::str::from_utf8(dp) {
+            obj.insert("device_preference".into(), serde_json::Value::String(ds.to_string()));
+        }
+    }
+    if let Some(tms) = input.timeout_ms {
+        obj.insert("timeout_ms".into(), serde_json::json!(tms));
+    }
+
+    let enhanced_str = serde_json::Value::Object(obj).to_string();
+    let _ = serde_json::from_str::<bitnet_server::EnhancedInferenceRequest>(&enhanced_str);
+
+    // ModelLoadRequest parsing.
+    let model_obj = serde_json::json!({
+        "model_path": model_path,
+    });
+    let _ = serde_json::from_str::<bitnet_server::ModelLoadRequest>(&model_obj.to_string());
+
+    // Edge: empty object, null values.
+    let _ = serde_json::from_str::<bitnet_server::InferenceRequest>("{}");
+    let _ = serde_json::from_str::<bitnet_server::InferenceRequest>("null");
+    let _ = serde_json::from_str::<bitnet_server::InferenceRequest>("[]");
+});


### PR DESCRIPTION
Add 7 new fuzz targets: gpu_hal_types, server_request_parse, cli_config_parse, gguf_metadata_validate, quantization_config_validate, attention_mask_gen, kv_cache_eviction. All targets build cleanly and follow existing conventions.