### PR TITLE
fix(kernels): gate Avx2Kernel import behind target_arch x86_64

### DIFF
--- a/crates/bitnet-kernels/src/gpu/benchmark.rs
+++ b/crates/bitnet-kernels/src/gpu/benchmark.rs
@@ -4,9 +4,11 @@
 //! GPU and CPU kernel performance across different matrix sizes and
 //! configurations.
 
+#[cfg(target_arch = "x86_64")]
+use crate::cpu::x86::Avx2Kernel;
 use crate::gpu::cuda::CudaKernel;
 use crate::gpu::validation::PerformanceResult;
-use crate::{KernelProvider, cpu::fallback::FallbackKernel, cpu::x86::Avx2Kernel};
+use crate::{KernelProvider, cpu::fallback::FallbackKernel};
 use bitnet_common::Result;
 
 use std::time::Instant;


### PR DESCRIPTION
## P0: Unblocks ~96 PRs

The `gpu/benchmark.rs` module imported `cpu::x86::Avx2Kernel` unconditionally, but the `cpu::x86` module is gated behind `#[cfg(target_arch = "x86_64")]`. This caused BDD Grid Check failures on ARM targets (including CI), blocking CI Core Success for nearly all open PRs.

### Fix
Gate the import with `#[cfg(target_arch = "x86_64")]`, matching the existing conditional usage pattern in the same file.

### Impact
- Unblocks BDD Grid Check → CI Core Success → merge readiness for ~96 PRs
- No behavior change on x86_64 targets

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>