### PR TITLE
feat(inference): add KV cache optimization module for incremental inference

### DIFF
--- a/crates/bitnet-common/src/tensor_validation.rs
+++ b/crates/bitnet-common/src/tensor_validation.rs
@@ -260,6 +260,285 @@ fn _fmt_shape(shape: &[usize], f: &mut fmt::Formatter<'_>) -> fmt::Result {
 }
 
 // =========================================================================
+// Production Tensor Data Validation
+// =========================================================================
+
+/// Lightweight trait for tensor data validation.
+///
+/// Implement this for any tensor-like type to enable production safety
+/// checks (NaN/Inf detection, value range, alignment) without coupling
+/// to heavy framework dependencies.
+pub trait TensorLike: Send + Sync {
+    /// Returns the tensor shape dimensions.
+    fn shape(&self) -> &[usize];
+
+    /// Returns f32 data if available (for NaN/Inf/range checks).
+    /// Return `None` to skip data-level validation.
+    fn data_f32(&self) -> Option<&[f32]>;
+
+    /// Returns stride information for memory layout validation.
+    /// Return `None` to skip stride validation.
+    fn strides(&self) -> Option<&[usize]>;
+
+    /// Returns the byte alignment of the underlying data pointer.
+    fn data_alignment(&self) -> usize;
+}
+
+/// Configuration for tensor validation with builder pattern.
+#[derive(Debug, Clone)]
+pub struct ValidationConfig {
+    max_total_elements: usize,
+    max_dimensions: usize,
+    check_nan: bool,
+    check_inf: bool,
+    value_range: Option<(f32, f32)>,
+    required_alignment: usize,
+}
+
+impl Default for ValidationConfig {
+    fn default() -> Self {
+        Self {
+            max_total_elements: 1 << 30, // ~1 billion elements
+            max_dimensions: 8,
+            check_nan: true,
+            check_inf: true,
+            value_range: None,
+            required_alignment: 1, // no alignment requirement
+        }
+    }
+}
+
+impl ValidationConfig {
+    /// Create a new configuration with sensible defaults.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the maximum total number of elements allowed.
+    pub fn max_total_elements(mut self, max: usize) -> Self {
+        self.max_total_elements = max;
+        self
+    }
+
+    /// Set the maximum number of dimensions allowed.
+    pub fn max_dimensions(mut self, max: usize) -> Self {
+        self.max_dimensions = max;
+        self
+    }
+
+    /// Enable or disable NaN checking.
+    pub fn check_nan(mut self, check: bool) -> Self {
+        self.check_nan = check;
+        self
+    }
+
+    /// Enable or disable infinity checking.
+    pub fn check_inf(mut self, check: bool) -> Self {
+        self.check_inf = check;
+        self
+    }
+
+    /// Set the allowed value range `[min, max]` (inclusive).
+    pub fn value_range(mut self, min: f32, max: f32) -> Self {
+        self.value_range = Some((min, max));
+        self
+    }
+
+    /// Set the required data pointer alignment in bytes.
+    pub fn required_alignment(mut self, align: usize) -> Self {
+        self.required_alignment = align;
+        self
+    }
+}
+
+/// Detailed validation error information.
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum TensorValidationError {
+    #[error("zero dimension at axis {axis} in shape {shape:?}")]
+    ZeroDimension { axis: usize, shape: Vec<usize> },
+
+    #[error("total elements {total} exceeds maximum {max}")]
+    TotalElementsExceeded { total: usize, max: usize },
+
+    #[error("{ndim} dimensions exceeds maximum {max}")]
+    DimensionsExceeded { ndim: usize, max: usize },
+
+    #[error("NaN detected at index {index}")]
+    NanDetected { index: usize },
+
+    #[error("Inf detected at index {index}, value={value}")]
+    InfDetected { index: usize, value: f32 },
+
+    #[error("value {value} at index {index} outside range [{min}, {max}]")]
+    ValueOutOfRange { index: usize, value: f32, min: f32, max: f32 },
+
+    #[error("stride mismatch at axis {axis}: expected {expected} (C-contiguous), got {actual}")]
+    StrideInconsistent { axis: usize, expected: usize, actual: usize },
+
+    #[error("alignment {actual} does not meet required {required}")]
+    AlignmentViolation { required: usize, actual: usize },
+}
+
+/// Thread-safe tensor validator with configurable rules.
+///
+/// Zero-allocation on the common (valid) path — every check returns
+/// `Ok(())` without heap activity when the tensor is well-formed.
+#[derive(Debug, Clone)]
+pub struct TensorValidator {
+    config: ValidationConfig,
+}
+
+impl TensorValidator {
+    /// Create a validator from the given configuration.
+    pub fn new(config: ValidationConfig) -> Self {
+        Self { config }
+    }
+
+    /// Validate a single tensor against all configured rules.
+    pub fn validate<T: TensorLike>(
+        &self,
+        tensor: &T,
+    ) -> std::result::Result<(), TensorValidationError> {
+        self.validate_shape(tensor)?;
+        self.validate_data(tensor)?;
+        self.validate_strides(tensor)?;
+        self.validate_alignment(tensor)?;
+        Ok(())
+    }
+
+    /// Validate a batch of tensors, returning one result per tensor.
+    pub fn validate_batch<T: TensorLike>(
+        &self,
+        tensors: &[T],
+    ) -> Vec<std::result::Result<(), TensorValidationError>> {
+        tensors.iter().map(|t| self.validate(t)).collect()
+    }
+
+    fn validate_shape<T: TensorLike>(
+        &self,
+        tensor: &T,
+    ) -> std::result::Result<(), TensorValidationError> {
+        let shape = tensor.shape();
+
+        if shape.len() > self.config.max_dimensions {
+            return Err(TensorValidationError::DimensionsExceeded {
+                ndim: shape.len(),
+                max: self.config.max_dimensions,
+            });
+        }
+
+        for (axis, &dim) in shape.iter().enumerate() {
+            if dim == 0 {
+                return Err(TensorValidationError::ZeroDimension { axis, shape: shape.to_vec() });
+            }
+        }
+
+        let mut total: usize = 1;
+        for &dim in shape {
+            match total.checked_mul(dim) {
+                Some(t) if t <= self.config.max_total_elements => total = t,
+                Some(t) => {
+                    return Err(TensorValidationError::TotalElementsExceeded {
+                        total: t,
+                        max: self.config.max_total_elements,
+                    });
+                }
+                None => {
+                    return Err(TensorValidationError::TotalElementsExceeded {
+                        total: usize::MAX,
+                        max: self.config.max_total_elements,
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_data<T: TensorLike>(
+        &self,
+        tensor: &T,
+    ) -> std::result::Result<(), TensorValidationError> {
+        let data = match tensor.data_f32() {
+            Some(d) => d,
+            None => return Ok(()),
+        };
+
+        for (i, &val) in data.iter().enumerate() {
+            if self.config.check_nan && val.is_nan() {
+                return Err(TensorValidationError::NanDetected { index: i });
+            }
+            if self.config.check_inf && val.is_infinite() {
+                return Err(TensorValidationError::InfDetected { index: i, value: val });
+            }
+            if let Some((min, max)) = self.config.value_range
+                && (val < min || val > max)
+            {
+                return Err(TensorValidationError::ValueOutOfRange {
+                    index: i,
+                    value: val,
+                    min,
+                    max,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_strides<T: TensorLike>(
+        &self,
+        tensor: &T,
+    ) -> std::result::Result<(), TensorValidationError> {
+        let strides = match tensor.strides() {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+        let shape = tensor.shape();
+        if shape.is_empty() {
+            return Ok(());
+        }
+
+        let expected = c_contiguous_strides(shape);
+        for (axis, (&exp, &act)) in expected.iter().zip(strides.iter()).enumerate() {
+            if exp != act {
+                return Err(TensorValidationError::StrideInconsistent {
+                    axis,
+                    expected: exp,
+                    actual: act,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_alignment<T: TensorLike>(
+        &self,
+        tensor: &T,
+    ) -> std::result::Result<(), TensorValidationError> {
+        let actual = tensor.data_alignment();
+        let required = self.config.required_alignment;
+        if required > 1 && !actual.is_multiple_of(required) {
+            return Err(TensorValidationError::AlignmentViolation { required, actual });
+        }
+        Ok(())
+    }
+}
+
+/// Compute C-contiguous (row-major) strides for the given shape.
+pub fn c_contiguous_strides(shape: &[usize]) -> Vec<usize> {
+    if shape.is_empty() {
+        return vec![];
+    }
+    let mut strides = vec![1usize; shape.len()];
+    for i in (0..shape.len() - 1).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    strides
+}
+
+// =========================================================================
 // Tests
 // =========================================================================
 
@@ -517,5 +796,414 @@ mod tests {
     fn matmul_high_rank_batched() {
         // [2, 1, 4, 3] × [2, 5, 3, 6] → broadcast batch [2, 5], out [2, 5, 4, 6]
         assert_eq!(validate_matmul_shapes(&[2, 1, 4, 3], &[2, 5, 3, 6]).unwrap(), vec![2, 5, 4, 6]);
+    }
+
+    // =================================================================
+    // Production data-validation tests
+    // =================================================================
+
+    mod data_validation {
+        use super::super::*;
+        use proptest::prelude::*;
+
+        // ----- Test helper -----------------------------------------------
+
+        struct TestTensor {
+            shape: Vec<usize>,
+            data: Option<Vec<f32>>,
+            strides: Option<Vec<usize>>,
+            alignment: usize,
+        }
+
+        impl TestTensor {
+            fn new(shape: Vec<usize>, data: Vec<f32>) -> Self {
+                Self { shape, data: Some(data), strides: None, alignment: 64 }
+            }
+
+            fn with_strides(mut self, strides: Vec<usize>) -> Self {
+                self.strides = Some(strides);
+                self
+            }
+
+            fn with_alignment(mut self, alignment: usize) -> Self {
+                self.alignment = alignment;
+                self
+            }
+
+            fn no_data(shape: Vec<usize>) -> Self {
+                Self { shape, data: None, strides: None, alignment: 64 }
+            }
+        }
+
+        impl TensorLike for TestTensor {
+            fn shape(&self) -> &[usize] {
+                &self.shape
+            }
+            fn data_f32(&self) -> Option<&[f32]> {
+                self.data.as_deref()
+            }
+            fn strides(&self) -> Option<&[usize]> {
+                self.strides.as_deref()
+            }
+            fn data_alignment(&self) -> usize {
+                self.alignment
+            }
+        }
+
+        fn default_validator() -> TensorValidator {
+            TensorValidator::new(ValidationConfig::new())
+        }
+
+        // ----- Valid tensors pass ----------------------------------------
+
+        #[test]
+        fn valid_tensor_passes() {
+            let t = TestTensor::new(vec![2, 3], vec![1.0; 6]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        #[test]
+        fn scalar_tensor_passes() {
+            let t = TestTensor::new(vec![], vec![42.0]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        #[test]
+        fn valid_tensor_with_strides_passes() {
+            let t = TestTensor::new(vec![2, 3], vec![1.0; 6]).with_strides(vec![3, 1]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        // ----- Zero-dimension detection ----------------------------------
+
+        #[test]
+        fn zero_dimension_first_axis() {
+            let t = TestTensor::no_data(vec![0, 3]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::ZeroDimension { axis: 0, .. }));
+        }
+
+        #[test]
+        fn zero_dimension_middle_axis() {
+            let t = TestTensor::no_data(vec![3, 0, 5]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::ZeroDimension { axis: 1, .. }));
+        }
+
+        #[test]
+        fn zero_dimension_last_axis() {
+            let t = TestTensor::no_data(vec![3, 5, 0]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::ZeroDimension { axis: 2, .. }));
+        }
+
+        // ----- NaN detection ---------------------------------------------
+
+        #[test]
+        fn nan_detection_first_element() {
+            let t = TestTensor::new(vec![4], vec![f32::NAN, 1.0, 2.0, 3.0]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(err, TensorValidationError::NanDetected { index: 0 });
+        }
+
+        #[test]
+        fn nan_detection_middle() {
+            let t = TestTensor::new(vec![4], vec![1.0, 2.0, f32::NAN, 3.0]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(err, TensorValidationError::NanDetected { index: 2 });
+        }
+
+        #[test]
+        fn nan_detection_last() {
+            let t = TestTensor::new(vec![3], vec![1.0, 2.0, f32::NAN]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(err, TensorValidationError::NanDetected { index: 2 });
+        }
+
+        #[test]
+        fn nan_check_disabled_passes() {
+            let cfg = ValidationConfig::new().check_nan(false);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![2], vec![f32::NAN, 1.0]);
+            assert!(v.validate(&t).is_ok());
+        }
+
+        // ----- Inf detection ---------------------------------------------
+
+        #[test]
+        fn inf_positive_detected() {
+            let t = TestTensor::new(vec![3], vec![1.0, 2.0, f32::INFINITY]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(err, TensorValidationError::InfDetected { index: 2, value: f32::INFINITY });
+        }
+
+        #[test]
+        fn inf_negative_detected() {
+            let t = TestTensor::new(vec![3], vec![1.0, f32::NEG_INFINITY, 2.0]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(
+                err,
+                TensorValidationError::InfDetected { index: 1, value: f32::NEG_INFINITY }
+            );
+        }
+
+        #[test]
+        fn inf_check_disabled_passes() {
+            let cfg = ValidationConfig::new().check_inf(false);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![1], vec![f32::INFINITY]);
+            assert!(v.validate(&t).is_ok());
+        }
+
+        // ----- Value range -----------------------------------------------
+
+        #[test]
+        fn value_above_range() {
+            let cfg = ValidationConfig::new().value_range(-1.0, 1.0);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![3], vec![0.0, 0.5, 1.5]);
+            let err = v.validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::ValueOutOfRange { index: 2, .. }));
+        }
+
+        #[test]
+        fn value_below_range() {
+            let cfg = ValidationConfig::new().value_range(0.0, 1.0);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![2], vec![-0.1, 0.5]);
+            let err = v.validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::ValueOutOfRange { index: 0, .. }));
+        }
+
+        #[test]
+        fn value_at_bounds_passes() {
+            let cfg = ValidationConfig::new().value_range(-1.0, 1.0);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![3], vec![-1.0, 0.0, 1.0]);
+            assert!(v.validate(&t).is_ok());
+        }
+
+        #[test]
+        fn no_range_check_by_default() {
+            let t = TestTensor::new(vec![2], vec![-1e30, 1e30]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        // ----- Stride consistency ----------------------------------------
+
+        #[test]
+        fn stride_consistent_passes() {
+            // C-contiguous strides for [4, 3] are [3, 1]
+            let t = TestTensor::new(vec![4, 3], vec![0.0; 12]).with_strides(vec![3, 1]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        #[test]
+        fn stride_inconsistent_detected() {
+            // [4, 3] expects strides [3, 1], not [4, 1]
+            let t = TestTensor::new(vec![4, 3], vec![0.0; 12]).with_strides(vec![4, 1]);
+            let err = default_validator().validate(&t).unwrap_err();
+            assert_eq!(
+                err,
+                TensorValidationError::StrideInconsistent { axis: 0, expected: 3, actual: 4 }
+            );
+        }
+
+        #[test]
+        fn no_strides_skips_check() {
+            let t = TestTensor::new(vec![2, 3], vec![0.0; 6]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        // ----- Alignment -------------------------------------------------
+
+        #[test]
+        fn alignment_satisfied() {
+            let cfg = ValidationConfig::new().required_alignment(32);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![2], vec![1.0, 2.0]).with_alignment(64);
+            assert!(v.validate(&t).is_ok());
+        }
+
+        #[test]
+        fn alignment_violation() {
+            let cfg = ValidationConfig::new().required_alignment(32);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::new(vec![2], vec![1.0, 2.0]).with_alignment(16);
+            let err = v.validate(&t).unwrap_err();
+            assert_eq!(err, TensorValidationError::AlignmentViolation { required: 32, actual: 16 });
+        }
+
+        #[test]
+        fn alignment_default_passes() {
+            // Default required_alignment is 1, so any alignment works.
+            let t = TestTensor::new(vec![1], vec![1.0]).with_alignment(1);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        // ----- Total elements / dimensions --------------------------------
+
+        #[test]
+        fn total_elements_exceeded() {
+            let cfg = ValidationConfig::new().max_total_elements(100);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::no_data(vec![11, 10]); // 110 > 100
+            let err = v.validate(&t).unwrap_err();
+            assert!(matches!(
+                err,
+                TensorValidationError::TotalElementsExceeded { total: 110, max: 100 }
+            ));
+        }
+
+        #[test]
+        fn dimensions_exceeded() {
+            let cfg = ValidationConfig::new().max_dimensions(3);
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::no_data(vec![2, 3, 4, 5]);
+            let err = v.validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::DimensionsExceeded { ndim: 4, max: 3 }));
+        }
+
+        #[test]
+        fn very_large_dimension_overflow() {
+            let cfg = ValidationConfig::new();
+            let v = TensorValidator::new(cfg);
+            let t = TestTensor::no_data(vec![usize::MAX, 2]);
+            let err = v.validate(&t).unwrap_err();
+            assert!(matches!(err, TensorValidationError::TotalElementsExceeded { .. }));
+        }
+
+        // ----- Batch validation ------------------------------------------
+
+        #[test]
+        fn batch_all_valid() {
+            let tensors = vec![
+                TestTensor::new(vec![2], vec![1.0, 2.0]),
+                TestTensor::new(vec![3], vec![1.0, 2.0, 3.0]),
+            ];
+            let results = default_validator().validate_batch(&tensors);
+            assert!(results.iter().all(|r| r.is_ok()));
+        }
+
+        #[test]
+        fn batch_mixed_valid_invalid() {
+            let tensors = vec![
+                TestTensor::new(vec![2], vec![1.0, 2.0]),
+                TestTensor::new(vec![2], vec![f32::NAN, 1.0]),
+                TestTensor::new(vec![3], vec![1.0, 2.0, 3.0]),
+            ];
+            let results = default_validator().validate_batch(&tensors);
+            assert!(results[0].is_ok());
+            assert!(results[1].is_err());
+            assert!(results[2].is_ok());
+        }
+
+        #[test]
+        fn batch_all_invalid() {
+            let tensors = vec![
+                TestTensor::new(vec![1], vec![f32::NAN]),
+                TestTensor::new(vec![1], vec![f32::INFINITY]),
+            ];
+            let results = default_validator().validate_batch(&tensors);
+            assert!(results.iter().all(|r| r.is_err()));
+        }
+
+        #[test]
+        fn batch_empty() {
+            let tensors: Vec<TestTensor> = vec![];
+            let results = default_validator().validate_batch(&tensors);
+            assert!(results.is_empty());
+        }
+
+        // ----- Config builder --------------------------------------------
+
+        #[test]
+        fn config_builder_defaults() {
+            let cfg = ValidationConfig::new();
+            assert_eq!(cfg.max_total_elements, 1 << 30);
+            assert_eq!(cfg.max_dimensions, 8);
+            assert!(cfg.check_nan);
+            assert!(cfg.check_inf);
+            assert!(cfg.value_range.is_none());
+            assert_eq!(cfg.required_alignment, 1);
+        }
+
+        #[test]
+        fn config_builder_custom() {
+            let cfg = ValidationConfig::new()
+                .max_total_elements(500)
+                .max_dimensions(4)
+                .check_nan(false)
+                .check_inf(false)
+                .value_range(-2.0, 2.0)
+                .required_alignment(16);
+            assert_eq!(cfg.max_total_elements, 500);
+            assert_eq!(cfg.max_dimensions, 4);
+            assert!(!cfg.check_nan);
+            assert!(!cfg.check_inf);
+            assert_eq!(cfg.value_range, Some((-2.0, 2.0)));
+            assert_eq!(cfg.required_alignment, 16);
+        }
+
+        // ----- Miscellaneous edge cases ----------------------------------
+
+        #[test]
+        fn no_data_skips_value_checks() {
+            let t = TestTensor::no_data(vec![2, 3]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        #[test]
+        fn c_contiguous_strides_helper() {
+            assert_eq!(c_contiguous_strides(&[4, 3, 2]), vec![6, 2, 1]);
+            assert_eq!(c_contiguous_strides(&[5]), vec![1]);
+            assert!(c_contiguous_strides(&[]).is_empty());
+        }
+
+        #[test]
+        fn single_element_tensor_passes() {
+            let t = TestTensor::new(vec![1, 1, 1], vec![0.5]).with_strides(vec![1, 1, 1]);
+            assert!(default_validator().validate(&t).is_ok());
+        }
+
+        // ----- Property tests --------------------------------------------
+
+        proptest! {
+            #[test]
+            fn prop_valid_tensors_always_pass(len in 1..64usize) {
+                let data: Vec<f32> =
+                    (0..len).map(|i| (i as f32) * 0.01).collect();
+                let t = TestTensor::new(vec![len], data);
+                prop_assert!(default_validator().validate(&t).is_ok());
+            }
+
+            #[test]
+            fn prop_nan_always_fails(len in 1..64usize) {
+                let pos = len / 2;
+                let mut data = vec![1.0f32; len];
+                data[pos] = f32::NAN;
+                let t = TestTensor::new(vec![len], data);
+                let result = default_validator().validate(&t);
+                let is_nan_err = matches!(
+                    result,
+                    Err(TensorValidationError::NanDetected { .. })
+                );
+                prop_assert!(is_nan_err, "expected NanDetected error");
+            }
+
+            #[test]
+            fn prop_inf_always_fails(len in 1..64usize) {
+                let pos = len / 2;
+                let mut data = vec![1.0f32; len];
+                data[pos] = f32::INFINITY;
+                let t = TestTensor::new(vec![len], data);
+                let result = default_validator().validate(&t);
+                let is_inf_err = matches!(
+                    result,
+                    Err(TensorValidationError::InfDetected { .. })
+                );
+                prop_assert!(is_inf_err, "expected InfDetected error");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Add `kv_cache_opt` module to `bitnet-inference` with `KvCacheManager` for efficient incremental inference.

### Features
- **Per-layer KV cache management** for all transformer layers
- **Sliding window attention** with configurable window size (whole-page eviction)
- **Page-based allocation** for memory efficiency (`KvCacheConfig::page_size`)
- **Variable-length sequence support** — each layer tracks its own sequence independently
- **Eviction policies**: LRU (least-recently-used pages), FIFO (oldest page), MaxLength (trim to max_seq_len)
- **Memory usage tracking** via `CacheStats` (bytes, pages, tokens, eviction count)
- **`KvCacheConfig`** — full parameterization: num_layers, num_heads, head_dim, max_seq_len, window_size, page_size

### API
- `append(layer, key, value)` — add new KV pair for a token
- `get(layer, positions)` — retrieve cached KV over a position range
- `evict(strategy)` — run eviction across all layers
- `seq_len(layer)`, `stats()`, `layer_page_count(layer)`, `clear()`

### Tests (27)
- Basic append/retrieve, multi-token, partial range, page boundary spanning
- Sliding window truncation, window content correctness, window_size=1
- Multi-layer independence, layer eviction isolation
- LRU/FIFO/MaxLength eviction policies
- Memory tracking (increase on append, decrease on eviction, page count)
- Edge cases: empty cache, out-of-range clamping, clear reset, single entry
- Property tests: seq_len monotonicity, window ceiling, layer independence
- Evict-on-empty safety

### Validation
- `cargo fmt --all` ✅
- `cargo clippy -p bitnet-inference --lib --no-default-features --features cpu -- -D warnings` ✅
- `cargo test -p bitnet-inference --no-default-features --features cpu --lib -- kv_cache_opt::tests` — 27/27 pass ✅