### PR TITLE
test(kernels): add 98 CPU kernel edge-case tests for activations, layer norm, embedding, RoPE

### DIFF
--- a/crates/bitnet-kernels/tests/cpu_activations_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_activations_edge_cases.rs
@@ -1,0 +1,422 @@
+//! Edge-case tests for CPU activation function kernels.
+//!
+//! Tests cover boundary conditions, special values (NaN, infinity, zero),
+//! mathematical properties, and consistency between scalar/batch variants.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::activations::{
+    ActivationType, activate, activate_derivative, activate_inplace, elu, gelu, gelu_tanh,
+    hard_sigmoid, hard_swish, leaky_relu, mish, quick_gelu, relu, selu, sigmoid, silu, softplus,
+    swish, tanh_act,
+};
+
+// ── ReLU ─────────────────────────────────────────────────────────────
+
+#[test]
+fn relu_positive() {
+    assert_eq!(relu(5.0), 5.0);
+}
+
+#[test]
+fn relu_negative() {
+    assert_eq!(relu(-5.0), 0.0);
+}
+
+#[test]
+fn relu_zero() {
+    assert_eq!(relu(0.0), 0.0);
+}
+
+#[test]
+fn relu_very_large() {
+    assert_eq!(relu(1e38), 1e38);
+}
+
+#[test]
+fn relu_neg_zero() {
+    assert_eq!(relu(-0.0), 0.0);
+}
+
+// ── Leaky ReLU ───────────────────────────────────────────────────────
+
+#[test]
+fn leaky_relu_positive() {
+    assert_eq!(leaky_relu(5.0, 0.01), 5.0);
+}
+
+#[test]
+fn leaky_relu_negative() {
+    assert!((leaky_relu(-5.0, 0.01) - (-0.05)).abs() < 1e-6);
+}
+
+#[test]
+fn leaky_relu_zero_alpha() {
+    // alpha=0 makes it identical to ReLU
+    assert_eq!(leaky_relu(-5.0, 0.0), 0.0);
+    assert_eq!(leaky_relu(5.0, 0.0), 5.0);
+}
+
+#[test]
+fn leaky_relu_alpha_one_is_identity() {
+    assert!((leaky_relu(-3.0, 1.0) - (-3.0)).abs() < 1e-6);
+    assert!((leaky_relu(3.0, 1.0) - 3.0).abs() < 1e-6);
+}
+
+// ── Sigmoid ──────────────────────────────────────────────────────────
+
+#[test]
+fn sigmoid_zero_is_half() {
+    assert!((sigmoid(0.0) - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn sigmoid_large_positive_near_one() {
+    assert!((sigmoid(100.0) - 1.0).abs() < 1e-5);
+}
+
+#[test]
+fn sigmoid_large_negative_near_zero() {
+    assert!(sigmoid(-100.0) < 1e-5);
+}
+
+#[test]
+fn sigmoid_symmetry() {
+    // sigmoid(-x) = 1 - sigmoid(x)
+    let x = 2.5;
+    assert!((sigmoid(-x) - (1.0 - sigmoid(x))).abs() < 1e-6);
+}
+
+#[test]
+fn sigmoid_output_range() {
+    for &x in &[-100.0, -10.0, -1.0, 0.0, 1.0, 10.0, 100.0] {
+        let y = sigmoid(x);
+        assert!(y >= 0.0 && y <= 1.0, "sigmoid({x}) = {y} out of [0,1]");
+    }
+}
+
+// ── Tanh ─────────────────────────────────────────────────────────────
+
+#[test]
+fn tanh_zero() {
+    assert!((tanh_act(0.0) - 0.0).abs() < 1e-6);
+}
+
+#[test]
+fn tanh_large_positive() {
+    assert!((tanh_act(100.0) - 1.0).abs() < 1e-5);
+}
+
+#[test]
+fn tanh_large_negative() {
+    assert!((tanh_act(-100.0) - (-1.0)).abs() < 1e-5);
+}
+
+#[test]
+fn tanh_odd_symmetry() {
+    let x = 1.5;
+    assert!((tanh_act(-x) - (-tanh_act(x))).abs() < 1e-6);
+}
+
+// ── GELU ─────────────────────────────────────────────────────────────
+
+#[test]
+fn gelu_zero() {
+    assert!(gelu(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn gelu_positive_large() {
+    // gelu(x) ≈ x for large x
+    assert!((gelu(10.0) - 10.0).abs() < 0.01);
+}
+
+#[test]
+fn gelu_negative_large() {
+    // gelu(x) ≈ 0 for large negative x
+    assert!(gelu(-10.0).abs() < 0.01);
+}
+
+#[test]
+fn gelu_tanh_approx_close_to_gelu() {
+    let x = 1.0;
+    assert!((gelu(x) - gelu_tanh(x)).abs() < 0.02);
+}
+
+// ── SiLU / Swish ─────────────────────────────────────────────────────
+
+#[test]
+fn silu_zero() {
+    assert!(silu(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn silu_positive() {
+    // silu(x) = x * sigmoid(x), for x=1: 1 * sigmoid(1) ≈ 0.7311
+    assert!((silu(1.0) - 0.7311).abs() < 0.01);
+}
+
+#[test]
+fn silu_negative_small_magnitude() {
+    // silu has a minimum around x ≈ -1.278
+    let y = silu(-1.278);
+    assert!(y < 0.0);
+}
+
+#[test]
+fn swish_beta_one_equals_silu() {
+    for &x in &[-2.0, -1.0, 0.0, 1.0, 2.0] {
+        assert!(
+            (swish(x, 1.0) - silu(x)).abs() < 1e-6,
+            "swish(x={x}, beta=1) should equal silu(x={x})"
+        );
+    }
+}
+
+#[test]
+fn swish_beta_zero_is_half_x() {
+    // swish(x, 0) = x * sigmoid(0) = x * 0.5
+    assert!((swish(4.0, 0.0) - 2.0).abs() < 1e-6);
+}
+
+// ── Hard Sigmoid / Hard Swish ────────────────────────────────────────
+
+#[test]
+fn hard_sigmoid_zero() {
+    assert!((hard_sigmoid(0.0) - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn hard_sigmoid_clamps_high() {
+    assert!((hard_sigmoid(10.0) - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn hard_sigmoid_clamps_low() {
+    assert!((hard_sigmoid(-10.0) - 0.0).abs() < 1e-6);
+}
+
+#[test]
+fn hard_swish_zero() {
+    assert!(hard_swish(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn hard_swish_large_positive_approximates_x() {
+    // hard_swish(x) ≈ x for large x (since hard_sigmoid → 1)
+    assert!((hard_swish(10.0) - 10.0).abs() < 1e-5);
+}
+
+// ── Softplus ─────────────────────────────────────────────────────────
+
+#[test]
+fn softplus_zero() {
+    // softplus(0) = ln(2) ≈ 0.6931
+    assert!((softplus(0.0) - 0.6931).abs() < 0.001);
+}
+
+#[test]
+fn softplus_large_positive_approx_x() {
+    // softplus(x) ≈ x for large x
+    assert!((softplus(100.0) - 100.0).abs() < 0.01);
+}
+
+#[test]
+fn softplus_always_non_negative() {
+    for &x in &[-10.0, -1.0, 0.0, 1.0, 10.0] {
+        assert!(softplus(x) > 0.0, "softplus({x}) should be positive");
+    }
+    // Very negative values may underflow to 0 due to exp precision
+    assert!(softplus(-100.0) >= 0.0);
+}
+
+// ── Mish ─────────────────────────────────────────────────────────────
+
+#[test]
+fn mish_zero() {
+    // mish(0) = 0 * tanh(ln(2)) ≈ 0
+    assert!(mish(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn mish_large_positive_approx_x() {
+    assert!((mish(10.0) - 10.0).abs() < 0.01);
+}
+
+// ── ELU ──────────────────────────────────────────────────────────────
+
+#[test]
+fn elu_positive() {
+    assert_eq!(elu(5.0, 1.0), 5.0);
+}
+
+#[test]
+fn elu_negative() {
+    // elu(-1, alpha=1) = 1*(exp(-1)-1) ≈ -0.6321
+    assert!((elu(-1.0, 1.0) - (-0.6321)).abs() < 0.001);
+}
+
+#[test]
+fn elu_zero() {
+    assert_eq!(elu(0.0, 1.0), 0.0);
+}
+
+#[test]
+fn elu_negative_bounded() {
+    // For x → -inf, elu → -alpha
+    assert!((elu(-100.0, 2.0) - (-2.0)).abs() < 0.01);
+}
+
+// ── SELU ─────────────────────────────────────────────────────────────
+
+#[test]
+fn selu_positive() {
+    // SELU lambda ≈ 1.0507, for positive x: selu(x) = lambda * x
+    let y = selu(1.0);
+    assert!((y - 1.0507).abs() < 0.001);
+}
+
+#[test]
+fn selu_zero() {
+    assert!(selu(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn selu_negative() {
+    let y = selu(-1.0);
+    assert!(y < 0.0);
+}
+
+// ── Quick GELU ───────────────────────────────────────────────────────
+
+#[test]
+fn quick_gelu_zero() {
+    assert!(quick_gelu(0.0).abs() < 1e-6);
+}
+
+#[test]
+fn quick_gelu_positive_large() {
+    assert!((quick_gelu(10.0) - 10.0).abs() < 0.01);
+}
+
+// ── Batch activate ───────────────────────────────────────────────────
+
+#[test]
+fn activate_empty_input() {
+    let result = activate(&[], ActivationType::ReLU);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn activate_relu_batch() {
+    let input = vec![-2.0, -1.0, 0.0, 1.0, 2.0];
+    let result = activate(&input, ActivationType::ReLU);
+    assert_eq!(result, vec![0.0, 0.0, 0.0, 1.0, 2.0]);
+}
+
+#[test]
+fn activate_silu_batch() {
+    let input = vec![0.0, 1.0, -1.0];
+    let result = activate(&input, ActivationType::SiLU);
+    assert_eq!(result.len(), 3);
+    assert!(result[0].abs() < 1e-6); // silu(0) = 0
+}
+
+#[test]
+fn activate_inplace_modifies_buffer() {
+    let mut input = vec![-2.0, 0.0, 2.0];
+    activate_inplace(&mut input, ActivationType::ReLU);
+    assert_eq!(input, vec![0.0, 0.0, 2.0]);
+}
+
+#[test]
+fn activate_vs_inplace_consistency() {
+    let input = vec![-3.0, -1.0, 0.0, 1.0, 3.0];
+    let result = activate(&input, ActivationType::Sigmoid);
+    let mut inplace = input.clone();
+    activate_inplace(&mut inplace, ActivationType::Sigmoid);
+    for (a, b) in result.iter().zip(inplace.iter()) {
+        assert!((a - b).abs() < 1e-6);
+    }
+}
+
+// ── Activate derivative ──────────────────────────────────────────────
+
+#[test]
+fn activate_derivative_relu() {
+    let input = vec![-2.0, 0.0, 2.0];
+    let deriv = activate_derivative(&input, ActivationType::ReLU);
+    assert_eq!(deriv.len(), 3);
+    assert_eq!(deriv[0], 0.0); // negative → 0
+    // deriv[1] is boundary, implementation-dependent (0 or 1)
+    assert_eq!(deriv[2], 1.0); // positive → 1
+}
+
+#[test]
+fn activate_derivative_sigmoid() {
+    let input = vec![0.0];
+    let deriv = activate_derivative(&input, ActivationType::Sigmoid);
+    // sigmoid'(0) = sigmoid(0) * (1 - sigmoid(0)) = 0.5 * 0.5 = 0.25
+    assert!((deriv[0] - 0.25).abs() < 1e-5);
+}
+
+#[test]
+fn activate_derivative_empty() {
+    let result = activate_derivative(&[], ActivationType::GELU);
+    assert!(result.is_empty());
+}
+
+// ── ActivationType enum ──────────────────────────────────────────────
+
+#[test]
+fn activation_type_clone_copy() {
+    let a = ActivationType::SiLU;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn activation_type_debug() {
+    let d = format!("{:?}", ActivationType::GELUTanh);
+    assert_eq!(d, "GELUTanh");
+}
+
+#[test]
+fn activation_type_with_params() {
+    let a = ActivationType::LeakyReLU(0.01);
+    let b = ActivationType::LeakyReLU(0.01);
+    assert_eq!(a, b);
+    let c = ActivationType::LeakyReLU(0.1);
+    assert_ne!(a, c);
+}
+
+// ── All activation types through batch activate ──────────────────────
+
+#[test]
+fn all_activation_types_produce_finite_output() {
+    let input = vec![-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0];
+    let types = vec![
+        ActivationType::ReLU,
+        ActivationType::LeakyReLU(0.01),
+        ActivationType::GELU,
+        ActivationType::GELUTanh,
+        ActivationType::SiLU,
+        ActivationType::Swish(1.0),
+        ActivationType::Sigmoid,
+        ActivationType::Tanh,
+        ActivationType::HardSigmoid,
+        ActivationType::HardSwish,
+        ActivationType::Mish,
+        ActivationType::Softplus,
+        ActivationType::ELU(1.0),
+        ActivationType::SELU,
+        ActivationType::QuickGELU,
+    ];
+    for act in types {
+        let result = activate(&input, act);
+        assert_eq!(result.len(), input.len(), "{act:?}: wrong output length");
+        for (i, &v) in result.iter().enumerate() {
+            assert!(v.is_finite(), "{act:?}: non-finite at index {i}: {v}");
+        }
+    }
+}

--- a/crates/bitnet-kernels/tests/cpu_embedding_rope_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_embedding_rope_edge_cases.rs
@@ -1,0 +1,276 @@
+//! Edge-case tests for CPU embedding lookup and RoPE kernels.
+//!
+//! Tests cover basic embedding operations, positional encodings,
+//! packed embeddings, and RoPE frequency computations.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::embedding::{
+    CpuEmbeddingConfig, EmbeddingConfig, embedding_accumulate, embedding_lookup,
+    normalize_embeddings, pack_embedding_table, positional_embedding, unpack_embedding_lookup,
+};
+use bitnet_kernels::cpu::rope::{RopeConfig, apply_rope, compute_frequencies};
+
+// ── embedding_lookup ─────────────────────────────────────────────────
+
+#[test]
+fn embedding_lookup_basic() {
+    let table = vec![
+        1.0, 0.0, // token 0
+        0.0, 1.0, // token 1
+        1.0, 1.0, // token 2
+    ];
+    let indices = vec![0, 2, 1];
+    let result = embedding_lookup(&table, &indices, 2).unwrap();
+    assert_eq!(result.len(), 6); // 3 tokens * dim 2
+    assert_eq!(&result[0..2], &[1.0, 0.0]); // token 0
+    assert_eq!(&result[2..4], &[1.0, 1.0]); // token 2
+    assert_eq!(&result[4..6], &[0.0, 1.0]); // token 1
+}
+
+#[test]
+fn embedding_lookup_single_token() {
+    let table = vec![0.5, 0.5, 0.5]; // 1 token, dim 3
+    let indices = vec![0];
+    let result = embedding_lookup(&table, &indices, 3).unwrap();
+    assert_eq!(result, vec![0.5, 0.5, 0.5]);
+}
+
+#[test]
+fn embedding_lookup_repeated_index() {
+    let table = vec![
+        1.0, 2.0, // token 0
+        3.0, 4.0, // token 1
+    ];
+    let indices = vec![1, 1, 1];
+    let result = embedding_lookup(&table, &indices, 2).unwrap();
+    assert_eq!(result.len(), 6);
+    assert_eq!(&result[0..2], &[3.0, 4.0]);
+    assert_eq!(&result[2..4], &[3.0, 4.0]);
+    assert_eq!(&result[4..6], &[3.0, 4.0]);
+}
+
+#[test]
+fn embedding_lookup_empty_indices() {
+    let table = vec![1.0, 2.0];
+    let indices: Vec<u32> = vec![];
+    let result = embedding_lookup(&table, &indices, 2).unwrap();
+    assert!(result.is_empty());
+}
+
+// ── embedding_accumulate ─────────────────────────────────────────────
+
+#[test]
+fn embedding_accumulate_weighted() {
+    let table = vec![
+        1.0, 0.0, // token 0
+        0.0, 1.0, // token 1
+    ];
+    let indices = vec![0, 1];
+    let weights = vec![0.5, 0.5];
+    let result = embedding_accumulate(&table, &indices, &weights, 2).unwrap();
+    assert_eq!(result.len(), 2); // weighted sum of embeddings
+    // 0.5 * [1,0] + 0.5 * [0,1] = [0.5, 0.5]
+    assert!((result[0] - 0.5).abs() < 1e-6);
+    assert!((result[1] - 0.5).abs() < 1e-6);
+}
+
+// ── normalize_embeddings ─────────────────────────────────────────────
+
+#[test]
+fn normalize_embeddings_unit_vectors() {
+    let mut embeddings = vec![3.0, 4.0, 0.0, 0.0]; // 2 vectors of dim 2
+    normalize_embeddings(&mut embeddings, 2);
+    // First vector: [3,4] → L2 = 5 → [0.6, 0.8]
+    assert!((embeddings[0] - 0.6).abs() < 1e-5);
+    assert!((embeddings[1] - 0.8).abs() < 1e-5);
+}
+
+#[test]
+fn normalize_embeddings_already_unit() {
+    let mut embeddings = vec![1.0, 0.0]; // already unit
+    normalize_embeddings(&mut embeddings, 2);
+    assert!((embeddings[0] - 1.0).abs() < 1e-5);
+    assert!((embeddings[1] - 0.0).abs() < 1e-5);
+}
+
+// ── packed embedding ─────────────────────────────────────────────────
+
+#[test]
+fn pack_unpack_roundtrip() {
+    let vocab_size = 4;
+    let embed_dim = 8;
+    let table: Vec<f32> = (0..vocab_size * embed_dim).map(|i| (i as f32) * 0.1).collect();
+    let packed = pack_embedding_table(&table, vocab_size, embed_dim);
+    assert_eq!(packed.vocab_size, vocab_size);
+    assert_eq!(packed.embed_dim, embed_dim);
+
+    // Unpack a token and check it's approximately the same
+    let result = unpack_embedding_lookup(&packed, &[0, 2]).unwrap();
+    assert_eq!(result.len(), 2 * embed_dim);
+    // Token 0 should be approximately [0.0, 0.1, 0.2, ...]
+    for i in 0..embed_dim {
+        let expected = (i as f32) * 0.1;
+        // Packed quantization introduces some error
+        assert!(
+            (result[i] - expected).abs() < 1.0,
+            "token 0, dim {i}: expected ~{expected}, got {}",
+            result[i]
+        );
+    }
+}
+
+#[test]
+fn pack_embedding_table_dimensions() {
+    let table = vec![1.0; 100]; // vocab=10, dim=10
+    let packed = pack_embedding_table(&table, 10, 10);
+    assert_eq!(packed.vocab_size, 10);
+    assert_eq!(packed.embed_dim, 10);
+}
+
+// ── positional_embedding ─────────────────────────────────────────────
+
+#[test]
+fn positional_embedding_shape() {
+    let pe = positional_embedding(8, 16);
+    assert_eq!(pe.len(), 8 * 16); // seq_len * dim
+}
+
+#[test]
+fn positional_embedding_first_position_known() {
+    let pe = positional_embedding(2, 4);
+    assert_eq!(pe.len(), 8);
+    // Position 0 should start with sin(0) for even dims
+    // and cos(0) for odd dims → [0, 1, 0, 1] pattern
+    assert!(pe[0].abs() < 1e-5); // sin(0) = 0
+    assert!((pe[1] - 1.0).abs() < 1e-5); // cos(0) = 1
+}
+
+#[test]
+fn positional_embedding_values_bounded() {
+    let pe = positional_embedding(32, 64);
+    for &v in &pe {
+        assert!(v >= -1.0 && v <= 1.0, "PE value {v} out of [-1,1]");
+    }
+}
+
+#[test]
+fn positional_embedding_different_positions_differ() {
+    let pe = positional_embedding(4, 8);
+    let row0 = &pe[0..8];
+    let row1 = &pe[8..16];
+    // Different positions should produce different embeddings
+    assert_ne!(row0, row1);
+}
+
+// ── EmbeddingConfig ──────────────────────────────────────────────────
+
+#[test]
+fn embedding_config_basic() {
+    let config = EmbeddingConfig { vocab_size: 32000, embedding_dim: 4096, padding_idx: Some(0) };
+    assert_eq!(config.vocab_size, 32000);
+    assert_eq!(config.embedding_dim, 4096);
+    assert_eq!(config.padding_idx, Some(0));
+}
+
+#[test]
+fn cpu_embedding_config_no_padding() {
+    let config = CpuEmbeddingConfig {
+        vocab_size: 100352,
+        embed_dim: 5120,
+        padding_idx: None,
+        max_norm: None,
+    };
+    assert_eq!(config.vocab_size, 100352); // Phi-4 vocab size
+}
+
+// ── RoPE ─────────────────────────────────────────────────────────────
+
+#[test]
+fn rope_config_basic() {
+    let config = RopeConfig { head_dim: 64, max_seq_len: 2048, base: 10000.0, scaling_factor: 1.0 };
+    assert_eq!(config.head_dim, 64);
+}
+
+#[test]
+fn compute_frequencies_shape() {
+    let config = RopeConfig { head_dim: 8, max_seq_len: 4, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    // Shape depends on implementation: typically max_seq_len * (head_dim / 2) or similar
+    assert!(freqs.len() > 0);
+    // Verify it's related to the config dimensions
+    assert_eq!(freqs.len() % (config.head_dim / 2), 0);
+}
+
+#[test]
+fn compute_frequencies_all_finite() {
+    let config =
+        RopeConfig { head_dim: 128, max_seq_len: 16384, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    for &f in &freqs {
+        assert!(f.is_finite(), "non-finite frequency: {f}");
+    }
+}
+
+#[test]
+fn compute_frequencies_position_zero() {
+    let config = RopeConfig { head_dim: 4, max_seq_len: 2, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    // At position 0, all angles are 0 → sin=0, cos=1
+    // But compute_frequencies returns the angles themselves
+    let half = config.head_dim / 2;
+    for i in 0..half {
+        // Position 0 should have angle = 0 * freq = 0
+        // (actual values depend on implementation, just check finite)
+        assert!(freqs[i].is_finite());
+    }
+}
+
+#[test]
+fn apply_rope_preserves_length() {
+    let config = RopeConfig { head_dim: 4, max_seq_len: 2, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    let mut data = vec![1.0f32, 2.0, 3.0, 4.0]; // one head, dim=4
+    apply_rope(&mut data, 0, 4, &freqs);
+    assert_eq!(data.len(), 4);
+    for &v in &data {
+        assert!(v.is_finite(), "non-finite after RoPE: {v}");
+    }
+}
+
+#[test]
+fn apply_rope_position_zero_preserves_input() {
+    let config = RopeConfig { head_dim: 4, max_seq_len: 2, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    let original = vec![1.0f32, 2.0, 3.0, 4.0];
+    let mut data = original.clone();
+    apply_rope(&mut data, 0, 4, &freqs);
+    // At position 0, rotation angles should be 0 → cos=1, sin=0
+    // So rotated vector should be ~same as original
+    for (a, b) in original.iter().zip(data.iter()) {
+        assert!((a - b).abs() < 0.1, "position 0 should ~preserve input: {a} vs {b}");
+    }
+}
+
+#[test]
+fn apply_rope_different_positions_differ() {
+    let config = RopeConfig { head_dim: 4, max_seq_len: 4, base: 10000.0, scaling_factor: 1.0 };
+    let freqs = compute_frequencies(&config);
+    let mut data0 = vec![1.0f32, 0.0, 0.0, 0.0];
+    let mut data1 = vec![1.0f32, 0.0, 0.0, 0.0];
+    apply_rope(&mut data0, 0, 4, &freqs);
+    apply_rope(&mut data1, 1, 4, &freqs);
+    // Different positions should produce different rotations
+    assert_ne!(data0, data1);
+}
+
+#[test]
+fn rope_scaling_factor_changes_frequencies() {
+    let config1 = RopeConfig { head_dim: 8, max_seq_len: 4, base: 10000.0, scaling_factor: 1.0 };
+    let config2 = RopeConfig { head_dim: 8, max_seq_len: 4, base: 10000.0, scaling_factor: 2.0 };
+    let freqs1 = compute_frequencies(&config1);
+    let freqs2 = compute_frequencies(&config2);
+    assert_eq!(freqs1.len(), freqs2.len());
+    // Different scaling factors should produce different frequencies
+    assert_ne!(freqs1, freqs2);
+}

--- a/crates/bitnet-kernels/tests/cpu_layer_norm_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_layer_norm_edge_cases.rs
@@ -1,0 +1,256 @@
+//! Edge-case tests for CPU layer normalization kernels.
+//!
+//! Tests cover LayerNorm, RMSNorm, GroupNorm, InstanceNorm with
+//! boundary conditions, special inputs, and batch variants.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::layer_norm::{
+    GroupNormConfig, LayerNormConfig, batch_layer_norm, batch_rms_norm, group_norm, instance_norm,
+    layer_norm, rms_norm,
+};
+
+fn approx_eq(a: f32, b: f32, tol: f32) {
+    assert!((a - b).abs() <= tol, "expected {a} ≈ {b} (tol={tol}, diff={})", (a - b).abs());
+}
+
+// ── LayerNormConfig ──────────────────────────────────────────────────
+
+#[test]
+fn layer_norm_config_basic() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    assert_eq!(config.normalized_shape, vec![4]);
+    assert!((config.eps - 1e-5).abs() < 1e-10);
+}
+
+// ── layer_norm ───────────────────────────────────────────────────────
+
+#[test]
+fn layer_norm_uniform_input() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0f32; 4];
+    let gamma = vec![1.0f32; 4];
+    let result = layer_norm(&input, &gamma, None, &config).unwrap();
+    // Uniform input → zero variance → output depends on eps
+    assert_eq!(result.len(), 4);
+    for v in &result {
+        assert!(v.is_finite());
+    }
+}
+
+#[test]
+fn layer_norm_with_known_values() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let gamma = vec![1.0; 4];
+    let beta = vec![0.0; 4];
+    let result = layer_norm(&input, &gamma, Some(&beta), &config).unwrap();
+    assert_eq!(result.len(), 4);
+    // Mean = 2.5, Var = 1.25, Std = ~1.118
+    // Normalized: [-1.342, -0.447, 0.447, 1.342] approximately
+    assert!(result[0] < 0.0);
+    assert!(result[3] > 0.0);
+    // Sum of normalized values should be ~0
+    let sum: f32 = result.iter().sum();
+    assert!(sum.abs() < 0.01);
+}
+
+#[test]
+fn layer_norm_with_beta_offset() {
+    let config = LayerNormConfig { normalized_shape: vec![2], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0, 3.0];
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![10.0, 10.0];
+    let result = layer_norm(&input, &gamma, Some(&beta), &config).unwrap();
+    // Result should be shifted by +10
+    for v in &result {
+        assert!(*v > 5.0, "expected values > 5 with beta=10, got {v}");
+    }
+}
+
+#[test]
+fn layer_norm_gamma_scaling() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0, 2.0, 3.0];
+    let gamma_one = vec![1.0; 3];
+    let gamma_two = vec![2.0; 3];
+    let r1 = layer_norm(&input, &gamma_one, None, &config).unwrap();
+    let r2 = layer_norm(&input, &gamma_two, None, &config).unwrap();
+    // Doubling gamma should approximately double the output
+    for (a, b) in r1.iter().zip(r2.iter()) {
+        approx_eq(*b, *a * 2.0, 0.01);
+    }
+}
+
+// ── rms_norm ─────────────────────────────────────────────────────────
+
+#[test]
+fn rms_norm_uniform_input() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    let input = vec![2.0f32; 4];
+    let gamma = vec![1.0; 4];
+    let result = rms_norm(&input, &gamma, &config).unwrap();
+    assert_eq!(result.len(), 4);
+    // RMS of [2,2,2,2] = 2, so normalized = 2/2 = 1.0
+    for v in &result {
+        approx_eq(*v, 1.0, 0.001);
+    }
+}
+
+#[test]
+fn rms_norm_known_values() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0, 2.0, 3.0];
+    let gamma = vec![1.0; 3];
+    let result = rms_norm(&input, &gamma, &config).unwrap();
+    // RMS = sqrt((1+4+9)/3) = sqrt(14/3) ≈ 2.16
+    let rms = (14.0f32 / 3.0).sqrt();
+    for (x, y) in input.iter().zip(result.iter()) {
+        approx_eq(*y, *x / rms, 0.01);
+    }
+}
+
+#[test]
+fn rms_norm_zero_input() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input = vec![0.0; 3];
+    let gamma = vec![1.0; 3];
+    let result = rms_norm(&input, &gamma, &config).unwrap();
+    // RMS ≈ eps, result should be 0/(eps) ≈ 0
+    for v in &result {
+        assert!(v.is_finite());
+    }
+}
+
+// ── GroupNormConfig ──────────────────────────────────────────────────
+
+#[test]
+fn group_norm_config_basic() {
+    let config = GroupNormConfig {
+        num_groups: 2,
+        num_channels: 4,
+        spatial_size: 1,
+        eps: 1e-5,
+        elementwise_affine: true,
+    };
+    assert_eq!(config.num_groups, 2);
+    assert_eq!(config.num_channels, 4);
+}
+
+// ── group_norm ───────────────────────────────────────────────────────
+
+#[test]
+fn group_norm_basic() {
+    let config = GroupNormConfig {
+        num_groups: 2,
+        num_channels: 4,
+        spatial_size: 1,
+        eps: 1e-5,
+        elementwise_affine: true,
+    };
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 4 channels, 1 spatial
+    let gamma = vec![1.0; 4];
+    let result = group_norm(&input, &gamma, None, &config).unwrap();
+    assert_eq!(result.len(), 4);
+    for v in &result {
+        assert!(v.is_finite());
+    }
+}
+
+// ── instance_norm ────────────────────────────────────────────────────
+
+#[test]
+fn instance_norm_basic() {
+    let config = GroupNormConfig {
+        num_groups: 4, // instance norm: groups == channels
+        num_channels: 4,
+        spatial_size: 1,
+        eps: 1e-5,
+        elementwise_affine: true,
+    };
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let gamma = vec![1.0; 4];
+    let result = instance_norm(&input, &gamma, None, &config).unwrap();
+    assert_eq!(result.len(), 4);
+    for v in &result {
+        assert!(v.is_finite());
+    }
+}
+
+// ── Batch variants ───────────────────────────────────────────────────
+
+#[test]
+fn batch_layer_norm_multiple_inputs() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input1 = vec![1.0f32, 2.0, 3.0];
+    let input2 = vec![4.0f32, 5.0, 6.0];
+    let inputs: Vec<&[f32]> = vec![&input1, &input2];
+    let gamma = vec![1.0; 3];
+    let results = batch_layer_norm(&inputs, &gamma, None, &config).unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].len(), 3);
+    assert_eq!(results[1].len(), 3);
+}
+
+#[test]
+fn batch_layer_norm_single_input_matches_non_batch() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1.0f32, 3.0, 5.0, 7.0];
+    let gamma = vec![1.0; 4];
+    let single = layer_norm(&input, &gamma, None, &config).unwrap();
+    let batch = batch_layer_norm(&[input.as_slice()], &gamma, None, &config).unwrap();
+    assert_eq!(batch.len(), 1);
+    for (a, b) in single.iter().zip(batch[0].iter()) {
+        approx_eq(*a, *b, 1e-6);
+    }
+}
+
+#[test]
+fn batch_rms_norm_multiple_inputs() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input1 = vec![1.0f32, 2.0, 3.0];
+    let input2 = vec![4.0f32, 5.0, 6.0];
+    let inputs: Vec<&[f32]> = vec![&input1, &input2];
+    let gamma = vec![1.0; 3];
+    let results = batch_rms_norm(&inputs, &gamma, &config).unwrap();
+    assert_eq!(results.len(), 2);
+}
+
+#[test]
+fn batch_rms_norm_single_matches_non_batch() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input = vec![2.0f32, 4.0, 6.0];
+    let gamma = vec![1.0; 3];
+    let single = rms_norm(&input, &gamma, &config).unwrap();
+    let batch = batch_rms_norm(&[input.as_slice()], &gamma, &config).unwrap();
+    assert_eq!(batch.len(), 1);
+    for (a, b) in single.iter().zip(batch[0].iter()) {
+        approx_eq(*a, *b, 1e-6);
+    }
+}
+
+// ── Numerical stability ──────────────────────────────────────────────
+
+#[test]
+fn layer_norm_large_values_stable() {
+    let config = LayerNormConfig { normalized_shape: vec![4], eps: 1e-5, elementwise_affine: true };
+    let input = vec![1e6, 1e6 + 1.0, 1e6 + 2.0, 1e6 + 3.0];
+    let gamma = vec![1.0; 4];
+    let result = layer_norm(&input, &gamma, None, &config).unwrap();
+    for v in &result {
+        assert!(v.is_finite(), "non-finite output for large input: {v}");
+    }
+}
+
+#[test]
+fn rms_norm_negative_values() {
+    let config = LayerNormConfig { normalized_shape: vec![3], eps: 1e-5, elementwise_affine: true };
+    let input = vec![-1.0, -2.0, -3.0];
+    let gamma = vec![1.0; 3];
+    let result = rms_norm(&input, &gamma, &config).unwrap();
+    // RMS is computed from squares, so negatives don't affect RMS
+    for v in &result {
+        assert!(v.is_finite());
+        assert!(*v < 0.0); // scaled negatives remain negative
+    }
+}


### PR DESCRIPTION
## Summary
Add 98 edge-case tests for CPU kernel operations across three new test files:

### cpu_activations_edge_cases.rs (58 tests)
- All 15 activation functions: ReLU, LeakyReLU, Sigmoid, Tanh, GELU, GELUTanh, SiLU, Swish, HardSigmoid, HardSwish, Softplus, Mish, ELU, SELU, QuickGELU
- Boundary conditions: zero, large positive/negative, symmetry, identity
- Batch variants: activate(), activate_inplace(), activate_derivative()
- All activation types produce finite output verification

### cpu_layer_norm_edge_cases.rs (17 tests)
- LayerNorm with known values, uniform input, beta offset, gamma scaling
- RMSNorm with uniform, known, zero inputs, negative values
- GroupNorm and InstanceNorm basic operation
- Batch layer norm and batch RMS norm variants
- Numerical stability with large values

### cpu_embedding_rope_edge_cases.rs (23 tests)
- Embedding lookup: basic, single token, repeated index, empty
- Embedding accumulate (weighted), normalize
- Packed embedding: pack/unpack roundtrip
- Positional embedding: shape, known values, bounds, uniqueness
- RoPE: frequency computation, shape, finiteness, position-0 preservation, scaling

All 98 tests pass locally with `--no-default-features --features cpu`.
