### PR TITLE
fuzz: add wave 14 targets (layer_norm, simd_math, loss_functions)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -390,6 +390,24 @@ test = false
 doc = false
 
 [[bin]]
+name = "layer_norm"
+path = "fuzz_targets/layer_norm.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "simd_math"
+path = "fuzz_targets/simd_math.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "loss_functions"
+path = "fuzz_targets/loss_functions.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "broadcast_shape_fuzz"
 path = "fuzz_targets/broadcast_shape_fuzz.rs"
 test = false

--- a/fuzz/fuzz_targets/layer_norm.rs
+++ b/fuzz/fuzz_targets/layer_norm.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::layer_norm::{LayerNormConfig, layer_norm, rms_norm};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz the real `bitnet_kernels::cpu::layer_norm` API with arbitrary
+/// inputs, gamma, beta, eps, and normalized shapes.
+#[derive(Arbitrary, Debug)]
+struct LayerNormFuzzInput {
+    /// Raw f32 data bytes for the input tensor.
+    data: Vec<f32>,
+    /// Raw f32 data bytes for gamma (scale).
+    gamma: Vec<f32>,
+    /// Raw f32 data bytes for beta (shift).
+    beta: Vec<f32>,
+    /// Normalized shape dimensions (each clamped to small range).
+    shape_dims: Vec<u8>,
+    /// Epsilon selector (mapped to a positive value).
+    eps_selector: u8,
+    /// Whether to include beta.
+    include_beta: bool,
+    /// Whether to enable elementwise affine.
+    elementwise_affine: bool,
+    /// Whether to also test rms_norm on the same input.
+    test_rms: bool,
+}
+
+fuzz_target!(|input: LayerNormFuzzInput| {
+    // Build normalized_shape from arbitrary dims, capped at 3 dims.
+    let shape_dims: Vec<usize> =
+        input.shape_dims.iter().take(3).map(|&d| (d as usize % 32) + 1).collect();
+    if shape_dims.is_empty() {
+        return;
+    }
+    let norm_size: usize = shape_dims.iter().product();
+    if norm_size == 0 || norm_size > 256 {
+        return;
+    }
+
+    // Pick a positive, finite eps.
+    let eps = match input.eps_selector % 4 {
+        0 => 1e-12,
+        1 => 1e-5,
+        2 => 1e-3,
+        _ => 1.0,
+    };
+
+    let config = LayerNormConfig {
+        normalized_shape: shape_dims,
+        eps,
+        elementwise_affine: input.elementwise_affine,
+    };
+
+    // Need enough data for at least one batch.
+    let data: Vec<f32> = input.data.iter().copied().take(256).collect();
+    if data.len() < norm_size || data.len() % norm_size != 0 {
+        return;
+    }
+
+    // Skip non-finite inputs — we want to fuzz logic, not float weirdness.
+    if data.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let gamma: Vec<f32> = input.gamma.iter().copied().take(norm_size).collect();
+    if gamma.len() != norm_size || gamma.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let beta_vec: Vec<f32> = input.beta.iter().copied().take(norm_size).collect();
+    let beta = if input.include_beta && beta_vec.len() == norm_size {
+        if beta_vec.iter().any(|x| !x.is_finite()) {
+            return;
+        }
+        Some(beta_vec)
+    } else {
+        None
+    };
+
+    // --- Fuzz layer_norm ---
+    let result = layer_norm(&data, &gamma, beta.as_deref(), &config);
+    match result {
+        Ok(output) => {
+            // Invariant 1: output length == input length
+            assert_eq!(output.len(), data.len());
+
+            // Invariant 2: output is finite for finite inputs
+            for (i, &v) in output.iter().enumerate() {
+                assert!(v.is_finite(), "layer_norm output non-finite at {i}: {v}");
+            }
+        }
+        Err(_) => {
+            // Validation errors are acceptable (dimension mismatches, etc.)
+        }
+    }
+
+    // --- Fuzz rms_norm ---
+    if input.test_rms {
+        let rms_result = rms_norm(&data, &gamma, &config);
+        match rms_result {
+            Ok(output) => {
+                assert_eq!(output.len(), data.len());
+                for (i, &v) in output.iter().enumerate() {
+                    assert!(v.is_finite(), "rms_norm output non-finite at {i}: {v}");
+                }
+            }
+            Err(_) => {}
+        }
+    }
+});

--- a/fuzz/fuzz_targets/loss_functions.rs
+++ b/fuzz/fuzz_targets/loss_functions.rs
@@ -1,0 +1,244 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::loss::{
+    LossReduction, binary_cross_entropy, contrastive_loss, cosine_similarity_loss,
+    cross_entropy_loss, kl_divergence, l1_loss, mse_loss, smooth_l1_loss,
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz all loss functions in `bitnet_kernels::cpu::loss` with
+/// arbitrary predictions, targets, and configuration.
+#[derive(Arbitrary, Debug)]
+struct LossFuzzInput {
+    /// Predictions / first vector.
+    predictions: Vec<f32>,
+    /// Targets / second vector.
+    targets: Vec<f32>,
+    /// Integer targets for cross-entropy.
+    class_targets: Vec<u8>,
+    /// Which loss function to fuzz (mod 8).
+    op: u8,
+    /// Reduction mode selector (mod 3).
+    reduction: u8,
+    /// Smooth-L1 beta selector.
+    beta_selector: u8,
+    /// Contrastive loss label (0 or 1).
+    contrastive_label: bool,
+    /// Contrastive margin selector.
+    margin_selector: u8,
+    /// Number of classes for cross-entropy.
+    num_classes: u8,
+}
+
+fn select_reduction(selector: u8) -> LossReduction {
+    match selector % 3 {
+        0 => LossReduction::Mean,
+        1 => LossReduction::Sum,
+        _ => LossReduction::None,
+    }
+}
+
+fuzz_target!(|input: LossFuzzInput| {
+    let reduction = select_reduction(input.reduction);
+
+    // Cap vector lengths to avoid slow iterations.
+    let preds: Vec<f32> = input.predictions.iter().copied().take(256).collect();
+    let tgts: Vec<f32> = input.targets.iter().copied().take(256).collect();
+
+    match input.op % 8 {
+        0 => {
+            // --- cross_entropy_loss ---
+            let num_classes = (input.num_classes as usize % 16) + 2;
+            let class_targets: Vec<usize> =
+                input.class_targets.iter().take(64).map(|&t| t as usize % num_classes).collect();
+            if class_targets.is_empty() {
+                return;
+            }
+            let batch_size = class_targets.len();
+            let needed = batch_size * num_classes;
+
+            // Build logits from predictions, pad if needed.
+            let logits: Vec<f32> = if preds.len() >= needed {
+                preds[..needed].to_vec()
+            } else {
+                let mut v = preds.clone();
+                v.resize(needed, 0.0);
+                v
+            };
+
+            // Skip non-finite logits.
+            if logits.iter().any(|x| !x.is_finite()) {
+                let _ = cross_entropy_loss(&logits, &class_targets, num_classes, reduction);
+                return;
+            }
+
+            match cross_entropy_loss(&logits, &class_targets, num_classes, reduction) {
+                Ok((scalar, per_sample)) => {
+                    assert_eq!(per_sample.len(), batch_size);
+                    // Cross-entropy per-sample losses should be non-negative.
+                    for (i, &l) in per_sample.iter().enumerate() {
+                        assert!(l >= -1e-5, "CE per-sample[{i}] negative: {l}");
+                        assert!(l.is_finite(), "CE per-sample[{i}] non-finite: {l}");
+                    }
+                    assert!(scalar.is_finite(), "CE scalar non-finite: {scalar}");
+                }
+                Err(_) => {}
+            }
+        }
+        1 => {
+            // --- mse_loss ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(mse_loss(&[], &[], reduction).is_err());
+                return;
+            }
+            let p = &preds[..len];
+            let t = &tgts[..len];
+            if p.iter().chain(t.iter()).any(|x| !x.is_finite()) {
+                let _ = mse_loss(p, t, reduction);
+                return;
+            }
+            match mse_loss(p, t, reduction) {
+                Ok(loss) => {
+                    assert!(loss >= 0.0, "MSE negative: {loss}");
+                    assert!(loss.is_finite(), "MSE non-finite: {loss}");
+                }
+                Err(_) => {}
+            }
+        }
+        2 => {
+            // --- l1_loss (MAE) ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(l1_loss(&[], &[], reduction).is_err());
+                return;
+            }
+            let p = &preds[..len];
+            let t = &tgts[..len];
+            if p.iter().chain(t.iter()).any(|x| !x.is_finite()) {
+                let _ = l1_loss(p, t, reduction);
+                return;
+            }
+            match l1_loss(p, t, reduction) {
+                Ok(loss) => {
+                    assert!(loss >= 0.0, "L1 negative: {loss}");
+                    assert!(loss.is_finite(), "L1 non-finite: {loss}");
+                }
+                Err(_) => {}
+            }
+        }
+        3 => {
+            // --- binary_cross_entropy ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(binary_cross_entropy(&[], &[], reduction).is_err());
+                return;
+            }
+            let p = &preds[..len];
+            let t = &tgts[..len];
+            if p.iter().chain(t.iter()).any(|x| !x.is_finite()) {
+                let _ = binary_cross_entropy(p, t, reduction);
+                return;
+            }
+            match binary_cross_entropy(p, t, reduction) {
+                Ok(loss) => {
+                    assert!(loss.is_finite(), "BCE non-finite: {loss}");
+                }
+                Err(_) => {}
+            }
+        }
+        4 => {
+            // --- smooth_l1_loss ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                return;
+            }
+            let p = &preds[..len];
+            let t = &tgts[..len];
+            let beta = match input.beta_selector % 3 {
+                0 => 0.5,
+                1 => 1.0,
+                _ => 2.0,
+            };
+            if p.iter().chain(t.iter()).any(|x| !x.is_finite()) {
+                let _ = smooth_l1_loss(p, t, beta, reduction);
+                return;
+            }
+            match smooth_l1_loss(p, t, beta, reduction) {
+                Ok(loss) => {
+                    assert!(loss >= 0.0, "Smooth L1 negative: {loss}");
+                    assert!(loss.is_finite(), "Smooth L1 non-finite: {loss}");
+                }
+                Err(_) => {}
+            }
+        }
+        5 => {
+            // --- kl_divergence ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(kl_divergence(&[], &[], reduction).is_err());
+                return;
+            }
+            let log_probs = &preds[..len];
+            let t = &tgts[..len];
+            if log_probs.iter().chain(t.iter()).any(|x| !x.is_finite()) {
+                let _ = kl_divergence(log_probs, t, reduction);
+                return;
+            }
+            // KL divergence can return any finite value — just check no panic.
+            let _ = kl_divergence(log_probs, t, reduction);
+        }
+        6 => {
+            // --- cosine_similarity_loss ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(cosine_similarity_loss(&[], &[]).is_err());
+                return;
+            }
+            let a = &preds[..len];
+            let b = &tgts[..len];
+            if a.iter().chain(b.iter()).any(|x| !x.is_finite()) {
+                let _ = cosine_similarity_loss(a, b);
+                return;
+            }
+            match cosine_similarity_loss(a, b) {
+                Ok(loss) => {
+                    assert!(loss.is_finite(), "cosine loss non-finite: {loss}");
+                    assert!(
+                        loss >= -1e-5 && loss <= 2.0 + 1e-5,
+                        "cosine loss out of [0,2]: {loss}"
+                    );
+                }
+                Err(_) => {}
+            }
+        }
+        _ => {
+            // --- contrastive_loss ---
+            let len = preds.len().min(tgts.len());
+            if len == 0 {
+                assert!(contrastive_loss(&[], &[], 1.0, 1.0).is_err());
+                return;
+            }
+            let a = &preds[..len];
+            let b = &tgts[..len];
+            let label = if input.contrastive_label { 1.0 } else { 0.0 };
+            let margin = match input.margin_selector % 3 {
+                0 => 0.5,
+                1 => 1.0,
+                _ => 5.0,
+            };
+            if a.iter().chain(b.iter()).any(|x| !x.is_finite()) {
+                let _ = contrastive_loss(a, b, label, margin);
+                return;
+            }
+            match contrastive_loss(a, b, label, margin) {
+                Ok(loss) => {
+                    assert!(loss >= 0.0, "contrastive loss negative: {loss}");
+                    assert!(loss.is_finite(), "contrastive loss non-finite: {loss}");
+                }
+                Err(_) => {}
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/simd_math.rs
+++ b/fuzz/fuzz_targets/simd_math.rs
@@ -1,0 +1,136 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::simd_math::{
+    fast_exp_f32, fast_sigmoid_f32, fast_tanh_f32, simd_dot_product, simd_vector_add,
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz the real SIMD math dispatch functions (AVX2 → scalar fallback)
+/// with arbitrary f32 vectors of varying lengths.
+#[derive(Arbitrary, Debug)]
+struct SimdMathInput {
+    /// First vector of f32 values.
+    a: Vec<f32>,
+    /// Second vector of f32 values (for binary ops).
+    b: Vec<f32>,
+    /// Which operation to fuzz (mod 5).
+    op: u8,
+}
+
+fuzz_target!(|input: SimdMathInput| {
+    let a: Vec<f32> = input.a.iter().copied().take(256).collect();
+    let b: Vec<f32> = input.b.iter().copied().take(256).collect();
+
+    match input.op % 5 {
+        0 => {
+            // --- dot product: requires equal lengths ---
+            let len = a.len().min(b.len());
+            if len == 0 {
+                // Empty dot product should return 0.
+                assert_eq!(simd_dot_product(&[], &[]), 0.0);
+                return;
+            }
+            let a = &a[..len];
+            let b = &b[..len];
+
+            // Skip if any input is non-finite.
+            if a.iter().chain(b.iter()).any(|x| !x.is_finite()) {
+                // Still must not panic.
+                let _ = simd_dot_product(a, b);
+                return;
+            }
+
+            let result = simd_dot_product(a, b);
+
+            // Scalar reference for comparison.
+            let reference: f32 = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum();
+
+            // Both should be finite for finite inputs (barring overflow).
+            if reference.is_finite() {
+                let tol = reference.abs() * 1e-4 + 1e-4;
+                assert!(
+                    (result - reference).abs() < tol,
+                    "dot product mismatch: simd={result}, scalar={reference}, len={len}"
+                );
+            }
+        }
+        1 => {
+            // --- vector add: requires equal lengths ---
+            let len = a.len().min(b.len());
+            if len == 0 {
+                assert!(simd_vector_add(&[], &[]).is_empty());
+                return;
+            }
+            let a = &a[..len];
+            let b = &b[..len];
+
+            let result = simd_vector_add(a, b);
+            assert_eq!(result.len(), len);
+
+            // Element-wise check for finite inputs.
+            for (i, ((&ai, &bi), &ri)) in a.iter().zip(b.iter()).zip(result.iter()).enumerate() {
+                if ai.is_finite() && bi.is_finite() {
+                    let expected = ai + bi;
+                    if expected.is_finite() {
+                        assert!(
+                            (ri - expected).abs() < 1e-5,
+                            "vector_add mismatch at {i}: {ri} vs {expected}"
+                        );
+                    }
+                }
+            }
+        }
+        2 => {
+            // --- fast_exp_f32 ---
+            let result = fast_exp_f32(&a);
+            assert_eq!(result.len(), a.len());
+
+            for (i, (&input_val, &out)) in a.iter().zip(result.iter()).enumerate() {
+                if input_val.is_nan() {
+                    assert!(out.is_nan(), "exp(NaN) should be NaN at {i}");
+                } else if input_val.is_finite() {
+                    let ref_val = input_val.exp();
+                    if ref_val.is_finite() && ref_val > 1e-30 {
+                        let rel = ((out - ref_val) / ref_val).abs();
+                        assert!(rel < 1e-4, "exp({input_val}) rel error {rel} at {i}");
+                    }
+                }
+            }
+        }
+        3 => {
+            // --- fast_tanh_f32 ---
+            let result = fast_tanh_f32(&a);
+            assert_eq!(result.len(), a.len());
+
+            for (i, (&input_val, &out)) in a.iter().zip(result.iter()).enumerate() {
+                if input_val.is_nan() {
+                    assert!(out.is_nan(), "tanh(NaN) should be NaN at {i}");
+                } else if input_val.is_finite() {
+                    // tanh output must be in [-1, 1].
+                    assert!(
+                        out >= -1.0 - 1e-5 && out <= 1.0 + 1e-5,
+                        "tanh({input_val}) = {out} out of range at {i}"
+                    );
+                }
+            }
+        }
+        _ => {
+            // --- fast_sigmoid_f32 ---
+            let result = fast_sigmoid_f32(&a);
+            assert_eq!(result.len(), a.len());
+
+            for (i, (&input_val, &out)) in a.iter().zip(result.iter()).enumerate() {
+                if input_val.is_nan() {
+                    assert!(out.is_nan(), "sigmoid(NaN) should be NaN at {i}");
+                } else if input_val.is_finite() {
+                    // sigmoid output must be in [0, 1].
+                    assert!(
+                        out >= -1e-5 && out <= 1.0 + 1e-5,
+                        "sigmoid({input_val}) = {out} out of range at {i}"
+                    );
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Fuzz Wave 14

Add three new fuzz targets exercising real crate APIs:

### New Targets

- **`layer_norm`** — Fuzzes `bitnet_kernels::cpu::layer_norm::{layer_norm, rms_norm}` with arbitrary inputs, gamma, beta, eps, and normalized shapes. Validates output dimension and finiteness invariants.

- **`simd_math`** — Fuzzes `bitnet_kernels::cpu::simd_math` dispatch functions (`simd_dot_product`, `simd_vector_add`, `fast_exp_f32`, `fast_tanh_f32`, `fast_sigmoid_f32`) with arbitrary f32 vectors. Cross-checks SIMD results against scalar references.

- **`loss_functions`** — Fuzzes all 8 loss functions in `bitnet_kernels::cpu::loss` (cross-entropy, MSE, L1, BCE, smooth L1, KL divergence, cosine similarity, contrastive) with arbitrary predictions/targets. Validates non-negativity, finiteness, and range invariants.

### Design

- Input sizes capped with `.take(256)` to bound iteration counts
- Non-finite (NaN/Inf) inputs are handled gracefully: either skipped or used to verify no-panic behavior
- Invariants checked: output dimensions, finiteness, value ranges, SIMD/scalar parity