### PR TITLE
fuzz: add wave-11 targets (attention, matmul, layer_norm, kv_cache, reduction)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -328,3 +328,33 @@ name = "memory_layout"
 path = "fuzz_targets/memory_layout.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_attention_scores"
+path = "fuzz_targets/fuzz_attention_scores.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_matmul_shapes"
+path = "fuzz_targets/fuzz_matmul_shapes.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_layer_norm"
+path = "fuzz_targets/fuzz_layer_norm.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_kv_cache_ops"
+path = "fuzz_targets/fuzz_kv_cache_ops.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_reduction_ops"
+path = "fuzz_targets/fuzz_reduction_ops.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_attention_scores.rs
+++ b/fuzz/fuzz_targets/fuzz_attention_scores.rs
@@ -1,0 +1,162 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct AttentionInput {
+    seq_len: u8,
+    head_dim: u8,
+    n_heads: u8,
+    q_data: Vec<u8>,
+    k_data: Vec<u8>,
+    v_data: Vec<u8>,
+    use_causal_mask: bool,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn softmax(logits: &mut [f32]) {
+    if logits.is_empty() {
+        return;
+    }
+    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+    if !max_val.is_finite() {
+        // Replace non-finite with uniform
+        let uniform = 1.0 / logits.len() as f32;
+        logits.fill(uniform);
+        return;
+    }
+    let mut sum = 0.0f32;
+    for v in logits.iter_mut() {
+        *v = (*v - max_val).exp();
+        sum += *v;
+    }
+    if sum > 0.0 && sum.is_finite() {
+        for v in logits.iter_mut() {
+            *v /= sum;
+        }
+    } else {
+        let uniform = 1.0 / logits.len() as f32;
+        logits.fill(uniform);
+    }
+}
+
+fn attention_scores(
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+    seq_len: usize,
+    head_dim: usize,
+    causal: bool,
+) -> Vec<f32> {
+    let scale = 1.0 / (head_dim as f32).sqrt();
+    let mut scores = vec![0.0f32; seq_len * seq_len];
+
+    // Q @ K^T with scaling
+    for i in 0..seq_len {
+        for j in 0..seq_len {
+            let mut dot = 0.0f32;
+            for d in 0..head_dim {
+                dot += q[i * head_dim + d] * k[j * head_dim + d];
+            }
+            scores[i * seq_len + j] = dot * scale;
+        }
+    }
+
+    // Causal mask: set future positions to -inf
+    if causal {
+        for i in 0..seq_len {
+            for j in (i + 1)..seq_len {
+                scores[i * seq_len + j] = f32::NEG_INFINITY;
+            }
+        }
+    }
+
+    // Softmax per row
+    for i in 0..seq_len {
+        let row = &mut scores[i * seq_len..(i + 1) * seq_len];
+        softmax(row);
+    }
+
+    // Scores @ V
+    let mut output = vec![0.0f32; seq_len * head_dim];
+    for i in 0..seq_len {
+        for d in 0..head_dim {
+            let mut sum = 0.0f32;
+            for j in 0..seq_len {
+                sum += scores[i * seq_len + j] * v[j * head_dim + d];
+            }
+            output[i * head_dim + d] = sum;
+        }
+    }
+
+    output
+}
+
+fuzz_target!(|input: AttentionInput| {
+    let seq_len = (input.seq_len as usize % 16) + 1;
+    let head_dim = (input.head_dim as usize % 16) + 1;
+    let n_heads = (input.n_heads as usize % 4) + 1;
+    let elems_per_head = seq_len * head_dim;
+
+    let q_all = bytes_to_f32(&input.q_data, n_heads * elems_per_head);
+    let k_all = bytes_to_f32(&input.k_data, n_heads * elems_per_head);
+    let v_all = bytes_to_f32(&input.v_data, n_heads * elems_per_head);
+
+    if q_all.len() < n_heads * elems_per_head
+        || k_all.len() < n_heads * elems_per_head
+        || v_all.len() < n_heads * elems_per_head
+    {
+        return;
+    }
+
+    // Filter out inputs with NaN/inf to test pure numerical stability
+    let has_nonfinite =
+        q_all.iter().chain(k_all.iter()).chain(v_all.iter()).any(|x| !x.is_finite());
+    if has_nonfinite {
+        return;
+    }
+
+    for h in 0..n_heads {
+        let offset = h * elems_per_head;
+        let q = &q_all[offset..offset + elems_per_head];
+        let k = &k_all[offset..offset + elems_per_head];
+        let v = &v_all[offset..offset + elems_per_head];
+
+        let output = attention_scores(q, k, v, seq_len, head_dim, input.use_causal_mask);
+
+        // Invariant 1: Output shape matches [seq_len, head_dim]
+        assert_eq!(
+            output.len(),
+            elems_per_head,
+            "output shape mismatch: expected {elems_per_head}, got {}",
+            output.len()
+        );
+
+        // Invariant 2: No NaN or Inf in output
+        for (i, &val) in output.iter().enumerate() {
+            assert!(val.is_finite(), "attention output non-finite at index {i}: {val} (head={h})");
+        }
+    }
+
+    // Invariant 3: With causal mask, running with seq_len=1 must match first row
+    if seq_len > 1 && !has_nonfinite {
+        let q_row = &q_all[..head_dim];
+        let k_row = &k_all[..head_dim];
+        let v_row = &v_all[..head_dim];
+
+        let single = attention_scores(q_row, k_row, v_row, 1, head_dim, input.use_causal_mask);
+        assert_eq!(single.len(), head_dim, "single-token output shape mismatch");
+        for &val in &single {
+            assert!(val.is_finite(), "single-token attention produced non-finite");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_kv_cache_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_kv_cache_ops.rs
@@ -1,0 +1,193 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct KvCacheInput {
+    n_layers: u8,
+    n_heads: u8,
+    head_dim: u8,
+    ops: Vec<CacheOp>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum CacheOp {
+    Append { layer: u8, data: Vec<u8> },
+    ReadLayer { layer: u8 },
+    ReadAll,
+    Reset,
+    TrimTo { max_seq: u8 },
+}
+
+struct KvCache {
+    n_layers: usize,
+    n_heads: usize,
+    head_dim: usize,
+    keys: Vec<Vec<f32>>,
+    values: Vec<Vec<f32>>,
+    seq_lens: Vec<usize>,
+}
+
+impl KvCache {
+    fn new(n_layers: usize, n_heads: usize, head_dim: usize) -> Self {
+        Self {
+            n_layers,
+            n_heads,
+            head_dim,
+            keys: vec![Vec::new(); n_layers],
+            values: vec![Vec::new(); n_layers],
+            seq_lens: vec![0; n_layers],
+        }
+    }
+
+    fn append(&mut self, layer: usize, k: &[f32], v: &[f32]) -> bool {
+        if layer >= self.n_layers {
+            return false;
+        }
+        let step_size = self.n_heads * self.head_dim;
+        if k.len() != step_size || v.len() != step_size {
+            return false;
+        }
+        self.keys[layer].extend_from_slice(k);
+        self.values[layer].extend_from_slice(v);
+        self.seq_lens[layer] += 1;
+        true
+    }
+
+    fn read_layer(&self, layer: usize) -> Option<(&[f32], &[f32], usize)> {
+        if layer >= self.n_layers {
+            return None;
+        }
+        Some((&self.keys[layer], &self.values[layer], self.seq_lens[layer]))
+    }
+
+    fn seq_len(&self, layer: usize) -> usize {
+        if layer >= self.n_layers {
+            return 0;
+        }
+        self.seq_lens[layer]
+    }
+
+    fn reset(&mut self) {
+        for layer in 0..self.n_layers {
+            self.keys[layer].clear();
+            self.values[layer].clear();
+            self.seq_lens[layer] = 0;
+        }
+    }
+
+    fn trim_to(&mut self, max_seq: usize) {
+        let step_size = self.n_heads * self.head_dim;
+        for layer in 0..self.n_layers {
+            if self.seq_lens[layer] > max_seq {
+                let keep = max_seq * step_size;
+                self.keys[layer].truncate(keep);
+                self.values[layer].truncate(keep);
+                self.seq_lens[layer] = max_seq;
+            }
+        }
+    }
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: KvCacheInput| {
+    let n_layers = (input.n_layers as usize % 4) + 1;
+    let n_heads = (input.n_heads as usize % 4) + 1;
+    let head_dim = (input.head_dim as usize % 16) + 1;
+    let step_size = n_heads * head_dim;
+
+    let mut cache = KvCache::new(n_layers, n_heads, head_dim);
+
+    // Invariant 1: Fresh cache has zero seq_len for all layers
+    for l in 0..n_layers {
+        assert_eq!(cache.seq_len(l), 0, "fresh cache layer {l} should have seq_len=0");
+    }
+
+    for op in input.ops.into_iter().take(256) {
+        match op {
+            CacheOp::Append { layer, data } => {
+                let layer_idx = layer as usize % n_layers;
+                let kv_data = bytes_to_f32(&data, step_size * 2);
+                if kv_data.len() >= step_size * 2 {
+                    let k = &kv_data[..step_size];
+                    let v = &kv_data[step_size..step_size * 2];
+                    let prev_len = cache.seq_len(layer_idx);
+                    let ok = cache.append(layer_idx, k, v);
+                    if ok {
+                        // Invariant 2: seq_len increments by 1 on successful append
+                        assert_eq!(
+                            cache.seq_len(layer_idx),
+                            prev_len + 1,
+                            "seq_len should increment by 1"
+                        );
+
+                        // Invariant 3: Key/value buffer size matches seq_len * step_size
+                        let (keys, values, seq) = cache.read_layer(layer_idx).unwrap();
+                        assert_eq!(keys.len(), seq * step_size, "key buffer size mismatch");
+                        assert_eq!(values.len(), seq * step_size, "value buffer size mismatch");
+                    }
+                }
+            }
+            CacheOp::ReadLayer { layer } => {
+                let layer_idx = layer as usize % n_layers;
+                let result = cache.read_layer(layer_idx);
+                // Invariant 4: Valid layer read always succeeds
+                assert!(result.is_some(), "valid layer {layer_idx} read should succeed");
+                let (keys, values, seq) = result.unwrap();
+                assert_eq!(keys.len(), values.len(), "k/v lengths should match");
+                assert_eq!(keys.len(), seq * step_size, "buffer size vs seq_len mismatch");
+            }
+            CacheOp::ReadAll => {
+                for l in 0..n_layers {
+                    let (keys, values, seq) = cache.read_layer(l).unwrap();
+                    assert_eq!(keys.len(), seq * step_size);
+                    assert_eq!(values.len(), seq * step_size);
+                }
+            }
+            CacheOp::Reset => {
+                cache.reset();
+                // Invariant 5: After reset, all layers have seq_len=0
+                for l in 0..n_layers {
+                    assert_eq!(cache.seq_len(l), 0, "after reset, layer {l} should have seq_len=0");
+                    let (keys, values, _) = cache.read_layer(l).unwrap();
+                    assert!(keys.is_empty(), "keys should be empty after reset");
+                    assert!(values.is_empty(), "values should be empty after reset");
+                }
+            }
+            CacheOp::TrimTo { max_seq } => {
+                let max = (max_seq as usize % 32) + 1;
+                cache.trim_to(max);
+                // Invariant 6: After trim, all seq_lens <= max
+                for l in 0..n_layers {
+                    assert!(
+                        cache.seq_len(l) <= max,
+                        "after trim to {max}, layer {l} has seq_len={}",
+                        cache.seq_len(l)
+                    );
+                }
+            }
+        }
+    }
+
+    // Invariant 7: Out-of-bounds layer reads return None
+    assert!(cache.read_layer(n_layers).is_none(), "OOB layer read should return None");
+    assert_eq!(cache.seq_len(n_layers), 0, "OOB layer seq_len should be 0");
+
+    // Invariant 8: Layers are independent — appending to one doesn't affect others
+    cache.reset();
+    let dummy_k = vec![1.0f32; step_size];
+    let dummy_v = vec![2.0f32; step_size];
+    cache.append(0, &dummy_k, &dummy_v);
+    for l in 1..n_layers {
+        assert_eq!(cache.seq_len(l), 0, "layer {l} should be unaffected by append to layer 0");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_layer_norm.rs
+++ b/fuzz/fuzz_targets/fuzz_layer_norm.rs
@@ -1,0 +1,142 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct LayerNormInput {
+    dim: u8,
+    batch_size: u8,
+    data: Vec<u8>,
+    gamma_data: Vec<u8>,
+    beta_data: Vec<u8>,
+    eps: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn layer_norm(input: &[f32], gamma: &[f32], beta: &[f32], dim: usize, eps: f32) -> Vec<f32> {
+    let mean: f32 = input.iter().sum::<f32>() / dim as f32;
+    let variance: f32 = input.iter().map(|x| (x - mean) * (x - mean)).sum::<f32>() / dim as f32;
+    let inv_std = 1.0 / (variance + eps).sqrt();
+
+    input
+        .iter()
+        .enumerate()
+        .map(|(i, &x)| {
+            let normalized = (x - mean) * inv_std;
+            normalized * gamma[i] + beta[i]
+        })
+        .collect()
+}
+
+fn rms_norm(input: &[f32], gamma: &[f32], dim: usize, eps: f32) -> Vec<f32> {
+    let rms: f32 = (input.iter().map(|x| x * x).sum::<f32>() / dim as f32 + eps).sqrt();
+    let inv_rms = 1.0 / rms;
+
+    input.iter().enumerate().map(|(i, &x)| x * inv_rms * gamma[i]).collect()
+}
+
+fuzz_target!(|input: LayerNormInput| {
+    let dim = (input.dim as usize % 64) + 2; // min 2 for meaningful stats
+    let batch_size = (input.batch_size as usize % 8) + 1;
+    let eps_val = 1e-5 * (1.0 + input.eps as f32); // Always positive epsilon
+
+    let all_data = bytes_to_f32(&input.data, batch_size * dim);
+    let gamma_raw = bytes_to_f32(&input.gamma_data, dim);
+    let beta_raw = bytes_to_f32(&input.beta_data, dim);
+
+    if all_data.len() < batch_size * dim || gamma_raw.len() < dim || beta_raw.len() < dim {
+        return;
+    }
+
+    let gamma = &gamma_raw[..dim];
+    let beta = &beta_raw[..dim];
+
+    // Skip non-finite inputs
+    if all_data[..batch_size * dim]
+        .iter()
+        .chain(gamma.iter())
+        .chain(beta.iter())
+        .any(|x| !x.is_finite())
+    {
+        return;
+    }
+
+    for b in 0..batch_size {
+        let row = &all_data[b * dim..(b + 1) * dim];
+
+        // --- LayerNorm ---
+        let ln_output = layer_norm(row, gamma, beta, dim, eps_val);
+
+        // Invariant 1: Output dimension matches input
+        assert_eq!(
+            ln_output.len(),
+            dim,
+            "layer_norm output dim mismatch: expected {dim}, got {}",
+            ln_output.len()
+        );
+
+        // Invariant 2: No NaN/Inf in output
+        for (i, &val) in ln_output.iter().enumerate() {
+            assert!(val.is_finite(), "layer_norm non-finite at batch={b} idx={i}: {val}");
+        }
+
+        // Invariant 3: With gamma=1 and beta=0, output has ~zero mean and ~unit variance
+        let ones = vec![1.0f32; dim];
+        let zeros = vec![0.0f32; dim];
+        let normalized = layer_norm(row, &ones, &zeros, dim, eps_val);
+
+        let mean: f32 = normalized.iter().sum::<f32>() / dim as f32;
+        assert!(
+            mean.abs() < 1e-3,
+            "normalized mean should be ~0, got {mean} (batch={b}, dim={dim})"
+        );
+
+        if dim >= 4 {
+            let var: f32 =
+                normalized.iter().map(|x| (x - mean) * (x - mean)).sum::<f32>() / dim as f32;
+            assert!(
+                (var - 1.0).abs() < 0.1,
+                "normalized variance should be ~1.0, got {var} (batch={b}, dim={dim})"
+            );
+        }
+
+        // --- RMSNorm ---
+        let rms_output = rms_norm(row, gamma, dim, eps_val);
+
+        // Invariant 4: RMSNorm output has correct dimension
+        assert_eq!(
+            rms_output.len(),
+            dim,
+            "rms_norm output dim mismatch: expected {dim}, got {}",
+            rms_output.len()
+        );
+
+        // Invariant 5: RMSNorm output is finite
+        for (i, &val) in rms_output.iter().enumerate() {
+            assert!(val.is_finite(), "rms_norm non-finite at batch={b} idx={i}: {val}");
+        }
+    }
+
+    // Invariant 6: Constant input produces constant output (after normalization)
+    let constant_input = vec![3.14f32; dim];
+    let ones = vec![1.0f32; dim];
+    let zeros = vec![0.0f32; dim];
+    let const_ln = layer_norm(&constant_input, &ones, &zeros, dim, eps_val);
+    let first = const_ln[0];
+    for (i, &val) in const_ln.iter().enumerate() {
+        let diff = (val - first).abs();
+        assert!(
+            diff < 1e-5,
+            "constant input should produce constant output, idx={i}: {first} vs {val}"
+        );
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_matmul_shapes.rs
+++ b/fuzz/fuzz_targets/fuzz_matmul_shapes.rs
@@ -1,0 +1,120 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MatMulShapeInput {
+    m: u8,
+    n: u8,
+    k: u8,
+    a_data: Vec<u8>,
+    b_data: Vec<u8>,
+    transpose_b: bool,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn matmul(a: &[f32], b: &[f32], m: usize, n: usize, k: usize) -> Vec<f32> {
+    let mut c = vec![0.0f32; m * n];
+    for i in 0..m {
+        for j in 0..n {
+            let mut sum = 0.0f32;
+            for l in 0..k {
+                sum += a[i * k + l] * b[l * n + j];
+            }
+            c[i * n + j] = sum;
+        }
+    }
+    c
+}
+
+fn transpose(mat: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+    let mut out = vec![0.0f32; rows * cols];
+    for i in 0..rows {
+        for j in 0..cols {
+            out[j * rows + i] = mat[i * cols + j];
+        }
+    }
+    out
+}
+
+fuzz_target!(|input: MatMulShapeInput| {
+    let m = (input.m as usize % 32) + 1;
+    let n = (input.n as usize % 32) + 1;
+    let k = (input.k as usize % 32) + 1;
+
+    let a_elems = m * k;
+    let b_elems = k * n;
+
+    let a = bytes_to_f32(&input.a_data, a_elems);
+    let b_raw = bytes_to_f32(&input.b_data, b_elems);
+
+    if a.len() < a_elems || b_raw.len() < b_elems {
+        return;
+    }
+
+    let a = &a[..a_elems];
+
+    // Filter non-finite inputs
+    if a.iter().chain(b_raw[..b_elems].iter()).any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let b;
+    let b_slice = if input.transpose_b {
+        // b_raw is [n, k], transpose to [k, n]
+        b = transpose(&b_raw[..b_elems], n, k);
+        &b[..]
+    } else {
+        &b_raw[..b_elems]
+    };
+
+    let c = matmul(a, b_slice, m, n, k);
+
+    // Invariant 1: Output has exactly m*n elements
+    assert_eq!(c.len(), m * n, "output shape: expected {}x{}={}, got {}", m, n, m * n, c.len());
+
+    // Invariant 2: All outputs are finite (given finite inputs)
+    for (i, &val) in c.iter().enumerate() {
+        assert!(
+            val.is_finite(),
+            "matmul output non-finite at index {i}: {val} (m={m}, n={n}, k={k})"
+        );
+    }
+
+    // Invariant 3: Zero matrix times anything = zero matrix
+    let zero_a = vec![0.0f32; a_elems];
+    let c_zero = matmul(&zero_a, b_slice, m, n, k);
+    for (i, &val) in c_zero.iter().enumerate() {
+        assert_eq!(val, 0.0, "zero*B should be zero at index {i}, got {val}");
+    }
+
+    // Invariant 4: Identity property for square matrices
+    if m == k && k == n && m <= 16 {
+        let mut identity = vec![0.0f32; m * m];
+        for i in 0..m {
+            identity[i * m + i] = 1.0;
+        }
+        let c_id = matmul(a, &identity, m, m, m);
+        for (i, (&orig, &result)) in a.iter().zip(c_id.iter()).enumerate() {
+            let diff = (orig - result).abs();
+            assert!(diff < 1e-4, "A*I != A at index {i}: {orig} vs {result} (diff={diff})");
+        }
+    }
+
+    // Invariant 5: (A*B) output dimensions match regardless of transpose path
+    if input.transpose_b {
+        let b_direct = &b_raw[..b_elems];
+        let b_t = transpose(b_direct, n, k);
+        let c2 = matmul(a, &b_t, m, n, k);
+        assert_eq!(c.len(), c2.len(), "transpose path should produce same output shape");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_reduction_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_reduction_ops.rs
@@ -1,0 +1,169 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ReductionInput {
+    data: Vec<u8>,
+    shape: Vec<u8>,
+    reduce_axis: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn reduce_sum(data: &[f32]) -> f32 {
+    data.iter().sum()
+}
+
+fn reduce_max(data: &[f32]) -> f32 {
+    data.iter().copied().fold(f32::NEG_INFINITY, f32::max)
+}
+
+fn reduce_min(data: &[f32]) -> f32 {
+    data.iter().copied().fold(f32::INFINITY, f32::min)
+}
+
+fn reduce_mean(data: &[f32]) -> f32 {
+    if data.is_empty() {
+        return 0.0;
+    }
+    data.iter().sum::<f32>() / data.len() as f32
+}
+
+fn reduce_along_axis(
+    data: &[f32],
+    rows: usize,
+    cols: usize,
+    axis: usize,
+    op: fn(&[f32]) -> f32,
+) -> Vec<f32> {
+    if axis == 0 {
+        // Reduce across rows, output has `cols` elements
+        (0..cols)
+            .map(|c| {
+                let col_vals: Vec<f32> = (0..rows).map(|r| data[r * cols + c]).collect();
+                op(&col_vals)
+            })
+            .collect()
+    } else {
+        // Reduce across cols, output has `rows` elements
+        (0..rows).map(|r| op(&data[r * cols..(r + 1) * cols])).collect()
+    }
+}
+
+fuzz_target!(|input: ReductionInput| {
+    let values = bytes_to_f32(&input.data, 256);
+    if values.is_empty() {
+        return;
+    }
+
+    // Skip non-finite inputs
+    if values.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    // --- Global reductions ---
+    let sum = reduce_sum(&values);
+    let max = reduce_max(&values);
+    let min = reduce_min(&values);
+    let mean = reduce_mean(&values);
+
+    // Invariant 1: All global reductions are finite
+    assert!(sum.is_finite(), "sum is not finite: {sum}");
+    assert!(max.is_finite(), "max is not finite: {max}");
+    assert!(min.is_finite(), "min is not finite: {min}");
+    assert!(mean.is_finite(), "mean is not finite: {mean}");
+
+    // Invariant 2: min <= mean <= max (for finite values)
+    assert!(min <= max, "min ({min}) should be <= max ({max})");
+
+    // mean is between min and max
+    assert!(
+        mean >= min - 1e-5 && mean <= max + 1e-5,
+        "mean ({mean}) should be between min ({min}) and max ({max})"
+    );
+
+    // Invariant 3: For all-positive values, max <= sum
+    let all_positive = values.iter().all(|&x| x >= 0.0);
+    if all_positive {
+        assert!(max <= sum + 1e-5, "for positive values, max ({max}) should be <= sum ({sum})");
+        // Also: min * len <= sum
+        let expected_min_sum = min * values.len() as f32;
+        assert!(
+            sum >= expected_min_sum - 1e-3,
+            "sum ({sum}) should be >= min*len ({expected_min_sum})"
+        );
+    }
+
+    // Invariant 4: mean * len ≈ sum
+    let expected_sum = mean * values.len() as f32;
+    assert!(
+        (expected_sum - sum).abs() < 1e-1 + sum.abs() * 1e-5,
+        "mean*len ({expected_sum}) should ≈ sum ({sum})"
+    );
+
+    // Invariant 5: max and min are actual values in the array
+    assert!(values.iter().any(|&x| (x - max).abs() < 1e-10), "max ({max}) not found in values");
+    assert!(values.iter().any(|&x| (x - min).abs() < 1e-10), "min ({min}) not found in values");
+
+    // --- Axis reductions (2D) ---
+    let ndims = input.shape.iter().take(2).collect::<Vec<_>>();
+    if ndims.len() >= 2 {
+        let rows = (*ndims[0] as usize % 16) + 1;
+        let cols = (*ndims[1] as usize % 16) + 1;
+        let total = rows * cols;
+
+        if values.len() >= total {
+            let mat = &values[..total];
+            let axis = (input.reduce_axis as usize) % 2;
+
+            let sum_reduced = reduce_along_axis(mat, rows, cols, axis, reduce_sum);
+            let max_reduced = reduce_along_axis(mat, rows, cols, axis, reduce_max);
+            let min_reduced = reduce_along_axis(mat, rows, cols, axis, reduce_min);
+
+            // Invariant 6: Axis reduction output has correct shape
+            let expected_len = if axis == 0 { cols } else { rows };
+            assert_eq!(
+                sum_reduced.len(),
+                expected_len,
+                "axis-{axis} sum reduction shape: expected {expected_len}, got {}",
+                sum_reduced.len()
+            );
+            assert_eq!(max_reduced.len(), expected_len);
+            assert_eq!(min_reduced.len(), expected_len);
+
+            // Invariant 7: Axis-reduced values are finite
+            for (i, (&s, (&mx, &mn))) in
+                sum_reduced.iter().zip(max_reduced.iter().zip(min_reduced.iter())).enumerate()
+            {
+                assert!(s.is_finite(), "axis sum non-finite at {i}");
+                assert!(mx.is_finite(), "axis max non-finite at {i}");
+                assert!(mn.is_finite(), "axis min non-finite at {i}");
+                assert!(mn <= mx, "axis min ({mn}) > max ({mx}) at index {i}");
+            }
+
+            // Invariant 8: Sum of axis sums ≈ global sum of the submatrix
+            let mat_sum: f32 = mat.iter().sum();
+            let axis_sum_total: f32 = sum_reduced.iter().sum();
+            assert!(
+                (mat_sum - axis_sum_total).abs() < 1e-2 + mat_sum.abs() * 1e-4,
+                "axis sum total ({axis_sum_total}) should ≈ matrix sum ({mat_sum})"
+            );
+        }
+    }
+
+    // Invariant 9: Single-element reduction is identity
+    let single = &values[..1];
+    assert_eq!(reduce_sum(single), values[0]);
+    assert_eq!(reduce_max(single), values[0]);
+    assert_eq!(reduce_min(single), values[0]);
+    assert_eq!(reduce_mean(single), values[0]);
+});


### PR DESCRIPTION
Adds 5 new fuzz targets for kernel operations:

- **fuzz_attention_scores** — Attention score computation with random Q/K/V matrices, varying dimensions, causal masking; checks for NaN/inf in outputs
- **fuzz_matmul_shapes** — Matrix multiplication with random M,N,K dimensions; verifies output shape invariants, zero-matrix property, identity property
- **fuzz_layer_norm** — Layer normalization and RMS normalization with random inputs/weights/biases; checks ~zero mean and ~unit variance for normalized output
- **fuzz_kv_cache_ops** — KV cache append/read/reset/trim operations with random sequence lengths, heads, dimensions; verifies layer independence and buffer consistency
- **fuzz_reduction_ops** — Reduction operations (sum, max, min, mean) with random tensors; verifies mathematical invariants (max ≤ sum for positive values, mean between min/max, axis reduction consistency)

All targets cap iterations at 256 to prevent timeouts.