### PR TITLE
fix: replace unwrap/expect with proper error handling in core crates

### DIFF
--- a/crates/bitnet-common/src/tensor.rs
+++ b/crates/bitnet-common/src/tensor.rs
@@ -223,7 +223,9 @@ impl Tensor for BitNetTensor {
                 BitNetError::Validation(format!("Failed to convert tensor to slice: {}", e))
             })?;
             let _ = self.host_data.set(vec);
-            Ok(cast_slice(self.host_data.get().unwrap().as_slice()))
+            // SAFETY: `set` was called immediately above; even if it fails (already
+            // initialized by a concurrent call), `get()` will return `Some`.
+            Ok(cast_slice(self.host_data.get().expect("host_data was just initialized").as_slice()))
         }
     }
 

--- a/crates/bitnet-inference/src/engine.rs
+++ b/crates/bitnet-inference/src/engine.rs
@@ -187,7 +187,8 @@ impl ModelInfo {
         if self.categorized_metadata.is_none() {
             self.categorized_metadata = Some(self.compute_categorized_metadata());
         }
-        self.categorized_metadata.as_ref().unwrap()
+        // SAFETY: `is_none()` guard above guarantees `Some`
+        self.categorized_metadata.as_ref().expect("categorized_metadata was just set above")
     }
 
     /// Get tensor statistics, computing them if not already available
@@ -195,7 +196,8 @@ impl ModelInfo {
         if self.tensor_statistics.is_none() {
             self.tensor_statistics = Some(self.compute_tensor_statistics());
         }
-        self.tensor_statistics.as_ref().unwrap()
+        // SAFETY: `is_none()` guard above guarantees `Some`
+        self.tensor_statistics.as_ref().expect("tensor_statistics was just set above")
     }
 
     /// Compute categorized metadata from raw KV pairs

--- a/crates/bitnet-inference/src/generation/autoregressive.rs
+++ b/crates/bitnet-inference/src/generation/autoregressive.rs
@@ -185,7 +185,7 @@ impl AutoregressiveGenerator {
     pub fn new(config: GenerationConfig, device: Device) -> Result<Self> {
         let seed = config.seed.unwrap_or_else(|| {
             use std::time::{SystemTime, UNIX_EPOCH};
-            SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64
+            SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos() as u64
         });
 
         let rng = ChaCha8Rng::seed_from_u64(seed);

--- a/crates/bitnet-inference/src/gguf.rs
+++ b/crates/bitnet-inference/src/gguf.rs
@@ -41,7 +41,7 @@ pub fn parse_header(buf: &[u8]) -> Result<GgufHeader> {
         return Err(GgufError::ShortHeader(buf.len()));
     }
 
-    let magic = <[u8; 4]>::try_from(&buf[0..4]).unwrap();
+    let magic = <[u8; 4]>::try_from(&buf[0..4]).map_err(|_| GgufError::Malformed)?;
     if &magic != b"GGUF" {
         return Err(GgufError::BadMagic(magic));
     }
@@ -316,4 +316,46 @@ pub fn read_kv_pairs(
     }
 
     Ok(kvs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_header_short_buffer_returns_error() {
+        let buf = [0u8; 10];
+        let err = parse_header(&buf).unwrap_err();
+        assert!(matches!(err, GgufError::ShortHeader(10)));
+    }
+
+    #[test]
+    fn parse_header_bad_magic_returns_error() {
+        let mut buf = [0u8; 24];
+        buf[0..4].copy_from_slice(b"BARF");
+        let err = parse_header(&buf).unwrap_err();
+        assert!(matches!(err, GgufError::BadMagic(_)));
+    }
+
+    #[test]
+    fn parse_header_unsupported_version_returns_error() {
+        let mut buf = [0u8; 24];
+        buf[0..4].copy_from_slice(b"GGUF");
+        buf[4..8].copy_from_slice(&99u32.to_le_bytes());
+        let err = parse_header(&buf).unwrap_err();
+        assert!(matches!(err, GgufError::UnsupportedVersion(99)));
+    }
+
+    #[test]
+    fn parse_header_valid_v3() {
+        let mut buf = [0u8; 24];
+        buf[0..4].copy_from_slice(b"GGUF");
+        buf[4..8].copy_from_slice(&3u32.to_le_bytes());
+        buf[8..16].copy_from_slice(&42u64.to_le_bytes());
+        buf[16..24].copy_from_slice(&7u64.to_le_bytes());
+        let hdr = parse_header(&buf).unwrap();
+        assert_eq!(hdr.version, 3);
+        assert_eq!(hdr.n_tensors, 42);
+        assert_eq!(hdr.n_kv, 7);
+    }
 }

--- a/crates/bitnet-inference/src/runtime_utils.rs
+++ b/crates/bitnet-inference/src/runtime_utils.rs
@@ -19,15 +19,19 @@ where
             // We're already in a runtime context, so we need to spawn a blocking task
             // to avoid blocking the runtime
             let result = std::thread::spawn(move || {
-                let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
-                rt.block_on(future)
+                let rt = tokio::runtime::Runtime::new().map_err(|e| {
+                    BitNetError::Inference(InferenceError::GenerationFailed {
+                        reason: format!("Failed to create runtime: {e}"),
+                    })
+                })?;
+                Ok::<T, BitNetError>(rt.block_on(future))
             })
             .join()
             .map_err(|_| {
                 BitNetError::Inference(InferenceError::GenerationFailed {
                     reason: "Thread panicked during block_on".to_string(),
                 })
-            })?;
+            })??;
             Ok(result)
         }
         Err(_) => {

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -383,11 +383,9 @@ impl GgufLoader {
 
         // Check if correction is configured (policy or env)
         let cfg = Self::select_ln_rescale_cfg(policy_plan);
-        if cfg.is_none() {
+        let Some((target_rms, clamp)) = cfg else {
             return Ok((w, None));
-        }
-
-        let (target_rms, clamp) = cfg.unwrap();
+        };
 
         // Convert to FP32 for statistics
         let w32 = w.to_dtype(DType::F32).map_err(|e| BitNetError::Validation(e.to_string()))?;
@@ -822,7 +820,8 @@ impl FormatLoader for GgufLoader {
             // Read entire file into memory
             let buf = std::fs::read(path).map_err(BitNetError::Io)?;
             _owned = Some(buf);
-            _owned.as_ref().unwrap().as_slice()
+            // SAFETY: `_owned` was just assigned `Some` on the line above
+            _owned.as_ref().expect("_owned was just assigned").as_slice()
         };
 
         let reader = GgufReader::new(data)?;

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -994,7 +994,9 @@ fn cast_scales_to_f32(
         candle_core::DType::F64 => {
             let mut out = Vec::with_capacity(n);
             for chunk in bytes.chunks_exact(8).take(n) {
-                out.push(f64::from_le_bytes(chunk.try_into().unwrap()) as f32);
+                out.push(f64::from_le_bytes(
+                    chunk.try_into().map_err(|_| anyhow::anyhow!("f64 chunk size mismatch"))?,
+                ) as f32);
             }
             Ok(out)
         }

--- a/crates/bitnet-models/src/security.rs
+++ b/crates/bitnet-models/src/security.rs
@@ -141,17 +141,19 @@ pub struct SecureModelDownloader {
 
 impl SecureModelDownloader {
     /// Create a new secure model downloader
-    pub fn new(config: ModelSecurity) -> Self {
+    pub fn new(config: ModelSecurity) -> Result<Self> {
         #[cfg(not(target_arch = "wasm32"))]
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(300)) // 5 minute timeout
             .build()
-            .expect("Failed to create HTTP client");
+            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
 
         #[cfg(target_arch = "wasm32")]
-        let client = reqwest::Client::builder().build().expect("Failed to create HTTP client");
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| anyhow!("Failed to create HTTP client: {e}"))?;
 
-        Self { verifier: ModelVerifier::new(config), client }
+        Ok(Self { verifier: ModelVerifier::new(config), client })
     }
 
     /// Download a model with integrity verification

--- a/crates/bitnet-quantization/src/qk256_dispatch.rs
+++ b/crates/bitnet-quantization/src/qk256_dispatch.rs
@@ -39,7 +39,7 @@ pub fn qk256_gemv(
     let row_stride_bytes = blocks_per_row * i2s_qk256::QK256_PACKED_BYTES;
 
     i2s_qk256::gemv_qk256(packed, activations, output, rows, cols, row_stride_bytes)
-        .expect("qk256_gemv dispatch should succeed for validated inputs");
+        .expect("qk256_gemv: internal dispatch failed after input validation (this is a bug)");
 }
 
 /// Scalar legacy QK256 GEMV (kept for benchmark compatibility).

--- a/crates/bitnet-server/src/caching/kv_cache.rs
+++ b/crates/bitnet-server/src/caching/kv_cache.rs
@@ -1,7 +1,7 @@
 //! KV cache optimization with memory pooling
 #![allow(dead_code, unused_imports, unused_variables)]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -267,7 +267,10 @@ impl MemoryPool {
     pub fn f32_slice_mut(&mut self, offset: usize, len_f32: usize) -> &mut [f32] {
         let bytes = len_f32.checked_mul(core::mem::size_of::<f32>()).expect("f32 len overflow");
         assert!(offset.is_multiple_of(core::mem::align_of::<f32>()), "unaligned f32 slice");
-        assert!(offset.checked_add(bytes).unwrap() <= self.memory.len(), "OOB f32 slice");
+        assert!(
+            offset.checked_add(bytes).is_some_and(|end| end <= self.memory.len()),
+            "OOB f32 slice"
+        );
         unsafe {
             let ptr = self.memory.as_mut_ptr().add(offset) as *mut f32;
             core::slice::from_raw_parts_mut(ptr, len_f32)
@@ -279,7 +282,10 @@ impl MemoryPool {
     pub fn f32_slice(&self, offset: usize, len_f32: usize) -> &[f32] {
         let bytes = len_f32.checked_mul(core::mem::size_of::<f32>()).expect("f32 len overflow");
         assert!(offset.is_multiple_of(core::mem::align_of::<f32>()), "unaligned f32 slice");
-        assert!(offset.checked_add(bytes).unwrap() <= self.memory.len(), "OOB f32 slice");
+        assert!(
+            offset.checked_add(bytes).is_some_and(|end| end <= self.memory.len()),
+            "OOB f32 slice"
+        );
         unsafe {
             let ptr = self.memory.as_ptr().add(offset) as *const f32;
             core::slice::from_raw_parts(ptr, len_f32)
@@ -394,8 +400,9 @@ impl KVCacheManager {
             // Zero-initialize the allocated memory
             {
                 let mut pool = self.memory_pool.write().await;
-                pool.zero_range(key_off, key_size).expect("zero_range failed for key region");
-                pool.zero_range(val_off, value_size).expect("zero_range failed for value region");
+                pool.zero_range(key_off, key_size).context("zero_range failed for key region")?;
+                pool.zero_range(val_off, value_size)
+                    .context("zero_range failed for value region")?;
             }
 
             // Create the cache entry
@@ -455,9 +462,9 @@ impl KVCacheManager {
                 {
                     let mut pool = self.memory_pool.write().await;
                     pool.zero_range(key_off, key_size)
-                        .expect("zero_range failed for key region (post-evict)");
+                        .context("zero_range failed for key region (post-evict)")?;
                     pool.zero_range(val_off, value_size)
-                        .expect("zero_range failed for value region (post-evict)");
+                        .context("zero_range failed for value region (post-evict)")?;
                 }
 
                 let entry = KVCacheEntry {


### PR DESCRIPTION
## Error Handling Audit

Audit and improve error handling across 6 core crates, replacing panicking `.unwrap()` and `.expect()` calls in production code paths with proper error propagation.

### Changes by crate

| Crate | File | Fix |
|-------|------|-----|
| `bitnet-common` | `tensor.rs` | Add safety comment on structurally-safe OnceLock `.expect()` |
| `bitnet-inference` | `gguf.rs` | Replace `.unwrap()` with `.map_err()` in GGUF header parsing |
| `bitnet-inference` | `autoregressive.rs` | Use `.unwrap_or_default()` for `SystemTime` fallback |
| `bitnet-inference` | `engine.rs` | Add safety comments on guarded `.unwrap()` → `.expect()` |
| `bitnet-inference` | `runtime_utils.rs` | Propagate `Runtime::new()` errors instead of panicking |
| `bitnet-models` | `loader.rs` | Use let-else for Option destructuring; add safety comment |
| `bitnet-models` | `gguf_simple.rs` | Propagate f64 chunk conversion errors via `?` |
| `bitnet-models` | `security.rs` | Return `Result` from `SecureModelDownloader::new()` |
| `bitnet-quantization` | `qk256_dispatch.rs` | Improve `.expect()` message to indicate bug |
| `bitnet-server` | `kv_cache.rs` | Propagate `zero_range` errors with `.context()`; eliminate nested `.unwrap()` in bounds checks |

### Tests
- Added 4 error-path unit tests for GGUF header parsing
- All existing tests pass (pre-existing fixture/runtime failures excluded)
- `cargo clippy` clean on all 5 crates

### Not changed (by design)
- `.unwrap()`/`.expect()` in test code (allowed by `clippy.toml`)
- Prometheus OnceLock getters (standard init-or-panic pattern)
- Regex OnceLock patterns (compile-time-verified literals)
- Hot-path `.expect()` with structural guarantees (e.g., `chunks_exact`)