### PR TITLE
docs: add Intel GPU architecture guide and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+### Wave 99: Intel GPU Integration & Documentation
+
+- **Intel GPU architecture guide** (#1687): comprehensive Intel Arc backend design doc with architecture diagram, kernel categories, Xe-HPG optimization notes, and testing strategy
+- **Intel GPU smoke CI** (#1686): weekly Intel Arc CI workflow with compute runtime setup and Arc A770 setup documentation
+- **KV cache optimization** (#1685): per-layer KV cache manager with sliding window, page-based allocation, LRU/FIFO/MaxLength eviction (27 tests)
+- **Cross-crate integration tests** (#1684): 59 integration tests for kernel dispatch, config serialization, and error handling across crates
+
+### Wave 98: Core Kernel Infrastructure
+
+- **Tensor data validation** (#1683): production `TensorValidator` with NaN/Inf detection, shape checks, stride consistency, and alignment verification (36 tests)
+- **CPU 1D convolution kernel** (#1682): 1D convolution with padding, stride, dilation, and multi-channel support (34 tests)
+- **GEMM kernel with CPU fallback** (#1681): general matrix multiply with naive, tiled, and transposed variants plus GPU dispatch stub (35 tests)
+- **Insta snapshot tests** (#1680): wave 6 insta snapshot tests across 3 crates (41 tests)
+
+### Wave 97: Edge Case Hardening
+
+- **Batch & streaming edge cases** (#1679): batch processing and streaming generation edge case tests for inference (43 tests)
+- **Generation config edge cases** (#1678): generation config and sampling strategy edge case tests (47 tests)
+- **CPU softmax kernel** (#1677): numerically stable softmax with temperature scaling and SIMD optimization (33 tests)
+- **Quantization edge cases** (#1675): quantization algorithm edge case and boundary condition tests (54 tests)
+- **Tokenizer discovery tests** (#1672): tokenizer discovery matrix and model type detection tests (26 tests)
+- **Kernel capabilities edge cases** (#1671): kernel capabilities and SIMD detection edge case tests (26 tests)
+- **Logits & engine-core edge cases** (#1670): logits processing and engine-core edge case tests (78 tests)
+
 ### Wave 96: Inference Pipeline & Scheduling
 
 - **Inference scheduler** (#1631): 112 tests for task scheduling with priority queues, work stealing, and deadline-aware dispatch

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -1,8 +1,20 @@
-# GPU Setup (CUDA 12.x)
+# GPU Setup
 
-This guide is the canonical setup for running BitNet-rs with the `gpu` feature.
+This guide is the canonical setup for running BitNet-rs with GPU acceleration.
 
-> **Status:** CUDA inference is implemented, but full GPU receipt-validation parity is still in progress.
+> **Status:** CUDA inference is implemented, but full GPU receipt-validation parity is still in progress. Intel Arc (OpenCL) support is under active development.
+
+## Supported Backends
+
+| Backend | Hardware | Feature Flag | Status |
+|---------|----------|-------------|--------|
+| CUDA | NVIDIA GPUs | `gpu` / `cuda` | Implemented |
+| OpenCL | Intel Arc (A770/A750/A580), AMD GPUs | `opencl` | In development |
+| CPU | Any x86-64 / ARM64 | `cpu` | Stable |
+
+---
+
+## CUDA Setup (NVIDIA, CUDA 12.x)
 
 ## Requirements
 
@@ -101,3 +113,39 @@ cargo build -vv --no-default-features --features gpu
 - `docs/development/gpu-setup-guide.md` (extended examples)
 - `docs/howto/receipt-verification.md`
 - `docs/reference/validation-gates.md`
+
+---
+
+## Intel Arc Setup (OpenCL)
+
+For Intel Arc A770/A750/A580 GPUs, see the dedicated guide:
+[`docs/GPU_SETUP_INTEL.md`](GPU_SETUP_INTEL.md) (PR #1686).
+
+For the overall Intel GPU backend architecture, see:
+[`docs/INTEL_GPU_ARCHITECTURE.md`](INTEL_GPU_ARCHITECTURE.md).
+
+### Quick Start (Intel)
+
+1. Install Intel compute runtime (NEO driver):
+
+```bash
+# Ubuntu 22.04+
+sudo apt-get install -y intel-opencl-icd intel-level-zero-gpu
+```
+
+2. Verify OpenCL:
+
+```bash
+clinfo | grep "Device Name"
+# Should show: Intel(R) Arc(TM) A770 Graphics
+```
+
+3. Build and test:
+
+```bash
+cargo build --no-default-features --features cpu   # CPU fallback (always works)
+cargo test -p bitnet-kernels --no-default-features --features cpu  # Kernel tests
+```
+
+> **Note:** The `opencl` feature flag is under development. Currently, OpenCL kernels
+> have CPU reference implementations that run in all builds.

--- a/docs/INTEL_GPU_ARCHITECTURE.md
+++ b/docs/INTEL_GPU_ARCHITECTURE.md
@@ -1,0 +1,104 @@
+# Intel GPU Backend Architecture
+
+## Overview
+
+BitNet-rs supports Intel Arc GPUs (A770, A750, A580) via OpenCL for compute acceleration.
+This document describes the architecture of the Intel GPU backend.
+
+## Architecture Diagram
+
+```
+┌──────────────────────────────────────────┐
+│           bitnet-inference               │
+│  ┌─────────────────────────────────────┐ │
+│  │     InferenceEngine                 │ │
+│  │  ┌──────────┐  ┌─────────────────┐ │ │
+│  │  │ CPU Path │  │   GPU Path      │ │ │
+│  │  │ (SIMD)   │  │  ┌───────────┐  │ │ │
+│  │  │          │  │  │ CUDA      │  │ │ │
+│  │  │          │  │  │ OpenCL    │  │ │ │
+│  │  │          │  │  │ Vulkan    │  │ │ │
+│  │  │          │  │  └───────────┘  │ │ │
+│  │  └──────────┘  └─────────────────┘ │ │
+│  └─────────────────────────────────────┘ │
+└──────────────────────────────────────────┘
+         │                    │
+    ┌────▼────┐         ┌────▼──────────┐
+    │ bitnet- │         │  bitnet-      │
+    │ kernels │         │  kernels      │
+    │ (CPU)   │         │  (OpenCL)     │
+    │         │         │               │
+    │ AVX2    │         │ matmul.cl     │
+    │ AVX-512 │         │ softmax.cl    │
+    │ NEON    │         │ layer_norm.cl │
+    │         │         │ rope.cl       │
+    │         │         │ elementwise.cl│
+    │         │         │ quantized.cl  │
+    └─────────┘         └───────────────┘
+```
+
+## Backend Selection
+
+The backend is selected at runtime with this priority:
+1. **CUDA** — NVIDIA GPUs (via cudarc)
+2. **OpenCL** — Intel Arc / AMD GPUs (via opencl3 or dynamic loading)
+3. **CPU** — SIMD-optimized fallback (AVX2/AVX-512/NEON)
+
+### Environment Variables
+
+| Variable | Values | Description |
+|----------|--------|-------------|
+| `BITNET_GPU_FAKE` | `opencl`, `intel`, `cuda`, `none` | Simulate GPU detection for testing |
+| `BITNET_STRICT_MODE` | `1` | Disable BITNET_GPU_FAKE, require real hardware |
+| `BITNET_DEVICE` | `cpu`, `cuda:0`, `opencl:0` | Force specific device |
+
+## OpenCL Kernel Design
+
+### Kernel Categories
+
+1. **Matrix Operations** — matmul (naive, tiled 16×16, batched)
+2. **Normalization** — LayerNorm, RMSNorm
+3. **Attention** — softmax with temperature scaling
+4. **Position Encoding** — RoPE (Rotary Position Embedding)
+5. **Activations** — SiLU, GELU (approximate), ReLU
+6. **Quantization** — I2_S dequantization, quantized matrix-vector multiply
+
+### Intel Xe-HPG Optimization Notes
+
+- A770 has 32 Xe-cores, 512 EUs
+- 16 GB GDDR6 @ 560 GB/s bandwidth
+- Prefer tile sizes that are multiples of 16 (SIMD lane width)
+- Use `__local` memory for tiled matmul
+- Use barrier synchronization for shared memory access
+- Prefer `float` over `double` (2:1 FP32:FP64 ratio)
+
+## Testing Strategy
+
+### CPU Reference Tests
+
+Every OpenCL kernel has a corresponding CPU reference implementation in
+`opencl_reference.rs` that implements the exact same algorithm. Tests verify:
+- Numerical accuracy (within floating-point tolerance)
+- Edge cases (empty inputs, single element, very large values)
+- Property tests (softmax sums to 1, layer norm mean ≈ 0)
+
+### Hardware Tests
+
+When Intel GPU hardware is available:
+- Build with `--features opencl`
+- Run `BITNET_GPU_FAKE=opencl cargo test` for simulated testing
+- Run `cargo test` on actual A770 hardware for integration testing
+
+## Performance Profiling
+
+Use these tools on Intel Arc:
+- `intel_gpu_top` — real-time GPU utilization
+- `clinfo` — OpenCL device capabilities
+- OpenCL event timing — per-kernel execution time
+- `RenderDoc` — compute shader debugging (Vulkan path)
+
+## Related Docs
+
+- [`docs/GPU_SETUP.md`](GPU_SETUP.md) — CUDA setup guide
+- [`docs/GPU_SETUP_INTEL.md`](GPU_SETUP_INTEL.md) — Intel Arc setup guide (PR #1686)
+- [`docs/architecture-overview.md`](architecture-overview.md) — Overall system architecture


### PR DESCRIPTION
Adds comprehensive Intel GPU backend architecture documentation including design diagram, kernel categories, Xe-HPG optimization notes, testing strategy, and profiling guide. Updates CHANGELOG with recent wave 97-99 PRs.