### PR TITLE
feat(gpu-hal): workspace integration v17 (91 modules across 20 categories)

### DIFF
--- a/crates/bitnet-gpu-hal/src/activation_functions.rs
+++ b/crates/bitnet-gpu-hal/src/activation_functions.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/arch_registry.rs
+++ b/crates/bitnet-gpu-hal/src/arch_registry.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/attention_compute.rs
+++ b/crates/bitnet-gpu-hal/src/attention_compute.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/attention_mechanism.rs
+++ b/crates/bitnet-gpu-hal/src/attention_mechanism.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/attention_patterns.rs
+++ b/crates/bitnet-gpu-hal/src/attention_patterns.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/autoregressive_generator.rs
+++ b/crates/bitnet-gpu-hal/src/autoregressive_generator.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/benchmark_harness.rs
+++ b/crates/bitnet-gpu-hal/src/benchmark_harness.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/cache_system.rs
+++ b/crates/bitnet-gpu-hal/src/cache_system.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/compatibility_checker.rs
+++ b/crates/bitnet-gpu-hal/src/compatibility_checker.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/compute_graph.rs
+++ b/crates/bitnet-gpu-hal/src/compute_graph.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/config_management.rs
+++ b/crates/bitnet-gpu-hal/src/config_management.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/context_window.rs
+++ b/crates/bitnet-gpu-hal/src/context_window.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/continuous_profiling.rs
+++ b/crates/bitnet-gpu-hal/src/continuous_profiling.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/convolution_kernels.rs
+++ b/crates/bitnet-gpu-hal/src/convolution_kernels.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/cross_attention.rs
+++ b/crates/bitnet-gpu-hal/src/cross_attention.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/cuda_backend.rs
+++ b/crates/bitnet-gpu-hal/src/cuda_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/device_abstraction.rs
+++ b/crates/bitnet-gpu-hal/src/device_abstraction.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/distributed_inference.rs
+++ b/crates/bitnet-gpu-hal/src/distributed_inference.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/docker_ci.rs
+++ b/crates/bitnet-gpu-hal/src/docker_ci.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/dynamic_batching.rs
+++ b/crates/bitnet-gpu-hal/src/dynamic_batching.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/dynamic_shapes.rs
+++ b/crates/bitnet-gpu-hal/src/dynamic_shapes.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/e2e_integration.rs
+++ b/crates/bitnet-gpu-hal/src/e2e_integration.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/embedding_layer.rs
+++ b/crates/bitnet-gpu-hal/src/embedding_layer.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/embedding_operations.rs
+++ b/crates/bitnet-gpu-hal/src/embedding_operations.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/error_taxonomy.rs
+++ b/crates/bitnet-gpu-hal/src/error_taxonomy.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/execution_planner.rs
+++ b/crates/bitnet-gpu-hal/src/execution_planner.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/ffn_block.rs
+++ b/crates/bitnet-gpu-hal/src/ffn_block.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/gguf_loader.rs
+++ b/crates/bitnet-gpu-hal/src/gguf_loader.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/gguf_writer.rs
+++ b/crates/bitnet-gpu-hal/src/gguf_writer.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/gpu_buffer.rs
+++ b/crates/bitnet-gpu-hal/src/gpu_buffer.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/gpu_memory_profiler.rs
+++ b/crates/bitnet-gpu-hal/src/gpu_memory_profiler.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/gradient_checkpoint.rs
+++ b/crates/bitnet-gpu-hal/src/gradient_checkpoint.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/inference_pipeline.rs
+++ b/crates/bitnet-gpu-hal/src/inference_pipeline.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/inference_scheduler.rs
+++ b/crates/bitnet-gpu-hal/src/inference_scheduler.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/instruction_tuning.rs
+++ b/crates/bitnet-gpu-hal/src/instruction_tuning.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/kernel_autotuner.rs
+++ b/crates/bitnet-gpu-hal/src/kernel_autotuner.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/kernel_fusion.rs
+++ b/crates/bitnet-gpu-hal/src/kernel_fusion.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/kv_cache_manager.rs
+++ b/crates/bitnet-gpu-hal/src/kv_cache_manager.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/layer_norm.rs
+++ b/crates/bitnet-gpu-hal/src/layer_norm.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/level_zero_backend.rs
+++ b/crates/bitnet-gpu-hal/src/level_zero_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/lib.rs
+++ b/crates/bitnet-gpu-hal/src/lib.rs
@@ -1,11 +1,129 @@
 // GPU hardware abstraction layer for `BitNet` inference.
 
+// === GPU Backend Implementations ===
+pub mod cuda_backend;
+pub mod level_zero_backend;
+pub mod metal_backend;
+pub mod opencl_backend;
+pub mod rocm_backend;
+pub mod vulkan_compute;
+pub mod webgpu_backend;
+
+// === HAL Core ===
 pub mod async_runtime;
 pub mod backend_selector;
 pub mod bench_harness;
-pub mod deployment_manager;
+pub mod device_abstraction;
+pub mod error_taxonomy;
 pub mod hal_traits;
-pub mod model_warmup;
+
+// === Compute Kernels ===
+pub mod activation_functions;
+pub mod attention_compute;
+pub mod convolution_kernels;
+pub mod embedding_operations;
+pub mod layer_norm;
+pub mod matmul_kernels;
+pub mod normalization_variants;
+pub mod softmax_kernel;
+
+// === Memory Management ===
+pub mod gpu_buffer;
+pub mod mmap_io;
+pub mod tensor_memory_pool;
+
+// === Tensor Operations ===
+pub mod dynamic_shapes;
+pub mod shape_tracker;
+pub mod sparse_operations;
+pub mod tensor_ops_v2;
+pub mod tensor_serde;
+
+// === Model Architecture ===
+pub mod attention_mechanism;
+pub mod attention_patterns;
+pub mod cross_attention;
+pub mod embedding_layer;
+pub mod ffn_block;
+pub mod rope_kernels;
+pub mod transformer_block;
+
+// === Inference Pipeline ===
+pub mod autoregressive_generator;
+pub mod context_window;
+pub mod dynamic_batching;
+pub mod inference_pipeline;
+pub mod kv_cache_manager;
+pub mod sampling_strategies;
+
+// === Quantization ===
+pub mod mixed_precision;
+pub mod model_quantizer;
+pub mod quantization_toolkit;
+pub mod weight_compression;
+
+// === Optimization ===
+pub mod compute_graph;
+pub mod execution_planner;
+pub mod kernel_autotuner;
+pub mod kernel_fusion;
+pub mod operator_registry;
+pub mod optimization_passes;
+pub mod simd_dispatch;
+
+// === I/O & Serialization ===
+pub mod gguf_loader;
+pub mod gguf_writer;
+pub mod mmap_io_v2;
+pub mod model_export;
+pub mod model_serialization;
+pub mod tokenizer_pipeline;
+pub mod tokenizer_wrapper;
+
+// === Profiling & Debugging ===
+pub mod benchmark_harness;
+pub mod continuous_profiling;
+pub mod gpu_memory_profiler;
+pub mod model_debugger;
+
+// === Testing & Validation ===
+pub mod compatibility_checker;
+pub mod e2e_integration;
+pub mod model_validator;
+pub mod test_harness;
+
+// === Infrastructure ===
+pub mod arch_registry;
+pub mod config_management;
+pub mod logging;
+pub mod migration_tool;
+pub mod thread_pool;
+
+// === Distributed ===
+pub mod distributed_inference;
+pub mod multi_device;
+pub mod parallel_communication;
+
+// === Server & Serving ===
+pub mod cache_system;
+pub mod inference_scheduler;
+pub mod server_protocol;
+pub mod serving_runtime;
+
+// === ML Operations ===
+pub mod gradient_checkpoint;
+pub mod instruction_tuning;
+pub mod model_hub;
+pub mod model_pruning;
+
+// === SPIR-V ===
+pub mod perf_comparison;
+pub mod spirv_compiler;
+
+// === Docker/CI ===
+pub mod docker_ci;
+
+// === Existing Modules (prior waves) ===
 
 // Provides checkpoint management for saving and resuming inference state,
 // with incremental diffs, compression, and automatic scheduling.
@@ -19,4 +137,6 @@ pub mod streaming_aggregator;
 // Parallel communication primitives for distributed GPU inference:
 // all-reduce, all-gather, reduce-scatter, broadcast, ring/tree
 // topologies, double-buffered comm, and profiling.
-pub mod parallel_communication;
+pub mod deployment_manager;
+pub mod generation;
+pub mod model_warmup;

--- a/crates/bitnet-gpu-hal/src/logging.rs
+++ b/crates/bitnet-gpu-hal/src/logging.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/matmul_kernels.rs
+++ b/crates/bitnet-gpu-hal/src/matmul_kernels.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/metal_backend.rs
+++ b/crates/bitnet-gpu-hal/src/metal_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/migration_tool.rs
+++ b/crates/bitnet-gpu-hal/src/migration_tool.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/mixed_precision.rs
+++ b/crates/bitnet-gpu-hal/src/mixed_precision.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/mmap_io.rs
+++ b/crates/bitnet-gpu-hal/src/mmap_io.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/mmap_io_v2.rs
+++ b/crates/bitnet-gpu-hal/src/mmap_io_v2.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_debugger.rs
+++ b/crates/bitnet-gpu-hal/src/model_debugger.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_export.rs
+++ b/crates/bitnet-gpu-hal/src/model_export.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_hub.rs
+++ b/crates/bitnet-gpu-hal/src/model_hub.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_pruning.rs
+++ b/crates/bitnet-gpu-hal/src/model_pruning.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_quantizer.rs
+++ b/crates/bitnet-gpu-hal/src/model_quantizer.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_serialization.rs
+++ b/crates/bitnet-gpu-hal/src/model_serialization.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/model_validator.rs
+++ b/crates/bitnet-gpu-hal/src/model_validator.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/multi_device.rs
+++ b/crates/bitnet-gpu-hal/src/multi_device.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/normalization_variants.rs
+++ b/crates/bitnet-gpu-hal/src/normalization_variants.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/opencl_backend.rs
+++ b/crates/bitnet-gpu-hal/src/opencl_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/operator_registry.rs
+++ b/crates/bitnet-gpu-hal/src/operator_registry.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/optimization_passes.rs
+++ b/crates/bitnet-gpu-hal/src/optimization_passes.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/perf_comparison.rs
+++ b/crates/bitnet-gpu-hal/src/perf_comparison.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/quantization_toolkit.rs
+++ b/crates/bitnet-gpu-hal/src/quantization_toolkit.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/rocm_backend.rs
+++ b/crates/bitnet-gpu-hal/src/rocm_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/rope_kernels.rs
+++ b/crates/bitnet-gpu-hal/src/rope_kernels.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/sampling_strategies.rs
+++ b/crates/bitnet-gpu-hal/src/sampling_strategies.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/server_protocol.rs
+++ b/crates/bitnet-gpu-hal/src/server_protocol.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/serving_runtime.rs
+++ b/crates/bitnet-gpu-hal/src/serving_runtime.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/shape_tracker.rs
+++ b/crates/bitnet-gpu-hal/src/shape_tracker.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/simd_dispatch.rs
+++ b/crates/bitnet-gpu-hal/src/simd_dispatch.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/softmax_kernel.rs
+++ b/crates/bitnet-gpu-hal/src/softmax_kernel.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/sparse_operations.rs
+++ b/crates/bitnet-gpu-hal/src/sparse_operations.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/spirv_compiler.rs
+++ b/crates/bitnet-gpu-hal/src/spirv_compiler.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/tensor_memory_pool.rs
+++ b/crates/bitnet-gpu-hal/src/tensor_memory_pool.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/tensor_ops_v2.rs
+++ b/crates/bitnet-gpu-hal/src/tensor_ops_v2.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/tensor_serde.rs
+++ b/crates/bitnet-gpu-hal/src/tensor_serde.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/thread_pool.rs
+++ b/crates/bitnet-gpu-hal/src/thread_pool.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/tokenizer_pipeline.rs
+++ b/crates/bitnet-gpu-hal/src/tokenizer_pipeline.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/tokenizer_wrapper.rs
+++ b/crates/bitnet-gpu-hal/src/tokenizer_wrapper.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/transformer_block.rs
+++ b/crates/bitnet-gpu-hal/src/transformer_block.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/vulkan_compute.rs
+++ b/crates/bitnet-gpu-hal/src/vulkan_compute.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/webgpu_backend.rs
+++ b/crates/bitnet-gpu-hal/src/webgpu_backend.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch

--- a/crates/bitnet-gpu-hal/src/weight_compression.rs
+++ b/crates/bitnet-gpu-hal/src/weight_compression.rs
@@ -1,0 +1,1 @@
+//! Module stub - implementation pending merge from feature branch


### PR DESCRIPTION
Updates bitnet-gpu-hal lib.rs with 91 modules organized across 20 categories (GPU backends, HAL core, compute kernels, memory management, tensor operations, model architecture, inference pipeline, quantization, optimization, I/O & serialization, profiling & debugging, testing & validation, infrastructure, distributed, server & serving, ML operations, SPIR-V, Docker/CI, plus existing prior-wave modules). Creates stubs for modules pending merge from feature branches. cargo check passes.