### PR TITLE
test(snapshot): wave 5 insta snapshots for common, kernels, and inference types

### DIFF
--- a/crates/bitnet-common/tests/snapshot_wave5.rs
+++ b/crates/bitnet-common/tests/snapshot_wave5.rs
@@ -1,0 +1,191 @@
+//! Wave 5 snapshot tests for `bitnet-common` public API surface.
+//!
+//! Pins Debug/Display formats and serialization of core types so that
+//! unintentional changes are caught at review time.
+
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+use bitnet_common::types::{Device, ModelMetadata, PerformanceMetrics, QuantizationType};
+use bitnet_common::{BackendRequest, BackendStartupSummary};
+
+// ---------------------------------------------------------------------------
+// Device Debug
+// ---------------------------------------------------------------------------
+
+#[test]
+fn device_all_variants_debug() {
+    let devices = [
+        Device::Cpu,
+        Device::Cuda(0),
+        Device::Hip(1),
+        Device::Npu,
+        Device::Metal,
+        Device::OpenCL(2),
+    ];
+    let output: Vec<String> = devices.iter().map(|d| format!("{d:?}")).collect();
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn device_default_is_cpu() {
+    let dev = Device::default();
+    insta::assert_snapshot!(format!("{dev:?}"));
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationType Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantization_type_display_all_variants() {
+    let qtypes = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    let displays: Vec<String> = qtypes.iter().map(|q| q.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn quantization_type_debug_all_variants() {
+    let qtypes = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    let debugs: Vec<String> = qtypes.iter().map(|q| format!("{q:?}")).collect();
+    insta::assert_debug_snapshot!(debugs);
+}
+
+// ---------------------------------------------------------------------------
+// KernelCapabilities summary (with SIMD filter)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kernel_capabilities_summary_cpu_only() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        hip_compiled: false,
+        hip_runtime: false,
+        oneapi_compiled: false,
+        oneapi_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    insta::with_settings!({filters => vec![(r"simd=\w+", "simd=[SIMD]")]}, {
+        insta::assert_snapshot!(caps.summary());
+    });
+}
+
+#[test]
+fn kernel_capabilities_summary_full_stack() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: true,
+        hip_compiled: false,
+        hip_runtime: false,
+        oneapi_compiled: false,
+        oneapi_runtime: false,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Avx512,
+    };
+    insta::with_settings!({filters => vec![(r"simd=\w+", "simd=[SIMD]")]}, {
+        insta::assert_snapshot!(caps.summary());
+    });
+}
+
+#[test]
+fn kernel_capabilities_compiled_backends_priority_order() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: false,
+        hip_compiled: true,
+        hip_runtime: false,
+        oneapi_compiled: true,
+        oneapi_runtime: false,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Scalar,
+    };
+    let backends: Vec<String> = caps.compiled_backends().iter().map(|b| b.to_string()).collect();
+    insta::assert_debug_snapshot!(backends);
+}
+
+// ---------------------------------------------------------------------------
+// BackendStartupSummary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backend_startup_summary_auto_cpu() {
+    let summary = BackendStartupSummary::new("auto", vec!["cpu-rust".to_string()], "cpu-rust");
+    insta::assert_snapshot!(summary.log_line());
+}
+
+#[test]
+fn backend_startup_summary_auto_gpu() {
+    let summary = BackendStartupSummary::new(
+        "auto",
+        vec!["cuda".to_string(), "cpu-rust".to_string()],
+        "cuda",
+    );
+    insta::assert_snapshot!(summary.log_line());
+}
+
+// ---------------------------------------------------------------------------
+// BackendRequest Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backend_request_display_all_variants() {
+    let requests = [
+        BackendRequest::Auto,
+        BackendRequest::Cpu,
+        BackendRequest::Gpu,
+        BackendRequest::Cuda,
+        BackendRequest::Hip,
+        BackendRequest::OneApi,
+    ];
+    let displays: Vec<String> = requests.iter().map(|r| r.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+// ---------------------------------------------------------------------------
+// ModelMetadata default Debug
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_metadata_debug_snapshot() {
+    let meta = ModelMetadata {
+        name: "test-model".to_string(),
+        version: "1.0.0".to_string(),
+        architecture: "bitnet".to_string(),
+        vocab_size: 32000,
+        context_length: 2048,
+        quantization: Some(QuantizationType::I2S),
+        fingerprint: None,
+        corrections_applied: None,
+    };
+    insta::assert_debug_snapshot!(meta);
+}
+
+// ---------------------------------------------------------------------------
+// PerformanceMetrics default Debug
+// ---------------------------------------------------------------------------
+
+#[test]
+fn performance_metrics_default_debug() {
+    let metrics = PerformanceMetrics::default();
+    insta::assert_debug_snapshot!(metrics);
+}
+
+// ---------------------------------------------------------------------------
+// KernelBackend Display — all variants including Hip/OneApi
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kernel_backend_display_all_five_variants() {
+    let backends = [
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::CppFfi,
+    ];
+    let displays: Vec<String> = backends.iter().map(|b| b.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_request_display_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_request_display_all_variants.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: displays
+---
+[
+    "auto",
+    "cpu",
+    "gpu",
+    "cuda",
+    "hip",
+    "oneapi",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_startup_summary_auto_cpu.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_startup_summary_auto_cpu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: summary.log_line()
+---
+requested=auto detected=[cpu-rust] selected=cpu-rust

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_startup_summary_auto_gpu.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__backend_startup_summary_auto_gpu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: summary.log_line()
+---
+requested=auto detected=[cuda, cpu-rust] selected=cuda

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__device_all_variants_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__device_all_variants_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: output
+---
+[
+    "Cpu",
+    "Cuda(0)",
+    "Hip(1)",
+    "Npu",
+    "Metal",
+    "OpenCL(2)",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__device_default_is_cpu.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__device_default_is_cpu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: "format!(\"{dev:?}\")"
+---
+Cpu

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_backend_display_all_five_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_backend_display_all_five_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: displays
+---
+[
+    "cpu-rust",
+    "cuda",
+    "hip",
+    "oneapi",
+    "cpp-ffi",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_compiled_backends_priority_order.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_compiled_backends_priority_order.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: backends
+---
+[
+    "cuda",
+    "hip",
+    "oneapi",
+    "cpp-ffi",
+    "cpu-rust",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_summary_cpu_only.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_summary_cpu_only.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: caps.summary()
+---
+simd=[SIMD] backends=[cpu-rust]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_summary_full_stack.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__kernel_capabilities_summary_full_stack.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: caps.summary()
+---
+simd=[SIMD] backends=[cuda,cpp-ffi,cpu-rust]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__model_metadata_debug_snapshot.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__model_metadata_debug_snapshot.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: meta
+---
+ModelMetadata {
+    name: "test-model",
+    version: "1.0.0",
+    architecture: "bitnet",
+    vocab_size: 32000,
+    context_length: 2048,
+    quantization: Some(
+        I2S,
+    ),
+    fingerprint: None,
+    corrections_applied: None,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__performance_metrics_default_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__performance_metrics_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: metrics
+---
+PerformanceMetrics {
+    tokens_per_second: 0.0,
+    latency_ms: 0.0,
+    memory_usage_mb: 0.0,
+    gpu_utilization: None,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__quantization_type_debug_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__quantization_type_debug_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: debugs
+---
+[
+    "I2S",
+    "TL1",
+    "TL2",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave5__quantization_type_display_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave5__quantization_type_display_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave5.rs
+expression: displays
+---
+[
+    "I2_S",
+    "TL1",
+    "TL2",
+]

--- a/crates/bitnet-inference/tests/snapshot_wave5.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave5.rs
@@ -1,0 +1,110 @@
+//! Wave 5 snapshot tests for `bitnet-inference` configuration and strategy types.
+//!
+//! Pins the Debug/Display formats and default values of types that must remain
+//! stable across releases.
+
+use bitnet_inference::config::{GenerationConfig, InferenceConfig};
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — balanced preset
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_balanced_snapshot() {
+    let cfg = GenerationConfig::balanced();
+    insta::assert_snapshot!(format!(
+        "temperature={} top_k={} top_p={} repetition_penalty={}",
+        cfg.temperature, cfg.top_k, cfg.top_p, cfg.repetition_penalty
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — default fields
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_default_all_fields() {
+    let cfg = GenerationConfig::default();
+    insta::assert_snapshot!(format!(
+        "max_new_tokens={} temperature={} top_k={} top_p={} \
+         repetition_penalty={} skip_special_tokens={} add_bos={}",
+        cfg.max_new_tokens,
+        cfg.temperature,
+        cfg.top_k,
+        cfg.top_p,
+        cfg.repetition_penalty,
+        cfg.skip_special_tokens,
+        cfg.add_bos,
+    ));
+}
+
+#[test]
+fn generation_config_greedy_fields() {
+    let cfg = GenerationConfig::greedy();
+    insta::assert_snapshot!(format!(
+        "temperature={} top_k={} top_p={} repetition_penalty={}",
+        cfg.temperature, cfg.top_k, cfg.top_p, cfg.repetition_penalty,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — builder chain snapshot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_builder_chain_fields() {
+    let cfg = GenerationConfig::greedy()
+        .with_max_tokens(16)
+        .with_temperature(0.5)
+        .with_top_k(10)
+        .with_top_p(0.8)
+        .with_seed(42);
+    insta::assert_snapshot!(format!(
+        "max_new_tokens={} temperature={} top_k={} top_p={} seed={:?}",
+        cfg.max_new_tokens, cfg.temperature, cfg.top_k, cfg.top_p, cfg.seed,
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — validation error messages
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_validate_negative_temperature_error() {
+    let cfg = GenerationConfig::default().with_temperature(-1.0);
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err);
+}
+
+#[test]
+fn generation_config_validate_invalid_top_p_error() {
+    let cfg = GenerationConfig::default().with_top_p(0.0);
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err);
+}
+
+// ---------------------------------------------------------------------------
+// InferenceConfig — full Debug output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inference_config_default_debug() {
+    let cfg = InferenceConfig::default();
+    insta::with_settings!({filters => vec![
+        (r"num_threads: \d+", "num_threads: [N]"),
+    ]}, {
+        insta::assert_debug_snapshot!(cfg);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// SamplingConfig — Debug output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sampling_config_default_debug() {
+    use bitnet_inference::generation::sampling::SamplingConfig;
+
+    let cfg = SamplingConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_balanced_snapshot.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_balanced_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: "format!(\"temperature={} top_k={} top_p={} repetition_penalty={}\",\ncfg.temperature, cfg.top_k, cfg.top_p, cfg.repetition_penalty)"
+---
+temperature=0.7 top_k=50 top_p=0.9 repetition_penalty=1.05

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_builder_chain_fields.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_builder_chain_fields.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: "format!(\"max_new_tokens={} temperature={} top_k={} top_p={} seed={:?}\",\ncfg.max_new_tokens, cfg.temperature, cfg.top_k, cfg.top_p, cfg.seed,)"
+---
+max_new_tokens=16 temperature=0.5 top_k=10 top_p=0.8 seed=Some(42)

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_default_all_fields.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_default_all_fields.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: "format!(\"max_new_tokens={} temperature={} top_k={} top_p={} \\\n         repetition_penalty={} skip_special_tokens={} add_bos={}\",\ncfg.max_new_tokens, cfg.temperature, cfg.top_k, cfg.top_p,\ncfg.repetition_penalty, cfg.skip_special_tokens, cfg.add_bos,)"
+---
+max_new_tokens=100 temperature=0.7 top_k=50 top_p=0.9 repetition_penalty=1 skip_special_tokens=true add_bos=false

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_greedy_fields.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_greedy_fields.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: "format!(\"temperature={} top_k={} top_p={} repetition_penalty={}\",\ncfg.temperature, cfg.top_k, cfg.top_p, cfg.repetition_penalty,)"
+---
+temperature=0 top_k=1 top_p=1 repetition_penalty=1

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_validate_invalid_top_p_error.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_validate_invalid_top_p_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: err
+---
+top_p must be in range (0.0, 1.0]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_validate_negative_temperature_error.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__generation_config_validate_negative_temperature_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: err
+---
+temperature must be non-negative

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__inference_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__inference_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: cfg
+---
+InferenceConfig {
+    max_context_length: 2048,
+    num_threads: [N],
+    batch_size: 1,
+    mixed_precision: false,
+    memory_pool_size: 536870912,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave5__sampling_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave5__sampling_config_default_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave5.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+}

--- a/crates/bitnet-kernels/tests/snapshot_wave5.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave5.rs
@@ -1,0 +1,81 @@
+//! Wave 5 snapshot tests for `bitnet-kernels` public API surface.
+//!
+//! Pins the kernel provider listing, SIMD detection, and capability summary
+//! formats so that unintentional changes are caught at review time.
+
+use bitnet_kernels::KernelManager;
+use bitnet_kernels::device_features;
+
+// ---------------------------------------------------------------------------
+// Kernel provider listing
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kernel_provider_list_non_empty() {
+    let mgr = KernelManager::new();
+    let providers = mgr.list_available_providers();
+    insta::assert_snapshot!(format!(
+        "provider_count={} providers={:?}",
+        providers.len(),
+        providers
+    ));
+}
+
+#[test]
+fn kernel_provider_list_always_has_cpu_fallback() {
+    let mgr = KernelManager::new();
+    let providers = mgr.list_available_providers();
+    let has_cpu = providers
+        .iter()
+        .any(|p| p.contains("cpu") || p.contains("fallback") || p.contains("Fallback"));
+    insta::assert_snapshot!(format!("has_cpu_fallback={has_cpu}"));
+}
+
+// ---------------------------------------------------------------------------
+// SIMD level detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detect_simd_level_is_stable() {
+    let level_a = device_features::detect_simd_level();
+    let level_b = device_features::detect_simd_level();
+    // Two consecutive calls must return the same level
+    assert_eq!(level_a, level_b);
+    insta::with_settings!({filters => vec![(r"(?:avx512|avx2|sse4\.2|neon|scalar)", "[SIMD]")]}, {
+        insta::assert_snapshot!(format!("simd_level={level_a}"));
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Device capability summary (with SIMD + CUDA version filter)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn device_capability_summary_format() {
+    let summary = device_features::device_capability_summary();
+    insta::with_settings!({filters => vec![
+        (r"(?:avx512|avx2|sse4\.2|neon|scalar)", "[SIMD]"),
+        (r"CUDA \d+\.\d+", "CUDA [VERSION]"),
+    ]}, {
+        insta::assert_snapshot!(summary);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// KernelCapabilities via current_kernel_capabilities
+// ---------------------------------------------------------------------------
+
+#[test]
+fn current_kernel_capabilities_summary() {
+    let caps = device_features::current_kernel_capabilities();
+    insta::with_settings!({filters => vec![(r"simd=\w+", "simd=[SIMD]")]}, {
+        insta::assert_snapshot!(caps.summary());
+    });
+}
+
+#[test]
+fn current_kernel_capabilities_cpu_is_compiled() {
+    let caps = device_features::current_kernel_capabilities();
+    // When built with --features cpu, cpu_rust must be true
+    insta::assert_snapshot!(format!("cpu_rust={}", caps.cpu_rust));
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_tests__kernel_manager_has_at_least_one_provider.snap.new
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_tests__kernel_manager_has_at_least_one_provider.snap.new
@@ -1,6 +1,0 @@
----
-source: crates/bitnet-kernels/tests/snapshot_tests.rs
-assertion_line: 10
-expression: "format!(\"count={} has_providers={}\", providers.len(), !providers.is_empty())"
----
-count=3 has_providers=true

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__current_kernel_capabilities_cpu_is_compiled.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__current_kernel_capabilities_cpu_is_compiled.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: "format!(\"cpu_rust={}\", caps.cpu_rust)"
+---
+cpu_rust=true

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__current_kernel_capabilities_summary.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__current_kernel_capabilities_summary.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: caps.summary()
+---
+simd=[SIMD] backends=[cpu-rust]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__detect_simd_level_is_stable.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__detect_simd_level_is_stable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: "format!(\"simd_level={level_a}\")"
+---
+simd_level=[SIMD]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__device_capability_summary_format.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__device_capability_summary_format.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: summary
+---
+Device Capabilities:
+  Compiled: CPU ✓
+  Runtime: CPU ✓

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__kernel_provider_list_always_has_cpu_fallback.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__kernel_provider_list_always_has_cpu_fallback.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: "format!(\"has_cpu_fallback={has_cpu}\")"
+---
+has_cpu_fallback=true

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__kernel_provider_list_non_empty.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave5__kernel_provider_list_non_empty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave5.rs
+expression: "format!(\"provider_count={} providers={:?}\", providers.len(), providers)"
+---
+provider_count=3 providers=["avx512", "avx2", "fallback"]


### PR DESCRIPTION
## Summary

Add 27 new insta snapshot tests across three core crates, pinning Debug/Display formats and default values of key public API types.

### bitnet-common (13 tests)
- `Device` Debug for all variants (Cpu, Cuda, Hip, Npu, Metal, OpenCL)
- `QuantizationType` Display and Debug for all variants
- `KernelCapabilities` summary with SIMD filter (cpu-only and full stack)
- `KernelCapabilities` compiled_backends priority order
- `BackendStartupSummary` log_line format (auto→cpu, auto→gpu)
- `BackendRequest` Display for all 6 variants
- `ModelMetadata` Debug snapshot
- `PerformanceMetrics` default Debug
- `KernelBackend` Display all 5 variants

### bitnet-kernels (6 tests)
- Kernel provider list (non-empty, CPU fallback presence)
- SIMD level detection stability (with SIMD filter)
- Device capability summary format (with SIMD + CUDA version filters)
- `current_kernel_capabilities` summary and cpu_rust flag

### bitnet-inference (8 tests)
- `GenerationConfig` balanced preset fields
- `GenerationConfig` default/greedy key fields
- `GenerationConfig` builder chain fields
- `GenerationConfig` validation errors (negative temp, invalid top_p)
- `InferenceConfig` default Debug (with num_threads filter)
- `SamplingConfig` default Debug

### Conventions
- No `GenerationConfig` struct literals in test source (compliant with pre-commit hook)
- Follows existing snapshot test patterns from waves 1-4