### PR TITLE
test(logits,engine-core): add edge case tests (78 tests)

### DIFF
--- a/crates/bitnet-engine-core/tests/session_management_edge_cases.rs
+++ b/crates/bitnet-engine-core/tests/session_management_edge_cases.rs
@@ -1,0 +1,333 @@
+//! Edge case and boundary tests for engine-core session management.
+//!
+//! Tests exercise validation, state machine transitions, concurrency limits,
+//! and session ID generation.
+
+use bitnet_engine_core::{
+    BackendInfo, ConcurrencyConfig, ConfigError, EngineState, EngineStateTracker, SessionConfig,
+    SessionId, SessionMetrics, VALID_BACKENDS,
+};
+
+// --- SessionConfig validation ---
+
+#[test]
+fn valid_config_passes_validation() {
+    let config = SessionConfig {
+        model_path: "model.gguf".to_string(),
+        tokenizer_path: "tokenizer.json".to_string(),
+        backend: "cpu".to_string(),
+        max_context: 4096,
+        seed: Some(42),
+    };
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn empty_model_path_fails() {
+    let config = SessionConfig {
+        model_path: String::new(),
+        tokenizer_path: "tokenizer.json".to_string(),
+        backend: "cpu".to_string(),
+        max_context: 4096,
+        seed: None,
+    };
+    assert_eq!(config.validate().unwrap_err(), ConfigError::EmptyModelPath);
+}
+
+#[test]
+fn empty_tokenizer_path_fails() {
+    let config = SessionConfig {
+        model_path: "model.gguf".to_string(),
+        tokenizer_path: String::new(),
+        backend: "cpu".to_string(),
+        max_context: 4096,
+        seed: None,
+    };
+    assert_eq!(config.validate().unwrap_err(), ConfigError::EmptyTokenizerPath);
+}
+
+#[test]
+fn unsupported_backend_fails() {
+    let config = SessionConfig {
+        model_path: "model.gguf".to_string(),
+        tokenizer_path: "tokenizer.json".to_string(),
+        backend: "tpu".to_string(),
+        max_context: 4096,
+        seed: None,
+    };
+    assert!(matches!(
+        config.validate().unwrap_err(),
+        ConfigError::UnsupportedBackend(b) if b == "tpu"
+    ));
+}
+
+#[test]
+fn zero_context_window_fails() {
+    let config = SessionConfig {
+        model_path: "model.gguf".to_string(),
+        tokenizer_path: "tokenizer.json".to_string(),
+        backend: "cpu".to_string(),
+        max_context: 0,
+        seed: None,
+    };
+    assert_eq!(config.validate().unwrap_err(), ConfigError::ZeroContextWindow);
+}
+
+#[test]
+fn all_valid_backends_accepted() {
+    for backend in VALID_BACKENDS {
+        let config = SessionConfig {
+            model_path: "m".to_string(),
+            tokenizer_path: "t".to_string(),
+            backend: backend.to_string(),
+            max_context: 1,
+            seed: None,
+        };
+        assert!(config.validate().is_ok(), "Backend '{backend}' should be valid");
+    }
+}
+
+#[test]
+fn validation_priority_model_path_first() {
+    // Both model_path and tokenizer_path are empty
+    let config = SessionConfig {
+        model_path: String::new(),
+        tokenizer_path: String::new(),
+        backend: "invalid".to_string(),
+        max_context: 0,
+        seed: None,
+    };
+    // Should report model_path error first
+    assert_eq!(config.validate().unwrap_err(), ConfigError::EmptyModelPath);
+}
+
+// --- EngineStateTracker transitions ---
+
+#[test]
+fn tracker_starts_idle() {
+    let tracker = EngineStateTracker::new();
+    assert_eq!(*tracker.state(), EngineState::Idle);
+}
+
+#[test]
+fn idle_to_running_succeeds() {
+    let mut tracker = EngineStateTracker::new();
+    assert!(tracker.start().is_ok());
+    assert_eq!(*tracker.state(), EngineState::Running);
+}
+
+#[test]
+fn running_to_done_succeeds() {
+    let mut tracker = EngineStateTracker::new();
+    tracker.start().unwrap();
+    assert!(tracker.finish().is_ok());
+    assert_eq!(*tracker.state(), EngineState::Done);
+}
+
+#[test]
+fn double_start_fails() {
+    let mut tracker = EngineStateTracker::new();
+    tracker.start().unwrap();
+    assert!(tracker.start().is_err());
+}
+
+#[test]
+fn finish_without_start_fails() {
+    let mut tracker = EngineStateTracker::new();
+    assert!(tracker.finish().is_err());
+}
+
+#[test]
+fn double_finish_fails() {
+    let mut tracker = EngineStateTracker::new();
+    tracker.start().unwrap();
+    tracker.finish().unwrap();
+    assert!(tracker.finish().is_err());
+}
+
+// --- SessionId ---
+
+#[test]
+fn session_id_generate_is_unique() {
+    let id1 = SessionId::generate();
+    let id2 = SessionId::generate();
+    assert_ne!(id1, id2);
+}
+
+#[test]
+fn session_id_starts_with_session_prefix() {
+    let id = SessionId::generate();
+    assert!(id.as_str().starts_with("session-"));
+}
+
+#[test]
+fn session_id_clone_equals_original() {
+    let id = SessionId::generate();
+    let cloned = id.clone();
+    assert_eq!(id, cloned);
+}
+
+#[test]
+fn session_id_debug_non_empty() {
+    let id = SessionId::generate();
+    assert!(!format!("{id:?}").is_empty());
+}
+
+// --- ConcurrencyConfig ---
+
+#[test]
+fn concurrency_allows_below_limit() {
+    let config = ConcurrencyConfig { max_concurrent: 4 };
+    assert!(config.allows(0));
+    assert!(config.allows(1));
+    assert!(config.allows(3));
+}
+
+#[test]
+fn concurrency_denies_at_limit() {
+    let config = ConcurrencyConfig { max_concurrent: 4 };
+    assert!(!config.allows(4));
+}
+
+#[test]
+fn concurrency_denies_above_limit() {
+    let config = ConcurrencyConfig { max_concurrent: 4 };
+    assert!(!config.allows(5));
+    assert!(!config.allows(100));
+}
+
+#[test]
+fn concurrency_zero_max_denies_all() {
+    let config = ConcurrencyConfig { max_concurrent: 0 };
+    assert!(!config.allows(0));
+    assert!(!config.allows(1));
+}
+
+#[test]
+fn concurrency_one_allows_only_zero_active() {
+    let config = ConcurrencyConfig { max_concurrent: 1 };
+    assert!(config.allows(0));
+    assert!(!config.allows(1));
+}
+
+// --- BackendInfo ---
+
+#[test]
+fn backend_info_default_is_empty() {
+    let info = BackendInfo::default();
+    assert!(info.backend_name.is_empty());
+    assert!(info.kernel_ids.is_empty());
+    assert!(info.backend_summary.is_empty());
+}
+
+#[test]
+fn backend_info_construction() {
+    let info = BackendInfo {
+        backend_name: "cuda".to_string(),
+        kernel_ids: vec!["matmul_f16".to_string(), "softmax".to_string()],
+        backend_summary: "CUDA 12.0".to_string(),
+    };
+    assert_eq!(info.backend_name, "cuda");
+    assert_eq!(info.kernel_ids.len(), 2);
+}
+
+#[test]
+fn backend_info_clone() {
+    let info = BackendInfo {
+        backend_name: "cpu".to_string(),
+        kernel_ids: vec!["avx2".to_string()],
+        backend_summary: "AVX2 optimized".to_string(),
+    };
+    let cloned = info.clone();
+    assert_eq!(info.backend_name, cloned.backend_name);
+}
+
+// --- SessionMetrics ---
+
+#[test]
+fn session_metrics_default_is_zero() {
+    let metrics = SessionMetrics::default();
+    assert_eq!(metrics.tokens_per_second, 0.0);
+    assert_eq!(metrics.time_to_first_token_ms, 0.0);
+    assert_eq!(metrics.total_tokens, 0);
+}
+
+#[test]
+fn session_metrics_construction() {
+    let metrics = SessionMetrics {
+        tokens_per_second: 45.5,
+        time_to_first_token_ms: 120.0,
+        total_tokens: 256,
+    };
+    assert!(metrics.tokens_per_second > 0.0);
+    assert_eq!(metrics.total_tokens, 256);
+}
+
+// --- EngineState enum ---
+
+#[test]
+fn engine_state_equality() {
+    assert_eq!(EngineState::Idle, EngineState::Idle);
+    assert_eq!(EngineState::Running, EngineState::Running);
+    assert_eq!(EngineState::Done, EngineState::Done);
+    assert_ne!(EngineState::Idle, EngineState::Running);
+    assert_ne!(EngineState::Running, EngineState::Done);
+}
+
+#[test]
+fn engine_state_debug_non_empty() {
+    for state in [EngineState::Idle, EngineState::Running, EngineState::Done] {
+        assert!(!format!("{state:?}").is_empty());
+    }
+}
+
+// --- ConfigError ---
+
+#[test]
+fn config_error_variants_are_distinct() {
+    let errors = [
+        ConfigError::EmptyModelPath,
+        ConfigError::EmptyTokenizerPath,
+        ConfigError::UnsupportedBackend("x".to_string()),
+        ConfigError::ZeroContextWindow,
+    ];
+    for (i, a) in errors.iter().enumerate() {
+        for (j, b) in errors.iter().enumerate() {
+            if i == j {
+                assert_eq!(a, b);
+            } else {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+#[test]
+fn config_error_debug_non_empty() {
+    let errors = [
+        ConfigError::EmptyModelPath,
+        ConfigError::EmptyTokenizerPath,
+        ConfigError::UnsupportedBackend("test".to_string()),
+        ConfigError::ZeroContextWindow,
+    ];
+    for error in &errors {
+        assert!(!format!("{error:?}").is_empty());
+    }
+}
+
+// --- VALID_BACKENDS ---
+
+#[test]
+fn valid_backends_contains_cpu() {
+    assert!(VALID_BACKENDS.contains(&"cpu"));
+}
+
+#[test]
+fn valid_backends_contains_cuda() {
+    assert!(VALID_BACKENDS.contains(&"cuda"));
+}
+
+#[test]
+fn valid_backends_non_empty() {
+    assert!(!VALID_BACKENDS.is_empty());
+}

--- a/crates/bitnet-logits/tests/logits_edge_cases.rs
+++ b/crates/bitnet-logits/tests/logits_edge_cases.rs
@@ -1,0 +1,377 @@
+//! Edge case and boundary tests for logits transformations.
+//!
+//! Tests exercise unusual inputs, boundary conditions, and numerical stability
+//! for all logits pipeline operations.
+
+use bitnet_logits::{
+    apply_min_p, apply_repetition_penalty, apply_temperature, apply_top_k, apply_top_p,
+    apply_typical, argmax, softmax_in_place,
+};
+
+// --- apply_temperature edge cases ---
+
+#[test]
+fn temperature_very_low_makes_distribution_peaked() {
+    let mut logits = vec![1.0, 2.0, 3.0];
+    apply_temperature(&mut logits, 0.01);
+    // The largest logit should be significantly larger relative to others
+    assert!(logits[2] > logits[0], "Max logit should be larger after low temperature");
+    assert!(logits[2] > logits[1], "Max logit should exceed second largest");
+}
+
+#[test]
+fn temperature_one_is_identity() {
+    let original = vec![1.0, 2.0, 3.0, -1.0];
+    let mut logits = original.clone();
+    apply_temperature(&mut logits, 1.0);
+    for (a, b) in logits.iter().zip(original.iter()) {
+        assert!((a - b).abs() < 1e-6, "Temperature 1.0 should be identity");
+    }
+}
+
+#[test]
+fn temperature_high_flattens_distribution() {
+    let mut logits = vec![1.0, 100.0, -50.0];
+    apply_temperature(&mut logits, 100.0);
+    // After high temperature, values should be closer together
+    let range = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max)
+        - logits.iter().cloned().fold(f32::INFINITY, f32::min);
+    assert!(range < 2.0, "High temperature should flatten distribution");
+}
+
+#[test]
+fn temperature_single_element() {
+    let mut logits = vec![5.0];
+    apply_temperature(&mut logits, 0.5);
+    assert_eq!(logits[0], 10.0); // 5.0 / 0.5
+}
+
+#[test]
+fn temperature_empty_array() {
+    let mut logits: Vec<f32> = vec![];
+    apply_temperature(&mut logits, 1.0);
+    assert!(logits.is_empty());
+}
+
+#[test]
+fn temperature_all_zeros() {
+    let mut logits = vec![0.0, 0.0, 0.0];
+    apply_temperature(&mut logits, 0.5);
+    assert!(logits.iter().all(|&x| x == 0.0));
+}
+
+// --- apply_top_k edge cases ---
+
+#[test]
+fn top_k_zero_returns_all() {
+    let mut logits = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let kept = apply_top_k(&mut logits, 0);
+    // k=0 should keep all
+    assert_eq!(kept, 5);
+}
+
+#[test]
+fn top_k_one_keeps_max() {
+    let mut logits = vec![1.0, 5.0, 3.0, 2.0];
+    apply_top_k(&mut logits, 1);
+    assert_eq!(logits[1], 5.0);
+    assert!(logits[0] == f32::NEG_INFINITY);
+    assert!(logits[2] == f32::NEG_INFINITY);
+    assert!(logits[3] == f32::NEG_INFINITY);
+}
+
+#[test]
+fn top_k_equal_to_length() {
+    let mut logits = vec![1.0, 2.0, 3.0];
+    let kept = apply_top_k(&mut logits, 3);
+    assert_eq!(kept, 3);
+    assert!(logits.iter().all(|&x| x != f32::NEG_INFINITY));
+}
+
+#[test]
+fn top_k_larger_than_length() {
+    let mut logits = vec![1.0, 2.0];
+    let kept = apply_top_k(&mut logits, 100);
+    assert_eq!(kept, 2);
+}
+
+#[test]
+fn top_k_single_element() {
+    let mut logits = vec![42.0];
+    let kept = apply_top_k(&mut logits, 1);
+    assert_eq!(kept, 1);
+    assert_eq!(logits[0], 42.0);
+}
+
+#[test]
+fn top_k_empty_array() {
+    let mut logits: Vec<f32> = vec![];
+    let kept = apply_top_k(&mut logits, 5);
+    assert_eq!(kept, 0);
+}
+
+#[test]
+fn top_k_with_duplicates() {
+    let mut logits = vec![3.0, 3.0, 3.0, 1.0, 2.0];
+    let kept = apply_top_k(&mut logits, 3);
+    assert!(kept >= 3);
+}
+
+// --- softmax_in_place edge cases ---
+
+#[test]
+fn softmax_sums_to_one() {
+    let mut logits = vec![1.0, 2.0, 3.0, 4.0];
+    softmax_in_place(&mut logits);
+    let sum: f32 = logits.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-5, "Softmax should sum to ~1.0, got {sum}");
+}
+
+#[test]
+fn softmax_all_equal_gives_uniform() {
+    let mut logits = vec![5.0, 5.0, 5.0, 5.0];
+    softmax_in_place(&mut logits);
+    for &p in &logits {
+        assert!((p - 0.25).abs() < 1e-5, "Equal logits should give uniform distribution");
+    }
+}
+
+#[test]
+fn softmax_single_element() {
+    let mut logits = vec![42.0];
+    softmax_in_place(&mut logits);
+    assert!((logits[0] - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn softmax_large_values_no_overflow() {
+    let mut logits = vec![1000.0, 1001.0, 999.0];
+    softmax_in_place(&mut logits);
+    let sum: f32 = logits.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-4, "Large values should not overflow");
+    assert!(logits.iter().all(|&x| x.is_finite()));
+}
+
+#[test]
+fn softmax_negative_values() {
+    let mut logits = vec![-100.0, -200.0, -50.0];
+    softmax_in_place(&mut logits);
+    let sum: f32 = logits.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-4);
+    assert!(logits[2] > logits[0]); // -50 > -100, so prob should be higher
+}
+
+#[test]
+fn softmax_empty_array() {
+    let mut logits: Vec<f32> = vec![];
+    softmax_in_place(&mut logits);
+    assert!(logits.is_empty());
+}
+
+// --- apply_top_p edge cases ---
+
+#[test]
+fn top_p_one_keeps_all() {
+    let mut probs = vec![0.1, 0.2, 0.3, 0.4];
+    apply_top_p(&mut probs, 1.0);
+    assert!(probs.iter().all(|&p| p > 0.0));
+}
+
+#[test]
+fn top_p_very_small_keeps_top() {
+    let mut probs = vec![0.1, 0.6, 0.2, 0.1];
+    apply_top_p(&mut probs, 0.01);
+    // The top probability (0.6) should remain
+    assert!(probs[1] > 0.0);
+}
+
+#[test]
+fn top_p_single_element() {
+    let mut probs = vec![1.0];
+    apply_top_p(&mut probs, 0.5);
+    assert!(probs[0] > 0.0);
+}
+
+#[test]
+fn top_p_empty_array() {
+    let mut probs: Vec<f32> = vec![];
+    apply_top_p(&mut probs, 0.9);
+    assert!(probs.is_empty());
+}
+
+// --- apply_repetition_penalty edge cases ---
+
+#[test]
+fn repetition_penalty_one_is_identity() {
+    let original = vec![1.0, 2.0, -1.0, 3.0];
+    let mut logits = original.clone();
+    apply_repetition_penalty(&mut logits, &[0, 1, 2, 3], 1.0);
+    for (a, b) in logits.iter().zip(original.iter()) {
+        assert!((a - b).abs() < 1e-6, "Penalty 1.0 should be identity");
+    }
+}
+
+#[test]
+fn repetition_penalty_reduces_positive_logits() {
+    let mut logits = vec![1.0, 5.0, 3.0];
+    apply_repetition_penalty(&mut logits, &[1], 2.0);
+    assert!(logits[1] < 5.0, "Positive logit should be reduced by penalty");
+    assert_eq!(logits[0], 1.0, "Unpenalized logit should be unchanged");
+}
+
+#[test]
+fn repetition_penalty_amplifies_negative_logits() {
+    let mut logits = vec![-1.0, 2.0, -3.0];
+    apply_repetition_penalty(&mut logits, &[0, 2], 2.0);
+    assert!(logits[0] < -1.0, "Negative logit should be more negative");
+    assert!(logits[2] < -3.0, "Negative logit should be more negative");
+}
+
+#[test]
+fn repetition_penalty_empty_token_ids() {
+    let original = vec![1.0, 2.0, 3.0];
+    let mut logits = original.clone();
+    apply_repetition_penalty(&mut logits, &[], 2.0);
+    for (a, b) in logits.iter().zip(original.iter()) {
+        assert!((a - b).abs() < 1e-6, "No tokens should leave logits unchanged");
+    }
+}
+
+#[test]
+fn repetition_penalty_out_of_bounds_token_ids_ignored() {
+    let mut logits = vec![1.0, 2.0, 3.0];
+    // Token ID 100 is out of bounds for a 3-element array
+    apply_repetition_penalty(&mut logits, &[100], 2.0);
+    // Should not panic, logits unchanged
+    assert_eq!(logits, vec![1.0, 2.0, 3.0]);
+}
+
+// --- argmax edge cases ---
+
+#[test]
+fn argmax_single_element() {
+    assert_eq!(argmax(&[42.0]), 0);
+}
+
+#[test]
+fn argmax_first_is_max() {
+    assert_eq!(argmax(&[10.0, 1.0, 2.0]), 0);
+}
+
+#[test]
+fn argmax_last_is_max() {
+    assert_eq!(argmax(&[1.0, 2.0, 10.0]), 2);
+}
+
+#[test]
+fn argmax_all_equal() {
+    let result = argmax(&[5.0, 5.0, 5.0]);
+    assert!(result < 3);
+}
+
+#[test]
+fn argmax_negative_values() {
+    assert_eq!(argmax(&[-10.0, -5.0, -1.0]), 2);
+}
+
+// --- apply_min_p edge cases ---
+
+#[test]
+fn min_p_zero_keeps_all() {
+    let mut probs = vec![0.001, 0.5, 0.3, 0.199];
+    apply_min_p(&mut probs, 0.0);
+    assert!(probs.iter().all(|&p| p > 0.0));
+}
+
+#[test]
+fn min_p_one_keeps_only_max() {
+    let mut probs = vec![0.1, 0.5, 0.3, 0.1];
+    apply_min_p(&mut probs, 1.0);
+    // Only the max (0.5) should remain non-zero
+    assert!(probs[1] > 0.0);
+    // Others below 1.0 * 0.5 = 0.5 should be zeroed
+    assert_eq!(probs[0], 0.0);
+    assert_eq!(probs[3], 0.0);
+}
+
+#[test]
+fn min_p_single_element() {
+    let mut probs = vec![1.0];
+    apply_min_p(&mut probs, 0.5);
+    assert!(probs[0] > 0.0);
+}
+
+#[test]
+fn min_p_empty_array() {
+    let mut probs: Vec<f32> = vec![];
+    apply_min_p(&mut probs, 0.5);
+    assert!(probs.is_empty());
+}
+
+// --- apply_typical edge cases ---
+
+#[test]
+fn typical_one_keeps_all() {
+    let mut probs = vec![0.25, 0.25, 0.25, 0.25];
+    apply_typical(&mut probs, 1.0);
+    assert!(probs.iter().all(|&p| p > 0.0));
+}
+
+#[test]
+fn typical_small_value_filters() {
+    let mut probs = vec![0.5, 0.3, 0.15, 0.05];
+    apply_typical(&mut probs, 0.1);
+    // Should keep at least one probability
+    let non_zero = probs.iter().filter(|&&p| p > 0.0).count();
+    assert!(non_zero >= 1);
+}
+
+#[test]
+fn typical_single_element() {
+    let mut probs = vec![1.0];
+    apply_typical(&mut probs, 0.5);
+    assert!(probs[0] > 0.0);
+}
+
+#[test]
+fn typical_empty_array() {
+    let mut probs: Vec<f32> = vec![];
+    apply_typical(&mut probs, 0.5);
+    assert!(probs.is_empty());
+}
+
+// --- Pipeline composition tests ---
+
+#[test]
+fn full_pipeline_temperature_topk_softmax_argmax() {
+    let mut logits = vec![1.0, 3.0, 2.0, 0.5, 4.0];
+    apply_temperature(&mut logits, 0.5);
+    apply_top_k(&mut logits, 3);
+    softmax_in_place(&mut logits);
+    let idx = argmax(&logits);
+    // Token 4 (value 4.0) should be picked
+    assert_eq!(idx, 4);
+}
+
+#[test]
+fn pipeline_with_repetition_penalty() {
+    let mut logits = vec![1.0, 5.0, 3.0, 2.0];
+    // Penalize token 1 (previously generated)
+    apply_repetition_penalty(&mut logits, &[1], 3.0);
+    apply_temperature(&mut logits, 1.0);
+    softmax_in_place(&mut logits);
+    // Token 1 should no longer be the argmax due to penalty
+    let idx = argmax(&logits);
+    assert_ne!(idx, 1, "Penalized token should not be argmax");
+}
+
+#[test]
+fn pipeline_topk_then_topp() {
+    let mut logits = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    apply_top_k(&mut logits, 3);
+    softmax_in_place(&mut logits);
+    apply_top_p(&mut logits, 0.9);
+    // Should have at most 3 non-zero probabilities
+    let non_zero = logits.iter().filter(|&&p| p > 0.0).count();
+    assert!(non_zero <= 3);
+}


### PR DESCRIPTION
Two test suites covering edge cases for SRP microcrates:

**Logits Pipeline Edge Cases (44 tests):**
- Temperature: identity, high/low values, empty/single element, all zeros
- Top-k: zero keeps all, one keeps max, equal/larger than length, duplicates
- Softmax: sums to one, uniform for equal inputs, large values no overflow, negatives
- Top-p: keeps all at 1.0, keeps top at small value
- Repetition penalty: identity at 1.0, positive/negative logit behavior, empty/OOB tokens
- Argmax: single element, first/last is max, all equal, negatives
- Min-p: zero keeps all, one keeps only max
- Typical sampling: boundary values
- Full pipeline composition: temp+topk+softmax+argmax, with repetition penalty, topk+topp

**Engine-Core Session Management (34 tests):**
- SessionConfig validation: all valid backends, empty paths, unsupported backend, zero context
- Validation priority ordering
- EngineStateTracker: state machine transitions (idle->running->done), invalid transitions
- SessionId: uniqueness, prefix, clone, debug
- ConcurrencyConfig: allows/denies at/below/above limit, zero max, single slot
- BackendInfo/SessionMetrics: defaults, construction, clone
- EngineState/ConfigError: equality, debug, variant distinctness
- VALID_BACKENDS constant coverage
- 78 tests total, all passing