### PR TITLE
test(integration): multi-SLM architecture pipeline integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,8 +874,8 @@ dependencies = [
  "env_logger",
  "log",
  "opencl3",
- "serial_test",
  "rand 0.9.2",
+ "serial_test",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bitnet-common/tests/multi_slm_integration_tests.rs
+++ b/crates/bitnet-common/tests/multi_slm_integration_tests.rs
@@ -1,0 +1,212 @@
+//! Integration tests for architecture detection → config defaults pipeline.
+//!
+//! Verifies that ArchitectureRegistry lookups correctly configure ModelConfig
+//! for all supported model families.
+
+use bitnet_common::ArchitectureRegistry;
+use bitnet_common::config::{ActivationType, ModelConfig, NormType};
+
+// ---------------------------------------------------------------------------
+// Architecture → Config defaults integration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phi4_architecture_defaults_applied() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("phi-4");
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Silu);
+    assert_eq!(cfg.max_position_embeddings, 16384);
+}
+
+#[test]
+fn phi3_architecture_defaults_applied() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("phi-3");
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Silu);
+    assert_eq!(cfg.max_position_embeddings, 4096);
+}
+
+#[test]
+fn phi2_uses_layernorm_gelu() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("phi-2");
+    assert_eq!(cfg.norm_type, NormType::LayerNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Gelu);
+    assert_eq!(cfg.max_position_embeddings, 2048);
+}
+
+#[test]
+fn llama_architecture_defaults() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("llama");
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Silu);
+    // No default context for generic llama, keeps 2048
+    assert_eq!(cfg.max_position_embeddings, 2048);
+}
+
+#[test]
+fn llama32_gets_extended_context() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("llama-3.2");
+    assert_eq!(cfg.max_position_embeddings, 131072);
+}
+
+#[test]
+fn gemma_uses_rmsnorm_gelu() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("gemma");
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Gelu);
+}
+
+#[test]
+fn qwen25_gets_32k_context() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("qwen2.5");
+    assert_eq!(cfg.max_position_embeddings, 32768);
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+}
+
+#[test]
+fn bitnet_uses_layernorm_silu() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("bitnet");
+    assert_eq!(cfg.norm_type, NormType::LayerNorm);
+    assert_eq!(cfg.activation_type, ActivationType::Silu);
+}
+
+#[test]
+fn deepseek_v3_gets_64k_context() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("deepseek-v3");
+    assert_eq!(cfg.max_position_embeddings, 65536);
+}
+
+#[test]
+fn unknown_arch_preserves_config_defaults() {
+    let mut cfg = ModelConfig::default();
+    let original_norm = cfg.norm_type;
+    let original_ctx = cfg.max_position_embeddings;
+    cfg.apply_architecture_defaults("unknown_model");
+    assert_eq!(cfg.norm_type, original_norm);
+    assert_eq!(cfg.max_position_embeddings, original_ctx);
+}
+
+#[test]
+fn case_insensitive_architecture_defaults() {
+    let mut cfg1 = ModelConfig::default();
+    let mut cfg2 = ModelConfig::default();
+    cfg1.apply_architecture_defaults("PHI-4");
+    cfg2.apply_architecture_defaults("phi-4");
+    assert_eq!(cfg1.norm_type, cfg2.norm_type);
+    assert_eq!(cfg1.activation_type, cfg2.activation_type);
+    assert_eq!(cfg1.max_position_embeddings, cfg2.max_position_embeddings);
+}
+
+// ---------------------------------------------------------------------------
+// Architecture families — norm/activation consistency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_phi_variants_use_rmsnorm_silu_except_phi2() {
+    for arch in ["phi", "phi-4", "phi-3"] {
+        let d = ArchitectureRegistry::lookup(arch).unwrap();
+        assert_eq!(d.norm_type, NormType::RmsNorm, "{arch} should use RmsNorm");
+        assert_eq!(d.activation_type, ActivationType::Silu, "{arch} should use Silu");
+    }
+    let phi2 = ArchitectureRegistry::lookup("phi-2").unwrap();
+    assert_eq!(phi2.norm_type, NormType::LayerNorm);
+    assert_eq!(phi2.activation_type, ActivationType::Gelu);
+}
+
+#[test]
+fn all_llama_variants_use_rmsnorm_silu() {
+    for arch in ["llama", "llama2", "llama-3.1", "llama-3.2", "mistral"] {
+        let d = ArchitectureRegistry::lookup(arch).unwrap();
+        assert_eq!(d.norm_type, NormType::RmsNorm, "{arch} should use RmsNorm");
+        assert_eq!(d.activation_type, ActivationType::Silu, "{arch} should use Silu");
+    }
+}
+
+#[test]
+fn all_gemma_variants_use_rmsnorm_gelu() {
+    for arch in ["gemma", "gemma2", "codegemma"] {
+        let d = ArchitectureRegistry::lookup(arch).unwrap();
+        assert_eq!(d.norm_type, NormType::RmsNorm, "{arch} should use RmsNorm");
+        assert_eq!(d.activation_type, ActivationType::Gelu, "{arch} should use Gelu");
+    }
+}
+
+#[test]
+fn context_lengths_increase_with_version() {
+    let phi2_ctx = ArchitectureRegistry::lookup("phi-2").unwrap().default_context_length.unwrap();
+    let phi3_ctx = ArchitectureRegistry::lookup("phi-3").unwrap().default_context_length.unwrap();
+    let phi4_ctx = ArchitectureRegistry::lookup("phi-4").unwrap().default_context_length.unwrap();
+    assert!(phi3_ctx > phi2_ctx, "Phi-3 ctx should exceed Phi-2");
+    assert!(phi4_ctx > phi3_ctx, "Phi-4 ctx should exceed Phi-3");
+}
+
+// ---------------------------------------------------------------------------
+// Architecture count regression guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn known_architectures_count_regression() {
+    let count = ArchitectureRegistry::known_architectures().len();
+    assert!(count >= 70, "Expected at least 70 known architecture strings, got {}", count);
+}
+
+// ---------------------------------------------------------------------------
+// Config defaults serde roundtrip with architecture applied
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_with_arch_defaults_survives_serde() {
+    let mut cfg = ModelConfig::default();
+    cfg.apply_architecture_defaults("phi-4");
+    let json = serde_json::to_string(&cfg).unwrap();
+    let cfg2: ModelConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(cfg2.norm_type, NormType::RmsNorm);
+    assert_eq!(cfg2.activation_type, ActivationType::Silu);
+    assert_eq!(cfg2.max_position_embeddings, 16384);
+}
+
+#[test]
+fn config_preserves_custom_fields_after_arch_defaults() {
+    let mut cfg = ModelConfig::default();
+    cfg.hidden_size = 5120;
+    cfg.num_heads = 40;
+    cfg.num_key_value_heads = 10;
+    cfg.apply_architecture_defaults("phi-4");
+    // Architecture defaults should NOT override custom fields
+    assert_eq!(cfg.hidden_size, 5120);
+    assert_eq!(cfg.num_heads, 40);
+    assert_eq!(cfg.num_key_value_heads, 10);
+    // But norm/activation/context should be set
+    assert_eq!(cfg.norm_type, NormType::RmsNorm);
+}
+
+// ---------------------------------------------------------------------------
+// Non-default context preserved for architectures without defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn custom_context_not_overwritten_for_generic_llama() {
+    let mut cfg = ModelConfig::default();
+    cfg.max_position_embeddings = 8192;
+    cfg.apply_architecture_defaults("llama");
+    // llama has no default context, so custom should be preserved
+    assert_eq!(cfg.max_position_embeddings, 8192);
+}
+
+#[test]
+fn non_default_context_overwritten_when_arch_has_default() {
+    let mut cfg = ModelConfig::default();
+    // Default is 2048; phi-4 should override to 16384
+    assert_eq!(cfg.max_position_embeddings, 2048);
+    cfg.apply_architecture_defaults("phi-4");
+    assert_eq!(cfg.max_position_embeddings, 16384);
+}

--- a/crates/bitnet-prompt-templates/tests/template_integration_tests.rs
+++ b/crates/bitnet-prompt-templates/tests/template_integration_tests.rs
@@ -1,0 +1,302 @@
+//! Integration tests for prompt template ↔ architecture pipeline.
+//!
+//! Verifies that template suggestion, rendering, chat formatting, and
+//! validation work correctly for all supported model families.
+
+use bitnet_prompt_templates::{ChatRole, ChatTurn, PromptTemplate, TemplateType};
+
+// ---------------------------------------------------------------------------
+// Architecture → Template suggestion
+// ---------------------------------------------------------------------------
+
+#[test]
+fn phi_suggests_template() {
+    let template = TemplateType::suggest_for_arch("phi");
+    assert!(template.is_some(), "phi should suggest a template");
+}
+
+#[test]
+fn llama_suggests_template() {
+    let template = TemplateType::suggest_for_arch("llama");
+    assert!(template.is_some(), "llama should suggest a template");
+}
+
+#[test]
+fn mistral_suggests_template() {
+    let template = TemplateType::suggest_for_arch("mistral");
+    assert!(template.is_some(), "mistral should suggest a template");
+}
+
+#[test]
+fn qwen_suggests_template() {
+    let template = TemplateType::suggest_for_arch("qwen");
+    assert!(template.is_some(), "qwen should suggest a template");
+}
+
+#[test]
+fn gemma_suggests_template() {
+    let template = TemplateType::suggest_for_arch("gemma");
+    assert!(template.is_some(), "gemma should suggest a template");
+}
+
+#[test]
+fn deepseek_suggests_template() {
+    let template = TemplateType::suggest_for_arch("deepseek");
+    assert!(template.is_some(), "deepseek should suggest a template");
+}
+
+#[test]
+fn falcon_suggests_template() {
+    let template = TemplateType::suggest_for_arch("falcon");
+    assert!(template.is_some(), "falcon should suggest a template");
+}
+
+#[test]
+fn unknown_arch_no_template_suggestion() {
+    let template = TemplateType::suggest_for_arch("totally_unknown_model");
+    assert!(template.is_none());
+}
+
+#[test]
+fn empty_arch_no_template_suggestion() {
+    let template = TemplateType::suggest_for_arch("");
+    assert!(template.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Template apply produces valid output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn instruct_template_apply_basic() {
+    let output = TemplateType::Instruct.apply("What is 2+2?", None);
+    assert!(!output.is_empty());
+    assert!(output.contains("2+2"));
+}
+
+#[test]
+fn phi4chat_template_apply_with_system() {
+    let output = TemplateType::Phi4Chat.apply("Hello", Some("You are a helpful assistant"));
+    assert!(output.contains("Hello"));
+    assert!(output.contains("helpful assistant"));
+}
+
+#[test]
+fn all_templates_handle_empty_prompt() {
+    for variant in TemplateType::all_variants() {
+        let output = variant.apply("", None);
+        let _ = output;
+    }
+}
+
+#[test]
+fn all_templates_handle_long_prompt() {
+    let long_prompt = "A".repeat(10_000);
+    for variant in TemplateType::all_variants() {
+        let output = variant.apply(&long_prompt, None);
+        assert!(output.len() >= long_prompt.len(), "Template {:?} truncated long prompt", variant);
+    }
+}
+
+#[test]
+fn all_templates_handle_unicode_prompt() {
+    let prompt = "こんにちは世界 🌍 Привет мир";
+    for variant in TemplateType::all_variants() {
+        let output = variant.apply(prompt, None);
+        assert!(output.contains(prompt), "Template {:?} lost unicode content", variant);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PromptTemplate builder
+// ---------------------------------------------------------------------------
+
+#[test]
+fn prompt_template_builder_basic() {
+    let pt = PromptTemplate::new(TemplateType::Instruct);
+    let output = pt.format("What is AI?");
+    assert!(!output.is_empty());
+    assert!(output.contains("AI"));
+}
+
+#[test]
+fn prompt_template_with_system() {
+    let pt = PromptTemplate::new(TemplateType::Phi4Chat).with_system_prompt("You are a math tutor");
+    let output = pt.format("What is calculus?");
+    assert!(output.contains("calculus"));
+}
+
+#[test]
+fn prompt_template_stop_sequences() {
+    let pt = PromptTemplate::new(TemplateType::Phi4Chat);
+    let stops = pt.stop_sequences();
+    assert!(!stops.is_empty(), "Phi4Chat should have stop sequences");
+}
+
+#[test]
+fn prompt_template_add_turn_and_format() {
+    let mut pt = PromptTemplate::new(TemplateType::Phi4Chat);
+    pt.add_turn("What is 1+1?", "2");
+    let output = pt.format("What is 2+2?");
+    assert!(output.contains("2+2"));
+}
+
+#[test]
+fn prompt_template_clear_history() {
+    let mut pt = PromptTemplate::new(TemplateType::Phi4Chat);
+    pt.add_turn("Hello", "Hi");
+    pt.clear_history();
+    let output = pt.format("New question");
+    assert!(output.contains("New question"));
+}
+
+#[test]
+fn prompt_template_type_accessor() {
+    let pt = PromptTemplate::new(TemplateType::Instruct);
+    assert!(matches!(pt.template_type(), TemplateType::Instruct));
+}
+
+// ---------------------------------------------------------------------------
+// ChatTurn / render_chat
+// ---------------------------------------------------------------------------
+
+#[test]
+fn render_chat_single_turn() {
+    let turns = vec![ChatTurn::new(ChatRole::User, "Hi there!")];
+    let result = TemplateType::Phi4Chat.render_chat(&turns, None);
+    assert!(result.is_ok());
+    let output = result.unwrap();
+    assert!(output.contains("Hi there!"));
+}
+
+#[test]
+fn render_chat_multi_turn() {
+    let turns = vec![
+        ChatTurn::new(ChatRole::User, "Hello"),
+        ChatTurn::new(ChatRole::Assistant, "Hi! How can I help?"),
+        ChatTurn::new(ChatRole::User, "Tell me about Rust"),
+    ];
+    let result = TemplateType::Phi4Chat.render_chat(&turns, None);
+    assert!(result.is_ok());
+    let output = result.unwrap();
+    assert!(output.contains("Hello"));
+    assert!(output.contains("Rust"));
+}
+
+#[test]
+fn render_chat_with_system() {
+    let turns = vec![ChatTurn::new(ChatRole::User, "Hi")];
+    let result = TemplateType::Phi4Chat.render_chat(&turns, Some("You are a helpful assistant"));
+    assert!(result.is_ok());
+    let output = result.unwrap();
+    assert!(output.contains("helpful assistant"));
+}
+
+#[test]
+fn render_chat_empty_turns() {
+    let turns: Vec<ChatTurn> = vec![];
+    let result = TemplateType::Phi4Chat.render_chat(&turns, None);
+    let _ = result;
+}
+
+// ---------------------------------------------------------------------------
+// All variants enumeration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn all_variants_returns_nonempty() {
+    let variants = TemplateType::all_variants();
+    assert!(!variants.is_empty());
+    assert!(variants.len() >= 40, "Expected at least 40 template variants, got {}", variants.len());
+}
+
+#[test]
+fn all_variants_have_valid_info() {
+    for variant in TemplateType::all_variants() {
+        let info = variant.info();
+        assert!(!info.name.is_empty(), "Template {:?} has empty name", variant);
+    }
+}
+
+#[test]
+fn all_variants_produce_nonempty_output() {
+    for variant in TemplateType::all_variants() {
+        let output = variant.apply("test prompt", None);
+        assert!(!output.is_empty(), "Template {:?} produced empty output", variant);
+    }
+}
+
+#[test]
+fn all_variants_stop_sequences_dont_panic() {
+    for variant in TemplateType::all_variants() {
+        let stops = variant.default_stop_sequences();
+        let _ = stops;
+    }
+}
+
+#[test]
+fn all_variants_render_chat_dont_panic() {
+    let turns = vec![ChatTurn::new(ChatRole::User, "test")];
+    for variant in TemplateType::all_variants() {
+        let _ = variant.render_chat(&turns, None);
+    }
+}
+
+#[test]
+fn all_variants_validate_output_dont_panic() {
+    for variant in TemplateType::all_variants() {
+        let output = variant.apply("hello", None);
+        let validation = variant.validate_output(&output, "hello");
+        let _ = validation;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Template detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn detect_chatml_from_jinja() {
+    let detected = TemplateType::detect(None, Some("{% if messages[0] %}"));
+    // Should not panic regardless of detection result
+    let _ = detected;
+}
+
+#[test]
+fn detect_with_no_hints_returns_default() {
+    let detected = TemplateType::detect(None, None);
+    let _ = detected;
+}
+
+// ---------------------------------------------------------------------------
+// ChatRole as_str
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chat_role_as_str() {
+    assert_eq!(ChatRole::System.as_str(), "system");
+    assert_eq!(ChatRole::User.as_str(), "user");
+    assert_eq!(ChatRole::Assistant.as_str(), "assistant");
+}
+
+// ---------------------------------------------------------------------------
+// Regression guards
+// ---------------------------------------------------------------------------
+
+#[test]
+fn template_count_regression_guard() {
+    let count = TemplateType::all_variants().len();
+    assert!(count >= 40, "Expected at least 40 template variants, got {}", count);
+}
+
+#[test]
+fn major_architectures_have_template_suggestions() {
+    let major_archs = ["phi", "llama", "mistral", "qwen", "gemma", "deepseek", "falcon"];
+    for arch in &major_archs {
+        assert!(
+            TemplateType::suggest_for_arch(arch).is_some(),
+            "Major architecture '{}' should have a template suggestion",
+            arch
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add 55 cross-crate integration tests verifying the multi-SLM architecture detection  config defaults  prompt template selection pipeline.

### bitnet-common (20 tests)
- Architecture  ModelConfig defaults for phi/llama/gemma/qwen/bitnet/deepseek
- Family consistency (phi variants use RmsNorm/Silu except Phi-2)
- Context length progression across model versions
- Config serde roundtrip with arch defaults applied
- Custom field preservation after apply_architecture_defaults
- Architecture count regression guard (70 strings)

### bitnet-prompt-templates (35 tests)
- Architecture  template suggestion for all major families
- Template apply with basic/system/empty/long/unicode prompts
- PromptTemplate builder: new, with_system, format, add_turn, clear_history
- ChatTurn/render_chat: single-turn, multi-turn, with system, empty turns
- All variants enumeration: info, output, stop sequences, render_chat, validate
- Template detection from jinja hints
- Regression guards for template count (40) and arch coverage

### Test Results
- All 55 tests pass locally (20 + 35)
- No new dependencies added