### PR TITLE
test(device-probe): add device probe edge case tests (36 tests)

### DIFF
--- a/crates/bitnet-device-probe/tests/device_probe_edge_cases.rs
+++ b/crates/bitnet-device-probe/tests/device_probe_edge_cases.rs
@@ -3,9 +3,8 @@
 //! the full DeviceProbe path.
 
 use bitnet_device_probe::{
-    CpuCapabilities, DeviceCapabilities, DeviceProbe, GpuCapabilities, SimdLevel,
-    detect_simd_level, gpu_available_runtime, gpu_compiled, probe_cpu, probe_device, probe_gpu,
-    simd_level_rank,
+    DeviceCapabilities, SimdLevel, detect_simd_level, gpu_available_runtime, gpu_compiled,
+    probe_cpu, probe_device, probe_gpu, simd_level_rank,
 };
 
 // ── CPU Capabilities ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Comprehensive edge-case tests for the \itnet-device-probe\ crate covering all device detection APIs.

## Test Coverage (36 tests)
- **CPU capabilities** (6 tests): core count, SIMD mutual exclusivity, AVX512AVX2 implication, determinism, debug, clone
- **GPU capabilities** (5 tests): CPU-only build all-false, compiled flag consistency, runtime consistency, debug, clone
- **SIMD detection** (3 tests): valid level, determinism, x86 not NEON
- **SimdLevel ranking** (4 tests): scalar=0, x86 ordering, NEON highest, all unique
- **DeviceCapabilities** (6 tests): CPU always available, GPU compiled consistency, no CUDA without compile, SIMD match, determinism, debug
- **DeviceProbe** (6 tests): cores  1, threads  cores, SIMD match, GPU consistency, determinism, debug
- **NPU** (2 tests): compiled flag, not available without feature
- **Vulkan** (2 tests): compiled flag, not available without feature
- **oneAPI** (2 tests): compiled flag, not available without feature

All 36 tests passing locally.