### PR TITLE
test(gguf,trace): add 48 edge-case tests for GGUF parsing and trace types

### DIFF
--- a/crates/bitnet-gguf/tests/gguf_types_edge_cases.rs
+++ b/crates/bitnet-gguf/tests/gguf_types_edge_cases.rs
@@ -1,0 +1,269 @@
+//! Edge-case tests for bitnet-gguf: magic validation, version reading,
+//! header parsing, GgufValueType enum, GgufValue variants, and file info.
+
+use bitnet_gguf::{
+    GGUF_MAGIC, GGUF_VERSION_MAX, GGUF_VERSION_MIN, GgufFileInfo, GgufMetadataKv, GgufValue,
+    GgufValueType, TensorInfo, check_magic, parse_header, read_version,
+};
+
+// ===========================================================================
+// Constants
+// ===========================================================================
+
+#[test]
+fn gguf_magic_bytes() {
+    assert_eq!(&GGUF_MAGIC, b"GGUF");
+}
+
+#[test]
+fn gguf_version_range() {
+    assert!(GGUF_VERSION_MIN <= GGUF_VERSION_MAX);
+    assert_eq!(GGUF_VERSION_MIN, 2);
+    assert_eq!(GGUF_VERSION_MAX, 3);
+}
+
+// ===========================================================================
+// check_magic
+// ===========================================================================
+
+#[test]
+fn check_magic_valid() {
+    assert!(check_magic(b"GGUF"));
+}
+
+#[test]
+fn check_magic_valid_with_extra() {
+    assert!(check_magic(b"GGUF\x03\x00\x00\x00"));
+}
+
+#[test]
+fn check_magic_invalid() {
+    assert!(!check_magic(b"LLAM"));
+}
+
+#[test]
+fn check_magic_too_short() {
+    assert!(!check_magic(b"GGU"));
+}
+
+#[test]
+fn check_magic_empty() {
+    assert!(!check_magic(b""));
+}
+
+// ===========================================================================
+// read_version
+// ===========================================================================
+
+#[test]
+fn read_version_v2() {
+    let buf = *b"GGUF\x02\x00\x00\x00";
+    assert_eq!(read_version(&buf), Some(2));
+}
+
+#[test]
+fn read_version_v3() {
+    let buf = *b"GGUF\x03\x00\x00\x00";
+    assert_eq!(read_version(&buf), Some(3));
+}
+
+#[test]
+fn read_version_too_short() {
+    assert_eq!(read_version(b"GGUF\x02"), None);
+}
+
+#[test]
+fn read_version_bad_magic() {
+    assert_eq!(read_version(b"LLAM\x02\x00\x00\x00"), None);
+}
+
+// ===========================================================================
+// parse_header
+// ===========================================================================
+
+fn gguf_v3_header(tensors: u64, metadata: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&3u32.to_le_bytes());
+    buf.extend_from_slice(&tensors.to_le_bytes());
+    buf.extend_from_slice(&metadata.to_le_bytes());
+    buf.extend_from_slice(&32u32.to_le_bytes()); // alignment
+    buf
+}
+
+fn gguf_v2_header(tensors: u64, metadata: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&2u32.to_le_bytes());
+    buf.extend_from_slice(&tensors.to_le_bytes());
+    buf.extend_from_slice(&metadata.to_le_bytes());
+    buf
+}
+
+#[test]
+fn parse_header_v3() {
+    let buf = gguf_v3_header(10, 5);
+    let info = parse_header(&buf).unwrap();
+    assert_eq!(info.version, 3);
+    assert_eq!(info.tensor_count, 10);
+    assert_eq!(info.metadata_count, 5);
+    assert_eq!(info.alignment, 32);
+}
+
+#[test]
+fn parse_header_v2() {
+    let buf = gguf_v2_header(8, 3);
+    let info = parse_header(&buf).unwrap();
+    assert_eq!(info.version, 2);
+    assert_eq!(info.tensor_count, 8);
+    assert_eq!(info.metadata_count, 3);
+    assert_eq!(info.alignment, 32); // default
+}
+
+#[test]
+fn parse_header_too_short() {
+    assert!(parse_header(b"GGUF\x03\x00").is_err());
+}
+
+#[test]
+fn parse_header_bad_magic() {
+    let mut buf = gguf_v3_header(0, 0);
+    buf[0] = b'X';
+    assert!(parse_header(&buf).is_err());
+}
+
+#[test]
+fn parse_header_unsupported_version() {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&99u32.to_le_bytes());
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    buf.extend_from_slice(&0u64.to_le_bytes());
+    assert!(parse_header(&buf).is_err());
+}
+
+#[test]
+fn parse_header_zero_counts() {
+    let buf = gguf_v3_header(0, 0);
+    let info = parse_header(&buf).unwrap();
+    assert_eq!(info.tensor_count, 0);
+    assert_eq!(info.metadata_count, 0);
+}
+
+// ===========================================================================
+// GgufValueType
+// ===========================================================================
+
+#[test]
+fn value_type_from_u32_all_valid() {
+    for i in 0..=12 {
+        assert!(GgufValueType::from_u32(i).is_some(), "expected Some for {i}");
+    }
+}
+
+#[test]
+fn value_type_from_u32_invalid() {
+    assert!(GgufValueType::from_u32(13).is_none());
+    assert!(GgufValueType::from_u32(255).is_none());
+}
+
+#[test]
+fn value_type_specific() {
+    assert_eq!(GgufValueType::from_u32(0), Some(GgufValueType::Uint8));
+    assert_eq!(GgufValueType::from_u32(6), Some(GgufValueType::Float32));
+    assert_eq!(GgufValueType::from_u32(8), Some(GgufValueType::String));
+    assert_eq!(GgufValueType::from_u32(12), Some(GgufValueType::Float64));
+}
+
+// ===========================================================================
+// GgufValue
+// ===========================================================================
+
+#[test]
+fn gguf_value_uint32_debug() {
+    let v = GgufValue::Uint32(42);
+    assert!(format!("{v:?}").contains("42"));
+}
+
+#[test]
+fn gguf_value_string_debug() {
+    let v = GgufValue::String("hello".into());
+    assert!(format!("{v:?}").contains("hello"));
+}
+
+#[test]
+fn gguf_value_array_debug() {
+    let v =
+        GgufValue::Array(GgufValueType::Uint32, vec![GgufValue::Uint32(1), GgufValue::Uint32(2)]);
+    let dbg = format!("{v:?}");
+    assert!(dbg.contains("Array"));
+}
+
+#[test]
+fn gguf_value_bool() {
+    let v = GgufValue::Bool(true);
+    let cloned = v.clone();
+    assert!(format!("{cloned:?}").contains("true"));
+}
+
+#[test]
+fn gguf_value_float64() {
+    let v = GgufValue::Float64(3.14);
+    let dbg = format!("{v:?}");
+    assert!(dbg.contains("3.14"));
+}
+
+// ===========================================================================
+// GgufMetadataKv
+// ===========================================================================
+
+#[test]
+fn metadata_kv_construction() {
+    let kv = GgufMetadataKv {
+        key: "general.architecture".into(),
+        value: GgufValue::String("llama".into()),
+    };
+    assert_eq!(kv.key, "general.architecture");
+}
+
+// ===========================================================================
+// TensorInfo
+// ===========================================================================
+
+#[test]
+fn tensor_info_construction() {
+    let ti = TensorInfo {
+        name: "blk.0.attn_q.weight".into(),
+        n_dims: 2,
+        dims: vec![4096, 4096],
+        dtype: 1, // F16
+        offset: 0,
+    };
+    assert_eq!(ti.n_dims, 2);
+    assert_eq!(ti.dims.len(), 2);
+}
+
+#[test]
+fn tensor_info_clone() {
+    let ti = TensorInfo {
+        name: "embedding".into(),
+        n_dims: 2,
+        dims: vec![32000, 4096],
+        dtype: 0,
+        offset: 1024,
+    };
+    let cloned = ti.clone();
+    assert_eq!(cloned.name, ti.name);
+    assert_eq!(cloned.offset, ti.offset);
+}
+
+// ===========================================================================
+// GgufFileInfo
+// ===========================================================================
+
+#[test]
+fn file_info_debug() {
+    let info = GgufFileInfo { version: 3, tensor_count: 100, metadata_count: 20, alignment: 32 };
+    let dbg = format!("{info:?}");
+    assert!(dbg.contains("100"));
+}

--- a/crates/bitnet-trace/tests/trace_types_edge_cases.rs
+++ b/crates/bitnet-trace/tests/trace_types_edge_cases.rs
@@ -1,0 +1,228 @@
+//! Edge-case tests for bitnet-trace: TraceRecord, TraceComparison,
+//! TraceSink, and compare_records.
+
+use bitnet_trace::{TraceComparison, TraceRecord, TraceSink, compare_records};
+
+// ===========================================================================
+// TraceRecord
+// ===========================================================================
+
+fn sample_record(name: &str, rms: f64) -> TraceRecord {
+    TraceRecord {
+        name: name.to_string(),
+        shape: vec![1, 2560],
+        dtype: "F32".to_string(),
+        blake3: "abcdef0123456789".to_string(),
+        rms,
+        num_elements: 2560,
+        seq: None,
+        layer: None,
+        stage: None,
+    }
+}
+
+#[test]
+fn trace_record_serde_roundtrip() {
+    let rec = sample_record("layer_0", 0.998);
+    let json = serde_json::to_string(&rec).unwrap();
+    let back: TraceRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(rec.name, back.name);
+    assert_eq!(rec.shape, back.shape);
+    assert_eq!(rec.rms, back.rms);
+}
+
+#[test]
+fn trace_record_optional_fields_omitted() {
+    let rec = sample_record("test", 1.0);
+    let json = serde_json::to_string(&rec).unwrap();
+    assert!(!json.contains("seq"));
+    assert!(!json.contains("layer"));
+    assert!(!json.contains("stage"));
+}
+
+#[test]
+fn trace_record_optional_fields_present() {
+    let rec = TraceRecord {
+        name: "attn_q".into(),
+        shape: vec![4, 128],
+        dtype: "F32".into(),
+        blake3: "hash123".into(),
+        rms: 0.5,
+        num_elements: 512,
+        seq: Some(0),
+        layer: Some(3),
+        stage: Some("q_proj".into()),
+    };
+    let json = serde_json::to_string(&rec).unwrap();
+    assert!(json.contains("\"seq\":0"));
+    assert!(json.contains("\"layer\":3"));
+    assert!(json.contains("q_proj"));
+}
+
+// ===========================================================================
+// compare_records
+// ===========================================================================
+
+#[test]
+fn compare_identical_records() {
+    let a = sample_record("layer", 0.998);
+    let b = sample_record("layer", 0.998);
+    let cmp = compare_records(&a, &b, 0.001);
+    assert!(cmp.is_ok());
+    assert!(cmp.shapes_match);
+    assert!(cmp.dtypes_match);
+    assert!(cmp.hashes_match);
+    assert!(cmp.rms_diff < f64::EPSILON);
+}
+
+#[test]
+fn compare_different_shapes() {
+    let a = sample_record("layer", 0.998);
+    let mut b = sample_record("layer", 0.998);
+    b.shape = vec![2, 1280];
+    let cmp = compare_records(&a, &b, 0.001);
+    assert!(!cmp.shapes_match);
+    assert!(!cmp.is_ok());
+}
+
+#[test]
+fn compare_different_dtypes() {
+    let a = sample_record("layer", 0.998);
+    let mut b = sample_record("layer", 0.998);
+    b.dtype = "F16".into();
+    let cmp = compare_records(&a, &b, 0.001);
+    assert!(!cmp.dtypes_match);
+    assert!(!cmp.is_ok());
+}
+
+#[test]
+fn compare_different_hashes() {
+    let a = sample_record("layer", 0.998);
+    let mut b = sample_record("layer", 0.998);
+    b.blake3 = "different_hash".into();
+    let cmp = compare_records(&a, &b, 0.001);
+    assert!(!cmp.hashes_match);
+    // is_ok doesn't require hash match—only shapes/dtypes/rms
+    assert!(cmp.is_ok());
+}
+
+#[test]
+fn compare_rms_within_tolerance() {
+    let a = sample_record("layer", 1.000);
+    let b = sample_record("layer", 1.0005);
+    let cmp = compare_records(&a, &b, 0.001);
+    assert!(cmp.rms_within_tolerance);
+    assert!(cmp.is_ok());
+}
+
+#[test]
+fn compare_rms_outside_tolerance() {
+    let a = sample_record("layer", 1.0);
+    let b = sample_record("layer", 1.1);
+    let cmp = compare_records(&a, &b, 0.01);
+    assert!(!cmp.rms_within_tolerance);
+    assert!(!cmp.is_ok());
+}
+
+// ===========================================================================
+// TraceComparison
+// ===========================================================================
+
+#[test]
+fn trace_comparison_is_ok_all_match() {
+    let cmp = TraceComparison {
+        shapes_match: true,
+        dtypes_match: true,
+        hashes_match: true,
+        rms_diff: 0.0,
+        rms_within_tolerance: true,
+    };
+    assert!(cmp.is_ok());
+}
+
+#[test]
+fn trace_comparison_is_ok_requires_shapes() {
+    let cmp = TraceComparison {
+        shapes_match: false,
+        dtypes_match: true,
+        hashes_match: true,
+        rms_diff: 0.0,
+        rms_within_tolerance: true,
+    };
+    assert!(!cmp.is_ok());
+}
+
+#[test]
+fn trace_comparison_clone_eq() {
+    let cmp = TraceComparison {
+        shapes_match: true,
+        dtypes_match: true,
+        hashes_match: false,
+        rms_diff: 0.05,
+        rms_within_tolerance: true,
+    };
+    let cloned = cmp.clone();
+    assert_eq!(cmp, cloned);
+}
+
+// ===========================================================================
+// TraceSink
+// ===========================================================================
+
+#[test]
+fn trace_sink_new_empty() {
+    let sink = TraceSink::new();
+    assert!(sink.is_empty());
+    assert_eq!(sink.len(), 0);
+}
+
+#[test]
+fn trace_sink_append_and_len() {
+    let mut sink = TraceSink::new();
+    sink.append(sample_record("a", 1.0));
+    sink.append(sample_record("b", 2.0));
+    assert_eq!(sink.len(), 2);
+    assert!(!sink.is_empty());
+}
+
+#[test]
+fn trace_sink_iter() {
+    let mut sink = TraceSink::new();
+    sink.append(sample_record("first", 1.0));
+    sink.append(sample_record("second", 2.0));
+    let names: Vec<_> = sink.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, &["first", "second"]);
+}
+
+#[test]
+fn trace_sink_filter_by_name() {
+    let mut sink = TraceSink::new();
+    sink.append(sample_record("blk0_attn", 1.0));
+    sink.append(sample_record("blk0_ffn", 2.0));
+    sink.append(sample_record("blk1_attn", 3.0));
+    let attn = sink.filter_by_name("attn");
+    assert_eq!(attn.len(), 2);
+}
+
+#[test]
+fn trace_sink_filter_no_match() {
+    let mut sink = TraceSink::new();
+    sink.append(sample_record("layer_0", 1.0));
+    let result = sink.filter_by_name("nonexistent");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn trace_sink_clear() {
+    let mut sink = TraceSink::new();
+    sink.append(sample_record("a", 1.0));
+    sink.append(sample_record("b", 2.0));
+    sink.clear();
+    assert!(sink.is_empty());
+}
+
+#[test]
+fn trace_sink_default() {
+    let sink = TraceSink::default();
+    assert!(sink.is_empty());
+}


### PR DESCRIPTION
## Summary
Add 48 edge-case tests across bitnet-gguf (29 tests) and bitnet-trace (19 tests).

## bitnet-gguf Tests (29)
- **Constants** (2): GGUF_MAGIC bytes, version range
- **check_magic** (5): valid, with extra bytes, invalid, too short, empty
- **read_version** (4): v2, v3, too short, bad magic
- **parse_header** (6): v3, v2, too short, bad magic, unsupported version, zero counts
- **GgufValueType** (3): all valid discriminants (0-12), invalid, specific mappings
- **GgufValue** (5): Uint32/String/Array/Bool/Float64 Debug
- **GgufMetadataKv** (1): construction
- **TensorInfo** (2): construction, clone
- **GgufFileInfo** (1): debug

## bitnet-trace Tests (19)
- **TraceRecord** (3): serde roundtrip, optional fields omitted, optional fields present
- **compare_records** (6): identical, different shapes/dtypes/hashes, RMS within/outside tolerance
- **TraceComparison** (3): is_ok all match, requires shapes, clone eq
- **TraceSink** (7): new empty, append+len, iter, filter_by_name, filter no match, clear, default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive edge-case test coverage for GGUF file format validation, including magic number validation, version handling, header parsing, and data structure integrity checks.
  * Expanded test suite for trace record serialization, comparison operations, and sink management to ensure data integrity and correct behavior across various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->