### PR TITLE
fix(gpu-hal): re-export HalError and HalResult from crate root

### DIFF
--- a/crates/bitnet-gpu-hal/src/lib.rs
+++ b/crates/bitnet-gpu-hal/src/lib.rs
@@ -18,6 +18,7 @@ pub mod device_abstraction;
 pub mod embedding_layer;
 pub mod error_taxonomy;
 pub mod hal_traits;
+pub use hal_traits::{HalError, HalResult};
 
 // === Compute Kernels ===
 pub mod activation_functions;


### PR DESCRIPTION
Several gpu-hal feature PRs import `crate::HalError` which is defined in `hal_traits` but not re-exported from the crate root. This causes documentation and grid-check failures.

Adds `pub use hal_traits::{HalError, HalResult};` to unblock ~10 gpu-hal PRs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>