### PR TITLE
feat(kernels): add CUDA embedding kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cuda/batch_norm.rs
+++ b/crates/bitnet-kernels/src/cuda/batch_norm.rs
@@ -514,7 +514,7 @@ pub fn batch_norm_cpu_fallback(
         }
         .into());
     }
-    if input.len() % c != 0 {
+    if !input.len().is_multiple_of(c) {
         return Err(KernelError::InvalidArguments {
             reason: format!(
                 "batch_norm_cpu_fallback: input length {} not divisible by num_features {c}",
@@ -601,7 +601,7 @@ pub fn batch_norm_inference_cpu_fallback(
         .into());
     }
     let c = gamma.len();
-    if input.len() % c != 0 {
+    if !input.len().is_multiple_of(c) {
         return Err(KernelError::InvalidArguments {
             reason: format!(
                 "batch_norm_inference_cpu_fallback: input length {} not divisible by \

--- a/crates/bitnet-kernels/src/cuda/qk256_gemv.rs
+++ b/crates/bitnet-kernels/src/cuda/qk256_gemv.rs
@@ -58,7 +58,7 @@ impl Qk256GemvConfig {
     ///
     /// `k` must be a multiple of 256 (the QK256 block size).
     pub fn for_shape(seq_len: usize, n_out: usize, k: usize) -> Result<Self> {
-        if k == 0 || k % 256 != 0 {
+        if k == 0 || !k.is_multiple_of(256) {
             return Err(KernelError::InvalidArguments {
                 reason: format!(
                     "QK256 GEMV inner dimension k={k} must be a positive multiple of 256"

--- a/crates/bitnet-kernels/src/cuda/rope.rs
+++ b/crates/bitnet-kernels/src/cuda/rope.rs
@@ -158,7 +158,7 @@ pub struct RopeConfig {
 impl RopeConfig {
     /// Create a configuration for the given shape.
     pub fn for_shape(head_dim: usize, n_heads: usize, seq_len: usize) -> Result<Self> {
-        if head_dim == 0 || head_dim % 2 != 0 {
+        if head_dim == 0 || !head_dim.is_multiple_of(2) {
             return Err(KernelError::InvalidArguments {
                 reason: format!("RoPE head_dim must be even and non-zero, got {head_dim}"),
             }
@@ -262,13 +262,12 @@ fn compute_inv_freq(head_dim: usize, base: f32) -> Vec<f32> {
 /// uses the same interleaved layout so that the two modules can share tables
 /// when needed.
 pub fn compute_sincos_table(config: &RopeConfig) -> Vec<f32> {
-    let half_dim = config.head_dim / 2;
     let inv_freq = compute_inv_freq(config.head_dim, config.base);
     let mut table = Vec::with_capacity(config.max_seq_len * config.head_dim);
 
     for pos in 0..config.max_seq_len {
-        for i in 0..half_dim {
-            let angle = (pos as f32) * inv_freq[i] * config.scaling_factor;
+        for &freq in &inv_freq {
+            let angle = (pos as f32) * freq * config.scaling_factor;
             table.push(angle.cos());
             table.push(angle.sin());
         }
@@ -302,8 +301,8 @@ pub fn rope_forward_cpu(input: &[f32], output: &mut [f32], config: &RopeConfig) 
             let actual_pos = (pos + config.position_offset) as f32;
             let row_start = head * config.seq_len * config.head_dim + pos * config.head_dim;
 
-            for i in 0..half_dim {
-                let angle = actual_pos * inv_freq[i] * config.scaling_factor;
+            for (i, &freq) in inv_freq.iter().enumerate() {
+                let angle = actual_pos * freq * config.scaling_factor;
                 let cos_val = angle.cos();
                 let sin_val = angle.sin();
 
@@ -362,11 +361,10 @@ pub fn launch_rope(_input: &[f32], _output: &mut [f32], config: &RopeConfig) -> 
 pub fn rope_forward(input: &[f32], output: &mut [f32], config: &RopeConfig) -> Result<()> {
     #[cfg(any(feature = "gpu", feature = "cuda"))]
     {
-        if crate::device_features::gpu_available_runtime() {
-            if let Ok(()) = launch_rope(input, output, config) {
-                return Ok(());
-            }
-            // GPU launch failed — fall through to CPU path
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = launch_rope(input, output, config)
+        {
+            return Ok(());
         }
     }
     rope_forward_cpu(input, output, config)
@@ -381,13 +379,12 @@ pub fn rope_forward(input: &[f32], output: &mut [f32], config: &RopeConfig) -> R
 /// around [`compute_sincos_table`] for callers who only need `(head_dim,
 /// max_seq_len, theta)` without constructing a full [`RopeConfig`].
 pub fn build_rope_freqs(head_dim: usize, max_seq_len: usize, theta: f32) -> Vec<f32> {
-    let half_dim = head_dim / 2;
     let inv_freq = compute_inv_freq(head_dim, theta);
     let mut table = Vec::with_capacity(max_seq_len * head_dim);
 
     for pos in 0..max_seq_len {
-        for i in 0..half_dim {
-            let angle = (pos as f32) * inv_freq[i];
+        for &freq in &inv_freq {
+            let angle = (pos as f32) * freq;
             table.push(angle.cos());
             table.push(angle.sin());
         }
@@ -417,10 +414,10 @@ pub fn apply_rope(input: &[f32], positions: &[u32], config: &RopeConfig) -> Vec<
 
     #[cfg(any(feature = "gpu", feature = "cuda"))]
     {
-        if crate::device_features::gpu_available_runtime() {
-            if let Ok(()) = launch_rope(input, &mut output, config) {
-                return output;
-            }
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = launch_rope(input, &mut output, config)
+        {
+            return output;
         }
     }
 
@@ -432,8 +429,8 @@ pub fn apply_rope(input: &[f32], positions: &[u32], config: &RopeConfig) -> Vec<
             let actual_pos = pos as f32;
             let row_start = head * positions.len() * config.head_dim + seq_idx * config.head_dim;
 
-            for i in 0..half_dim {
-                let angle = actual_pos * inv_freq[i] * config.scaling_factor;
+            for (i, &freq) in inv_freq.iter().enumerate() {
+                let angle = actual_pos * freq * config.scaling_factor;
                 let cos_val = angle.cos();
                 let sin_val = angle.sin();
 
@@ -480,11 +477,11 @@ pub fn apply_rope_batched(
 
         #[cfg(any(feature = "gpu", feature = "cuda"))]
         {
-            if crate::device_features::gpu_available_runtime() {
-                if let Ok(()) = launch_rope(&input[start..end], &mut batch_out, &batch_cfg) {
-                    output[start..end].copy_from_slice(&batch_out);
-                    continue;
-                }
+            if crate::device_features::gpu_available_runtime()
+                && let Ok(()) = launch_rope(&input[start..end], &mut batch_out, &batch_cfg)
+            {
+                output[start..end].copy_from_slice(&batch_out);
+                continue;
             }
         }
 
@@ -528,8 +525,8 @@ pub fn rope_backward_cpu(
             let actual_pos = (pos + config.position_offset) as f32;
             let row_start = head * config.seq_len * config.head_dim + pos * config.head_dim;
 
-            for i in 0..half_dim {
-                let angle = actual_pos * inv_freq[i] * config.scaling_factor;
+            for (i, &freq) in inv_freq.iter().enumerate() {
+                let angle = actual_pos * freq * config.scaling_factor;
                 let cos_val = angle.cos();
                 let sin_val = angle.sin();
 
@@ -582,10 +579,10 @@ pub fn rope_backward(
 ) -> Result<()> {
     #[cfg(any(feature = "gpu", feature = "cuda"))]
     {
-        if crate::device_features::gpu_available_runtime() {
-            if let Ok(()) = launch_rope_backward(grad_output, grad_input, config) {
-                return Ok(());
-            }
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = launch_rope_backward(grad_output, grad_input, config)
+        {
+            return Ok(());
         }
     }
     rope_backward_cpu(grad_output, grad_input, config)

--- a/crates/bitnet-kernels/src/cuda/transpose.rs
+++ b/crates/bitnet-kernels/src/cuda/transpose.rs
@@ -168,8 +168,8 @@ pub fn launch_transpose_2d(
         .map_err(|e| KernelError::GpuError { reason: format!("device alloc failed: {e:?}") })?;
 
     let tile = 32u32;
-    let gx = (cols as u32 + tile - 1) / tile;
-    let gy = (rows as u32 + tile - 1) / tile;
+    let gx = (cols as u32).div_ceil(tile);
+    let gy = (rows as u32).div_ceil(tile);
     let launch_cfg =
         LaunchConfig { grid_dim: (gx, gy, 1), block_dim: (tile, tile, 1), shared_mem_bytes: 0 };
     let rows_i = rows as i32;

--- a/crates/bitnet-kernels/src/scatter_gather.rs
+++ b/crates/bitnet-kernels/src/scatter_gather.rs
@@ -402,10 +402,10 @@ pub fn gather_forward(
 ) -> Result<()> {
     #[cfg(any(feature = "gpu", feature = "cuda"))]
     {
-        if crate::device_features::gpu_available_runtime() {
-            if let Ok(()) = launch_gather(src, indices, output, kernel, config) {
-                return Ok(());
-            }
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = launch_gather(src, indices, output, kernel, config)
+        {
+            return Ok(());
         }
     }
     gather_cpu(src, indices, output, kernel, config)
@@ -422,10 +422,10 @@ pub fn scatter_forward(
 ) -> Result<()> {
     #[cfg(any(feature = "gpu", feature = "cuda"))]
     {
-        if crate::device_features::gpu_available_runtime() {
-            if let Ok(()) = launch_scatter(src, indices, dst, dst_shape, config, mode) {
-                return Ok(());
-            }
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = launch_scatter(src, indices, dst, dst_shape, config, mode)
+        {
+            return Ok(());
         }
     }
     scatter_cpu(src, indices, dst, dst_shape, config, mode)


### PR DESCRIPTION
## Summary

Add token embedding lookup and positional embedding CUDA kernels to `bitnet-kernels` with full CPU fallback support.

## Changes

### New file: `crates/bitnet-kernels/src/cuda/embedding.rs`

- **CUDA kernel sources** (feature-gated `gpu`/`cuda`):
  - `embedding_lookup_f32`: maps token IDs → embedding vectors with optional padding-index zeroing
  - `positional_embedding_f32`: adds position-dependent vectors element-wise

- **Configuration structs**:
  - `EmbeddingConfig`: `vocab_size`, `embedding_dim`, `padding_idx` with validation
  - `PositionalEmbeddingConfig`: `max_seq_len`, `embedding_dim`, `position_offset` with builder pattern

- **CPU fallbacks**:
  - `embedding_cpu_fallback`: row-gather with bounds checking and padding support
  - `positional_embedding_cpu`: element-wise addition with position offset

- **Unified dispatch**:
  - `embedding_forward` / `positional_embedding_forward`: GPU→CPU automatic fallback

- **33 tests** (31 CPU pass, 2 GPU correctly ignored):
  - Config validation (zero vocab/dim, OOB padding)
  - Lookup correctness, padding zeroing, duplicate tokens, empty sequence
  - Positional embedding with offset, overflow detection
  - Large vocab (32K×128), error handling for short buffers
  - Unified dispatch verification

### Modified: `crates/bitnet-kernels/src/cuda/mod.rs`
- Register `embedding` submodule
- Re-export public types and functions
- Feature-gated kernel source re-exports

## Testing

```
cargo test -p bitnet-kernels --lib --no-default-features --features cpu,cuda -- cuda::embedding
# 31 passed; 0 failed; 2 ignored
```

Clippy (lib) and fmt pass clean.