### PR TITLE
feat(kernels): add CUDA transpose kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -20,6 +20,7 @@ pub mod rope;
 pub mod scatter_gather;
 pub mod simd_math;
 pub mod simd_matmul;
+pub mod transpose;
 
 #[cfg(target_arch = "x86_64")]
 pub mod x86;

--- a/crates/bitnet-kernels/src/cpu/transpose.rs
+++ b/crates/bitnet-kernels/src/cpu/transpose.rs
@@ -1,0 +1,371 @@
+//! CPU transpose and reshape operations.
+//!
+//! Pure-Rust implementations of 2D/ND transpose and reshape for
+//! correctness testing and non-GPU environments.  The CUDA-accelerated
+//! versions live in [`crate::cuda::transpose`] (feature-gated behind
+//! `gpu`/`cuda`).
+
+use bitnet_common::{KernelError, Result};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for a transpose operation.
+#[derive(Debug, Clone)]
+pub struct TransposeConfig {
+    /// Shape of the input tensor (e.g. `[rows, cols]` for 2D).
+    pub shape: Vec<usize>,
+    /// Permutation of axes.  For a 2D transpose this is `[1, 0]`.
+    pub permutation: Vec<usize>,
+}
+
+impl TransposeConfig {
+    /// Total number of elements described by `shape`.
+    pub fn num_elements(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    /// Compute the output shape after applying the permutation.
+    pub fn output_shape(&self) -> Vec<usize> {
+        self.permutation.iter().map(|&p| self.shape[p]).collect()
+    }
+
+    /// Validate that the permutation is a valid bijection over `[0, ndim)`.
+    pub fn validate(&self) -> Result<()> {
+        let ndim = self.shape.len();
+        if self.permutation.len() != ndim {
+            return Err(KernelError::InvalidArguments {
+                reason: format!(
+                    "permutation length ({}) must equal shape rank ({})",
+                    self.permutation.len(),
+                    ndim
+                ),
+            }
+            .into());
+        }
+        let mut seen = vec![false; ndim];
+        for &p in &self.permutation {
+            if p >= ndim {
+                return Err(KernelError::InvalidArguments {
+                    reason: format!("permutation index {p} out of range for rank {ndim}"),
+                }
+                .into());
+            }
+            if seen[p] {
+                return Err(KernelError::InvalidArguments {
+                    reason: format!("duplicate index {p} in permutation"),
+                }
+                .into());
+            }
+            seen[p] = true;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CPU implementations
+// ---------------------------------------------------------------------------
+
+/// Transpose a 2D row-major matrix (rows × cols) → (cols × rows).
+pub fn transpose_2d(data: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+    assert_eq!(data.len(), rows * cols, "data length {} != rows*cols {}", data.len(), rows * cols,);
+    let mut out = vec![0.0f32; rows * cols];
+    for r in 0..rows {
+        for c in 0..cols {
+            out[c * rows + r] = data[r * cols + c];
+        }
+    }
+    out
+}
+
+/// Transpose an N-dimensional tensor according to a permutation.
+///
+/// `shape` describes the input dimensions and `perm` is a permutation of
+/// `[0, 1, …, ndim-1]`.  Returns a new `Vec<f32>` with the transposed
+/// data in row-major order.
+pub fn transpose_nd(data: &[f32], shape: &[usize], perm: &[usize]) -> Vec<f32> {
+    let ndim = shape.len();
+    assert_eq!(perm.len(), ndim, "permutation rank mismatch");
+    let total: usize = shape.iter().product();
+    assert_eq!(data.len(), total, "data length mismatch");
+
+    let in_strides = compute_strides(shape);
+    let out_shape: Vec<usize> = perm.iter().map(|&p| shape[p]).collect();
+    let out_strides = compute_strides(&out_shape);
+
+    let mut out = vec![0.0f32; total];
+    for (i, out_elem) in out.iter_mut().enumerate() {
+        let mut remaining = i;
+        let mut in_idx = 0usize;
+        for d in 0..ndim {
+            let coord = remaining / out_strides[d];
+            remaining %= out_strides[d];
+            in_idx += coord * in_strides[perm[d]];
+        }
+        *out_elem = data[in_idx];
+    }
+    out
+}
+
+/// Reshape `data` from `old_shape` to `new_shape` (both must have the same
+/// total element count).  This is a logical operation — the data is simply
+/// returned in a new `Vec` with identical contents.
+pub fn reshape(data: &[f32], old_shape: &[usize], new_shape: &[usize]) -> Result<Vec<f32>> {
+    let old_total: usize = old_shape.iter().product();
+    let new_total: usize = new_shape.iter().product();
+    if old_total != new_total {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("reshape total mismatch: old={old_total}, new={new_total}"),
+        }
+        .into());
+    }
+    if data.len() != old_total {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("data length {} != old shape total {old_total}", data.len()),
+        }
+        .into());
+    }
+    Ok(data.to_vec())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Compute row-major strides for the given shape.
+fn compute_strides(shape: &[usize]) -> Vec<usize> {
+    let ndim = shape.len();
+    let mut strides = vec![1usize; ndim];
+    for i in (0..ndim.saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    strides
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- 2D transpose -------------------------------------------------------
+
+    #[test]
+    fn test_transpose_2d_square() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let out = transpose_2d(&data, 3, 3);
+        assert_eq!(out, vec![1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_rect_wide() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let out = transpose_2d(&data, 2, 3);
+        assert_eq!(out, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_rect_tall() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let out = transpose_2d(&data, 3, 2);
+        assert_eq!(out, vec![1.0, 3.0, 5.0, 2.0, 4.0, 6.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_single_row() {
+        let data = vec![10.0, 20.0, 30.0, 40.0];
+        let out = transpose_2d(&data, 1, 4);
+        assert_eq!(out, vec![10.0, 20.0, 30.0, 40.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_single_col() {
+        let data = vec![10.0, 20.0, 30.0];
+        let out = transpose_2d(&data, 3, 1);
+        assert_eq!(out, vec![10.0, 20.0, 30.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_1x1() {
+        let out = transpose_2d(&[42.0], 1, 1);
+        assert_eq!(out, vec![42.0]);
+    }
+
+    #[test]
+    fn test_transpose_2d_double_roundtrip() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let t1 = transpose_2d(&data, 2, 3);
+        let t2 = transpose_2d(&t1, 3, 2);
+        assert_eq!(t2, data);
+    }
+
+    // -- ND transpose -------------------------------------------------------
+
+    #[test]
+    fn test_transpose_nd_2d_equiv() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let nd = transpose_nd(&data, &[2, 3], &[1, 0]);
+        let tw = transpose_2d(&data, 2, 3);
+        assert_eq!(nd, tw);
+    }
+
+    #[test]
+    fn test_transpose_nd_identity_2d() {
+        let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let out = transpose_nd(&data, &[2, 3], &[0, 1]);
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_transpose_nd_identity_3d() {
+        let data: Vec<f32> = (0..24).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4], &[0, 1, 2]);
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_transpose_nd_3d_swap_last_two() {
+        // (2,3,4) perm [0,2,1] → (2,4,3)
+        let data: Vec<f32> = (0..24).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4], &[0, 2, 1]);
+        assert_eq!(out[0], 0.0);
+        // out shape [2,4,3]; out[0][1][0] at linear index 3
+        // → input coords: dim0=0, dim2=1, dim1=0 → data[0*12+0*4+1]=1.0
+        assert_eq!(out[3], 1.0);
+    }
+
+    #[test]
+    fn test_transpose_nd_3d_full_reverse() {
+        // (2,3,4) perm [2,1,0] → (4,3,2)
+        let data: Vec<f32> = (0..24).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4], &[2, 1, 0]);
+        assert_eq!(out[0], 0.0);
+        // out[0][0][1] == data[1][0][0] == 12.0
+        assert_eq!(out[1], 12.0);
+    }
+
+    #[test]
+    fn test_transpose_nd_3d_roundtrip() {
+        let data: Vec<f32> = (0..60).map(|i| i as f32).collect();
+        let perm = [2, 0, 1];
+        let inv = [1, 2, 0];
+        let t1 = transpose_nd(&data, &[3, 4, 5], &perm);
+        let mid_shape: Vec<usize> = perm.iter().map(|&p| [3, 4, 5][p]).collect();
+        let t2 = transpose_nd(&t1, &mid_shape, &inv);
+        assert_eq!(t2, data);
+    }
+
+    #[test]
+    fn test_transpose_nd_4d_identity() {
+        let data: Vec<f32> = (0..120).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4, 5], &[0, 1, 2, 3]);
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_transpose_nd_4d_swap_middle() {
+        // (2,3,4,5) perm [0,2,1,3] → (2,4,3,5)
+        let data: Vec<f32> = (0..120).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4, 5], &[0, 2, 1, 3]);
+        assert_eq!(out[0], 0.0);
+        assert_eq!(out.len(), 120);
+        // Self-inverse roundtrip.
+        let back = transpose_nd(&out, &[2, 4, 3, 5], &[0, 2, 1, 3]);
+        assert_eq!(back, data);
+    }
+
+    #[test]
+    fn test_transpose_nd_4d_full_reverse() {
+        let data: Vec<f32> = (0..120).map(|i| i as f32).collect();
+        let out = transpose_nd(&data, &[2, 3, 4, 5], &[3, 2, 1, 0]);
+        assert_eq!(out.len(), 120);
+        let back = transpose_nd(&out, &[5, 4, 3, 2], &[3, 2, 1, 0]);
+        assert_eq!(back, data);
+    }
+
+    // -- config validation --------------------------------------------------
+
+    #[test]
+    fn test_config_validate_ok() {
+        let cfg = TransposeConfig { shape: vec![2, 3, 4], permutation: vec![2, 0, 1] };
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn test_config_validate_length_mismatch() {
+        let cfg = TransposeConfig { shape: vec![2, 3], permutation: vec![0, 1, 2] };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validate_out_of_range() {
+        let cfg = TransposeConfig { shape: vec![2, 3], permutation: vec![0, 5] };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_validate_duplicate() {
+        let cfg = TransposeConfig { shape: vec![2, 3], permutation: vec![0, 0] };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn test_config_output_shape() {
+        let cfg = TransposeConfig { shape: vec![2, 3, 4], permutation: vec![2, 0, 1] };
+        assert_eq!(cfg.output_shape(), vec![4, 2, 3]);
+    }
+
+    #[test]
+    fn test_config_num_elements() {
+        let cfg = TransposeConfig { shape: vec![2, 3, 4], permutation: vec![0, 1, 2] };
+        assert_eq!(cfg.num_elements(), 24);
+    }
+
+    // -- reshape ------------------------------------------------------------
+
+    #[test]
+    fn test_reshape_same_total() {
+        let data: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        let out = reshape(&data, &[3, 4], &[2, 6]).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_reshape_flatten() {
+        let data: Vec<f32> = (0..24).map(|i| i as f32).collect();
+        let out = reshape(&data, &[2, 3, 4], &[24]).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_reshape_expand_dims() {
+        let data: Vec<f32> = (0..6).map(|i| i as f32).collect();
+        let out = reshape(&data, &[6], &[1, 2, 3]).unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn test_reshape_mismatch_total() {
+        let data: Vec<f32> = (0..12).map(|i| i as f32).collect();
+        assert!(reshape(&data, &[3, 4], &[5, 3]).is_err());
+    }
+
+    #[test]
+    fn test_reshape_data_length_mismatch() {
+        let data = vec![1.0, 2.0, 3.0];
+        assert!(reshape(&data, &[2, 2], &[4]).is_err());
+    }
+
+    // -- helper tests -------------------------------------------------------
+
+    #[test]
+    fn test_compute_strides() {
+        assert_eq!(compute_strides(&[2, 3, 4]), vec![12, 4, 1]);
+        assert_eq!(compute_strides(&[5]), vec![1]);
+        assert_eq!(compute_strides(&[2, 3]), vec![3, 1]);
+    }
+}

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -16,6 +16,7 @@
 //! - [`softmax`]: Numerically stable row-wise softmax with temperature scaling,
 //!   causal masking, log-softmax, in-place mode, and batched multi-head support
 //! - [`quantized_matmul`]: I2_S quantized matrix multiplication with CPU fallback
+//! - [`transpose`]: 2D/ND transpose and reshape with tiled shared-memory CUDA kernels
 //! - [`crate::scatter_gather`]: Scatter/gather indexed tensor operations with reductions
 //!
 //! All code is feature-gated behind `#[cfg(any(feature = "gpu", feature = "cuda"))]`.
@@ -35,6 +36,7 @@ pub mod quantized_matmul;
 pub mod rmsnorm;
 pub mod rope;
 pub mod softmax;
+pub mod transpose;
 
 pub use activations::{
     ActivationConfig, ActivationType, SiluGateConfig, activation_cpu, launch_activation,
@@ -72,6 +74,10 @@ pub use pooling::{CudaPoolType, PoolingConfig, pooling_cpu, pooling_forward};
 pub use softmax::{SoftmaxConfig, launch_softmax, softmax_cpu, softmax_forward};
 
 pub use quantized_matmul::{I2sMatmulConfig, i2s_matmul_cpu, i2s_matmul_forward, pack_i2s};
+pub use transpose::{
+    CudaTransposeConfig, reshape_cpu, transpose_2d_cpu_fallback, transpose_2d_forward,
+    transpose_nd_cpu_fallback,
+};
 
 #[cfg(any(feature = "gpu", feature = "cuda"))]
 pub use activations::{ACTIVATION_KERNEL_SRC, launch_activation_cuda, launch_silu_gate_cuda};
@@ -84,3 +90,6 @@ pub use fusion::{
     FUSION_KERNEL_SRC, launch_fused_add_rmsnorm_cuda, launch_fused_gelu_linear_cuda,
     launch_fused_rmsnorm_linear_cuda, launch_fused_scale_add_cuda, launch_fused_softmax_mask_cuda,
 };
+
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub use transpose::{TRANSPOSE_2D_KERNEL_SRC, TRANSPOSE_ND_KERNEL_SRC, launch_transpose_2d};

--- a/crates/bitnet-kernels/src/cuda/transpose.rs
+++ b/crates/bitnet-kernels/src/cuda/transpose.rs
@@ -1,0 +1,217 @@
+//! CUDA transpose and reshape kernels with CPU fallback.
+//!
+//! # Transpose operations
+//!
+//! - **2D transpose**: Tiled shared-memory transpose for row-major matrices.
+//!   Uses 32×32 tiles with +1 padding to avoid bank conflicts.
+//! - **ND transpose**: Generalised permutation-based transpose for
+//!   arbitrary-rank tensors, computing output strides from the inverse
+//!   permutation.
+//!
+//! # Reshape
+//!
+//! [`reshape_cpu`] validates that old and new shapes have the same total
+//! element count and returns a reinterpreted (zero-copy logical) copy of
+//! the data.
+//!
+//! # Kernel strategy
+//!
+//! The 2D CUDA kernel uses 32×32 shared-memory tiles with a +1 column
+//! padding to avoid bank conflicts on 32-bit accesses.  Each block loads
+//! one tile collaboratively, synchronises, then writes the transposed tile
+//! to global memory in coalesced order.
+//!
+//! The ND kernel maps each output element to a linear thread index, then
+//! computes the corresponding input index via the inverse permutation.
+//!
+//! # CPU fallback
+//!
+//! CPU implementations live in [`crate::cpu::transpose`] and are
+//! re-exported here for convenience.
+
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+use bitnet_common::KernelError;
+use bitnet_common::Result;
+
+// Re-export CPU fallback functions.
+pub use crate::cpu::transpose::{
+    TransposeConfig as CudaTransposeConfig, reshape as reshape_cpu,
+    transpose_2d as transpose_2d_cpu_fallback, transpose_nd as transpose_nd_cpu_fallback,
+};
+
+// ---------------------------------------------------------------------------
+// CUDA kernel source (feature-gated)
+// ---------------------------------------------------------------------------
+
+/// Tiled 2D transpose CUDA kernel using 32×32 shared-memory tiles.
+///
+/// Padding (`TILE+1` columns) eliminates shared-memory bank conflicts.
+/// Grid dimensions should cover `ceil(cols/TILE) × ceil(rows/TILE)` blocks.
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub const TRANSPOSE_2D_KERNEL_SRC: &str = r#"
+#define TILE 32
+
+extern "C" __global__ void transpose_2d_f32(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    int rows,
+    int cols)
+{
+    __shared__ float tile[TILE][TILE + 1];
+
+    int bx = blockIdx.x * TILE;
+    int by = blockIdx.y * TILE;
+
+    int ix = bx + threadIdx.x;
+    int iy = by + threadIdx.y;
+
+    if (ix < cols && iy < rows) {
+        tile[threadIdx.y][threadIdx.x] = input[iy * cols + ix];
+    }
+    __syncthreads();
+
+    int ox = by + threadIdx.x;
+    int oy = bx + threadIdx.y;
+
+    if (ox < rows && oy < cols) {
+        output[oy * rows + ox] = tile[threadIdx.x][threadIdx.y];
+    }
+}
+"#;
+
+/// ND transpose CUDA kernel using permutation-based index mapping.
+///
+/// Each thread computes the output-space coordinates from its linear index,
+/// applies the inverse permutation to find the input-space coordinates, and
+/// copies the element.  `ndim` must be ≤ 8.
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub const TRANSPOSE_ND_KERNEL_SRC: &str = r#"
+#define MAX_DIMS 8
+
+extern "C" __global__ void transpose_nd_f32(
+    const float* __restrict__ input,
+    float* __restrict__ output,
+    const int* __restrict__ out_shape,
+    const int* __restrict__ in_strides,
+    const int* __restrict__ perm,
+    int ndim,
+    int total)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    for (int i = idx; i < total; i += blockDim.x * gridDim.x) {
+        int coords[MAX_DIMS];
+        int tmp = i;
+        for (int d = ndim - 1; d >= 0; d--) {
+            coords[d] = tmp % out_shape[d];
+            tmp /= out_shape[d];
+        }
+
+        int in_idx = 0;
+        for (int d = 0; d < ndim; d++) {
+            in_idx += coords[d] * in_strides[perm[d]];
+        }
+        output[i] = input[in_idx];
+    }
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+// Re-export `TransposeConfig` as `CudaTransposeConfig` for cuda-module
+// consumers; the canonical implementation lives in `crate::cpu::transpose`.
+
+// ---------------------------------------------------------------------------
+// CUDA dispatch (feature-gated)
+// ---------------------------------------------------------------------------
+
+/// Launch the tiled 2D transpose kernel on the CUDA device.
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub fn launch_transpose_2d(
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) -> Result<()> {
+    use cudarc::driver::{CudaContext, CudaSlice, LaunchConfig, PushKernelArg};
+    use cudarc::nvrtc::compile_ptx;
+
+    let n = rows * cols;
+    if input.len() < n || output.len() < n {
+        return Err(KernelError::InvalidArguments {
+            reason: "buffer too small for transpose".into(),
+        }
+        .into());
+    }
+
+    let ctx = CudaContext::new(0).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to acquire CUDA device 0: {e:?}"),
+    })?;
+    let stream = ctx.default_stream();
+
+    let ptx = compile_ptx(TRANSPOSE_2D_KERNEL_SRC).map_err(|e| KernelError::GpuError {
+        reason: format!("NVRTC compilation failed: {e:?}"),
+    })?;
+    let module = ctx.load_module(ptx).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to load PTX module: {e:?}"),
+    })?;
+    let func = module.load_function("transpose_2d_f32").map_err(|e| KernelError::GpuError {
+        reason: format!("transpose_2d_f32 not found: {e:?}"),
+    })?;
+
+    let input_dev = stream
+        .memcpy_stod(input)
+        .map_err(|e| KernelError::GpuError { reason: format!("memcpy H→D failed: {e:?}") })?;
+    let mut output_dev: CudaSlice<f32> = stream
+        .alloc_zeros(n)
+        .map_err(|e| KernelError::GpuError { reason: format!("device alloc failed: {e:?}") })?;
+
+    let tile = 32u32;
+    let gx = (cols as u32 + tile - 1) / tile;
+    let gy = (rows as u32 + tile - 1) / tile;
+    let launch_cfg =
+        LaunchConfig { grid_dim: (gx, gy, 1), block_dim: (tile, tile, 1), shared_mem_bytes: 0 };
+    let rows_i = rows as i32;
+    let cols_i = cols as i32;
+
+    let mut builder = stream.launch_builder(&func);
+    builder.arg(&input_dev);
+    builder.arg(&mut output_dev);
+    builder.arg(&rows_i);
+    builder.arg(&cols_i);
+
+    // Safety: kernel signature matches CUDA source; buffers validated above.
+    unsafe { builder.launch(launch_cfg) }
+        .map_err(|e| KernelError::GpuError { reason: format!("CUDA launch failed: {e:?}") })?;
+
+    stream
+        .synchronize()
+        .map_err(|e| KernelError::GpuError { reason: format!("stream sync failed: {e:?}") })?;
+
+    let host: Vec<f32> = stream
+        .memcpy_dtov(&output_dev)
+        .map_err(|e| KernelError::GpuError { reason: format!("memcpy D→H failed: {e:?}") })?;
+    output[..n].copy_from_slice(&host[..n]);
+    Ok(())
+}
+
+/// Unified 2D transpose dispatcher: tries GPU, falls back to CPU.
+pub fn transpose_2d_forward(
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) -> Result<()> {
+    #[cfg(any(feature = "gpu", feature = "cuda"))]
+    {
+        if let Ok(()) = launch_transpose_2d(input, output, rows, cols) {
+            return Ok(());
+        }
+        log::debug!("CUDA transpose_2d unavailable, falling back to CPU");
+    }
+    let result = transpose_2d_cpu_fallback(input, rows, cols);
+    let n = rows * cols;
+    output[..n].copy_from_slice(&result);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add CUDA transpose/reshape kernels with pure-Rust CPU fallback implementations.

### New files

- **`crates/bitnet-kernels/src/cpu/transpose.rs`** — CPU implementations:
  - `transpose_2d()` — 2D row-major matrix transpose
  - `transpose_nd()` — N-dimensional permutation-based transpose
  - `reshape()` — validates and reshapes (same total element count)
  - `TransposeConfig` — shape + permutation with validation
  - 28 unit tests covering 2D, 3D, 4D transposes, identity permutations, roundtrips, reshape validation, config validation, and stride computation

- **`crates/bitnet-kernels/src/cuda/transpose.rs`** — CUDA kernels + dispatch:
  - `TRANSPOSE_2D_KERNEL_SRC` — tiled 32×32 shared-memory kernel with +1 padding to avoid bank conflicts
  - `TRANSPOSE_ND_KERNEL_SRC` — grid-stride ND kernel with permutation-based index mapping (≤8 dims)
  - `launch_transpose_2d()` — CUDA dispatch via cudarc
  - `transpose_2d_forward()` — unified dispatcher (GPU → CPU fallback)
  - Re-exports CPU fallback functions as `transpose_2d_cpu_fallback`, `transpose_nd_cpu_fallback`, `reshape_cpu`

### Design

- All CUDA code guarded with `#[cfg(any(feature = "gpu", feature = "cuda"))]`
- CPU fallback always available via `cpu::transpose` module
- Follows existing kernel patterns (activations, pooling, quantized_matmul)

### Verification

- `cargo fmt --all` ✅
- `cargo clippy -p bitnet-kernels --no-default-features --features cpu -- -D warnings` ✅
- `cargo test -p bitnet-kernels --no-default-features --features cpu --lib -- transpose` — 28/28 pass ✅