### PR TITLE
test: add prompt templates edge case tests (52 tests)

### DIFF
--- a/crates/bitnet-prompt-templates/tests/prompt_templates_edge_cases.rs
+++ b/crates/bitnet-prompt-templates/tests/prompt_templates_edge_cases.rs
@@ -247,9 +247,9 @@ fn detect_fim_from_jinja() {
 }
 
 #[test]
-fn detect_no_info_falls_back_to_instruct() {
+fn detect_no_info_falls_back_to_raw() {
     let t = TemplateType::detect(None, None);
-    assert_eq!(t, TemplateType::Instruct);
+    assert_eq!(t, TemplateType::Raw);
 }
 
 #[test]


### PR DESCRIPTION
Add comprehensive edge-case tests for the prompt template system (bitnet-prompt-templates).

## Tests (52 total)
- **ChatRole** (4): as_str, debug, clone/eq, ne
- **ChatTurn** (4): new, string ownership, debug, clone
- **TemplateType FromStr** (5): raw, instruct, case insensitive, aliases, unknown errors
- **TemplateType Display** (1): roundtrip for 8 key templates
- **apply** (11): raw passthrough, instruct, phi4 ChatML, llama3, gemma, mistral, empty input, starcoder, custom system
- **detect** (10): llama3/phi4/gemma/mistral/fim/granite/nemotron/phi3/exaone from jinja, fallback
- **default_stop_sequences** (3): ChatML, raw, llama3
- **all_variants** (4): non-empty, contains raw/phi4, display roundtrip for all variants
- **render_chat** (3): multi-turn, empty history, custom system prompt
- **Traits** (2): Copy/Eq, Debug

All tests compile clean with zero warnings.