### PR TITLE
Fix workspace crates to be publishable to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,8 @@ name = "bitnet-gpu-hal"
 version = "0.2.0-alpha.1"
 dependencies = [
  "proptest",
- "thiserror 2.0.18",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/bitnet-common/Cargo.toml
+++ b/crates/bitnet-common/Cargo.toml
@@ -34,7 +34,7 @@ serial_test.workspace = true
 temp-env.workspace = true
 tracing-subscriber.workspace = true
 insta = { workspace = true }
-bitnet-test-support.workspace = true
+bitnet-test-support = { path = "../bitnet-test-support", version = "0.2.0-alpha.1" }
 
 [features]
 integration-tests = []

--- a/crates/bitnet-inference/tests/ac10_error_handling_robustness.rs
+++ b/crates/bitnet-inference/tests/ac10_error_handling_robustness.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// Tests feature spec: issue-248-spec.md#ac10
 /// Validates proper handling of quantization failures with anyhow::Result patterns
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac10_quantization_error_handling() -> Result<()> {
     let invalid_data = vec![f32::NAN, f32::INFINITY, -f32::INFINITY];
     let quantizer = create_test_quantizer()?;
@@ -35,7 +35,7 @@ async fn test_ac10_quantization_error_handling() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac10
 /// Validates graceful handling of out-of-memory conditions
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac10_memory_error_recovery() -> Result<()> {
     let _oversized_config = ModelConfig { vocab_size: usize::MAX, hidden_size: usize::MAX };
     let error = anyhow::anyhow!("Mock OutOfMemory error for testing");
@@ -47,7 +47,7 @@ async fn test_ac10_memory_error_recovery() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac10
 /// Validates proper handling of invalid token IDs with detailed context
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac10_invalid_token_error_handling() {
     let model = create_test_model().unwrap();
     let tokenizer = create_test_tokenizer().unwrap();
@@ -68,7 +68,7 @@ async fn test_ac10_invalid_token_error_handling() {
 /// Tests feature spec: issue-248-spec.md#ac10
 /// Validates graceful fallback when device selection fails
 #[cfg(all(feature = "cpu", feature = "gpu"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac10_device_selection_error_recovery() -> Result<()> {
     let model: Arc<dyn Model> = Arc::new(create_test_model()?);
     let tokenizer: Arc<dyn Tokenizer> = Arc::new(create_test_tokenizer()?);

--- a/crates/bitnet-inference/tests/ac1_quantized_linear_layers.rs
+++ b/crates/bitnet-inference/tests/ac1_quantized_linear_layers.rs
@@ -35,7 +35,7 @@ impl Default for AC1TestConfig {
 /// Tests feature spec: issue-248-spec.md#ac1
 /// Validates I2S quantization maintains >99% accuracy in linear transformations
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_i2s_quantized_linear_forward_pass_cpu() -> Result<()> {
     let config = AC1TestConfig::default();
     let input = create_mock_tensor(config.batch_size, config.sequence_length, config.hidden_size)?;
@@ -78,7 +78,7 @@ async fn test_ac1_i2s_quantized_linear_forward_pass_cpu() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac1
 /// Validates GPU acceleration maintains accuracy parity with CPU implementation
 #[cfg(feature = "gpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_i2s_quantized_linear_forward_pass_gpu() -> Result<()> {
     let config = AC1TestConfig::default();
     if !is_gpu_available() {
@@ -96,7 +96,7 @@ async fn test_ac1_i2s_quantized_linear_forward_pass_gpu() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac1
 /// Validates TL1 table lookup quantization eliminates FP32 dequantization in hot path
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_tl1_quantized_linear_forward_pass() -> Result<()> {
     use bitnet_inference::layers::LookupTable;
     let config = AC1TestConfig {
@@ -185,7 +185,7 @@ async fn test_ac1_tl1_quantized_linear_forward_pass() -> Result<()> {
 /// - 256-entry lookup table fits in L2 cache (≤1KB)
 /// - Numerical stability: no NaN/Inf in outputs
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_tl2_quantized_linear_forward_pass() -> Result<()> {
     use bitnet_inference::layers::LookupTable;
     let config = AC1TestConfig {
@@ -296,7 +296,7 @@ async fn test_ac1_tl2_quantized_linear_forward_pass() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac1
 /// Validates consistent results across CPU/GPU/FFI implementations
 #[cfg(all(feature = "cpu", feature = "gpu"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_cross_platform_quantized_linear_consistency() -> Result<()> {
     let config = AC1TestConfig::default();
     if !is_gpu_available() || !is_ffi_available() {

--- a/crates/bitnet-inference/tests/ac2_multi_head_attention.rs
+++ b/crates/bitnet-inference/tests/ac2_multi_head_attention.rs
@@ -98,7 +98,7 @@ impl Default for AC2TestConfig {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates attention mechanism with I2S quantized Q, K, V projections
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_quantized_multi_head_attention_forward_pass() -> Result<()> {
     log::warn!("AC2.1: Quantized multi-head attention not yet fully implemented - skipping test");
     return Ok(());
@@ -179,7 +179,7 @@ async fn test_ac2_quantized_multi_head_attention_forward_pass() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates proper attention masking for causal (autoregressive) attention
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_attention_mask_handling() -> Result<()> {
     log::warn!("AC2.2: Attention mask handling not yet fully implemented - skipping test");
     return Ok(());
@@ -218,7 +218,7 @@ async fn test_ac2_attention_mask_handling() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates GPU acceleration for attention computation with mixed precision
 #[cfg(feature = "gpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_gpu_multi_head_attention_performance() -> Result<()> {
     log::warn!("AC2.3: GPU multi-head attention not yet fully implemented - skipping test");
     return Ok(());
@@ -273,7 +273,7 @@ async fn test_ac2_gpu_multi_head_attention_performance() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates attention patterns maintain linguistic coherence after quantization
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_attention_pattern_analysis() -> Result<()> {
     log::warn!("AC2.4: Attention pattern analysis not yet fully implemented - skipping test");
     return Ok(());
@@ -320,7 +320,7 @@ async fn test_ac2_attention_pattern_analysis() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates proper gradient flow through quantized attention layers
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_attention_gradient_flow() -> Result<()> {
     log::warn!("AC2.5: Attention gradient flow not yet fully implemented - skipping test");
     return Ok(());

--- a/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
+++ b/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
@@ -97,7 +97,7 @@ impl Default for AC3TestConfig {
 /// Tests feature spec: issue-248-spec.md#ac3
 /// Validates complete generation loop from prompt to output tokens
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_basic_autoregressive_generation() -> Result<()> {
     let config = AC3TestConfig::default();
     let model = create_mock_bitnet_model(config.vocab_size, 2048)?;
@@ -165,7 +165,7 @@ async fn test_ac3_basic_autoregressive_generation() -> Result<()> {
 /// cargo test test_ac3_temperature_sampling_validation --package bitnet-inference -- --ignored --nocapture
 /// ```
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_temperature_sampling_validation() -> Result<()> {
     if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
@@ -235,7 +235,7 @@ async fn test_ac3_temperature_sampling_validation() -> Result<()> {
 /// cargo test test_ac3_top_k_sampling_validation --package bitnet-inference -- --ignored --nocapture
 /// ```
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_top_k_sampling_validation() -> Result<()> {
     if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
@@ -302,7 +302,7 @@ async fn test_ac3_top_k_sampling_validation() -> Result<()> {
 /// cargo test test_ac3_nucleus_sampling_validation --package bitnet-inference -- --ignored --nocapture
 /// ```
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_nucleus_sampling_validation() -> Result<()> {
     if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
@@ -358,7 +358,7 @@ async fn test_ac3_nucleus_sampling_validation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac3
 /// Validates deterministic seed support produces reproducible outputs
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_deterministic_generation_with_seeding() -> Result<()> {
     let config = AC3TestConfig::default();
     unsafe {
@@ -419,7 +419,7 @@ async fn test_ac3_deterministic_generation_with_seeding() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac3
 /// Validates proper handling of end-of-sequence tokens and early stopping
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_early_stopping_and_eos_handling() -> Result<()> {
     let config = AC3TestConfig::default();
     let model = create_mock_bitnet_model(config.vocab_size, 2048)?;

--- a/crates/bitnet-inference/tests/ac4_cross_validation_accuracy.rs
+++ b/crates/bitnet-inference/tests/ac4_cross_validation_accuracy.rs
@@ -45,7 +45,7 @@ impl Default for AC4TestConfig {
 /// Tests feature spec: issue-248-spec.md#ac4
 /// Validates I2S quantization maintains >99% accuracy vs C++ reference
 #[cfg(all(feature = "cpu", feature = "crossval"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_i2s_quantization_cross_validation() -> Result<()> {
     let config = AC4TestConfig::default();
     if !is_crossval_environment_ready() {
@@ -115,7 +115,7 @@ async fn test_ac4_i2s_quantization_cross_validation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac4
 /// Validates TL1/TL2 quantization accuracy vs reference implementation
 #[cfg(all(feature = "cpu", feature = "crossval"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_table_lookup_quantization_cross_validation() -> Result<()> {
     let config = AC4TestConfig::default();
     if !is_crossval_environment_ready() {
@@ -193,7 +193,7 @@ async fn test_ac4_table_lookup_quantization_cross_validation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac4
 /// Validates IQ2_S format maintains bit-exact compatibility with GGML
 #[cfg(all(feature = "cpu", feature = "crossval"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_iq2s_ggml_compatibility_cross_validation() -> Result<()> {
     let config = AC4TestConfig::default();
     if !is_crossval_environment_ready() || !is_ggml_ffi_available() {
@@ -262,7 +262,7 @@ async fn test_ac4_iq2s_ggml_compatibility_cross_validation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac4
 /// Runs complete cross-validation suite using xtask crossval command
 #[cfg(all(feature = "cpu", feature = "crossval"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_comprehensive_cross_validation_suite() -> Result<()> {
     let config = AC4TestConfig::default();
     if !is_crossval_environment_ready() {

--- a/crates/bitnet-inference/tests/ac5_performance_targets.rs
+++ b/crates/bitnet-inference/tests/ac5_performance_targets.rs
@@ -41,7 +41,7 @@ impl Default for AC5TestConfig {
 /// Tests feature spec: issue-248-spec.md#ac5
 /// Validates 5-15 tokens/sec performance target for BitNet 2B model on CPU
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac5_cpu_performance_targets() -> Result<()> {
     let config = AC5TestConfig::default();
     let model = load_bitnet_2b_model_for_performance_testing()
@@ -107,7 +107,7 @@ async fn test_ac5_cpu_performance_targets() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac5
 /// Validates 2-5x GPU speedup over CPU with mixed precision support
 #[cfg(all(feature = "cpu", feature = "gpu"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac5_gpu_performance_speedup() -> Result<()> {
     let config = AC5TestConfig::default();
     if !is_gpu_available() {
@@ -169,7 +169,7 @@ async fn test_ac5_gpu_performance_speedup() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac5
 /// Validates efficient KV-cache utilization improves generation performance
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac5_kv_cache_utilization_performance() -> Result<()> {
     let _config = AC5TestConfig::default();
     let model = load_bitnet_2b_model_for_performance_testing()?;
@@ -211,7 +211,7 @@ async fn test_ac5_kv_cache_utilization_performance() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac5
 /// Validates efficient batch processing scales performance linearly
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac5_batch_processing_performance() -> Result<()> {
     let config = AC5TestConfig::default();
     let model = load_bitnet_2b_model_for_performance_testing()?;

--- a/crates/bitnet-inference/tests/ac7_deterministic_inference.rs
+++ b/crates/bitnet-inference/tests/ac7_deterministic_inference.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// Tests feature spec: issue-248-spec.md#ac7
 /// Validates reproducible outputs with BITNET_DETERMINISTIC=1 and BITNET_SEED=42
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_deterministic_inference_with_fixed_seed() -> Result<()> {
     unsafe {
         std::env::set_var("BITNET_DETERMINISTIC", "1");

--- a/crates/bitnet-inference/tests/ac8_mock_implementation_replacement.rs
+++ b/crates/bitnet-inference/tests/ac8_mock_implementation_replacement.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// Tests feature spec: issue-248-spec.md#ac8
 /// Validates real implementations replace mock placeholders
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac8_mock_vs_real_inference_detection() {
     let model = create_test_model();
     let tokenizer = create_test_tokenizer();

--- a/crates/bitnet-inference/tests/ac9_comprehensive_integration_testing.rs
+++ b/crates/bitnet-inference/tests/ac9_comprehensive_integration_testing.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 /// Tests feature spec: issue-248-spec.md#ac9
 /// Validates complete transformer pipeline from tokenization to detokenization
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac9_end_to_end_transformer_pipeline() -> Result<()> {
     let workspace_root = find_workspace_root().unwrap();
     let model_path =
@@ -53,7 +53,7 @@ async fn test_ac9_end_to_end_transformer_pipeline() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac9
 /// Validates individual transformer blocks work correctly in isolation
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac9_individual_transformer_components() -> Result<()> {
     let workspace_root = find_workspace_root().unwrap();
     let model_path =

--- a/crates/bitnet-inference/tests/async_runtime_tests.rs
+++ b/crates/bitnet-inference/tests/async_runtime_tests.rs
@@ -4,7 +4,7 @@
 //! and prevent "no reactor running" errors.
 use bitnet_common::Result;
 use bitnet_inference::runtime_utils::{block_on_with_runtime, spawn_blocking_with_fallback};
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_spawn_blocking_with_runtime_context() {
     let result = spawn_blocking_with_fallback(|| Ok("async context test")).await;
     assert!(result.is_ok());
@@ -27,7 +27,7 @@ fn test_spawn_blocking_fallback_to_sync() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "fallback test");
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_complex_async_operation() {
     let result = spawn_blocking_with_fallback(|| {
         std::thread::sleep(std::time::Duration::from_millis(10));
@@ -48,7 +48,7 @@ fn test_block_on_with_runtime() {
     assert_eq!(nested_result.unwrap(), "nested async test");
 }
 /// Test that models the backend forward pass behavior
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_backend_forward_simulation() {
     use std::sync::Arc;
     let model_data = Arc::new(vec![1.0f32, 2.0, 3.0, 4.0]);
@@ -73,7 +73,7 @@ async fn test_backend_forward_simulation() {
     assert_eq!(output[1], 3.0);
     assert_eq!(output[2], 7.5);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_concurrent_spawn_blocking_operations() {
     use futures_util::{FutureExt, future::join_all};
     let futures: Vec<_> = (0..5)
@@ -92,7 +92,7 @@ async fn test_concurrent_spawn_blocking_operations() {
     }
 }
 /// Test error handling in spawn_blocking_with_fallback
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_error_handling() {
     let result = spawn_blocking_with_fallback(|| -> Result<()> {
         Err(bitnet_common::BitNetError::Validation("test error".to_string()))

--- a/crates/bitnet-inference/tests/batch_prefill.rs
+++ b/crates/bitnet-inference/tests/batch_prefill.rs
@@ -137,7 +137,7 @@ struct TimingMetrics {
     pub generate: f64,
     pub total: f64,
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_batch_prefill_timing() {
     let model = Arc::new(MockModelWithTiming::new());
     let tokenizer = Arc::new(MockTokenizerWithTiming::new());
@@ -205,7 +205,7 @@ async fn test_batch_prefill_timing() {
 /// - Tokenize time: 1.0-1.5ms (1ms sleep + overhead)
 /// - Prefill time: 10-15ms (10ms sleep + overhead)
 /// - If timings exceed these by 50%+ on stable hardware, investigate system load
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_batch_prefill_performance_consistency() {
     if std::env::var("RUN_PERF_TESTS").is_err() {
         eprintln!("⏭️  Skipping performance test; set RUN_PERF_TESTS=1 to enable");
@@ -243,7 +243,7 @@ async fn test_batch_prefill_performance_consistency() {
         );
     }
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_prefill_error_recovery() {
     let model = Arc::new(MockModelWithTiming::new());
     let tokenizer = Arc::new(MockTokenizerWithTiming::new());
@@ -256,7 +256,7 @@ async fn test_prefill_error_recovery() {
     let result = engine.prefill(&valid_tokens).await;
     assert!(result.is_ok(), "Should recover with valid tokens");
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_empty_batch_handling() {
     let model = Arc::new(MockModelWithTiming::new());
     let tokenizer = Arc::new(MockTokenizerWithTiming::new());
@@ -266,7 +266,7 @@ async fn test_empty_batch_handling() {
     let results = processor.process_batch(&empty_prompts).await.unwrap();
     assert_eq!(results.len(), 0, "Empty batch should return empty results");
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_single_prompt_batch() {
     let model = Arc::new(MockModelWithTiming::new());
     let tokenizer = Arc::new(MockTokenizerWithTiming::new());

--- a/crates/bitnet-inference/tests/batch_tests.rs
+++ b/crates/bitnet-inference/tests/batch_tests.rs
@@ -314,14 +314,14 @@ mod batch_processing_tests {
         let device = Device::Cpu;
         Arc::new(InferenceEngine::new(model, tokenizer, device).unwrap())
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processor_creation() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
         let processor = MockBatchProcessor::new(engine, config);
         assert!(processor.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_single_batch_processing() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -338,7 +338,7 @@ mod batch_processing_tests {
         assert!(responses[0].result.is_ok());
         assert!(responses[0].processing_time > Duration::from_millis(0));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_multiple_batch_processing() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -374,7 +374,7 @@ mod batch_processing_tests {
         assert!(response_ids.contains(&"req-2".to_string()));
         assert!(response_ids.contains(&"req-3".to_string()));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_processing_limits() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig { max_concurrent_requests: 2, ..Default::default() };
@@ -394,7 +394,7 @@ mod batch_processing_tests {
         assert!(total_time > Duration::from_millis(10));
         assert!(total_time < Duration::from_millis(500));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processing_with_different_configs() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -425,7 +425,7 @@ mod batch_processing_tests {
             assert!(response.result.is_ok());
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processing_performance() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig { max_concurrent_requests: 4, ..Default::default() };
@@ -449,7 +449,7 @@ mod batch_processing_tests {
         let successful_requests = responses.iter().filter(|r| r.result.is_ok()).count();
         assert_eq!(successful_requests, num_requests);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processing_with_timeouts() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -466,7 +466,7 @@ mod batch_processing_tests {
         assert_eq!(responses.len(), 1);
         assert!(responses[0].result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_empty_batch_processing() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -475,7 +475,7 @@ mod batch_processing_tests {
         let responses = processor.process_batch(requests).await;
         assert_eq!(responses.len(), 0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_large_batch_processing() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig {
@@ -504,7 +504,7 @@ mod batch_processing_tests {
 }
 mod batch_error_handling_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processor_invalid_config() {
         let engine = create_test_engine().await;
         let invalid_config = BatchProcessorConfig { max_batch_size: 0, ..Default::default() };
@@ -517,7 +517,7 @@ mod batch_error_handling_tests {
         let device = Device::Cpu;
         Arc::new(InferenceEngine::new(model, tokenizer, device).unwrap())
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processing_with_mixed_results() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();
@@ -548,7 +548,7 @@ mod batch_error_handling_tests {
             assert!(response.result.is_ok());
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_processing_resource_limits() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig {
@@ -580,7 +580,7 @@ mod batch_performance_tests {
         let device = Device::Cpu;
         Arc::new(InferenceEngine::new(model, tokenizer, device).unwrap())
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_vs_sequential_performance() {
         let engine = create_test_engine().await;
         let start_time = std::time::Instant::now();
@@ -606,7 +606,7 @@ mod batch_performance_tests {
         println!("Sequential time: {:?}, Batch time: {:?}", sequential_time, batch_time);
         assert!(batch_time <= sequential_time + Duration::from_millis(100));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_throughput_scaling() {
         let engine = create_test_engine().await;
         for concurrency in [1, 2, 4, 8] {
@@ -631,7 +631,7 @@ mod batch_performance_tests {
             assert!(throughput > 0.0);
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_memory_usage() {
         let engine = create_test_engine().await;
         let config = BatchProcessorConfig::default();

--- a/crates/bitnet-inference/tests/e2e_cpu_golden_path.rs
+++ b/crates/bitnet-inference/tests/e2e_cpu_golden_path.rs
@@ -102,7 +102,7 @@ fn synthetic_model() -> Result<Arc<BitNetModel>> {
 
 /// Deterministic CPU inference using a synthetic-weight model.
 /// Verifies output shape and receipt invariants without any file download.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_mock_golden_path() -> Result<()> {
     let model = synthetic_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -138,7 +138,7 @@ async fn test_e2e_mock_golden_path() -> Result<()> {
 
 /// Two independent runs on the same synthetic model with seed=42 must produce
 /// identical token sequences, proving the full pipeline is deterministic.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_golden_path_reproducible() -> Result<()> {
     async fn run_once(n: u32) -> Result<Vec<u32>> {
         let model = synthetic_model()?;
@@ -166,7 +166,7 @@ async fn test_e2e_golden_path_reproducible() -> Result<()> {
 /// Token IDs were captured from the first correct run and are intentionally pinned
 /// here as a regression guard.  Update them only after a deliberate model/pipeline
 /// change and re-capture.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_golden_path_pinned_output() -> Result<()> {
     // Greedy argmax on the fixed sin/cos synthetic weights, prompt "2+2=".
     // Captured from the first passing run; update only after an intentional change.
@@ -197,7 +197,7 @@ async fn test_e2e_golden_path_pinned_output() -> Result<()> {
 /// The pinned golden sequence with seed=42 is `[140, 459, 459, 459]`.
 /// Setting stop_token_id=459 must cause the engine to stop after emitting 140,
 /// because 459 is checked *before* it is appended to the output.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_stop_token_id_halts_generation_early() -> Result<()> {
     let model = synthetic_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -225,7 +225,7 @@ async fn test_e2e_stop_token_id_halts_generation_early() -> Result<()> {
 /// All kernel IDs recorded during a real inference pass must satisfy the schema
 /// constraints required for honest-compute receipts: non-empty strings, at most
 /// 128 characters each, and a total count ≤ 10 000.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_receipt_kernel_ids_schema_constraints() -> Result<()> {
     let model = synthetic_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -261,7 +261,7 @@ async fn test_e2e_receipt_kernel_ids_schema_constraints() -> Result<()> {
 
 /// The receipt schema version must always be the pinned literal "1.0.0" and
 /// must match the `RECEIPT_SCHEMA_VERSION` constant exported by `bitnet_receipts`.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_receipt_schema_version_is_1_0_0() -> Result<()> {
     let model = synthetic_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -289,7 +289,7 @@ async fn test_e2e_receipt_schema_version_is_1_0_0() -> Result<()> {
 
 /// `max_tokens` must be respected exactly across small values when no stop token
 /// is encountered, validating the generation loop termination condition.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_max_tokens_boundary() -> Result<()> {
     for &n in &[1u32, 2, 3, 4] {
         let model = synthetic_model()?;
@@ -315,7 +315,7 @@ async fn test_e2e_max_tokens_boundary() -> Result<()> {
 /// Every token ID produced by the engine must be a valid index into the
 /// vocabulary, i.e. strictly less than `vocab_size`.  An out-of-bounds token
 /// ID would corrupt any downstream detokenization step.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_output_token_ids_in_vocab_range() -> Result<()> {
     let model = synthetic_model()?;
     let vocab_size = 512u32; // matches the synthetic_model() configuration
@@ -381,7 +381,7 @@ fn test_e2e_mini_gguf_fixture_accessible() {
 /// Deterministic CPU inference with a real GGUF model.
 ///
 /// Skipped unless `BITNET_MODEL_PATH` (or `BITNET_GGUF`) is set.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_e2e_real_model_golden_path() -> Result<()> {
     let model_path = match std::env::var("BITNET_MODEL_PATH").or(std::env::var("BITNET_GGUF")) {
         Ok(p) => p,

--- a/crates/bitnet-inference/tests/greedy_decode_parity.rs
+++ b/crates/bitnet-inference/tests/greedy_decode_parity.rs
@@ -183,7 +183,7 @@ mod deterministic_inference_tests {
     /// Verify deterministic multi-step greedy decoding
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_deterministic_multi_step_greedy() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: deterministic multi-step greedy");
@@ -231,7 +231,7 @@ mod deterministic_inference_tests {
     /// Verify temperature=0 is equivalent to greedy mode
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_temperature_zero_equivalence() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: temperature=0 equivalence");
@@ -280,7 +280,7 @@ mod deterministic_inference_tests {
     /// Verify reproducibility with fixed seed across multiple runs
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_reproducibility_with_seed() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: reproducibility with seed");
@@ -337,7 +337,7 @@ mod logits_validation_tests {
     /// Verify logits output shape matches vocab size
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_logits_shape_validation() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: logits shape validation");
@@ -380,7 +380,7 @@ mod logits_validation_tests {
     /// Verify first generated token matches argmax from eval_ids
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_logits_argmax_consistency() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: logits argmax consistency");

--- a/crates/bitnet-inference/tests/integration_tests.rs
+++ b/crates/bitnet-inference/tests/integration_tests.rs
@@ -117,7 +117,7 @@ impl Tokenizer for MockTokenizer {
 }
 mod engine_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_creation_cpu() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -128,7 +128,7 @@ mod engine_tests {
         let stats = engine.get_stats().await;
         assert_eq!(stats.backend_type, "cpu");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_creation_with_config() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -140,7 +140,7 @@ mod engine_tests {
         let engine = InferenceEngine::with_config(model, tokenizer, device, config);
         assert!(engine.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_creation_gpu_fallback() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -148,7 +148,7 @@ mod engine_tests {
         let engine = InferenceEngine::new(model, tokenizer, device);
         assert!(engine.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_basic_text_generation() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -160,7 +160,7 @@ mod engine_tests {
         assert!(!generated_text.is_empty());
         assert!(generated_text.starts_with("decoded_"));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_text_generation_with_config() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -174,7 +174,7 @@ mod engine_tests {
         let result = engine.generate_with_config("Test prompt", &config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_generation_with_stop_sequences() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -185,7 +185,7 @@ mod engine_tests {
         let result = engine.generate_with_config("Test prompt", &config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_model_config_access() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -194,7 +194,7 @@ mod engine_tests {
         let model_config = engine.model_config();
         assert!(model_config.model.vocab_size > 0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_management() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -206,7 +206,7 @@ mod engine_tests {
         let stats_after = engine.get_stats().await;
         assert!(stats_after.cache_size <= stats_before.cache_size);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_error_handling() {
         let model = Arc::new(MockModel::new().with_failure());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -215,7 +215,7 @@ mod engine_tests {
         let result = engine.generate("Test prompt").await;
         assert!(result.is_err());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_tokenizer_error_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new().with_failure());
@@ -227,7 +227,7 @@ mod engine_tests {
 }
 mod streaming_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_generation() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -254,7 +254,7 @@ mod streaming_tests {
         assert!(token_count > 0);
         assert!(!total_text.is_empty());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_with_config() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -276,7 +276,7 @@ mod streaming_tests {
         }
         assert!(received_tokens > 0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_early_termination() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -287,7 +287,7 @@ mod streaming_tests {
         assert!(first_result.is_ok());
         drop(stream);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_config_validation() {
         let config = StreamingConfig {
             buffer_size: 5,
@@ -423,7 +423,7 @@ mod config_tests {
 mod performance_tests {
     use super::*;
     use std::time::Instant;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_inference_performance_metrics() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -443,7 +443,7 @@ mod performance_tests {
         );
         assert!(!stats.backend_type.is_empty(), "backend_type should be specified");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_inference() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -468,7 +468,7 @@ mod performance_tests {
         }
         assert!(success_count > 0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_usage_monitoring() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -480,7 +480,7 @@ mod performance_tests {
         assert!(stats_after.cache_usage >= 0.0);
         assert!(stats_after.cache_usage <= 100.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_resource_cleanup() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -492,7 +492,7 @@ mod performance_tests {
         let stats_after = engine.get_stats().await;
         assert!(stats_after.cache_size <= stats_before.cache_size);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_throughput_measurement() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -526,7 +526,7 @@ mod performance_tests {
 }
 mod error_handling_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_model_failure_handling() {
         let model = Arc::new(MockModel::new().with_failure());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -537,7 +537,7 @@ mod error_handling_tests {
         let error = result.unwrap_err();
         assert!(error.to_string().contains("Mock model failure"));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_tokenizer_failure_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new().with_failure());
@@ -548,7 +548,7 @@ mod error_handling_tests {
         let error = result.unwrap_err();
         assert!(error.to_string().contains("Mock tokenizer failure"));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_empty_prompt_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -557,7 +557,7 @@ mod error_handling_tests {
         let result = engine.generate("").await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_very_long_prompt_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -567,7 +567,7 @@ mod error_handling_tests {
         let result = engine.generate(&long_prompt).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_generation_config() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -576,7 +576,7 @@ mod error_handling_tests {
         let invalid_config = GenerationConfig::default().with_max_tokens(0);
         assert!(invalid_config.validate().is_err());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_error_propagation() {
         let model = Arc::new(MockModel::new().with_failure());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -594,7 +594,7 @@ mod error_handling_tests {
 }
 mod edge_case_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_unicode_prompt_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -604,7 +604,7 @@ mod edge_case_tests {
         let result = engine.generate(unicode_prompt).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_special_characters_prompt() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -614,7 +614,7 @@ mod edge_case_tests {
         let result = engine.generate(special_prompt).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_zero_temperature_generation() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -624,7 +624,7 @@ mod edge_case_tests {
         let result = engine.generate_with_config("Test prompt", &config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_high_temperature_generation() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -634,7 +634,7 @@ mod edge_case_tests {
         let result = engine.generate_with_config("Test prompt", &config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_single_token_generation() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -644,7 +644,7 @@ mod edge_case_tests {
         let result = engine.generate_with_config("Test prompt", &config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_max_context_length_handling() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());

--- a/crates/bitnet-inference/tests/issue_254_ac1_quantized_linear_no_fp32_staging.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac1_quantized_linear_no_fp32_staging.rs
@@ -12,7 +12,7 @@ use bitnet_inference::{LookupTable, QuantizedLinear};
 use bitnet_quantization::{I2SQuantizer, TL1Quantizer, TL2Quantizer};
 /// AC:1.1 - I2S quantized linear forward pass with NO FP32 staging
 /// Validates that I2S GEMV kernel is used directly without dequantization
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_i2s_quantized_linear_no_fp32_staging() -> Result<()> {
     let input_shape = vec![1, 16, 128];
     let input = BitNetTensor::zeros(&input_shape, candle_core::DType::F32, &Device::Cpu)
@@ -38,7 +38,7 @@ async fn test_ac1_i2s_quantized_linear_no_fp32_staging() -> Result<()> {
 }
 /// AC:1.2 - TL1 quantized linear forward pass with NO FP32 staging
 /// Validates that TL1 table lookup matmul kernel is used directly
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_tl1_quantized_linear_no_fp32_staging() -> Result<()> {
     let input_shape = vec![1, 8, 64];
     let input = BitNetTensor::zeros(&input_shape, candle_core::DType::F32, &Device::Cpu)?;
@@ -58,7 +58,7 @@ async fn test_ac1_tl1_quantized_linear_no_fp32_staging() -> Result<()> {
 }
 /// AC:1.3 - TL2 quantized linear forward pass with NO FP32 staging
 /// Validates that TL2 table lookup matmul kernel is used directly
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_tl2_quantized_linear_no_fp32_staging() -> Result<()> {
     let input_shape = vec![1, 4, 32];
     let input = BitNetTensor::zeros(&input_shape, candle_core::DType::F32, &Device::Cpu)?;
@@ -78,7 +78,7 @@ async fn test_ac1_tl2_quantized_linear_no_fp32_staging() -> Result<()> {
 }
 /// AC:1.4 - Verify NO FP32 dequantization in hot path (instrumentation test)
 /// This test validates that quantized kernels are used without FP32 fallback
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_verify_no_fp32_dequant_in_hot_path() -> Result<()> {
     {
         let input_shape = vec![1, 16, 128];

--- a/crates/bitnet-inference/tests/issue_254_ac2_attention_real_qkvo_rope_gqa.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac2_attention_real_qkvo_rope_gqa.rs
@@ -16,7 +16,7 @@ use bitnet_common::{BitNetTensor, Device, Tensor};
 use bitnet_quantization::I2SQuantizer;
 /// AC:2.1 - Real attention with quantized Q/K/V/O projections
 /// Validates attention computation uses QuantizedLinear for all projections
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_real_attention_quantized_qkvo_projections() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -36,7 +36,7 @@ async fn test_ac2_real_attention_quantized_qkvo_projections() -> Result<()> {
 }
 /// AC:2.2 - RoPE (Rotary Position Embeddings) application to Q/K
 /// Validates RoPE is applied before attention score computation
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_rope_positional_embeddings() -> Result<()> {
     let batch_size = 1;
     let seq_len = 16;
@@ -53,7 +53,7 @@ async fn test_ac2_rope_positional_embeddings() -> Result<()> {
 }
 /// AC:2.3 - GQA (Grouped Query Attention) expansion
 /// Validates GQA expands K/V when num_key_value_heads < num_attention_heads
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_gqa_grouped_query_attention() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -71,7 +71,7 @@ async fn test_ac2_gqa_grouped_query_attention() -> Result<()> {
 }
 /// AC:2.4 - Causal masking for autoregressive generation
 /// Validates causal attention mask prevents attending to future tokens
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_causal_masking() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -86,7 +86,7 @@ async fn test_ac2_causal_masking() -> Result<()> {
 }
 /// AC:2.5 - KV-cache update during forward pass
 /// Validates KV-cache is updated with new key/value states
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_kv_cache_update() -> Result<()> {
     let batch_size = 1;
     let seq_len = 4;
@@ -106,7 +106,7 @@ async fn test_ac2_kv_cache_update() -> Result<()> {
 }
 /// AC:2.6 - Full attention pipeline integration test
 /// Validates complete attention computation with all components
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_full_attention_pipeline() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;

--- a/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
@@ -15,7 +15,7 @@ use bitnet_models::BitNetModel;
 use bitnet_tokenizers::{Tokenizer, UniversalTokenizer};
 use serial_test::serial;
 use support::EnvGuard;
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC3.1: Deterministic Generation - SLOW INTEGRATION TEST
 ///
@@ -66,7 +66,7 @@ async fn test_ac3_deterministic_generation_identical_sequences() -> Result<()> {
 }
 /// AC:3.2 - Greedy sampling (temperature=0 or top_k=1) is deterministic
 /// Validates greedy decoding produces same result without seed
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_greedy_sampling_deterministic() -> Result<()> {
     let config = GenConfig {
         max_new_tokens: 20,
@@ -93,7 +93,7 @@ async fn test_ac3_greedy_sampling_deterministic() -> Result<()> {
     println!("AC3.2: Greedy sampling determinism test - PENDING IMPLEMENTATION");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC3.3: Top-k Seeded Sampling - SLOW INTEGRATION TEST
 ///
@@ -135,7 +135,7 @@ async fn test_ac3_top_k_sampling_seeded() -> Result<()> {
     println!("AC3.3: Top-k seeded sampling test - PENDING IMPLEMENTATION");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC3.4: Top-p Nucleus Sampling - SLOW INTEGRATION TEST
 ///
@@ -177,7 +177,7 @@ async fn test_ac3_top_p_nucleus_sampling_seeded() -> Result<()> {
     println!("AC3.4: Nucleus seeded sampling test - PENDING IMPLEMENTATION");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC3.5: Different Seeds Produce Different Outputs - SLOW INTEGRATION TEST
 ///
@@ -227,7 +227,7 @@ async fn test_ac3_different_seeds_different_outputs() -> Result<()> {
     println!("AC3.5: Different seeds test - PENDING IMPLEMENTATION");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC3.6: Rayon Single-Thread Determinism - SLOW INTEGRATION TEST
 ///

--- a/crates/bitnet-inference/tests/issue_254_ac4_receipt_generation.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac4_receipt_generation.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use support::EnvGuard;
 /// AC:4.1 - Generate inference receipt with compute_path="real"
 /// Validates receipt schema and required fields
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 async fn test_ac4_receipt_generation_real_path() -> Result<()> {
     let receipt =
@@ -37,7 +37,7 @@ async fn test_ac4_receipt_generation_real_path() -> Result<()> {
 }
 /// AC:4.2 - Receipt fails if compute_path="mock"
 /// Validates strict enforcement of real inference path
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_receipt_rejects_mock_path() -> Result<()> {
     let mock_receipt = create_mock_receipt("cpu", vec!["mock_gemv".to_string()])?;
     assert_eq!(
@@ -49,7 +49,7 @@ async fn test_ac4_receipt_rejects_mock_path() -> Result<()> {
 }
 /// AC:4.3 - Save receipt to ci/inference.json
 /// Validates receipt file creation
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_save_receipt_to_file() -> Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let receipt_path = temp_dir.path().join("inference.json");
@@ -65,7 +65,7 @@ async fn test_ac4_save_receipt_to_file() -> Result<()> {
 }
 /// AC:4.4 - Receipt includes environment variables
 /// Validates environment section in receipt
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 async fn test_ac4_receipt_environment_variables_long() -> Result<()> {
     if std::env::var("RUN_SLOW_RECEIPT_TESTS").ok().as_deref() != Some("1") {
@@ -94,7 +94,7 @@ async fn test_ac4_receipt_environment_variables_long() -> Result<()> {
 }
 /// AC:4.5 - Receipt includes performance baseline
 /// Validates performance metrics in receipt
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_receipt_performance_baseline() -> Result<()> {
     let receipt = create_mock_receipt("cpu", vec!["i2s_gemv".to_string()])?;
     assert!(

--- a/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
@@ -14,7 +14,7 @@ use bitnet_models::BitNetModel;
 use bitnet_tokenizers::{Tokenizer, UniversalTokenizer};
 use serial_test::serial;
 use support::EnvGuard;
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC6.1: Deterministic Inference - SLOW INTEGRATION TEST
 ///
@@ -59,7 +59,7 @@ async fn test_ac6_deterministic_inference_identical_runs() -> Result<()> {
     println!("AC6.1: Deterministic inference test - PENDING IMPLEMENTATION");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial(bitnet_env)]
 /// AC6.2: Determinism Multiple Runs - SLOW INTEGRATION TEST
 ///

--- a/crates/bitnet-inference/tests/issue_254_ac7_kv_cache_parity.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac7_kv_cache_parity.rs
@@ -12,7 +12,7 @@ use bitnet_common::{BitNetTensor, Device};
 use bitnet_inference::KVCache;
 /// AC:7.1 - KV-cache prefill + decode parity with full recompute
 /// Validates that cached attention matches full attention computation
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_kv_cache_parity_prefill_decode() -> Result<()> {
     let batch_size = 1;
     let max_seq_len = 128;
@@ -33,7 +33,7 @@ async fn test_ac7_kv_cache_parity_prefill_decode() -> Result<()> {
 }
 /// AC:7.2 - Multi-step KV-cache decode parity
 /// Validates cached decode over multiple steps
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_kv_cache_multi_step_parity() -> Result<()> {
     let max_seq_len = 128;
     let num_layers = 2;
@@ -45,7 +45,7 @@ async fn test_ac7_kv_cache_multi_step_parity() -> Result<()> {
 }
 /// AC:7.3 - KV-cache correctness with GQA
 /// Validates KV-cache works correctly with Grouped Query Attention
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_kv_cache_gqa_correctness() -> Result<()> {
     let max_seq_len = 128;
     let num_layers = 2;
@@ -57,7 +57,7 @@ async fn test_ac7_kv_cache_gqa_correctness() -> Result<()> {
 }
 /// AC:7.4 - KV-cache update validation
 /// Validates KV-cache accumulates states correctly
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_kv_cache_update_validation() -> Result<()> {
     let max_seq_len = 128;
     let num_layers = 2;

--- a/crates/bitnet-inference/tests/issue_462_cpu_forward_tests.rs
+++ b/crates/bitnet-inference/tests/issue_462_cpu_forward_tests.rs
@@ -111,7 +111,7 @@ mod test_utils {
 /// - All logits finite (no NaN/Inf)
 /// - At least 50% of logits are non-zero
 /// - KV cache updated at position 0
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "cpu")]
 async fn test_ac1_cpu_forward_bos_nonzero_logits() -> Result<()> {
     use bitnet_inference::InferenceEngine;
@@ -179,7 +179,7 @@ async fn test_ac1_cpu_forward_bos_nonzero_logits() -> Result<()> {
 /// - Deterministic output (same seed → same tokens)
 /// - All token IDs within vocab range
 /// - KV cache length increments correctly: 1, 2, 3, ..., 17
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "cpu")]
 async fn test_ac1_greedy_decode_16_tokens() -> Result<()> {
     use bitnet_inference::InferenceEngine;
@@ -260,7 +260,7 @@ async fn test_ac1_greedy_decode_16_tokens() -> Result<()> {
 /// - No FP32 staging kernels allowed
 /// - Receipt contains ≥1 quantized kernel (i2s_*, tl1_*, tl2_*)
 /// - No fallback kernels (fp32_*, fallback_*, dequant*)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "cpu")]
 async fn test_ac1_quantized_linear_strict_mode() -> Result<()> {
     use bitnet_inference::InferenceEngine;
@@ -328,7 +328,7 @@ async fn test_ac1_quantized_linear_strict_mode() -> Result<()> {
 /// - K,V shapes: [current_len, num_heads, head_dim]
 /// - Cache contains non-zero values (not all zeros)
 /// - Cache accessible for all layers
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "cpu")]
 async fn test_ac1_kv_cache_update_retrieval() -> Result<()> {
     use bitnet_inference::InferenceEngine;

--- a/crates/bitnet-inference/tests/logits_greedy_smoke.rs
+++ b/crates/bitnet-inference/tests/logits_greedy_smoke.rs
@@ -7,7 +7,7 @@ use bitnet_inference::{GenerationConfig, InferenceEngine};
 use bitnet_models::ModelLoader;
 use bitnet_tokenizers::auto;
 use std::env;
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn logits_and_greedy_smoke() {
     let model_path = match env::var("CROSSVAL_GGUF") {
         Ok(p) => p,

--- a/crates/bitnet-inference/tests/neural_network_integration.rs
+++ b/crates/bitnet-inference/tests/neural_network_integration.rs
@@ -18,7 +18,7 @@ use bitnet_inference::layers::quantized_linear::{LookupTable, QuantizedLinear};
 use bitnet_quantization::{I2SQuantizer, TL1Quantizer, TL2Quantizer};
 /// Test I2S quantized linear forward pass with real tensor operations
 /// Coverage target: quantized_linear.rs:forward_i2s()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_i2s_quantized_linear_forward_real_inference() -> Result<()> {
     let batch_size = 2;
     let seq_len = 16;
@@ -64,7 +64,7 @@ async fn test_i2s_quantized_linear_forward_real_inference() -> Result<()> {
 }
 /// Test TL1 quantized linear forward pass with table lookup
 /// Coverage target: quantized_linear.rs:forward_tl1()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tl1_quantized_linear_forward_real_inference() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -99,7 +99,7 @@ async fn test_tl1_quantized_linear_forward_real_inference() -> Result<()> {
 }
 /// Test TL2 quantized linear forward pass with 2-level table lookup
 /// Coverage target: quantized_linear.rs:forward_tl2()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tl2_quantized_linear_forward_real_inference() -> Result<()> {
     let batch_size = 1;
     let seq_len = 4;
@@ -138,7 +138,7 @@ async fn test_tl2_quantized_linear_forward_real_inference() -> Result<()> {
 }
 /// Test quantized linear with bias addition
 /// Coverage target: quantized_linear.rs:apply_bias_if_present()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_quantized_linear_with_bias() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -168,7 +168,7 @@ async fn test_quantized_linear_with_bias() -> Result<()> {
 }
 /// Test quantized linear input validation and error handling
 /// Coverage target: quantized_linear.rs:validate_input(), validate_input_dimensions()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_quantized_linear_input_validation() -> Result<()> {
     let hidden_size = 128;
     let out_features = 256;
@@ -193,7 +193,7 @@ async fn test_quantized_linear_input_validation() -> Result<()> {
 }
 /// Test KV-cache creation and initialization
 /// Coverage target: attention.rs:KVCache::new()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_kv_cache_initialization() -> Result<()> {
     let max_seq_len = 128;
     let num_layers = 12;
@@ -220,7 +220,7 @@ async fn test_kv_cache_initialization() -> Result<()> {
 }
 /// Test KV-cache update and retrieval
 /// Coverage target: attention.rs:KVCache::update(), get()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_kv_cache_update_and_retrieval() -> Result<()> {
     let max_seq_len = 64;
     let num_layers = 4;
@@ -257,7 +257,7 @@ async fn test_kv_cache_update_and_retrieval() -> Result<()> {
 }
 /// Test KV-cache clearing
 /// Coverage target: attention.rs:KVCache::clear()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_kv_cache_clear() -> Result<()> {
     let max_seq_len = 32;
     let num_layers = 2;
@@ -289,7 +289,7 @@ async fn test_kv_cache_clear() -> Result<()> {
 }
 /// Test KV-cache error handling for invalid layer indices
 /// Coverage target: attention.rs:KVCache::validate_layer_index()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_kv_cache_error_handling() -> Result<()> {
     let cache = KVCache::new(64, 4, 4, 32, &Device::Cpu)?;
     let result = cache.get(10);
@@ -301,7 +301,7 @@ async fn test_kv_cache_error_handling() -> Result<()> {
 }
 /// Test multi-layer quantized forward pass simulating transformer block
 /// Coverage target: Combined quantized_linear.rs + attention.rs integration
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multi_layer_quantized_transformer_block() -> Result<()> {
     let batch_size = 1;
     let seq_len = 8;
@@ -334,7 +334,7 @@ async fn test_multi_layer_quantized_transformer_block() -> Result<()> {
 }
 /// Test quantized linear with extreme input values
 /// Coverage target: quantized_linear.rs numerical stability
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_quantized_linear_extreme_values() -> Result<()> {
     let hidden_size = 64;
     let out_features = 64;

--- a/crates/bitnet-inference/tests/neural_network_test_scaffolding.rs
+++ b/crates/bitnet-inference/tests/neural_network_test_scaffolding.rs
@@ -40,7 +40,7 @@ impl Default for NeuralNetworkTestConfig {
 /// Tests feature spec: issue-248-spec.md#ac1
 /// Validates I2S, TL1, TL2 quantization maintains >99% accuracy
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac1_quantized_linear_layer_forward_pass() -> Result<()> {
     let config = NeuralNetworkTestConfig::default();
     let input = create_mock_tensor(config.batch_size, config.sequence_length, config.hidden_size)
@@ -69,7 +69,7 @@ async fn test_ac1_quantized_linear_layer_forward_pass() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac2
 /// Validates attention with quantized Q, K, V projections
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac2_multi_head_attention_mechanism() -> Result<()> {
     // Use a small config: the default (hidden=2048, seq=512) requires ~10B scalar FLOPs
     // which exceeds the 5-minute CI timeout on unoptimized MVP kernels.
@@ -103,7 +103,7 @@ async fn test_ac2_multi_head_attention_mechanism() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac3
 /// Validates temperature, top-k, nucleus sampling with deterministic seeding
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac3_autoregressive_token_generation() -> Result<()> {
     let config = NeuralNetworkTestConfig::default();
     let prompt = "The future of artificial intelligence";
@@ -128,7 +128,7 @@ async fn test_ac3_autoregressive_token_generation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac4
 /// Validates >99% accuracy vs C++ reference using xtask crossval
 #[cfg(all(feature = "cpu", feature = "crossval"))]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac4_cross_validation_accuracy_preservation() -> Result<()> {
     if std::env::var("BITNET_CROSSVAL_ENABLED").is_err() {
         log::warn!("Skipping cross-validation test: BITNET_CROSSVAL_ENABLED not set");
@@ -156,7 +156,7 @@ async fn test_ac4_cross_validation_accuracy_preservation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac5
 /// Validates 5-15 tok/sec CPU, 2-5x GPU speedup
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac5_performance_targets_validation() -> Result<()> {
     let config = NeuralNetworkTestConfig::default();
     let test_prompt = "Performance test sequence";
@@ -241,7 +241,7 @@ fn test_ac6_quantization_format_compatibility() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac7
 /// Validates reproducible outputs with BITNET_DETERMINISTIC=1, BITNET_SEED=42
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac7_deterministic_inference_behavior() -> Result<()> {
     unsafe {
         std::env::set_var("BITNET_DETERMINISTIC", "1");
@@ -274,7 +274,7 @@ async fn test_ac7_deterministic_inference_behavior() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac8
 /// Validates real implementations replace mock placeholders
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac8_mock_implementation_replacement_validation() -> Result<()> {
     let test_prompt = "Mock detection test";
     let mock_detection_result = test_mock_replacement_validation(test_prompt)
@@ -316,7 +316,7 @@ async fn test_ac8_mock_implementation_replacement_validation() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac9
 /// Validates end-to-end transformer pipeline integration
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac9_comprehensive_integration_testing() -> Result<()> {
     let test_prompts =
         vec!["Integration test prompt 1", "Integration test prompt 2", "Integration test prompt 3"];
@@ -342,7 +342,7 @@ async fn test_ac9_comprehensive_integration_testing() -> Result<()> {
 /// Tests feature spec: issue-248-spec.md#ac10
 /// Validates anyhow::Result<T> patterns for error conditions
 #[cfg(feature = "cpu")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ac10_error_handling_robustness() -> Result<()> {
     let nan_data = vec![f32::NAN; 100];
     let nan_result = test_quantization_error_handling(&nan_data);

--- a/crates/bitnet-inference/tests/performance_tests.rs
+++ b/crates/bitnet-inference/tests/performance_tests.rs
@@ -138,7 +138,7 @@ mod latency_tests {
         let device = Device::Cpu;
         InferenceEngine::new(model, tokenizer, device).unwrap()
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_single_inference_latency() {
         let engine = create_test_engine().await;
         let start_time = Instant::now();
@@ -148,7 +148,7 @@ mod latency_tests {
         assert!(latency < Duration::from_millis(100));
         println!("Single inference latency: {:?}", latency);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_inference_latency_with_different_prompt_lengths() {
         let engine = create_test_engine().await;
         let prompt_lengths = [10, 50, 100, 500, 1000];
@@ -162,7 +162,7 @@ mod latency_tests {
             assert!(latency < Duration::from_millis(200));
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_inference_latency_with_different_generation_lengths() {
         let engine = create_test_engine().await;
         let generation_lengths = [1, 10, 50, 100];
@@ -177,7 +177,7 @@ mod latency_tests {
             assert!(latency < expected_max_latency);
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_first_token_latency() {
         let engine = create_test_engine().await;
         let start_time = Instant::now();
@@ -195,7 +195,7 @@ mod latency_tests {
             panic!("First token generation timed out");
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_latency_consistency() {
         let engine = create_test_engine().await;
         let num_runs = 10;
@@ -228,7 +228,7 @@ mod throughput_tests {
         let device = Device::Cpu;
         InferenceEngine::new(model, tokenizer, device).unwrap()
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_sequential_throughput() {
         let engine = create_test_engine().await;
         let num_requests = 20;
@@ -244,7 +244,7 @@ mod throughput_tests {
         assert!(throughput > 0.0);
         assert!(throughput < 1000.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_throughput() {
         let engine = Arc::new(create_test_engine().await);
         let num_requests = 20;
@@ -276,7 +276,7 @@ mod throughput_tests {
         assert_eq!(successful_requests, num_requests);
         assert!(throughput > 0.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_streaming_throughput() {
         let engine = create_test_engine().await;
         let config = GenerationConfig::default().with_max_tokens(20);
@@ -301,7 +301,7 @@ mod throughput_tests {
         assert!(token_count > 0);
         assert!(tokens_per_second > 0.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_throughput_scaling() {
         let engine = Arc::new(create_test_engine().await);
         let base_requests = 10;
@@ -342,7 +342,7 @@ mod memory_tests {
         let device = Device::Cpu;
         InferenceEngine::new(model, tokenizer, device).unwrap()
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_usage_single_inference() {
         let engine = create_test_engine().await;
         let stats_before = engine.get_stats().await;
@@ -356,7 +356,7 @@ mod memory_tests {
             stats_before.cache_usage, stats_after.cache_usage
         );
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_usage_multiple_inferences() {
         let engine = create_test_engine().await;
         let num_inferences = 5;
@@ -374,7 +374,7 @@ mod memory_tests {
             assert!(*usage <= 100.0);
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_cleanup_after_cache_clear() {
         let engine = create_test_engine().await;
         for i in 0..5 {
@@ -390,7 +390,7 @@ mod memory_tests {
             stats_before_clear.cache_usage, stats_after_clear.cache_usage
         );
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_usage_with_different_context_lengths() {
         let context_lengths = [512, 1024, 2048];
         for context_length in context_lengths {
@@ -408,7 +408,7 @@ mod memory_tests {
             assert!(stats.cache_usage <= 100.0);
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_efficiency_with_batching() {
         let engine = Arc::new(create_test_engine().await);
         let num_concurrent = 4;
@@ -451,7 +451,7 @@ mod cache_performance_tests {
         let device = Device::Cpu;
         InferenceEngine::new(model, tokenizer, device).unwrap()
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_hit_performance() {
         let engine = create_test_engine().await;
         let prompt = "Cache performance test prompt";
@@ -470,7 +470,7 @@ mod cache_performance_tests {
         assert!(first_inference_time > Duration::from_millis(0));
         assert!(second_inference_time > Duration::from_millis(0));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_efficiency_with_similar_prompts() {
         let engine = create_test_engine().await;
         let base_prompt = "This is a test prompt for cache efficiency";
@@ -488,7 +488,7 @@ mod cache_performance_tests {
             assert!(*time < Duration::from_millis(100));
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_size_impact_on_performance() {
         let cache_sizes = [1024, 4096, 16384];
         for cache_size in cache_sizes {
@@ -509,7 +509,7 @@ mod cache_performance_tests {
             assert!(throughput > 0.0);
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_clear_performance_impact() {
         let engine = create_test_engine().await;
         for i in 0..5 {
@@ -536,7 +536,7 @@ mod cache_performance_tests {
 }
 mod backend_performance_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_performance() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -556,7 +556,7 @@ mod backend_performance_tests {
         let stats = engine.get_stats().await;
         assert_eq!(stats.backend_type, "cpu");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_backend_selection_performance() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -575,7 +575,7 @@ mod backend_performance_tests {
         assert!(cpu_time > Duration::from_millis(0));
         assert!(gpu_time > Duration::from_millis(0));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_backend_warmup_performance() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -602,7 +602,7 @@ mod stress_tests {
         let device = Device::Cpu;
         InferenceEngine::new(model, tokenizer, device).unwrap()
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_high_concurrency_stress() {
         let engine = Arc::new(create_test_engine().await);
         let num_requests = 50;
@@ -643,7 +643,7 @@ mod stress_tests {
         assert!(successful_requests > num_requests * 8 / 10);
         assert!(throughput > 0.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_long_running_performance() {
         let engine = create_test_engine().await;
         let duration = Duration::from_secs(10);
@@ -682,7 +682,7 @@ mod stress_tests {
         assert!(throughput > 0.0);
         assert!(avg_latency < Duration::from_millis(100));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_stress() {
         let engine = create_test_engine().await;
         let num_requests = 100;

--- a/crates/bitnet-inference/tests/performance_tracking_tests.rs
+++ b/crates/bitnet-inference/tests/performance_tracking_tests.rs
@@ -106,7 +106,7 @@ async fn create_test_engine_with_delays(
     InferenceEngine::new(model, tokenizer, device).unwrap()
 }
 mod performance_metrics_tests {
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_metrics_default() {
         use super::*;
         let metrics = PerformanceMetrics::default();
@@ -116,7 +116,7 @@ mod performance_metrics_tests {
         assert_eq!(metrics.backend_type, "unknown");
         assert!(metrics.validate().is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_metrics_validation() {
         use super::*;
         let mut metrics = PerformanceMetrics {
@@ -137,7 +137,7 @@ mod performance_metrics_tests {
         metrics.average_token_latency_ms = Some(-10.0);
         assert!(metrics.validate().is_err());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_metrics_efficiency_ratio() {
         use super::*;
         let mut metrics =
@@ -150,7 +150,7 @@ mod performance_metrics_tests {
         metrics.tokens_generated = 200;
         assert_eq!(metrics.efficiency_ratio(), 2.0);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_metrics_computation_accuracy() {
         use super::*;
         let metrics = PerformanceMetrics {
@@ -182,7 +182,7 @@ mod performance_metrics_tests {
     }
 }
 mod performance_tracker_tests {
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_tracker_creation() {
         use super::*;
         let tracker = PerformanceTracker::new();
@@ -194,7 +194,7 @@ mod performance_tracker_tests {
         assert_eq!(tracker.memory_peak_bytes, 0);
         assert!(tracker.start_time.is_some());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_tracker_recording() {
         use super::*;
         let mut tracker = PerformanceTracker::new();
@@ -219,7 +219,7 @@ mod performance_tracker_tests {
         tracker.update_memory_peak(2048);
         assert_eq!(tracker.memory_peak_bytes, 2048);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_tracker_metrics_computation() {
         use super::*;
         let mut tracker = PerformanceTracker::new();
@@ -234,7 +234,7 @@ mod performance_tracker_tests {
         tracker.record_cache_miss();
         assert_eq!(tracker.get_cache_hit_rate(), Some(0.75));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_performance_tracker_uptime() {
         use super::*;
         let tracker = PerformanceTracker::new();
@@ -246,7 +246,7 @@ mod performance_tracker_tests {
 }
 mod engine_integration_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_performance_tracking_integration() {
         let engine = create_test_engine().await;
         let initial_metrics = engine.get_performance_metrics().await.unwrap();
@@ -256,7 +256,7 @@ mod engine_integration_tests {
         assert!(initial_metrics.validate().is_ok());
         assert_eq!(initial_metrics.backend_type, "cpu");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_performance_metrics_accuracy() {
         let model_delay = Duration::from_millis(50);
         let tokenizer_delay = Duration::from_millis(10);
@@ -268,7 +268,7 @@ mod engine_integration_tests {
         let reset_result = engine.reset_performance_tracking();
         assert!(reset_result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_performance_tracking_reset() {
         let engine = create_test_engine().await;
         let initial_metrics = engine.get_performance_metrics().await.unwrap();
@@ -285,7 +285,7 @@ mod engine_integration_tests {
 mod environment_variable_tests {
     use super::*;
     use std::env;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_deterministic_environment_variables() {
         unsafe {
             env::remove_var("BITNET_DETERMINISTIC");
@@ -306,7 +306,7 @@ mod environment_variable_tests {
             env::remove_var("RAYON_NUM_THREADS");
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_batch_size_environment_variable() {
         unsafe {
             env::remove_var("BITNET_BATCH_SIZE");
@@ -326,7 +326,7 @@ mod environment_variable_tests {
             env::remove_var("BITNET_BATCH_SIZE");
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_memory_limit_environment_variable() {
         unsafe {
             env::remove_var("BITNET_MEMORY_LIMIT");
@@ -343,7 +343,7 @@ mod environment_variable_tests {
             env::remove_var("BITNET_MEMORY_LIMIT");
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_invalid_environment_variables() {
         let result = "invalid_seed".parse::<u64>();
         assert!(result.is_err(), "String parsing should fail for invalid seed");
@@ -355,7 +355,7 @@ mod environment_variable_tests {
 }
 mod stress_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_high_volume_performance_tracking() {
         let mut tracker = PerformanceTracker::new();
         let num_simulated_inferences = 100;

--- a/crates/bitnet-inference/tests/qk256_dispatch.rs
+++ b/crates/bitnet-inference/tests/qk256_dispatch.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use bitnet_common::{BitNetTensor, Device, Tensor};
 use bitnet_inference::layers::quantized_linear::QuantizedLinear;
 use bitnet_quantization::I2SQuantizer;
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_qk256_dispatch_basic() -> Result<()> {
     let in_features = 256;
     let out_features = 64;
@@ -52,7 +52,7 @@ async fn test_qk256_dispatch_basic() -> Result<()> {
     println!("✓ QK256 dispatch test passed: output shape and numerical correctness verified");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_qk256_with_non_aligned_dims() -> Result<()> {
     let in_features = 300;
     let out_features = 32;
@@ -89,7 +89,7 @@ async fn test_qk256_with_non_aligned_dims() -> Result<()> {
     println!("✓ QK256 non-aligned dimensions test passed");
     Ok(())
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_qk256_dimension_validation() -> Result<()> {
     let in_features = 256;
     let out_features = 64;

--- a/crates/bitnet-inference/tests/simple_real_inference.rs
+++ b/crates/bitnet-inference/tests/simple_real_inference.rs
@@ -88,7 +88,7 @@ fn create_minimal_model() -> Result<(Arc<BitNetModel>, BitNetConfig)> {
 }
 
 /// Test that we can create an inference engine with a properly initialized model
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_real_inference_engine_creation() -> Result<()> {
     let (model, _config) = create_minimal_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -97,7 +97,7 @@ async fn test_real_inference_engine_creation() -> Result<()> {
     Ok(())
 }
 /// Test forward pass with actual token IDs
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_forward_pass_with_tokens() -> Result<()> {
     let (model, _config) = create_minimal_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -117,7 +117,7 @@ async fn test_forward_pass_with_tokens() -> Result<()> {
     Ok(())
 }
 /// Test text generation (basic autoregressive functionality)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_basic_text_generation() -> Result<()> {
     let (model, _config) = create_minimal_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -138,7 +138,7 @@ async fn test_basic_text_generation() -> Result<()> {
     Ok(())
 }
 /// Test that the model configuration is properly loaded
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_model_configuration() -> Result<()> {
     let (model, config) = create_minimal_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());
@@ -153,7 +153,7 @@ async fn test_model_configuration() -> Result<()> {
     Ok(())
 }
 /// Integration test: measure basic performance
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_basic_performance() -> Result<()> {
     let (model, _config) = create_minimal_model()?;
     let tokenizer = Arc::new(MockTokenizer::new());

--- a/crates/bitnet-inference/tests/simple_tests.rs
+++ b/crates/bitnet-inference/tests/simple_tests.rs
@@ -6,7 +6,7 @@
 //! comprehensive coverage of the inference engine.
 use bitnet_inference::prelude::*;
 use std::time::Duration;
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_inference_config_defaults() {
     let config = InferenceConfig::default();
     assert!(config.max_context_length > 0);
@@ -14,7 +14,7 @@ async fn test_inference_config_defaults() {
     assert!(config.batch_size > 0);
     assert!(config.memory_pool_size > 0);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_inference_config_validation() {
     let mut config = InferenceConfig::default();
     assert!(config.validate().is_ok());
@@ -30,7 +30,7 @@ async fn test_inference_config_validation() {
     config.memory_pool_size = 0;
     assert!(config.validate().is_err());
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_inference_config_builder() {
     let config = InferenceConfig::default()
         .with_threads(8)
@@ -42,7 +42,7 @@ async fn test_inference_config_builder() {
     assert!(config.mixed_precision);
     assert_eq!(config.memory_pool_size, 1024 * 1024 * 1024);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_inference_config_presets() {
     let cpu_config = InferenceConfig::cpu_optimized();
     assert!(!cpu_config.mixed_precision);
@@ -54,7 +54,7 @@ async fn test_inference_config_presets() {
     assert_eq!(memory_config.max_context_length, 1024);
     assert_eq!(memory_config.memory_pool_size, 1024 * 1024 * 256);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_generation_config_defaults() {
     let config = GenerationConfig::default();
     assert_eq!(config.max_new_tokens, 100);
@@ -66,7 +66,7 @@ async fn test_generation_config_defaults() {
     assert!(config.seed.is_none());
     assert!(config.skip_special_tokens);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_generation_config_validation() {
     let mut config = GenerationConfig::default();
     assert!(config.validate().is_ok());
@@ -84,7 +84,7 @@ async fn test_generation_config_validation() {
     config.repetition_penalty = 0.0;
     assert!(config.validate().is_err());
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_generation_config_presets() {
     let greedy = GenerationConfig::greedy();
     assert_eq!(greedy.temperature, 0.0);
@@ -96,7 +96,7 @@ async fn test_generation_config_presets() {
     assert_eq!(balanced.temperature, 0.7);
     assert_eq!(balanced.repetition_penalty, 1.05);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_generation_config_builder() {
     let config = GenerationConfig::default()
         .with_seed(42)
@@ -112,7 +112,7 @@ async fn test_generation_config_builder() {
     assert_eq!(config.top_k, 40);
     assert_eq!(config.top_p, 0.95);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_config_serialization() {
     let gen_config = GenerationConfig::default();
     let serialized = serde_json::to_string(&gen_config).unwrap();
@@ -125,13 +125,13 @@ async fn test_config_serialization() {
     assert_eq!(inf_config.max_context_length, deserialized.max_context_length);
     assert_eq!(inf_config.num_threads, deserialized.num_threads);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cache_config_creation() {
     let config = CacheConfig::default();
     assert!(config.max_size_bytes > 0);
     assert!(config.max_sequence_length > 0);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cache_creation() {
     let config = CacheConfig::default();
     let cache = KVCache::new(config);
@@ -140,7 +140,7 @@ async fn test_cache_creation() {
     assert_eq!(cache.size(), 0);
     assert_eq!(cache.usage_percent(), 0.0);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cache_operations() {
     let config = CacheConfig::default();
     let mut cache = KVCache::new(config).unwrap();
@@ -149,7 +149,7 @@ async fn test_cache_operations() {
     cache.clear();
     assert_eq!(cache.size(), 0);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_streaming_config() {
     let config = StreamingConfig::default();
     assert!(config.buffer_size > 0);
@@ -164,7 +164,7 @@ async fn test_streaming_config() {
     assert_eq!(custom_config.buffer_size, 5);
     assert_eq!(custom_config.flush_interval_ms, 100);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sampling_config() {
     let config = SamplingConfig {
         temperature: 0.7,
@@ -179,7 +179,7 @@ async fn test_sampling_config() {
     assert_eq!(config.repetition_penalty, 1.0);
     assert_eq!(config.seed, Some(42));
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sampling_strategy_creation() {
     let config = SamplingConfig {
         temperature: 0.7,
@@ -190,7 +190,7 @@ async fn test_sampling_strategy_creation() {
     };
     let _strategy = SamplingStrategy::new(config);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sampling_with_different_parameters() {
     let logits = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
     let context = vec![1, 2, 3];
@@ -215,7 +215,7 @@ async fn test_sampling_with_different_parameters() {
     let high_temp_token = high_temp_strategy.sample(&logits, &context);
     assert!(high_temp_token.is_ok());
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sampling_reproducibility() {
     let logits = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
     let context = vec![1, 2, 3];
@@ -232,7 +232,7 @@ async fn test_sampling_reproducibility() {
     let token2 = strategy2.sample(&logits, &context).unwrap();
     assert_eq!(token1, token2);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_sampling_edge_cases() {
     let context = vec![1, 2, 3];
     let empty_logits = vec![];
@@ -272,7 +272,7 @@ async fn test_sampling_edge_cases() {
     let token = result.unwrap();
     assert!(token < logits.len() as u32);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_error_handling() {
     let mut config = InferenceConfig { max_context_length: 0, ..Default::default() };
     let error = config.validate().unwrap_err();
@@ -290,7 +290,7 @@ async fn test_error_handling() {
     let error = config.validate().unwrap_err();
     assert!(error.contains("memory_pool_size"));
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_generation_config_error_handling() {
     let mut config = GenerationConfig::default().with_max_tokens(0);
     let error = config.validate().unwrap_err();
@@ -311,7 +311,7 @@ async fn test_generation_config_error_handling() {
     let error = config.validate().unwrap_err();
     assert!(error.contains("repetition_penalty"));
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_performance_characteristics() {
     let start = std::time::Instant::now();
     for _ in 0..1000 {
@@ -327,14 +327,14 @@ async fn test_performance_characteristics() {
     let duration = start.elapsed();
     assert!(duration < Duration::from_millis(10));
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_memory_efficiency() {
     let configs: Vec<_> = (0..1000).map(|_| InferenceConfig::default()).collect();
     assert_eq!(configs.len(), 1000);
     let gen_configs: Vec<_> = (0..1000).map(|_| GenerationConfig::default()).collect();
     assert_eq!(gen_configs.len(), 1000);
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_concurrent_config_access() {
     use std::sync::Arc;
     use tokio::task;
@@ -354,7 +354,7 @@ async fn test_concurrent_config_access() {
         handle.await.unwrap();
     }
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_config_edge_cases() {
     let config =
         InferenceConfig::default().with_threads(1).with_batch_size(1).with_memory_pool_size(1024);
@@ -377,7 +377,7 @@ async fn test_config_edge_cases() {
         .with_max_tokens(100000);
     assert!(gen_config.validate().is_ok());
 }
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_comprehensive_coverage() {
     let _cpu = InferenceConfig::cpu_optimized();
     let _gpu = InferenceConfig::gpu_optimized();

--- a/crates/bitnet-inference/tests/strict_mode_runtime_guards.rs
+++ b/crates/bitnet-inference/tests/strict_mode_runtime_guards.rs
@@ -75,7 +75,7 @@ fn create_fallback_layer(
     }
 }
 /// AC1: Test that strict mode blocks FP32 fallback in QuantizedLinear::forward()
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_strict_blocks_fp32_fallback_i2s() -> Result<()> {
     let layer = create_fallback_layer(128, 256, QuantizationType::I2S)?;
     let input = create_mock_tensor(1, 10, 128)?;
@@ -84,7 +84,7 @@ async fn test_strict_blocks_fp32_fallback_i2s() -> Result<()> {
     Ok(())
 }
 /// AC1: Test strict mode with TL1 quantization (may not have native kernels)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_strict_mode_tl1_quantization() -> Result<()> {
     let layer = create_fallback_layer(64, 128, QuantizationType::TL1)?;
     let input = create_mock_tensor(1, 5, 64)?;
@@ -105,7 +105,7 @@ async fn test_strict_mode_tl1_quantization() -> Result<()> {
     }
 }
 /// AC1: Test strict mode with TL2 quantization
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_strict_mode_tl2_quantization() -> Result<()> {
     let layer = create_fallback_layer(64, 128, QuantizationType::TL2)?;
     let input = create_mock_tensor(1, 5, 64)?;
@@ -126,7 +126,7 @@ async fn test_strict_mode_tl2_quantization() -> Result<()> {
     }
 }
 /// Test that non-strict mode allows fallback (when kernels unavailable)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_non_strict_allows_fallback() -> Result<()> {
     let layer = create_fallback_layer(64, 128, QuantizationType::I2S)?;
     let input = create_mock_tensor(1, 5, 64)?;
@@ -135,7 +135,7 @@ async fn test_non_strict_allows_fallback() -> Result<()> {
     Ok(())
 }
 /// Test error message format includes layer information
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_error_message_includes_layer_info() -> Result<()> {
     let layer = create_fallback_layer(256, 512, QuantizationType::I2S)?;
     if layer.is_fallback_path() {
@@ -158,7 +158,7 @@ async fn test_error_message_includes_layer_info() -> Result<()> {
     Ok(())
 }
 /// AC4: Test that attention projection validation works in strict mode
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_attention_projection_validation() -> Result<()> {
     Ok(())
 }
@@ -234,7 +234,7 @@ fn test_non_strict_mode_skips_validation() {
     assert!(result.is_ok(), "validate_quantization_fallback should return Ok in non-strict mode");
 }
 /// Integration test: Verify end-to-end strict mode behavior
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_strict_mode_end_to_end() -> Result<()> {
     let layer = create_fallback_layer(100, 200, QuantizationType::I2S)?;
     let input = create_mock_tensor(2, 8, 100)?;

--- a/crates/bitnet-inference/tests/template_comparison.rs
+++ b/crates/bitnet-inference/tests/template_comparison.rs
@@ -210,7 +210,7 @@ mod template_comparison_tests {
     /// Compare output across all three templates (raw, instruct, llama3-chat)
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_template_comparison_capital_city() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: template comparison");
@@ -281,7 +281,7 @@ mod template_comparison_tests {
     /// Verify stop sequence behavior is template-specific
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_template_stop_sequence_behavior() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: template stop sequence behavior");
@@ -327,7 +327,7 @@ mod template_comparison_tests {
     /// Compare raw template vs instruct template for Q&A
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_raw_vs_instruct_qa() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: raw vs instruct comparison");
@@ -400,7 +400,7 @@ mod template_comparison_tests {
     /// Verify LLaMA-3 chat template with system prompts
     ///
     /// **TDD Scaffolding**: Test compiles but requires model file to execute
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_llama3_chat_system_prompt() -> Result<()> {
         if std::env::var("BITNET_SKIP_SLOW_TESTS").is_ok() {
             eprintln!("Skipping slow test: LLaMA-3 chat system prompt");

--- a/crates/bitnet-inference/tests/test_real_inference.rs
+++ b/crates/bitnet-inference/tests/test_real_inference.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Instant;
 /// AC1: Test real transformer forward pass with quantized weights
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_real_transformer_forward_pass() -> Result<()> {
     let config = create_test_bitnet_config();
     let model = create_real_model_with_weights(&config)?;
@@ -37,13 +37,13 @@ async fn test_real_transformer_forward_pass() -> Result<()> {
     Ok(())
 }
 /// AC2: Test multi-head attention with quantized projections
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_multi_head_attention() -> Result<()> {
     println!("✅ AC2: Multi-head attention module available");
     Ok(())
 }
 /// AC3: Test autoregressive generation with sampling
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_autoregressive_generation() -> Result<()> {
     let config = create_test_bitnet_config();
     let model = create_real_model_with_weights(&config)?;
@@ -64,7 +64,7 @@ async fn test_autoregressive_generation() -> Result<()> {
     Ok(())
 }
 /// AC5: Test performance targets (5-15 tok/sec on CPU)
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_performance_targets() -> Result<()> {
     let config = create_test_bitnet_config();
     let model = create_real_model_with_weights(&config)?;

--- a/crates/bitnet-inference/tests/test_real_vs_mock_comparison.rs
+++ b/crates/bitnet-inference/tests/test_real_vs_mock_comparison.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 /// Test showing that models initialized with real weights produce meaningful logits
 ///
 /// This validates Issue #248 resolution: transformer forward pass is real computation.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_real_vs_mock_inference_comparison() -> Result<()> {
     println!("=== Issue #248 Validation: Real Inference with Weighted Model ===");
     println!("\nTesting model with weights (real computation):");

--- a/crates/bitnet-inference/tests/unit_tests.rs
+++ b/crates/bitnet-inference/tests/unit_tests.rs
@@ -427,7 +427,7 @@ mod backend_unit_tests {
     use bitnet_inference::backends::{
         Backend, BackendCapabilities, CpuBackend, GpuBackend, select_backend,
     };
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_creation() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::new(model);
@@ -435,7 +435,7 @@ mod backend_unit_tests {
         let backend = backend.unwrap();
         assert_eq!(backend.backend_type(), "cpu");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_with_threads() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::with_threads(model, 4);
@@ -443,7 +443,7 @@ mod backend_unit_tests {
         let backend = backend.unwrap();
         assert_eq!(backend.backend_type(), "cpu");
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_capabilities() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::new(model).unwrap();
@@ -453,7 +453,7 @@ mod backend_unit_tests {
         assert!(capabilities.max_batch_size > 0);
         assert!(capabilities.memory_efficient);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_forward() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::new(model).unwrap();
@@ -464,14 +464,14 @@ mod backend_unit_tests {
         let output_tensor = output.unwrap();
         assert_eq!(output_tensor.shape(), &[1, 50257]);
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_warmup() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::new(model).unwrap();
         let result = backend.warmup().await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cpu_backend_clone() {
         let model = Arc::new(MockModel::new());
         let backend = CpuBackend::new(model).unwrap();
@@ -482,7 +482,7 @@ mod backend_unit_tests {
     fn test_gpu_backend_availability() {
         let _is_available = GpuBackend::is_available();
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_gpu_backend_creation() {
         let model = Arc::new(MockModel::new());
         let device = Device::Cuda(0);
@@ -495,7 +495,7 @@ mod backend_unit_tests {
             assert!(backend.is_err());
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_gpu_backend_with_mixed_precision() {
         let model = Arc::new(MockModel::new());
         let device = Device::Cuda(0);
@@ -506,7 +506,7 @@ mod backend_unit_tests {
             assert!(backend.is_err());
         }
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_gpu_backend_capabilities() {
         if !GpuBackend::is_available() {
             return;
@@ -639,7 +639,7 @@ mod error_handling_unit_tests {
         let error = config.validate().unwrap_err();
         assert!(error.contains("repetition_penalty"));
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_backend_error_handling() {
         let model = Arc::new(MockModel::new());
         let invalid_device = Device::Cpu;
@@ -658,7 +658,7 @@ mod error_handling_unit_tests {
 }
 mod integration_unit_tests {
     use super::*;
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_engine_with_different_configs() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -678,7 +678,7 @@ mod integration_unit_tests {
         let engine = InferenceEngine::with_config(model, tokenizer, Device::Cuda(0), gpu_config);
         assert!(engine.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_generation_with_different_configs() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());
@@ -694,7 +694,7 @@ mod integration_unit_tests {
         let result = engine.generate_with_config("Test", &balanced_config).await;
         assert!(result.is_ok());
     }
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cache_integration() {
         let model = Arc::new(MockModel::new());
         let tokenizer = Arc::new(MockTokenizer::new());

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -12,7 +12,6 @@ categories.workspace = true
 description = "Low-level FFI bindings to BitNet C++ implementation for cross-validation"
 readme = "README.md"
 rust-version.workspace = true
-publish = false                                                                          # Internal crate, not published
 
 [features]
 default = []

--- a/xtask-build-helper/Cargo.toml
+++ b/xtask-build-helper/Cargo.toml
@@ -2,7 +2,6 @@
 name = "xtask-build-helper"
 version.workspace = true
 edition.workspace = true
-publish = false
 license = "MIT OR Apache-2.0"
 description = "Build script helpers for FFI compilation (AC6 FFI build hygiene)"
 


### PR DESCRIPTION
Fix workspace crates to be publishable to crates.io

- Removed `publish = false` from `bitnet-sys` and `xtask-build-helper` since they are dependencies of `bitnet-inference` which needs to be published.
- Set explicit versions for local workspace dependencies in `crates/bitnet-common/Cargo.toml` (`bitnet-test-support`).
- Fixed broken async runtime in multiple test files under `bitnet-inference/tests/*.rs` which were failing due to missing `flavor = "multi_thread"` config in `#[tokio::test]`.

---
*PR created automatically by Jules for task [12563138218137900523](https://jules.google.com/task/12563138218137900523) started by @EffortlessSteven*