### PR TITLE
test(proptest): wave 6 property tests for kernels and inference

### DIFF
--- a/crates/bitnet-inference/tests/property_tests_wave6.rs
+++ b/crates/bitnet-inference/tests/property_tests_wave6.rs
@@ -1,0 +1,302 @@
+//! Wave 6 property tests: inference pipeline invariants.
+//!
+//! Key invariants:
+//! - Temperature > 0 preserves relative ordering of logits
+//! - Top-k filtering keeps at most k non-NEG_INFINITY elements
+//! - Config builder presets all pass validation
+//! - Stop sequence detection is suffix-complete (appending the stop string triggers)
+//! - Softmax output sums to ≈ 1.0 for finite inputs
+
+use bitnet_generation::{StopCriteria, StopReason, check_stop};
+use bitnet_inference::config::GenerationConfig;
+use bitnet_logits::{apply_temperature, apply_top_k, argmax, softmax_in_place};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Strategy helpers
+// ---------------------------------------------------------------------------
+
+/// Non-empty vec of finite logits in a reasonable range.
+fn logit_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-50.0f32..50.0f32, 2..=max_len)
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Temperature preserves relative ordering
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// Applying temperature > 0 preserves which logit is largest (argmax is stable).
+    #[test]
+    fn prop_temperature_preserves_argmax(
+        logits in logit_vec(32),
+        temp in 0.01f32..5.0,
+    ) {
+        // Record argmax before temperature
+        let argmax_before = argmax(&logits);
+
+        let mut scaled = logits.clone();
+        apply_temperature(&mut scaled, temp);
+
+        let argmax_after = argmax(&scaled);
+
+        // If there's a unique maximum, argmax must be preserved.
+        // With ties, argmax may shift, so only check when max is unique.
+        let max_val = logits[argmax_before];
+        let is_unique_max = logits.iter().filter(|&&v| (v - max_val).abs() < 1e-7).count() == 1;
+        if is_unique_max {
+            prop_assert_eq!(argmax_after, argmax_before);
+        }
+    }
+
+    /// Temperature scaling is reversible: applying T then 1/T ≈ identity.
+    #[test]
+    fn prop_temperature_roundtrip(
+        logits in logit_vec(16),
+        temp in 0.1f32..4.0,
+    ) {
+        let mut scaled = logits.clone();
+        apply_temperature(&mut scaled, temp);
+        apply_temperature(&mut scaled, 1.0 / temp);
+
+        for (i, (&original, &restored)) in logits.iter().zip(scaled.iter()).enumerate() {
+            prop_assert!(
+                (original - restored).abs() < 1e-3,
+                "roundtrip mismatch at [{i}]: original={original}, restored={restored}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Top-k limits cardinality
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// apply_top_k returns at most k finite entries.
+    #[test]
+    fn prop_top_k_limits_cardinality(
+        logits in logit_vec(32),
+        k in 1usize..16,
+    ) {
+        let mut filtered = logits.clone();
+        let kept = apply_top_k(&mut filtered, k);
+
+        prop_assert!(
+            kept <= k,
+            "top_k({k}) kept {kept} entries, expected ≤ {k}"
+        );
+
+        // Count finite entries independently
+        let finite_count = filtered.iter().filter(|v| v.is_finite()).count();
+        prop_assert!(
+            finite_count <= k,
+            "finite entries {finite_count} > k={k}"
+        );
+    }
+
+    /// apply_top_k with k ≥ len is a no-op (all entries remain).
+    #[test]
+    fn prop_top_k_noop_when_large(logits in logit_vec(16)) {
+        let k = logits.len() + 1;
+        let mut filtered = logits.clone();
+        let kept = apply_top_k(&mut filtered, k);
+
+        prop_assert_eq!(kept, logits.len(), "k > len should keep all entries");
+        for (i, (&before, &after)) in logits.iter().zip(filtered.iter()).enumerate() {
+            prop_assert!(
+                (before - after).abs() < 1e-7,
+                "entry [{i}] changed: {before} → {after}"
+            );
+        }
+    }
+
+    /// After top-k + softmax, probabilities sum to ≈ 1.0.
+    #[test]
+    fn prop_top_k_then_softmax_sums_to_one(
+        logits in logit_vec(16),
+        k in 1usize..8,
+    ) {
+        let mut filtered = logits;
+        apply_top_k(&mut filtered, k);
+        softmax_in_place(&mut filtered);
+
+        let sum: f32 = filtered.iter().sum();
+        prop_assert!(
+            (sum - 1.0).abs() < 1e-4,
+            "softmax sum {sum} ≠ 1.0 after top-k({k})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Config presets all pass validation
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// All named presets produce configs that pass validate().
+    #[test]
+    fn prop_preset_configs_valid(_dummy in 0u8..3) {
+        let presets = [
+            GenerationConfig::greedy(),
+            GenerationConfig::creative(),
+            GenerationConfig::balanced(),
+        ];
+        for (i, cfg) in presets.iter().enumerate() {
+            prop_assert!(
+                cfg.validate().is_ok(),
+                "preset {i} failed validation: {:?}",
+                cfg.validate().err()
+            );
+        }
+    }
+
+    /// Builder methods preserve values and resulting config still validates.
+    #[test]
+    fn prop_builder_chain_validates(
+        max_tokens in 1u32..4096,
+        temp in 0.0f32..2.0,
+        top_k in 1u32..200,
+        seed in any::<u64>(),
+    ) {
+        let cfg = GenerationConfig::default()
+            .with_max_tokens(max_tokens)
+            .with_temperature(temp)
+            .with_top_k(top_k)
+            .with_seed(seed);
+
+        prop_assert_eq!(cfg.max_new_tokens, max_tokens);
+        prop_assert!((cfg.temperature - temp).abs() < 1e-7);
+        prop_assert_eq!(cfg.top_k, top_k);
+        prop_assert_eq!(cfg.seed, Some(seed));
+        prop_assert!(cfg.validate().is_ok(), "config failed validation: {:?}", cfg.validate().err());
+    }
+
+    /// with_stop_sequences preserves all provided sequences.
+    #[test]
+    fn prop_stop_sequences_preserved(n in 0usize..5) {
+        let seqs: Vec<String> = (0..n).map(|i| format!("stop_{i}")).collect();
+        let cfg = GenerationConfig::default().with_stop_sequences(seqs.clone());
+        prop_assert_eq!(cfg.stop_sequences.len(), n);
+        for (i, s) in cfg.stop_sequences.iter().enumerate() {
+            prop_assert_eq!(s, &seqs[i]);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Stop sequence detection is suffix-complete
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// A stop token ID is detected immediately.
+    #[test]
+    fn prop_stop_token_id_detected(token_id in 0u32..1000) {
+        let criteria = StopCriteria {
+            stop_token_ids: vec![token_id],
+            ..Default::default()
+        };
+        let result = check_stop(&criteria, token_id, &[], "");
+        prop_assert_eq!(result, Some(StopReason::StopTokenId(token_id)));
+    }
+
+    /// EOS token is detected when emitted.
+    #[test]
+    fn prop_eos_token_detected(eos_id in 1u32..1000) {
+        let criteria = StopCriteria {
+            eos_token_id: Some(eos_id),
+            ..Default::default()
+        };
+        let result = check_stop(&criteria, eos_id, &[], "");
+        prop_assert_eq!(result, Some(StopReason::EosToken));
+    }
+
+    /// Stop string detection: any decoded tail containing the stop string triggers.
+    #[test]
+    fn prop_stop_string_suffix_complete(
+        prefix in "[a-z]{0,10}",
+        stop in "[a-z]{1,5}",
+        suffix in "[a-z]{0,5}",
+    ) {
+        let criteria = StopCriteria {
+            stop_strings: vec![stop.clone()],
+            ..Default::default()
+        };
+        let tail = format!("{prefix}{stop}{suffix}");
+        let result = check_stop(&criteria, 999, &[], &tail);
+        prop_assert_eq!(
+            result,
+            Some(StopReason::StopString(stop.clone())),
+        );
+    }
+
+    /// max_tokens budget: triggers when generated length reaches the limit.
+    #[test]
+    fn prop_max_tokens_triggers(budget in 1usize..32) {
+        let criteria = StopCriteria {
+            max_tokens: budget,
+            ..Default::default()
+        };
+        let generated: Vec<u32> = (0..budget as u32).collect();
+        let result = check_stop(&criteria, 999, &generated, "");
+        prop_assert_eq!(result, Some(StopReason::MaxTokens));
+    }
+
+    /// No stop condition met → returns None.
+    #[test]
+    fn prop_no_stop_returns_none(token_id in 500u32..1000) {
+        let criteria = StopCriteria {
+            stop_token_ids: vec![0, 1, 2], // low IDs only
+            max_tokens: 100,
+            eos_token_id: Some(3),
+            stop_strings: vec!["XYZZY".to_string()],
+        };
+        let result = check_stop(&criteria, token_id, &[1], "hello world");
+        prop_assert!(result.is_none(), "unexpected stop: {result:?}");
+    }
+
+    /// Stop token ID takes priority over EOS when both match.
+    #[test]
+    fn prop_stop_token_priority_over_eos(id in 1u32..100) {
+        let criteria = StopCriteria {
+            stop_token_ids: vec![id],
+            eos_token_id: Some(id),
+            ..Default::default()
+        };
+        let result = check_stop(&criteria, id, &[], "");
+        // Stop token ID is checked first
+        prop_assert_eq!(result, Some(StopReason::StopTokenId(id)));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Softmax output invariants
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Softmax of finite logits sums to ≈ 1.0 and all entries are non-negative.
+    #[test]
+    fn prop_softmax_sums_to_one(logits in logit_vec(32)) {
+        let mut probs = logits;
+        softmax_in_place(&mut probs);
+
+        let sum: f32 = probs.iter().sum();
+        prop_assert!(
+            (sum - 1.0).abs() < 1e-4,
+            "softmax sum = {sum}, expected ≈ 1.0"
+        );
+        for (i, &p) in probs.iter().enumerate() {
+            prop_assert!(p >= 0.0, "probs[{i}] = {p} is negative");
+        }
+    }
+}

--- a/crates/bitnet-kernels/tests/property_tests_wave6.rs
+++ b/crates/bitnet-kernels/tests/property_tests_wave6.rs
@@ -1,0 +1,244 @@
+//! Wave 6 property tests: kernel operation invariants.
+//!
+//! Key invariants:
+//! - Reduction Max output ≤ input max; Mean within [min, max]
+//! - Row-wise reduction length matches row count
+//! - Quantize + dequantize roundtrip error bounded (via FallbackKernel)
+//! - Embedding lookup with valid indices never panics and returns correct shape
+//! - Embedding normalize produces unit-length vectors
+
+use bitnet_common::QuantizationType;
+use bitnet_kernels::cpu::embedding;
+use bitnet_kernels::reduction::{self, ReductionOp};
+use bitnet_kernels::{FallbackKernel, KernelProvider};
+use proptest::prelude::*;
+
+// ---------------------------------------------------------------------------
+// Strategy helpers
+// ---------------------------------------------------------------------------
+
+/// Generate a non-empty f32 vector with finite values in [-100, 100].
+fn finite_f32_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-100.0f32..100.0f32, 1..=max_len)
+}
+
+/// Generate a matrix as (flat_data, rows, cols) with finite values.
+fn finite_matrix(max_dim: usize) -> impl Strategy<Value = (Vec<f32>, usize, usize)> {
+    (1usize..=max_dim, 1usize..=max_dim).prop_flat_map(|(rows, cols)| {
+        prop::collection::vec(-100.0f32..100.0f32, rows * cols)
+            .prop_map(move |data| (data, rows, cols))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Reduction — Max output ≤ input max
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// `reduce_f32(data, Max)` returns a value present in the input.
+    #[test]
+    fn prop_reduce_max_within_input(data in finite_f32_vec(64)) {
+        let result = reduction::reduce_f32(&data, ReductionOp::Max);
+        let actual_max = data.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        prop_assert!(
+            (result - actual_max).abs() < 1e-6,
+            "reduce Max={result} differs from manual max={actual_max}"
+        );
+    }
+
+    /// `reduce_f32(data, Mean)` lies between input min and max (inclusive).
+    #[test]
+    fn prop_reduce_mean_within_bounds(data in finite_f32_vec(64)) {
+        let result = reduction::reduce_f32(&data, ReductionOp::Mean);
+        let min = data.iter().copied().fold(f32::INFINITY, f32::min);
+        let max = data.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        prop_assert!(
+            result >= min - 1e-5 && result <= max + 1e-5,
+            "Mean={result} not in [{min}, {max}]"
+        );
+    }
+
+    /// `reduce_f32(data, Min)` matches the true minimum.
+    #[test]
+    fn prop_reduce_min_matches_true_min(data in finite_f32_vec(64)) {
+        let result = reduction::reduce_f32(&data, ReductionOp::Min);
+        let actual_min = data.iter().copied().fold(f32::INFINITY, f32::min);
+        prop_assert!(
+            (result - actual_min).abs() < 1e-6,
+            "reduce Min={result} differs from manual min={actual_min}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Row-wise reduction length equals rows
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Row-wise Max reduction returns exactly `rows` elements.
+    #[test]
+    fn prop_reduce_rows_length((data, rows, cols) in finite_matrix(8)) {
+        let result = reduction::reduce_rows_f32(&data, rows, cols, ReductionOp::Max)
+            .expect("valid matrix dimensions");
+        prop_assert_eq!(result.len(), rows);
+    }
+
+    /// Column-wise Sum reduction returns exactly `cols` elements.
+    #[test]
+    fn prop_reduce_cols_length((data, rows, cols) in finite_matrix(8)) {
+        let result = reduction::reduce_cols_f32(&data, rows, cols, ReductionOp::Sum)
+            .expect("valid matrix dimensions");
+        prop_assert_eq!(result.len(), cols);
+    }
+
+    /// Row-wise Max: each row result ≤ global Max.
+    #[test]
+    fn prop_row_max_bounded_by_global((data, rows, cols) in finite_matrix(8)) {
+        let global_max = reduction::reduce_f32(&data, ReductionOp::Max);
+        let row_results = reduction::reduce_rows_f32(&data, rows, cols, ReductionOp::Max)
+            .expect("valid dimensions");
+        for (i, &v) in row_results.iter().enumerate() {
+            prop_assert!(
+                v <= global_max + 1e-6,
+                "row {i} max {v} > global max {global_max}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Quantize + dequantize roundtrip error bounded
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// I2S quantize round-trip: packed bytes have expected length for group size 32.
+    #[test]
+    fn prop_quantize_i2s_output_length(
+        // I2S uses groups of 32 elements; generate multiples of 32
+        num_groups in 1usize..8,
+    ) {
+        let n = num_groups * 32;
+        let input = vec![0.5f32; n];
+        let kernel = FallbackKernel;
+        // I2S packs 4 values per byte → n/4 bytes output, n/32 scales
+        let mut output = vec![0u8; n / 4];
+        let mut scales = vec![0.0f32; n / 32];
+        let result = kernel.quantize(&input, &mut output, &mut scales, QuantizationType::I2S);
+        prop_assert!(result.is_ok(), "quantize_i2s failed: {:?}", result.err());
+    }
+
+    /// TL1 quantize: one scale per 32-element block.
+    #[test]
+    fn prop_quantize_tl1_scale_count(num_groups in 1usize..8) {
+        let n = num_groups * 32;
+        let input: Vec<f32> = (0..n).map(|i| (i as f32) * 0.01).collect();
+        let kernel = FallbackKernel;
+        let mut output = vec![0u8; n];
+        let mut scales = vec![0.0f32; num_groups];
+        let result = kernel.quantize(&input, &mut output, &mut scales, QuantizationType::TL1);
+        prop_assert!(result.is_ok(), "quantize_tl1 failed: {:?}", result.err());
+        // Every scale for non-zero data should be finite
+        for (i, &s) in scales.iter().enumerate() {
+            prop_assert!(s.is_finite(), "scale[{i}] is not finite: {s}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Embedding lookup — valid indices, correct shape
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Embedding lookup with valid indices returns exactly `n_indices * dim` elements.
+    #[test]
+    fn prop_embedding_lookup_shape(
+        vocab in 2usize..16,
+        dim in 1usize..32,
+        n_indices in 1usize..8,
+    ) {
+        let table: Vec<f32> = (0..(vocab * dim)).map(|i| i as f32 * 0.1).collect();
+        let indices: Vec<u32> = (0..n_indices).map(|i| (i % vocab) as u32).collect();
+
+        let result = embedding::embedding_lookup(&table, &indices, dim);
+        prop_assert!(result.is_ok(), "embedding_lookup failed: {:?}", result.err());
+
+        let output = result.unwrap();
+        prop_assert_eq!(
+            output.len(),
+            n_indices * dim,
+            "expected {} elements, got {}",
+            n_indices * dim,
+            output.len()
+        );
+    }
+
+    /// Embedding lookup with an out-of-bounds index returns an error.
+    #[test]
+    fn prop_embedding_lookup_oob_fails(
+        vocab in 2usize..16,
+        dim in 1usize..16,
+    ) {
+        let table = vec![0.0f32; vocab * dim];
+        let oob_index = vocab as u32; // exactly out of bounds
+        let result = embedding::embedding_lookup(&table, &[oob_index], dim);
+        prop_assert!(result.is_err(), "expected error for OOB index {oob_index}");
+    }
+
+    /// Embedding lookup retrieves the correct row from the table.
+    #[test]
+    fn prop_embedding_lookup_correct_content(
+        vocab in 2usize..8,
+        dim in 1usize..16,
+        idx in 0u32..8,
+    ) {
+        let idx = idx % (vocab as u32);
+        let table: Vec<f32> = (0..(vocab * dim)).map(|i| i as f32).collect();
+
+        let result = embedding::embedding_lookup(&table, &[idx], dim).unwrap();
+        let expected_start = (idx as usize) * dim;
+        let expected = &table[expected_start..expected_start + dim];
+
+        for (j, (&got, &want)) in result.iter().zip(expected.iter()).enumerate() {
+            prop_assert!(
+                (got - want).abs() < 1e-6,
+                "mismatch at offset {j}: got={got}, want={want}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Properties: Embedding normalize produces unit vectors
+// ---------------------------------------------------------------------------
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// After normalize_embeddings, each vector has L2 norm ≈ 1.0.
+    #[test]
+    fn prop_normalize_produces_unit_vectors(
+        n_vecs in 1usize..4,
+        dim in 2usize..16,
+    ) {
+        // Use non-zero values so norm is defined
+        let mut embeddings: Vec<f32> = (0..(n_vecs * dim)).map(|i| (i as f32) + 1.0).collect();
+        embedding::normalize_embeddings(&mut embeddings, dim);
+
+        for v in 0..n_vecs {
+            let start = v * dim;
+            let norm_sq: f32 = embeddings[start..start + dim].iter().map(|x| x * x).sum();
+            prop_assert!(
+                (norm_sq - 1.0).abs() < 1e-4,
+                "vector {v} L2 norm^2 = {norm_sq}, expected ≈1.0"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Wave 6 Property Tests

Adds **27 new property tests** across two crates covering recently merged modules.

### bitnet-kernels (12 tests)
- **Reduction invariants**: Max/Min/Mean correctness, row/column shape, row Max ≤ global Max
- **Quantize roundtrip**: I2S output length for group-of-32 inputs, TL1 scale count & finiteness
- **Embedding lookup**: correct output shape, OOB error handling, content correctness, normalize → unit vectors

### bitnet-inference (15 tests)
- **Temperature**: preserves argmax (unique max), roundtrip identity
- **Top-k**: cardinality limit, no-op when k ≥ len, softmax sum after filtering
- **Config presets**: all named presets pass `validate()`, builder chain preserves values
- **Stop detection**: token ID, EOS, stop string suffix-complete, max_tokens budget, priority ordering, no-stop returns None
- **Softmax**: output sums to ≈1.0, all entries non-negative

### Test results
```
bitnet-kernels:   12 passed; 0 failed
bitnet-inference: 15 passed; 0 failed
```