### PR TITLE
test(inference): add prefix cache edge case tests (42 tests)

### DIFF
--- a/crates/bitnet-inference/tests/prefix_cache_edge_cases.rs
+++ b/crates/bitnet-inference/tests/prefix_cache_edge_cases.rs
@@ -50,12 +50,8 @@ fn config_custom() {
 
 #[test]
 fn eviction_policy_variants_are_distinct() {
-    let policies = [
-        EvictionPolicy::LRU,
-        EvictionPolicy::LFU,
-        EvictionPolicy::FIFO,
-        EvictionPolicy::TTL,
-    ];
+    let policies =
+        [EvictionPolicy::LRU, EvictionPolicy::LFU, EvictionPolicy::FIFO, EvictionPolicy::TTL];
     for (i, a) in policies.iter().enumerate() {
         for (j, b) in policies.iter().enumerate() {
             if i == j {
@@ -378,11 +374,8 @@ fn cache_entry_hits_increment() {
 
 #[test]
 fn eviction_on_max_entries() {
-    let cfg = PrefixCacheConfig {
-        max_entries: 2,
-        min_prefix_length: 1,
-        ..PrefixCacheConfig::default()
-    };
+    let cfg =
+        PrefixCacheConfig { max_entries: 2, min_prefix_length: 1, ..PrefixCacheConfig::default() };
     let mut cache = PrefixCache::new(cfg);
 
     cache.insert(&[1, 2, 3, 4], vec![0u8; 8]).unwrap();
@@ -557,11 +550,8 @@ fn stats_clone() {
 
 #[test]
 fn many_entries_with_eviction() {
-    let cfg = PrefixCacheConfig {
-        max_entries: 10,
-        min_prefix_length: 1,
-        ..PrefixCacheConfig::default()
-    };
+    let cfg =
+        PrefixCacheConfig { max_entries: 10, min_prefix_length: 1, ..PrefixCacheConfig::default() };
     let mut cache = PrefixCache::new(cfg);
 
     // Insert 20 entries — should trigger eviction after 10


### PR DESCRIPTION
## Summary
Comprehensive edge-case tests for the trie-backed prefix cache subsystem.

## Test Coverage (42 tests)
- **PrefixCacheConfig** (2): defaults, custom configuration
- **EvictionPolicy** (3): variant equality, Debug, Clone/Copy
- **PrefixCache empty state** (4): is_empty, stats, lookup returns None, evict returns false
- **Insert and lookup** (5): exact match, prefix match, no match, partial no entry, len+memory
- **Min prefix length** (3): too short fails, exact min succeeds, empty prefix fails
- **Overwrite** (1): same prefix replaces entry
- **Longest match** (2): longer prefix preferred, shorter returned when longer not cached
- **Invalidation** (3): removes entry, nonexistent is noop, frees memory
- **Clear** (1): removes all entries and resets stats
- **Statistics** (3): hit/miss tracking, avg prefix match length, hit count increment
- **Eviction max_entries** (1): triggers eviction at capacity
- **Eviction max_memory** (1): memory-based eviction
- **Eviction policies** (3): LRU, LFU, FIFO behavior
- **CacheEntry fields** (2): size_bytes, token_prefix preserved
- **PrefixCacheStats** (2): Debug, Clone
- **Stress** (1): 20 inserts with max_entries=10
- **Edge case** (1): empty state vector

All tests verified via \cargo check\ locally.