### PR TITLE
test(gpu-hal): add 83 model pruning and attention compute edge tests

### DIFF
--- a/crates/bitnet-gpu-hal/tests/attention_compute_edge_cases.rs
+++ b/crates/bitnet-gpu-hal/tests/attention_compute_edge_cases.rs
@@ -1,0 +1,355 @@
+//! Edge-case tests for attention_compute module.
+//!
+//! Covers: AttentionConfig, AttentionType, QKVProjection,
+//! OutputProjection, CausalMask, AttentionMask, KVCacheEntry,
+//! KVCache, ScaledDotProductAttention, AttentionEngine.
+
+use bitnet_gpu_hal::attention_compute::*;
+
+// ── AttentionConfig ─────────────────────────────────────────────
+
+#[test]
+fn attention_config_new() {
+    let cfg = AttentionConfig::new(8, 64, 2048, true);
+    assert_eq!(cfg.num_heads, 8);
+    assert_eq!(cfg.head_dim, 64);
+    assert_eq!(cfg.max_seq_len, 2048);
+    assert!(cfg.causal);
+}
+
+#[test]
+fn attention_config_model_dim() {
+    let cfg = AttentionConfig::new(8, 64, 2048, true);
+    assert_eq!(cfg.model_dim(), 512);
+}
+
+#[test]
+fn attention_config_scale_factor() {
+    let cfg = AttentionConfig::new(4, 16, 1024, false);
+    // scale_factor = 1/sqrt(head_dim) = 1/4
+    assert!((cfg.scale_factor - 0.25).abs() < 1e-5);
+}
+
+#[test]
+fn attention_config_clone() {
+    let cfg = AttentionConfig::new(4, 32, 512, true);
+    let cfg2 = cfg.clone();
+    assert_eq!(cfg2.num_heads, 4);
+    assert_eq!(cfg2.model_dim(), 128);
+}
+
+// ── AttentionType ───────────────────────────────────────────────
+
+#[test]
+fn attention_type_multi_head() {
+    let at = AttentionType::MultiHead;
+    assert_eq!(at.num_kv_heads(8), 8);
+    // MultiHead: each head is its own group (group size = 1)
+    assert_eq!(at.heads_per_group(8), Some(1));
+}
+
+#[test]
+fn attention_type_multi_query() {
+    let at = AttentionType::MultiQuery;
+    assert_eq!(at.num_kv_heads(8), 1);
+}
+
+#[test]
+fn attention_type_grouped_query() {
+    let at = AttentionType::GroupedQuery(2);
+    assert_eq!(at.num_kv_heads(8), 2);
+    assert_eq!(at.heads_per_group(8), Some(4));
+}
+
+#[test]
+fn attention_type_cross_attention() {
+    let at = AttentionType::CrossAttention;
+    let _ = format!("{}", at);
+}
+
+#[test]
+fn attention_type_display() {
+    assert_eq!(format!("{}", AttentionType::MultiHead), "MHA");
+    assert_eq!(format!("{}", AttentionType::MultiQuery), "MQA");
+    assert_eq!(format!("{}", AttentionType::GroupedQuery(4)), "GQA(4)");
+    assert_eq!(format!("{}", AttentionType::CrossAttention), "CrossAttn");
+}
+
+#[test]
+fn attention_type_clone_eq() {
+    let a = AttentionType::GroupedQuery(2);
+    let b = a.clone();
+    assert_eq!(a, b);
+}
+
+// ── QKVProjection ───────────────────────────────────────────────
+
+#[test]
+fn qkv_projection_no_bias() {
+    let proj = QKVProjection::new(64, 64, false);
+    let input = vec![0.0; 64];
+    let (q, k, v) = proj.forward(&input);
+    assert_eq!(q.len(), 64);
+    assert_eq!(k.len(), 64);
+    assert_eq!(v.len(), 64);
+}
+
+#[test]
+fn qkv_projection_with_bias() {
+    let proj = QKVProjection::new(32, 32, true);
+    let input = vec![1.0; 32];
+    let (q, k, v) = proj.forward(&input);
+    assert_eq!(q.len(), 32);
+    assert_eq!(k.len(), 32);
+    assert_eq!(v.len(), 32);
+}
+
+#[test]
+fn qkv_projection_clone() {
+    let proj = QKVProjection::new(16, 16, false);
+    let proj2 = proj.clone();
+    let input = vec![0.0; 16];
+    let (q, _, _) = proj2.forward(&input);
+    assert_eq!(q.len(), 16);
+}
+
+// ── OutputProjection ────────────────────────────────────────────
+
+#[test]
+fn output_projection_no_bias() {
+    let proj = OutputProjection::new(64, 64, false);
+    let input = vec![1.0; 64];
+    let out = proj.forward(&input);
+    assert_eq!(out.len(), 64);
+}
+
+#[test]
+fn output_projection_with_bias() {
+    let proj = OutputProjection::new(32, 32, true);
+    let input = vec![1.0; 32];
+    let out = proj.forward(&input);
+    assert_eq!(out.len(), 32);
+}
+
+// ── CausalMask ──────────────────────────────────────────────────
+
+#[test]
+fn causal_mask_basic() {
+    let mask = CausalMask::new(4);
+    assert_eq!(mask.size(), 4);
+    // Lower triangle (including diagonal) should be allowed
+    assert!(mask.is_allowed(0, 0));
+    assert!(mask.is_allowed(1, 0));
+    assert!(mask.is_allowed(1, 1));
+    // Upper triangle should be blocked
+    assert!(!mask.is_allowed(0, 1));
+}
+
+#[test]
+fn causal_mask_apply() {
+    let mask = CausalMask::new(2);
+    // 2x2 attention scores
+    let mut scores = vec![1.0, 1.0, 1.0, 1.0];
+    mask.apply(&mut scores, 2, f32::NEG_INFINITY);
+    assert_eq!(scores[0], 1.0); // (0,0) allowed
+    assert_eq!(scores[1], f32::NEG_INFINITY); // (0,1) blocked
+    assert_eq!(scores[2], 1.0); // (1,0) allowed
+    assert_eq!(scores[3], 1.0); // (1,1) allowed
+}
+
+#[test]
+fn causal_mask_size_1() {
+    let mask = CausalMask::new(1);
+    assert!(mask.is_allowed(0, 0));
+}
+
+// ── AttentionMask ───────────────────────────────────────────────
+
+#[test]
+fn attention_mask_all_allowed() {
+    let mask = AttentionMask::all_allowed(2, 3);
+    assert_eq!(mask.dims(), (2, 3));
+    assert!(mask.is_allowed(0, 0));
+    assert!(mask.is_allowed(1, 2));
+}
+
+#[test]
+fn attention_mask_padding() {
+    let mask = AttentionMask::padding(2, 4, 2);
+    // Seq len=2, total=4. Positions 0,1 allowed; 2,3 masked
+    assert!(mask.is_allowed(0, 0));
+    assert!(mask.is_allowed(0, 1));
+    assert!(!mask.is_allowed(0, 2));
+    assert!(!mask.is_allowed(0, 3));
+}
+
+#[test]
+fn attention_mask_from_raw() {
+    let raw = vec![true, false, true, false];
+    let mask = AttentionMask::from_raw(raw, 2, 2);
+    assert!(mask.is_allowed(0, 0));
+    assert!(!mask.is_allowed(0, 1));
+    assert!(mask.is_allowed(1, 0));
+    assert!(!mask.is_allowed(1, 1));
+}
+
+#[test]
+fn attention_mask_apply() {
+    let mask = AttentionMask::padding(1, 3, 2);
+    let mut scores = vec![1.0, 1.0, 1.0];
+    mask.apply(&mut scores, f32::NEG_INFINITY);
+    assert_eq!(scores[0], 1.0);
+    assert_eq!(scores[1], 1.0);
+    assert_eq!(scores[2], f32::NEG_INFINITY);
+}
+
+// ── KVCacheEntry ────────────────────────────────────────────────
+
+#[test]
+fn kv_cache_entry_new() {
+    let entry = KVCacheEntry::new(10, 64);
+    assert_eq!(entry.seq_len, 0);
+    assert_eq!(entry.capacity, 10);
+    assert_eq!(entry.remaining(), 10);
+}
+
+#[test]
+fn kv_cache_entry_append() {
+    let mut entry = KVCacheEntry::new(5, 2);
+    let key = vec![1.0, 2.0];
+    let val = vec![3.0, 4.0];
+    assert!(entry.append(&key, &val));
+    assert_eq!(entry.seq_len, 1);
+    assert_eq!(entry.remaining(), 4);
+}
+
+#[test]
+fn kv_cache_entry_get() {
+    let mut entry = KVCacheEntry::new(5, 2);
+    entry.append(&[1.0, 2.0], &[3.0, 4.0]);
+    let k = entry.get_key(0).unwrap();
+    assert_eq!(k, &[1.0, 2.0]);
+    let v = entry.get_value(0).unwrap();
+    assert_eq!(v, &[3.0, 4.0]);
+}
+
+#[test]
+fn kv_cache_entry_get_out_of_bounds() {
+    let entry = KVCacheEntry::new(5, 2);
+    assert!(entry.get_key(0).is_none());
+}
+
+#[test]
+fn kv_cache_entry_clear() {
+    let mut entry = KVCacheEntry::new(5, 2);
+    entry.append(&[1.0, 2.0], &[3.0, 4.0]);
+    entry.clear();
+    assert_eq!(entry.seq_len, 0);
+    assert_eq!(entry.remaining(), 5);
+}
+
+#[test]
+fn kv_cache_entry_fill_to_capacity() {
+    let mut entry = KVCacheEntry::new(2, 1);
+    assert!(entry.append(&[1.0], &[2.0]));
+    assert!(entry.append(&[3.0], &[4.0]));
+    assert!(!entry.append(&[5.0], &[6.0])); // full
+    assert_eq!(entry.remaining(), 0);
+}
+
+// ── KVCache ─────────────────────────────────────────────────────
+
+#[test]
+fn kv_cache_new() {
+    let cache = KVCache::new(4, 128, 64);
+    assert_eq!(cache.num_layers(), 4);
+    assert_eq!(cache.seq_len(), 0);
+}
+
+#[test]
+fn kv_cache_layer_access() {
+    let mut cache = KVCache::new(2, 10, 4);
+    cache.layer_mut(0).append(&[1.0; 4], &[2.0; 4]);
+    assert_eq!(cache.layer(0).seq_len, 1);
+    assert_eq!(cache.layer(1).seq_len, 0);
+}
+
+#[test]
+fn kv_cache_clear() {
+    let mut cache = KVCache::new(2, 10, 4);
+    cache.layer_mut(0).append(&[1.0; 4], &[2.0; 4]);
+    cache.clear();
+    assert_eq!(cache.layer(0).seq_len, 0);
+}
+
+// ── ScaledDotProductAttention ───────────────────────────────────
+
+#[test]
+fn sdpa_standard() {
+    let sdpa = ScaledDotProductAttention::standard(64);
+    // scale = 1/sqrt(64) = 0.125
+    let _ = format!("{:?}", sdpa);
+}
+
+#[test]
+fn sdpa_forward_trivial() {
+    let sdpa = ScaledDotProductAttention::new(1.0);
+    // 1 query, 1 key, 1 value, head_dim=2
+    let q = vec![1.0, 0.0];
+    let k = vec![1.0, 0.0];
+    let v = vec![1.0, 2.0];
+    let out = sdpa.forward(&q, &k, &v, 2, None);
+    assert_eq!(out.len(), 2);
+    // With only one key, output should be close to v
+    assert!((out[0] - 1.0).abs() < 1e-3);
+    assert!((out[1] - 2.0).abs() < 1e-3);
+}
+
+#[test]
+fn sdpa_forward_multiple_keys() {
+    let sdpa = ScaledDotProductAttention::new(0.5);
+    let q = vec![1.0, 0.0]; // 1 query, head_dim=2
+    let k = vec![1.0, 0.0, 0.0, 1.0]; // 2 keys
+    let v = vec![1.0, 0.0, 0.0, 1.0]; // 2 values
+    let out = sdpa.forward(&q, &k, &v, 2, None);
+    assert_eq!(out.len(), 2);
+}
+
+// ── AttentionEngine ─────────────────────────────────────────────
+
+#[test]
+fn attention_engine_mha() {
+    let cfg = AttentionConfig::new(1, 4, 16, false);
+    let engine = AttentionEngine::new(cfg, AttentionType::MultiHead);
+    let _ = format!("{:?}", engine);
+}
+
+#[test]
+fn attention_engine_forward_with_cache() {
+    let cfg = AttentionConfig::new(1, 4, 16, false);
+    let engine = AttentionEngine::new(cfg, AttentionType::MultiHead);
+    let mut cache = KVCacheEntry::new(16, 4);
+    let input = vec![1.0; 4]; // model_dim = 1*4 = 4
+    let out = engine.forward_with_cache(&input, &mut cache);
+    assert_eq!(out.len(), 4);
+    assert_eq!(cache.seq_len, 1);
+}
+
+#[test]
+fn attention_engine_sequential() {
+    let cfg = AttentionConfig::new(1, 4, 16, true);
+    let engine = AttentionEngine::new(cfg, AttentionType::MultiHead);
+    let mut cache = KVCacheEntry::new(16, 4);
+
+    // Process 3 tokens sequentially
+    let out1 = engine.forward_with_cache(&[1.0; 4], &mut cache);
+    assert_eq!(cache.seq_len, 1);
+    let out2 = engine.forward_with_cache(&[2.0; 4], &mut cache);
+    assert_eq!(cache.seq_len, 2);
+    let out3 = engine.forward_with_cache(&[3.0; 4], &mut cache);
+    assert_eq!(cache.seq_len, 3);
+
+    assert_eq!(out1.len(), 4);
+    assert_eq!(out2.len(), 4);
+    assert_eq!(out3.len(), 4);
+}

--- a/crates/bitnet-gpu-hal/tests/model_pruning_edge_cases.rs
+++ b/crates/bitnet-gpu-hal/tests/model_pruning_edge_cases.rs
@@ -1,0 +1,478 @@
+//! Edge-case tests for model_pruning module.
+//!
+//! Covers: PruningMethod, PruningGranularity, ScheduleKind,
+//! PruningConfig, PruningSchedule, PruneMaskManager, MagnitudePruner,
+//! StructuredPruner, MovementPruner, LotteryTicket, SensitivityAnalyzer,
+//! PruningReport, PruningEngine.
+
+use bitnet_gpu_hal::model_pruning::*;
+
+// ── PruningMethod ───────────────────────────────────────────────
+
+#[test]
+fn pruning_method_all_variants() {
+    let v = vec![
+        PruningMethod::Magnitude,
+        PruningMethod::Structured,
+        PruningMethod::Movement,
+        PruningMethod::LotteryTicket,
+    ];
+    assert_eq!(v.len(), 4);
+}
+
+#[test]
+fn pruning_method_clone_eq() {
+    let a = PruningMethod::Magnitude;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+#[test]
+fn pruning_method_debug() {
+    let dbg = format!("{:?}", PruningMethod::Movement);
+    assert!(dbg.contains("Movement"));
+}
+
+// ── PruningGranularity ──────────────────────────────────────────
+
+#[test]
+fn pruning_granularity_all_variants() {
+    let v = vec![
+        PruningGranularity::Weight,
+        PruningGranularity::Channel,
+        PruningGranularity::Head,
+        PruningGranularity::Layer,
+    ];
+    assert_eq!(v.len(), 4);
+}
+
+#[test]
+fn pruning_granularity_clone_eq() {
+    let a = PruningGranularity::Channel;
+    let b = a;
+    assert_eq!(a, b);
+}
+
+// ── ScheduleKind ────────────────────────────────────────────────
+
+#[test]
+fn schedule_kind_all_variants() {
+    let v = vec![ScheduleKind::OneShot, ScheduleKind::Linear, ScheduleKind::Cubic];
+    assert_eq!(v.len(), 3);
+}
+
+// ── PruningConfig ───────────────────────────────────────────────
+
+#[test]
+fn pruning_config_magnitude() {
+    let c = PruningConfig::magnitude(0.5);
+    assert_eq!(c.method, PruningMethod::Magnitude);
+    assert!((c.target_sparsity - 0.5).abs() < 1e-6);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn pruning_config_structured() {
+    let c = PruningConfig::structured(0.3, PruningGranularity::Channel);
+    assert_eq!(c.method, PruningMethod::Structured);
+    assert_eq!(c.granularity, PruningGranularity::Channel);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn pruning_config_movement() {
+    let c = PruningConfig::movement(0.5, 1000);
+    assert_eq!(c.method, PruningMethod::Movement);
+    assert_eq!(c.total_steps, 1000);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn pruning_config_lottery_ticket() {
+    let c = PruningConfig::lottery_ticket(0.8);
+    assert_eq!(c.method, PruningMethod::LotteryTicket);
+    assert!(c.validate().is_ok());
+}
+
+#[test]
+fn pruning_config_clone() {
+    let c = PruningConfig::magnitude(0.5);
+    let c2 = c.clone();
+    assert_eq!(c2.method, PruningMethod::Magnitude);
+}
+
+// ── PruningSchedule ─────────────────────────────────────────────
+
+#[test]
+fn schedule_one_shot() {
+    let cfg = PruningConfig::magnitude(0.5);
+    let sched = PruningSchedule::from_config(&cfg);
+    assert!((sched.target_sparsity() - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn schedule_sparsity_at_step_one_shot() {
+    let sched = PruningSchedule::new(ScheduleKind::OneShot, 0.5, 0, 100);
+    // One-shot should be full target at any step >= begin
+    let s = sched.sparsity_at_step(50);
+    assert!((s - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn schedule_linear() {
+    let sched = PruningSchedule::new(ScheduleKind::Linear, 0.5, 0, 100);
+    let s0 = sched.sparsity_at_step(0);
+    let s50 = sched.sparsity_at_step(50);
+    let s100 = sched.sparsity_at_step(100);
+    // Linear: 0→0.5 over steps 0..100
+    assert!(s0 <= s50);
+    assert!(s50 <= s100);
+    assert!((s100 - 0.5).abs() < 1e-5);
+}
+
+#[test]
+fn schedule_cubic() {
+    let sched = PruningSchedule::new(ScheduleKind::Cubic, 0.5, 0, 100);
+    let s0 = sched.sparsity_at_step(0);
+    let s100 = sched.sparsity_at_step(100);
+    assert!(s0 <= s100);
+    assert!((s100 - 0.5).abs() < 1e-5);
+}
+
+// ── PruneMaskManager ────────────────────────────────────────────
+
+#[test]
+fn mask_manager_default() {
+    let mgr = PruneMaskManager::new();
+    assert_eq!(mgr.tensor_count(), 0);
+    assert!((mgr.overall_sparsity() - 0.0).abs() < 1e-6 || mgr.overall_sparsity().is_nan());
+}
+
+#[test]
+fn mask_manager_register_and_set() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("layer.0.weight", 100);
+    mgr.set_mask("layer.0.weight", vec![true; 100]);
+    let mask = mgr.get_mask("layer.0.weight").unwrap();
+    assert_eq!(mask.len(), 100);
+    assert!(mask.iter().all(|&m| m));
+}
+
+#[test]
+fn mask_manager_apply() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("w", 4);
+    mgr.set_mask("w", vec![true, false, true, false]);
+    let mut weights = vec![1.0, 2.0, 3.0, 4.0];
+    mgr.apply("w", &mut weights);
+    assert_eq!(weights[0], 1.0);
+    assert_eq!(weights[1], 0.0);
+    assert_eq!(weights[2], 3.0);
+    assert_eq!(weights[3], 0.0);
+}
+
+#[test]
+fn mask_manager_sparsity() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("w", 4);
+    mgr.set_mask("w", vec![true, false, true, false]);
+    let s = mgr.sparsity("w").unwrap();
+    assert!((s - 0.5).abs() < 1e-6);
+}
+
+#[test]
+fn mask_manager_overall_sparsity() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("a", 4);
+    mgr.register("b", 4);
+    mgr.set_mask("a", vec![true, false, true, false]);
+    mgr.set_mask("b", vec![true, true, true, true]);
+    let s = mgr.overall_sparsity();
+    // (2 zeros / 8 total) = 0.25
+    assert!((s - 0.25).abs() < 1e-6);
+}
+
+#[test]
+fn mask_manager_tensor_names() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("x", 10);
+    mgr.register("y", 20);
+    let names: Vec<&str> = mgr.tensor_names().collect();
+    assert_eq!(names.len(), 2);
+}
+
+#[test]
+fn mask_manager_get_mask_missing() {
+    let mgr = PruneMaskManager::new();
+    assert!(mgr.get_mask("nonexistent").is_none());
+}
+
+// ── MagnitudePruner ─────────────────────────────────────────────
+
+#[test]
+fn magnitude_pruner_compute_mask() {
+    let cfg = PruningConfig::magnitude(0.5);
+    let pruner = MagnitudePruner::new(cfg);
+    let weights = vec![0.1, -0.5, 0.3, -0.8, 0.01, 0.9, -0.2, 0.4];
+    let mask = pruner.compute_mask(&weights, 0.5);
+    assert_eq!(mask.len(), 8);
+    // ~50% should be false (pruned)
+    let pruned_count = mask.iter().filter(|&&m| !m).count();
+    assert_eq!(pruned_count, 4);
+}
+
+#[test]
+fn magnitude_pruner_prune() {
+    let cfg = PruningConfig::magnitude(0.25);
+    let pruner = MagnitudePruner::new(cfg);
+    let mut weights = vec![0.1, 0.5, 0.3, 0.8];
+    let mask = pruner.prune(&mut weights);
+    assert_eq!(mask.len(), 4);
+    // Some weights should be zeroed
+    let zeroed = weights.iter().filter(|&&w| w == 0.0).count();
+    assert_eq!(zeroed, 1); // 25% of 4 = 1
+}
+
+#[test]
+fn magnitude_pruner_target_sparsity() {
+    let cfg = PruningConfig::magnitude(0.7);
+    let pruner = MagnitudePruner::new(cfg);
+    assert!((pruner.target_sparsity() - 0.7).abs() < 1e-6);
+}
+
+// ── StructuredPruner ────────────────────────────────────────────
+
+#[test]
+fn structured_pruner_channels() {
+    let cfg = PruningConfig::structured(0.5, PruningGranularity::Channel);
+    let pruner = StructuredPruner::new(cfg);
+    // 4 output channels, 3 input features
+    let weights = vec![
+        0.1, 0.2, 0.3, // channel 0 (small)
+        0.5, 0.6, 0.7, // channel 1 (medium)
+        0.01, 0.02, 0.03, // channel 2 (smallest)
+        0.8, 0.9, 1.0, // channel 3 (large)
+    ];
+    let mask = pruner.prune_channels(&weights, 4, 3);
+    assert_eq!(mask.len(), 4);
+    // 50% pruned → 2 channels
+    let kept = mask.iter().filter(|&&m| m).count();
+    assert_eq!(kept, 2);
+}
+
+#[test]
+fn structured_pruner_heads() {
+    let cfg = PruningConfig::structured(0.5, PruningGranularity::Head);
+    let pruner = StructuredPruner::new(cfg);
+    let head_norms = vec![0.1, 0.8, 0.3, 0.9]; // 4 heads
+    let mask = pruner.prune_heads(&head_norms);
+    assert_eq!(mask.len(), 4);
+    let kept = mask.iter().filter(|&&m| m).count();
+    assert_eq!(kept, 2);
+}
+
+#[test]
+fn structured_pruner_layers() {
+    let cfg = PruningConfig::structured(0.25, PruningGranularity::Layer);
+    let pruner = StructuredPruner::new(cfg);
+    let layer_scores = vec![0.5, 0.1, 0.8, 0.3]; // 4 layers
+    let mask = pruner.prune_layers(&layer_scores);
+    assert_eq!(mask.len(), 4);
+    let kept = mask.iter().filter(|&&m| m).count();
+    assert_eq!(kept, 3); // prune 25% = 1
+}
+
+#[test]
+fn structured_pruner_granularity() {
+    let cfg = PruningConfig::structured(0.5, PruningGranularity::Head);
+    let pruner = StructuredPruner::new(cfg);
+    assert_eq!(pruner.granularity(), PruningGranularity::Head);
+}
+
+// ── MovementPruner ──────────────────────────────────────────────
+
+#[test]
+fn movement_pruner_scores() {
+    let weights = vec![0.1, -0.5, 0.3, -0.8];
+    let grads = vec![0.2, 0.1, -0.1, -0.3];
+    let scores = MovementPruner::movement_scores(&weights, &grads);
+    assert_eq!(scores.len(), 4);
+}
+
+#[test]
+fn movement_pruner_step() {
+    let cfg = PruningConfig::movement(0.5, 10);
+    let mut pruner = MovementPruner::new(cfg);
+    let weights = vec![0.1, -0.5, 0.3, -0.8];
+    let grads = vec![0.2, 0.1, -0.1, -0.3];
+    let mask = pruner.step(&weights, &grads);
+    assert_eq!(mask.len(), 4);
+    assert_eq!(pruner.current_step(), 1);
+}
+
+#[test]
+fn movement_pruner_current_sparsity() {
+    let cfg = PruningConfig::movement(0.5, 100);
+    let pruner = MovementPruner::new(cfg);
+    let s = pruner.current_sparsity();
+    assert!(s >= 0.0 && s <= 1.0);
+}
+
+// ── LotteryTicket ───────────────────────────────────────────────
+
+#[test]
+fn lottery_ticket_basic() {
+    let cfg = PruningConfig::lottery_ticket(0.8);
+    let lt = LotteryTicket::new(cfg, 5);
+    assert_eq!(lt.round(), 0);
+    assert_eq!(lt.max_rounds(), 5);
+    assert!(!lt.is_complete());
+}
+
+#[test]
+fn lottery_ticket_save_and_rewind() {
+    let cfg = PruningConfig::lottery_ticket(0.5);
+    let mut lt = LotteryTicket::new(cfg, 3);
+    let initial = vec![1.0, 2.0, 3.0, 4.0];
+    lt.save_initial_weights("w", &initial);
+    assert_eq!(lt.initial_weights("w").unwrap(), &initial);
+
+    // Simulate training
+    let trained = vec![0.5, 0.1, 2.5, 0.05];
+    let mask = lt.prune_round("w", &trained);
+    assert_eq!(mask.len(), 4);
+
+    // Rewind
+    let mut weights = vec![0.0; 4];
+    lt.rewind("w", &mut weights, &mask);
+    // Active weights should be restored to initial values
+    for (i, (&m, &w)) in mask.iter().zip(weights.iter()).enumerate() {
+        if m {
+            assert_eq!(w, initial[i]);
+        } else {
+            assert_eq!(w, 0.0);
+        }
+    }
+}
+
+#[test]
+fn lottery_ticket_sparsity_at_round() {
+    let cfg = PruningConfig::lottery_ticket(0.8);
+    let lt = LotteryTicket::new(cfg, 5);
+    let s0 = lt.sparsity_at_round(0);
+    let s5 = lt.sparsity_at_round(5);
+    assert!(s0 <= s5);
+}
+
+// ── SensitivityAnalyzer ─────────────────────────────────────────
+
+#[test]
+fn sensitivity_analyzer_default() {
+    let sa = SensitivityAnalyzer::new();
+    assert_eq!(sa.record_count(), 0);
+}
+
+#[test]
+fn sensitivity_analyzer_record() {
+    let mut sa = SensitivityAnalyzer::new();
+    sa.record("layer.0", 0.1, 0.01);
+    sa.record("layer.0", 0.5, 0.05);
+    sa.record("layer.0", 0.9, 0.20);
+    assert_eq!(sa.record_count(), 3);
+}
+
+#[test]
+fn sensitivity_analyzer_curve() {
+    let mut sa = SensitivityAnalyzer::new();
+    sa.record("layer.0", 0.1, 0.01);
+    sa.record("layer.0", 0.5, 0.05);
+    let curve = sa.sensitivity_curve("layer.0");
+    assert_eq!(curve.len(), 2);
+}
+
+#[test]
+fn sensitivity_analyzer_recommend() {
+    let mut sa = SensitivityAnalyzer::new();
+    sa.record("layer.0", 0.5, 0.02);
+    sa.record("layer.1", 0.5, 0.10);
+    let recs = sa.recommend(0.5, 0.05);
+    // layer.0 is less sensitive, should get higher sparsity recommendation
+    assert!(!recs.is_empty());
+}
+
+// ── PruningReport ───────────────────────────────────────────────
+
+#[test]
+fn pruning_report_from_mask_manager() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("w", 10);
+    mgr.set_mask("w", vec![true, false, true, false, true, false, true, false, true, false]);
+    let report = PruningReport::from_mask_manager(&mgr, PruningMethod::Magnitude);
+    assert_eq!(report.total_params, 10);
+    assert_eq!(report.pruned_params, 5);
+    assert_eq!(report.remaining_params, 5);
+    assert!((report.overall_sparsity - 0.5).abs() < 1e-6);
+    assert_eq!(report.method, PruningMethod::Magnitude);
+}
+
+#[test]
+fn pruning_report_from_weights() {
+    let w1 = vec![0.0, 1.0, 0.0, 2.0];
+    let w2 = vec![3.0, 0.0, 0.0, 4.0];
+    let report =
+        PruningReport::from_weights(&[("a", &w1[..]), ("b", &w2[..])], PruningMethod::Structured);
+    assert_eq!(report.total_params, 8);
+    // 4 zeros out of 8
+    assert_eq!(report.pruned_params, 4);
+}
+
+#[test]
+fn pruning_report_with_quality_metric() {
+    let mut mgr = PruneMaskManager::new();
+    mgr.register("w", 4);
+    mgr.set_mask("w", vec![true; 4]);
+    let report =
+        PruningReport::from_mask_manager(&mgr, PruningMethod::Magnitude).with_quality_metric(0.95);
+    assert_eq!(report.quality_metric, Some(0.95));
+}
+
+// ── PruningEngine ───────────────────────────────────────────────
+
+#[test]
+fn pruning_engine_magnitude() {
+    let cfg = PruningConfig::magnitude(0.5);
+    let mut engine = PruningEngine::new(cfg);
+    engine.register_tensor("w", 8);
+    let mut weights = vec![0.1, -0.5, 0.3, -0.8, 0.01, 0.9, -0.2, 0.4];
+    engine.prune_step("w", &mut weights, None);
+    let zeroed = weights.iter().filter(|&&w| w == 0.0).count();
+    assert!(zeroed > 0);
+}
+
+#[test]
+fn pruning_engine_advance_step() {
+    let cfg = PruningConfig::magnitude(0.5);
+    let mut engine = PruningEngine::new(cfg);
+    assert_eq!(engine.current_step(), 0);
+    engine.advance_step();
+    assert_eq!(engine.current_step(), 1);
+}
+
+#[test]
+fn pruning_engine_report() {
+    let cfg = PruningConfig::magnitude(0.5);
+    let mut engine = PruningEngine::new(cfg);
+    engine.register_tensor("w", 4);
+    let mut weights = vec![0.1, 0.5, 0.01, 0.8];
+    engine.prune_step("w", &mut weights, None);
+    let report = engine.report();
+    assert_eq!(report.total_params, 4);
+    assert!(report.pruned_params > 0);
+}
+
+#[test]
+fn pruning_engine_config() {
+    let cfg = PruningConfig::magnitude(0.3);
+    let engine = PruningEngine::new(cfg);
+    assert_eq!(engine.config().method, PruningMethod::Magnitude);
+}


### PR DESCRIPTION
## Summary
Add 83 edge-case tests for model pruning and attention compute modules in bitnet-gpu-hal.

### model_pruning_edge_cases.rs (46 tests)
- **PruningMethod**: all 4 variants, clone/eq, debug
- **PruningGranularity**: all 4 variants (Weight/Channel/Head/Layer), clone/eq
- **ScheduleKind**: all 3 variants (OneShot/Linear/Cubic)
- **PruningConfig**: magnitude/structured/movement/lottery_ticket constructors
- **PruningSchedule**: sparsity_at_step for one_shot/linear/cubic schedules
- **PruneMaskManager**: register, set, apply, sparsity calculations
- **MagnitudePruner**: compute_mask, prune, target_sparsity
- **StructuredPruner**: channels/heads/layers granularity pruning
- **MovementPruner**: scores, step, current_sparsity
- **LotteryTicket**: save/prune/rewind lifecycle, sparsity_at_round
- **SensitivityAnalyzer**: record, curve, recommend
- **PruningReport**: from_mask_manager, from_weights, quality_metric
- **PruningEngine**: magnitude prune_step, advance_step, report

### attention_compute_edge_cases.rs (37 tests)
- **AttentionConfig**: new, model_dim, scale_factor, clone
- **AttentionType**: MHA/MQA/GQA/CrossAttention variants, Display
- **QKVProjection/OutputProjection**: forward with/without bias
- **CausalMask**: lower triangle, apply with neg_inf
- **AttentionMask**: all_allowed, padding, from_raw, apply
- **KVCacheEntry**: new, append, get, clear, capacity
- **KVCache**: new, layer access, clear
- **ScaledDotProductAttention**: standard, trivial/multi-key forward
- **AttentionEngine**: MHA forward_with_cache, sequential tokens

All 83 tests passing locally.
