### PR TITLE
feat(templates): add suggest_for_arch mapping and Criterion benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "chrono",
- "criterion",
+ "criterion 0.7.0",
  "ctor",
  "env_logger",
  "fastrand",
@@ -497,7 +497,7 @@ dependencies = [
  "bitnet-test-support",
  "bytemuck",
  "candle-core",
- "criterion",
+ "criterion 0.7.0",
  "insta",
  "proptest",
  "serde",
@@ -546,7 +546,7 @@ dependencies = [
  "cc",
  "chrono",
  "console 0.16.2",
- "criterion",
+ "criterion 0.7.0",
  "dirs",
  "half",
  "humantime",
@@ -768,7 +768,7 @@ dependencies = [
  "bitnet-tests",
  "bytemuck",
  "cc",
- "criterion",
+ "criterion 0.7.0",
  "cudarc 0.17.8",
  "env_logger",
  "half",
@@ -844,6 +844,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-tokenizers",
+ "criterion 0.5.1",
  "insta",
  "proptest",
  "serde",
@@ -886,7 +887,7 @@ dependencies = [
  "bitnet-models",
  "bytemuck",
  "candle-core",
- "criterion",
+ "criterion 0.7.0",
  "insta",
  "proptest",
  "rand 0.9.2",
@@ -1985,6 +1986,32 @@ dependencies = [
 
 [[package]]
 name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
@@ -1993,7 +2020,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.6.0",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -2004,6 +2031,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -4458,6 +4495,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -22,3 +22,8 @@ proptest = { workspace = true }
 insta = { workspace = true }
 tracing-test.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "template_ops"
+harness = false

--- a/crates/bitnet-prompt-templates/benches/template_ops.rs
+++ b/crates/bitnet-prompt-templates/benches/template_ops.rs
@@ -1,0 +1,132 @@
+//! Criterion benchmarks for prompt template operations.
+//!
+//! Measures throughput of template detection, application, and multi-turn
+//! chat rendering across representative template families.
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use bitnet_prompt_templates::{ChatRole, ChatTurn, TemplateType};
+
+fn bench_detect(c: &mut Criterion) {
+    let mut group = c.benchmark_group("template_detect");
+
+    group.bench_function("chatml_jinja", |b| {
+        b.iter(|| {
+            TemplateType::detect(
+                black_box(Some("phi-4")),
+                black_box(Some("<|im_start|>system\n{system}<|im_end|>")),
+            )
+        })
+    });
+
+    group.bench_function("llama3_jinja", |b| {
+        b.iter(|| {
+            TemplateType::detect(
+                black_box(Some("llama-3")),
+                black_box(Some("<|start_header_id|>system<|end_header_id|>\n{system}<|eot_id|>")),
+            )
+        })
+    });
+
+    group.bench_function("name_only_fallback", |b| {
+        b.iter(|| TemplateType::detect(black_box(Some("gemma")), black_box(None)))
+    });
+
+    group.bench_function("no_hints", |b| {
+        b.iter(|| TemplateType::detect(black_box(None), black_box(None)))
+    });
+
+    group.finish();
+}
+
+fn bench_apply(c: &mut Criterion) {
+    let mut group = c.benchmark_group("template_apply");
+    let user_text = "Explain quantum computing in simple terms.";
+    let system = Some("You are a helpful assistant.");
+
+    for template in &[
+        TemplateType::Llama3Chat,
+        TemplateType::Phi4Chat,
+        TemplateType::QwenChat,
+        TemplateType::GemmaChat,
+        TemplateType::MistralChat,
+        TemplateType::AlpacaInstruct,
+        TemplateType::VicunaChat,
+    ] {
+        group.bench_function(format!("{template}"), |b| {
+            b.iter(|| template.apply(black_box(user_text), black_box(system)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_render_chat(c: &mut Criterion) {
+    let mut group = c.benchmark_group("template_render_chat");
+
+    let history_3 = vec![
+        ChatTurn::new(ChatRole::User, "Hello"),
+        ChatTurn::new(ChatRole::Assistant, "Hi! How can I help?"),
+        ChatTurn::new(ChatRole::User, "Tell me about Rust."),
+    ];
+
+    let history_10: Vec<ChatTurn> = (0..10)
+        .flat_map(|i| {
+            vec![
+                ChatTurn::new(ChatRole::User, format!("Question {i}")),
+                ChatTurn::new(ChatRole::Assistant, format!("Answer {i} with some detail.")),
+            ]
+        })
+        .collect();
+
+    let system = Some("You are a helpful assistant.");
+
+    for template in &[TemplateType::Llama3Chat, TemplateType::Phi4Chat, TemplateType::MistralChat] {
+        group.bench_function(format!("{template}/3_turns"), |b| {
+            b.iter(|| template.render_chat(black_box(&history_3), black_box(system)))
+        });
+
+        group.bench_function(format!("{template}/20_turns"), |b| {
+            b.iter(|| template.render_chat(black_box(&history_10), black_box(system)))
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_suggest_for_arch(c: &mut Criterion) {
+    let mut group = c.benchmark_group("suggest_for_arch");
+
+    group.bench_function("known_arch", |b| {
+        b.iter(|| TemplateType::suggest_for_arch(black_box("llama-3.2")))
+    });
+
+    group.bench_function("unknown_arch", |b| {
+        b.iter(|| TemplateType::suggest_for_arch(black_box("unknown-model")))
+    });
+
+    group.bench_function("case_insensitive", |b| {
+        b.iter(|| TemplateType::suggest_for_arch(black_box("Phi-4")))
+    });
+
+    group.finish();
+}
+
+fn bench_all_variants(c: &mut Criterion) {
+    c.bench_function("all_variants_count", |b| {
+        b.iter(|| {
+            let variants = TemplateType::all_variants();
+            black_box(variants.len())
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_detect,
+    bench_apply,
+    bench_render_chat,
+    bench_suggest_for_arch,
+    bench_all_variants,
+);
+criterion_main!(benches);

--- a/crates/bitnet-prompt-templates/src/lib.rs
+++ b/crates/bitnet-prompt-templates/src/lib.rs
@@ -3205,6 +3205,106 @@ impl TemplateType {
             Self::Phi2Instruct,
         ]
     }
+
+    /// Suggest a prompt template for the given architecture string.
+    ///
+    /// Maps architecture identifiers (as used in `ArchitectureRegistry`) to the
+    /// most appropriate prompt template.  Returns `None` for architectures that
+    /// have no natural chat/instruct template (e.g. `"bert"`, `"bitnet"`).
+    ///
+    /// The match is **case-insensitive**.
+    pub fn suggest_for_arch(architecture: &str) -> Option<Self> {
+        match architecture.to_lowercase().as_str() {
+            // Phi family
+            "phi" | "phi-4" => Some(Self::Phi4Chat),
+            "phi-3" | "phi3" => Some(Self::Phi3Instruct),
+            "phi-2" | "phi2" => Some(Self::Phi2Instruct),
+
+            // LLaMA family
+            "llama-3.2" | "llama3.2" | "llama32" => Some(Self::Llama32Chat),
+            "llama-3.1" | "llama3.1" | "llama31" => Some(Self::Llama31Chat),
+            "llama" => Some(Self::Llama3Chat),
+            "llama2" | "llama-2" => Some(Self::Llama2Chat),
+
+            // Mistral family
+            "mistral-nemo" | "nemo" => Some(Self::MistralNemoChat),
+            "mistral" => Some(Self::MistralChat),
+            "mixtral" => Some(Self::MixtralInstruct),
+
+            // Qwen family
+            "qwen2.5" | "qwen-2.5" => Some(Self::Qwen25Chat),
+            "qwen" | "qwen2" => Some(Self::QwenChat),
+
+            // Gemma family
+            "gemma2" | "gemma-2" => Some(Self::Gemma2Chat),
+            "gemma" => Some(Self::GemmaChat),
+            "codegemma" | "code-gemma" => Some(Self::CodeGemma),
+
+            // DeepSeek family
+            "deepseek-v3" | "deepseekv3" | "deepseek3" => Some(Self::DeepSeekV3Chat),
+            "deepseek" | "deepseek2" => Some(Self::DeepSeekChat),
+
+            // Code models
+            "starcoder" | "starcoder2" => Some(Self::StarCoder),
+            "codellama" | "code-llama" => Some(Self::CodeLlamaInstruct),
+
+            // Falcon family
+            "falcon-2" | "falcon2" => Some(Self::Falcon2Chat),
+            "falcon" => Some(Self::FalconChat),
+
+            // Cohere family
+            "command-r-plus" => Some(Self::CommandRPlus),
+            "command" | "command-r" | "cohere" => Some(Self::CohereCommand),
+            "aya" => Some(Self::CohereAya),
+
+            // OLMo family
+            "olmo2" | "olmo-2" => Some(Self::OLMo2Chat),
+            "olmo" => Some(Self::OlmoInstruct),
+
+            // Chinese models
+            "internlm" | "internlm2" => Some(Self::InternLMChat),
+            "yi" | "yi-1.5" => Some(Self::YiChat),
+            "baichuan" | "baichuan2" => Some(Self::BaichuanChat),
+            "chatglm" | "chatglm2" | "chatglm3" | "glm-4" => Some(Self::ChatGLMChat),
+            "xverse" => Some(Self::XverseChat),
+            "minicpm" => Some(Self::MiniCPMChat),
+
+            // Community / fine-tune families
+            "zephyr" => Some(Self::ZephyrChat),
+            "vicuna" => Some(Self::VicunaChat),
+            "orca" => Some(Self::OrcaChat),
+            "solar" => Some(Self::SolarInstruct),
+            "alpaca" => Some(Self::AlpacaInstruct),
+            "nous-hermes" | "hermes" => Some(Self::NousHermes),
+            "wizardlm" | "wizard" => Some(Self::WizardLM),
+            "openchat" => Some(Self::OpenChat),
+            "granite" => Some(Self::GraniteChat),
+            "nemotron" => Some(Self::NemotronChat),
+            "saiga" => Some(Self::SaigaChat),
+            "tinyllama" => Some(Self::TinyLlamaChat),
+            "dolphin" => Some(Self::DolphinChat),
+            "stablelm" | "stable-lm" | "stablecode" => Some(Self::StableLMChat),
+            "bloom" | "bloomz" => Some(Self::BloomChat),
+            "jamba" => Some(Self::JambaChat),
+            "persimmon" | "adept" => Some(Self::PersimmonChat),
+            "arctic" => Some(Self::ArcticInstruct),
+            "dbrx" => Some(Self::DbrxInstruct),
+            "exaone" => Some(Self::ExaoneChat),
+            "smollm" | "smol-lm" => Some(Self::SmolLMChat),
+
+            // GPT/ChatGPT (GGUF exports)
+            "chatgpt" | "gpt4" | "gpt-4" => Some(Self::ChatGptChat),
+
+            // MPT / RWKV
+            "mpt" => Some(Self::MptInstruct),
+            "rwkv" | "rwkv5" | "rwkv6" => Some(Self::RwkvWorld),
+
+            // Architectures without a natural chat template
+            "gpt" | "bert" | "bitnet" | "bitnet-b1.58" => None,
+
+            _ => None,
+        }
+    }
 }
 
 /// Validation result for template output.
@@ -3980,6 +4080,70 @@ mod tests {
             let v = template.validate_output(&output, "Test input");
             assert!(v.is_valid, "Template {:?} failed self-validation: {:?}", template, v.warnings);
         }
+    }
+
+    #[test]
+    fn suggest_for_arch_covers_major_families() {
+        let expected = &[
+            ("phi-4", TemplateType::Phi4Chat),
+            ("phi-3", TemplateType::Phi3Instruct),
+            ("phi-2", TemplateType::Phi2Instruct),
+            ("llama", TemplateType::Llama3Chat),
+            ("llama2", TemplateType::Llama2Chat),
+            ("llama-3.1", TemplateType::Llama31Chat),
+            ("llama-3.2", TemplateType::Llama32Chat),
+            ("mistral", TemplateType::MistralChat),
+            ("mistral-nemo", TemplateType::MistralNemoChat),
+            ("mixtral", TemplateType::MixtralInstruct),
+            ("qwen", TemplateType::QwenChat),
+            ("qwen2.5", TemplateType::Qwen25Chat),
+            ("gemma", TemplateType::GemmaChat),
+            ("gemma2", TemplateType::Gemma2Chat),
+            ("codegemma", TemplateType::CodeGemma),
+            ("deepseek", TemplateType::DeepSeekChat),
+            ("deepseek-v3", TemplateType::DeepSeekV3Chat),
+            ("falcon", TemplateType::FalconChat),
+            ("falcon-2", TemplateType::Falcon2Chat),
+            ("command", TemplateType::CohereCommand),
+            ("command-r-plus", TemplateType::CommandRPlus),
+            ("aya", TemplateType::CohereAya),
+            ("starcoder", TemplateType::StarCoder),
+            ("codellama", TemplateType::CodeLlamaInstruct),
+            ("olmo", TemplateType::OlmoInstruct),
+            ("olmo2", TemplateType::OLMo2Chat),
+            ("smollm", TemplateType::SmolLMChat),
+            ("granite", TemplateType::GraniteChat),
+            ("rwkv", TemplateType::RwkvWorld),
+            ("mpt", TemplateType::MptInstruct),
+        ];
+        for (arch, expected_template) in expected {
+            assert_eq!(
+                TemplateType::suggest_for_arch(arch),
+                Some(*expected_template),
+                "arch '{}' should suggest {:?}",
+                arch,
+                expected_template,
+            );
+        }
+    }
+
+    #[test]
+    fn suggest_for_arch_returns_none_for_non_chat() {
+        for arch in &["gpt", "bert", "bitnet", "bitnet-b1.58", "unknown-model"] {
+            assert_eq!(
+                TemplateType::suggest_for_arch(arch),
+                None,
+                "arch '{}' should return None",
+                arch,
+            );
+        }
+    }
+
+    #[test]
+    fn suggest_for_arch_case_insensitive() {
+        // Uses to_lowercase internally
+        assert_eq!(TemplateType::suggest_for_arch("Phi-4"), Some(TemplateType::Phi4Chat),);
+        assert_eq!(TemplateType::suggest_for_arch("LLAMA"), Some(TemplateType::Llama3Chat),);
     }
 }
 


### PR DESCRIPTION
## Summary

Adds architecture-to-template mapping and performance benchmarks for the prompt template system.

### Changes

- **\TemplateType::suggest_for_arch(arch)\**  Maps architecture strings (from \ArchitectureRegistry\) to the most appropriate prompt template. Covers 50+ architecture variants across all major model families. Returns \None\ for architectures without chat templates (gpt, bert, bitnet).

- **Criterion benchmark suite** (\enches/template_ops.rs\)  5 benchmark groups:
  - \	emplate_detect\  Measures detection from jinja/name hints
  - \	emplate_apply\  Measures single-turn formatting across 7 template families
  - \	emplate_render_chat\  Measures multi-turn rendering (3 and 20 turns)
  - \suggest_for_arch\  Measures archtemplate lookup performance
  - \ll_variants_count\  Baseline for variant enumeration

- **3 new unit tests**  Coverage for 30 architecture mappings, None returns, case-insensitivity

- **Newline normalization**  Fixed newline style in test files (LF consistency)

### Test Results
- 411 tests pass (182 unit + 51 property + 177 snapshot + 1 doc-test)
- Clippy clean
- Formatting clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>