### PR TITLE
test: add wave 6 insta snapshot tests (41 tests across 3 crates)

### DIFF
--- a/crates/bitnet-models/tests/snapshot_model_config.rs
+++ b/crates/bitnet-models/tests/snapshot_model_config.rs
@@ -1,0 +1,164 @@
+//! Wave 6 snapshot tests for bitnet-models configuration types.
+//!
+//! Pins ModelFormat Debug, GgufModelConfig defaults per architecture,
+//! GgufQuantizationConfig defaults, and config JSON serialization.
+
+use bitnet_models::config::{
+    GgufModelConfig, GgufQuantizationConfig, RopeScaling, RopeScalingType,
+};
+use bitnet_models::formats::ModelFormat;
+use bitnet_models::loader::LoadConfig;
+use bitnet_models::production_loader::ProductionLoadConfig;
+use std::collections::HashMap;
+
+// ── ModelFormat Debug / name / extension ─────────────────────────────────────
+
+#[test]
+fn snapshot_model_format_debug_safetensors() {
+    insta::assert_snapshot!(
+        "model_format_debug_safetensors",
+        format!("{:?}", ModelFormat::SafeTensors)
+    );
+}
+
+#[test]
+fn snapshot_model_format_debug_gguf() {
+    insta::assert_snapshot!("model_format_debug_gguf", format!("{:?}", ModelFormat::Gguf));
+}
+
+#[test]
+fn snapshot_model_format_names() {
+    insta::assert_snapshot!(
+        "model_format_names",
+        format!(
+            "SafeTensors={} Gguf={}",
+            ModelFormat::SafeTensors.name(),
+            ModelFormat::Gguf.name(),
+        )
+    );
+}
+
+#[test]
+fn snapshot_model_format_extensions() {
+    insta::assert_snapshot!(
+        "model_format_extensions",
+        format!(
+            "SafeTensors={} Gguf={}",
+            ModelFormat::SafeTensors.extension(),
+            ModelFormat::Gguf.extension(),
+        )
+    );
+}
+
+#[test]
+fn snapshot_model_format_serialization() {
+    let formats = vec![ModelFormat::SafeTensors, ModelFormat::Gguf];
+    insta::assert_json_snapshot!("model_format_json", formats);
+}
+
+// ── GgufQuantizationConfig defaults ─────────────────────────────────────────
+
+#[test]
+fn snapshot_gguf_quantization_config_default() {
+    insta::assert_debug_snapshot!("gguf_quant_config_default", GgufQuantizationConfig::default());
+}
+
+#[test]
+fn snapshot_gguf_quantization_config_json() {
+    insta::assert_json_snapshot!("gguf_quant_config_json", GgufQuantizationConfig::default());
+}
+
+// ── Architecture-specific GgufModelConfig from metadata ─────────────────────
+
+fn make_metadata(
+    arch: &str,
+    hidden: u32,
+    layers: u32,
+    heads: u32,
+) -> HashMap<String, bitnet_models::formats::gguf::GgufValue> {
+    use bitnet_models::formats::gguf::GgufValue;
+    let mut m = HashMap::new();
+    m.insert("general.architecture".into(), GgufValue::String(arch.into()));
+    m.insert(format!("{arch}.embedding_length"), GgufValue::U32(hidden));
+    m.insert(format!("{arch}.block_count"), GgufValue::U32(layers));
+    m.insert(format!("{arch}.attention.head_count"), GgufValue::U32(heads));
+    m.insert(format!("{arch}.attention.head_count_kv"), GgufValue::U32(heads));
+    m.insert(format!("{arch}.feed_forward_length"), GgufValue::U32(hidden * 4));
+    m.insert(format!("{arch}.context_length"), GgufValue::U32(2048));
+    m.insert(format!("{arch}.vocab_size"), GgufValue::U32(32000));
+    m.insert(format!("{arch}.rope.freq_base"), GgufValue::F32(10000.0));
+    m
+}
+
+#[test]
+fn snapshot_gguf_config_arch_llama() {
+    let meta = make_metadata("llama", 4096, 32, 32);
+    let config = GgufModelConfig::from_gguf_metadata(&meta).unwrap();
+    insta::assert_json_snapshot!("gguf_config_arch_llama", config);
+}
+
+#[test]
+fn snapshot_gguf_config_arch_bitnet() {
+    let meta = make_metadata("bitnet", 2048, 24, 16);
+    let config = GgufModelConfig::from_gguf_metadata(&meta).unwrap();
+    insta::assert_json_snapshot!("gguf_config_arch_bitnet", config);
+}
+
+#[test]
+fn snapshot_gguf_config_arch_mistral() {
+    let meta = make_metadata("mistral", 4096, 32, 32);
+    let config = GgufModelConfig::from_gguf_metadata(&meta).unwrap();
+    insta::assert_json_snapshot!("gguf_config_arch_mistral", config);
+}
+
+#[test]
+fn snapshot_gguf_config_arch_gpt() {
+    let meta = make_metadata("gpt2", 768, 12, 12);
+    let config = GgufModelConfig::from_gguf_metadata(&meta).unwrap();
+    insta::assert_json_snapshot!("gguf_config_arch_gpt2", config);
+}
+
+// ── Config serialization round-trip ─────────────────────────────────────────
+
+#[test]
+fn snapshot_gguf_config_json_roundtrip() {
+    let meta = make_metadata("llama", 4096, 32, 32);
+    let config = GgufModelConfig::from_gguf_metadata(&meta).unwrap();
+    let json = serde_json::to_string_pretty(&config).unwrap();
+    let deserialized: GgufModelConfig = serde_json::from_str(&json).unwrap();
+    insta::assert_json_snapshot!("gguf_config_json_roundtrip", deserialized);
+}
+
+// ── RopeScaling serialization ───────────────────────────────────────────────
+
+#[test]
+fn snapshot_rope_scaling_types() {
+    let types = vec![
+        RopeScalingType::None,
+        RopeScalingType::Linear,
+        RopeScalingType::Ntk,
+        RopeScalingType::YaRn,
+    ];
+    insta::assert_json_snapshot!("rope_scaling_types", types);
+}
+
+#[test]
+fn snapshot_rope_scaling_config() {
+    let scaling = RopeScaling { scaling_type: RopeScalingType::Linear, factor: 2.0 };
+    insta::assert_json_snapshot!("rope_scaling_config_linear", scaling);
+}
+
+// ── LoadConfig / ProductionLoadConfig defaults ──────────────────────────────
+
+#[test]
+fn snapshot_load_config_default_debug() {
+    insta::assert_debug_snapshot!("load_config_default_debug", LoadConfig::default());
+}
+
+#[test]
+fn snapshot_production_load_config_default_debug() {
+    insta::assert_debug_snapshot!(
+        "production_load_config_default_debug",
+        ProductionLoadConfig::default()
+    );
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_bitnet.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_bitnet.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: config
+---
+{
+  "architecture": "bitnet",
+  "model_name": null,
+  "vocab_size": 32000,
+  "hidden_size": 2048,
+  "num_layers": 24,
+  "num_heads": 16,
+  "num_kv_heads": 16,
+  "head_dim": 128,
+  "intermediate_size": 8192,
+  "max_seq_len": 2048,
+  "rope_theta": 10000.0,
+  "rope_scaling": null,
+  "quantization": {
+    "bit_width": 2,
+    "block_size": 64,
+    "format": "I2_S"
+  }
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_gpt2.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_gpt2.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: config
+---
+{
+  "architecture": "gpt2",
+  "model_name": null,
+  "vocab_size": 32000,
+  "hidden_size": 768,
+  "num_layers": 12,
+  "num_heads": 12,
+  "num_kv_heads": 12,
+  "head_dim": 64,
+  "intermediate_size": 3072,
+  "max_seq_len": 2048,
+  "rope_theta": 10000.0,
+  "rope_scaling": null,
+  "quantization": {
+    "bit_width": 2,
+    "block_size": 64,
+    "format": "I2_S"
+  }
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_llama.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_llama.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: config
+---
+{
+  "architecture": "llama",
+  "model_name": null,
+  "vocab_size": 32000,
+  "hidden_size": 4096,
+  "num_layers": 32,
+  "num_heads": 32,
+  "num_kv_heads": 32,
+  "head_dim": 128,
+  "intermediate_size": 16384,
+  "max_seq_len": 2048,
+  "rope_theta": 10000.0,
+  "rope_scaling": null,
+  "quantization": {
+    "bit_width": 2,
+    "block_size": 64,
+    "format": "I2_S"
+  }
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_mistral.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_arch_mistral.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: config
+---
+{
+  "architecture": "mistral",
+  "model_name": null,
+  "vocab_size": 32000,
+  "hidden_size": 4096,
+  "num_layers": 32,
+  "num_heads": 32,
+  "num_kv_heads": 32,
+  "head_dim": 128,
+  "intermediate_size": 16384,
+  "max_seq_len": 2048,
+  "rope_theta": 10000.0,
+  "rope_scaling": null,
+  "quantization": {
+    "bit_width": 2,
+    "block_size": 64,
+    "format": "I2_S"
+  }
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_json_roundtrip.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_config_json_roundtrip.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: deserialized
+---
+{
+  "architecture": "llama",
+  "model_name": null,
+  "vocab_size": 32000,
+  "hidden_size": 4096,
+  "num_layers": 32,
+  "num_heads": 32,
+  "num_kv_heads": 32,
+  "head_dim": 128,
+  "intermediate_size": 16384,
+  "max_seq_len": 2048,
+  "rope_theta": 10000.0,
+  "rope_scaling": null,
+  "quantization": {
+    "bit_width": 2,
+    "block_size": 64,
+    "format": "I2_S"
+  }
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_quant_config_default.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_quant_config_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "GgufQuantizationConfig::default()"
+---
+GgufQuantizationConfig {
+    bit_width: 2,
+    block_size: 64,
+    format: "I2_S",
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_quant_config_json.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__gguf_quant_config_json.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "GgufQuantizationConfig::default()"
+---
+{
+  "bit_width": 2,
+  "block_size": 64,
+  "format": "I2_S"
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__load_config_default_debug.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__load_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "LoadConfig::default()"
+---
+LoadConfig {
+    use_mmap: true,
+    validate_checksums: true,
+    progress_callback: false,
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_debug_gguf.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_debug_gguf.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "format!(\"{:?}\", ModelFormat::Gguf)"
+---
+Gguf

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_debug_safetensors.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_debug_safetensors.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "format!(\"{:?}\", ModelFormat::SafeTensors)"
+---
+SafeTensors

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_extensions.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_extensions.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "format!(\"SafeTensors={} Gguf={}\", ModelFormat::SafeTensors.extension(),\nModelFormat::Gguf.extension(),)"
+---
+SafeTensors=safetensors Gguf=gguf

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_json.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_json.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: formats
+---
+[
+  "SafeTensors",
+  "Gguf"
+]

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_names.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__model_format_names.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "format!(\"SafeTensors={} Gguf={}\", ModelFormat::SafeTensors.name(),\nModelFormat::Gguf.name(),)"
+---
+SafeTensors=SafeTensors Gguf=GGUF

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__production_load_config_default_debug.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__production_load_config_default_debug.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: "ProductionLoadConfig::default()"
+---
+ProductionLoadConfig {
+    base: LoadConfig {
+        use_mmap: true,
+        validate_checksums: true,
+        progress_callback: false,
+    },
+    strict_validation: true,
+    validate_tensor_alignment: true,
+    max_model_size_bytes: Some(
+        34359738368,
+    ),
+    target_device: Cpu,
+    profile_memory: false,
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__rope_scaling_config_linear.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__rope_scaling_config_linear.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: scaling
+---
+{
+  "scaling_type": "Linear",
+  "factor": 2.0
+}

--- a/crates/bitnet-models/tests/snapshots/snapshot_model_config__rope_scaling_types.snap
+++ b/crates/bitnet-models/tests/snapshots/snapshot_model_config__rope_scaling_types.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-models/tests/snapshot_model_config.rs
+expression: types
+---
+[
+  "None",
+  "Linear",
+  "Ntk",
+  "YaRn"
+]

--- a/crates/bitnet-quantization/tests/snapshot_quantization.rs
+++ b/crates/bitnet-quantization/tests/snapshot_quantization.rs
@@ -1,0 +1,197 @@
+//! Wave 6 snapshot tests for bitnet-quantization.
+//!
+//! Pins QuantizationType Display output, I2S quantization of known vectors,
+//! scale factor computation, and block size configurations.
+
+use bitnet_common::QuantizationType;
+use bitnet_quantization::QuantizedTensor;
+use bitnet_quantization::i2s::{I2SLayout, I2SQuantizer};
+use bitnet_quantization::utils::{
+    calculate_grouped_scales, calculate_scale, pack_2bit_values, unpack_2bit_values,
+};
+
+// ── QuantizationType Display for each variant ───────────────────────────────
+
+#[test]
+fn snapshot_quantization_type_display_i2s() {
+    insta::assert_snapshot!("qtype_display_i2s", QuantizationType::I2S.to_string());
+}
+
+#[test]
+fn snapshot_quantization_type_display_tl1() {
+    insta::assert_snapshot!("qtype_display_tl1", QuantizationType::TL1.to_string());
+}
+
+#[test]
+fn snapshot_quantization_type_display_tl2() {
+    insta::assert_snapshot!("qtype_display_tl2", QuantizationType::TL2.to_string());
+}
+
+#[test]
+fn snapshot_quantization_type_debug_all() {
+    let all = vec![QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    insta::assert_json_snapshot!("qtype_debug_all", all);
+}
+
+// ── I2S quantization of known input vectors ─────────────────────────────────
+
+#[cfg(feature = "cpu")]
+#[test]
+fn snapshot_i2s_quantize_known_vector() {
+    let data: Vec<f32> = vec![
+        1.0, -1.0, 0.5, -0.5, 0.0, 0.25, -0.25, 0.75, -0.75, 1.0, -1.0, 0.5, -0.5, 0.0, 0.25,
+        -0.25, 0.75, -0.75, 1.0, -1.0, 0.5, -0.5, 0.0, 0.25, -0.25, 0.75, -0.75, 1.0, -1.0, 0.5,
+        -0.5, 0.0,
+    ];
+    let tensor =
+        bitnet_common::BitNetTensor::from_slice(&data, &[32], &bitnet_common::Device::Cpu).unwrap();
+    let quantizer = I2SQuantizer::new();
+    let quantized = quantizer.quantize_tensor(&tensor).unwrap();
+
+    // Snapshot metadata (data bytes are platform-independent for this input)
+    insta::assert_snapshot!(
+        "i2s_known_vector_meta",
+        format!(
+            "shape={:?} qtype={} block_size={} numel={} scales_len={} data_len={}",
+            quantized.shape,
+            quantized.qtype,
+            quantized.block_size,
+            quantized.numel(),
+            quantized.scales.len(),
+            quantized.data.len(),
+        )
+    );
+}
+
+#[cfg(feature = "cpu")]
+#[test]
+fn snapshot_i2s_quantize_zeros() {
+    let data = vec![0.0f32; 32];
+    let tensor =
+        bitnet_common::BitNetTensor::from_slice(&data, &[32], &bitnet_common::Device::Cpu).unwrap();
+    let quantizer = I2SQuantizer::new();
+    let quantized = quantizer.quantize_tensor(&tensor).unwrap();
+
+    insta::assert_snapshot!(
+        "i2s_zeros_meta",
+        format!(
+            "shape={:?} qtype={} numel={} compression_ratio={:.1}",
+            quantized.shape,
+            quantized.qtype,
+            quantized.numel(),
+            quantized.compression_ratio(),
+        )
+    );
+}
+
+// ── Scale factor computation ────────────────────────────────────────────────
+
+#[test]
+fn snapshot_scale_factor_uniform() {
+    let data: Vec<f32> = vec![1.0, -1.0, 0.5, -0.5];
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_uniform", format!("{scale:.6}"));
+}
+
+#[test]
+fn snapshot_scale_factor_zeros() {
+    let data = vec![0.0f32; 8];
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_zeros", format!("{scale:.6}"));
+}
+
+#[test]
+fn snapshot_scale_factor_large_range() {
+    let data: Vec<f32> = vec![100.0, -50.0, 25.0, -12.5];
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_large_range", format!("{scale:.6}"));
+}
+
+#[test]
+fn snapshot_grouped_scales() {
+    let data: Vec<f32> = vec![
+        1.0, -1.0, 0.5, -0.5, 0.0, 0.25, -0.25, 0.75, // block 1 (max=1.0)
+        2.0, -2.0, 1.5, -1.5, 0.0, 0.5, -0.5, 1.0, // block 2 (max=2.0)
+    ];
+    let scales = calculate_grouped_scales(&data, 8, 2);
+    let formatted: Vec<String> = scales.iter().map(|s| format!("{s:.6}")).collect();
+    insta::assert_json_snapshot!("grouped_scales_two_blocks", formatted);
+}
+
+// ── Block size configurations ───────────────────────────────────────────────
+
+#[test]
+fn snapshot_i2s_layout_default() {
+    let layout = I2SLayout::default();
+    insta::assert_snapshot!(
+        "i2s_layout_default",
+        format!(
+            "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+            layout.block_size,
+            layout.bytes_per_block,
+            layout.data_bytes_per_block,
+            layout.scale_bytes_per_block,
+        )
+    );
+}
+
+#[test]
+fn snapshot_i2s_layout_custom_64() {
+    let layout = I2SLayout::with_block_size(64);
+    insta::assert_snapshot!(
+        "i2s_layout_64",
+        format!(
+            "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+            layout.block_size,
+            layout.bytes_per_block,
+            layout.data_bytes_per_block,
+            layout.scale_bytes_per_block,
+        )
+    );
+}
+
+#[test]
+fn snapshot_i2s_layout_custom_256() {
+    let layout = I2SLayout::with_block_size(256);
+    insta::assert_snapshot!(
+        "i2s_layout_256",
+        format!(
+            "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+            layout.block_size,
+            layout.bytes_per_block,
+            layout.data_bytes_per_block,
+            layout.scale_bytes_per_block,
+        )
+    );
+}
+
+// ── Pack / unpack round-trip ────────────────────────────────────────────────
+
+#[test]
+fn snapshot_pack_2bit_known_values() {
+    let values: Vec<i8> = vec![1, 0, -1, -2, 1, -1, 0, -2];
+    let packed = pack_2bit_values(&values);
+    let unpacked = unpack_2bit_values(&packed, values.len());
+    insta::assert_snapshot!(
+        "pack_2bit_roundtrip",
+        format!("packed={:?} unpacked={:?}", packed, unpacked)
+    );
+}
+
+// ── QuantizedTensor metadata snapshot ───────────────────────────────────────
+
+#[test]
+fn snapshot_quantized_tensor_new() {
+    let qt = QuantizedTensor::new(vec![0u8; 8], vec![1.0], vec![32], QuantizationType::I2S);
+    insta::assert_snapshot!(
+        "quantized_tensor_new_meta",
+        format!(
+            "shape={:?} qtype={} block_size={} numel={} compression_ratio={:.1}",
+            qt.shape,
+            qt.qtype,
+            qt.block_size,
+            qt.numel(),
+            qt.compression_ratio(),
+        )
+    );
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__grouped_scales_two_blocks.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__grouped_scales_two_blocks.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: formatted
+---
+[
+  "1.000000",
+  "2.000000"
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_known_vector_meta.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_known_vector_meta.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"shape={:?} qtype={} block_size={} numel={} scales_len={} data_len={}\",\nquantized.shape, quantized.qtype, quantized.block_size, quantized.numel(),\nquantized.scales.len(), quantized.data.len(),)"
+---
+shape=[32] qtype=I2_S block_size=32 numel=32 scales_len=1 data_len=8

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_256.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_256.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"block_size={} bytes_per_block={} data_bytes={} scale_bytes={}\",\nlayout.block_size, layout.bytes_per_block, layout.data_bytes_per_block,\nlayout.scale_bytes_per_block,)"
+---
+block_size=256 bytes_per_block=66 data_bytes=64 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_64.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_64.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"block_size={} bytes_per_block={} data_bytes={} scale_bytes={}\",\nlayout.block_size, layout.bytes_per_block, layout.data_bytes_per_block,\nlayout.scale_bytes_per_block,)"
+---
+block_size=64 bytes_per_block=18 data_bytes=16 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_layout_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"block_size={} bytes_per_block={} data_bytes={} scale_bytes={}\",\nlayout.block_size, layout.bytes_per_block, layout.data_bytes_per_block,\nlayout.scale_bytes_per_block,)"
+---
+block_size=32 bytes_per_block=10 data_bytes=8 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_zeros_meta.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__i2s_zeros_meta.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"shape={:?} qtype={} numel={} compression_ratio={:.1}\",\nquantized.shape, quantized.qtype, quantized.numel(),\nquantized.compression_ratio(),)"
+---
+shape=[32] qtype=I2_S numel=32 compression_ratio=10.7

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__pack_2bit_roundtrip.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__pack_2bit_roundtrip.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"packed={:?} unpacked={:?}\", packed, unpacked)"
+---
+packed=[27, 39] unpacked=[1, 0, -1, -2, 1, -1, 0, -2]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_debug_all.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_debug_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: all
+---
+[
+  "I2S",
+  "TL1",
+  "TL2"
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_i2s.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_i2s.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "QuantizationType::I2S.to_string()"
+---
+I2_S

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_tl1.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_tl1.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "QuantizationType::TL1.to_string()"
+---
+TL1

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_tl2.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__qtype_display_tl2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "QuantizationType::TL2.to_string()"
+---
+TL2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__quantized_tensor_new_meta.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__quantized_tensor_new_meta.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"shape={:?} qtype={} block_size={} numel={} compression_ratio={:.1}\",\nqt.shape, qt.qtype, qt.block_size, qt.numel(), qt.compression_ratio(),)"
+---
+shape=[32] qtype=I2_S block_size=32 numel=32 compression_ratio=10.7

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_large_range.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_large_range.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"{scale:.6}\")"
+---
+100.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_uniform.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_uniform.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_zeros.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quantization__scale_zeros.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quantization.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+++ b/crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
@@ -1,0 +1,150 @@
+//! Wave 6 snapshot tests for bitnet-tokenizers configuration types.
+//!
+//! Pins TokenizerConfig defaults, special token configurations,
+//! and config serialization.
+
+use bitnet_tokenizers::{BasicTokenizer, Tokenizer, TokenizerConfig};
+
+// ── TokenizerConfig defaults ────────────────────────────────────────────────
+
+#[test]
+fn snapshot_tokenizer_config_default_debug() {
+    insta::assert_debug_snapshot!("tokenizer_config_default_debug", TokenizerConfig::default());
+}
+
+#[test]
+fn snapshot_tokenizer_config_default_json() {
+    insta::assert_json_snapshot!("tokenizer_config_default_json", TokenizerConfig::default());
+}
+
+#[test]
+fn snapshot_tokenizer_config_new_equals_default() {
+    let new = TokenizerConfig::new();
+    let default = TokenizerConfig::default();
+    // Both should produce identical snapshots
+    insta::assert_snapshot!(
+        "tokenizer_config_new_eq_default",
+        format!(
+            "new_model_type={} default_model_type={} equal={}",
+            new.model_type,
+            default.model_type,
+            new.model_type == default.model_type
+                && new.vocab_size == default.vocab_size
+                && new.add_bos == default.add_bos
+                && new.add_eos == default.add_eos,
+        )
+    );
+}
+
+// ── Special token configurations ────────────────────────────────────────────
+
+#[test]
+fn snapshot_tokenizer_config_special_tokens_default() {
+    let cfg = TokenizerConfig::default();
+    insta::assert_snapshot!(
+        "tokenizer_config_special_tokens",
+        format!(
+            "bos={:?} eos={:?} pad={:?} unk={:?}",
+            cfg.bos_token_id, cfg.eos_token_id, cfg.pad_token_id, cfg.unk_token_id,
+        )
+    );
+}
+
+#[test]
+fn snapshot_tokenizer_config_with_special_tokens() {
+    let cfg = TokenizerConfig {
+        model_type: "llama".into(),
+        vocab_size: 32000,
+        bos_token_id: Some(1),
+        eos_token_id: Some(2),
+        pad_token_id: Some(0),
+        unk_token_id: Some(3),
+        add_bos: true,
+        add_eos: false,
+        ..Default::default()
+    };
+    insta::assert_json_snapshot!("tokenizer_config_llama_special_tokens", cfg);
+}
+
+#[test]
+fn snapshot_tokenizer_config_gpt2_style() {
+    let cfg = TokenizerConfig {
+        model_type: "gpt2".into(),
+        vocab_size: 50257,
+        bos_token_id: None,
+        eos_token_id: Some(50256),
+        pad_token_id: None,
+        unk_token_id: None,
+        pre_tokenizer: Some("ByteLevel".into()),
+        byte_fallback: false,
+        ..Default::default()
+    };
+    insta::assert_json_snapshot!("tokenizer_config_gpt2_style", cfg);
+}
+
+#[test]
+fn snapshot_tokenizer_config_bitnet_style() {
+    let cfg = TokenizerConfig {
+        model_type: "bitnet".into(),
+        vocab_size: 32064,
+        bos_token_id: Some(1),
+        eos_token_id: Some(2),
+        pad_token_id: None,
+        unk_token_id: Some(0),
+        add_bos: true,
+        add_eos: true,
+        add_space_prefix: true,
+        byte_fallback: true,
+        ..Default::default()
+    };
+    insta::assert_json_snapshot!("tokenizer_config_bitnet_style", cfg);
+}
+
+// ── Config serialization round-trip ─────────────────────────────────────────
+
+#[test]
+fn snapshot_tokenizer_config_json_roundtrip() {
+    let cfg = TokenizerConfig {
+        model_type: "llama".into(),
+        vocab_size: 32000,
+        bos_token_id: Some(1),
+        eos_token_id: Some(2),
+        add_bos: true,
+        ..Default::default()
+    };
+    let json = serde_json::to_string_pretty(&cfg).unwrap();
+    let deserialized: TokenizerConfig = serde_json::from_str(&json).unwrap();
+    insta::assert_json_snapshot!("tokenizer_config_json_roundtrip", deserialized);
+}
+
+// ── BasicTokenizer special token snapshots ──────────────────────────────────
+
+#[test]
+fn snapshot_basic_tokenizer_special_token_ids() {
+    let tok = BasicTokenizer::new();
+    insta::assert_snapshot!(
+        "basic_tokenizer_special_ids",
+        format!(
+            "bos={:?} eos={:?} pad={:?} vocab_size={}",
+            tok.bos_token_id(),
+            tok.eos_token_id(),
+            tok.pad_token_id(),
+            tok.vocab_size(),
+        )
+    );
+}
+
+#[test]
+fn snapshot_basic_tokenizer_custom_config() {
+    let tok = BasicTokenizer::with_config(128256, Some(128000), Some(128001), Some(128002));
+    insta::assert_snapshot!(
+        "basic_tokenizer_custom_special_ids",
+        format!(
+            "bos={:?} eos={:?} pad={:?} vocab_size={}",
+            tok.bos_token_id(),
+            tok.eos_token_id(),
+            tok.pad_token_id(),
+            tok.vocab_size(),
+        )
+    );
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__basic_tokenizer_custom_special_ids.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__basic_tokenizer_custom_special_ids.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "format!(\"bos={:?} eos={:?} pad={:?} vocab_size={}\", tok.bos_token_id(),\ntok.eos_token_id(), tok.pad_token_id(), tok.vocab_size(),)"
+---
+bos=Some(128000) eos=Some(128001) pad=Some(128002) vocab_size=128256

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__basic_tokenizer_special_ids.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__basic_tokenizer_special_ids.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "format!(\"bos={:?} eos={:?} pad={:?} vocab_size={}\", tok.bos_token_id(),\ntok.eos_token_id(), tok.pad_token_id(), tok.vocab_size(),)"
+---
+bos=None eos=Some(50256) pad=None vocab_size=50257

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_bitnet_style.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_bitnet_style.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: cfg
+---
+{
+  "model_type": "bitnet",
+  "vocab_size": 32064,
+  "pre_tokenizer": null,
+  "add_bos": true,
+  "add_eos": true,
+  "add_space_prefix": true,
+  "byte_fallback": true,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "pad_token_id": null,
+  "unk_token_id": 0,
+  "vocabulary": null,
+  "bpe_merges": null
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_default_debug.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_default_debug.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "TokenizerConfig::default()"
+---
+TokenizerConfig {
+    model_type: "",
+    vocab_size: 0,
+    pre_tokenizer: None,
+    add_bos: false,
+    add_eos: false,
+    add_space_prefix: false,
+    byte_fallback: false,
+    bos_token_id: None,
+    eos_token_id: None,
+    pad_token_id: None,
+    unk_token_id: None,
+    vocabulary: None,
+    bpe_merges: None,
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_default_json.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_default_json.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "TokenizerConfig::default()"
+---
+{
+  "model_type": "",
+  "vocab_size": 0,
+  "pre_tokenizer": null,
+  "add_bos": false,
+  "add_eos": false,
+  "add_space_prefix": false,
+  "byte_fallback": false,
+  "bos_token_id": null,
+  "eos_token_id": null,
+  "pad_token_id": null,
+  "unk_token_id": null,
+  "vocabulary": null,
+  "bpe_merges": null
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_gpt2_style.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_gpt2_style.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: cfg
+---
+{
+  "model_type": "gpt2",
+  "vocab_size": 50257,
+  "pre_tokenizer": "ByteLevel",
+  "add_bos": false,
+  "add_eos": false,
+  "add_space_prefix": false,
+  "byte_fallback": false,
+  "bos_token_id": null,
+  "eos_token_id": 50256,
+  "pad_token_id": null,
+  "unk_token_id": null,
+  "vocabulary": null,
+  "bpe_merges": null
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_json_roundtrip.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_json_roundtrip.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: deserialized
+---
+{
+  "model_type": "llama",
+  "vocab_size": 32000,
+  "pre_tokenizer": null,
+  "add_bos": true,
+  "add_eos": false,
+  "add_space_prefix": false,
+  "byte_fallback": false,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "pad_token_id": null,
+  "unk_token_id": null,
+  "vocabulary": null,
+  "bpe_merges": null
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_llama_special_tokens.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_llama_special_tokens.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: cfg
+---
+{
+  "model_type": "llama",
+  "vocab_size": 32000,
+  "pre_tokenizer": null,
+  "add_bos": true,
+  "add_eos": false,
+  "add_space_prefix": false,
+  "byte_fallback": false,
+  "bos_token_id": 1,
+  "eos_token_id": 2,
+  "pad_token_id": 0,
+  "unk_token_id": 3,
+  "vocabulary": null,
+  "bpe_merges": null
+}

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_new_eq_default.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_new_eq_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "format!(\"new_model_type={} default_model_type={} equal={}\", new.model_type,\ndefault.model_type, new.model_type == default.model_type && new.vocab_size ==\ndefault.vocab_size && new.add_bos == default.add_bos && new.add_eos ==\ndefault.add_eos,)"
+---
+new_model_type= default_model_type= equal=true

--- a/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_special_tokens.snap
+++ b/crates/bitnet-tokenizers/tests/snapshots/snapshot_tokenizer_config__tokenizer_config_special_tokens.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-tokenizers/tests/snapshot_tokenizer_config.rs
+expression: "format!(\"bos={:?} eos={:?} pad={:?} unk={:?}\", cfg.bos_token_id,\ncfg.eos_token_id, cfg.pad_token_id, cfg.unk_token_id,)"
+---
+bos=None eos=None pad=None unk=None


### PR DESCRIPTION
## Summary

Add 41 new insta snapshot tests across three crates for additional regression coverage.

### bitnet-quantization (15 tests)
- `QuantizationType` Display output for each variant (I2S, TL1, TL2)
- `QuantizationType` Debug serialization (JSON)
- I2S quantization of known input vectors (metadata snapshots)
- Scale factor computation (`calculate_scale`, `calculate_grouped_scales`)
- Block size configurations (`I2SLayout` default, 64, 256)
- 2-bit pack/unpack round-trip
- `QuantizedTensor` metadata snapshot

### bitnet-models (16 tests)
- `ModelFormat` Debug, name, extension, and JSON serialization
- `GgufQuantizationConfig` defaults (Debug and JSON)
- Architecture-specific `GgufModelConfig` from metadata (llama, bitnet, mistral, gpt2)
- Config JSON serialization round-trip
- `RopeScaling` types and config serialization
- `LoadConfig` and `ProductionLoadConfig` default Debug output

### bitnet-tokenizers (10 tests)
- `TokenizerConfig` defaults (Debug and JSON)
- Special token configurations (default, llama, gpt2, bitnet styles)
- Config JSON serialization round-trip
- `BasicTokenizer` special token ID snapshots (default and custom)

### Testing
```bash
cargo test -p bitnet-quantization --test snapshot_quantization \
  -p bitnet-models --test snapshot_model_config \
  -p bitnet-tokenizers --test snapshot_tokenizer_config \
  --no-default-features --features cpu
# 41 passed; 0 failed
```