### PR TITLE
feat(cli): add global output-format, quiet, verbose, no-color flags

### DIFF
--- a/crates/bitnet-cli/src/lib.rs
+++ b/crates/bitnet-cli/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod config;
 pub mod exit;
 pub mod ln_rules;
+pub mod output;
 pub mod tokenizer_discovery;
 
 /// Build the CLI command for external use (e.g., in tests)

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -19,6 +19,8 @@ use console::style;
 use std::io;
 use tracing::{debug, error, info, warn};
 
+use output::{OutputConfig, OutputFormat};
+
 mod backend;
 #[cfg(feature = "full-cli")]
 mod commands;
@@ -26,6 +28,7 @@ mod config;
 mod exit;
 #[cfg(feature = "full-cli")]
 mod ln_rules;
+pub mod output;
 mod sampling;
 mod score;
 pub mod tokenizer_discovery;
@@ -150,6 +153,22 @@ struct Cli {
     /// Print CLI interface version and exit
     #[arg(long)]
     interface_version: bool,
+
+    /// Output format (text, json)
+    #[arg(long = "output-format", value_name = "FORMAT", default_value = "text", global = true)]
+    output_format: String,
+
+    /// Suppress all non-essential output
+    #[arg(long, global = true)]
+    quiet: bool,
+
+    /// Enable verbose/debug-level output
+    #[arg(long, global = true, conflicts_with = "quiet")]
+    verbose: bool,
+
+    /// Disable colored output
+    #[arg(long, global = true)]
+    no_color: bool,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -443,6 +462,24 @@ async fn main() -> Result<()> {
     // Parse CLI arguments
     let cli = Cli::parse();
 
+    // Build global output configuration from CLI flags
+    if cli.no_color {
+        console::set_colors_enabled(false);
+        console::set_colors_enabled_stderr(false);
+    }
+
+    let output_format: OutputFormat = cli.output_format.parse().unwrap_or_else(|e| {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    });
+
+    let out = OutputConfig {
+        format: output_format,
+        quiet: cli.quiet,
+        verbose: cli.verbose,
+        color: !cli.no_color,
+    };
+
     // Handle shell completions
     if let Some(shell) = cli.completions {
         generate_completions(shell);
@@ -465,8 +502,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Setup logging
-    setup_logging(&config, cli.log_level.as_deref())?;
+    // Setup logging (--quiet/--verbose override --log-level)
+    let effective_log_level = out.log_level_override().map(String::from).or(cli.log_level.clone());
+    setup_logging(&config, effective_log_level.as_deref())?;
 
     let startup_contract_report =
         evaluate_and_emit(RuntimeComponent::Cli, ContractPolicy::Observe)?;
@@ -558,6 +596,7 @@ async fn main() -> Result<()> {
                 logits_topk,
                 assert_greedy,
                 no_warnings,
+                &out,
             )
             .await
         }
@@ -576,7 +615,7 @@ async fn main() -> Result<()> {
         }
         Some(Commands::Score(args)) => score::run_score(&args).await,
         Some(Commands::Config { action }) => handle_config_command(action, &config).await,
-        Some(Commands::Info) => show_system_info().await,
+        Some(Commands::Info) => show_system_info(&out).await,
         #[cfg(feature = "full-cli")]
         Some(Commands::Inspect(cmd)) => cmd.execute().await,
         Some(Commands::CompatCheck { path, json, strict, show_kv, kv_limit }) => {
@@ -596,6 +635,49 @@ async fn main() -> Result<()> {
 
     // Handle errors gracefully
     if let Err(e) = result {
+        let msg = format!("{}", e);
+
+        // Provide flag suggestions for common misspellings
+        if msg.contains("unexpected argument") || msg.contains("unrecognized") {
+            let known_flags = &[
+                "--max-tokens",
+                "--max-new-tokens",
+                "--n-predict",
+                "--temperature",
+                "--top-k",
+                "--top-p",
+                "--repetition-penalty",
+                "--model",
+                "--tokenizer",
+                "--prompt",
+                "--prompt-template",
+                "--greedy",
+                "--seed",
+                "--format",
+                "--quiet",
+                "--verbose",
+                "--no-color",
+                "--json-out",
+            ];
+            if let Some(start) = msg.find("'--")
+                && let Some(end) = msg[start + 1..].find('\'')
+            {
+                let unknown = &msg[start + 1..start + 1 + end];
+                let suggestions = output::suggest_flag(unknown, known_flags);
+                if !suggestions.is_empty() {
+                    eprintln!(
+                        "\n  {} Did you mean {}?",
+                        style("hint:").cyan().bold(),
+                        suggestions
+                            .iter()
+                            .map(|s| format!("'{}'", style(s).green()))
+                            .collect::<Vec<_>>()
+                            .join(" or ")
+                    );
+                }
+            }
+        }
+
         error!("Command failed: {}", e);
 
         // Show error chain
@@ -893,6 +975,7 @@ async fn run_simple_generation(
     logits_topk: usize,
     assert_greedy: bool,
     no_warnings: bool,
+    out: &OutputConfig,
 ) -> Result<()> {
     use crate::sampling::Sampler;
     use bitnet_common::Device;
@@ -945,15 +1028,35 @@ async fn run_simple_generation(
         })?
     };
 
-    println!("Loading model from: {}", model_path.display());
+    // Show model summary at startup (before loading)
+    if let Some(summary) = output::summarize_model(&model_path, "cpu") {
+        out.status(&format!("\n{}", style("Model Info").bold().cyan()));
+        out.status(&format!("{summary}"));
+    }
+
+    out.status(&format!("Loading model from: {}", model_path.display()));
 
     // Check for QK256 scalar kernel usage and emit performance warnings
     if !no_warnings {
         check_and_warn_qk256_performance(&model_path, max_new_tokens)?;
     }
 
-    // Try real loader first
+    // Try real loader first, with a progress spinner
     use bitnet_models::loader::{LoadConfig, ModelLoader};
+
+    let spinner = if !out.quiet && out.format != OutputFormat::Json {
+        let pb = indicatif::ProgressBar::new_spinner();
+        pb.set_style(
+            indicatif::ProgressStyle::default_spinner()
+                .template("{spinner:.cyan} {msg}")
+                .expect("valid template"),
+        );
+        pb.set_message("Loading model...");
+        pb.enable_steady_tick(std::time::Duration::from_millis(80));
+        Some(pb)
+    } else {
+        None
+    };
 
     let loader = ModelLoader::new(Device::Cpu);
     let load_config =
@@ -1017,6 +1120,11 @@ async fn run_simple_generation(
         }
     };
 
+    // Finish spinner after model loading
+    if let Some(pb) = spinner {
+        pb.finish_with_message("Model loaded \u{2713}");
+    }
+
     // Load tokenizer with auto-discovery
     // Priority: explicit path → sibling tokenizer.json → parent tokenizer.json → GGUF embedded → mock
 
@@ -1038,7 +1146,7 @@ async fn run_simple_generation(
             Ok(path) => {
                 // Found tokenizer via discovery
                 external_tokenizer = true;
-                println!("Loading tokenizer from: {}", path.display());
+                out.status(&format!("Loading tokenizer from: {}", path.display()));
 
                 match bitnet_tokenizers::load_tokenizer(&path) {
                     Ok(tok) => tok,
@@ -1053,14 +1161,14 @@ async fn run_simple_generation(
                                 path.display()
                             );
                         }
-                        println!("Warning: Using mock tokenizer due to: {e}");
+                        out.warn(&format!("Warning: Using mock tokenizer due to: {e}"));
                         std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
                     }
                 }
             }
             Err(_discovery_err) => {
                 // Discovery failed, try GGUF embedded as fallback
-                println!("No external tokenizer found, attempting to load from GGUF model...");
+                out.status("No external tokenizer found, attempting to load from GGUF model...");
 
                 // Read the GGUF file to get tokenizer metadata
                 let gguf_data = std::fs::read(&model_path)
@@ -1075,7 +1183,7 @@ async fn run_simple_generation(
 
                 match bitnet_tokenizers::loader::load_tokenizer_from_gguf_reader(&reader) {
                     Ok(tok) => {
-                        println!("Successfully loaded SentencePiece tokenizer from GGUF");
+                        out.status("Successfully loaded SentencePiece tokenizer from GGUF");
                         tok
                     }
                     Err(e) => {
@@ -1102,7 +1210,7 @@ async fn run_simple_generation(
                                 model_dir.display()
                             );
                         }
-                        println!("Warning: Using mock tokenizer due to: {e}");
+                        out.warn(&format!("Warning: Using mock tokenizer due to: {e}"));
                         std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
                     }
                 }
@@ -1160,7 +1268,7 @@ async fn run_simple_generation(
     // Tokenize formatted prompt with proper BOS policy and special token parsing
     let parse_special = template_type.parse_special();
     let mut tokens = tokenizer.encode(&formatted_prompt, bos_policy, parse_special)?;
-    println!("Input tokens ({}): {:?}", tokens.len(), &tokens[..10.min(tokens.len())]);
+    out.debug(&format!("Input tokens ({}): {:?}", tokens.len(), &tokens[..10.min(tokens.len())]));
 
     // Create KV cache
     let cache = KVCache::new(&config, 1, &candle_core::Device::Cpu)?;
@@ -1169,8 +1277,10 @@ async fn run_simple_generation(
     // Create sampler
     let mut sampler = Sampler::new(temperature, top_k, top_p, repetition_penalty, seed);
 
-    print!("Generating: {}", formatted_prompt);
-    std::io::Write::flush(&mut std::io::stdout())?;
+    if !out.quiet && out.format != OutputFormat::Json {
+        print!("Generating: {}", formatted_prompt);
+        std::io::Write::flush(&mut std::io::stdout())?;
+    }
 
     // Track timing
     let start_time = std::time::Instant::now();
@@ -1357,10 +1467,12 @@ async fn run_simple_generation(
             first_token_ms = Some(start_time.elapsed().as_millis() as u64);
         }
 
-        // Decode and print the new token
+        // Decode and print the new token (streaming text output)
         let token_text = tokenizer.decode(&[next_token])?;
-        print!("{}", token_text);
-        std::io::Write::flush(&mut std::io::stdout())?;
+        if !out.quiet && out.format != OutputFormat::Json {
+            print!("{}", token_text);
+            std::io::Write::flush(&mut std::io::stdout())?;
+        }
 
         // Maintain rolling tail (if present)
         if let Some(t) = &mut tail {
@@ -1411,16 +1523,18 @@ async fn run_simple_generation(
         0.0
     };
 
-    println!("\n\nGeneration complete!");
-    println!(
-        "Generated {} tokens in {}ms ({:.1} tok/s)",
-        generated_tokens.len(),
-        total_ms,
-        tok_per_sec
-    );
+    if !out.quiet && out.format != OutputFormat::Json {
+        println!("\n\nGeneration complete!");
+        println!(
+            "Generated {} tokens in {}ms ({:.1} tok/s)",
+            generated_tokens.len(),
+            total_ms,
+            tok_per_sec
+        );
+    }
 
     // Output JSON if requested
-    if let Some(json_path) = json_out {
+    if let Some(ref json_path) = json_out {
         let generated_text = tokenizer.decode(&generated_tokens)?;
 
         // Get tokenizer info
@@ -1481,8 +1595,31 @@ async fn run_simple_generation(
                 None
             },
         });
-        std::fs::write(&json_path, serde_json::to_string_pretty(&output)?)?;
+        std::fs::write(json_path, serde_json::to_string_pretty(&output)?)?;
         println!("JSON output written to: {}", json_path.display());
+    }
+
+    // Emit JSON to stdout if --format json was used (distinct from --json-out file)
+    if out.format == OutputFormat::Json && json_out.is_none() {
+        let generated_text = tokenizer.decode(&generated_tokens)?;
+        let prompt_tokens_len = tokens.len() - generated_tokens.len();
+        let result = serde_json::json!({
+            "prompt": prompt,
+            "text": generated_text,
+            "tokens": {
+                "prompt": prompt_tokens_len,
+                "generated": generated_tokens.len(),
+                "total": prompt_tokens_len + generated_tokens.len(),
+            },
+            "latency": {
+                "total_ms": total_ms,
+                "first_token_ms": first_token_ms,
+            },
+            "throughput": {
+                "tokens_per_second": tok_per_sec,
+            },
+        });
+        println!("{}", serde_json::to_string_pretty(&result)?);
     }
 
     // Dump IDs if requested
@@ -1608,7 +1745,20 @@ fn compute_rms(xs: &[f32]) -> f32 {
 }
 
 /// Show system information
-async fn show_system_info() -> Result<()> {
+async fn show_system_info(out: &OutputConfig) -> Result<()> {
+    // JSON mode: collect all info and emit as JSON
+    if out.format == OutputFormat::Json {
+        let info = serde_json::json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "cpu_cores": num_cpus::get(),
+            "gpu_compiled": cfg!(any(feature = "gpu", feature = "cuda")),
+        });
+        println!("{}", serde_json::to_string_pretty(&info)?);
+        return Ok(());
+    }
+
     println!("{}", style("BitNet System Information").bold().cyan());
     println!();
 

--- a/crates/bitnet-cli/src/output.rs
+++ b/crates/bitnet-cli/src/output.rs
@@ -1,0 +1,345 @@
+//! Centralized output configuration for CLI commands.
+//!
+//! Provides [`OutputConfig`] which controls how CLI output is rendered:
+//! - `--format json` emits machine-readable JSON to stdout
+//! - `--quiet` suppresses all non-essential output
+//! - `--verbose` enables debug-level messages
+//! - `--no-color` disables ANSI color codes
+
+use serde::Serialize;
+use std::io::Write;
+
+/// Output format for CLI commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutputFormat {
+    /// Human-readable text (default).
+    #[default]
+    Text,
+    /// Machine-readable JSON.
+    Json,
+}
+
+impl std::str::FromStr for OutputFormat {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "text" => Ok(Self::Text),
+            "json" => Ok(Self::Json),
+            other => Err(format!("unknown format '{other}'. Expected one of: text, json")),
+        }
+    }
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text => write!(f, "text"),
+            Self::Json => write!(f, "json"),
+        }
+    }
+}
+
+/// Global output configuration derived from CLI flags.
+#[derive(Debug, Clone)]
+pub struct OutputConfig {
+    pub format: OutputFormat,
+    pub quiet: bool,
+    pub verbose: bool,
+    pub color: bool,
+}
+
+impl Default for OutputConfig {
+    fn default() -> Self {
+        Self { format: OutputFormat::Text, quiet: false, verbose: false, color: true }
+    }
+}
+
+impl OutputConfig {
+    /// Print a status message (suppressed in quiet mode and JSON mode).
+    pub fn status(&self, msg: &str) {
+        if self.quiet || self.format == OutputFormat::Json {
+            return;
+        }
+        eprintln!("{}", msg);
+    }
+
+    /// Print a verbose/debug message (only when `--verbose` is active).
+    pub fn debug(&self, msg: &str) {
+        if !self.verbose || self.format == OutputFormat::Json {
+            return;
+        }
+        eprintln!("[debug] {}", msg);
+    }
+
+    /// Print a warning (shown unless quiet).
+    pub fn warn(&self, msg: &str) {
+        if self.quiet {
+            return;
+        }
+        if self.format == OutputFormat::Json {
+            return;
+        }
+        eprintln!("{}", msg);
+    }
+
+    /// Emit a final result value. In JSON mode it is serialized to stdout;
+    /// in text mode `text_fn` is called to render human output.
+    pub fn emit_result<T: Serialize>(
+        &self,
+        value: &T,
+        text_fn: impl FnOnce(&T),
+    ) -> anyhow::Result<()> {
+        match self.format {
+            OutputFormat::Json => {
+                let json = serde_json::to_string_pretty(value)?;
+                let mut stdout = std::io::stdout().lock();
+                writeln!(stdout, "{json}")?;
+            }
+            OutputFormat::Text => {
+                text_fn(value);
+            }
+        }
+        Ok(())
+    }
+
+    /// Return the tracing log level implied by the flags.
+    ///
+    /// `--quiet` forces `error`, `--verbose` forces `debug`,
+    /// otherwise returns `None` (use existing default).
+    pub fn log_level_override(&self) -> Option<&'static str> {
+        if self.quiet {
+            Some("error")
+        } else if self.verbose {
+            Some("debug")
+        } else {
+            None
+        }
+    }
+}
+
+/// Summary of the loaded model, printed at startup.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelSummary {
+    pub path: String,
+    pub format: String,
+    pub quantization: String,
+    pub parameters: Option<String>,
+    pub device: String,
+    pub vocab_size: Option<u32>,
+    pub context_length: Option<u32>,
+}
+
+impl std::fmt::Display for ModelSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "  Model:          {}", self.path)?;
+        writeln!(f, "  Format:         {}", self.format)?;
+        writeln!(f, "  Quantization:   {}", self.quantization)?;
+        if let Some(p) = &self.parameters {
+            writeln!(f, "  Parameters:     {p}")?;
+        }
+        writeln!(f, "  Device:         {}", self.device)?;
+        if let Some(v) = self.vocab_size {
+            writeln!(f, "  Vocab size:     {v}")?;
+        }
+        if let Some(c) = self.context_length {
+            writeln!(f, "  Context length: {c}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Build a [`ModelSummary`] from a GGUF file path without loading tensors.
+pub fn summarize_model(model_path: &std::path::Path, device: &str) -> Option<ModelSummary> {
+    use bitnet_models::GgufReader;
+
+    let data = std::fs::read(model_path).ok()?;
+    let reader = GgufReader::new(&data).ok()?;
+
+    let quantization =
+        reader.get_string_metadata("general.quantization_type").unwrap_or_else(|| {
+            reader
+                .get_quantization_type()
+                .map(|q| format!("{q:?}"))
+                .unwrap_or_else(|| "unknown".into())
+        });
+
+    let vocab_size = reader
+        .get_u32_metadata("llama.vocab_size")
+        .or_else(|| reader.get_u32_metadata("tokenizer.ggml.tokens"));
+
+    let context_length = reader.get_u32_metadata("llama.context_length");
+
+    // Estimate parameter count from model name heuristics
+    let parameters = reader
+        .get_string_metadata("general.name")
+        .and_then(|name| {
+            let name_upper = name.to_uppercase();
+            for suffix in ["B", "M"] {
+                for part in name_upper.split(|c: char| !c.is_alphanumeric()) {
+                    if let Some(num_str) = part.strip_suffix(suffix)
+                        && let Ok(n) = num_str.parse::<f64>()
+                    {
+                        let count = if suffix == "B" { n * 1e9 } else { n * 1e6 };
+                        return Some(format_param_count(count as u64));
+                    }
+                }
+            }
+            None
+        })
+        .or_else(|| {
+            let tc = reader.tensor_count();
+            if tc > 0 { Some(format!("{tc} tensors")) } else { None }
+        });
+
+    Some(ModelSummary {
+        path: model_path.display().to_string(),
+        format: "GGUF".into(),
+        quantization,
+        parameters,
+        device: device.into(),
+        vocab_size,
+        context_length,
+    })
+}
+
+fn format_param_count(count: u64) -> String {
+    if count >= 1_000_000_000 {
+        format!("{:.1}B", count as f64 / 1e9)
+    } else if count >= 1_000_000 {
+        format!("{:.0}M", count as f64 / 1e6)
+    } else {
+        format!("{count}")
+    }
+}
+
+/// Suggest corrections for an unknown CLI flag.
+///
+/// Returns up to 3 candidates sorted by edit distance.
+pub fn suggest_flag(unknown: &str, known: &[&str]) -> Vec<String> {
+    let mut scored: Vec<(&str, usize)> = known
+        .iter()
+        .filter_map(|k| {
+            let d = edit_distance(unknown, k);
+            if d <= 3 && d < k.len() { Some((*k, d)) } else { None }
+        })
+        .collect();
+    scored.sort_by_key(|&(_, d)| d);
+    scored.into_iter().take(3).map(|(k, _)| k.to_string()).collect()
+}
+
+/// Simple Levenshtein edit distance.
+#[allow(clippy::needless_range_loop)]
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let (m, n) = (a.len(), b.len());
+    let mut dp = vec![vec![0usize; n + 1]; m + 1];
+    for i in 0..=m {
+        dp[i][0] = i;
+    }
+    for j in 0..=n {
+        dp[0][j] = j;
+    }
+    for i in 1..=m {
+        for j in 1..=n {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            dp[i][j] = (dp[i - 1][j] + 1).min(dp[i][j - 1] + 1).min(dp[i - 1][j - 1] + cost);
+        }
+    }
+    dp[m][n]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_output_format_parse() {
+        assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+        assert_eq!("text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
+        assert_eq!("JSON".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+        assert!("xml".parse::<OutputFormat>().is_err());
+    }
+
+    #[test]
+    fn test_output_format_display() {
+        assert_eq!(OutputFormat::Text.to_string(), "text");
+        assert_eq!(OutputFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn test_suggest_flag_close_match() {
+        let known = &["--max-tokens", "--max-new-tokens", "--temperature", "--top-k"];
+        let suggestions = suggest_flag("--max-token", known);
+        assert!(!suggestions.is_empty());
+        assert_eq!(suggestions[0], "--max-tokens");
+    }
+
+    #[test]
+    fn test_suggest_flag_no_match() {
+        let known = &["--max-tokens", "--temperature"];
+        let suggestions = suggest_flag("--zzzzzzzzz", known);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn test_edit_distance_identical() {
+        assert_eq!(edit_distance("abc", "abc"), 0);
+    }
+
+    #[test]
+    fn test_edit_distance_one_off() {
+        assert_eq!(edit_distance("abc", "abd"), 1);
+        assert_eq!(edit_distance("abc", "abcd"), 1);
+    }
+
+    #[test]
+    fn test_output_config_log_level() {
+        let quiet = OutputConfig { quiet: true, ..Default::default() };
+        assert_eq!(quiet.log_level_override(), Some("error"));
+
+        let verbose = OutputConfig { verbose: true, ..Default::default() };
+        assert_eq!(verbose.log_level_override(), Some("debug"));
+
+        let default = OutputConfig::default();
+        assert_eq!(default.log_level_override(), None);
+    }
+
+    #[test]
+    fn test_output_config_status_suppressed_in_quiet() {
+        let config = OutputConfig { quiet: true, ..Default::default() };
+        config.status("should be suppressed");
+    }
+
+    #[test]
+    fn test_output_config_emit_json() {
+        let config = OutputConfig { format: OutputFormat::Json, ..Default::default() };
+        let value = serde_json::json!({"key": "value"});
+        assert!(config.emit_result(&value, |_| {}).is_ok());
+    }
+
+    #[test]
+    fn test_model_summary_display() {
+        let summary = ModelSummary {
+            path: "model.gguf".into(),
+            format: "GGUF".into(),
+            quantization: "I2_S".into(),
+            parameters: Some("2.0B".into()),
+            device: "cpu".into(),
+            vocab_size: Some(32000),
+            context_length: Some(2048),
+        };
+        let display = format!("{summary}");
+        assert!(display.contains("model.gguf"));
+        assert!(display.contains("I2_S"));
+        assert!(display.contains("2.0B"));
+    }
+
+    #[test]
+    fn test_format_param_count() {
+        assert_eq!(format_param_count(2_000_000_000), "2.0B");
+        assert_eq!(format_param_count(7_500_000_000), "7.5B");
+        assert_eq!(format_param_count(350_000_000), "350M");
+        assert_eq!(format_param_count(1000), "1000");
+    }
+}

--- a/crates/bitnet-cli/tests/cli_ux_flags.rs
+++ b/crates/bitnet-cli/tests/cli_ux_flags.rs
@@ -1,0 +1,248 @@
+//! Tests for CLI UX improvements: --format, --quiet, --verbose, --no-color flags.
+//!
+//! These tests verify the output module and the new global CLI flags
+//! without requiring a model file.
+
+#![cfg(feature = "full-cli")]
+
+use bitnet_cli::output::{ModelSummary, OutputConfig, OutputFormat, suggest_flag};
+
+#[cfg(test)]
+mod output_format_tests {
+    use super::*;
+
+    #[test]
+    fn parse_text_format() {
+        assert_eq!("text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
+    }
+
+    #[test]
+    fn parse_json_format() {
+        assert_eq!("json".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+    }
+
+    #[test]
+    fn parse_case_insensitive() {
+        assert_eq!("JSON".parse::<OutputFormat>().unwrap(), OutputFormat::Json);
+        assert_eq!("Text".parse::<OutputFormat>().unwrap(), OutputFormat::Text);
+    }
+
+    #[test]
+    fn parse_invalid_format_rejected() {
+        assert!("xml".parse::<OutputFormat>().is_err());
+        assert!("yaml".parse::<OutputFormat>().is_err());
+    }
+}
+
+#[cfg(test)]
+mod output_config_tests {
+    use super::*;
+
+    #[test]
+    fn quiet_overrides_log_level_to_error() {
+        let config = OutputConfig { quiet: true, ..Default::default() };
+        assert_eq!(config.log_level_override(), Some("error"));
+    }
+
+    #[test]
+    fn verbose_overrides_log_level_to_debug() {
+        let config = OutputConfig { verbose: true, ..Default::default() };
+        assert_eq!(config.log_level_override(), Some("debug"));
+    }
+
+    #[test]
+    fn default_has_no_log_level_override() {
+        let config = OutputConfig::default();
+        assert_eq!(config.log_level_override(), None);
+    }
+
+    #[test]
+    fn emit_result_json_mode_serializes() {
+        let config = OutputConfig { format: OutputFormat::Json, ..Default::default() };
+        let value = serde_json::json!({"status": "ok"});
+        // Should not panic
+        config.emit_result(&value, |_| {}).unwrap();
+    }
+
+    #[test]
+    fn emit_result_text_mode_calls_fn() {
+        let config = OutputConfig { format: OutputFormat::Text, ..Default::default() };
+        let mut called = false;
+        config
+            .emit_result(&serde_json::json!({}), |_| {
+                called = true;
+            })
+            .unwrap();
+        assert!(called);
+    }
+
+    #[test]
+    fn status_suppressed_in_quiet_mode() {
+        // This test verifies no panic; actual output goes to stderr
+        let config = OutputConfig { quiet: true, ..Default::default() };
+        config.status("this should not appear");
+    }
+
+    #[test]
+    fn debug_only_shown_when_verbose() {
+        let config = OutputConfig { verbose: false, ..Default::default() };
+        config.debug("should not appear");
+        let verbose = OutputConfig { verbose: true, ..Default::default() };
+        verbose.debug("should appear");
+    }
+}
+
+#[cfg(test)]
+mod suggest_flag_tests {
+    use super::*;
+
+    #[test]
+    fn suggests_close_match() {
+        let known = &["--max-tokens", "--temperature", "--top-k"];
+        let suggestions = suggest_flag("--max-token", known);
+        assert!(!suggestions.is_empty());
+        assert_eq!(suggestions[0], "--max-tokens");
+    }
+
+    #[test]
+    fn suggests_nothing_for_unrelated() {
+        let known = &["--max-tokens", "--temperature"];
+        let suggestions = suggest_flag("--zzzzzzzzz", known);
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn suggests_multiple_candidates() {
+        let known = &["--max-tokens", "--max-new-tokens"];
+        let suggestions = suggest_flag("--max-token", known);
+        // Should suggest both since both are close
+        assert!(!suggestions.is_empty());
+    }
+
+    #[test]
+    fn suggests_verbose_for_verbos() {
+        let known = &["--verbose", "--version", "--quiet"];
+        let suggestions = suggest_flag("--verbos", known);
+        assert!(!suggestions.is_empty());
+        assert!(suggestions.contains(&"--verbose".to_string()));
+    }
+}
+
+#[cfg(test)]
+mod model_summary_tests {
+    use super::*;
+
+    #[test]
+    fn model_summary_display_contains_fields() {
+        let summary = ModelSummary {
+            path: "test-model.gguf".into(),
+            format: "GGUF".into(),
+            quantization: "I2_S".into(),
+            parameters: Some("2.0B".into()),
+            device: "cpu".into(),
+            vocab_size: Some(32000),
+            context_length: Some(2048),
+        };
+        let output = format!("{summary}");
+        assert!(output.contains("test-model.gguf"));
+        assert!(output.contains("GGUF"));
+        assert!(output.contains("I2_S"));
+        assert!(output.contains("2.0B"));
+        assert!(output.contains("cpu"));
+        assert!(output.contains("32000"));
+        assert!(output.contains("2048"));
+    }
+
+    #[test]
+    fn model_summary_optional_fields_omitted() {
+        let summary = ModelSummary {
+            path: "model.gguf".into(),
+            format: "GGUF".into(),
+            quantization: "unknown".into(),
+            parameters: None,
+            device: "cpu".into(),
+            vocab_size: None,
+            context_length: None,
+        };
+        let output = format!("{summary}");
+        assert!(output.contains("model.gguf"));
+        assert!(!output.contains("Parameters"));
+        assert!(!output.contains("Vocab size"));
+    }
+
+    #[test]
+    fn model_summary_serializes_to_json() {
+        let summary = ModelSummary {
+            path: "model.gguf".into(),
+            format: "GGUF".into(),
+            quantization: "I2_S".into(),
+            parameters: Some("2.0B".into()),
+            device: "cpu".into(),
+            vocab_size: Some(32000),
+            context_length: Some(2048),
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["quantization"], "I2_S");
+        assert_eq!(json["device"], "cpu");
+    }
+}
+
+/// Integration-style test that verifies the CLI parses the new global flags
+/// without requiring a model.
+#[cfg(test)]
+mod cli_global_flags {
+    use clap::Parser;
+
+    /// Minimal stub that mirrors the global flags from main.rs Cli struct
+    #[derive(Parser, Debug)]
+    #[command(name = "bitnet-test")]
+    struct TestCli {
+        #[arg(long = "output-format", default_value = "text", global = true)]
+        output_format: String,
+        #[arg(long, global = true)]
+        quiet: bool,
+        #[arg(long, global = true, conflicts_with = "quiet")]
+        verbose: bool,
+        #[arg(long, global = true)]
+        no_color: bool,
+    }
+
+    #[test]
+    fn default_flags() {
+        let cli = TestCli::try_parse_from(["bitnet-test"]).unwrap();
+        assert_eq!(cli.output_format, "text");
+        assert!(!cli.quiet);
+        assert!(!cli.verbose);
+        assert!(!cli.no_color);
+    }
+
+    #[test]
+    fn format_json_accepted() {
+        let cli = TestCli::try_parse_from(["bitnet-test", "--output-format", "json"]).unwrap();
+        assert_eq!(cli.output_format, "json");
+    }
+
+    #[test]
+    fn quiet_flag() {
+        let cli = TestCli::try_parse_from(["bitnet-test", "--quiet"]).unwrap();
+        assert!(cli.quiet);
+    }
+
+    #[test]
+    fn verbose_flag() {
+        let cli = TestCli::try_parse_from(["bitnet-test", "--verbose"]).unwrap();
+        assert!(cli.verbose);
+    }
+
+    #[test]
+    fn no_color_flag() {
+        let cli = TestCli::try_parse_from(["bitnet-test", "--no-color"]).unwrap();
+        assert!(cli.no_color);
+    }
+
+    #[test]
+    fn quiet_and_verbose_conflict() {
+        let result = TestCli::try_parse_from(["bitnet-test", "--quiet", "--verbose"]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
@@ -26,14 +26,29 @@ Options:
           
           [default: auto]
 
-      --log-level <LEVEL>
-          Log level (trace, debug, info, warn, error)
+      --backend <BACKEND>
+          GPU backend to use
+
+          Possible values:
+          - auto:   Automatically detect best available backend
+          - cpu:    CPU only (no GPU)
+          - cuda:   NVIDIA CUDA
+          - opencl: Intel OpenCL (Arc, Xe)
+          - vulkan: Vulkan compute
+          - metal:  Apple Metal
+          - rocm:   AMD ROCm/HIP
+          - webgpu: WebGPU (experimental)
+          
+          [default: auto]
 
   -p, --prompt <TEXT>
           Input prompt (if not provided, interactive mode is used)
 
       --input-file <PATH>
           Input file containing prompts (one per line)
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
 
   -o, --output <PATH>
           Output file for results
@@ -55,8 +70,16 @@ Options:
           
           [default: 0.7]
 
+      --output-format <FORMAT>
+          Output format (text, json)
+          
+          [default: text]
+
       --top-k <K>
           Top-k sampling parameter
+
+      --quiet
+          Suppress all non-essential output
 
       --top-p <P>
           Top-p (nucleus) sampling parameter
@@ -65,6 +88,9 @@ Options:
           Repetition penalty
           
           [default: 1.1]
+
+      --no-color
+          Disable colored output
 
       --seed <SEED>
           Random seed for reproducible generation

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
@@ -43,26 +43,42 @@ PERFORMANCE:
 Usage: bitnet [OPTIONS] [COMMAND]
 
 Commands:
-  run           Run simple text generation
-  tokenize      Tokenize text and output token IDs as JSON
-  score         Calculate perplexity score for a model
-  inference     Run inference on a model
-  chat          Interactive chat mode (streaming)
-  convert       Convert between model formats
-  benchmark     Benchmark model performance
-  serve         Start inference server
-  config        Manage configuration
-  info          Show system information
-  inspect       Inspect model metadata and diagnostics
-  compat-check  Check GGUF file compatibility using header validation
-  help          Print this message or the help of the given subcommand(s)
+  run            Run simple text generation
+  tokenize       Tokenize text and output token IDs as JSON
+  score          Calculate perplexity score for a model
+  inference      Run inference on a model
+  chat           Interactive chat mode (streaming)
+  convert        Convert between model formats
+  benchmark      Benchmark model performance
+  serve          Start inference server
+  config         Manage configuration
+  info           Show system information
+  inspect        Inspect model metadata and diagnostics
+  compat-check   Check GGUF file compatibility using header validation
+  list-backends  List available GPU backends and their detection status
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
   -c, --config <PATH>
           Configuration file path
 
   -d, --device <DEVICE>
-          Device to use (cpu, cuda, auto)
+          Device to use (cpu, cuda, oneapi, gpu, npu, auto)
+
+      --backend <BACKEND>
+          GPU backend to use
+
+          Possible values:
+          - auto:   Automatically detect best available backend
+          - cpu:    CPU only (no GPU)
+          - cuda:   NVIDIA CUDA
+          - opencl: Intel OpenCL (Arc, Xe)
+          - vulkan: Vulkan compute
+          - metal:  Apple Metal
+          - rocm:   AMD ROCm/HIP
+          - webgpu: WebGPU (experimental)
+          
+          [default: auto]
 
       --log-level <LEVEL>
           Log level (trace, debug, info, warn, error)
@@ -83,6 +99,20 @@ Options:
 
       --interface-version
           Print CLI interface version and exit
+
+      --output-format <FORMAT>
+          Output format (text, json)
+          
+          [default: text]
+
+      --quiet
+          Suppress all non-essential output
+
+      --verbose
+          Enable verbose/debug-level output
+
+      --no-color
+          Disable colored output
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
@@ -7,16 +7,67 @@ Check GGUF file compatibility using header validation
 Usage: bitnet compat-check [OPTIONS] <PATH>
 
 Arguments:
-  <PATH>  Path to .gguf file
+  <PATH>
+          Path to .gguf file
 
 Options:
-  -c, --config <PATH>        Configuration file path
-      --json                 Output JSON
-  -d, --device <DEVICE>      Device to use (cpu, cuda, auto)
-      --strict               Fail on unsupported version or suspicious counts
-      --log-level <LEVEL>    Log level (trace, debug, info, warn, error)
-      --show-kv              Show key-value metadata (limit with --kv-limit)
-      --kv-limit <KV_LIMIT>  Limit number of KV pairs to show (default: 20) [default: 20]
-      --threads <N>          Number of CPU threads
-      --batch-size <SIZE>    Batch size for processing
-  -h, --help                 Print help
+  -c, --config <PATH>
+          Configuration file path
+
+      --json
+          Output JSON
+
+  -d, --device <DEVICE>
+          Device to use (cpu, cuda, oneapi, gpu, npu, auto)
+
+      --strict
+          Fail on unsupported version or suspicious counts
+
+      --backend <BACKEND>
+          GPU backend to use
+
+          Possible values:
+          - auto:   Automatically detect best available backend
+          - cpu:    CPU only (no GPU)
+          - cuda:   NVIDIA CUDA
+          - opencl: Intel OpenCL (Arc, Xe)
+          - vulkan: Vulkan compute
+          - metal:  Apple Metal
+          - rocm:   AMD ROCm/HIP
+          - webgpu: WebGPU (experimental)
+          
+          [default: auto]
+
+      --show-kv
+          Show key-value metadata (limit with --kv-limit)
+
+      --kv-limit <KV_LIMIT>
+          Limit number of KV pairs to show (default: 20)
+          
+          [default: 20]
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
+
+      --threads <N>
+          Number of CPU threads
+
+      --batch-size <SIZE>
+          Batch size for processing
+
+      --output-format <FORMAT>
+          Output format (text, json)
+          
+          [default: text]
+
+      --quiet
+          Suppress all non-essential output
+
+      --verbose
+          Enable verbose/debug-level output
+
+      --no-color
+          Disable colored output
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
@@ -7,17 +7,70 @@ Inspect model metadata and diagnostics
 Usage: bitnet inspect [OPTIONS] <MODEL>
 
 Arguments:
-  <MODEL>  Model file path
+  <MODEL>
+          Model file path
 
 Options:
-  -c, --config <PATH>            Configuration file path
-      --ln-stats                 Compute and display LayerNorm gamma statistics
-  -d, --device <DEVICE>          Device to use (cpu, cuda, auto)
-      --gate <GATE>              Gate behavior: none|auto|policy [default: auto]
-      --log-level <LEVEL>        Log level (trace, debug, info, warn, error)
-      --policy <POLICY>          Policy file (YAML) for custom validation rules
-      --policy-key <POLICY_KEY>  Policy key (architecture ID) for rules lookup
-      --threads <N>              Number of CPU threads
-      --batch-size <SIZE>        Batch size for processing
-      --json                     Output format as JSON
-  -h, --help                     Print help
+  -c, --config <PATH>
+          Configuration file path
+
+      --ln-stats
+          Compute and display LayerNorm gamma statistics
+
+  -d, --device <DEVICE>
+          Device to use (cpu, cuda, oneapi, gpu, npu, auto)
+
+      --gate <GATE>
+          Gate behavior: none|auto|policy
+          
+          [default: auto]
+
+      --backend <BACKEND>
+          GPU backend to use
+
+          Possible values:
+          - auto:   Automatically detect best available backend
+          - cpu:    CPU only (no GPU)
+          - cuda:   NVIDIA CUDA
+          - opencl: Intel OpenCL (Arc, Xe)
+          - vulkan: Vulkan compute
+          - metal:  Apple Metal
+          - rocm:   AMD ROCm/HIP
+          - webgpu: WebGPU (experimental)
+          
+          [default: auto]
+
+      --policy <POLICY>
+          Policy file (YAML) for custom validation rules
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
+
+      --policy-key <POLICY_KEY>
+          Policy key (architecture ID) for rules lookup
+
+      --json
+          Output format as JSON
+
+      --threads <N>
+          Number of CPU threads
+
+      --batch-size <SIZE>
+          Batch size for processing
+
+      --output-format <FORMAT>
+          Output format (text, json)
+          
+          [default: text]
+
+      --quiet
+          Suppress all non-essential output
+
+      --verbose
+          Enable verbose/debug-level output
+
+      --no-color
+          Disable colored output
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
@@ -26,16 +26,31 @@ Options:
           Model file path
 
   -d, --device <DEVICE>
-          Device to use (cpu, cuda, auto)
+          Device to use (cpu, cuda, oneapi, gpu, npu, auto)
 
       --tokenizer <TOKENIZER>
           Tokenizer file path (optional, will look for sibling file if not provided)
 
-      --log-level <LEVEL>
-          Log level (trace, debug, info, warn, error)
+      --backend <BACKEND>
+          GPU backend to use
+
+          Possible values:
+          - auto:   Automatically detect best available backend
+          - cpu:    CPU only (no GPU)
+          - cuda:   NVIDIA CUDA
+          - opencl: Intel OpenCL (Arc, Xe)
+          - vulkan: Vulkan compute
+          - metal:  Apple Metal
+          - rocm:   AMD ROCm/HIP
+          - webgpu: WebGPU (experimental)
+          
+          [default: auto]
 
   -p, --prompt <PROMPT>
           Input prompt
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
 
       --max-new-tokens <MAX_NEW_TOKENS>
           Maximum new tokens to generate (aliases: --max-tokens, --n-predict)
@@ -43,13 +58,13 @@ Options:
           [default: 32]
           [aliases: --max-tokens, --n-predict]
 
-      --batch-size <SIZE>
-          Batch size for processing
-
       --temperature <TEMPERATURE>
           Temperature for sampling (0 = greedy)
           
           [default: 1]
+
+      --batch-size <SIZE>
+          Batch size for processing
 
       --top-k <TOP_K>
           Top-k sampling (0 = disabled)
@@ -74,11 +89,25 @@ Options:
           
           [env: BITNET_ALLOW_MOCK=]
 
+      --output-format <FORMAT>
+          Output format (text, json)
+          
+          [default: text]
+
+      --quiet
+          Suppress all non-essential output
+
       --strict-mapping
           Strict mapping mode: fail if any tensors are unmapped
 
       --strict-tokenizer
           Strict tokenizer mode: fail if no real tokenizer available
+
+      --verbose
+          Enable verbose/debug-level output
+
+      --no-color
+          Disable colored output
 
       --strict-loader
           Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1, BITNET_STRICT_MODE=1)


### PR DESCRIPTION
## Summary

Add CLI UX improvements for better usability and scriptability.

### New Global Flags

| Flag | Description |
|------|-------------|
| `--output-format json\|text` | Machine-readable JSON output for `run` and `info` commands |
| `--quiet` | Suppress non-essential output (forces log level to error) |
| `--verbose` | Enable debug-level output (forces log level to debug) |
| `--no-color` | Disable colored output globally |

### Additional Improvements

- **Progress spinner** for model loading (suppressed in quiet/json mode)
- **Model info summary** at startup: path, format, quantization, params, device, vocab, context length
- **Typo-tolerant flag suggestions** using Levenshtein edit distance (up to 3 candidates)

### New Files

- `crates/bitnet-cli/src/output.rs` — `OutputConfig`, `OutputFormat`, `ModelSummary`, `suggest_flag`, `edit_distance` helpers + 11 unit tests
- `crates/bitnet-cli/tests/cli_ux_flags.rs` — 24 integration tests covering all new flags

### Testing

- 35 new tests (11 unit + 24 integration), all passing
- All existing CLI tests pass (including updated snapshots)
- `cargo clippy -D warnings` clean on library code
