### PR TITLE
test: add convolution, GGUF KV, and quantization edge-case tests (134 tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "memmap2",
  "proptest",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/bitnet-gguf/Cargo.toml
+++ b/crates/bitnet-gguf/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { workspace = true, optional = true }
 proptest.workspace = true
 insta = { workspace = true }
 tempfile.workspace = true
+serde_json.workspace = true
 
 [features]
 default = []

--- a/crates/bitnet-gguf/tests/kv_edge_cases.rs
+++ b/crates/bitnet-gguf/tests/kv_edge_cases.rs
@@ -1,0 +1,690 @@
+//! Edge-case tests for bitnet-gguf KV header parsing.
+//!
+//! Tests cover `parse_header`, `GgufError` variants, `GgufHeader` fields,
+//! `GgufValue` enum, `GgufKv` struct, and `read_kv_pairs` with synthetic GGUF files.
+
+use bitnet_gguf::kv::{GGUF_HEADER_LEN, GgufError, GgufHeader, GgufValue, parse_header};
+use std::io::Write;
+
+// ── Helper: build a minimal GGUF header buffer ──────────────────────────────
+
+fn build_header(version: u32, n_tensors: u64, n_kv: u64) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(GGUF_HEADER_LEN);
+    buf.extend_from_slice(b"GGUF");
+    buf.extend_from_slice(&version.to_le_bytes());
+    buf.extend_from_slice(&n_tensors.to_le_bytes());
+    buf.extend_from_slice(&n_kv.to_le_bytes());
+    buf
+}
+
+// ── parse_header: valid inputs ───────────────────────────────────────────────
+
+#[test]
+fn parse_header_v1() {
+    let buf = build_header(1, 10, 5);
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.version, 1);
+    assert_eq!(h.n_tensors, 10);
+    assert_eq!(h.n_kv, 5);
+}
+
+#[test]
+fn parse_header_v2() {
+    let buf = build_header(2, 100, 50);
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.version, 2);
+    assert_eq!(h.n_tensors, 100);
+    assert_eq!(h.n_kv, 50);
+}
+
+#[test]
+fn parse_header_v3() {
+    let buf = build_header(3, 0, 0);
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.version, 3);
+    assert_eq!(h.n_tensors, 0);
+    assert_eq!(h.n_kv, 0);
+}
+
+#[test]
+fn parse_header_max_counts() {
+    let buf = build_header(3, u64::MAX, u64::MAX);
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.n_tensors, u64::MAX);
+    assert_eq!(h.n_kv, u64::MAX);
+}
+
+#[test]
+fn parse_header_zero_counts() {
+    let buf = build_header(1, 0, 0);
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.n_tensors, 0);
+    assert_eq!(h.n_kv, 0);
+}
+
+#[test]
+fn parse_header_extra_bytes_ignored() {
+    let mut buf = build_header(2, 5, 3);
+    buf.extend_from_slice(&[0xFF; 100]); // extra bytes after header
+    let h = parse_header(&buf).unwrap();
+    assert_eq!(h.version, 2);
+    assert_eq!(h.n_tensors, 5);
+    assert_eq!(h.n_kv, 3);
+}
+
+// ── parse_header: error cases ────────────────────────────────────────────────
+
+#[test]
+fn parse_header_too_short_empty() {
+    let result = parse_header(&[]);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::ShortHeader(n) => assert_eq!(n, 0),
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_too_short_partial() {
+    let result = parse_header(&[0x47, 0x47, 0x55, 0x46]); // just "GGUF"
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::ShortHeader(4) => {}
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_too_short_23_bytes() {
+    let buf = &build_header(2, 5, 3)[..23]; // one byte too short
+    let result = parse_header(buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::ShortHeader(23) => {}
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_bad_magic_null() {
+    let mut buf = build_header(2, 1, 1);
+    buf[0..4].copy_from_slice(&[0, 0, 0, 0]);
+    let result = parse_header(&buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::BadMagic(m) => assert_eq!(m, [0, 0, 0, 0]),
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_bad_magic_wrong_bytes() {
+    let mut buf = build_header(2, 1, 1);
+    buf[0..4].copy_from_slice(b"GGML");
+    let result = parse_header(&buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::BadMagic(m) => assert_eq!(&m, b"GGML"),
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_unsupported_version_0() {
+    let buf = build_header(0, 1, 1);
+    let result = parse_header(&buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::UnsupportedVersion(0) => {}
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_unsupported_version_4() {
+    let buf = build_header(4, 1, 1);
+    let result = parse_header(&buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::UnsupportedVersion(4) => {}
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn parse_header_unsupported_version_max() {
+    let buf = build_header(u32::MAX, 1, 1);
+    let result = parse_header(&buf);
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        GgufError::UnsupportedVersion(v) => assert_eq!(v, u32::MAX),
+        e => panic!("unexpected error: {e:?}"),
+    }
+}
+
+// ── GgufHeader: struct traits ────────────────────────────────────────────────
+
+#[test]
+fn gguf_header_clone_copy() {
+    let h = GgufHeader { version: 3, n_tensors: 10, n_kv: 5 };
+    let h2 = h; // copy
+    let h3 = h.clone();
+    assert_eq!(h, h2);
+    assert_eq!(h, h3);
+}
+
+#[test]
+fn gguf_header_debug_display() {
+    let h = GgufHeader { version: 2, n_tensors: 42, n_kv: 7 };
+    let dbg = format!("{h:?}");
+    assert!(dbg.contains("GgufHeader"));
+    assert!(dbg.contains("42"));
+    assert!(dbg.contains("7"));
+}
+
+#[test]
+fn gguf_header_equality() {
+    let h1 = GgufHeader { version: 3, n_tensors: 10, n_kv: 5 };
+    let h2 = GgufHeader { version: 3, n_tensors: 10, n_kv: 5 };
+    let h3 = GgufHeader { version: 2, n_tensors: 10, n_kv: 5 };
+    assert_eq!(h1, h2);
+    assert_ne!(h1, h3);
+}
+
+// ── GgufValue: variant construction and Debug ────────────────────────────────
+
+#[test]
+fn gguf_value_u8() {
+    let v = GgufValue::U8(255);
+    let dbg = format!("{v:?}");
+    assert!(dbg.contains("U8"));
+    assert!(dbg.contains("255"));
+}
+
+#[test]
+fn gguf_value_i8() {
+    let v = GgufValue::I8(-128);
+    let dbg = format!("{v:?}");
+    assert!(dbg.contains("I8"));
+}
+
+#[test]
+fn gguf_value_u16() {
+    let v = GgufValue::U16(65535);
+    if let GgufValue::U16(x) = v {
+        assert_eq!(x, 65535);
+    }
+}
+
+#[test]
+fn gguf_value_i16() {
+    let v = GgufValue::I16(-32768);
+    if let GgufValue::I16(x) = v {
+        assert_eq!(x, -32768);
+    }
+}
+
+#[test]
+fn gguf_value_u32() {
+    let v = GgufValue::U32(u32::MAX);
+    if let GgufValue::U32(x) = v {
+        assert_eq!(x, u32::MAX);
+    }
+}
+
+#[test]
+fn gguf_value_i32() {
+    let v = GgufValue::I32(i32::MIN);
+    if let GgufValue::I32(x) = v {
+        assert_eq!(x, i32::MIN);
+    }
+}
+
+#[test]
+fn gguf_value_f32() {
+    let v = GgufValue::F32(std::f32::consts::PI);
+    if let GgufValue::F32(x) = v {
+        assert!((x - std::f32::consts::PI).abs() < 1e-7);
+    }
+}
+
+#[test]
+fn gguf_value_bool_true() {
+    let v = GgufValue::Bool(true);
+    assert_eq!(v, GgufValue::Bool(true));
+    assert_ne!(v, GgufValue::Bool(false));
+}
+
+#[test]
+fn gguf_value_bool_false() {
+    let v = GgufValue::Bool(false);
+    assert_eq!(v, GgufValue::Bool(false));
+}
+
+#[test]
+fn gguf_value_string() {
+    let v = GgufValue::String("hello".to_string());
+    if let GgufValue::String(s) = &v {
+        assert_eq!(s, "hello");
+    }
+}
+
+#[test]
+fn gguf_value_string_empty() {
+    let v = GgufValue::String(String::new());
+    if let GgufValue::String(s) = &v {
+        assert!(s.is_empty());
+    }
+}
+
+#[test]
+fn gguf_value_u64() {
+    let v = GgufValue::U64(u64::MAX);
+    if let GgufValue::U64(x) = v {
+        assert_eq!(x, u64::MAX);
+    }
+}
+
+#[test]
+fn gguf_value_i64() {
+    let v = GgufValue::I64(i64::MIN);
+    if let GgufValue::I64(x) = v {
+        assert_eq!(x, i64::MIN);
+    }
+}
+
+#[test]
+fn gguf_value_f64() {
+    let v = GgufValue::F64(std::f64::consts::E);
+    if let GgufValue::F64(x) = v {
+        assert!((x - std::f64::consts::E).abs() < 1e-15);
+    }
+}
+
+#[test]
+fn gguf_value_array_empty() {
+    let v = GgufValue::Array(vec![]);
+    if let GgufValue::Array(arr) = &v {
+        assert!(arr.is_empty());
+    }
+}
+
+#[test]
+fn gguf_value_array_mixed() {
+    let v = GgufValue::Array(vec![
+        GgufValue::U8(1),
+        GgufValue::String("two".to_string()),
+        GgufValue::F32(3.0),
+    ]);
+    if let GgufValue::Array(arr) = &v {
+        assert_eq!(arr.len(), 3);
+    }
+}
+
+#[test]
+fn gguf_value_nested_array() {
+    let v = GgufValue::Array(vec![GgufValue::Array(vec![GgufValue::U8(42)])]);
+    if let GgufValue::Array(outer) = &v {
+        if let GgufValue::Array(inner) = &outer[0] {
+            assert_eq!(inner[0], GgufValue::U8(42));
+        }
+    }
+}
+
+#[test]
+fn gguf_value_clone_eq() {
+    let v1 = GgufValue::String("test".to_string());
+    let v2 = v1.clone();
+    assert_eq!(v1, v2);
+}
+
+// ── GgufKv: struct tests ─────────────────────────────────────────────────────
+
+#[test]
+fn gguf_kv_construction() {
+    let kv = bitnet_gguf::kv::GgufKv {
+        key: "general.name".to_string(),
+        value: GgufValue::String("TestModel".to_string()),
+    };
+    assert_eq!(kv.key, "general.name");
+    if let GgufValue::String(s) = &kv.value {
+        assert_eq!(s, "TestModel");
+    }
+}
+
+#[test]
+fn gguf_kv_debug() {
+    let kv = bitnet_gguf::kv::GgufKv { key: "test.key".to_string(), value: GgufValue::U32(42) };
+    let dbg = format!("{kv:?}");
+    assert!(dbg.contains("GgufKv"));
+    assert!(dbg.contains("test.key"));
+}
+
+#[test]
+fn gguf_kv_clone() {
+    let kv = bitnet_gguf::kv::GgufKv { key: "a.b".to_string(), value: GgufValue::Bool(true) };
+    let kv2 = kv.clone();
+    assert_eq!(kv.key, kv2.key);
+}
+
+// ── GgufError: Display ──────────────────────────────────────────────────────
+
+#[test]
+fn gguf_error_bad_magic_display() {
+    let e = GgufError::BadMagic([0xDE, 0xAD, 0xBE, 0xEF]);
+    let msg = e.to_string();
+    assert!(msg.contains("bad magic"));
+}
+
+#[test]
+fn gguf_error_unsupported_version_display() {
+    let e = GgufError::UnsupportedVersion(99);
+    let msg = e.to_string();
+    assert!(msg.contains("unsupported GGUF version"));
+    assert!(msg.contains("99"));
+}
+
+#[test]
+fn gguf_error_short_header_display() {
+    let e = GgufError::ShortHeader(12);
+    let msg = e.to_string();
+    assert!(msg.contains("short header"));
+    assert!(msg.contains("12"));
+}
+
+#[test]
+fn gguf_error_malformed_display() {
+    let e = GgufError::Malformed;
+    let msg = e.to_string();
+    assert!(msg.contains("malformed"));
+}
+
+#[test]
+fn gguf_error_invalid_kv_type_display() {
+    let e = GgufError::InvalidKvType(255);
+    let msg = e.to_string();
+    assert!(msg.contains("invalid KV type"));
+    assert!(msg.contains("255"));
+}
+
+#[test]
+fn gguf_error_string_too_large_display() {
+    let e = GgufError::StringTooLarge(999999);
+    let msg = e.to_string();
+    assert!(msg.contains("string too large"));
+    assert!(msg.contains("999999"));
+}
+
+// ── read_kv_pairs: synthetic GGUF files ─────────────────────────────────────
+
+fn write_synthetic_gguf_with_kv(
+    f: &mut impl Write,
+    version: u32,
+    n_tensors: u64,
+    kvs: &[(&str, u32, &[u8])],
+) {
+    // Header
+    f.write_all(b"GGUF").unwrap();
+    f.write_all(&version.to_le_bytes()).unwrap();
+    f.write_all(&n_tensors.to_le_bytes()).unwrap();
+    f.write_all(&(kvs.len() as u64).to_le_bytes()).unwrap();
+
+    // KV pairs
+    for &(key, ty, value_bytes) in kvs {
+        // key: u64 len + utf8 bytes
+        f.write_all(&(key.len() as u64).to_le_bytes()).unwrap();
+        f.write_all(key.as_bytes()).unwrap();
+        // type
+        f.write_all(&ty.to_le_bytes()).unwrap();
+        // value
+        f.write_all(value_bytes).unwrap();
+    }
+}
+
+#[test]
+fn read_kv_pairs_u32_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(
+        &mut f,
+        3,
+        0,
+        &[("test.count", 4, &42u32.to_le_bytes())], // type 4 = U32
+    );
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs.len(), 1);
+    assert_eq!(kvs[0].key, "test.count");
+    assert_eq!(kvs[0].value, GgufValue::U32(42));
+}
+
+#[test]
+fn read_kv_pairs_string_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+
+    // String type = 8, value = u64 len + bytes
+    let val = "hello";
+    let mut val_bytes = (val.len() as u64).to_le_bytes().to_vec();
+    val_bytes.extend_from_slice(val.as_bytes());
+
+    write_synthetic_gguf_with_kv(&mut f, 3, 0, &[("general.name", 8, &val_bytes)]);
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs.len(), 1);
+    assert_eq!(kvs[0].key, "general.name");
+    assert_eq!(kvs[0].value, GgufValue::String("hello".to_string()));
+}
+
+#[test]
+fn read_kv_pairs_bool_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(&mut f, 3, 0, &[("flag.on", 7, &[1u8])]);
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs[0].value, GgufValue::Bool(true));
+}
+
+#[test]
+fn read_kv_pairs_bool_false() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(&mut f, 3, 0, &[("flag.off", 7, &[0u8])]);
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs[0].value, GgufValue::Bool(false));
+}
+
+#[test]
+fn read_kv_pairs_multiple() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(
+        &mut f,
+        3,
+        5,
+        &[("count", 4, &10u32.to_le_bytes()), ("flag", 7, &[1u8])],
+    );
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs.len(), 2);
+    assert_eq!(kvs[0].key, "count");
+    assert_eq!(kvs[1].key, "flag");
+}
+
+#[test]
+fn read_kv_pairs_with_limit() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(
+        &mut f,
+        3,
+        0,
+        &[
+            ("a", 4, &1u32.to_le_bytes()),
+            ("b", 4, &2u32.to_le_bytes()),
+            ("c", 4, &3u32.to_le_bytes()),
+        ],
+    );
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, Some(2)).unwrap();
+    assert_eq!(kvs.len(), 2);
+    assert_eq!(kvs[0].key, "a");
+    assert_eq!(kvs[1].key, "b");
+}
+
+#[test]
+fn read_kv_pairs_i8_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(&mut f, 3, 0, &[("val", 1, &[0x80u8])]); // type 1 = I8
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs[0].value, GgufValue::I8(-128));
+}
+
+#[test]
+fn read_kv_pairs_f32_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(&mut f, 3, 0, &[("pi", 6, &std::f32::consts::PI.to_le_bytes())]);
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    if let GgufValue::F32(x) = kvs[0].value {
+        assert!((x - std::f32::consts::PI).abs() < 1e-7);
+    } else {
+        panic!("expected F32");
+    }
+}
+
+#[test]
+fn read_kv_pairs_u64_value() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    write_synthetic_gguf_with_kv(
+        &mut f,
+        3,
+        0,
+        &[("big", 10, &u64::MAX.to_le_bytes())], // type 10 = U64
+    );
+    drop(f);
+
+    let kvs = bitnet_gguf::kv::read_kv_pairs(&path, None).unwrap();
+    assert_eq!(kvs[0].value, GgufValue::U64(u64::MAX));
+}
+
+#[test]
+fn read_kv_pairs_nonexistent_file() {
+    let result = bitnet_gguf::kv::read_kv_pairs("/nonexistent/file.gguf", None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_kv_pairs_empty_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.gguf");
+    std::fs::File::create(&path).unwrap();
+
+    let result = bitnet_gguf::kv::read_kv_pairs(&path, None);
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_kv_pairs_bad_magic() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bad.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(b"GGML").unwrap(); // wrong magic
+    f.write_all(&3u32.to_le_bytes()).unwrap();
+    f.write_all(&0u64.to_le_bytes()).unwrap();
+    f.write_all(&0u64.to_le_bytes()).unwrap();
+    drop(f);
+
+    let result = bitnet_gguf::kv::read_kv_pairs(&path, None);
+    assert!(result.is_err());
+}
+
+// ── GGUF_HEADER_LEN constant ────────────────────────────────────────────────
+
+#[test]
+fn gguf_header_len_is_24() {
+    assert_eq!(GGUF_HEADER_LEN, 24);
+}
+
+// ── Serialization round-trip ─────────────────────────────────────────────────
+
+#[test]
+fn gguf_header_serde_roundtrip() {
+    let h = GgufHeader { version: 3, n_tensors: 42, n_kv: 7 };
+    let json = serde_json::to_string(&h).unwrap();
+    let h2: GgufHeader = serde_json::from_str(&json).unwrap();
+    assert_eq!(h, h2);
+}
+
+#[test]
+fn gguf_value_serde_roundtrip() {
+    let v = GgufValue::String("model_name".to_string());
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: GgufValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(v, v2);
+}
+
+#[test]
+fn gguf_value_array_serde_roundtrip() {
+    let v = GgufValue::Array(vec![GgufValue::U32(1), GgufValue::U32(2), GgufValue::U32(3)]);
+    let json = serde_json::to_string(&v).unwrap();
+    let v2: GgufValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(v, v2);
+}
+
+// ── read_header_blocking ─────────────────────────────────────────────────────
+
+#[test]
+fn read_header_blocking_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(&build_header(3, 10, 5)).unwrap();
+    drop(f);
+
+    let h = bitnet_gguf::kv::read_header_blocking(&path).unwrap();
+    assert_eq!(h.version, 3);
+    assert_eq!(h.n_tensors, 10);
+    assert_eq!(h.n_kv, 5);
+}
+
+#[test]
+fn read_header_blocking_truncated() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("trunc.gguf");
+    let mut f = std::fs::File::create(&path).unwrap();
+    f.write_all(&build_header(3, 10, 5)[..20]).unwrap(); // 20 < 24
+    drop(f);
+
+    let result = bitnet_gguf::kv::read_header_blocking(&path);
+    assert!(result.is_err());
+}
+
+#[test]
+fn read_header_blocking_nonexistent() {
+    let result = bitnet_gguf::kv::read_header_blocking("/no/such/file.gguf");
+    assert!(result.is_err());
+}

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -18,6 +18,7 @@
 //!   causal masking, log-softmax, in-place mode, and batched multi-head support
 //! - [`quantized_matmul`]: I2_S quantized matrix multiplication with CPU fallback
 //! - [`transpose`]: 2D/ND transpose and reshape with tiled shared-memory CUDA kernels
+//! - [`embedding`]: Token and positional embedding lookup with padding support
 //! - [`crate::scatter_gather`]: Scatter/gather indexed tensor operations with reductions
 //! - [`elementwise`]: Element-wise arithmetic (add/mul/sub/div) and activations with fused ops
 //!

--- a/crates/bitnet-kernels/tests/convolution_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/convolution_edge_cases.rs
@@ -1,0 +1,596 @@
+//! Edge-case tests for the convolution module.
+//!
+//! Tests cover `conv2d`, `conv2d_quantized`, `Conv2DParams`, dimension validation,
+//! padding, stride, dilation, bias, batch processing, and quantization types (I2S, TL1, TL2).
+
+use bitnet_common::QuantizationType;
+use bitnet_kernels::convolution::{Conv2DParams, conv2d, conv2d_quantized};
+
+// ── Conv2DParams ─────────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_params_default() {
+    let p = Conv2DParams::default();
+    assert_eq!(p.stride, (1, 1));
+    assert_eq!(p.padding, (0, 0));
+    assert_eq!(p.dilation, (1, 1));
+}
+
+#[test]
+fn conv2d_params_clone_debug() {
+    let p = Conv2DParams { stride: (2, 2), padding: (1, 1), dilation: (1, 1) };
+    let p2 = p;
+    assert_eq!(p2.stride, (2, 2));
+    let dbg = format!("{:?}", p);
+    assert!(dbg.contains("Conv2DParams"));
+}
+
+// ── conv2d: basic correctness ────────────────────────────────────────────────
+
+#[test]
+fn conv2d_identity_1x1_kernel() {
+    // 1x1 kernel with weight=1 should copy input values
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn conv2d_identity_1x1_with_scaling() {
+    // 1x1 kernel with weight=2 should double input
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![2.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![2.0, 4.0, 6.0, 8.0]);
+}
+
+#[test]
+fn conv2d_3x3_single_pixel_output() {
+    // 3x3 input with 3x3 kernel → 1x1 output (sum of element-wise products)
+    let input: Vec<f32> = (1..=9).map(|x| x as f32).collect(); // 1x1x3x3
+    let weight = vec![1.0; 9]; // 1x1x3x3 (all ones)
+    let mut output = vec![0.0; 1]; // 1x1x1x1
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 3, 3), (1, 1, 3, 3))
+        .unwrap();
+    // Sum of 1..=9 = 45
+    assert_eq!(output[0], 45.0);
+}
+
+// ── conv2d: bias ─────────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_with_bias() {
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let bias = vec![10.0]; // bias for 1 output channel
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d(
+        &input,
+        &weight,
+        Some(&bias),
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+    )
+    .unwrap();
+    assert_eq!(output, vec![11.0, 12.0, 13.0, 14.0]);
+}
+
+#[test]
+fn conv2d_with_multi_channel_bias() {
+    // 2 output channels, each with different bias
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight = vec![1.0, 1.0]; // 2x1x1x1
+    let bias = vec![10.0, 20.0]; // bias for 2 channels
+    let mut output = vec![0.0; 8]; // 1x2x2x2
+    conv2d(
+        &input,
+        &weight,
+        Some(&bias),
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (2, 1, 1, 1),
+    )
+    .unwrap();
+    // Channel 0: 1.0 + 10.0 = 11.0 for each pixel
+    // Channel 1: 1.0 + 20.0 = 21.0 for each pixel
+    assert_eq!(&output[..4], &[11.0, 11.0, 11.0, 11.0]);
+    assert_eq!(&output[4..], &[21.0, 21.0, 21.0, 21.0]);
+}
+
+// ── conv2d: stride ───────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_stride_2() {
+    // 4x4 input with 1x1 kernel, stride 2 → 2x2 output
+    let input: Vec<f32> = (1..=16).map(|x| x as f32).collect(); // 1x1x4x4
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    let params = Conv2DParams { stride: (2, 2), ..Default::default() };
+    conv2d(&input, &weight, None, &mut output, params, (1, 1, 4, 4), (1, 1, 1, 1)).unwrap();
+    // Picks positions (0,0), (0,2), (2,0), (2,2) = 1, 3, 9, 11
+    assert_eq!(output, vec![1.0, 3.0, 9.0, 11.0]);
+}
+
+// ── conv2d: padding ──────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_padding_same_3x3() {
+    // 3x3 input, 3x3 kernel, padding=1 → 3x3 output (same size)
+    let input = vec![1.0; 9]; // 1x1x3x3 all ones
+    let weight = vec![1.0; 9]; // 1x1x3x3 all ones
+    let mut output = vec![0.0; 9]; // 1x1x3x3
+    let params = Conv2DParams { padding: (1, 1), ..Default::default() };
+    conv2d(&input, &weight, None, &mut output, params, (1, 1, 3, 3), (1, 1, 3, 3)).unwrap();
+    // Center pixel sees all 9 ones → 9.0
+    // Edge pixels see fewer → check center
+    assert_eq!(output[4], 9.0); // center (1,1) sees full 3x3
+}
+
+// ── conv2d: dilation ─────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_dilation_2() {
+    // 5x5 input, 3x3 kernel, dilation=2 → effective 5x5 receptive field → 1x1 output
+    let input = vec![1.0; 25]; // 1x1x5x5
+    let weight = vec![1.0; 9]; // 1x1x3x3
+    let mut output = vec![0.0; 1]; // 1x1x1x1
+    let params = Conv2DParams { dilation: (2, 2), ..Default::default() };
+    conv2d(&input, &weight, None, &mut output, params, (1, 1, 5, 5), (1, 1, 3, 3)).unwrap();
+    // With dilation=2 on 5x5 all-ones, the 3x3 kernel picks 9 positions → 9.0
+    assert_eq!(output[0], 9.0);
+}
+
+// ── conv2d: multiple channels ────────────────────────────────────────────────
+
+#[test]
+fn conv2d_multi_input_channels() {
+    // 2 input channels, 1 output channel, 1x1 kernel
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // 1x2x2x2
+    let weight = vec![1.0, 1.0]; // 1x2x1x1 (sum of both channels)
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 2, 2, 2), (1, 2, 1, 1))
+        .unwrap();
+    // output[0] = input[0]*1 + input[4]*1 = 1+5 = 6
+    // output[1] = input[1]*1 + input[5]*1 = 2+6 = 8
+    assert_eq!(output, vec![6.0, 8.0, 10.0, 12.0]);
+}
+
+// ── conv2d: batch processing ─────────────────────────────────────────────────
+
+#[test]
+fn conv2d_batch_size_2() {
+    // Batch of 2, each 1x2x2 input with 1x1x1x1 kernel
+    let input = vec![1.0, 2.0, 3.0, 4.0, 10.0, 20.0, 30.0, 40.0]; // 2x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 8]; // 2x1x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (2, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(&output[..4], &[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(&output[4..], &[10.0, 20.0, 30.0, 40.0]);
+}
+
+// ── conv2d: zero weight ──────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_zero_kernel() {
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![0.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![0.0, 0.0, 0.0, 0.0]);
+}
+
+// ── conv2d: validation errors ────────────────────────────────────────────────
+
+#[test]
+fn conv2d_channel_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight = vec![1.0; 4]; // 1x2x1x2 (2 input channels in weight, but input has 1)
+    let mut output = vec![0.0; 4];
+    let result = conv2d(
+        &input,
+        &weight,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 2, 1, 2),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_input_size_mismatch() {
+    let input = vec![1.0; 3]; // wrong size
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4];
+    let result = conv2d(
+        &input,
+        &weight,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_weight_size_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight = vec![1.0; 3]; // wrong size
+    let mut output = vec![0.0; 4];
+    let result = conv2d(
+        &input,
+        &weight,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_output_size_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 3]; // wrong size (should be 4)
+    let result = conv2d(
+        &input,
+        &weight,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_bias_size_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let bias = vec![1.0, 2.0]; // 2 bias values for 1 output channel
+    let mut output = vec![0.0; 4];
+    let result = conv2d(
+        &input,
+        &weight,
+        Some(&bias),
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+    );
+    assert!(result.is_err());
+}
+
+// ── conv2d_quantized: I2S ────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_quantized_i2s_basic() {
+    // 1x1 quantized kernel, I2S format
+    // Packed: 4 values per byte. Single value at bit offset 0.
+    // 0x02 = binary 10 → dequantized to 1.0, times scale
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![0x02u8]; // 1 element packed (value = 1.0 * scale)
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::I2S,
+    )
+    .unwrap();
+    // weight = 1.0 * 1.0 = 1.0, so output = input
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn conv2d_quantized_i2s_negative() {
+    // 0x01 = binary 01 → dequantized to -1.0
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![0x01u8]; // value = -1.0 * scale
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4]; // 1x1x2x2
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::I2S,
+    )
+    .unwrap();
+    assert_eq!(output, vec![-1.0, -2.0, -3.0, -4.0]);
+}
+
+#[test]
+fn conv2d_quantized_i2s_with_scale() {
+    // 0x02 → 1.0, scale=0.5 → effective weight 0.5
+    let input = vec![2.0, 4.0, 6.0, 8.0]; // 1x1x2x2
+    let weight_quantized = vec![0x02u8];
+    let weight_scales = vec![0.5];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::I2S,
+    )
+    .unwrap();
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+// ── conv2d_quantized: TL1 ───────────────────────────────────────────────────
+
+#[test]
+fn conv2d_quantized_tl1_midpoint() {
+    // TL1: byte 128 → (128-128)/127 = 0.0
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![128u8]; // → 0.0 * scale
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL1,
+    )
+    .unwrap();
+    // All zeros since weight is 0
+    assert!(output.iter().all(|&v| v.abs() < 1e-6));
+}
+
+#[test]
+fn conv2d_quantized_tl1_max() {
+    // TL1: byte 255 → (255-128)/127 = 1.0
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![255u8]; // → 1.0 * scale
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL1,
+    )
+    .unwrap();
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+// ── conv2d_quantized: TL2 ───────────────────────────────────────────────────
+
+#[test]
+fn conv2d_quantized_tl2_midpoint() {
+    // TL2: byte 127 → (127/255)*2 - 1 ≈ -0.00392
+    // byte 128 → (128/255)*2 - 1 ≈ 0.00392
+    // Both are near zero
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight_quantized = vec![128u8];
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL2,
+    )
+    .unwrap();
+    // Close to zero but not exactly zero
+    for v in &output {
+        assert!(v.abs() < 0.01);
+    }
+}
+
+#[test]
+fn conv2d_quantized_tl2_max() {
+    // TL2: byte 255 → (255/255)*2 - 1 = 1.0
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![255u8];
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL2,
+    )
+    .unwrap();
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+// ── conv2d_quantized: validation ─────────────────────────────────────────────
+
+#[test]
+fn conv2d_quantized_channel_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight_quantized = vec![0u8; 4]; // 1x2x... (2 input channels)
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    let result = conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 2, 1, 2), // 2 input channels in weight != 1 in input
+        QuantizationType::TL1,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_quantized_scales_mismatch() {
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight_quantized = vec![128u8];
+    let weight_scales = vec![1.0, 2.0]; // 2 scales for 1 output channel
+    let mut output = vec![0.0; 4];
+    let result = conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL1,
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn conv2d_quantized_i2s_weight_size_mismatch() {
+    // I2S packs 4 elements per byte. For 1x1x1x1 kernel: 1 element → div_ceil(1,4) = 1 byte
+    let input = vec![1.0; 4]; // 1x1x2x2
+    let weight_quantized = vec![0u8; 5]; // too many bytes
+    let weight_scales = vec![1.0];
+    let mut output = vec![0.0; 4];
+    let result = conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        None,
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::I2S,
+    );
+    assert!(result.is_err());
+}
+
+// ── conv2d_quantized: with bias ──────────────────────────────────────────────
+
+#[test]
+fn conv2d_quantized_with_bias() {
+    // TL1: byte 255 → 1.0, + bias 5.0
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight_quantized = vec![255u8]; // → 1.0
+    let weight_scales = vec![1.0];
+    let bias = vec![5.0];
+    let mut output = vec![0.0; 4];
+    conv2d_quantized(
+        &input,
+        &weight_quantized,
+        &weight_scales,
+        Some(&bias),
+        &mut output,
+        Conv2DParams::default(),
+        (1, 1, 2, 2),
+        (1, 1, 1, 1),
+        QuantizationType::TL1,
+    )
+    .unwrap();
+    assert_eq!(output, vec![6.0, 7.0, 8.0, 9.0]);
+}
+
+// ── conv2d: negative values ──────────────────────────────────────────────────
+
+#[test]
+fn conv2d_negative_input() {
+    let input = vec![-1.0, -2.0, -3.0, -4.0]; // 1x1x2x2
+    let weight = vec![1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4];
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![-1.0, -2.0, -3.0, -4.0]);
+}
+
+#[test]
+fn conv2d_negative_weight() {
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![-1.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4];
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![-1.0, -2.0, -3.0, -4.0]);
+}
+
+// ── conv2d: 1x1 input ───────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_1x1_input_1x1_kernel() {
+    let input = vec![5.0]; // 1x1x1x1
+    let weight = vec![3.0]; // 1x1x1x1
+    let mut output = vec![0.0; 1];
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 1, 1), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output[0], 15.0);
+}
+
+// ── conv2d: multiple output channels ─────────────────────────────────────────
+
+#[test]
+fn conv2d_multiple_output_channels() {
+    let input = vec![1.0, 2.0, 3.0, 4.0]; // 1x1x2x2
+    let weight = vec![1.0, 2.0]; // 2x1x1x1
+    let mut output = vec![0.0; 8]; // 1x2x2x2
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (2, 1, 1, 1))
+        .unwrap();
+    // Channel 0: weight=1 → identity
+    assert_eq!(&output[..4], &[1.0, 2.0, 3.0, 4.0]);
+    // Channel 1: weight=2 → doubled
+    assert_eq!(&output[4..], &[2.0, 4.0, 6.0, 8.0]);
+}
+
+// ── conv2d: all zeros ────────────────────────────────────────────────────────
+
+#[test]
+fn conv2d_all_zeros_input() {
+    let input = vec![0.0; 4]; // 1x1x2x2
+    let weight = vec![5.0]; // 1x1x1x1
+    let mut output = vec![0.0; 4];
+    conv2d(&input, &weight, None, &mut output, Conv2DParams::default(), (1, 1, 2, 2), (1, 1, 1, 1))
+        .unwrap();
+    assert_eq!(output, vec![0.0, 0.0, 0.0, 0.0]);
+}


### PR DESCRIPTION
## Summary

Adds 97 edge-case tests across two untested modules:

### bitnet-kernels: convolution_edge_cases.rs (34 tests)
- **conv2d correctness**: 1x1 identity, 3x3 sum, scaling, multi-channel I/O
- **Stride/padding/dilation**: stride-2 downsampling, same-padding, dilated convolution
- **Bias**: single-channel, multi-channel bias application
- **Batch processing**: batch size 2 with independent results
- **Validation errors**: channel mismatch, input/output/weight/bias size mismatches
- **Quantized conv2d**: I2S (2-bit packed), TL1 (linear mapping), TL2 (non-linear mapping)
- **Quantized parameters**: scale factors, negative weights, bias with quantized weights
- **Edge values**: zero kernel, negative inputs/weights, 1x1 minimal input

### bitnet-gguf: kv_edge_cases.rs (63 tests)
- **parse_header**: versions 1-3, max/zero counts, extra bytes, error cases (short, bad magic, unsupported version)
- **GgufHeader traits**: Clone, Copy, Debug, PartialEq
- **GgufValue variants**: all 14 types (U8/I8/U16/I16/U32/I32/F32/Bool/String/Array/U64/I64/F64), empty/nested arrays
- **GgufKv struct**: construction, Debug, Clone
- **GgufError Display**: all 6 error variants
- **read_kv_pairs**: synthetic GGUF files with U32/String/Bool/I8/F32/U64, multi-KV, limit, error cases
- **read_header_blocking**: valid, truncated, nonexistent
- **Serde roundtrips**: header, value, array serialization/deserialization

### Dependency change
- Added serde_json as dev-dependency to itnet-gguf for serde roundtrip tests

All 97 tests pass locally with `--no-default-features --features cpu`.
