### PR TITLE
feat(inference): add ReLU ops and activation/norm dispatch

### DIFF
--- a/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac3_deterministic_generation.rs
@@ -299,6 +299,7 @@ fn create_test_model() -> Result<BitNetModel> {
         rope_scaling: None,
         rms_norm_eps: None,
         tokenizer: bitnet_common::config::TokenizerConfig::default(),
+        ..Default::default()
     };
     let config = BitNetConfig { model: model_config, ..Default::default() };
     Ok(BitNetModel::new(config, Device::Cpu))

--- a/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
+++ b/crates/bitnet-inference/tests/issue_254_ac6_determinism_integration.rs
@@ -123,6 +123,7 @@ fn create_test_model() -> Result<BitNetModel> {
         rope_scaling: None,
         rms_norm_eps: None,
         tokenizer: bitnet_common::TokenizerConfig::default(),
+        ..Default::default()
     };
     let config = BitNetConfig { model: model_config, ..Default::default() };
     Ok(BitNetModel::new(config, Device::Cpu))

--- a/crates/bitnet-inference/tests/test_real_inference.rs
+++ b/crates/bitnet-inference/tests/test_real_inference.rs
@@ -101,6 +101,7 @@ fn create_test_bitnet_config() -> BitNetConfig {
             rope_scaling: None,
             rms_norm_eps: None,
             tokenizer: bitnet_common::TokenizerConfig::default(),
+            ..Default::default()
         },
         quantization: Default::default(),
         inference: Default::default(),


### PR DESCRIPTION
## Summary

Adds activation and normalization dispatch functions to cpu_opt.rs, enabling the inference engine to dynamically select the correct activation and normalization based on model configuration.

### Changes

**New functions:**
- \elu2()\ / \elu2_in_place()\  Squared ReLU activation (BitNet-specific)
- \pply_activation()\  Dispatch by \ActivationType\ enum (SiLU/GELU/ReLU)
- \pply_norm()\  Dispatch by \NormType\ enum (RMSNorm/LayerNorm)

**Bug fixes (pre-existing on main):**
- Fixed ModelConfig struct initialization in 3 test files (missing \ctivation_type\ and \
orm_type\ fields) by adding \..Default::default()\

### Tests
27 tests covering all dispatch paths, including exhaustive variant coverage.

Supersedes #1574 (which had merge conflicts after #1570 merged).