### PR TITLE
feat(kernels): add CPU attention operations with GQA support

### DIFF
--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -2,6 +2,11 @@
 
 pub mod activations;
 pub mod attention;
+pub use attention::{
+    AttentionConfig, AttentionKernel, CpuAttentionConfig, GqaConfig, apply_rotary_embedding,
+    attention_with_kv_cache, causal_attention, causal_mask, masked_attention,
+    multi_head_attention_cpu, scaled_dot_product_attention,
+};
 pub mod batch_norm;
 pub mod embedding;
 pub mod fallback;


### PR DESCRIPTION
## Summary

Extends the CPU attention module (`crates/bitnet-kernels/src/cpu/attention.rs`) with two new public functions and re-exports all attention types from `cpu::mod`.

### New Functions

- **`causal_attention(q, k, v, config) -> Result<Vec<f32>>`** — Config-driven convenience wrapper that forces causal masking regardless of the `AttentionConfig.causal` field. Delegates to `AttentionKernel::multi_head_attention`.

- **`apply_rotary_embedding(q, k, positions, head_dim) -> Result<()>`** — Applies Rotary Position Embeddings (RoPE) to both Q and K tensors in-place. Supports multi-head layouts (any number of heads per row) and arbitrary position indices. Uses base frequency 10000 following the original RoPE paper.

### Re-exports

Added `pub use attention::{...}` in `cpu/mod.rs` for ergonomic access to all public attention types and functions: `AttentionConfig`, `GqaConfig`, `CpuAttentionConfig`, `AttentionKernel`, `causal_attention`, `apply_rotary_embedding`, `scaled_dot_product_attention`, `masked_attention`, `multi_head_attention_cpu`, `attention_with_kv_cache`, `causal_mask`.

### Tests

16 new tests (70 total in attention module), covering:
- Causal attention: first-position self-only, matches MHA causal, forces causal flag, single token
- RoPE: position-zero no-op, nonzero position modifies values, pair-rotation norm preservation, multi-head consistency, multiple positions, odd/zero head_dim rejection, empty positions, Q/K independence, dimension mismatch, large head_dim norm, determinism

### Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy -p bitnet-kernels --lib --no-default-features --features cpu -- -D warnings` ✅
- `cargo test -p bitnet-kernels --lib --no-default-features --features cpu -- cpu::attention` — **70 passed** ✅