### PR TITLE
test(transformer,ffi): add 37 edge-case tests for transformer + FFI

### DIFF
--- a/crates/bitnet-ffi/tests/ffi_c_api_edge_cases.rs
+++ b/crates/bitnet-ffi/tests/ffi_c_api_edge_cases.rs
@@ -1,0 +1,193 @@
+//! Edge-case tests for the bitnet-ffi C API surface.
+//!
+//! Tests cover version queries, init/cleanup lifecycle, error handling,
+//! config construction, performance metrics, and model operations.
+
+use bitnet_ffi::config::{BitNetCConfig, BitNetCInferenceConfig, BitNetCPerformanceMetrics};
+use bitnet_ffi::error::{BitNetCError, clear_last_error, get_last_error, set_last_error};
+use bitnet_ffi::{
+    BITNET_SUCCESS, bitnet_abi_version, bitnet_cleanup, bitnet_ffi_api_version,
+    bitnet_garbage_collect, bitnet_get_memory_usage, bitnet_get_num_threads, bitnet_init,
+    bitnet_is_gpu_available, bitnet_model_is_loaded, bitnet_set_num_threads, bitnet_version,
+};
+use std::ffi::CStr;
+
+// ── Version queries ──────────────────────────────────────────────────
+
+#[test]
+fn abi_version_is_nonzero() {
+    let v = bitnet_abi_version();
+    assert!(v > 0, "ABI version should be > 0, got {v}");
+}
+
+#[test]
+fn ffi_api_version_is_nonzero() {
+    let v = bitnet_ffi_api_version();
+    assert!(v > 0, "FFI API version should be > 0, got {v}");
+}
+
+#[test]
+fn version_string_is_valid_utf8() {
+    let ptr = bitnet_version();
+    assert!(!ptr.is_null(), "version pointer should not be null");
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    let s = cstr.to_str().expect("version should be valid UTF-8");
+    assert!(!s.is_empty(), "version string should not be empty");
+}
+
+#[test]
+fn version_contains_semver_pattern() {
+    let ptr = bitnet_version();
+    let cstr = unsafe { CStr::from_ptr(ptr) };
+    let s = cstr.to_str().unwrap();
+    // Should contain at least one dot (X.Y.Z pattern)
+    assert!(s.contains('.'), "version '{s}' should contain '.'");
+}
+
+// ── Init / Cleanup lifecycle ─────────────────────────────────────────
+
+#[test]
+fn init_returns_success() {
+    let rc = bitnet_init();
+    assert_eq!(rc, BITNET_SUCCESS as i32);
+    bitnet_cleanup();
+}
+
+#[test]
+fn double_init_is_safe() {
+    let rc1 = bitnet_init();
+    let rc2 = bitnet_init();
+    assert_eq!(rc1, BITNET_SUCCESS as i32);
+    assert_eq!(rc2, BITNET_SUCCESS as i32);
+    bitnet_cleanup();
+}
+
+// ── Error handling ───────────────────────────────────────────────────
+
+#[test]
+fn error_clear_then_get_returns_none() {
+    clear_last_error();
+    let err = get_last_error();
+    assert!(err.is_none(), "should be None after clear");
+}
+
+#[test]
+fn error_set_then_get_returns_message() {
+    set_last_error(BitNetCError::InvalidArgument("test arg".into()));
+    let err = get_last_error();
+    assert!(err.is_some(), "should have error after set");
+    clear_last_error();
+}
+
+#[test]
+fn error_clear_is_idempotent() {
+    clear_last_error();
+    clear_last_error();
+    clear_last_error();
+    assert!(get_last_error().is_none());
+}
+
+#[test]
+fn error_variants_display() {
+    let errors = vec![
+        BitNetCError::InvalidArgument("bad arg".into()),
+        BitNetCError::ModelNotFound("missing.gguf".into()),
+        BitNetCError::ModelLoadFailed("corrupt".into()),
+        BitNetCError::InferenceFailed("oom".into()),
+        BitNetCError::OutOfMemory("12GB needed".into()),
+        BitNetCError::Internal("unknown".into()),
+    ];
+    for err in errors {
+        let msg = format!("{err:?}");
+        assert!(!msg.is_empty());
+    }
+}
+
+// ── Config construction ──────────────────────────────────────────────
+
+#[test]
+fn config_default_has_sane_values() {
+    let cfg = BitNetCConfig::default();
+    assert!(cfg.model_path.is_null());
+    assert_eq!(cfg.num_threads, 0);
+}
+
+#[test]
+fn inference_config_default_values() {
+    let cfg = BitNetCInferenceConfig::default();
+    // Default inference config should have sensible defaults
+    let _ = format!("{cfg:?}");
+}
+
+#[test]
+fn performance_metrics_default_zeroed() {
+    let m = BitNetCPerformanceMetrics::default();
+    assert_eq!(m.tokens_generated, 0);
+    assert_eq!(m.prompt_tokens, 0);
+    assert_eq!(m.tokens_per_second, 0.0);
+}
+
+#[test]
+fn performance_metrics_debug_display() {
+    let m = BitNetCPerformanceMetrics::default();
+    let s = format!("{m:?}");
+    assert!(s.contains("BitNetCPerformanceMetrics"));
+}
+
+// ── Thread management ────────────────────────────────────────────────
+
+#[test]
+fn get_num_threads_returns_positive() {
+    let n = bitnet_get_num_threads();
+    assert!(n > 0, "thread count should be > 0, got {n}");
+}
+
+#[test]
+fn set_num_threads_roundtrip() {
+    let rc = bitnet_set_num_threads(2);
+    assert_eq!(rc, BITNET_SUCCESS as i32);
+    let n = bitnet_get_num_threads();
+    assert_eq!(n, 2, "thread count should be 2 after set");
+}
+
+// ── Memory & GPU ─────────────────────────────────────────────────────
+
+#[test]
+fn memory_usage_is_sane() {
+    let usage = bitnet_get_memory_usage();
+    assert!(usage < 100_000_000_000, "usage too large: {usage}");
+}
+
+#[test]
+fn garbage_collect_returns_success() {
+    let rc = bitnet_garbage_collect();
+    assert_eq!(rc, BITNET_SUCCESS as i32);
+}
+
+#[test]
+fn gpu_available_returns_valid_bool() {
+    let rc = bitnet_is_gpu_available();
+    assert!(rc == 0 || rc == 1, "expected 0 or 1, got {rc}");
+}
+
+// ── Model operations (no model loaded) ───────────────────────────────
+
+#[test]
+fn model_not_loaded_by_default() {
+    // Model ID 0 should not be loaded
+    let loaded = bitnet_model_is_loaded(0);
+    assert_eq!(loaded, 0, "no model should be loaded for ID 0");
+}
+
+#[test]
+fn model_not_loaded_negative_id() {
+    let loaded = bitnet_model_is_loaded(-1);
+    // Negative ID returns -1 (error) or 0 (not loaded)
+    assert!(loaded <= 0, "negative model ID should not return 'loaded'");
+}
+
+#[test]
+fn model_not_loaded_large_id() {
+    let loaded = bitnet_model_is_loaded(999999);
+    assert_eq!(loaded, 0, "large model ID should not be loaded");
+}

--- a/crates/bitnet-transformer/tests/transformer_edge_cases.rs
+++ b/crates/bitnet-transformer/tests/transformer_edge_cases.rs
@@ -1,0 +1,159 @@
+//! Edge-case tests for transformer layer components.
+//!
+//! Tests cover KVCache operations, RotaryEmbedding, config validation,
+//! and TransformerModel construction on CPU device.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_common::BitNetConfig;
+use bitnet_transformer::{KVCache, LayerKVCache, RotaryEmbedding};
+use candle_core::{DType, Device, Tensor};
+
+fn small_config(num_heads: usize, num_kv_heads: usize, max_seq_len: usize) -> BitNetConfig {
+    let mut cfg = BitNetConfig::default();
+    cfg.model.num_layers = 2;
+    cfg.model.num_heads = num_heads;
+    cfg.model.num_key_value_heads = num_kv_heads;
+    cfg.model.hidden_size = num_heads * 4; // head_dim = 4
+    cfg.model.max_position_embeddings = max_seq_len;
+    cfg
+}
+
+// ── LayerKVCache ─────────────────────────────────────────────────────
+
+#[test]
+fn layer_kv_cache_new_empty() {
+    // batch_size, n_kv_heads, max_seq_len, head_dim, device
+    let cache = LayerKVCache::new(1, 4, 16, 8, &Device::Cpu);
+    assert!(cache.is_ok());
+}
+
+#[test]
+fn layer_kv_cache_append_and_clear() {
+    let mut cache = LayerKVCache::new(1, 4, 16, 8, &Device::Cpu).unwrap();
+    let k = Tensor::zeros(&[1, 4, 1, 8], DType::F32, &Device::Cpu).unwrap();
+    let v = Tensor::zeros(&[1, 4, 1, 8], DType::F32, &Device::Cpu).unwrap();
+    cache.append(&k, &v).unwrap();
+    cache.clear();
+}
+
+#[test]
+fn layer_kv_cache_multiple_appends() {
+    let mut cache = LayerKVCache::new(1, 2, 64, 4, &Device::Cpu).unwrap();
+    for _ in 0..5 {
+        let k = Tensor::zeros(&[1, 2, 1, 4], DType::F32, &Device::Cpu).unwrap();
+        let v = Tensor::zeros(&[1, 2, 1, 4], DType::F32, &Device::Cpu).unwrap();
+        cache.append(&k, &v).unwrap();
+    }
+}
+
+#[test]
+fn layer_kv_cache_single_head() {
+    let mut cache = LayerKVCache::new(1, 1, 32, 16, &Device::Cpu).unwrap();
+    let k = Tensor::ones(&[1, 1, 1, 16], DType::F32, &Device::Cpu).unwrap();
+    let v = Tensor::ones(&[1, 1, 1, 16], DType::F32, &Device::Cpu).unwrap();
+    cache.append(&k, &v).unwrap();
+}
+
+// ── RotaryEmbedding ──────────────────────────────────────────────────
+
+#[test]
+fn rope_preserves_shape() {
+    // dim, max_seq_len, rope_theta (Option<f32>), device
+    let rope = RotaryEmbedding::new(64, 128, Some(10000.0), &Device::Cpu).unwrap();
+    let x = Tensor::randn(0.0f32, 1.0, &[1, 8, 1, 64], &Device::Cpu).unwrap();
+    let result = rope.apply(&x, 0).unwrap();
+    assert_eq!(result.dims(), &[1, 8, 1, 64]);
+}
+
+#[test]
+fn rope_different_positions() {
+    let rope = RotaryEmbedding::new(32, 64, Some(10000.0), &Device::Cpu).unwrap();
+    let x = Tensor::ones(&[1, 4, 1, 32], DType::F32, &Device::Cpu).unwrap();
+    let pos0 = rope.apply(&x, 0).unwrap();
+    let pos1 = rope.apply(&x, 1).unwrap();
+    let diff =
+        pos0.sub(&pos1).unwrap().abs().unwrap().sum_all().unwrap().to_scalar::<f32>().unwrap();
+    assert!(diff > 0.0, "Different positions should produce different embeddings");
+}
+
+#[test]
+fn rope_position_zero_preserves_magnitude() {
+    let rope = RotaryEmbedding::new(16, 32, Some(10000.0), &Device::Cpu).unwrap();
+    let x = Tensor::ones(&[1, 2, 1, 16], DType::F32, &Device::Cpu).unwrap();
+    let result = rope.apply(&x, 0).unwrap();
+    let input_norm = x.sqr().unwrap().sum_all().unwrap().to_scalar::<f32>().unwrap().sqrt();
+    let result_norm = result.sqr().unwrap().sum_all().unwrap().to_scalar::<f32>().unwrap().sqrt();
+    assert!(
+        (input_norm - result_norm).abs() < 0.1,
+        "RoPE at pos 0 should preserve magnitude: in={input_norm}, out={result_norm}"
+    );
+}
+
+#[test]
+fn rope_small_head_dim() {
+    let rope = RotaryEmbedding::new(4, 16, Some(10000.0), &Device::Cpu).unwrap();
+    let x = Tensor::randn(0.0f32, 1.0, &[1, 1, 1, 4], &Device::Cpu).unwrap();
+    let result = rope.apply(&x, 5).unwrap();
+    assert_eq!(result.dims(), &[1, 1, 1, 4]);
+}
+
+#[test]
+fn rope_default_theta() {
+    // Pass None for theta to test default behavior
+    let rope = RotaryEmbedding::new(32, 64, None, &Device::Cpu).unwrap();
+    let x = Tensor::ones(&[1, 4, 1, 32], DType::F32, &Device::Cpu).unwrap();
+    let result = rope.apply(&x, 0).unwrap();
+    assert_eq!(result.dims(), &[1, 4, 1, 32]);
+}
+
+#[test]
+fn rope_large_position() {
+    let rope = RotaryEmbedding::new(16, 2048, Some(10000.0), &Device::Cpu).unwrap();
+    let x = Tensor::ones(&[1, 2, 1, 16], DType::F32, &Device::Cpu).unwrap();
+    // Should work at position near max_seq_len
+    let result = rope.apply(&x, 2000).unwrap();
+    assert_eq!(result.dims(), &[1, 2, 1, 16]);
+}
+
+// ── KVCache (full model cache) ───────────────────────────────────────
+
+#[test]
+fn kv_cache_clear_all_layers() {
+    let config = small_config(4, 2, 32);
+    let mut cache = KVCache::new(&config, 1, &Device::Cpu).unwrap();
+    cache.clear();
+}
+
+#[test]
+fn kv_cache_layer_access() {
+    let config = small_config(4, 2, 32);
+    let mut cache = KVCache::new(&config, 1, &Device::Cpu).unwrap();
+    assert!(cache.layer_mut(0).is_some());
+    assert!(cache.layer_mut(1).is_some());
+    assert!(cache.layer_mut(2).is_none()); // only 2 layers
+}
+
+#[test]
+fn kv_cache_gqa_config() {
+    // Grouped query attention: fewer KV heads than query heads
+    let config = small_config(8, 2, 64);
+    let cache = KVCache::new(&config, 1, &Device::Cpu);
+    assert!(cache.is_ok(), "GQA config (8 heads, 2 KV heads) should work");
+}
+
+#[test]
+fn kv_cache_equal_heads() {
+    // Standard MHA: same number of KV and query heads
+    let config = small_config(4, 4, 32);
+    let cache = KVCache::new(&config, 1, &Device::Cpu);
+    assert!(cache.is_ok(), "MHA config (equal heads) should work");
+}
+
+#[test]
+fn kv_cache_single_kv_head() {
+    // Multi-query attention: single KV head
+    let config = small_config(8, 1, 32);
+    let cache = KVCache::new(&config, 1, &Device::Cpu);
+    assert!(cache.is_ok(), "MQA config (1 KV head) should work");
+}


### PR DESCRIPTION
## Summary
Adds 37 edge-case tests across bitnet-transformer (15) and bitnet-ffi (22).

## Transformer Tests (15)
- **LayerKVCache**: construction, append+clear, multiple appends, single head
- **RotaryEmbedding**: shape preservation, position differentiation, magnitude preservation, small head dim, default theta, large position
- **KVCache**: clear all layers, layer access bounds, GQA/MHA/MQA configurations

## FFI C API Tests (22)
- **Version queries**: ABI version, API version, version string validity, semver pattern
- **Lifecycle**: init success, double init idempotency
- **Error handling**: clear+get, set+get, idempotent clear, variant display
- **Config**: default BitNetCConfig, InferenceConfig, PerformanceMetrics zeroed/debug
- **Threading**: get threads positive, set roundtrip
- **Memory/GPU**: usage bounds, garbage collect, GPU availability
- **Model ops**: not loaded for default/negative/large IDs

All 37 tests pass locally with `--no-default-features --features cpu`
