### PR TITLE
fix(inference): add missing ModelConfig fields for MSRV compatibility

### DIFF
--- a/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
+++ b/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
@@ -490,6 +490,7 @@ fn create_mock_bitnet_model(vocab_size: usize, hidden_size: usize) -> Result<Bit
         rope_scaling: None,
         rms_norm_eps: None,
         tokenizer: bitnet_common::config::TokenizerConfig::default(),
+        ..Default::default()
     };
     let config = BitNetConfig { model: model_config, ..Default::default() };
     let device = Device::Cpu;

--- a/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
@@ -299,6 +299,7 @@ fn create_test_model() -> Result<BitNetModel> {
         rope_scaling: None,
         rms_norm_eps: None,
         tokenizer: bitnet_common::config::TokenizerConfig::default(),
+        ..Default::default()
     };
     let config = BitNetConfig { model: model_config, ..Default::default() };
     Ok(BitNetModel::new(config, Device::Cpu))

--- a/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
@@ -123,6 +123,7 @@ fn create_test_model() -> Result<BitNetModel> {
         rope_scaling: None,
         rms_norm_eps: None,
         tokenizer: bitnet_common::TokenizerConfig::default(),
+        ..Default::default()
     };
     let config = BitNetConfig { model: model_config, ..Default::default() };
     Ok(BitNetModel::new(config, Device::Cpu))

--- a/crates/bitnet-inference/tests/template_comparison.rs
+++ b/crates/bitnet-inference/tests/template_comparison.rs
@@ -154,6 +154,7 @@ impl TemplateConfig {
                     sys, user_prompt
                 )
             }
+            _ => user_prompt.to_string(),
         }
     }
 }

--- a/crates/bitnet-inference/tests/test_real_inference.rs
+++ b/crates/bitnet-inference/tests/test_real_inference.rs
@@ -101,6 +101,7 @@ fn create_test_bitnet_config() -> BitNetConfig {
             rope_scaling: None,
             rms_norm_eps: None,
             tokenizer: bitnet_common::TokenizerConfig::default(),
+            ..Default::default()
         },
         quantization: Default::default(),
         inference: Default::default(),


### PR DESCRIPTION
## Summary
Fixes MSRV compilation failure caused by ModelConfig struct initializers missing the new \ctivation_type\ and \
orm_type\ fields.

### Changes
- Added \..Default::default()\ to ModelConfig initializers in 4 test files
- Added wildcard arm to TemplateType match in template_comparison test

These fields were added to ModelConfig but the test files were not updated, causing compilation failure on the MSRV check.