### PR TITLE
test(inference): add config builder + architecture integration tests (21 tests)

### DIFF
--- a/crates/bitnet-inference/tests/config_builder_arch_integration.rs
+++ b/crates/bitnet-inference/tests/config_builder_arch_integration.rs
@@ -31,10 +31,7 @@ fn llama_config_with_fast_preset() {
     let mut model = ModelConfig::default();
     model.apply_architecture_defaults("llama");
 
-    let inference = InferenceConfigBuilder::new()
-        .preset(InferencePreset::Fast)
-        .build()
-        .unwrap();
+    let inference = InferenceConfigBuilder::new().preset(InferencePreset::Fast).build().unwrap();
 
     assert_eq!(model.norm_type, NormType::RmsNorm);
     assert_eq!(model.activation_type, ActivationType::Silu);
@@ -65,10 +62,8 @@ fn bitnet_config_with_deterministic_preset() {
     let mut model = ModelConfig::default();
     model.apply_architecture_defaults("bitnet");
 
-    let inference = InferenceConfigBuilder::new()
-        .preset(InferencePreset::Deterministic)
-        .build()
-        .unwrap();
+    let inference =
+        InferenceConfigBuilder::new().preset(InferencePreset::Deterministic).build().unwrap();
 
     assert_eq!(model.norm_type, NormType::LayerNorm);
     assert_eq!(model.activation_type, ActivationType::Silu);
@@ -81,10 +76,7 @@ fn mistral_config_with_debug_preset() {
     let mut model = ModelConfig::default();
     model.apply_architecture_defaults("mistral");
 
-    let inference = InferenceConfigBuilder::new()
-        .preset(InferencePreset::Debug)
-        .build()
-        .unwrap();
+    let inference = InferenceConfigBuilder::new().preset(InferencePreset::Debug).build().unwrap();
 
     assert_eq!(model.norm_type, NormType::RmsNorm);
     assert_eq!(model.activation_type, ActivationType::Silu);


### PR DESCRIPTION
## Summary

Add 21 integration tests verifying InferenceConfigBuilder presets work correctly with architecture-aware ModelConfig defaults for multi-SLM support.

### Tests

**Preset + Architecture (5 tests)**
- Phi-4 + Balanced, LLaMA + Fast, Gemma + Quality, BitNet + Deterministic, Mistral + Debug

**Builder Chaining (4 tests)**  
- Preset then override preserves overrides
- Multiple presets (last wins)
- Stop sequences accumulate
- Stop sequences replaced by setter

**Validation Edge Cases (7 tests)**
- Negative temperature, zero top_p, top_p > 1, zero repetition penalty
- Zero max_tokens, excessive threads, valid boundary values

**Serialization + Presets (2 tests)**
- JSON roundtrip serialization
- All presets produce valid configs

**Multi-SLM Scenarios (3 tests)**
- Phi-4 16K streaming with stop tokens
- Qwen2 config scenario
- DeepSeek config scenario

All 21 tests pass locally.