### PR TITLE
feat(kernels): add comprehensive CPU activation functions (15 types)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,7 @@ dependencies = [
  "env_logger",
  "half",
  "insta",
+ "libm",
  "log",
  "memory-stats",
  "opencl3",

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -29,6 +29,7 @@ opencl3 = { version = "0.9", optional = true }
 cc = { version = "1.2.46", optional = true }
 bindgen = { version = "0.72.1", optional = true }
 half = { version = "2.7.1", optional = true }
+libm = "0.2.16"
 sysinfo = "0.37.2"
 memory-stats = "1.2.0"
 

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -28,6 +28,7 @@ pub mod x86;
 #[cfg(target_arch = "aarch64")]
 pub mod arm;
 
+pub use activations::ActivationType;
 pub use batch_norm::BatchNormConfig;
 pub use fallback::*;
 pub use scatter_gather::{


### PR DESCRIPTION
## Summary

Add a new `activations` module to `bitnet-kernels` with 15 activation function types commonly used in neural networks.

## Activation Types

`ActivationType` enum with variants:
- **ReLU**, **LeakyReLU(f32)**, **GELU**, **GELUTanh**, **SiLU**, **Swish(f32)**
- **Sigmoid**, **Tanh**, **HardSigmoid**, **HardSwish**
- **Mish**, **Softplus**, **ELU(f32)**, **SELU**, **QuickGELU**

## API

- `activate(input: &[f32], activation: ActivationType) -> Vec<f32>` — elementwise apply
- `activate_inplace(input: &mut [f32], activation: ActivationType)` — in-place variant
- `activate_derivative(input: &[f32], activation: ActivationType) -> Vec<f32>` — compute derivative
- Individual functions: `relu`, `gelu`, `silu`, `sigmoid`, `tanh_act`, etc.

## Tests

51 tests covering:
- All 15 activation types at key points (zero, positive, negative, extremes)
- NaN propagation for all activation types
- Infinity handling
- Derivative correctness via numerical verification (central differences)
- Monotonicity checks (sigmoid, relu)
- Dispatch consistency (activate() matches individual functions)
- Large input numerical stability
- Empty input edge cases

## Changes

- `crates/bitnet-kernels/src/cpu/activations.rs` — new module (794 lines)
- `crates/bitnet-kernels/src/cpu/mod.rs` — register module, re-export `ActivationType`
- `crates/bitnet-kernels/Cargo.toml` — add `libm` dependency for erf in GELU