### PR TITLE
test: execution router and concurrency edge case tests (93 tests)

### DIFF
--- a/crates/bitnet-server/tests/concurrency_edge_cases.rs
+++ b/crates/bitnet-server/tests/concurrency_edge_cases.rs
@@ -1,0 +1,534 @@
+//! Edge-case tests for concurrency management: ConcurrencyConfig, CircuitBreakerState,
+//! RequestMetadata, ConcurrencyManager, ConcurrencyStats, ConcurrencyHealth, and
+//! request admission/rate-limiting behaviors.
+
+use bitnet_server::batch_engine::RequestPriority;
+use bitnet_server::concurrency::{
+    CircuitBreakerState, ConcurrencyConfig, ConcurrencyHealth, ConcurrencyManager,
+    ConcurrencyStats, RequestAdmission, RequestMetadata,
+};
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+// ─── ConcurrencyConfig ─────────────────────────────────────────────
+
+#[test]
+fn concurrency_config_defaults() {
+    let config = ConcurrencyConfig::default();
+    assert_eq!(config.max_concurrent_requests, 100);
+    assert_eq!(config.max_requests_per_second, 50);
+    assert_eq!(config.max_requests_per_minute, 1000);
+    assert_eq!(config.rate_limit_window, Duration::from_secs(60));
+    assert_eq!(config.backpressure_threshold, 0.8);
+    assert!(config.circuit_breaker_enabled);
+    assert_eq!(config.circuit_breaker_failure_threshold, 10);
+    assert_eq!(config.circuit_breaker_timeout, Duration::from_secs(30));
+    assert_eq!(config.per_ip_rate_limit, Some(10));
+    assert_eq!(config.global_rate_limit, Some(100));
+}
+
+#[test]
+fn concurrency_config_clone() {
+    let config = ConcurrencyConfig::default();
+    let cloned = config.clone();
+    assert_eq!(cloned.max_concurrent_requests, 100);
+    assert_eq!(cloned.per_ip_rate_limit, Some(10));
+}
+
+#[test]
+fn concurrency_config_debug() {
+    let config = ConcurrencyConfig::default();
+    let debug = format!("{:?}", config);
+    assert!(debug.contains("ConcurrencyConfig"));
+    assert!(debug.contains("max_concurrent_requests"));
+}
+
+#[test]
+fn concurrency_config_serde_roundtrip() {
+    let config = ConcurrencyConfig::default();
+    let json = serde_json::to_string(&config).unwrap();
+    let deser: ConcurrencyConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.max_concurrent_requests, 100);
+    assert_eq!(deser.backpressure_threshold, 0.8);
+}
+
+#[test]
+fn concurrency_config_custom_values() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 10,
+        max_requests_per_second: 5,
+        max_requests_per_minute: 100,
+        rate_limit_window: Duration::from_secs(120),
+        backpressure_threshold: 0.5,
+        circuit_breaker_enabled: false,
+        circuit_breaker_failure_threshold: 3,
+        circuit_breaker_timeout: Duration::from_secs(10),
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+    };
+    assert_eq!(config.max_concurrent_requests, 10);
+    assert!(!config.circuit_breaker_enabled);
+    assert!(config.per_ip_rate_limit.is_none());
+    assert!(config.global_rate_limit.is_none());
+}
+
+#[test]
+fn concurrency_config_zero_limits() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 0,
+        max_requests_per_second: 0,
+        max_requests_per_minute: 0,
+        rate_limit_window: Duration::from_secs(0),
+        backpressure_threshold: 0.0,
+        circuit_breaker_enabled: false,
+        circuit_breaker_failure_threshold: 0,
+        circuit_breaker_timeout: Duration::from_secs(0),
+        per_ip_rate_limit: Some(0),
+        global_rate_limit: Some(0),
+    };
+    assert_eq!(config.max_concurrent_requests, 0);
+    assert_eq!(config.per_ip_rate_limit, Some(0));
+}
+
+// ─── CircuitBreakerState ────────────────────────────────────────────
+
+#[test]
+fn circuit_breaker_state_debug() {
+    assert!(format!("{:?}", CircuitBreakerState::Closed).contains("Closed"));
+    assert!(format!("{:?}", CircuitBreakerState::Open).contains("Open"));
+    assert!(format!("{:?}", CircuitBreakerState::HalfOpen).contains("HalfOpen"));
+}
+
+#[test]
+fn circuit_breaker_state_clone() {
+    let state = CircuitBreakerState::HalfOpen;
+    let cloned = state.clone();
+    assert_eq!(cloned, CircuitBreakerState::HalfOpen);
+}
+
+#[test]
+fn circuit_breaker_state_eq() {
+    assert_eq!(CircuitBreakerState::Closed, CircuitBreakerState::Closed);
+    assert_ne!(CircuitBreakerState::Closed, CircuitBreakerState::Open);
+    assert_ne!(CircuitBreakerState::Open, CircuitBreakerState::HalfOpen);
+}
+
+#[test]
+fn circuit_breaker_state_serialize() {
+    let json = serde_json::to_string(&CircuitBreakerState::Closed).unwrap();
+    assert!(json.contains("Closed"));
+    let json2 = serde_json::to_string(&CircuitBreakerState::Open).unwrap();
+    assert!(json2.contains("Open"));
+}
+
+// ─── RequestMetadata ────────────────────────────────────────────────
+
+fn make_metadata(id: &str) -> RequestMetadata {
+    RequestMetadata {
+        id: id.to_string(),
+        client_ip: "127.0.0.1".parse().unwrap(),
+        user_agent: None,
+        start_time: Instant::now(),
+        priority: RequestPriority::Normal,
+    }
+}
+
+fn make_metadata_ip(id: &str, ip: &str) -> RequestMetadata {
+    RequestMetadata {
+        id: id.to_string(),
+        client_ip: ip.parse().unwrap(),
+        user_agent: None,
+        start_time: Instant::now(),
+        priority: RequestPriority::Normal,
+    }
+}
+
+#[test]
+fn request_metadata_debug() {
+    let meta = make_metadata("test-1");
+    let debug = format!("{:?}", meta);
+    assert!(debug.contains("test-1"));
+}
+
+#[test]
+fn request_metadata_clone() {
+    let meta = make_metadata("test-2");
+    let cloned = meta.clone();
+    assert_eq!(cloned.id, "test-2");
+    assert_eq!(cloned.client_ip, meta.client_ip);
+}
+
+#[test]
+fn request_metadata_with_user_agent() {
+    let meta = RequestMetadata {
+        id: "req-1".to_string(),
+        client_ip: "10.0.0.1".parse().unwrap(),
+        user_agent: Some("test-agent/1.0".to_string()),
+        start_time: Instant::now(),
+        priority: RequestPriority::High,
+    };
+    assert_eq!(meta.user_agent.as_deref(), Some("test-agent/1.0"));
+}
+
+#[test]
+fn request_metadata_ipv6() {
+    let meta = RequestMetadata {
+        id: "req-ipv6".to_string(),
+        client_ip: "::1".parse().unwrap(),
+        user_agent: None,
+        start_time: Instant::now(),
+        priority: RequestPriority::Low,
+    };
+    assert!(meta.client_ip.is_loopback());
+}
+
+#[test]
+fn request_metadata_all_priorities() {
+    let priorities = [
+        RequestPriority::Low,
+        RequestPriority::Normal,
+        RequestPriority::High,
+        RequestPriority::Critical,
+    ];
+    for p in priorities {
+        let meta = RequestMetadata {
+            id: "test".to_string(),
+            client_ip: "127.0.0.1".parse().unwrap(),
+            user_agent: None,
+            start_time: Instant::now(),
+            priority: p,
+        };
+        let _ = format!("{:?}", meta);
+    }
+}
+
+// ─── ConcurrencyManager ────────────────────────────────────────────
+
+#[tokio::test]
+async fn concurrency_manager_initial_stats() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 0);
+    assert_eq!(stats.max_concurrent_requests, 100);
+    assert_eq!(stats.current_load, 0.0);
+    assert_eq!(stats.total_requests, 0);
+    assert_eq!(stats.rejected_requests, 0);
+    assert_eq!(stats.backpressure_activations, 0);
+    assert_eq!(stats.available_permits, 100);
+    assert_eq!(stats.per_ip_limiter_count, 0);
+}
+
+#[tokio::test]
+async fn concurrency_manager_initial_health() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let health = manager.get_health().await;
+    assert!(health.healthy);
+    assert_eq!(health.current_load, 0.0);
+    assert_eq!(health.circuit_breaker_state, CircuitBreakerState::Closed);
+    assert!(health.issues.is_empty());
+}
+
+#[tokio::test]
+async fn concurrency_manager_should_admit_request() {
+    let config = ConcurrencyConfig {
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    let meta = make_metadata("req-1");
+    let admission = manager.should_admit_request(&meta).await.unwrap();
+    assert!(matches!(admission, RequestAdmission::Admitted));
+}
+
+#[tokio::test]
+async fn concurrency_manager_acquire_and_release() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 2,
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        backpressure_threshold: 1.0, // Disable backpressure
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    let meta = make_metadata("req-acquire");
+
+    let slot = manager.acquire_request_slot(meta).await.unwrap();
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 1);
+    assert_eq!(stats.total_requests, 1);
+
+    slot.mark_success().await;
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 0);
+}
+
+#[tokio::test]
+async fn concurrency_manager_record_success() {
+    let config = ConcurrencyConfig {
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    manager.record_success("req-1").await;
+    // Should not panic, removes from active (noop if not present)
+}
+
+#[tokio::test]
+async fn concurrency_manager_record_failure() {
+    let config = ConcurrencyConfig {
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    manager.record_failure("req-1", "test error").await;
+    // Should not panic
+}
+
+#[tokio::test]
+async fn concurrency_manager_slot_mark_failure() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 10,
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        backpressure_threshold: 1.0,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    let slot = manager.acquire_request_slot(make_metadata("fail-req")).await.unwrap();
+    slot.mark_failure("something went wrong").await;
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 0);
+}
+
+#[tokio::test]
+async fn concurrency_manager_slot_metadata() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 10,
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        backpressure_threshold: 1.0,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    let slot = manager.acquire_request_slot(make_metadata("meta-req")).await.unwrap();
+    assert_eq!(slot.metadata().id, "meta-req");
+    assert_eq!(slot.metadata().client_ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+    slot.mark_success().await;
+}
+
+#[tokio::test]
+async fn concurrency_manager_cleanup_rate_limiters_empty() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    // Should not panic on empty state
+    manager.cleanup_rate_limiters(Duration::from_secs(1)).await;
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.per_ip_limiter_count, 0);
+}
+
+#[tokio::test]
+async fn concurrency_manager_clone_shares_state() {
+    let config = ConcurrencyConfig {
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+    let cloned = manager.clone();
+
+    // Recording on original should affect cloned (shared Arc state)
+    manager.record_success("shared-req").await;
+    let stats = cloned.get_stats().await;
+    // Stats counters are cloned (not shared via Arc) so values may differ
+    // But the circuit breaker and active requests are shared
+    assert_eq!(stats.active_requests, 0);
+}
+
+// ─── ConcurrencyStats ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn concurrency_stats_serialize() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let stats = manager.get_stats().await;
+    let json = serde_json::to_string(&stats).unwrap();
+    assert!(json.contains("active_requests"));
+    assert!(json.contains("max_concurrent_requests"));
+    assert!(json.contains("circuit_breaker_state"));
+    assert!(json.contains("per_ip_limiter_count"));
+}
+
+#[tokio::test]
+async fn concurrency_stats_debug() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let stats = manager.get_stats().await;
+    let debug = format!("{:?}", stats);
+    assert!(debug.contains("ConcurrencyStats"));
+}
+
+#[tokio::test]
+async fn concurrency_stats_clone() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let stats = manager.get_stats().await;
+    let cloned = stats.clone();
+    assert_eq!(cloned.active_requests, stats.active_requests);
+    assert_eq!(cloned.max_concurrent_requests, stats.max_concurrent_requests);
+}
+
+// ─── ConcurrencyHealth ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn concurrency_health_serialize() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let health = manager.get_health().await;
+    let json = serde_json::to_string(&health).unwrap();
+    assert!(json.contains("healthy"));
+    assert!(json.contains("current_load"));
+    assert!(json.contains("circuit_breaker_state"));
+}
+
+#[tokio::test]
+async fn concurrency_health_debug() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let health = manager.get_health().await;
+    let debug = format!("{:?}", health);
+    assert!(debug.contains("ConcurrencyHealth"));
+}
+
+#[tokio::test]
+async fn concurrency_health_clone() {
+    let manager = ConcurrencyManager::new(ConcurrencyConfig::default());
+    let health = manager.get_health().await;
+    let cloned = health.clone();
+    assert_eq!(cloned.healthy, health.healthy);
+    assert_eq!(cloned.circuit_breaker_state, health.circuit_breaker_state);
+}
+
+// ─── RequestAdmission ───────────────────────────────────────────────
+
+#[test]
+fn request_admission_debug() {
+    let admitted = RequestAdmission::Admitted;
+    assert!(format!("{:?}", admitted).contains("Admitted"));
+
+    let rejected = RequestAdmission::Rejected {
+        reason: "rate limited".to_string(),
+        retry_after: Some(Duration::from_secs(1)),
+    };
+    assert!(format!("{:?}", rejected).contains("Rejected"));
+    assert!(format!("{:?}", rejected).contains("rate limited"));
+}
+
+#[test]
+fn request_admission_rejected_no_retry() {
+    let rejected =
+        RequestAdmission::Rejected { reason: "permanently banned".to_string(), retry_after: None };
+    let debug = format!("{:?}", rejected);
+    assert!(debug.contains("permanently banned"));
+}
+
+// ─── Circuit breaker behavior through ConcurrencyManager ────────────
+
+#[tokio::test]
+async fn circuit_breaker_opens_after_threshold_failures() {
+    let config = ConcurrencyConfig {
+        circuit_breaker_enabled: true,
+        circuit_breaker_failure_threshold: 3,
+        circuit_breaker_timeout: Duration::from_secs(60),
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+
+    // Record failures up to threshold
+    for i in 0..3 {
+        manager.record_failure(&format!("fail-{}", i), "error").await;
+    }
+
+    // Health should reflect circuit breaker is open
+    let health = manager.get_health().await;
+    assert_eq!(health.circuit_breaker_state, CircuitBreakerState::Open);
+    assert!(!health.healthy);
+    assert!(health.issues.iter().any(|i| i.contains("Circuit breaker")));
+}
+
+#[tokio::test]
+async fn circuit_breaker_rejects_when_open() {
+    let config = ConcurrencyConfig {
+        circuit_breaker_enabled: true,
+        circuit_breaker_failure_threshold: 2,
+        circuit_breaker_timeout: Duration::from_secs(60),
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+
+    // Trip the circuit breaker
+    manager.record_failure("f1", "err").await;
+    manager.record_failure("f2", "err").await;
+
+    // New requests should be rejected
+    let meta = make_metadata("should-reject");
+    let admission = manager.should_admit_request(&meta).await.unwrap();
+    assert!(matches!(admission, RequestAdmission::Rejected { .. }));
+
+    if let RequestAdmission::Rejected { reason, retry_after } = admission {
+        assert!(reason.contains("Circuit breaker"));
+        assert!(retry_after.is_some());
+    }
+}
+
+#[tokio::test]
+async fn circuit_breaker_disabled_allows_all() {
+    let config = ConcurrencyConfig {
+        circuit_breaker_enabled: false,
+        per_ip_rate_limit: None,
+        global_rate_limit: None,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+
+    // Even with many failures, requests should be admitted
+    for i in 0..20 {
+        manager.record_failure(&format!("fail-{}", i), "error").await;
+    }
+
+    let meta = make_metadata("should-admit");
+    let admission = manager.should_admit_request(&meta).await.unwrap();
+    assert!(matches!(admission, RequestAdmission::Admitted));
+}
+
+// ─── Multiple IP tracking ───────────────────────────────────────────
+
+#[tokio::test]
+async fn concurrency_manager_tracks_multiple_ips() {
+    let config = ConcurrencyConfig {
+        max_concurrent_requests: 100,
+        per_ip_rate_limit: Some(100), // High limit so we don't get rate limited
+        global_rate_limit: None,
+        backpressure_threshold: 1.0,
+        ..ConcurrencyConfig::default()
+    };
+    let manager = ConcurrencyManager::new(config);
+
+    // Send requests from different IPs
+    let slot1 = manager.acquire_request_slot(make_metadata_ip("r1", "10.0.0.1")).await.unwrap();
+    let slot2 = manager.acquire_request_slot(make_metadata_ip("r2", "10.0.0.2")).await.unwrap();
+    let slot3 = manager.acquire_request_slot(make_metadata_ip("r3", "10.0.0.3")).await.unwrap();
+
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 3);
+    assert_eq!(stats.per_ip_limiter_count, 3);
+
+    slot1.mark_success().await;
+    slot2.mark_success().await;
+    slot3.mark_success().await;
+
+    let stats = manager.get_stats().await;
+    assert_eq!(stats.active_requests, 0);
+    // Rate limiters persist even after requests complete
+    assert_eq!(stats.per_ip_limiter_count, 3);
+}

--- a/crates/bitnet-server/tests/execution_router_edge_cases.rs
+++ b/crates/bitnet-server/tests/execution_router_edge_cases.rs
@@ -1,0 +1,675 @@
+//! Edge-case tests for execution_router: DeviceCapabilities, DeviceSelectionStrategy,
+//! ExecutionRouterConfig, DeviceHealth, DeviceStats, DeviceMonitor, ExecutionRouter,
+//! DeviceStatus, and ExecutionRouterHealth.
+
+use bitnet_common::Device;
+use bitnet_server::execution_router::{
+    DeviceCapabilities, DeviceHealth, DeviceMonitor, DeviceSelectionStrategy, DeviceStats,
+    ExecutionRouter, ExecutionRouterConfig, ExecutionRouterHealth,
+};
+use std::time::Duration;
+
+// ─── DeviceCapabilities ─────────────────────────────────────────────
+
+#[test]
+fn device_capabilities_cpu_defaults() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: true,
+        memory_total_mb: 16384,
+        memory_free_mb: 8192,
+        compute_capability: None,
+        simd_support: vec!["AVX2".to_string()],
+        avg_tokens_per_second: 35.0,
+        last_benchmark: None,
+    };
+    assert_eq!(caps.device, Device::Cpu);
+    assert!(caps.available);
+    assert_eq!(caps.memory_total_mb, 16384);
+    assert_eq!(caps.memory_free_mb, 8192);
+    assert!(caps.compute_capability.is_none());
+    assert_eq!(caps.simd_support.len(), 1);
+    assert_eq!(caps.avg_tokens_per_second, 35.0);
+    assert!(caps.last_benchmark.is_none());
+}
+
+#[test]
+fn device_capabilities_clone() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: true,
+        memory_total_mb: 1024,
+        memory_free_mb: 512,
+        compute_capability: Some("8.6".to_string()),
+        simd_support: vec!["AVX-512".to_string(), "AVX2".to_string()],
+        avg_tokens_per_second: 100.0,
+        last_benchmark: Some(std::time::SystemTime::now()),
+    };
+    let cloned = caps.clone();
+    assert_eq!(cloned.device, caps.device);
+    assert_eq!(cloned.memory_total_mb, caps.memory_total_mb);
+    assert_eq!(cloned.compute_capability, caps.compute_capability);
+    assert_eq!(cloned.simd_support, caps.simd_support);
+}
+
+#[test]
+fn device_capabilities_debug() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: false,
+        memory_total_mb: 0,
+        memory_free_mb: 0,
+        compute_capability: None,
+        simd_support: vec![],
+        avg_tokens_per_second: 0.0,
+        last_benchmark: None,
+    };
+    let debug = format!("{:?}", caps);
+    assert!(debug.contains("DeviceCapabilities"));
+    assert!(debug.contains("Cpu"));
+}
+
+#[test]
+fn device_capabilities_serde_roundtrip() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: true,
+        memory_total_mb: 32768,
+        memory_free_mb: 16384,
+        compute_capability: None,
+        simd_support: vec!["AVX2".to_string()],
+        avg_tokens_per_second: 42.0,
+        last_benchmark: None,
+    };
+    let json = serde_json::to_string(&caps).unwrap();
+    let deser: DeviceCapabilities = serde_json::from_str(&json).unwrap();
+    assert_eq!(deser.device, Device::Cpu);
+    assert_eq!(deser.memory_total_mb, 32768);
+    assert_eq!(deser.avg_tokens_per_second, 42.0);
+}
+
+#[test]
+fn device_capabilities_zero_memory() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: true,
+        memory_total_mb: 0,
+        memory_free_mb: 0,
+        compute_capability: None,
+        simd_support: vec![],
+        avg_tokens_per_second: 0.0,
+        last_benchmark: None,
+    };
+    assert_eq!(caps.memory_total_mb, 0);
+    assert_eq!(caps.memory_free_mb, 0);
+}
+
+#[test]
+fn device_capabilities_huge_memory() {
+    let caps = DeviceCapabilities {
+        device: Device::Cpu,
+        available: true,
+        memory_total_mb: u64::MAX,
+        memory_free_mb: u64::MAX / 2,
+        compute_capability: None,
+        simd_support: vec![],
+        avg_tokens_per_second: 0.0,
+        last_benchmark: None,
+    };
+    assert!(caps.memory_free_mb < caps.memory_total_mb);
+}
+
+// ─── DeviceSelectionStrategy ────────────────────────────────────────
+
+#[test]
+fn device_selection_strategy_debug() {
+    let strategies = vec![
+        DeviceSelectionStrategy::PreferGpu,
+        DeviceSelectionStrategy::CpuOnly,
+        DeviceSelectionStrategy::PerformanceBased,
+        DeviceSelectionStrategy::LoadBalance,
+        DeviceSelectionStrategy::UserPreference(Device::Cpu),
+    ];
+    for s in &strategies {
+        let debug = format!("{:?}", s);
+        assert!(!debug.is_empty());
+    }
+}
+
+#[test]
+fn device_selection_strategy_clone() {
+    let s = DeviceSelectionStrategy::UserPreference(Device::Cpu);
+    let cloned = s.clone();
+    assert!(format!("{:?}", cloned).contains("UserPreference"));
+}
+
+#[test]
+fn device_selection_strategy_serde_roundtrip() {
+    let strategies = vec![
+        DeviceSelectionStrategy::PreferGpu,
+        DeviceSelectionStrategy::CpuOnly,
+        DeviceSelectionStrategy::PerformanceBased,
+        DeviceSelectionStrategy::LoadBalance,
+    ];
+    for s in &strategies {
+        let json = serde_json::to_string(s).unwrap();
+        let deser: DeviceSelectionStrategy = serde_json::from_str(&json).unwrap();
+        assert_eq!(format!("{:?}", s), format!("{:?}", deser));
+    }
+}
+
+#[test]
+fn device_selection_strategy_user_preference_serde() {
+    let s = DeviceSelectionStrategy::UserPreference(Device::Cpu);
+    let json = serde_json::to_string(&s).unwrap();
+    assert!(json.contains("UserPreference"));
+    let deser: DeviceSelectionStrategy = serde_json::from_str(&json).unwrap();
+    assert!(format!("{:?}", deser).contains("UserPreference"));
+}
+
+// ─── ExecutionRouterConfig ──────────────────────────────────────────
+
+#[test]
+fn execution_router_config_defaults() {
+    let config = ExecutionRouterConfig::default();
+    assert!(matches!(config.strategy, DeviceSelectionStrategy::PerformanceBased));
+    assert!(config.fallback_enabled);
+    assert_eq!(config.health_check_interval, Duration::from_secs(30));
+    assert_eq!(config.performance_threshold_tps, 10.0);
+    assert_eq!(config.memory_threshold_percent, 0.8);
+    assert!(config.benchmark_on_startup);
+}
+
+#[test]
+fn execution_router_config_clone() {
+    let config = ExecutionRouterConfig::default();
+    let cloned = config.clone();
+    assert!(cloned.fallback_enabled);
+    assert_eq!(cloned.performance_threshold_tps, 10.0);
+}
+
+#[test]
+fn execution_router_config_debug() {
+    let config = ExecutionRouterConfig::default();
+    let debug = format!("{:?}", config);
+    assert!(debug.contains("ExecutionRouterConfig"));
+    assert!(debug.contains("fallback_enabled"));
+}
+
+#[test]
+fn execution_router_config_serde_roundtrip() {
+    let config = ExecutionRouterConfig::default();
+    let json = serde_json::to_string(&config).unwrap();
+    let deser: ExecutionRouterConfig = serde_json::from_str(&json).unwrap();
+    assert!(deser.fallback_enabled);
+    assert_eq!(deser.performance_threshold_tps, 10.0);
+}
+
+#[test]
+fn execution_router_config_custom_values() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        fallback_enabled: false,
+        health_check_interval: Duration::from_secs(5),
+        performance_threshold_tps: 1.0,
+        memory_threshold_percent: 0.5,
+        benchmark_on_startup: false,
+    };
+    assert!(!config.fallback_enabled);
+    assert_eq!(config.health_check_interval, Duration::from_secs(5));
+    assert_eq!(config.performance_threshold_tps, 1.0);
+    assert_eq!(config.memory_threshold_percent, 0.5);
+    assert!(!config.benchmark_on_startup);
+}
+
+// ─── DeviceHealth ───────────────────────────────────────────────────
+
+#[test]
+fn device_health_healthy() {
+    let h = DeviceHealth::Healthy;
+    let debug = format!("{:?}", h);
+    assert!(debug.contains("Healthy"));
+}
+
+#[test]
+fn device_health_degraded() {
+    let h = DeviceHealth::Degraded { reason: "Low memory".to_string() };
+    let debug = format!("{:?}", h);
+    assert!(debug.contains("Degraded"));
+    assert!(debug.contains("Low memory"));
+}
+
+#[test]
+fn device_health_unavailable() {
+    let h = DeviceHealth::Unavailable { reason: "Device disconnected".to_string() };
+    let debug = format!("{:?}", h);
+    assert!(debug.contains("Unavailable"));
+    assert!(debug.contains("Device disconnected"));
+}
+
+#[test]
+fn device_health_clone() {
+    let h = DeviceHealth::Degraded { reason: "test reason".to_string() };
+    let cloned = h.clone();
+    assert!(format!("{:?}", cloned).contains("test reason"));
+}
+
+#[test]
+fn device_health_serialize() {
+    let h = DeviceHealth::Healthy;
+    let json = serde_json::to_string(&h).unwrap();
+    assert!(json.contains("Healthy"));
+
+    let h2 = DeviceHealth::Degraded { reason: "test".to_string() };
+    let json2 = serde_json::to_string(&h2).unwrap();
+    assert!(json2.contains("Degraded"));
+    assert!(json2.contains("test"));
+}
+
+// ─── DeviceStats ────────────────────────────────────────────────────
+
+#[test]
+fn device_stats_new_defaults() {
+    let stats = DeviceStats::new();
+    assert_eq!(stats.requests_processed.load(std::sync::atomic::Ordering::Relaxed), 0);
+    assert_eq!(stats.total_tokens_generated.load(std::sync::atomic::Ordering::Relaxed), 0);
+    assert_eq!(stats.total_execution_time.load(std::sync::atomic::Ordering::Relaxed), 0);
+    assert_eq!(stats.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 0);
+}
+
+#[test]
+fn device_stats_default_is_new() {
+    let stats = DeviceStats::default();
+    assert_eq!(stats.requests_processed.load(std::sync::atomic::Ordering::Relaxed), 0);
+}
+
+#[test]
+fn device_stats_avg_tokens_zero() {
+    let stats = DeviceStats::new();
+    assert_eq!(stats.get_avg_tokens_per_second(), 0.0);
+}
+
+#[tokio::test]
+async fn device_stats_record_success() {
+    let stats = DeviceStats::new();
+    stats.record_success(100, Duration::from_secs(1)).await;
+    assert_eq!(stats.requests_processed.load(std::sync::atomic::Ordering::Relaxed), 1);
+    assert_eq!(stats.total_tokens_generated.load(std::sync::atomic::Ordering::Relaxed), 100);
+    assert!(stats.get_avg_tokens_per_second() > 0.0);
+}
+
+#[tokio::test]
+async fn device_stats_record_multiple_successes() {
+    let stats = DeviceStats::new();
+    stats.record_success(50, Duration::from_millis(500)).await;
+    stats.record_success(50, Duration::from_millis(500)).await;
+    assert_eq!(stats.requests_processed.load(std::sync::atomic::Ordering::Relaxed), 2);
+    assert_eq!(stats.total_tokens_generated.load(std::sync::atomic::Ordering::Relaxed), 100);
+    // 100 tokens / 1000ms = 100 tps
+    let avg = stats.get_avg_tokens_per_second();
+    assert!(avg > 90.0 && avg < 110.0, "avg was {}", avg);
+}
+
+#[test]
+fn device_stats_record_failure() {
+    let stats = DeviceStats::new();
+    stats.record_failure();
+    assert_eq!(stats.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 1);
+    stats.record_failure();
+    assert_eq!(stats.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn device_stats_success_resets_failures() {
+    let stats = DeviceStats::new();
+    stats.record_failure();
+    stats.record_failure();
+    assert_eq!(stats.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 2);
+    stats.record_success(10, Duration::from_millis(100)).await;
+    assert_eq!(stats.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 0);
+}
+
+#[test]
+fn device_stats_clone() {
+    let stats = DeviceStats::new();
+    stats.record_failure();
+    let cloned = stats.clone();
+    assert_eq!(cloned.consecutive_failures.load(std::sync::atomic::Ordering::Relaxed), 1);
+}
+
+#[test]
+fn device_stats_debug() {
+    let stats = DeviceStats::new();
+    let debug = format!("{:?}", stats);
+    assert!(debug.contains("DeviceStats"));
+}
+
+// ─── DeviceMonitor ──────────────────────────────────────────────────
+
+#[test]
+fn device_monitor_new_cpu() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    assert_eq!(monitor.device, Device::Cpu);
+}
+
+#[tokio::test]
+async fn device_monitor_cpu_capabilities() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let caps = monitor.capabilities.read().await;
+    assert_eq!(caps.device, Device::Cpu);
+    assert!(caps.available);
+    // CPU should have non-zero total memory
+    assert!(caps.memory_total_mb > 0);
+}
+
+#[tokio::test]
+async fn device_monitor_benchmark_cpu() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let tps = monitor.benchmark().await.unwrap();
+    assert!(tps > 0.0, "CPU benchmark should return positive tps");
+    // Check capabilities updated
+    let caps = monitor.capabilities.read().await;
+    assert!(caps.avg_tokens_per_second > 0.0);
+    assert!(caps.last_benchmark.is_some());
+}
+
+#[tokio::test]
+async fn device_monitor_update_health() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    monitor.update_health().await;
+    let health = monitor.health.read().await;
+    // CPU should be available — exact health depends on host memory pressure
+    assert!(!matches!(*health, DeviceHealth::Unavailable { .. }));
+}
+
+#[tokio::test]
+async fn device_monitor_get_status() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let status = monitor.get_status().await;
+    assert_eq!(status.device, Device::Cpu);
+    assert_eq!(status.requests_processed, 0);
+    assert_eq!(status.consecutive_failures, 0);
+}
+
+#[tokio::test]
+async fn device_monitor_stats_accumulate() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    monitor.stats.record_success(50, Duration::from_millis(500)).await;
+    let status = monitor.get_status().await;
+    assert_eq!(status.requests_processed, 1);
+    assert!(status.avg_tokens_per_second > 0.0);
+}
+
+// ─── DeviceStatus ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn device_status_serialize() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let status = monitor.get_status().await;
+    let json = serde_json::to_string(&status).unwrap();
+    assert!(json.contains("Cpu"));
+    assert!(json.contains("requests_processed"));
+}
+
+#[tokio::test]
+async fn device_status_debug() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let status = monitor.get_status().await;
+    let debug = format!("{:?}", status);
+    assert!(debug.contains("DeviceStatus"));
+}
+
+#[tokio::test]
+async fn device_status_clone() {
+    let monitor = DeviceMonitor::new(Device::Cpu);
+    let status = monitor.get_status().await;
+    let cloned = status.clone();
+    assert_eq!(cloned.device, status.device);
+    assert_eq!(cloned.requests_processed, status.requests_processed);
+}
+
+// ─── ExecutionRouter ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn execution_router_cpu_only_strategy() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    assert_eq!(device, Some(Device::Cpu));
+}
+
+#[tokio::test]
+async fn execution_router_empty_devices() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![]).await.unwrap();
+    let device = router.select_device().await;
+    assert_eq!(device, None);
+}
+
+#[tokio::test]
+async fn execution_router_performance_based() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::PerformanceBased,
+        benchmark_on_startup: true,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    // On machines with high memory usage, device health may be Degraded, so None is also valid
+    assert!(device == Some(Device::Cpu) || device.is_none());
+}
+
+#[tokio::test]
+async fn execution_router_load_balance_single_device() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::LoadBalance,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    // Load balance requires device to be Healthy; on high-memory-usage hosts it may be Degraded
+    let device = router.select_device().await;
+    assert!(device == Some(Device::Cpu) || device.is_none());
+}
+
+#[tokio::test]
+async fn execution_router_user_preference_cpu() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::UserPreference(Device::Cpu),
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    assert_eq!(device, Some(Device::Cpu));
+}
+
+#[tokio::test]
+async fn execution_router_user_preference_unavailable_with_fallback() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::UserPreference(Device::Cuda(99)),
+        fallback_enabled: true,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    // Cuda(99) not in devices, fallback to CPU
+    let device = router.select_device().await;
+    assert_eq!(device, Some(Device::Cpu));
+}
+
+#[tokio::test]
+async fn execution_router_user_preference_unavailable_no_fallback() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::UserPreference(Device::Cuda(99)),
+        fallback_enabled: false,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    assert_eq!(device, None);
+}
+
+#[tokio::test]
+async fn execution_router_record_execution_result() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    router.record_execution_result(&Device::Cpu, 100, Duration::from_secs(1), true).await;
+    let statuses = router.get_device_statuses().await;
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].requests_processed, 1);
+}
+
+#[tokio::test]
+async fn execution_router_record_failure() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    router.record_execution_result(&Device::Cpu, 0, Duration::from_secs(0), false).await;
+    let statuses = router.get_device_statuses().await;
+    assert_eq!(statuses[0].consecutive_failures, 1);
+}
+
+#[tokio::test]
+async fn execution_router_get_device_statuses() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let statuses = router.get_device_statuses().await;
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].device, Device::Cpu);
+}
+
+#[tokio::test]
+async fn execution_router_update_device_health() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    // Should not panic
+    router.update_device_health().await;
+}
+
+#[tokio::test]
+async fn execution_router_prefer_gpu_falls_back_to_cpu() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::PreferGpu,
+        fallback_enabled: true,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    // Only CPU available — no GPU
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    assert_eq!(device, Some(Device::Cpu));
+}
+
+#[tokio::test]
+async fn execution_router_prefer_gpu_no_fallback_no_gpu() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::PreferGpu,
+        fallback_enabled: false,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let device = router.select_device().await;
+    // No GPU, no fallback
+    assert_eq!(device, None);
+}
+
+// ─── ExecutionRouterHealth ──────────────────────────────────────────
+
+#[tokio::test]
+async fn execution_router_health_summary() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![Device::Cpu]).await.unwrap();
+    let health = router.get_health_summary().await;
+    assert_eq!(health.total_devices, 1);
+    // Device health depends on host memory pressure
+    assert_eq!(health.healthy_devices + health.degraded_devices + health.unavailable_devices, 1);
+    assert!(health.fallback_enabled);
+    assert!(health.strategy.contains("CpuOnly"));
+}
+
+#[tokio::test]
+async fn execution_router_health_empty() {
+    let config = ExecutionRouterConfig {
+        strategy: DeviceSelectionStrategy::CpuOnly,
+        benchmark_on_startup: false,
+        ..ExecutionRouterConfig::default()
+    };
+    let router = ExecutionRouter::new(config, vec![]).await.unwrap();
+    let health = router.get_health_summary().await;
+    assert_eq!(health.total_devices, 0);
+    assert_eq!(health.healthy_devices, 0);
+}
+
+#[test]
+fn execution_router_health_serialize() {
+    let health = ExecutionRouterHealth {
+        total_devices: 2,
+        healthy_devices: 1,
+        degraded_devices: 1,
+        unavailable_devices: 0,
+        fallback_enabled: true,
+        strategy: "PerformanceBased".to_string(),
+    };
+    let json = serde_json::to_string(&health).unwrap();
+    assert!(json.contains("total_devices"));
+    assert!(json.contains("PerformanceBased"));
+}
+
+#[test]
+fn execution_router_health_debug() {
+    let health = ExecutionRouterHealth {
+        total_devices: 3,
+        healthy_devices: 2,
+        degraded_devices: 0,
+        unavailable_devices: 1,
+        fallback_enabled: false,
+        strategy: "LoadBalance".to_string(),
+    };
+    let debug = format!("{:?}", health);
+    assert!(debug.contains("ExecutionRouterHealth"));
+}
+
+#[test]
+fn execution_router_health_clone() {
+    let health = ExecutionRouterHealth {
+        total_devices: 1,
+        healthy_devices: 1,
+        degraded_devices: 0,
+        unavailable_devices: 0,
+        fallback_enabled: true,
+        strategy: "CpuOnly".to_string(),
+    };
+    let cloned = health.clone();
+    assert_eq!(cloned.total_devices, 1);
+    assert_eq!(cloned.strategy, "CpuOnly");
+}


### PR DESCRIPTION
## Summary
Add comprehensive edge-case tests for the execution router and concurrency management modules in bitnet-server.

## Tests Added
### execution_router_edge_cases.rs (56 tests)
- **DeviceCapabilities**: construction, clone, debug, serde roundtrip, zero/huge memory
- **DeviceSelectionStrategy**: all variants debug, clone, serde roundtrip
- **ExecutionRouterConfig**: defaults, custom values, clone, debug, serde
- **DeviceHealth**: Healthy/Degraded/Unavailable variants, clone, serialize
- **DeviceStats**: new, default, avg_tokens calculation, record_success/failure, clone
- **DeviceMonitor**: CPU capabilities, benchmark, update_health, get_status, stats accumulation
- **ExecutionRouter**: CpuOnly/PerformanceBased/LoadBalance/UserPreference strategies, empty devices, record results, fallback behavior
- **ExecutionRouterHealth**: summary, serialize, debug, clone

### concurrency_edge_cases.rs (37 tests)
- **ConcurrencyConfig**: defaults, clone, debug, serde roundtrip, custom/zero values
- **CircuitBreakerState**: debug, clone, eq, serialize
- **RequestMetadata**: debug, clone, user_agent, IPv6, all priorities
- **ConcurrencyManager**: initial stats/health, admission, acquire/release slots, cleanup
- **Circuit breaker behavior**: opens after threshold, rejects when open, disabled allows all
- **Multi-IP tracking**: rate limiter creation per IP, cleanup

## Verification
All 93 tests pass locally with `--no-default-features --features cpu`
