### PR TITLE
feat(cpu): add embedding kernel with position encoding support

### DIFF
--- a/crates/bitnet-kernels/src/cpu/embedding.rs
+++ b/crates/bitnet-kernels/src/cpu/embedding.rs
@@ -1,8 +1,9 @@
 //! CPU SIMD-optimized embedding lookup kernel.
 //!
 //! Provides embedding table lookups with optional SIMD acceleration for
-//! memcpy-style fast paths, weighted accumulation for bag-of-words, and
-//! L2 normalization of embedding vectors.
+//! memcpy-style fast paths, weighted accumulation for bag-of-words,
+//! L2 normalization, sinusoidal/learned position encoding, max-norm
+//! clipping, and 8-bit quantized embedding table support.
 
 #[cfg(target_arch = "x86_64")]
 #[allow(clippy::wildcard_imports)]
@@ -319,6 +320,253 @@ pub fn normalize_embeddings(embeddings: &mut [f32], dim: usize) {
     scalar_normalize(embeddings, dim);
 }
 
+// ── Extended CPU embedding with position encoding ───────────────
+
+/// Extended configuration for CPU embedding operations with
+/// position encoding and norm clipping support.
+#[derive(Debug, Clone)]
+pub struct CpuEmbeddingConfig {
+    /// Number of entries (rows) in the embedding table.
+    pub vocab_size: usize,
+    /// Dimensionality of each embedding vector.
+    pub embed_dim: usize,
+    /// Optional padding index whose embedding is always zeros.
+    pub padding_idx: Option<u32>,
+    /// Optional max-norm constraint for embedding vectors.
+    pub max_norm: Option<f32>,
+}
+
+impl CpuEmbeddingConfig {
+    /// Create a new configuration with required fields.
+    pub fn new(vocab_size: usize, embed_dim: usize) -> Self {
+        Self { vocab_size, embed_dim, padding_idx: None, max_norm: None }
+    }
+
+    /// Set the padding index.
+    #[must_use]
+    pub fn with_padding_idx(mut self, idx: u32) -> Self {
+        self.padding_idx = Some(idx);
+        self
+    }
+
+    /// Set the max-norm constraint.
+    #[must_use]
+    pub fn with_max_norm(mut self, norm: f32) -> Self {
+        self.max_norm = Some(norm);
+        self
+    }
+}
+
+/// Compute sinusoidal position encoding for a single position.
+///
+/// Even indices: `sin(pos / 10000^(2i/d))`
+/// Odd indices: `cos(pos / 10000^(2i/d))`
+fn compute_sinusoidal_pe(pos: usize, embed_dim: usize, output: &mut [f32]) {
+    let d = embed_dim as f32;
+    for (i, val) in output.iter_mut().enumerate().take(embed_dim) {
+        let dim_pair = (i / 2) as f32;
+        let angle = (pos as f32) / 10_000f32.powf(2.0 * dim_pair / d);
+        *val = if i % 2 == 0 { angle.sin() } else { angle.cos() };
+    }
+}
+
+/// Look up embeddings and add sinusoidal position encoding.
+///
+/// Returns `[len(indices), embed_dim]` with each row being
+/// `embedding_table[id] + PE(position_offset + i)`.
+pub fn embedding_with_position(
+    table: &[f32],
+    indices: &[u32],
+    config: &CpuEmbeddingConfig,
+    position_offset: usize,
+) -> Result<Vec<f32>> {
+    let dim = config.embed_dim;
+    if dim == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut output = scalar_lookup(table, indices, dim, config.padding_idx)?;
+    let mut pe_buf = vec![0.0f32; dim];
+
+    for (i, &idx) in indices.iter().enumerate() {
+        if Some(idx) == config.padding_idx {
+            continue;
+        }
+        let pos = position_offset + i;
+        compute_sinusoidal_pe(pos, dim, &mut pe_buf);
+        let offset = i * dim;
+        for (o, &p) in output[offset..offset + dim].iter_mut().zip(pe_buf.iter()) {
+            *o += p;
+        }
+    }
+
+    if let Some(max_norm) = config.max_norm {
+        clip_max_norm(&mut output, dim, max_norm);
+    }
+    Ok(output)
+}
+
+/// Look up embeddings and add learned position embeddings.
+///
+/// `position_table` has shape `[max_positions, embed_dim]`.
+/// Position for token `i` is `position_offset + i`.
+pub fn embedding_with_learned_position(
+    table: &[f32],
+    indices: &[u32],
+    config: &CpuEmbeddingConfig,
+    position_table: &[f32],
+    position_offset: usize,
+) -> Result<Vec<f32>> {
+    let dim = config.embed_dim;
+    if dim == 0 {
+        return Ok(Vec::new());
+    }
+
+    let max_positions = position_table.len() / dim;
+    let max_pos_needed = position_offset + indices.len();
+    if max_pos_needed > max_positions {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "position_offset({position_offset}) + \
+                     n_tokens({}) = {max_pos_needed} exceeds \
+                     position_table rows ({max_positions})",
+                indices.len(),
+            ),
+        }));
+    }
+
+    let mut output = scalar_lookup(table, indices, dim, config.padding_idx)?;
+
+    for (i, &idx) in indices.iter().enumerate() {
+        if Some(idx) == config.padding_idx {
+            continue;
+        }
+        let pos = position_offset + i;
+        let pe_start = pos * dim;
+        let out_start = i * dim;
+        for (o, &p) in output[out_start..out_start + dim]
+            .iter_mut()
+            .zip(position_table[pe_start..pe_start + dim].iter())
+        {
+            *o += p;
+        }
+    }
+
+    if let Some(max_norm) = config.max_norm {
+        clip_max_norm(&mut output, dim, max_norm);
+    }
+    Ok(output)
+}
+
+/// Clip each embedding vector to a maximum L2 norm.
+fn clip_max_norm(embeddings: &mut [f32], dim: usize, max_norm: f32) {
+    if dim == 0 {
+        return;
+    }
+    for chunk in embeddings.chunks_exact_mut(dim) {
+        let norm_sq: f32 = chunk.iter().map(|&x| x * x).sum();
+        let norm = norm_sq.sqrt();
+        if norm > max_norm {
+            let scale = max_norm / norm;
+            for v in chunk.iter_mut() {
+                *v *= scale;
+            }
+        }
+    }
+}
+
+/// Apply norm clipping to embedding vectors in-place.
+///
+/// When `max_norm` is `Some(n)`, vectors exceeding L2 norm `n` are
+/// scaled down. When `l2_normalize` is true, all vectors are
+/// normalized to unit length after clipping.
+pub fn embedding_norm(
+    embeddings: &mut [f32],
+    dim: usize,
+    max_norm: Option<f32>,
+    l2_normalize: bool,
+) {
+    if dim == 0 || embeddings.is_empty() {
+        return;
+    }
+    if let Some(mn) = max_norm {
+        clip_max_norm(embeddings, dim, mn);
+    }
+    if l2_normalize {
+        scalar_normalize(embeddings, dim);
+    }
+}
+
+// ── Quantized embedding packing ─────────────────────────────────
+
+/// An 8-bit quantized embedding table with per-row scales.
+#[derive(Debug, Clone)]
+pub struct PackedEmbeddingTable {
+    /// Quantized embedding values (signed 8-bit).
+    pub data: Vec<i8>,
+    /// Per-row scale factors for dequantization.
+    pub scales: Vec<f32>,
+    /// Number of entries (rows).
+    pub vocab_size: usize,
+    /// Dimensionality of each embedding vector.
+    pub embed_dim: usize,
+}
+
+/// Pack a float embedding table into 8-bit quantized form.
+///
+/// Each row is independently scaled so that `max(abs(row))` maps
+/// to 127. Dequantization: `float_val = data[i] * scale`.
+pub fn pack_embedding_table(
+    table: &[f32],
+    vocab_size: usize,
+    embed_dim: usize,
+) -> PackedEmbeddingTable {
+    let mut data = vec![0i8; vocab_size * embed_dim];
+    let mut scales = vec![0.0f32; vocab_size];
+
+    for (row, scale_out) in scales.iter_mut().enumerate() {
+        let start = row * embed_dim;
+        let end = start + embed_dim;
+        let src = &table[start..end];
+        let abs_max = src.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+        let scale = if abs_max > 0.0 { abs_max / 127.0 } else { 1.0 };
+        *scale_out = scale;
+
+        let dst = &mut data[start..end];
+        for (d, &s) in dst.iter_mut().zip(src.iter()) {
+            *d = (s / scale).round().clamp(-128.0, 127.0) as i8;
+        }
+    }
+
+    PackedEmbeddingTable { data, scales, vocab_size, embed_dim }
+}
+
+/// Look up embeddings from a packed (quantized) table.
+///
+/// Dequantizes on-the-fly: `output[j] = data[idx][j] * scale[idx]`.
+pub fn unpack_embedding_lookup(packed: &PackedEmbeddingTable, indices: &[u32]) -> Result<Vec<f32>> {
+    let dim = packed.embed_dim;
+    let vocab = packed.vocab_size;
+    let mut output = vec![0.0f32; indices.len() * dim];
+
+    for (i, &idx) in indices.iter().enumerate() {
+        if (idx as usize) >= vocab {
+            return Err(index_out_of_bounds(idx, vocab));
+        }
+        let row = idx as usize;
+        let scale = packed.scales[row];
+        let start = row * dim;
+        let src = &packed.data[start..start + dim];
+        let dst_start = i * dim;
+        let dst = &mut output[dst_start..dst_start + dim];
+        for (d, &s) in dst.iter_mut().zip(src.iter()) {
+            *d = s as f32 * scale;
+        }
+    }
+
+    Ok(output)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -572,5 +820,319 @@ mod tests {
         for (s, sc) in simd_data.iter().zip(scalar_data.iter()) {
             assert!((s - sc).abs() < 1e-6, "simd={s} scalar={sc}");
         }
+    }
+
+    // ── CpuEmbeddingConfig ──────────────────────────────────
+
+    #[test]
+    fn test_cpu_config_builder() {
+        let cfg = CpuEmbeddingConfig::new(1000, 64);
+        assert_eq!(cfg.vocab_size, 1000);
+        assert_eq!(cfg.embed_dim, 64);
+        assert!(cfg.padding_idx.is_none());
+        assert!(cfg.max_norm.is_none());
+    }
+
+    #[test]
+    fn test_cpu_config_with_padding() {
+        let cfg = CpuEmbeddingConfig::new(100, 32).with_padding_idx(0);
+        assert_eq!(cfg.padding_idx, Some(0));
+    }
+
+    #[test]
+    fn test_cpu_config_with_max_norm() {
+        let cfg = CpuEmbeddingConfig::new(100, 32).with_max_norm(1.5);
+        assert_eq!(cfg.max_norm, Some(1.5));
+    }
+
+    // ── Sinusoidal position encoding ────────────────────────
+
+    #[test]
+    fn test_sinusoidal_pe_at_zero() {
+        let mut pe = vec![0.0f32; 4];
+        compute_sinusoidal_pe(0, 4, &mut pe);
+        // sin(0) = 0, cos(0) = 1
+        assert!((pe[0] - 0.0).abs() < 1e-6);
+        assert!((pe[1] - 1.0).abs() < 1e-6);
+        assert!((pe[2] - 0.0).abs() < 1e-6);
+        assert!((pe[3] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_sinusoidal_pe_varies_with_position() {
+        let dim = 8;
+        let mut pe0 = vec![0.0f32; dim];
+        let mut pe1 = vec![0.0f32; dim];
+        compute_sinusoidal_pe(0, dim, &mut pe0);
+        compute_sinusoidal_pe(1, dim, &mut pe1);
+        assert_ne!(pe0, pe1);
+    }
+
+    #[test]
+    fn test_sinusoidal_pe_bounded() {
+        let dim = 64;
+        let mut pe = vec![0.0f32; dim];
+        for pos in [0, 1, 50, 1000, 10_000] {
+            compute_sinusoidal_pe(pos, dim, &mut pe);
+            for &v in &pe {
+                assert!((-1.0..=1.0).contains(&v), "PE out of [-1,1] at pos={pos}: {v}");
+            }
+        }
+    }
+
+    // ── embedding_with_position ─────────────────────────────
+
+    #[test]
+    fn test_embedding_with_position_basic() {
+        // All-zero table so output == PE only.
+        let table = vec![0.0f32; 6]; // vocab=2, dim=3
+        let cfg = CpuEmbeddingConfig::new(2, 3);
+        let result = embedding_with_position(&table, &[0], &cfg, 1).unwrap();
+
+        let mut expected = vec![0.0f32; 3];
+        compute_sinusoidal_pe(1, 3, &mut expected);
+        for (a, b) in result.iter().zip(expected.iter()) {
+            assert!((a - b).abs() < 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_embedding_with_position_adds_to_embedding() {
+        let table = vec![
+            1.0, 2.0, 3.0, // token 0
+            4.0, 5.0, 6.0, // token 1
+        ];
+        let cfg = CpuEmbeddingConfig::new(2, 3);
+        let result = embedding_with_position(&table, &[0], &cfg, 0).unwrap();
+
+        let mut pe = vec![0.0f32; 3];
+        compute_sinusoidal_pe(0, 3, &mut pe);
+        assert!((result[0] - (1.0 + pe[0])).abs() < 1e-6);
+        assert!((result[1] - (2.0 + pe[1])).abs() < 1e-6);
+        assert!((result[2] - (3.0 + pe[2])).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_embedding_with_position_offset() {
+        let table = vec![0.0f32; 4]; // vocab=2, dim=2
+        let cfg = CpuEmbeddingConfig::new(2, 2);
+        let r0 = embedding_with_position(&table, &[0], &cfg, 0).unwrap();
+        let r5 = embedding_with_position(&table, &[0], &cfg, 5).unwrap();
+        // Different offsets → different PE.
+        assert_ne!(r0, r5);
+    }
+
+    #[test]
+    fn test_embedding_with_position_padding_zeroed() {
+        let table = vec![
+            1.0, 2.0, // token 0
+            3.0, 4.0, // token 1
+        ];
+        let cfg = CpuEmbeddingConfig::new(2, 2).with_padding_idx(1);
+        let result = embedding_with_position(&table, &[0, 1], &cfg, 0).unwrap();
+        // Token 1 is padding → stays zero.
+        assert_eq!(result[2], 0.0);
+        assert_eq!(result[3], 0.0);
+    }
+
+    #[test]
+    fn test_embedding_with_position_empty_input() {
+        let table = vec![1.0, 2.0];
+        let cfg = CpuEmbeddingConfig::new(1, 2);
+        let result = embedding_with_position(&table, &[], &cfg, 0).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_embedding_with_position_batch() {
+        let table = vec![0.0f32; 8]; // vocab=4, dim=2
+        let cfg = CpuEmbeddingConfig::new(4, 2);
+        let result = embedding_with_position(&table, &[0, 1, 2, 3], &cfg, 0).unwrap();
+        assert_eq!(result.len(), 8);
+        // Each pair should differ due to different positions.
+        assert_ne!(&result[0..2], &result[2..4]);
+    }
+
+    #[test]
+    fn test_embedding_with_position_out_of_range() {
+        let table = vec![1.0, 2.0]; // vocab=1, dim=2
+        let cfg = CpuEmbeddingConfig::new(1, 2);
+        let result = embedding_with_position(&table, &[5], &cfg, 0);
+        assert!(result.is_err());
+    }
+
+    // ── embedding_with_learned_position ─────────────────────
+
+    #[test]
+    fn test_learned_position_basic() {
+        let table = vec![
+            1.0, 2.0, // token 0
+            3.0, 4.0, // token 1
+        ];
+        let pos_table = vec![
+            0.1, 0.2, // position 0
+            0.3, 0.4, // position 1
+        ];
+        let cfg = CpuEmbeddingConfig::new(2, 2);
+        let result = embedding_with_learned_position(&table, &[0, 1], &cfg, &pos_table, 0).unwrap();
+        assert!((result[0] - 1.1).abs() < 1e-6);
+        assert!((result[1] - 2.2).abs() < 1e-6);
+        assert!((result[2] - 3.3).abs() < 1e-6);
+        assert!((result[3] - 4.4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_learned_position_with_offset() {
+        let table = vec![1.0, 2.0]; // vocab=1, dim=2
+        let pos_table = vec![
+            0.1, 0.2, // position 0
+            0.3, 0.4, // position 1
+            0.5, 0.6, // position 2
+        ];
+        let cfg = CpuEmbeddingConfig::new(1, 2);
+        let result = embedding_with_learned_position(&table, &[0], &cfg, &pos_table, 2).unwrap();
+        // Uses position 2.
+        assert!((result[0] - 1.5).abs() < 1e-6);
+        assert!((result[1] - 2.6).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_learned_position_out_of_bounds() {
+        let table = vec![1.0, 2.0];
+        let pos_table = vec![0.1, 0.2]; // only 1 position
+        let cfg = CpuEmbeddingConfig::new(1, 2);
+        let result = embedding_with_learned_position(&table, &[0], &cfg, &pos_table, 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_learned_position_padding_zeroed() {
+        let table = vec![
+            1.0, 2.0, // token 0
+            3.0, 4.0, // token 1
+        ];
+        let pos_table = vec![0.5, 0.5, 0.5, 0.5];
+        let cfg = CpuEmbeddingConfig::new(2, 2).with_padding_idx(0);
+        let result = embedding_with_learned_position(&table, &[0, 1], &cfg, &pos_table, 0).unwrap();
+        // Token 0 is padding → zeros.
+        assert_eq!(result[0], 0.0);
+        assert_eq!(result[1], 0.0);
+        // Token 1 gets embedding + position.
+        assert!((result[2] - 3.5).abs() < 1e-6);
+        assert!((result[3] - 4.5).abs() < 1e-6);
+    }
+
+    // ── embedding_norm ──────────────────────────────────────
+
+    #[test]
+    fn test_embedding_norm_max_norm_clips() {
+        // Vector [3, 4] has norm 5; clip to 2.5.
+        let mut data = vec![3.0, 4.0];
+        embedding_norm(&mut data, 2, Some(2.5), false);
+        let norm: f32 = data.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 2.5).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_embedding_norm_no_clip_when_within() {
+        // Vector [1, 0] has norm 1; max_norm=5 should not clip.
+        let mut data = vec![1.0, 0.0];
+        embedding_norm(&mut data, 2, Some(5.0), false);
+        assert_eq!(data, vec![1.0, 0.0]);
+    }
+
+    #[test]
+    fn test_embedding_norm_l2_normalize() {
+        let mut data = vec![3.0, 4.0];
+        embedding_norm(&mut data, 2, None, true);
+        let norm: f32 = data.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_embedding_norm_combined() {
+        // Clip to 2.5 then normalize to unit.
+        let mut data = vec![3.0, 4.0];
+        embedding_norm(&mut data, 2, Some(2.5), true);
+        let norm: f32 = data.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_embedding_norm_zero_vector() {
+        let mut data = vec![0.0, 0.0, 0.0];
+        embedding_norm(&mut data, 3, Some(1.0), true);
+        assert_eq!(data, vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn test_embedding_norm_empty() {
+        let mut data: Vec<f32> = vec![];
+        embedding_norm(&mut data, 3, Some(1.0), true);
+        assert!(data.is_empty());
+    }
+
+    // ── Quantized embedding packing ─────────────────────────
+
+    #[test]
+    fn test_pack_embedding_roundtrip() {
+        let table = vec![
+            1.0, 2.0, 3.0, // token 0
+            -1.0, -2.0, -3.0, // token 1
+        ];
+        let packed = pack_embedding_table(&table, 2, 3);
+        let unpacked = unpack_embedding_lookup(&packed, &[0, 1]).unwrap();
+        for (orig, reconst) in table.iter().zip(unpacked.iter()) {
+            assert!((orig - reconst).abs() < 0.05, "orig={orig} reconst={reconst}");
+        }
+    }
+
+    #[test]
+    fn test_pack_embedding_zero_row() {
+        let table = vec![0.0, 0.0, 0.0, 1.0, 2.0, 3.0];
+        let packed = pack_embedding_table(&table, 2, 3);
+        let unpacked = unpack_embedding_lookup(&packed, &[0]).unwrap();
+        // Zero row stays zero.
+        assert!(unpacked.iter().all(|&v| v == 0.0));
+    }
+
+    #[test]
+    fn test_pack_embedding_out_of_bounds() {
+        let table = vec![1.0, 2.0];
+        let packed = pack_embedding_table(&table, 1, 2);
+        assert!(unpack_embedding_lookup(&packed, &[5]).is_err());
+    }
+
+    #[test]
+    fn test_pack_preserves_sign() {
+        let table = vec![-10.0, 10.0, -5.0, 5.0];
+        let packed = pack_embedding_table(&table, 2, 2);
+        let unpacked = unpack_embedding_lookup(&packed, &[0, 1]).unwrap();
+        assert!(unpacked[0] < 0.0);
+        assert!(unpacked[1] > 0.0);
+        assert!(unpacked[2] < 0.0);
+        assert!(unpacked[3] > 0.0);
+    }
+
+    // ── max_norm via position-encoding path ─────────────────
+
+    #[test]
+    fn test_embedding_with_position_max_norm() {
+        // Large embeddings + PE; max_norm should clip result.
+        let table = vec![100.0, 200.0]; // vocab=1, dim=2
+        let cfg = CpuEmbeddingConfig::new(1, 2).with_max_norm(1.0);
+        let result = embedding_with_position(&table, &[0], &cfg, 0).unwrap();
+        let norm: f32 = result.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_learned_position_max_norm() {
+        let table = vec![50.0, 60.0];
+        let pos = vec![10.0, 20.0];
+        let cfg = CpuEmbeddingConfig::new(1, 2).with_max_norm(2.0);
+        let result = embedding_with_learned_position(&table, &[0], &cfg, &pos, 0).unwrap();
+        let norm: f32 = result.iter().map(|x| x * x).sum::<f32>().sqrt();
+        assert!((norm - 2.0).abs() < 1e-4);
     }
 }

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -20,6 +20,9 @@ pub mod arm;
 pub use fallback::*;
 pub use simd_math::*;
 
+// Re-export position-encoding embedding types.
+pub use embedding::{CpuEmbeddingConfig, PackedEmbeddingTable};
+
 #[cfg(target_arch = "x86_64")]
 pub use x86::*;
 


### PR DESCRIPTION
## Summary

CPU embedding implementation extending the existing SIMD-optimized lookup kernel with:

- **`CpuEmbeddingConfig`** — extended config with `vocab_size`, `embed_dim`, optional `padding_idx` and `max_norm`
- **`embedding_with_position`** — embedding lookup + sinusoidal position encoding (Vaswani et al.)
- **`embedding_with_learned_position`** — embedding lookup + learned position embeddings from a separate table
- **`embedding_norm`** — max-norm clipping and L2 normalization for embedding vectors
- **`pack_embedding_table` / `unpack_embedding_lookup`** — 8-bit quantized embedding table support with per-row scales

### Tests

24 new tests covering:
- Config builder pattern
- Sinusoidal PE at position 0, varying positions, bounded values
- Embedding + sinusoidal PE correctness, offset, batch, empty input
- Padding index zeroed (with both PE types)
- Learned position encoding with offset, out-of-bounds error
- Max-norm clipping, L2 normalization, combined norm
- Zero vector / empty input edge cases
- Quantized pack/unpack roundtrip, sign preservation, OOB error
- Max-norm applied through position encoding paths

All 83 embedding tests pass (1 ignored for CUDA).