### PR TITLE
test(kernels): add 66 CPU advanced ops edge-case tests (SIMD, fusion, KV cache, conv2d, batch norm)

### DIFF
--- a/crates/bitnet-kernels/tests/cpu_batch_norm_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_batch_norm_edge_cases.rs
@@ -1,0 +1,111 @@
+//! Edge-case tests for CPU batch normalization.
+//!
+//! Tests cover batch norm forward and inference modes,
+//! with various configurations and edge cases.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::batch_norm::{BatchNormConfig, batch_norm_forward, batch_norm_inference};
+
+// ── BatchNormConfig ──────────────────────────────────────────────────
+
+#[test]
+fn config_new() {
+    let config = BatchNormConfig::new(64);
+    assert_eq!(config.num_features, 64);
+}
+
+// ── batch_norm_inference ─────────────────────────────────────────────
+
+#[test]
+fn inference_identity_params() {
+    // gamma=1, beta=0, mean=0, var=1 → output ≈ input
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 4 features, 1 sample
+    let gamma = vec![1.0, 1.0, 1.0, 1.0];
+    let beta = vec![0.0, 0.0, 0.0, 0.0];
+    let mean = vec![0.0, 0.0, 0.0, 0.0];
+    let var = vec![1.0, 1.0, 1.0, 1.0];
+    let result = batch_norm_inference(&input, &gamma, &beta, &mean, &var, 1e-5).unwrap();
+    assert_eq!(result.len(), 4);
+    for (r, i) in result.iter().zip(input.iter()) {
+        assert!((r - i).abs() < 0.01, "Expected {i}, got {r}");
+    }
+}
+
+#[test]
+fn inference_with_scale() {
+    // gamma=2 → doubles the normalized output
+    let input = vec![0.0, 0.0, 0.0, 0.0]; // mean-centered
+    let gamma = vec![2.0, 2.0, 2.0, 2.0];
+    let beta = vec![0.0, 0.0, 0.0, 0.0];
+    let mean = vec![0.0, 0.0, 0.0, 0.0];
+    let var = vec![1.0, 1.0, 1.0, 1.0];
+    let result = batch_norm_inference(&input, &gamma, &beta, &mean, &var, 1e-5).unwrap();
+    for val in &result {
+        assert!(val.abs() < 0.01, "Expected ~0, got {val}");
+    }
+}
+
+#[test]
+fn inference_with_shift() {
+    // beta=5 → shifts output by 5
+    let input = vec![0.0, 0.0];
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![5.0, 5.0];
+    let mean = vec![0.0, 0.0];
+    let var = vec![1.0, 1.0];
+    let result = batch_norm_inference(&input, &gamma, &beta, &mean, &var, 1e-5).unwrap();
+    for val in &result {
+        assert!((val - 5.0).abs() < 0.01, "Expected ~5, got {val}");
+    }
+}
+
+#[test]
+fn inference_with_nonzero_mean() {
+    // input=5, mean=5 → normalized=0 → output=beta=0
+    let input = vec![5.0, 5.0];
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![0.0, 0.0];
+    let mean = vec![5.0, 5.0];
+    let var = vec![1.0, 1.0];
+    let result = batch_norm_inference(&input, &gamma, &beta, &mean, &var, 1e-5).unwrap();
+    for val in &result {
+        assert!(val.abs() < 0.01, "Expected ~0, got {val}");
+    }
+}
+
+// ── batch_norm_forward ───────────────────────────────────────────────
+
+#[test]
+fn forward_basic() {
+    let config = BatchNormConfig::new(2);
+    // 2 features, batch of 2: [[1, 2], [3, 4]] flattened
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![0.0, 0.0];
+    let running_mean = vec![0.0, 0.0];
+    let running_var = vec![1.0, 1.0];
+    let (output, _new_mean, _new_var) =
+        batch_norm_forward(&input, &gamma, &beta, &running_mean, &running_var, &config).unwrap();
+    assert!(!output.is_empty());
+    for val in &output {
+        assert!(val.is_finite());
+    }
+}
+
+#[test]
+fn forward_returns_statistics() {
+    let config = BatchNormConfig::new(2);
+    let input = vec![1.0, 10.0, 3.0, 20.0]; // 2 features, batch 2
+    let gamma = vec![1.0, 1.0];
+    let beta = vec![0.0, 0.0];
+    let running_mean = vec![0.0, 0.0];
+    let running_var = vec![1.0, 1.0];
+    let (_output, new_mean, new_var) =
+        batch_norm_forward(&input, &gamma, &beta, &running_mean, &running_var, &config).unwrap();
+    assert!(!new_mean.is_empty());
+    assert!(!new_var.is_empty());
+    for val in &new_var {
+        assert!(*val >= 0.0, "Variance should be non-negative");
+    }
+}

--- a/crates/bitnet-kernels/tests/cpu_conv2d_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_conv2d_edge_cases.rs
@@ -1,0 +1,124 @@
+//! Edge-case tests for CPU conv2d operations.
+//!
+//! Tests cover 2D convolution, depthwise convolution,
+//! output size computation, and configuration.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::conv2d::{Conv2dConfig, compute_output_size, conv2d, depthwise_conv2d};
+
+// ── Output size computation ──────────────────────────────────────────
+
+#[test]
+fn output_size_no_padding() {
+    // in=4, kernel=3, stride=1, pad=0, dilation=1 → out=2
+    let out = compute_output_size(4, 3, 1, 0, 1);
+    assert_eq!(out, 2);
+}
+
+#[test]
+fn output_size_with_padding() {
+    // in=4, kernel=3, stride=1, pad=1, dilation=1 → out=4
+    let out = compute_output_size(4, 3, 1, 1, 1);
+    assert_eq!(out, 4);
+}
+
+#[test]
+fn output_size_stride_2() {
+    // in=6, kernel=3, stride=2, pad=0, dilation=1 → out=2
+    let out = compute_output_size(6, 3, 2, 0, 1);
+    assert_eq!(out, 2);
+}
+
+#[test]
+fn output_size_dilation() {
+    // in=7, kernel=3, stride=1, pad=0, dilation=2 → effective_k=5, out=3
+    let out = compute_output_size(7, 3, 1, 0, 2);
+    assert_eq!(out, 3);
+}
+
+#[test]
+fn output_size_1x1() {
+    // 1x1 conv with stride=1
+    let out = compute_output_size(8, 1, 1, 0, 1);
+    assert_eq!(out, 8);
+}
+
+// ── Conv2dConfig ─────────────────────────────────────────────────────
+
+#[test]
+fn config_defaults() {
+    let config = Conv2dConfig::new(3, 16, 3);
+    assert_eq!(config.in_channels, 3);
+    assert_eq!(config.out_channels, 16);
+    assert_eq!(config.kernel_h, 3);
+    assert_eq!(config.kernel_w, 3);
+}
+
+// ── conv2d ───────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_1x1_identity_like() {
+    let config = Conv2dConfig::new(1, 1, 1); // 1 in, 1 out, 1x1 kernel
+    // Single channel 2x2 input
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    // 1x1 kernel weight = 1.0
+    let weight = vec![1.0];
+    let result = conv2d(&input, &weight, None, &config, 1, 2, 2).unwrap();
+    assert_eq!(result.len(), 4);
+    assert!((result[0] - 1.0).abs() < 1e-6);
+    assert!((result[3] - 4.0).abs() < 1e-6);
+}
+
+#[test]
+fn conv2d_with_bias() {
+    let config = Conv2dConfig::new(1, 1, 1);
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1 batch, 1 chan, 2x2
+    let weight = vec![1.0];
+    let bias = vec![10.0];
+    let result = conv2d(&input, &weight, Some(&bias), &config, 1, 2, 2).unwrap();
+    assert!((result[0] - 11.0).abs() < 1e-6);
+    assert!((result[1] - 12.0).abs() < 1e-6);
+}
+
+#[test]
+fn conv2d_3x3_on_4x4() {
+    let mut config = Conv2dConfig::new(1, 1, 3);
+    config.stride_h = 1;
+    config.stride_w = 1;
+    config.padding_h = 0;
+    config.padding_w = 0;
+    // 4x4 input with all 1s
+    let input = vec![1.0; 16];
+    // 3x3 kernel with all 1s → each output = 9.0
+    let weight = vec![1.0; 9];
+    let result = conv2d(&input, &weight, None, &config, 1, 4, 4).unwrap();
+    // Output: 2x2
+    assert_eq!(result.len(), 4);
+    for val in &result {
+        assert!((val - 9.0).abs() < 1e-4, "Expected 9.0, got {val}");
+    }
+}
+
+// ── depthwise_conv2d ─────────────────────────────────────────────────
+
+#[test]
+fn depthwise_conv2d_single_channel() {
+    let config = Conv2dConfig::new(1, 1, 1);
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let weight = vec![2.0]; // scale by 2
+    let result = depthwise_conv2d(&input, &weight, None, &config, 1, 2, 2).unwrap();
+    assert_eq!(result.len(), 4);
+    assert!((result[0] - 2.0).abs() < 1e-6);
+    assert!((result[3] - 8.0).abs() < 1e-6);
+}
+
+#[test]
+fn depthwise_conv2d_with_bias() {
+    let config = Conv2dConfig::new(1, 1, 1);
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let weight = vec![1.0];
+    let bias = vec![5.0];
+    let result = depthwise_conv2d(&input, &weight, Some(&bias), &config, 1, 2, 2).unwrap();
+    assert!((result[0] - 6.0).abs() < 1e-6);
+}

--- a/crates/bitnet-kernels/tests/cpu_fusion_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_fusion_edge_cases.rs
@@ -1,0 +1,157 @@
+//! Edge-case tests for CPU kernel fusion operations.
+//!
+//! Tests cover fused RMSNorm+linear, GELU+linear, softmax+mask,
+//! add+normalize, and scale+add operations.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::fusion::{
+    FusionConfig, fused_add_normalize, fused_gelu_linear, fused_rmsnorm_linear, fused_scale_add,
+    fused_softmax_mask,
+};
+
+// ── FusionConfig ─────────────────────────────────────────────────────
+
+#[test]
+fn fusion_config_disabled() {
+    let config = FusionConfig::disabled();
+    assert!(config.validate().is_ok());
+}
+
+// ── fused_rmsnorm_linear ─────────────────────────────────────────────
+
+#[test]
+fn fused_rmsnorm_linear_basic() {
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let weight =
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]; // 4x4 identity
+    let gamma = vec![1.0, 1.0, 1.0, 1.0];
+    let result = fused_rmsnorm_linear(&input, &weight, &gamma, 1e-5).unwrap();
+    assert_eq!(result.len(), 4);
+    for val in &result {
+        assert!(val.is_finite());
+    }
+}
+
+#[test]
+fn fused_rmsnorm_linear_uniform() {
+    let input = vec![1.0, 1.0, 1.0, 1.0];
+    let weight =
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    let gamma = vec![1.0, 1.0, 1.0, 1.0];
+    let result = fused_rmsnorm_linear(&input, &weight, &gamma, 1e-5).unwrap();
+    // Uniform input → RMS = 1.0 → normalized = [1,1,1,1] → identity linear = [1,1,1,1]
+    for val in &result {
+        assert!((val - 1.0).abs() < 0.01, "Expected ~1.0, got {val}");
+    }
+}
+
+// ── fused_gelu_linear ────────────────────────────────────────────────
+
+#[test]
+fn fused_gelu_linear_basic() {
+    let input = vec![1.0, 2.0, 3.0, 4.0];
+    let weight =
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    let bias = vec![0.0, 0.0, 0.0, 0.0];
+    let result = fused_gelu_linear(&input, &weight, &bias).unwrap();
+    assert_eq!(result.len(), 4);
+    // GELU of positive values ≈ x for large x
+    assert!(result[3] > 3.0, "GELU(4) should be close to 4");
+}
+
+#[test]
+fn fused_gelu_linear_zeros() {
+    let input = vec![0.0, 0.0, 0.0, 0.0];
+    let weight =
+        vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0];
+    let bias = vec![0.0, 0.0, 0.0, 0.0];
+    let result = fused_gelu_linear(&input, &weight, &bias).unwrap();
+    for val in &result {
+        assert!(val.abs() < 0.01, "GELU(0) should be ~0, got {val}");
+    }
+}
+
+// ── fused_softmax_mask ───────────────────────────────────────────────
+
+#[test]
+fn fused_softmax_mask_basic() {
+    let scores = vec![1.0, 2.0, 3.0, 4.0];
+    let mask = vec![1.0, 1.0, 1.0, 1.0]; // no masking
+    let result = fused_softmax_mask(&scores, &mask, 1.0).unwrap();
+    assert_eq!(result.len(), 4);
+    let sum: f32 = result.iter().sum();
+    assert!((sum - 1.0).abs() < 0.01, "Softmax should sum to 1.0: {sum}");
+}
+
+#[test]
+fn fused_softmax_mask_with_zeros() {
+    let scores = vec![1.0, 2.0, 3.0, 4.0];
+    let mask = vec![1.0, 1.0, 0.0, 0.0]; // partial mask
+    let result = fused_softmax_mask(&scores, &mask, 1.0).unwrap();
+    assert_eq!(result.len(), 4);
+    for val in &result {
+        assert!(*val >= 0.0 && val.is_finite(), "Invalid probability: {val}");
+    }
+}
+
+#[test]
+fn fused_softmax_mask_scale() {
+    let scores = vec![1.0, 1.0, 1.0, 1.0]; // uniform
+    let mask = vec![1.0, 1.0, 1.0, 1.0];
+    let result = fused_softmax_mask(&scores, &mask, 0.5).unwrap();
+    // Uniform scores → uniform probabilities regardless of scale
+    for val in &result {
+        assert!((val - 0.25).abs() < 0.01);
+    }
+}
+
+// ── fused_add_normalize ──────────────────────────────────────────────
+
+#[test]
+fn fused_add_normalize_basic() {
+    let a = vec![1.0, 2.0, 3.0, 4.0];
+    let b = vec![1.0, 1.0, 1.0, 1.0];
+    let gamma = vec![1.0, 1.0, 1.0, 1.0];
+    let result = fused_add_normalize(&a, &b, &gamma, 1e-5).unwrap();
+    assert_eq!(result.len(), 4);
+    for val in &result {
+        assert!(val.is_finite());
+    }
+}
+
+#[test]
+fn fused_add_normalize_zeros() {
+    let a = vec![0.0, 0.0, 0.0, 0.0];
+    let b = vec![1.0, 1.0, 1.0, 1.0];
+    let gamma = vec![1.0, 1.0, 1.0, 1.0];
+    let result = fused_add_normalize(&a, &b, &gamma, 1e-5).unwrap();
+    // [1,1,1,1] → RMS=1 → normalized=[1,1,1,1]
+    for val in &result {
+        assert!((val - 1.0).abs() < 0.01, "Expected ~1.0, got {val}");
+    }
+}
+
+// ── fused_scale_add ──────────────────────────────────────────────────
+
+#[test]
+fn fused_scale_add_basic() {
+    let a = vec![1.0, 2.0, 3.0];
+    let b = vec![10.0, 20.0, 30.0];
+    let result = fused_scale_add(&a, &b, 0.1).unwrap();
+    // a + b * scale = [1+1, 2+2, 3+3] = [2, 4, 6]
+    assert_eq!(result.len(), 3);
+    for val in &result {
+        assert!(val.is_finite());
+    }
+}
+
+#[test]
+fn fused_scale_add_zero_scale() {
+    let a = vec![5.0, 10.0];
+    let b = vec![100.0, 200.0];
+    let result = fused_scale_add(&a, &b, 0.0).unwrap();
+    // a + b * 0 = a
+    assert!((result[0] - 5.0).abs() < 1e-6);
+    assert!((result[1] - 10.0).abs() < 1e-6);
+}

--- a/crates/bitnet-kernels/tests/cpu_kv_cache_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_kv_cache_edge_cases.rs
@@ -1,0 +1,147 @@
+//! Edge-case tests for CPU KV cache operations.
+//!
+//! Tests cover cache creation, append, slice, clear,
+//! memory usage tracking, and paged allocation.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::kv_cache::{
+    KvCache, KvCacheConfig, KvDtype, kv_cache_append, kv_cache_clear, kv_cache_memory_usage,
+    kv_cache_slice,
+};
+
+fn make_config(
+    num_layers: usize,
+    max_seq: usize,
+    num_heads: usize,
+    head_dim: usize,
+) -> KvCacheConfig {
+    KvCacheConfig { num_layers, max_seq_len: max_seq, num_heads, head_dim, dtype: KvDtype::F32 }
+}
+
+// ── Cache creation ───────────────────────────────────────────────────
+
+#[test]
+fn create_cache_basic() {
+    let config = make_config(2, 64, 4, 16);
+    assert!(config.validate().is_ok());
+    let cache = KvCache::new(config).unwrap();
+    assert_eq!(cache.num_layers(), 2);
+}
+
+#[test]
+fn create_cache_single_layer() {
+    let config = make_config(1, 32, 1, 8);
+    let cache = KvCache::new(config).unwrap();
+    assert_eq!(cache.num_layers(), 1);
+    assert_eq!(cache.seq_len(0).unwrap(), 0);
+}
+
+// ── Append and read back ─────────────────────────────────────────────
+
+#[test]
+fn append_and_seq_len() {
+    let config = make_config(1, 64, 2, 4);
+    let mut cache = KvCache::new(config).unwrap();
+    assert_eq!(cache.seq_len(0).unwrap(), 0);
+
+    // Append 1 token: num_heads * head_dim = 2*4 = 8 floats
+    let keys = vec![1.0; 8];
+    let values = vec![2.0; 8];
+    kv_cache_append(&mut cache, 0, &keys, &values).unwrap();
+    assert_eq!(cache.seq_len(0).unwrap(), 1);
+}
+
+#[test]
+fn append_multiple_tokens() {
+    let config = make_config(1, 64, 2, 4);
+    let mut cache = KvCache::new(config).unwrap();
+
+    let kv_size = 8; // 2 heads * 4 dim
+    for i in 0..5 {
+        let keys = vec![i as f32; kv_size];
+        let values = vec![(i * 10) as f32; kv_size];
+        kv_cache_append(&mut cache, 0, &keys, &values).unwrap();
+    }
+    assert_eq!(cache.seq_len(0).unwrap(), 5);
+}
+
+#[test]
+fn append_to_multiple_layers() {
+    let config = make_config(3, 64, 2, 4);
+    let mut cache = KvCache::new(config).unwrap();
+    let kv_size = 8;
+
+    for layer in 0..3 {
+        let keys = vec![layer as f32; kv_size];
+        let values = vec![(layer * 10) as f32; kv_size];
+        kv_cache_append(&mut cache, layer, &keys, &values).unwrap();
+    }
+
+    for layer in 0..3 {
+        assert_eq!(cache.seq_len(layer).unwrap(), 1);
+    }
+}
+
+// ── Slice operations ─────────────────────────────────────────────────
+
+#[test]
+fn slice_after_append() {
+    let config = make_config(1, 64, 1, 4);
+    let mut cache = KvCache::new(config).unwrap();
+
+    let keys = vec![1.0, 2.0, 3.0, 4.0];
+    let values = vec![10.0, 20.0, 30.0, 40.0];
+    kv_cache_append(&mut cache, 0, &keys, &values).unwrap();
+
+    let (k_slice, v_slice) = kv_cache_slice(&cache, 0, 0, 1).unwrap();
+    assert!(!k_slice.is_empty());
+    assert!(!v_slice.is_empty());
+}
+
+// ── Clear operations ─────────────────────────────────────────────────
+
+#[test]
+fn clear_resets_seq_len() {
+    let config = make_config(2, 64, 2, 4);
+    let mut cache = KvCache::new(config).unwrap();
+    let kv_size = 8;
+
+    let keys = vec![1.0; kv_size];
+    let values = vec![2.0; kv_size];
+    kv_cache_append(&mut cache, 0, &keys, &values).unwrap();
+    kv_cache_append(&mut cache, 1, &keys, &values).unwrap();
+
+    kv_cache_clear(&mut cache);
+
+    assert_eq!(cache.seq_len(0).unwrap(), 0);
+    assert_eq!(cache.seq_len(1).unwrap(), 0);
+}
+
+// ── Memory usage ─────────────────────────────────────────────────────
+
+#[test]
+fn memory_usage_empty() {
+    let config = make_config(1, 64, 2, 4);
+    let cache = KvCache::new(config).unwrap();
+    let usage = kv_cache_memory_usage(&cache);
+    // Should be non-zero even for empty cache (allocated capacity)
+    assert!(usage > 0);
+}
+
+#[test]
+fn memory_usage_grows_with_layers() {
+    let config_1 = make_config(1, 64, 2, 4);
+    let config_4 = make_config(4, 64, 2, 4);
+    let cache_1 = KvCache::new(config_1).unwrap();
+    let cache_4 = KvCache::new(config_4).unwrap();
+    assert!(kv_cache_memory_usage(&cache_4) > kv_cache_memory_usage(&cache_1));
+}
+
+// ── KvDtype ──────────────────────────────────────────────────────────
+
+#[test]
+fn kv_dtype_element_bytes() {
+    assert_eq!(KvDtype::F32.element_bytes(), 4);
+    assert_eq!(KvDtype::F16.element_bytes(), 2);
+}

--- a/crates/bitnet-kernels/tests/cpu_simd_math_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/cpu_simd_math_edge_cases.rs
@@ -1,0 +1,219 @@
+//! Edge-case tests for CPU SIMD math operations.
+//!
+//! Tests cover fast approximations (exp, tanh, sigmoid),
+//! dot product, vector arithmetic, and L2 norm.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::simd_math::{
+    fast_exp_f32, fast_sigmoid_f32, fast_tanh_f32, simd_dot_product, simd_l2_norm, simd_vector_add,
+    simd_vector_mul, simd_vector_scale,
+};
+
+// ── fast_exp_f32 ─────────────────────────────────────────────────────
+
+#[test]
+fn fast_exp_zero() {
+    let result = fast_exp_f32(&[0.0]);
+    assert!((result[0] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn fast_exp_one() {
+    let result = fast_exp_f32(&[1.0]);
+    assert!((result[0] - std::f32::consts::E).abs() < 0.05);
+}
+
+#[test]
+fn fast_exp_negative() {
+    let result = fast_exp_f32(&[-1.0]);
+    let expected = (-1.0f32).exp();
+    assert!((result[0] - expected).abs() < 0.05);
+}
+
+#[test]
+fn fast_exp_batch() {
+    let input = vec![0.0, 1.0, -1.0, 2.0];
+    let result = fast_exp_f32(&input);
+    assert_eq!(result.len(), 4);
+    for val in &result {
+        assert!(val.is_finite());
+        assert!(*val >= 0.0);
+    }
+}
+
+// ── fast_tanh_f32 ────────────────────────────────────────────────────
+
+#[test]
+fn fast_tanh_zero() {
+    let result = fast_tanh_f32(&[0.0]);
+    assert!(result[0].abs() < 0.01);
+}
+
+#[test]
+fn fast_tanh_large_positive() {
+    let result = fast_tanh_f32(&[10.0]);
+    assert!((result[0] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn fast_tanh_large_negative() {
+    let result = fast_tanh_f32(&[-10.0]);
+    assert!((result[0] - (-1.0)).abs() < 0.01);
+}
+
+#[test]
+fn fast_tanh_bounds() {
+    let input = vec![-5.0, -1.0, 0.0, 1.0, 5.0];
+    let result = fast_tanh_f32(&input);
+    for val in &result {
+        assert!(*val >= -1.0 && *val <= 1.0, "tanh out of [-1,1]: {val}");
+    }
+}
+
+// ── fast_sigmoid_f32 ─────────────────────────────────────────────────
+
+#[test]
+fn fast_sigmoid_zero() {
+    let result = fast_sigmoid_f32(&[0.0]);
+    assert!((result[0] - 0.5).abs() < 0.01);
+}
+
+#[test]
+fn fast_sigmoid_large_positive() {
+    let result = fast_sigmoid_f32(&[10.0]);
+    assert!((result[0] - 1.0).abs() < 0.01);
+}
+
+#[test]
+fn fast_sigmoid_large_negative() {
+    let result = fast_sigmoid_f32(&[-10.0]);
+    assert!(result[0].abs() < 0.01);
+}
+
+#[test]
+fn fast_sigmoid_bounds() {
+    let input = vec![-100.0, -1.0, 0.0, 1.0, 100.0];
+    let result = fast_sigmoid_f32(&input);
+    for val in &result {
+        assert!(*val >= 0.0 && *val <= 1.0, "sigmoid out of [0,1]: {val}");
+    }
+}
+
+// ── simd_dot_product ─────────────────────────────────────────────────
+
+#[test]
+fn dot_product_basic() {
+    let a = vec![1.0, 2.0, 3.0];
+    let b = vec![4.0, 5.0, 6.0];
+    let result = simd_dot_product(&a, &b);
+    assert!((result - 32.0).abs() < 1e-5); // 4+10+18
+}
+
+#[test]
+fn dot_product_orthogonal() {
+    let a = vec![1.0, 0.0];
+    let b = vec![0.0, 1.0];
+    let result = simd_dot_product(&a, &b);
+    assert!((result - 0.0).abs() < 1e-6);
+}
+
+#[test]
+fn dot_product_self() {
+    let a = vec![3.0, 4.0];
+    let result = simd_dot_product(&a, &a);
+    assert!((result - 25.0).abs() < 1e-5);
+}
+
+#[test]
+fn dot_product_large() {
+    let n = 1024;
+    let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.001).collect();
+    let b: Vec<f32> = (0..n).map(|i| (n - i) as f32 * 0.001).collect();
+    let result = simd_dot_product(&a, &b);
+    assert!(result.is_finite());
+}
+
+// ── simd_vector_add ──────────────────────────────────────────────────
+
+#[test]
+fn vector_add_basic() {
+    let a = vec![1.0, 2.0, 3.0];
+    let b = vec![4.0, 5.0, 6.0];
+    let result = simd_vector_add(&a, &b);
+    assert_eq!(result, vec![5.0, 7.0, 9.0]);
+}
+
+#[test]
+fn vector_add_negatives() {
+    let a = vec![1.0, -2.0, 3.0];
+    let b = vec![-1.0, 2.0, -3.0];
+    let result = simd_vector_add(&a, &b);
+    for val in &result {
+        assert!((val - 0.0).abs() < 1e-6);
+    }
+}
+
+// ── simd_vector_mul ──────────────────────────────────────────────────
+
+#[test]
+fn vector_mul_basic() {
+    let a = vec![2.0, 3.0, 4.0];
+    let b = vec![5.0, 6.0, 7.0];
+    let result = simd_vector_mul(&a, &b);
+    assert_eq!(result, vec![10.0, 18.0, 28.0]);
+}
+
+#[test]
+fn vector_mul_zeros() {
+    let a = vec![1.0, 2.0, 3.0];
+    let b = vec![0.0, 0.0, 0.0];
+    let result = simd_vector_mul(&a, &b);
+    assert_eq!(result, vec![0.0, 0.0, 0.0]);
+}
+
+// ── simd_vector_scale ────────────────────────────────────────────────
+
+#[test]
+fn vector_scale_basic() {
+    let data = vec![1.0, 2.0, 3.0];
+    let result = simd_vector_scale(&data, 2.0);
+    assert_eq!(result, vec![2.0, 4.0, 6.0]);
+}
+
+#[test]
+fn vector_scale_zero() {
+    let data = vec![1.0, 2.0, 3.0];
+    let result = simd_vector_scale(&data, 0.0);
+    assert_eq!(result, vec![0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn vector_scale_negative() {
+    let data = vec![1.0, -2.0, 3.0];
+    let result = simd_vector_scale(&data, -1.0);
+    assert_eq!(result, vec![-1.0, 2.0, -3.0]);
+}
+
+// ── simd_l2_norm ─────────────────────────────────────────────────────
+
+#[test]
+fn l2_norm_pythagorean() {
+    let data = vec![3.0, 4.0];
+    let result = simd_l2_norm(&data);
+    assert!((result - 5.0).abs() < 1e-5);
+}
+
+#[test]
+fn l2_norm_unit() {
+    let data = vec![1.0, 0.0, 0.0];
+    let result = simd_l2_norm(&data);
+    assert!((result - 1.0).abs() < 1e-6);
+}
+
+#[test]
+fn l2_norm_zeros() {
+    let data = vec![0.0, 0.0, 0.0];
+    let result = simd_l2_norm(&data);
+    assert!((result - 0.0).abs() < 1e-6);
+}


### PR DESCRIPTION
## Summary
Add 66 edge-case integration tests for 5 advanced CPU kernel modules.

## Test Files (5 new)
- **cpu_simd_math_edge_cases.rs** (26 tests): fast exp/tanh/sigmoid approximations, dot product, vector add/mul/scale, L2 norm
- **cpu_fusion_edge_cases.rs** (12 tests): fused RMSNorm+linear, GELU+linear, softmax+mask, add+normalize, scale+add
- **cpu_kv_cache_edge_cases.rs** (10 tests): cache create/append/slice/clear, memory usage, multi-layer ops
- **cpu_conv2d_edge_cases.rs** (11 tests): output size computation, 1x1/3x3 conv2d, depthwise convolution
- **cpu_batch_norm_edge_cases.rs** (7 tests): inference/forward with identity params, scale, shift, nonzero mean

## Validation
All 66 tests pass with `--no-default-features --features cpu`
