### PR TITLE
feat(kernels): add CUDA RoPE kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -63,7 +63,14 @@ pub use layernorm::{
 };
 pub use qk256_gemv::{Qk256GemvConfig, launch_qk256_gemv};
 pub use rmsnorm::{RmsNormConfig, launch_rmsnorm};
-pub use rope::{RopeConfig, compute_sincos_table, launch_rope, rope_forward, rope_forward_cpu};
+pub use rope::{
+    RopeConfig, apply_rope, apply_rope_batched, build_rope_freqs, compute_sincos_table,
+    launch_rope, launch_rope_backward, rope_backward, rope_backward_cpu, rope_forward,
+    rope_forward_cpu,
+};
+
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub use rope::{ROPE_BACKWARD_KERNEL_SRC, ROPE_FORWARD_KERNEL_SRC};
 
 // Re-export scatter/gather types from the crate-level module (always compiled).
 pub use crate::scatter_gather::{


### PR DESCRIPTION
## Summary

Add comprehensive CUDA RoPE (Rotary Position Embedding) kernel module with forward/backward pass support, interleaved layout, explicit position arrays, and batched operations.

## New Features

- **CUDA kernel source strings** (`rope_forward_f32`, `rope_backward_f32`) with interleaved layout support and `__sincosf` on-the-fly computation
- **Interleaved layout** (GPT-NeoX style) option on `RopeConfig` — pairs at `(i, i+head_dim/2)` instead of `(2i, 2i+1)`
- **`apply_rope()`** — explicit per-token position array with GPU→CPU fallback, enabling non-contiguous KV-cache positions
- **`apply_rope_batched()`** — batched tensor rotation across multiple sequences with CPU fallback
- **`build_rope_freqs()`** — standalone frequency table precomputation without constructing a full `RopeConfig`
- **Backward pass** (`rope_backward_cpu` / `launch_rope_backward` / `rope_backward`) — rotation matrix transpose for gradient computation
- Updated `mod.rs` re-exports including GPU-gated kernel source strings (`ROPE_FORWARD_KERNEL_SRC`, `ROPE_BACKWARD_KERNEL_SRC`)

## Tests

58 total tests (28 new):
- Numerical accuracy (known angle values, sincos table consistency)
- Norm preservation (rotation invariant across forward and backward)
- Interleaved layout (identity, norm, differs from default)
- Backward roundtrip (`backward(forward(x)) ≈ x`)
- Batched operations (single/multi batch parity, per-batch independence)
- Frequency tables (length, position-zero, custom theta, config parity)
- Explicit positions (sequential matches forward, non-contiguous, multi-head)
- 3 GPU-only tests: `#[ignore = "requires CUDA runtime"]`

## Feature gating

All GPU paths use the unified predicate `#[cfg(any(feature = "gpu", feature = "cuda"))]`. CPU fallbacks are always available within the `cuda` module (which itself is gated behind the `gpu`/`cuda` feature in `lib.rs`).