### PR TITLE
feat(kernels): add CPU embedding operations

### DIFF
--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -46,6 +46,11 @@ pub use kv_cache::{
     kv_cache_memory_usage, kv_cache_slice, paged_kv_cache_alloc,
 };
 
+// Re-export new embedding operations.
+pub use embedding::{
+    embedding_bag_mean, embedding_bag_sum, embedding_lookup_with_padding, positional_embedding,
+};
+
 #[cfg(target_arch = "x86_64")]
 pub use x86::*;
 


### PR DESCRIPTION
## Summary

Add convenience CPU embedding operations to `bitnet-kernels`:

- **`embedding_lookup_with_padding`** — lookup with explicit padding-idx zeroing (usize indices)
- **`embedding_bag_sum`** — EmbeddingBag with sum reduction over bag offsets
- **`embedding_bag_mean`** — EmbeddingBag with mean reduction over bag offsets
- **`positional_embedding`** — generate sinusoidal positional encoding matrix (`[seq_len, dim]`)

All functions are re-exported from `cpu::mod` for ergonomic access.

## Tests

32 new tests covering:
- Basic lookup with/without padding
- Bag sum/mean: single/multi bags, empty bags, padding, out-of-bounds
- Positional encoding: shape, bounds, sin/cos pattern, determinism, edge cases

All 87 embedding tests pass (55 existing + 32 new).

## Changes

- `crates/bitnet-kernels/src/cpu/embedding.rs` — new public functions + internal `BagReduce` helper
- `crates/bitnet-kernels/src/cpu/mod.rs` — re-exports