### PR TITLE
test(opencl): add 123 edge-case tests for backend dispatcher, KV cache, paged attention, SPIR-V, and context pool

### DIFF
--- a/crates/bitnet-opencl/tests/opencl_backend_dispatcher_edge_cases.rs
+++ b/crates/bitnet-opencl/tests/opencl_backend_dispatcher_edge_cases.rs
@@ -1,0 +1,494 @@
+//! Edge-case tests for OpenCL backend dispatcher, registry, and dispatch strategies.
+//!
+//! Tests cover mock backends, all dispatch strategies (priority, round-robin,
+//! load-based, specific backend), error paths, capability matrix queries,
+//! dispatch logging, and degraded/unavailable backend handling.
+
+use bitnet_opencl::backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
+use bitnet_opencl::{
+    BackendCapabilityMatrix, BackendDispatcher, BackendStatus, DispatchError, DispatchLog,
+    DispatchStrategy, Operation,
+};
+
+// ── Mock backend ─────────────────────────────────────────────────────────────
+
+struct MockBackend {
+    name: String,
+    status: BackendStatus,
+    capabilities: Vec<Operation>,
+    priority: u32,
+}
+
+impl MockBackend {
+    fn available(name: &str, priority: u32, caps: Vec<Operation>) -> Box<Self> {
+        Box::new(Self {
+            name: name.to_string(),
+            status: BackendStatus::Available,
+            capabilities: caps,
+            priority,
+        })
+    }
+
+    fn degraded(name: &str, priority: u32, caps: Vec<Operation>, reason: &str) -> Box<Self> {
+        Box::new(Self {
+            name: name.to_string(),
+            status: BackendStatus::Degraded(reason.to_string()),
+            capabilities: caps,
+            priority,
+        })
+    }
+
+    fn unavailable(name: &str, reason: &str) -> Box<Self> {
+        Box::new(Self {
+            name: name.to_string(),
+            status: BackendStatus::Unavailable(reason.to_string()),
+            capabilities: vec![],
+            priority: 0,
+        })
+    }
+}
+
+impl BackendProvider for MockBackend {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn status(&self) -> BackendStatus {
+        self.status.clone()
+    }
+
+    fn capabilities(&self) -> Vec<Operation> {
+        self.capabilities.clone()
+    }
+
+    fn priority_score(&self) -> u32 {
+        self.priority
+    }
+}
+
+fn all_ops() -> Vec<Operation> {
+    vec![
+        Operation::MatMul,
+        Operation::Quantize,
+        Operation::Dequantize,
+        Operation::Softmax,
+        Operation::LayerNorm,
+        Operation::Attention,
+        Operation::RoPE,
+        Operation::Sampling,
+    ]
+}
+
+// ── BackendStatus tests ──────────────────────────────────────────────────────
+
+#[test]
+fn available_is_usable() {
+    assert!(BackendStatus::Available.is_usable());
+}
+
+#[test]
+fn degraded_is_usable() {
+    assert!(BackendStatus::Degraded("low memory".into()).is_usable());
+}
+
+#[test]
+fn unavailable_is_not_usable() {
+    assert!(!BackendStatus::Unavailable("driver missing".into()).is_usable());
+}
+
+// ── BackendRegistry tests ────────────────────────────────────────────────────
+
+#[test]
+fn empty_registry() {
+    let reg = BackendRegistry::new();
+    assert!(reg.is_empty());
+    assert_eq!(reg.len(), 0);
+    assert!(reg.get("nonexistent").is_none());
+}
+
+#[test]
+fn register_and_lookup() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, all_ops()));
+    assert_eq!(reg.len(), 1);
+    assert!(!reg.is_empty());
+    assert!(reg.get("cuda").is_some());
+    assert_eq!(reg.get("cuda").unwrap().name(), "cuda");
+}
+
+#[test]
+fn register_replaces_existing() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, all_ops()));
+    reg.register("cuda", MockBackend::available("cuda", 200, all_ops()));
+    assert_eq!(reg.len(), 1);
+    assert_eq!(reg.get("cuda").unwrap().priority_score(), 200);
+}
+
+#[test]
+fn unregister_existing() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, all_ops()));
+    assert!(reg.unregister("cuda"));
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn unregister_nonexistent_returns_false() {
+    let mut reg = BackendRegistry::new();
+    assert!(!reg.unregister("nonexistent"));
+}
+
+#[test]
+fn discover_available_returns_all() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, vec![Operation::MatMul]));
+    reg.register("opencl", MockBackend::degraded("opencl", 50, vec![Operation::Softmax], "hot"));
+    reg.register("cpu", MockBackend::unavailable("cpu", "no SIMD"));
+
+    let infos = reg.discover_available();
+    assert_eq!(infos.len(), 3);
+}
+
+#[test]
+fn default_registry_is_empty() {
+    let reg = BackendRegistry::default();
+    assert!(reg.is_empty());
+}
+
+// ── DispatchLog tests ────────────────────────────────────────────────────────
+
+#[test]
+fn dispatch_log_starts_empty() {
+    let log = DispatchLog::new();
+    assert!(log.is_empty());
+    assert_eq!(log.len(), 0);
+    assert!(log.entries().is_empty());
+}
+
+#[test]
+fn dispatch_log_default_is_empty() {
+    let log = DispatchLog::default();
+    assert!(log.is_empty());
+}
+
+#[test]
+fn dispatch_log_record_and_retrieve() {
+    let log = DispatchLog::new();
+    log.record(bitnet_opencl::DispatchDecision {
+        chosen_backend: "cuda".into(),
+        reason: "test".into(),
+        alternatives_available: vec!["cpu".into()],
+        operation: Operation::MatMul,
+    });
+    assert_eq!(log.len(), 1);
+    assert!(!log.is_empty());
+    let entries = log.entries();
+    assert_eq!(entries[0].chosen_backend, "cuda");
+    assert_eq!(entries[0].operation, Operation::MatMul);
+}
+
+#[test]
+fn dispatch_log_clear() {
+    let log = DispatchLog::new();
+    log.record(bitnet_opencl::DispatchDecision {
+        chosen_backend: "x".into(),
+        reason: "y".into(),
+        alternatives_available: vec![],
+        operation: Operation::Softmax,
+    });
+    assert_eq!(log.len(), 1);
+    log.clear();
+    assert!(log.is_empty());
+}
+
+// ── Priority dispatch tests ──────────────────────────────────────────────────
+
+fn two_backend_registry() -> BackendRegistry {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, all_ops()));
+    reg.register("cpu", MockBackend::available("cpu", 10, all_ops()));
+    reg
+}
+
+#[test]
+fn priority_dispatch_selects_highest() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::Priority);
+    let decision = dispatcher.dispatch(Operation::MatMul).unwrap();
+    assert_eq!(decision.chosen_backend, "cuda");
+    assert_eq!(decision.operation, Operation::MatMul);
+    assert!(decision.alternatives_available.contains(&"cpu".to_string()));
+}
+
+#[test]
+fn priority_dispatch_logs_decision() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::Priority);
+    dispatcher.dispatch(Operation::Softmax).unwrap();
+    assert_eq!(dispatcher.log().len(), 1);
+}
+
+#[test]
+fn priority_dispatch_no_backend_for_unsupported_op() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, vec![Operation::MatMul]));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let err = dispatcher.dispatch(Operation::Softmax).unwrap_err();
+    assert!(matches!(err, DispatchError::NoBackendAvailable { .. }));
+}
+
+// ── Round-robin dispatch tests ───────────────────────────────────────────────
+
+#[test]
+fn round_robin_alternates() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::RoundRobin);
+
+    let d1 = dispatcher.dispatch(Operation::MatMul).unwrap();
+    let d2 = dispatcher.dispatch(Operation::MatMul).unwrap();
+
+    // Should pick different backends on consecutive calls
+    // (sorted by name: cpu < cuda, so idx 0=cpu, idx 1=cuda)
+    assert_ne!(d1.chosen_backend, d2.chosen_backend);
+}
+
+#[test]
+fn round_robin_wraps_around() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::RoundRobin);
+
+    let d1 = dispatcher.dispatch(Operation::MatMul).unwrap();
+    let _d2 = dispatcher.dispatch(Operation::MatMul).unwrap();
+    let d3 = dispatcher.dispatch(Operation::MatMul).unwrap();
+
+    // After 2 dispatches, should wrap back to first backend
+    assert_eq!(d1.chosen_backend, d3.chosen_backend);
+}
+
+#[test]
+fn round_robin_single_backend() {
+    let mut reg = BackendRegistry::new();
+    reg.register("only", MockBackend::available("only", 50, all_ops()));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::RoundRobin);
+
+    let d1 = dispatcher.dispatch(Operation::MatMul).unwrap();
+    let d2 = dispatcher.dispatch(Operation::MatMul).unwrap();
+    assert_eq!(d1.chosen_backend, d2.chosen_backend);
+    assert_eq!(d1.chosen_backend, "only");
+}
+
+// ── LoadBased dispatch tests ─────────────────────────────────────────────────
+
+#[test]
+fn load_based_falls_back_to_priority() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::LoadBased);
+    let decision = dispatcher.dispatch(Operation::MatMul).unwrap();
+    // LoadBased currently falls back to priority
+    assert_eq!(decision.chosen_backend, "cuda");
+}
+
+// ── SpecificBackend dispatch tests ───────────────────────────────────────────
+
+#[test]
+fn specific_backend_selects_named() {
+    let dispatcher = BackendDispatcher::new(
+        two_backend_registry(),
+        DispatchStrategy::SpecificBackend("cpu".into()),
+    );
+    let decision = dispatcher.dispatch(Operation::MatMul).unwrap();
+    assert_eq!(decision.chosen_backend, "cpu");
+}
+
+#[test]
+fn specific_backend_not_found() {
+    let dispatcher = BackendDispatcher::new(
+        two_backend_registry(),
+        DispatchStrategy::SpecificBackend("vulkan".into()),
+    );
+    let err = dispatcher.dispatch(Operation::MatMul).unwrap_err();
+    assert!(matches!(err, DispatchError::BackendNotFound { .. }));
+}
+
+#[test]
+fn specific_backend_unavailable() {
+    let mut reg = BackendRegistry::new();
+    reg.register("down", MockBackend::unavailable("down", "crashed"));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::SpecificBackend("down".into()));
+    let err = dispatcher.dispatch(Operation::MatMul).unwrap_err();
+    assert!(matches!(err, DispatchError::BackendNotUsable { .. }));
+}
+
+#[test]
+fn specific_backend_does_not_support_op() {
+    let mut reg = BackendRegistry::new();
+    reg.register("limited", MockBackend::available("limited", 50, vec![Operation::MatMul]));
+    let dispatcher =
+        BackendDispatcher::new(reg, DispatchStrategy::SpecificBackend("limited".into()));
+    let err = dispatcher.dispatch(Operation::Softmax).unwrap_err();
+    assert!(matches!(err, DispatchError::OperationNotSupported { .. }));
+}
+
+// ── Degraded backend tests ───────────────────────────────────────────────────
+
+#[test]
+fn degraded_backend_is_usable_for_dispatch() {
+    let mut reg = BackendRegistry::new();
+    reg.register("degraded", MockBackend::degraded("degraded", 50, all_ops(), "overheating"));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let decision = dispatcher.dispatch(Operation::MatMul).unwrap();
+    assert_eq!(decision.chosen_backend, "degraded");
+}
+
+#[test]
+fn degraded_lower_priority_than_available() {
+    let mut reg = BackendRegistry::new();
+    reg.register("degraded", MockBackend::degraded("degraded", 100, all_ops(), "hot"));
+    reg.register("healthy", MockBackend::available("healthy", 100, all_ops()));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let decision = dispatcher.dispatch(Operation::MatMul).unwrap();
+    // Both have same priority, but order depends on HashMap iteration
+    assert!(decision.chosen_backend == "degraded" || decision.chosen_backend == "healthy");
+}
+
+// ── Dispatch with fallback tests ─────────────────────────────────────────────
+
+#[test]
+fn dispatch_with_fallback_selects_first_usable() {
+    let mut reg = BackendRegistry::new();
+    reg.register("cuda", MockBackend::available("cuda", 100, all_ops()));
+    reg.register("cpu", MockBackend::available("cpu", 10, all_ops()));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let decision = dispatcher.dispatch_with_fallback(Operation::MatMul).unwrap();
+    assert_eq!(decision.chosen_backend, "cuda");
+}
+
+#[test]
+fn dispatch_with_fallback_empty_registry() {
+    let reg = BackendRegistry::new();
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let err = dispatcher.dispatch_with_fallback(Operation::MatMul).unwrap_err();
+    assert!(matches!(err, DispatchError::NoBackendAvailable { .. }));
+}
+
+// ── Capability matrix tests ──────────────────────────────────────────────────
+
+#[test]
+fn capability_matrix_supported() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::Priority);
+    let matrix = dispatcher.capability_matrix();
+    assert!(matrix.is_supported(Operation::MatMul));
+    assert!(matrix.is_supported(Operation::Softmax));
+}
+
+#[test]
+fn capability_matrix_not_supported() {
+    let mut reg = BackendRegistry::new();
+    reg.register("limited", MockBackend::available("limited", 50, vec![Operation::MatMul]));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let matrix = dispatcher.capability_matrix();
+    assert!(matrix.is_supported(Operation::MatMul));
+    assert!(!matrix.is_supported(Operation::Softmax));
+}
+
+#[test]
+fn capability_matrix_backends_for() {
+    let dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::Priority);
+    let matrix = dispatcher.capability_matrix();
+    let backends = matrix.backends_for(Operation::MatMul);
+    assert!(backends.contains(&"cuda".to_string()));
+    assert!(backends.contains(&"cpu".to_string()));
+}
+
+#[test]
+fn capability_matrix_excludes_unavailable() {
+    let mut reg = BackendRegistry::new();
+    reg.register("down", MockBackend::unavailable("down", "crashed"));
+    reg.register("up", MockBackend::available("up", 50, all_ops()));
+    let dispatcher = BackendDispatcher::new(reg, DispatchStrategy::Priority);
+    let matrix = dispatcher.capability_matrix();
+    let backends = matrix.backends_for(Operation::MatMul);
+    assert_eq!(backends, vec!["up"]);
+}
+
+// ── Strategy mutation tests ──────────────────────────────────────────────────
+
+#[test]
+fn set_strategy_changes_behavior() {
+    let mut dispatcher = BackendDispatcher::new(two_backend_registry(), DispatchStrategy::Priority);
+    assert_eq!(dispatcher.strategy(), &DispatchStrategy::Priority);
+
+    dispatcher.set_strategy(DispatchStrategy::RoundRobin);
+    assert_eq!(dispatcher.strategy(), &DispatchStrategy::RoundRobin);
+}
+
+#[test]
+fn registry_mut_add_backend() {
+    let mut dispatcher = BackendDispatcher::new(BackendRegistry::new(), DispatchStrategy::Priority);
+    dispatcher.registry_mut().register("new", MockBackend::available("new", 50, all_ops()));
+    assert_eq!(dispatcher.registry().len(), 1);
+}
+
+// ── Operation enum tests ─────────────────────────────────────────────────────
+
+#[test]
+fn operation_debug_and_clone() {
+    let op = Operation::MatMul;
+    let op2 = op;
+    assert_eq!(op, op2);
+    assert_eq!(format!("{op:?}"), "MatMul");
+}
+
+#[test]
+fn all_operations_distinct() {
+    let ops = all_ops();
+    for (i, a) in ops.iter().enumerate() {
+        for (j, b) in ops.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b);
+            }
+        }
+    }
+}
+
+// ── Error display tests ─────────────────────────────────────────────────────
+
+#[test]
+fn dispatch_error_display_no_backend() {
+    let err = DispatchError::NoBackendAvailable { op: Operation::MatMul };
+    let msg = format!("{err}");
+    assert!(msg.contains("MatMul"));
+}
+
+#[test]
+fn dispatch_error_display_not_found() {
+    let err = DispatchError::BackendNotFound { name: "vulkan".into() };
+    let msg = format!("{err}");
+    assert!(msg.contains("vulkan"));
+}
+
+#[test]
+fn dispatch_error_display_not_supported() {
+    let err = DispatchError::OperationNotSupported { name: "cpu".into(), op: Operation::Attention };
+    let msg = format!("{err}");
+    assert!(msg.contains("cpu"));
+    assert!(msg.contains("Attention"));
+}
+
+#[test]
+fn dispatch_error_display_not_usable() {
+    let err = DispatchError::BackendNotUsable {
+        name: "dead".into(),
+        status: BackendStatus::Unavailable("gone".into()),
+    };
+    let msg = format!("{err}");
+    assert!(msg.contains("dead"));
+}
+
+#[test]
+fn dispatch_error_display_all_failed() {
+    let err = DispatchError::AllBackendsFailed {
+        op: Operation::RoPE,
+        last_backend: "cpu".into(),
+        last_reason: "timeout".into(),
+    };
+    let msg = format!("{err}");
+    assert!(msg.contains("RoPE"));
+    assert!(msg.contains("timeout"));
+}

--- a/crates/bitnet-opencl/tests/opencl_paged_kv_edge_cases.rs
+++ b/crates/bitnet-opencl/tests/opencl_paged_kv_edge_cases.rs
@@ -1,0 +1,503 @@
+//! Edge-case tests for OpenCL paged attention, page allocator, KV cache,
+//! and GQA configuration.
+
+use bitnet_opencl::kv_cache::{CacheMemoryStats, GpuKvCache, KvCacheConfig, PageTable};
+use bitnet_opencl::paged_attention::{
+    GqaConfig, PageAllocator, PagedAttentionEngine, kv_config_for_gqa,
+};
+
+// ── PageAllocator tests ──────────────────────────────────────────────────────
+
+#[test]
+fn allocator_new_all_free() {
+    let alloc = PageAllocator::new(16);
+    assert_eq!(alloc.total_pages(), 16);
+    assert_eq!(alloc.free_count(), 16);
+    assert_eq!(alloc.used_count(), 0);
+}
+
+#[test]
+fn allocator_zero_pages() {
+    let alloc = PageAllocator::new(0);
+    assert_eq!(alloc.total_pages(), 0);
+    assert_eq!(alloc.free_count(), 0);
+    assert_eq!(alloc.used_count(), 0);
+}
+
+#[test]
+fn allocator_allocate_returns_page_index() {
+    let mut alloc = PageAllocator::new(4);
+    let page = alloc.allocate();
+    assert!(page.is_some());
+    assert_eq!(alloc.used_count(), 1);
+    assert_eq!(alloc.free_count(), 3);
+}
+
+#[test]
+fn allocator_allocate_all_pages() {
+    let mut alloc = PageAllocator::new(3);
+    assert!(alloc.allocate().is_some());
+    assert!(alloc.allocate().is_some());
+    assert!(alloc.allocate().is_some());
+    assert_eq!(alloc.free_count(), 0);
+    assert_eq!(alloc.used_count(), 3);
+}
+
+#[test]
+fn allocator_allocate_exhausted() {
+    let mut alloc = PageAllocator::new(1);
+    assert!(alloc.allocate().is_some());
+    assert!(alloc.allocate().is_none());
+}
+
+#[test]
+fn allocator_free_returns_true() {
+    let mut alloc = PageAllocator::new(4);
+    let page = alloc.allocate().unwrap();
+    assert!(alloc.free(page));
+    assert_eq!(alloc.free_count(), 4);
+    assert_eq!(alloc.used_count(), 0);
+}
+
+#[test]
+fn allocator_free_nonexistent_returns_false() {
+    let mut alloc = PageAllocator::new(4);
+    assert!(!alloc.free(999));
+}
+
+#[test]
+fn allocator_free_already_freed_returns_false() {
+    let mut alloc = PageAllocator::new(4);
+    let page = alloc.allocate().unwrap();
+    alloc.free(page);
+    assert!(!alloc.free(page));
+}
+
+#[test]
+fn allocator_defragment_no_moves_when_contiguous() {
+    let mut alloc = PageAllocator::new(4);
+    alloc.allocate(); // page 3 (reversed)
+    alloc.allocate(); // page 2
+    // After defrag, pages 0..2 are used
+    let mapping = alloc.defragment();
+    // Pages should be compacted to 0, 1
+    assert_eq!(alloc.used_count(), 2);
+    assert_eq!(alloc.free_count(), 2);
+    // Mapping contains remapped pages (if any)
+    for (old, new) in &mapping {
+        assert_ne!(old, new);
+    }
+}
+
+#[test]
+fn allocator_defragment_with_gap() {
+    let mut alloc = PageAllocator::new(8);
+    let p0 = alloc.allocate().unwrap(); // gets page from end
+    let p1 = alloc.allocate().unwrap();
+    let _p2 = alloc.allocate().unwrap();
+
+    // Free middle page to create gap
+    alloc.free(p1);
+    assert_eq!(alloc.used_count(), 2);
+
+    let mapping = alloc.defragment();
+    assert_eq!(alloc.used_count(), 2);
+    assert_eq!(alloc.free_count(), 6);
+    // After defrag, used pages should be contiguous 0..2
+    // mapping shows which pages moved
+    let _ = mapping; // verify it compiles and runs
+}
+
+#[test]
+fn allocator_defragment_empty() {
+    let mut alloc = PageAllocator::new(4);
+    let mapping = alloc.defragment();
+    assert!(mapping.is_empty());
+}
+
+#[test]
+fn allocator_single_page() {
+    let mut alloc = PageAllocator::new(1);
+    let p = alloc.allocate().unwrap();
+    assert_eq!(alloc.free_count(), 0);
+    alloc.free(p);
+    assert_eq!(alloc.free_count(), 1);
+}
+
+// ── GqaConfig tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn gqa_config_group_size_standard() {
+    let gqa = GqaConfig { num_q_heads: 32, num_kv_heads: 8, head_dim: 128 };
+    assert_eq!(gqa.group_size(), 4);
+}
+
+#[test]
+fn gqa_config_mha_group_size_1() {
+    let gqa = GqaConfig { num_q_heads: 16, num_kv_heads: 16, head_dim: 64 };
+    assert_eq!(gqa.group_size(), 1);
+}
+
+#[test]
+fn gqa_config_mqa_full_sharing() {
+    let gqa = GqaConfig { num_q_heads: 40, num_kv_heads: 1, head_dim: 128 };
+    assert_eq!(gqa.group_size(), 40);
+}
+
+#[test]
+fn gqa_config_phi4_like() {
+    let gqa = GqaConfig { num_q_heads: 40, num_kv_heads: 10, head_dim: 128 };
+    assert_eq!(gqa.group_size(), 4);
+}
+
+// ── KvCacheConfig / kv_config_for_gqa tests ──────────────────────────────────
+
+#[test]
+fn kv_config_for_gqa_populates_fields() {
+    let gqa = GqaConfig { num_q_heads: 32, num_kv_heads: 8, head_dim: 128 };
+    let config = kv_config_for_gqa(&gqa, 40, 4096, 256);
+    assert_eq!(config.num_layers, 40);
+    assert_eq!(config.num_heads, 8);
+    assert_eq!(config.head_dim, 128);
+    assert_eq!(config.max_seq_len, 4096);
+    assert_eq!(config.page_size, 256);
+}
+
+// ── GpuKvCache tests ─────────────────────────────────────────────────────────
+
+fn small_cache_config() -> KvCacheConfig {
+    KvCacheConfig { num_layers: 2, num_heads: 4, head_dim: 8, max_seq_len: 16, page_size: 4 }
+}
+
+#[test]
+fn kv_cache_new_empty() {
+    let cache = GpuKvCache::new(small_cache_config());
+    assert_eq!(cache.seq_len(0), 0);
+    assert_eq!(cache.seq_len(1), 0);
+}
+
+#[test]
+#[should_panic(expected = "page_size must be > 0")]
+fn kv_cache_zero_page_size_panics() {
+    GpuKvCache::new(KvCacheConfig {
+        num_layers: 1,
+        num_heads: 1,
+        head_dim: 1,
+        max_seq_len: 4,
+        page_size: 0,
+    });
+}
+
+#[test]
+fn kv_cache_append_increments_seq_len() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim; // 32
+    let mut cache = GpuKvCache::new(cfg);
+    let k = vec![1.0f32; stride];
+    let v = vec![2.0f32; stride];
+    cache.append(0, &k, &v);
+    assert_eq!(cache.seq_len(0), 1);
+    assert_eq!(cache.seq_len(1), 0); // other layer unchanged
+}
+
+#[test]
+fn kv_cache_append_and_get_roundtrip() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    let k: Vec<f32> = (0..stride).map(|i| i as f32).collect();
+    let v: Vec<f32> = (0..stride).map(|i| (i as f32) * 10.0).collect();
+    cache.append(0, &k, &v);
+
+    let (got_k, got_v) = cache.get(0, 0..1);
+    assert_eq!(got_k, k);
+    assert_eq!(got_v, v);
+}
+
+#[test]
+fn kv_cache_multiple_appends() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    for i in 0..5 {
+        let k = vec![i as f32; stride];
+        let v = vec![(i as f32) * -1.0; stride];
+        cache.append(0, &k, &v);
+    }
+    assert_eq!(cache.seq_len(0), 5);
+
+    let (keys, vals) = cache.get(0, 0..5);
+    assert_eq!(keys.len(), 5 * stride);
+    assert_eq!(vals.len(), 5 * stride);
+    // First position should be all 0.0
+    assert!((keys[0] - 0.0).abs() < 1e-6);
+    // Last position should be all 4.0
+    assert!((keys[4 * stride] - 4.0).abs() < 1e-6);
+}
+
+#[test]
+fn kv_cache_multiple_layers() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    cache.append(0, &vec![2.0; stride], &vec![2.0; stride]);
+    cache.append(1, &vec![3.0; stride], &vec![3.0; stride]);
+
+    assert_eq!(cache.seq_len(0), 2);
+    assert_eq!(cache.seq_len(1), 1);
+}
+
+#[test]
+#[should_panic(expected = "k length mismatch")]
+fn kv_cache_wrong_k_length_panics() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+    cache.append(0, &vec![1.0; stride + 1], &vec![1.0; stride]);
+}
+
+#[test]
+#[should_panic(expected = "v length mismatch")]
+fn kv_cache_wrong_v_length_panics() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride - 1]);
+}
+
+#[test]
+fn kv_cache_trim() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    for i in 0..8 {
+        cache.append(0, &vec![i as f32; stride], &vec![i as f32; stride]);
+    }
+    assert_eq!(cache.seq_len(0), 8);
+
+    cache.trim(3);
+    assert_eq!(cache.seq_len(0), 3);
+
+    // Verify data integrity after trim
+    let (keys, _) = cache.get(0, 0..3);
+    assert!((keys[0] - 0.0).abs() < 1e-6);
+}
+
+#[test]
+fn kv_cache_trim_to_zero() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    cache.trim(0);
+    assert_eq!(cache.seq_len(0), 0);
+}
+
+#[test]
+fn kv_cache_trim_larger_than_current_is_noop() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    cache.trim(100); // larger than current
+    assert_eq!(cache.seq_len(0), 1);
+}
+
+#[test]
+fn kv_cache_clear() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    cache.append(1, &vec![2.0; stride], &vec![2.0; stride]);
+    cache.clear();
+    assert_eq!(cache.seq_len(0), 0);
+    assert_eq!(cache.seq_len(1), 0);
+}
+
+#[test]
+fn kv_cache_memory_usage_initially_zero_utilization() {
+    let cache = GpuKvCache::new(small_cache_config());
+    let stats = cache.memory_usage();
+    // All pages are pre-allocated but free
+    assert!(stats.total_bytes > 0);
+    assert_eq!(stats.used_bytes, 0);
+    assert_eq!(stats.utilization_pct, 0.0);
+}
+
+#[test]
+fn kv_cache_memory_usage_after_append() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    let stats = cache.memory_usage();
+    assert!(stats.used_bytes > 0);
+    assert!(stats.utilization_pct > 0.0);
+}
+
+#[test]
+fn kv_cache_page_table_empty() {
+    let cache = GpuKvCache::new(small_cache_config());
+    let table = cache.page_table();
+    assert!(table.pages_for_layer(0).is_empty());
+    assert!(table.pages_for_layer(1).is_empty());
+}
+
+#[test]
+fn kv_cache_page_table_after_append() {
+    let cfg = small_cache_config();
+    let stride = cfg.num_heads * cfg.head_dim;
+    let mut cache = GpuKvCache::new(cfg);
+
+    cache.append(0, &vec![1.0; stride], &vec![1.0; stride]);
+    let table = cache.page_table();
+    assert_eq!(table.pages_for_layer(0).len(), 1);
+    assert!(table.pages_for_layer(1).is_empty());
+}
+
+#[test]
+fn kv_cache_config_accessor() {
+    let cfg = small_cache_config();
+    let cache = GpuKvCache::new(cfg.clone());
+    assert_eq!(cache.config().num_layers, 2);
+    assert_eq!(cache.config().head_dim, 8);
+}
+
+// ── PagedAttentionEngine tests ───────────────────────────────────────────────
+
+fn simple_gqa() -> GqaConfig {
+    GqaConfig { num_q_heads: 2, num_kv_heads: 1, head_dim: 4 }
+}
+
+fn simple_kv_config() -> KvCacheConfig {
+    let gqa = simple_gqa();
+    kv_config_for_gqa(&gqa, 1, 16, 4)
+}
+
+#[test]
+fn paged_attention_empty_cache_returns_zeros() {
+    let engine = PagedAttentionEngine::new(simple_gqa());
+    let cache = GpuKvCache::new(simple_kv_config());
+    let q = vec![1.0f32; 2 * 4]; // num_q_heads * head_dim
+    let output = engine.compute_attention(&q, &cache, 0, &[]);
+    assert_eq!(output.len(), 8);
+    assert!(output.iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn paged_attention_single_position() {
+    let gqa = simple_gqa();
+    let engine = PagedAttentionEngine::new(gqa.clone());
+    let kv_cfg = simple_kv_config();
+    let mut cache = GpuKvCache::new(kv_cfg);
+
+    // Append one KV pair: k = [1,0,0,0], v = [0,0,0,1]
+    let k = vec![1.0, 0.0, 0.0, 0.0];
+    let v = vec![0.0, 0.0, 0.0, 1.0];
+    cache.append(0, &k, &v);
+
+    // Query
+    let q = vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+    let output = engine.compute_attention(&q, &cache, 0, &[]);
+
+    // With single position, softmax is 1.0, so output = value
+    assert_eq!(output.len(), 8);
+    // Both heads should produce [0,0,0,1] since there's only one position
+    assert!((output[3] - 1.0).abs() < 1e-5);
+    assert!((output[7] - 1.0).abs() < 1e-5);
+}
+
+#[test]
+fn paged_attention_with_mask() {
+    let gqa = simple_gqa();
+    let engine = PagedAttentionEngine::new(gqa);
+    let kv_cfg = simple_kv_config();
+    let mut cache = GpuKvCache::new(kv_cfg);
+
+    let k1 = vec![1.0, 0.0, 0.0, 0.0];
+    let v1 = vec![10.0, 0.0, 0.0, 0.0];
+    let k2 = vec![0.0, 1.0, 0.0, 0.0];
+    let v2 = vec![0.0, 20.0, 0.0, 0.0];
+    cache.append(0, &k1, &v1);
+    cache.append(0, &k2, &v2);
+
+    let q = vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0];
+
+    // Mask out position 0 (attend only to position 1)
+    let mask = vec![0u8, 1u8];
+    let output = engine.compute_attention(&q, &cache, 0, &mask);
+    // Only position 1 attended; its value is [0,20,0,0]
+    assert!((output[1] - 20.0).abs() < 1e-5);
+}
+
+#[test]
+fn paged_attention_blocked_matches_standard() {
+    let gqa = simple_gqa();
+    let engine = PagedAttentionEngine::new(gqa);
+    let kv_cfg = simple_kv_config();
+    let mut cache = GpuKvCache::new(kv_cfg);
+
+    for i in 0..4 {
+        let k = vec![i as f32, 0.0, 0.0, 0.0];
+        let v = vec![0.0, i as f32, 0.0, 0.0];
+        cache.append(0, &k, &v);
+    }
+
+    let q = vec![1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+    let standard = engine.compute_attention(&q, &cache, 0, &[]);
+    let blocked = engine.compute_attention_blocked(&q, &cache, 0, &[], 2);
+
+    // Both should produce the same output
+    for (a, b) in standard.iter().zip(blocked.iter()) {
+        assert!((a - b).abs() < 1e-5, "standard={a}, blocked={b}");
+    }
+}
+
+#[test]
+fn paged_attention_blocked_zero_block_size_returns_zeros() {
+    let engine = PagedAttentionEngine::new(simple_gqa());
+    let kv_cfg = simple_kv_config();
+    let mut cache = GpuKvCache::new(kv_cfg);
+
+    let k = vec![1.0, 0.0, 0.0, 0.0];
+    let v = vec![0.0, 1.0, 0.0, 0.0];
+    cache.append(0, &k, &v);
+
+    let q = vec![1.0; 8];
+    let output = engine.compute_attention_blocked(&q, &cache, 0, &[], 0);
+    assert!(output.iter().all(|&v| v == 0.0));
+}
+
+#[test]
+fn paged_attention_gqa_config_accessor() {
+    let gqa = simple_gqa();
+    let engine = PagedAttentionEngine::new(gqa);
+    assert_eq!(engine.gqa_config().num_q_heads, 2);
+    assert_eq!(engine.gqa_config().num_kv_heads, 1);
+    assert_eq!(engine.gqa_config().head_dim, 4);
+}
+
+// ── CacheMemoryStats tests ───────────────────────────────────────────────────
+
+#[test]
+fn cache_memory_stats_equality() {
+    let a = CacheMemoryStats {
+        total_bytes: 1024,
+        used_bytes: 512,
+        page_count: 4,
+        utilization_pct: 50.0,
+    };
+    let b = a.clone();
+    assert_eq!(a, b);
+}

--- a/crates/bitnet-opencl/tests/opencl_spirv_context_edge_cases.rs
+++ b/crates/bitnet-opencl/tests/opencl_spirv_context_edge_cases.rs
@@ -1,0 +1,415 @@
+//! Edge-case tests for OpenCL SPIR-V kernel registry, SPIR-V types,
+//! and context pool with mock factory.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use bitnet_opencl::context_pool::{
+    ContextFactory, ContextPool, ContextPoolConfig, ContextPoolError, MemoryBytes,
+};
+use bitnet_opencl::{
+    CompileOptions, CompilerBackend, KernelSource, OptimizationLevel, SPIRV_MAGIC, SpirVCompiler,
+    SpirVError, SpirVModule, SpirVValidator, SpirvKernelRegistry,
+};
+
+// ── SpirvKernelRegistry tests ────────────────────────────────────────────────
+
+#[test]
+fn empty_registry() {
+    let reg = SpirvKernelRegistry::new();
+    assert!(reg.is_empty());
+    assert_eq!(reg.len(), 0);
+    assert!(reg.get("nonexistent").is_none());
+}
+
+#[test]
+fn default_registry_is_empty() {
+    let reg = SpirvKernelRegistry::default();
+    assert!(reg.is_empty());
+}
+
+#[test]
+fn register_cl_source() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("my_kernel", KernelSource::ClSource("__kernel void f() {}".into()));
+    assert_eq!(reg.len(), 1);
+    assert!(!reg.is_empty());
+    assert!(reg.get("my_kernel").is_some());
+}
+
+#[test]
+fn register_spirv_binary() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("binary_kernel", KernelSource::SpirV(vec![0x07, 0x23, 0x02, 0x03]));
+    assert!(reg.get("binary_kernel").is_some());
+    match reg.get("binary_kernel").unwrap() {
+        KernelSource::SpirV(bytes) => assert_eq!(bytes.len(), 4),
+        _ => panic!("expected SpirV variant"),
+    }
+}
+
+#[test]
+fn register_overwrites_same_name() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("k", KernelSource::ClSource("v1".into()));
+    reg.register("k", KernelSource::ClSource("v2".into()));
+    assert_eq!(reg.len(), 1);
+    match reg.get("k").unwrap() {
+        KernelSource::ClSource(s) => assert_eq!(s, "v2"),
+        _ => panic!("expected ClSource"),
+    }
+}
+
+#[test]
+fn register_multiple_kernels() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("a", KernelSource::ClSource("a".into()));
+    reg.register("b", KernelSource::SpirV(vec![1, 2, 3]));
+    reg.register("c", KernelSource::ClSource("c".into()));
+    assert_eq!(reg.len(), 3);
+}
+
+#[test]
+fn names_iterator() {
+    let mut reg = SpirvKernelRegistry::new();
+    reg.register("alpha", KernelSource::ClSource("a".into()));
+    reg.register("beta", KernelSource::SpirV(vec![]));
+    let mut names: Vec<&str> = reg.names().collect();
+    names.sort();
+    assert_eq!(names, vec!["alpha", "beta"]);
+}
+
+#[test]
+fn builtin_kernels_populated() {
+    let reg = SpirvKernelRegistry::with_builtin_kernels();
+    assert!(!reg.is_empty());
+    assert!(reg.get("matmul_i2").is_some());
+    assert!(reg.get("dequant_i2s").is_some());
+}
+
+#[test]
+fn builtin_kernels_are_cl_source() {
+    let reg = SpirvKernelRegistry::with_builtin_kernels();
+    for name in reg.names() {
+        match reg.get(name).unwrap() {
+            KernelSource::ClSource(src) => assert!(!src.is_empty()),
+            KernelSource::SpirV(_) => {} // also acceptable
+        }
+    }
+}
+
+#[test]
+fn kernel_source_clone() {
+    let src = KernelSource::ClSource("test".into());
+    let cloned = src.clone();
+    match (&src, &cloned) {
+        (KernelSource::ClSource(a), KernelSource::ClSource(b)) => assert_eq!(a, b),
+        _ => panic!("clone mismatch"),
+    }
+}
+
+#[test]
+fn kernel_source_debug() {
+    let src = KernelSource::ClSource("hello".into());
+    let dbg = format!("{src:?}");
+    assert!(dbg.contains("ClSource"));
+}
+
+// ── SPIR-V types tests ──────────────────────────────────────────────────────
+
+#[test]
+fn spirv_magic_constant() {
+    assert_eq!(SPIRV_MAGIC, 0x0723_0203);
+}
+
+#[test]
+fn compile_options_default() {
+    let opts = CompileOptions::default();
+    assert!(opts.target_device.is_none());
+    assert_eq!(opts.optimization_level, OptimizationLevel::Full);
+    assert!(opts.defines.is_empty());
+}
+
+#[test]
+fn compile_options_custom() {
+    let opts = CompileOptions {
+        target_device: Some("arc".into()),
+        optimization_level: OptimizationLevel::None,
+        defines: vec![("KEY".into(), "VAL".into())],
+    };
+    assert_eq!(opts.target_device.as_deref(), Some("arc"));
+    assert_eq!(opts.optimization_level, OptimizationLevel::None);
+    assert_eq!(opts.defines.len(), 1);
+}
+
+#[test]
+fn optimization_level_equality() {
+    assert_eq!(OptimizationLevel::None, OptimizationLevel::None);
+    assert_ne!(OptimizationLevel::None, OptimizationLevel::Basic);
+    assert_ne!(OptimizationLevel::Basic, OptimizationLevel::Full);
+}
+
+#[test]
+fn compiler_backend_equality() {
+    assert_eq!(CompilerBackend::Clang, CompilerBackend::Clang);
+    assert_ne!(CompilerBackend::Clang, CompilerBackend::Ocloc);
+}
+
+#[test]
+fn spirv_module_debug() {
+    let m = SpirVModule {
+        bytecode: vec![1, 2, 3, 4],
+        source_hash: "abc123".into(),
+        compiler: Some(CompilerBackend::Clang),
+    };
+    let dbg = format!("{m:?}");
+    assert!(dbg.contains("abc123"));
+    assert!(dbg.contains("Clang"));
+}
+
+#[test]
+fn spirv_module_clone() {
+    let m = SpirVModule { bytecode: vec![0x07, 0x23], source_hash: "hash".into(), compiler: None };
+    let cloned = m.clone();
+    assert_eq!(cloned.bytecode, m.bytecode);
+    assert_eq!(cloned.source_hash, m.source_hash);
+}
+
+#[test]
+fn spirv_compiler_no_backend() {
+    let compiler = SpirVCompiler::with_backend(None);
+    assert!(compiler.backend().is_none());
+}
+
+#[test]
+fn spirv_compiler_explicit_backend() {
+    let compiler = SpirVCompiler::with_backend(Some(CompilerBackend::Clang));
+    assert_eq!(compiler.backend(), Some(CompilerBackend::Clang));
+}
+
+#[test]
+fn spirv_compiler_no_backend_compile_fails() {
+    let compiler = SpirVCompiler::with_backend(None);
+    let result = compiler.compile_to_spirv("__kernel void f() {}", &CompileOptions::default());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        SpirVError::NoCompilerAvailable => {}
+        other => panic!("expected NoCompilerAvailable, got {other:?}"),
+    }
+}
+
+// ── SpirVError tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn spirv_error_display_validation() {
+    let err = SpirVError::ValidationFailed("bad magic".into());
+    assert!(format!("{err}").contains("bad magic"));
+}
+
+#[test]
+fn spirv_error_display_compilation() {
+    let err = SpirVError::CompilationFailed("syntax error".into());
+    assert!(format!("{err}").contains("syntax error"));
+}
+
+#[test]
+fn spirv_error_display_no_compiler() {
+    let err = SpirVError::NoCompilerAvailable;
+    assert!(format!("{err}").contains("no SPIR-V compiler"));
+}
+
+// ── ContextPool with mock factory ────────────────────────────────────────────
+
+struct MockFactory {
+    memory_per_context: MemoryBytes,
+    total_used: AtomicU64,
+    fail_on_create: bool,
+}
+
+impl MockFactory {
+    fn new(memory_per_context: MemoryBytes) -> Self {
+        Self { memory_per_context, total_used: AtomicU64::new(0), fail_on_create: false }
+    }
+
+    fn failing() -> Self {
+        Self { memory_per_context: 0, total_used: AtomicU64::new(0), fail_on_create: true }
+    }
+}
+
+impl ContextFactory for MockFactory {
+    fn create_context(&self, id: &str) -> Result<MemoryBytes, ContextPoolError> {
+        if self.fail_on_create {
+            return Err(ContextPoolError::CreationFailed {
+                id: id.to_string(),
+                reason: "mock failure".into(),
+            });
+        }
+        self.total_used.fetch_add(self.memory_per_context, Ordering::Relaxed);
+        Ok(self.memory_per_context)
+    }
+
+    fn compile_programs(&self, _id: &str) -> Result<(), ContextPoolError> {
+        Ok(())
+    }
+
+    fn release_context(&self, _id: &str) -> Result<(), ContextPoolError> {
+        self.total_used.fetch_sub(self.memory_per_context, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn total_gpu_memory_used(&self) -> MemoryBytes {
+        self.total_used.load(Ordering::Relaxed)
+    }
+}
+
+fn mock_pool(max_contexts: usize) -> ContextPool {
+    let factory = Arc::new(MockFactory::new(1024 * 1024)); // 1 MiB each
+    let config = ContextPoolConfig {
+        max_contexts,
+        memory_limit: 100 * 1024 * 1024, // 100 MiB
+        idle_timeout: Duration::from_secs(60),
+        lazy_creation: true,
+    };
+    ContextPool::new(config, factory)
+}
+
+#[test]
+fn context_pool_starts_empty() {
+    let pool = mock_pool(4);
+    assert!(pool.is_empty());
+    assert_eq!(pool.len(), 0);
+    assert_eq!(pool.total_memory_usage(), 0);
+}
+
+#[test]
+fn context_pool_acquire_creates() {
+    let pool = mock_pool(4);
+    let entry = pool.acquire("model-a").unwrap();
+    assert_eq!(entry.id, "model-a");
+    assert_eq!(pool.len(), 1);
+    assert!(entry.compiled);
+    assert!(entry.in_use);
+}
+
+#[test]
+fn context_pool_acquire_existing_reuses() {
+    let pool = mock_pool(4);
+    let e1 = pool.acquire("model-a").unwrap();
+    pool.release("model-a").unwrap();
+    let e2 = pool.acquire("model-a").unwrap();
+    assert_eq!(pool.len(), 1); // still just one context
+    assert!(e2.use_count > e1.use_count);
+}
+
+#[test]
+fn context_pool_release() {
+    let pool = mock_pool(4);
+    pool.acquire("model-a").unwrap();
+    pool.release("model-a").unwrap();
+    // Still in pool but not in use
+    assert_eq!(pool.len(), 1);
+}
+
+#[test]
+fn context_pool_release_nonexistent_fails() {
+    let pool = mock_pool(4);
+    let err = pool.release("nonexistent").unwrap_err();
+    assert!(matches!(err, ContextPoolError::NotFound { .. }));
+}
+
+#[test]
+fn context_pool_evict() {
+    let pool = mock_pool(4);
+    pool.acquire("model-a").unwrap();
+    pool.release("model-a").unwrap();
+    pool.evict("model-a").unwrap();
+    assert!(pool.is_empty());
+}
+
+#[test]
+fn context_pool_evict_nonexistent_fails() {
+    let pool = mock_pool(4);
+    let err = pool.evict("ghost").unwrap_err();
+    assert!(matches!(err, ContextPoolError::NotFound { .. }));
+}
+
+#[test]
+fn context_pool_memory_tracking() {
+    let pool = mock_pool(4);
+    pool.acquire("model-a").unwrap();
+    assert!(pool.total_memory_usage() > 0);
+}
+
+#[test]
+fn context_pool_entries_snapshot() {
+    let pool = mock_pool(4);
+    pool.acquire("model-a").unwrap();
+    pool.acquire("model-b").unwrap();
+    let entries = pool.entries();
+    assert_eq!(entries.len(), 2);
+}
+
+#[test]
+fn context_pool_capacity_exhausted() {
+    let pool = mock_pool(1);
+    pool.acquire("model-a").unwrap();
+    // Context is in use, can't evict — capacity should be exhausted
+    let err = pool.acquire("model-b").unwrap_err();
+    assert!(matches!(err, ContextPoolError::CapacityExhausted { .. }));
+}
+
+#[test]
+fn context_pool_creation_failure() {
+    let factory = Arc::new(MockFactory::failing());
+    let config = ContextPoolConfig {
+        max_contexts: 4,
+        memory_limit: 1_000_000_000,
+        idle_timeout: Duration::from_secs(60),
+        lazy_creation: true,
+    };
+    let pool = ContextPool::new(config, factory);
+    let err = pool.acquire("model-a").unwrap_err();
+    assert!(matches!(err, ContextPoolError::CreationFailed { .. }));
+}
+
+// ── ContextPoolConfig tests ──────────────────────────────────────────────────
+
+#[test]
+fn context_pool_config_default() {
+    let cfg = ContextPoolConfig::default();
+    assert_eq!(cfg.max_contexts, 4);
+    assert_eq!(cfg.memory_limit, 2 * 1024 * 1024 * 1024);
+    assert_eq!(cfg.idle_timeout, Duration::from_secs(300));
+    assert!(cfg.lazy_creation);
+}
+
+// ── ContextPoolError display tests ───────────────────────────────────────────
+
+#[test]
+fn context_pool_error_capacity_display() {
+    let err = ContextPoolError::CapacityExhausted { max: 4 };
+    assert!(format!("{err}").contains("4"));
+}
+
+#[test]
+fn context_pool_error_creation_display() {
+    let err = ContextPoolError::CreationFailed { id: "test".into(), reason: "boom".into() };
+    let msg = format!("{err}");
+    assert!(msg.contains("test"));
+    assert!(msg.contains("boom"));
+}
+
+#[test]
+fn context_pool_error_not_found_display() {
+    let err = ContextPoolError::NotFound { id: "missing".into() };
+    assert!(format!("{err}").contains("missing"));
+}
+
+#[test]
+fn context_pool_error_memory_pressure_display() {
+    let err = ContextPoolError::MemoryPressure { used: 100, limit: 50 };
+    let msg = format!("{err}");
+    assert!(msg.contains("100"));
+    assert!(msg.contains("50"));
+}


### PR DESCRIPTION
## Summary

Add 123 comprehensive edge-case tests for the `bitnet-opencl` crate covering backend dispatcher, KV cache, paged attention, SPIR-V compilation types, and context pool.

## Test Files

### `opencl_backend_dispatcher_edge_cases.rs` (42 tests)
- Mock `BackendProvider` implementation for testing without GPU
- All 4 dispatch strategies: Priority, RoundRobin, LoadBased, SpecificBackend
- Error paths: no backend available, not found, not usable, unsupported op
- Capability matrix queries and filtering
- Dispatch logging and clearing
- Degraded backend handling
- Strategy mutation and registry access

### `opencl_paged_kv_edge_cases.rs` (41 tests)
- `PageAllocator`: allocation, exhaustion, free, defragment
- `GqaConfig`: group size for MHA/GQA/MQA configurations (Phi-4 style)
- `GpuKvCache`: append, get roundtrip, multi-layer, trim, clear
- Panic tests: zero page_size, wrong k/v length
- Memory usage statistics and page table access
- `PagedAttentionEngine`: empty cache, single position, masking, blocked vs standard equivalence

### `opencl_spirv_context_edge_cases.rs` (40 tests)
- `SpirvKernelRegistry`: register/lookup/overwrite/names, builtin kernels
- SPIR-V types: `CompileOptions`, `OptimizationLevel`, `CompilerBackend`
- `SpirVCompiler` with explicit/no backend
- Context pool with mock `ContextFactory`: acquire, release, evict, capacity limits
- `ContextPoolConfig` defaults and error display

## Validation

All 123 tests pass locally:
`cargo test -p bitnet-opencl --test opencl_backend_dispatcher_edge_cases`
`cargo test -p bitnet-opencl --test opencl_paged_kv_edge_cases`
`cargo test -p bitnet-opencl --test opencl_spirv_context_edge_cases`
