### PR TITLE
feat(kernels): add CUDA batch normalization kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -54,7 +54,10 @@ pub use attention::{
 
 #[cfg(any(feature = "gpu", feature = "cuda"))]
 pub use attention::ATTENTION_KERNEL_SRC;
-pub use batch_norm::{BatchNormConfig, BatchNormKernel, BatchNormState, batch_norm_cpu};
+pub use batch_norm::{
+    BatchNormConfig, BatchNormKernel, BatchNormState, CudaBatchNormConfig, batch_norm_cpu,
+    batch_norm_cpu_fallback, batch_norm_inference_cpu_fallback,
+};
 pub use conv1d::{Conv1dConfig, PaddingMode, conv1d_cpu, conv1d_forward, launch_conv1d};
 pub use kv_cache::{CacheDtype, CacheStats, KvCacheBuffer, KvCacheConfig, launch_append_kv};
 pub use layernorm::{
@@ -112,6 +115,9 @@ pub use activations::{ACTIVATION_KERNEL_SRC, launch_activation_cuda, launch_silu
 #[cfg(any(feature = "gpu", feature = "cuda"))]
 pub use elementwise::{ELEMENTWISE_BINARY_KERNEL_SRC, ELEMENTWISE_UNARY_KERNEL_SRC};
 pub use layernorm::LAYERNORM_KERNEL_SRC;
+
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub use batch_norm::{BATCH_NORM_INFERENCE_KERNEL_SRC, BATCH_NORM_TRAIN_KERNEL_SRC};
 
 #[cfg(any(feature = "gpu", feature = "cuda"))]
 pub use quantized_matmul::launch_i2s_matmul;


### PR DESCRIPTION
## Summary

Add CUDA kernel source strings and standalone CPU fallback functions for batch normalization to `bitnet-kernels`.

## Changes

### CUDA Kernel Sources (feature-gated: `gpu`/`cuda`)
- **`BATCH_NORM_TRAIN_KERNEL_SRC`** — Training-mode kernel with parallel reduction over the batch dimension, EMA running statistics updates (with Bessel's correction), and affine transform
- **`BATCH_NORM_INFERENCE_KERNEL_SRC`** — Inference-mode kernel using pre-computed running mean/variance via grid-stride loop (no shared memory)

### `CudaBatchNormConfig` struct
Lightweight GPU launch config carrying `num_features`, `eps`, `momentum` with helpers for grid/block dims and shared memory sizing. Convertible from the existing `BatchNormConfig`.

### Standalone CPU Fallback Functions
- **`batch_norm_cpu_fallback`** — Training mode: accepts explicit `gamma`, `beta`, `running_mean`, `running_var` slices; computes batch statistics, updates running stats via EMA, returns `Vec<f32>`
- **`batch_norm_inference_cpu_fallback`** — Inference mode: uses pre-computed running statistics, no mutation, returns `Vec<f32>`

### Tests
51 total tests (20 new) covering:
- `CudaBatchNormConfig` construction, conversion, grid/block/shmem helpers
- Standalone fallback: normalisation correctness, multi-channel, running stats update, affine transform
- Inference fallback: basic, multi-channel, affine, numerical stability
- Error handling: empty input, misaligned shapes, short parameter slices
- Cross-validation: standalone fallback output matches `BatchNormKernel` for both training and eval modes
- CUDA kernel source string smoke test (non-empty, contains expected function names)

All CUDA code guarded with `#[cfg(any(feature = "gpu", feature = "cuda"))]`.

## Testing
```
cargo test -p bitnet-kernels --no-default-features --features gpu --lib -- batch_norm
# 51 passed, 1 ignored (requires CUDA runtime)
```