### PR TITLE
test(fuzz): add fuzz wave 12 — softmax, rope, conv1d, reduction, embedding targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -358,3 +358,21 @@ name = "fuzz_reduction_ops"
 path = "fuzz_targets/fuzz_reduction_ops.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "rope_rotation"
+path = "fuzz_targets/rope_rotation.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "conv1d_shapes"
+path = "fuzz_targets/conv1d_shapes.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "reduction_ops"
+path = "fuzz_targets/reduction_ops.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/conv1d_shapes.rs
+++ b/fuzz/fuzz_targets/conv1d_shapes.rs
@@ -1,0 +1,151 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum PaddingMode {
+    Zero(u8),
+    Same,
+}
+
+#[derive(Arbitrary, Debug)]
+struct Conv1dInput {
+    input_width: u8,
+    kernel_size: u8,
+    stride: u8,
+    padding: PaddingMode,
+    dilation: u8,
+    in_channels: u8,
+    out_channels: u8,
+    /// Raw weight data.
+    weight_data: Vec<u8>,
+    /// Raw input data.
+    input_data: Vec<u8>,
+}
+
+/// Compute expected conv1d output width using the standard formula.
+fn conv1d_output_width(
+    input_width: usize,
+    kernel_size: usize,
+    stride: usize,
+    padding: usize,
+    dilation: usize,
+) -> Option<usize> {
+    if stride == 0 || dilation == 0 || kernel_size == 0 {
+        return None;
+    }
+    let effective_kernel = dilation * (kernel_size - 1) + 1;
+    let numerator = input_width + 2 * padding;
+    if numerator < effective_kernel {
+        return None;
+    }
+    Some((numerator - effective_kernel) / stride + 1)
+}
+
+/// Minimal 1D convolution for shape validation (single-channel, no bias).
+fn conv1d_forward(input: &[f32], kernel: &[f32], stride: usize, padding: usize) -> Vec<f32> {
+    let input_len = input.len();
+    let kernel_len = kernel.len();
+    let out_len = match conv1d_output_width(input_len, kernel_len, stride, padding, 1) {
+        Some(n) => n,
+        None => return vec![],
+    };
+
+    // Build zero-padded input.
+    let padded_len = input_len + 2 * padding;
+    let mut padded = vec![0.0f32; padded_len];
+    padded[padding..padding + input_len].copy_from_slice(input);
+
+    let mut output = Vec::with_capacity(out_len);
+    for i in 0..out_len {
+        let start = i * stride;
+        let mut acc = 0.0f32;
+        for k in 0..kernel_len {
+            if start + k < padded_len {
+                acc += padded[start + k] * kernel[k];
+            }
+        }
+        output.push(acc);
+    }
+    output
+}
+
+fuzz_target!(|input: Conv1dInput| {
+    // Clamp all dimensions to small but meaningful ranges.
+    let input_width = (input.input_width as usize % 64) + 1;
+    let kernel_size = (input.kernel_size as usize % 16) + 1;
+    let stride = (input.stride as usize % 8) + 1;
+    let dilation = (input.dilation as usize % 4) + 1;
+    let _in_channels = (input.in_channels as usize % 8) + 1;
+    let _out_channels = (input.out_channels as usize % 8) + 1;
+
+    let padding = match input.padding {
+        PaddingMode::Zero(p) => (p as usize) % 16,
+        PaddingMode::Same => {
+            let effective_kernel = dilation * (kernel_size - 1) + 1;
+            (effective_kernel - 1) / 2
+        }
+    };
+
+    // Invariant 1: Output width formula should not panic.
+    let expected_width = conv1d_output_width(input_width, kernel_size, stride, padding, dilation);
+
+    if let Some(width) = expected_width {
+        // Invariant 2: Output width must be positive for valid inputs.
+        assert!(width > 0, "output width must be >0 for valid config");
+
+        // Invariant 3: Same-padding preserves ceil(input_width / stride).
+        if matches!(input.padding, PaddingMode::Same) {
+            let expected_same = (input_width + stride - 1) / stride;
+            assert_eq!(width, expected_same, "Same-padding: expected {expected_same}, got {width}");
+        }
+    }
+
+    // Invariant 4: Actual convolution must not panic and output size must match.
+    let aligned_len = (input.input_data.len() / 4) * 4;
+    let inp: Vec<f32> = input.input_data[..aligned_len]
+        .chunks_exact(4)
+        .take(256)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+
+    let aligned_wt = (input.weight_data.len() / 4) * 4;
+    let wt: Vec<f32> = input.weight_data[..aligned_wt]
+        .chunks_exact(4)
+        .take(256)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+
+    if inp.len() < input_width || wt.len() < kernel_size {
+        return;
+    }
+
+    let inp_slice = &inp[..input_width];
+    let wt_slice = &wt[..kernel_size];
+
+    // Only use dilation=1 for actual forward pass (minimal implementation).
+    if dilation == 1 {
+        let output = conv1d_forward(inp_slice, wt_slice, stride, padding);
+        if let Some(expected) = conv1d_output_width(input_width, kernel_size, stride, padding, 1) {
+            assert_eq!(
+                output.len(),
+                expected,
+                "conv1d output len mismatch: expected {expected}, got {}",
+                output.len()
+            );
+        }
+
+        // Invariant 5: Identity kernel (size=1, weight=1.0) with stride=1, pad=0 is a no-op.
+        if kernel_size == 1 && stride == 1 && padding == 0 {
+            let identity_kernel = [1.0f32];
+            let identity_out = conv1d_forward(inp_slice, &identity_kernel, 1, 0);
+            assert_eq!(identity_out.len(), input_width);
+            for (a, b) in identity_out.iter().zip(inp_slice.iter()) {
+                if a.is_finite() && b.is_finite() {
+                    assert!((a - b).abs() < 1e-6, "identity kernel not no-op: {a} != {b}");
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/reduction_ops.rs
+++ b/fuzz/fuzz_targets/reduction_ops.rs
@@ -1,0 +1,118 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::reduction::{ReductionOp, reduce_f32, reduce_rows_f32};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ReductionInput {
+    /// Raw data bytes (interpreted as f32).
+    data: Vec<u8>,
+    /// Number of rows for matrix reduction.
+    rows: u8,
+    /// Which operation to test (mod 5 maps to the enum variants).
+    op_idx: u8,
+}
+
+fn op_from_idx(idx: u8) -> ReductionOp {
+    match idx % 5 {
+        0 => ReductionOp::Sum,
+        1 => ReductionOp::Max,
+        2 => ReductionOp::Min,
+        3 => ReductionOp::Mean,
+        _ => ReductionOp::L2Norm,
+    }
+}
+
+fuzz_target!(|input: ReductionInput| {
+    let aligned_len = (input.data.len() / 4) * 4;
+    if aligned_len == 0 {
+        return;
+    }
+
+    let data: Vec<f32> = input.data[..aligned_len]
+        .chunks_exact(4)
+        .take(256)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+
+    // Filter to finite values to get meaningful results.
+    let finite: Vec<f32> = data.iter().copied().filter(|x| x.is_finite()).collect();
+    if finite.is_empty() {
+        return;
+    }
+
+    let op = op_from_idx(input.op_idx);
+
+    // Invariant 1: Flat reduction must not panic.
+    let result = reduce_f32(&finite, op);
+
+    // Invariant 2: Result must be finite for finite inputs.
+    assert!(
+        result.is_finite(),
+        "reduce_f32({op:?}) produced non-finite {result} from {} finite elements",
+        finite.len()
+    );
+
+    // Invariant 3: Operation-specific bounds.
+    match op {
+        ReductionOp::Sum => {
+            // Sum of positives must be non-negative if all inputs non-negative.
+            if finite.iter().all(|&x| x >= 0.0) {
+                assert!(result >= 0.0, "Sum of non-negatives is negative: {result}");
+            }
+        }
+        ReductionOp::Max => {
+            // Max must be >= every element.
+            for &v in &finite {
+                assert!(result >= v, "Max {result} < element {v}");
+            }
+        }
+        ReductionOp::Min => {
+            // Min must be <= every element.
+            for &v in &finite {
+                assert!(result <= v, "Min {result} > element {v}");
+            }
+        }
+        ReductionOp::Mean => {
+            // Mean must be between min and max.
+            let lo = finite.iter().copied().fold(f32::INFINITY, f32::min);
+            let hi = finite.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            assert!(
+                result >= lo - 1e-5 && result <= hi + 1e-5,
+                "Mean {result} outside [{lo}, {hi}]"
+            );
+        }
+        ReductionOp::L2Norm => {
+            // L2 norm must be non-negative.
+            assert!(result >= 0.0, "L2 norm is negative: {result}");
+        }
+    }
+
+    // Invariant 4: Row-wise reduction must not panic and output length == rows.
+    let rows = ((input.rows as usize) % 16) + 1;
+    let cols = finite.len() / rows;
+    if cols > 0 {
+        let matrix = &finite[..rows * cols];
+        if let Ok(row_results) = reduce_rows_f32(matrix, rows, cols, op) {
+            assert_eq!(row_results.len(), rows, "row reduction output length mismatch");
+            for (i, &v) in row_results.iter().enumerate() {
+                assert!(v.is_finite(), "row reduction [{i}] non-finite: {v} for op {op:?}");
+            }
+        }
+    }
+
+    // Invariant 5: Empty slice returns identity.
+    let empty_result = reduce_f32(&[], op);
+    match op {
+        ReductionOp::Sum | ReductionOp::Mean | ReductionOp::L2Norm => {
+            assert_eq!(empty_result, 0.0, "empty {op:?} should be 0.0");
+        }
+        ReductionOp::Max => {
+            assert_eq!(empty_result, f32::NEG_INFINITY, "empty Max should be -inf");
+        }
+        ReductionOp::Min => {
+            assert_eq!(empty_result, f32::INFINITY, "empty Min should be +inf");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/rope_rotation.rs
+++ b/fuzz/fuzz_targets/rope_rotation.rs
@@ -1,0 +1,93 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct RopeInput {
+    /// Head dimension (will be clamped to even value 2..=64).
+    dim: u8,
+    /// Sequence position (clamped to 0..=255).
+    position: u8,
+    /// RoPE base theta.
+    base: f32,
+    /// Raw vector data (interpreted as f32 pairs).
+    data: Vec<u8>,
+}
+
+fuzz_target!(|input: RopeInput| {
+    use bitnet_rope::build_tables;
+
+    // Clamp dim to a small even number >= 2.
+    let dim = (((input.dim as usize) % 32) + 1) * 2; // 2, 4, ..., 64
+    let position = input.position as usize;
+    let max_seq_len = position + 1;
+
+    // Sanitise base: must be finite and positive.
+    let base = input.base.abs();
+    if !base.is_finite() || base <= 0.0 {
+        return;
+    }
+
+    let tables = match build_tables(dim, max_seq_len, base) {
+        Ok(t) => t,
+        Err(_) => return, // Invalid inputs are expected; no panic = success.
+    };
+
+    // Parse fuzz data into an f32 vector of length `dim`.
+    let aligned_len = (input.data.len() / 4) * 4;
+    let raw: Vec<f32> = input.data[..aligned_len]
+        .chunks_exact(4)
+        .take(256)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+
+    if raw.len() < dim {
+        return;
+    }
+    let vec = &raw[..dim];
+
+    // Skip vectors with non-finite components (norm is meaningless).
+    if vec.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let half = tables.half_dim;
+    let row_offset = position * half;
+    if row_offset + half > tables.sin.len() {
+        return;
+    }
+
+    let sin_row = &tables.sin[row_offset..row_offset + half];
+    let cos_row = &tables.cos[row_offset..row_offset + half];
+
+    // Apply RoPE rotation: for each pair (x_i, x_{i+half}),
+    //   out_i       = x_i * cos - x_{i+half} * sin
+    //   out_{i+half}= x_i * sin + x_{i+half} * cos
+    let mut rotated = vec![0.0f32; dim];
+    for i in 0..half {
+        let x0 = vec[i];
+        let x1 = vec[i + half];
+        let s = sin_row[i];
+        let c = cos_row[i];
+        rotated[i] = x0 * c - x1 * s;
+        rotated[i + half] = x0 * s + x1 * c;
+    }
+
+    // Invariant 1: No NaN or Inf in output.
+    for (i, &v) in rotated.iter().enumerate() {
+        assert!(v.is_finite(), "RoPE output non-finite at index {i}: {v}");
+    }
+
+    // Invariant 2: Norm preservation — rotation must not change vector magnitude.
+    let norm_in: f32 = vec.iter().map(|x| x * x).sum();
+    let norm_out: f32 = rotated.iter().map(|x| x * x).sum();
+
+    if norm_in > 1e-12 {
+        let ratio = norm_out / norm_in;
+        assert!(
+            (ratio - 1.0).abs() < 1e-4,
+            "Norm not preserved: in={norm_in} out={norm_out} ratio={ratio}"
+        );
+    }
+});


### PR DESCRIPTION
## Fuzz Wave 12 — Kernel Operation Targets

Adds 3 new kernel-focused fuzz targets for wave 12:

### New Targets

| Target | What it fuzzes | Key invariants |
|--------|---------------|----------------|
| `rope_rotation` | RoPE rotation with random dims, positions, base values | No panics, norm preservation (rotation is isometry) |
| `conv1d_shapes` | Conv1d with random kernel sizes, strides, padding, dilation | Output size formula, Same-padding invariant, identity-kernel no-op |
| `reduction_ops` | Sum/Max/Min/Mean/L2Norm via `bitnet_kernels::reduction` | Op-specific bounds, row-wise shape, empty-slice identity |

### Already on main (wave 12 spec)

| Target | Status |
|--------|--------|
| `softmax_stability` | ✅ Already exists — fuzzes softmax with extreme values (NaN, inf), verifies sum ≈ 1.0 |
| `embedding_lookup` | ✅ Already exists — fuzzes embedding with random vocab sizes/indices, OOB safety |

### Design

All targets follow the established conventions:
- `Arbitrary` derive for structured fuzzing
- `.take(256)` cap on iteration-heavy loops
- Dimensions clamped to small ranges to avoid OOM

### Testing

Targets are registered in `fuzz/Cargo.toml` as `[[bin]]` entries. They require `cargo-fuzz` to run and are exercised by the nightly fuzz workflow.