### PR TITLE
test(gguf,generation): add edge case tests for parsers and stop criteria (68 tests)

### DIFF
--- a/crates/bitnet-generation/tests/stop_criteria_edge_cases.rs
+++ b/crates/bitnet-generation/tests/stop_criteria_edge_cases.rs
@@ -1,0 +1,392 @@
+//! Edge case and boundary tests for generation stop criteria.
+//!
+//! Tests exercise unusual inputs, priority ordering, and boundary conditions
+//! for the `check_stop` function and related types.
+
+use bitnet_generation::{
+    GenerationConfig, GenerationStats, StopCriteria, StopReason, StreamEvent, TokenEvent,
+    check_stop,
+};
+
+// --- check_stop priority and ordering ---
+
+#[test]
+fn stop_token_id_takes_priority_over_max_tokens() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![42],
+        stop_strings: vec![],
+        max_tokens: 1,
+        eos_token_id: None,
+    };
+    // generated has 1 token (at max), AND token_id is a stop token
+    let result = check_stop(&criteria, 42, &[42], "hello");
+    assert!(matches!(result, Some(StopReason::StopTokenId(42))));
+}
+
+#[test]
+fn stop_token_id_takes_priority_over_eos() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![42],
+        stop_strings: vec![],
+        max_tokens: 100,
+        eos_token_id: Some(42),
+    };
+    // token_id matches both stop_token_ids and eos_token_id
+    let result = check_stop(&criteria, 42, &[42], "");
+    assert!(matches!(result, Some(StopReason::StopTokenId(42))));
+}
+
+#[test]
+fn eos_takes_priority_over_max_tokens() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 1,
+        eos_token_id: Some(99),
+    };
+    let result = check_stop(&criteria, 99, &[99], "");
+    assert!(matches!(result, Some(StopReason::EosToken)));
+}
+
+#[test]
+fn max_tokens_takes_priority_over_stop_strings() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["stop".to_string()],
+        max_tokens: 1,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[1], "stop");
+    assert!(matches!(result, Some(StopReason::MaxTokens)));
+}
+
+// --- Empty criteria ---
+
+#[test]
+fn empty_criteria_never_stops() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 0,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 42, &[1, 2, 3], "hello world");
+    assert!(result.is_none());
+}
+
+#[test]
+fn zero_max_tokens_means_no_limit() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 0,
+        eos_token_id: None,
+    };
+    let generated: Vec<u32> = (0..10000).collect();
+    let result = check_stop(&criteria, 9999, &generated, "");
+    assert!(result.is_none());
+}
+
+// --- Stop token ID edge cases ---
+
+#[test]
+fn multiple_stop_token_ids_first_match_wins() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![10, 20, 30],
+        stop_strings: vec![],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 20, &[20], "");
+    assert!(matches!(result, Some(StopReason::StopTokenId(20))));
+}
+
+#[test]
+fn stop_token_id_zero_works() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![0],
+        stop_strings: vec![],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 0, &[0], "");
+    assert!(matches!(result, Some(StopReason::StopTokenId(0))));
+}
+
+#[test]
+fn stop_token_id_u32_max_works() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![u32::MAX],
+        stop_strings: vec![],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, u32::MAX, &[u32::MAX], "");
+    assert!(matches!(result, Some(StopReason::StopTokenId(id)) if id == u32::MAX));
+}
+
+// --- Stop string edge cases ---
+
+#[test]
+fn stop_string_substring_match() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["end".to_string()],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[], "the end is near");
+    assert!(matches!(result, Some(StopReason::StopString(s)) if s == "end"));
+}
+
+#[test]
+fn stop_string_empty_string_always_matches() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["".to_string()],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    // Empty string is contained in any string
+    let result = check_stop(&criteria, 1, &[], "anything");
+    assert!(matches!(result, Some(StopReason::StopString(_))));
+}
+
+#[test]
+fn stop_string_unicode_match() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["终".to_string()],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[], "这是终点");
+    assert!(matches!(result, Some(StopReason::StopString(s)) if s == "终"));
+}
+
+#[test]
+fn stop_string_no_match_returns_none() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["stop".to_string()],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[], "this does not match");
+    assert!(result.is_none());
+}
+
+#[test]
+fn multiple_stop_strings_first_match_wins() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec!["alpha".to_string(), "beta".to_string()],
+        max_tokens: 100,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[], "contains beta and alpha");
+    // "alpha" is checked first in the list
+    assert!(matches!(result, Some(StopReason::StopString(s)) if s == "alpha"));
+}
+
+// --- Max tokens boundary ---
+
+#[test]
+fn max_tokens_exact_boundary() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 5,
+        eos_token_id: None,
+    };
+    // generated has exactly 4 tokens (one less than max)
+    let result_under = check_stop(&criteria, 1, &[1, 2, 3, 4], "");
+    assert!(result_under.is_none());
+
+    // generated has exactly 5 tokens (at max)
+    let result_at = check_stop(&criteria, 1, &[1, 2, 3, 4, 5], "");
+    assert!(matches!(result_at, Some(StopReason::MaxTokens)));
+}
+
+#[test]
+fn max_tokens_one() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 1,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 1, &[1], "");
+    assert!(matches!(result, Some(StopReason::MaxTokens)));
+}
+
+// --- Type construction and cloning ---
+
+#[test]
+fn stop_criteria_default_does_not_stop() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 0,
+        eos_token_id: None,
+    };
+    let result = check_stop(&criteria, 42, &[1, 2, 3, 4, 5], "hello world");
+    assert!(result.is_none());
+}
+
+#[test]
+fn generation_config_with_seed() {
+    let config = GenerationConfig {
+        max_new_tokens: 100,
+        seed: Some(42),
+        stop_criteria: StopCriteria {
+            stop_token_ids: vec![],
+            stop_strings: vec![],
+            max_tokens: 100,
+            eos_token_id: None,
+        },
+    };
+    assert_eq!(config.seed, Some(42));
+    assert_eq!(config.max_new_tokens, 100);
+}
+
+#[test]
+fn generation_config_without_seed() {
+    let config = GenerationConfig {
+        max_new_tokens: 50,
+        seed: None,
+        stop_criteria: StopCriteria {
+            stop_token_ids: vec![1, 2],
+            stop_strings: vec!["stop".to_string()],
+            max_tokens: 50,
+            eos_token_id: Some(0),
+        },
+    };
+    assert!(config.seed.is_none());
+    assert_eq!(config.stop_criteria.stop_token_ids.len(), 2);
+}
+
+#[test]
+fn token_event_with_empty_text() {
+    let event = TokenEvent { id: 42, text: String::new() };
+    assert_eq!(event.id, 42);
+    assert!(event.text.is_empty());
+}
+
+#[test]
+fn token_event_with_unicode() {
+    let event = TokenEvent { id: 1, text: "🎉".to_string() };
+    assert_eq!(event.text, "🎉");
+}
+
+#[test]
+fn generation_stats_zero_values() {
+    let stats = GenerationStats { tokens_generated: 0, tokens_per_second: 0.0 };
+    assert_eq!(stats.tokens_generated, 0);
+    assert_eq!(stats.tokens_per_second, 0.0);
+}
+
+#[test]
+fn generation_stats_high_throughput() {
+    let stats = GenerationStats { tokens_generated: 1_000_000, tokens_per_second: 50000.0 };
+    assert_eq!(stats.tokens_generated, 1_000_000);
+    assert!(stats.tokens_per_second > 0.0);
+}
+
+#[test]
+fn stream_event_token_variant() {
+    let event = StreamEvent::Token(TokenEvent { id: 1, text: "hello".to_string() });
+    match event {
+        StreamEvent::Token(t) => {
+            assert_eq!(t.id, 1);
+            assert_eq!(t.text, "hello");
+        }
+        _ => panic!("Expected Token variant"),
+    }
+}
+
+#[test]
+fn stream_event_done_variant() {
+    let event = StreamEvent::Done {
+        reason: StopReason::MaxTokens,
+        stats: GenerationStats { tokens_generated: 10, tokens_per_second: 5.0 },
+    };
+    match event {
+        StreamEvent::Done { reason, stats } => {
+            assert!(matches!(reason, StopReason::MaxTokens));
+            assert_eq!(stats.tokens_generated, 10);
+        }
+        _ => panic!("Expected Done variant"),
+    }
+}
+
+// --- StopReason equality and debug ---
+
+#[test]
+fn stop_reason_variants_are_distinct() {
+    let reasons = [
+        StopReason::MaxTokens,
+        StopReason::StopTokenId(1),
+        StopReason::StopString("s".to_string()),
+        StopReason::EosToken,
+    ];
+    for (i, a) in reasons.iter().enumerate() {
+        for (j, b) in reasons.iter().enumerate() {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn stop_reason_debug_is_non_empty() {
+    let reasons = [
+        StopReason::MaxTokens,
+        StopReason::StopTokenId(42),
+        StopReason::StopString("test".to_string()),
+        StopReason::EosToken,
+    ];
+    for reason in &reasons {
+        let debug = format!("{reason:?}");
+        assert!(!debug.is_empty());
+    }
+}
+
+// --- Combined scenario tests ---
+
+#[test]
+fn realistic_generation_scenario() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![2], // EOS-like
+        stop_strings: vec!["<|endoftext|>".to_string()],
+        max_tokens: 128,
+        eos_token_id: Some(1),
+    };
+
+    // Normal token, no stop
+    let r1 = check_stop(&criteria, 100, &[100], "Hello");
+    assert!(r1.is_none());
+
+    // Still going
+    let r2 = check_stop(&criteria, 200, &[100, 200], "Hello world");
+    assert!(r2.is_none());
+
+    // Hit stop token
+    let r3 = check_stop(&criteria, 2, &[100, 200, 2], "Hello world.");
+    assert!(matches!(r3, Some(StopReason::StopTokenId(2))));
+}
+
+#[test]
+fn eos_in_middle_of_generation() {
+    let criteria = StopCriteria {
+        stop_token_ids: vec![],
+        stop_strings: vec![],
+        max_tokens: 100,
+        eos_token_id: Some(50256),
+    };
+    let result = check_stop(&criteria, 50256, &[1, 2, 3], "some text");
+    assert!(matches!(result, Some(StopReason::EosToken)));
+}

--- a/crates/bitnet-gguf/tests/gguf_parser_edge_cases.rs
+++ b/crates/bitnet-gguf/tests/gguf_parser_edge_cases.rs
@@ -1,0 +1,403 @@
+//! Edge case and boundary tests for GGUF parsing primitives.
+//!
+//! Tests focus on malformed input handling, boundary values, and type system coverage.
+
+use bitnet_gguf::{
+    GGUF_MAGIC, GGUF_VERSION_MAX, GGUF_VERSION_MIN, GgufFileInfo, GgufMetadataKv, GgufValue,
+    GgufValueType, TensorInfo, check_magic, parse_header, read_version,
+};
+
+// --- Magic constant tests ---
+
+#[test]
+fn magic_constant_is_gguf_bytes() {
+    assert_eq!(&GGUF_MAGIC, b"GGUF");
+}
+
+#[test]
+fn check_magic_valid() {
+    assert!(check_magic(b"GGUF"));
+    assert!(check_magic(b"GGUF\x03\x00\x00\x00"));
+    assert!(check_magic(b"GGUFextra bytes after"));
+}
+
+#[test]
+fn check_magic_too_short() {
+    assert!(!check_magic(b""));
+    assert!(!check_magic(b"G"));
+    assert!(!check_magic(b"GG"));
+    assert!(!check_magic(b"GGU"));
+}
+
+#[test]
+fn check_magic_wrong_bytes() {
+    assert!(!check_magic(b"GGML"));
+    assert!(!check_magic(b"gguf"));
+    assert!(!check_magic(b"\x00\x00\x00\x00"));
+    assert!(!check_magic(b"FUGG"));
+}
+
+// --- Version reading tests ---
+
+#[test]
+fn version_constants() {
+    assert_eq!(GGUF_VERSION_MIN, 2);
+    assert_eq!(GGUF_VERSION_MAX, 3);
+}
+
+#[test]
+fn read_version_v2() {
+    let mut data = Vec::from(b"GGUF" as &[u8]);
+    data.extend_from_slice(&2u32.to_le_bytes());
+    assert_eq!(read_version(&data), Some(2));
+}
+
+#[test]
+fn read_version_v3() {
+    let mut data = Vec::from(b"GGUF" as &[u8]);
+    data.extend_from_slice(&3u32.to_le_bytes());
+    assert_eq!(read_version(&data), Some(3));
+}
+
+#[test]
+fn read_version_too_short() {
+    assert_eq!(read_version(b""), None);
+    assert_eq!(read_version(b"GGUF"), None);
+    assert_eq!(read_version(b"GGUF\x03"), None);
+    assert_eq!(read_version(b"GGUF\x03\x00"), None);
+    assert_eq!(read_version(b"GGUF\x03\x00\x00"), None);
+}
+
+#[test]
+fn read_version_bad_magic() {
+    let mut data = Vec::from(b"GGML" as &[u8]);
+    data.extend_from_slice(&3u32.to_le_bytes());
+    assert_eq!(read_version(&data), None);
+}
+
+#[test]
+fn read_version_future_version() {
+    let mut data = Vec::from(b"GGUF" as &[u8]);
+    data.extend_from_slice(&99u32.to_le_bytes());
+    // read_version just reads the bytes, doesn't validate range
+    assert_eq!(read_version(&data), Some(99));
+}
+
+// --- parse_header tests ---
+
+fn make_v3_header(tensor_count: u64, metadata_count: u64) -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"GGUF");
+    data.extend_from_slice(&3u32.to_le_bytes());
+    data.extend_from_slice(&tensor_count.to_le_bytes());
+    data.extend_from_slice(&metadata_count.to_le_bytes());
+    data
+}
+
+#[test]
+fn parse_header_v3_zero_counts() {
+    let data = make_v3_header(0, 0);
+    let info = parse_header(&data).unwrap();
+    assert_eq!(info.version, 3);
+    assert_eq!(info.tensor_count, 0);
+    assert_eq!(info.metadata_count, 0);
+}
+
+#[test]
+fn parse_header_v3_large_counts() {
+    let data = make_v3_header(1000, 500);
+    let info = parse_header(&data).unwrap();
+    assert_eq!(info.tensor_count, 1000);
+    assert_eq!(info.metadata_count, 500);
+}
+
+#[test]
+fn parse_header_v2() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"GGUF");
+    data.extend_from_slice(&2u32.to_le_bytes());
+    data.extend_from_slice(&10u64.to_le_bytes());
+    data.extend_from_slice(&5u64.to_le_bytes());
+    let info = parse_header(&data).unwrap();
+    assert_eq!(info.version, 2);
+    assert_eq!(info.tensor_count, 10);
+    assert_eq!(info.metadata_count, 5);
+}
+
+#[test]
+fn parse_header_too_short() {
+    assert!(parse_header(b"").is_err());
+    assert!(parse_header(b"GGUF").is_err());
+    assert!(parse_header(b"GGUF\x03\x00\x00\x00").is_err());
+}
+
+#[test]
+fn parse_header_bad_magic() {
+    let mut data = Vec::from(b"GGML" as &[u8]);
+    data.extend_from_slice(&3u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    assert!(parse_header(&data).is_err());
+}
+
+#[test]
+fn parse_header_version_1_rejected() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"GGUF");
+    data.extend_from_slice(&1u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    assert!(parse_header(&data).is_err());
+}
+
+#[test]
+fn parse_header_version_4_rejected() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"GGUF");
+    data.extend_from_slice(&4u32.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    data.extend_from_slice(&0u64.to_le_bytes());
+    assert!(parse_header(&data).is_err());
+}
+
+#[test]
+fn parse_header_alignment_defaults_to_32() {
+    let data = make_v3_header(0, 0);
+    let info = parse_header(&data).unwrap();
+    assert_eq!(info.alignment, 32);
+}
+
+// --- GgufValueType tests ---
+
+#[test]
+fn value_type_from_u32_all_valid() {
+    let valid_pairs = [
+        (0, GgufValueType::Uint8),
+        (1, GgufValueType::Int8),
+        (2, GgufValueType::Uint16),
+        (3, GgufValueType::Int16),
+        (4, GgufValueType::Uint32),
+        (5, GgufValueType::Int32),
+        (6, GgufValueType::Float32),
+        (7, GgufValueType::Bool),
+        (8, GgufValueType::String),
+        (9, GgufValueType::Array),
+        (10, GgufValueType::Uint64),
+        (11, GgufValueType::Int64),
+        (12, GgufValueType::Float64),
+    ];
+    for (disc, expected) in &valid_pairs {
+        assert_eq!(
+            GgufValueType::from_u32(*disc),
+            Some(*expected),
+            "from_u32({disc}) should return {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn value_type_from_u32_invalid() {
+    assert_eq!(GgufValueType::from_u32(13), None);
+    assert_eq!(GgufValueType::from_u32(100), None);
+    assert_eq!(GgufValueType::from_u32(u32::MAX), None);
+}
+
+#[test]
+fn value_type_debug_is_non_empty() {
+    let types =
+        [GgufValueType::Uint8, GgufValueType::Float32, GgufValueType::String, GgufValueType::Array];
+    for t in &types {
+        assert!(!format!("{t:?}").is_empty());
+    }
+}
+
+#[test]
+fn value_type_copy_semantics() {
+    let a = GgufValueType::Float32;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+// --- GgufValue construction tests ---
+
+#[test]
+fn gguf_value_numeric_types() {
+    let _ = GgufValue::Uint8(0);
+    let _ = GgufValue::Uint8(255);
+    let _ = GgufValue::Int8(-128);
+    let _ = GgufValue::Int8(127);
+    let _ = GgufValue::Uint16(0);
+    let _ = GgufValue::Uint16(65535);
+    let _ = GgufValue::Int16(-32768);
+    let _ = GgufValue::Uint32(0);
+    let _ = GgufValue::Uint32(u32::MAX);
+    let _ = GgufValue::Int32(i32::MIN);
+    let _ = GgufValue::Float32(std::f32::NAN);
+    let _ = GgufValue::Float32(std::f32::INFINITY);
+    let _ = GgufValue::Uint64(0);
+    let _ = GgufValue::Uint64(u64::MAX);
+    let _ = GgufValue::Int64(i64::MIN);
+    let _ = GgufValue::Float64(std::f64::NAN);
+    let _ = GgufValue::Float64(std::f64::INFINITY);
+    let _ = GgufValue::Bool(true);
+    let _ = GgufValue::Bool(false);
+}
+
+#[test]
+fn gguf_value_string() {
+    let v = GgufValue::String("hello".to_string());
+    match &v {
+        GgufValue::String(s) => assert_eq!(s, "hello"),
+        _ => panic!("Expected String variant"),
+    }
+}
+
+#[test]
+fn gguf_value_empty_string() {
+    let v = GgufValue::String(String::new());
+    match &v {
+        GgufValue::String(s) => assert!(s.is_empty()),
+        _ => panic!("Expected String variant"),
+    }
+}
+
+#[test]
+fn gguf_value_unicode_string() {
+    let v = GgufValue::String("🎉 unicode ñ".to_string());
+    match &v {
+        GgufValue::String(s) => assert!(s.contains("🎉")),
+        _ => panic!("Expected String variant"),
+    }
+}
+
+#[test]
+fn gguf_value_array_empty() {
+    let v = GgufValue::Array(GgufValueType::Uint32, vec![]);
+    match &v {
+        GgufValue::Array(_, items) => assert!(items.is_empty()),
+        _ => panic!("Expected Array variant"),
+    }
+}
+
+#[test]
+fn gguf_value_array_nested() {
+    let inner = GgufValue::Array(GgufValueType::Uint8, vec![GgufValue::Uint8(1)]);
+    let outer = GgufValue::Array(GgufValueType::Array, vec![inner]);
+    match &outer {
+        GgufValue::Array(_, items) => assert_eq!(items.len(), 1),
+        _ => panic!("Expected Array variant"),
+    }
+}
+
+#[test]
+fn gguf_value_clone() {
+    let v = GgufValue::Float32(3.14);
+    let v2 = v.clone();
+    match (&v, &v2) {
+        (GgufValue::Float32(a), GgufValue::Float32(b)) => assert_eq!(a, b),
+        _ => panic!("Clone should preserve variant"),
+    }
+}
+
+// --- GgufMetadataKv tests ---
+
+#[test]
+fn metadata_kv_construction() {
+    let kv = GgufMetadataKv {
+        key: "model.name".to_string(),
+        value: GgufValue::String("test".to_string()),
+    };
+    assert_eq!(kv.key, "model.name");
+}
+
+#[test]
+fn metadata_kv_empty_key() {
+    let kv = GgufMetadataKv { key: String::new(), value: GgufValue::Bool(true) };
+    assert!(kv.key.is_empty());
+}
+
+#[test]
+fn metadata_kv_debug_non_empty() {
+    let kv = GgufMetadataKv { key: "test".to_string(), value: GgufValue::Uint32(42) };
+    assert!(!format!("{kv:?}").is_empty());
+}
+
+// --- TensorInfo tests ---
+
+#[test]
+fn tensor_info_construction() {
+    let info = TensorInfo {
+        name: "weight.0".to_string(),
+        n_dims: 2,
+        dims: vec![1024, 512],
+        dtype: 0,
+        offset: 0,
+    };
+    assert_eq!(info.name, "weight.0");
+    assert_eq!(info.n_dims, 2);
+    assert_eq!(info.dims.len(), 2);
+}
+
+#[test]
+fn tensor_info_zero_dims() {
+    let info =
+        TensorInfo { name: "scalar".to_string(), n_dims: 0, dims: vec![], dtype: 0, offset: 0 };
+    assert_eq!(info.n_dims, 0);
+    assert!(info.dims.is_empty());
+}
+
+#[test]
+fn tensor_info_large_dims() {
+    let info = TensorInfo {
+        name: "embedding".to_string(),
+        n_dims: 2,
+        dims: vec![100352, 5120],
+        dtype: 1,
+        offset: 1024,
+    };
+    assert_eq!(info.dims[0], 100352);
+    assert_eq!(info.dims[1], 5120);
+}
+
+#[test]
+fn tensor_info_max_offset() {
+    let info = TensorInfo {
+        name: "last_tensor".to_string(),
+        n_dims: 1,
+        dims: vec![1],
+        dtype: 0,
+        offset: u64::MAX,
+    };
+    assert_eq!(info.offset, u64::MAX);
+}
+
+#[test]
+fn tensor_info_clone() {
+    let info = TensorInfo {
+        name: "test".to_string(),
+        n_dims: 3,
+        dims: vec![2, 3, 4],
+        dtype: 6,
+        offset: 100,
+    };
+    let cloned = info.clone();
+    assert_eq!(info.name, cloned.name);
+    assert_eq!(info.dims, cloned.dims);
+}
+
+// --- GgufFileInfo tests ---
+
+#[test]
+fn file_info_debug_contains_version() {
+    let info = GgufFileInfo { version: 3, tensor_count: 10, metadata_count: 5, alignment: 32 };
+    let debug = format!("{info:?}");
+    assert!(debug.contains("3"), "Debug should contain version");
+}
+
+#[test]
+fn file_info_clone() {
+    let info = GgufFileInfo { version: 3, tensor_count: 10, metadata_count: 5, alignment: 32 };
+    let cloned = info.clone();
+    assert_eq!(info.version, cloned.version);
+    assert_eq!(info.tensor_count, cloned.tensor_count);
+}


### PR DESCRIPTION
Two test suites covering edge cases:

**GGUF Parser (39 tests):**
- Magic byte validation (valid, too short, wrong bytes)
- Version reading (v2, v3, future version, bad magic, too short)
- Header parsing (v2/v3, zero/large counts, bad magic, invalid versions, alignment)
- GgufValueType discriminant mapping (all 13 types + invalid)
- GgufValue construction (all numeric types, strings, unicode, arrays, nested arrays)
- GgufMetadataKv construction and debug
- TensorInfo (zero/large dims, max offset, clone)
- GgufFileInfo debug and clone

**Generation Stop Criteria (29 tests):**
- Priority ordering (stop_token > eos > max_tokens > stop_strings)
- Empty criteria behavior
- Stop token ID edge cases (zero, u32::MAX, multiple IDs)
- Stop string edge cases (substring match, unicode, empty string, no match)
- Max tokens boundary testing (exact boundary, off-by-one)
- Type construction and cloning
- StopReason variant equality and debug
- Realistic generation scenarios
- StreamEvent variant tests
- 68 tests total, all passing