### PR TITLE
feat(kernels): enhance CUDA RoPE kernel with scaling_factor, sincos table, and expanded tests

### DIFF
--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -37,7 +37,7 @@ pub use batch_norm::{BatchNormConfig, BatchNormKernel, BatchNormState, batch_nor
 pub use kv_cache::{CacheDtype, CacheStats, KvCacheBuffer, KvCacheConfig, launch_append_kv};
 pub use qk256_gemv::{Qk256GemvConfig, launch_qk256_gemv};
 pub use rmsnorm::{RmsNormConfig, launch_rmsnorm};
-pub use rope::{RopeConfig, launch_rope, rope_forward, rope_forward_cpu};
+pub use rope::{RopeConfig, compute_sincos_table, launch_rope, rope_forward, rope_forward_cpu};
 
 // Re-export scatter/gather types from the crate-level module (always compiled).
 pub use crate::scatter_gather::{


### PR DESCRIPTION
## Summary

Enhances the CUDA RoPE kernel module with frequency scaling support and pre-computed sin/cos tables for GPU-ready position encoding.

### Changes

**`crates/bitnet-kernels/src/cuda/rope.rs`**
- Add `scaling_factor: f32` (default 1.0) and `max_seq_len: usize` fields to `RopeConfig`
- Add `with_scaling_factor()` and `with_max_seq_len()` builder methods
- Add `compute_sincos_table()` — pre-computes interleaved `[cos, sin, ...]` tables for `max_seq_len` positions, matching CPU rope's `compute_frequencies()` layout
- Apply `scaling_factor` multiplier in `rope_forward_cpu()` forward path
- Expand test suite from 21 → 32 tests (config builders, sincos table correctness, scaling factor identity/divergence, property tests)

**`crates/bitnet-kernels/src/cuda/mod.rs`**
- Re-export `compute_sincos_table`

**`crates/bitnet-kernels/src/cpu/rope.rs`**
- Add 2 new tests: `test_apply_rope_zero_input_preserved` and `test_batch_rope_norm_preservation_many_positions`

### Test Results

- **57 rope-related tests pass** with `--features gpu` (21 CPU rope + 32 CUDA rope + 4 matmul)
- **25 rope-related tests pass** with `--features cpu` (21 CPU rope + 4 matmul)
- GPU compilation clean (`cargo check --features gpu`)
- Clippy clean (`cargo clippy --features cpu -- -D warnings`)
- 1 test ignored (CUDA launch stub — requires GPU hardware)

### Motivation

Adds foundation for NTK-aware RoPE and YaRN-style frequency interpolation. The `compute_sincos_table()` function enables GPU kernels to use pre-computed tables rather than computing sin/cos per-element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Position embedding configuration now includes scaling factor and maximum sequence length parameters for advanced customization
  * Precomputation utility for trigonometric tables is now publicly available to optimize performance

* **Tests**
  * Comprehensive test coverage added to validate position embedding accuracy and numerical stability across various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->