### PR TITLE
feat(kernels): add CPU scatter/gather operations

### DIFF
--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -20,6 +20,10 @@ pub mod x86;
 pub mod arm;
 
 pub use fallback::*;
+pub use scatter_gather::{
+    ScatterGatherConfig, ScatterReduce, gather_1d, gather_2d, index_select, scatter_1d, scatter_2d,
+    scatter_add, scatter_max,
+};
 pub use simd_math::*;
 
 // Re-export position-encoding embedding types.


### PR DESCRIPTION
## Summary

Add 1D/2D scatter/gather convenience functions, scatter_add, scatter_max, index_select, and ScatterGatherConfig to the existing `cpu::scatter_gather` module in `bitnet-kernels`.

## New Public API

- `scatter_1d` / `gather_1d` — simple indexed element access on flat `&[f32]`
- `scatter_2d` / `gather_2d` — row-level operations on `Vec<Vec<f32>>`
- `scatter_add` — accumulative 1D scatter (`data[idx] += val`)
- `scatter_max` — max-reduction 1D scatter (`data[idx] = max(old, val)`)
- `index_select` — slice selection along first dimension of a flat tensor
- `ScatterGatherConfig` — configuration struct (bounds_check + reduce mode)

All new symbols are re-exported from `cpu::mod`.

## Tests

30+ new tests added (57 total in the module), covering:
- Basic operations, edge cases, error paths
- Bounds checking and OOB handling
- Duplicate indices behavior
- Roundtrip (scatter then gather) verification
- Empty inputs

## Verification

```bash
cargo fmt --all -- --check              # ✅
cargo clippy -p bitnet-kernels --lib --no-default-features --features cpu -- -D warnings  # ✅
cargo test -p bitnet-kernels --lib --no-default-features --features cpu -- cpu::scatter_gather  # ✅ 57 passed
```