### PR TITLE
feat(wgpu): add WGSL compute shader library (matmul, elementwise, softmax, layernorm, rope)

### DIFF
--- a/crates/bitnet-wgpu-shaders/Cargo.toml
+++ b/crates/bitnet-wgpu-shaders/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bitnet-wgpu-shaders"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "WGSL compute shader sources for BitNet inference kernels"
+rust-version.workspace = true
+
+[dependencies]
+# Pure embedded shader sources – no runtime deps required.
+
+[dev-dependencies]
+naga = { version = "24", features = ["wgsl-in"] }
+
+[features]
+default = []
+cpu = []
+gpu = ["cuda"]
+cuda = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-shaders/src/elementwise.rs
+++ b/crates/bitnet-wgpu-shaders/src/elementwise.rs
@@ -1,0 +1,112 @@
+//! Element-wise WGSL compute shaders.
+//!
+//! All kernels use workgroup size [256, 1, 1] and operate on flat `array<f32>`
+//! storage buffers with a uniform `length` parameter for bounds checking.
+
+/// Element-wise addition: result[i] = a[i] + b[i].
+pub const ADD_SRC: &str = r"
+struct Params { length: u32, }
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256, 1, 1)
+fn add(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    result[idx] = a[idx] + b[idx];
+}
+";
+
+/// Element-wise multiplication: result[i] = a[i] * b[i].
+pub const MUL_SRC: &str = r"
+struct Params { length: u32, }
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+@group(0) @binding(3) var<uniform> params: Params;
+
+@compute @workgroup_size(256, 1, 1)
+fn mul(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    result[idx] = a[idx] * b[idx];
+}
+";
+
+/// Scalar multiplication: result[i] = a[i] * scalar.
+pub const SCALE_SRC: &str = r"
+struct Params {
+    length: u32,
+    scalar: f32,
+}
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> result: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256, 1, 1)
+fn scale(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    result[idx] = a[idx] * params.scalar;
+}
+";
+
+/// `ReLU` activation: result[i] = max(0, a[i]).
+pub const RELU_SRC: &str = r"
+struct Params { length: u32, }
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> result: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256, 1, 1)
+fn relu(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    result[idx] = max(a[idx], 0.0);
+}
+";
+
+/// GELU activation (tanh approximation):
+/// result[i] = 0.5 * x * (1 + tanh(sqrt(2/π) * (x + 0.044715 * x³)))
+pub const GELU_SRC: &str = r"
+struct Params { length: u32, }
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> result: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+const SQRT_2_OVER_PI: f32 = 0.7978845608;
+const GELU_COEFF: f32 = 0.044715;
+
+@compute @workgroup_size(256, 1, 1)
+fn gelu(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    let x = a[idx];
+    let inner = SQRT_2_OVER_PI * (x + GELU_COEFF * x * x * x);
+    result[idx] = 0.5 * x * (1.0 + tanh(inner));
+}
+";
+
+/// `SiLU` (Swish) activation: result[i] = x / (1 + exp(-x)).
+pub const SILU_SRC: &str = r"
+struct Params { length: u32, }
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> result: array<f32>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(256, 1, 1)
+fn silu(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if idx >= params.length { return; }
+    let x = a[idx];
+    result[idx] = x / (1.0 + exp(-x));
+}
+";

--- a/crates/bitnet-wgpu-shaders/src/layer_norm.rs
+++ b/crates/bitnet-wgpu-shaders/src/layer_norm.rs
@@ -1,0 +1,144 @@
+//! Layer normalization WGSL compute shaders.
+//!
+//! Provides standard `LayerNorm` (with gamma/beta) and RMS normalization
+//! (LLaMA-style, gamma only). Each workgroup processes one row.
+
+/// Layer normalization with learnable gamma (weight) and beta (bias).
+///
+/// y[i] = gamma[i] * (x[i] - mean) / sqrt(var + eps) + beta[i]
+///
+/// Each workgroup handles one row. Workgroup size: [256, 1, 1].
+pub const LAYER_NORM_SRC: &str = r"
+struct LayerNormParams {
+    rows: u32,
+    cols: u32,
+    eps: f32,
+}
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> gamma: array<f32>;
+@group(0) @binding(2) var<storage, read> beta: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+@group(0) @binding(4) var<uniform> params: LayerNormParams;
+
+const WG_SIZE: u32 = 256u;
+
+var<workgroup> shared_sum: array<f32, 256>;
+var<workgroup> shared_sq_sum: array<f32, 256>;
+
+@compute @workgroup_size(256, 1, 1)
+fn layer_norm(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id) wgid: vec3<u32>,
+) {
+    let row = wgid.x;
+    if row >= params.rows { return; }
+
+    let tid = lid.x;
+    let row_offset = row * params.cols;
+
+    // Phase 1: compute sum and squared sum for mean and variance
+    var local_sum: f32 = 0.0;
+    var local_sq_sum: f32 = 0.0;
+    var col = tid;
+    while col < params.cols {
+        let val = input[row_offset + col];
+        local_sum = local_sum + val;
+        local_sq_sum = local_sq_sum + val * val;
+        col = col + WG_SIZE;
+    }
+    shared_sum[tid] = local_sum;
+    shared_sq_sum[tid] = local_sq_sum;
+    workgroupBarrier();
+
+    // Tree reduction
+    var stride: u32 = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_sum[tid] = shared_sum[tid] + shared_sum[tid + stride];
+            shared_sq_sum[tid] = shared_sq_sum[tid] + shared_sq_sum[tid + stride];
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+
+    let n = f32(params.cols);
+    let mean = shared_sum[0] / n;
+    let variance = shared_sq_sum[0] / n - mean * mean;
+    let inv_std = 1.0 / sqrt(variance + params.eps);
+    workgroupBarrier();
+
+    // Phase 2: normalize with gamma and beta
+    col = tid;
+    while col < params.cols {
+        let normalized = (input[row_offset + col] - mean) * inv_std;
+        output[row_offset + col] = gamma[col] * normalized + beta[col];
+        col = col + WG_SIZE;
+    }
+}
+";
+
+/// RMS normalization (LLaMA-style): y[i] = gamma[i] * x[i] / rms(x).
+///
+/// rms(x) = sqrt(mean(x²) + eps). No mean subtraction or beta.
+/// Each workgroup handles one row. Workgroup size: [256, 1, 1].
+pub const RMS_NORM_SRC: &str = r"
+struct RmsNormParams {
+    rows: u32,
+    cols: u32,
+    eps: f32,
+}
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> gamma: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+@group(0) @binding(3) var<uniform> params: RmsNormParams;
+
+const WG_SIZE: u32 = 256u;
+
+var<workgroup> shared_sq_sum: array<f32, 256>;
+
+@compute @workgroup_size(256, 1, 1)
+fn rms_norm(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id) wgid: vec3<u32>,
+) {
+    let row = wgid.x;
+    if row >= params.rows { return; }
+
+    let tid = lid.x;
+    let row_offset = row * params.cols;
+
+    // Phase 1: compute sum of squares
+    var local_sq_sum: f32 = 0.0;
+    var col = tid;
+    while col < params.cols {
+        let val = input[row_offset + col];
+        local_sq_sum = local_sq_sum + val * val;
+        col = col + WG_SIZE;
+    }
+    shared_sq_sum[tid] = local_sq_sum;
+    workgroupBarrier();
+
+    // Tree reduction for sum of squares
+    var stride: u32 = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_sq_sum[tid] = shared_sq_sum[tid] + shared_sq_sum[tid + stride];
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+
+    let rms = sqrt(shared_sq_sum[0] / f32(params.cols) + params.eps);
+    let inv_rms = 1.0 / rms;
+    workgroupBarrier();
+
+    // Phase 2: scale by gamma / rms
+    col = tid;
+    while col < params.cols {
+        output[row_offset + col] = gamma[col] * input[row_offset + col] * inv_rms;
+        col = col + WG_SIZE;
+    }
+}
+";

--- a/crates/bitnet-wgpu-shaders/src/lib.rs
+++ b/crates/bitnet-wgpu-shaders/src/lib.rs
@@ -1,0 +1,169 @@
+//! WGSL compute shader sources for `BitNet` inference kernels.
+//!
+//! This crate provides embedded WGSL shader sources for core neural network
+//! operations targeting WebGPU / wgpu. Shaders are exposed as `&'static str`
+//! constants for runtime compilation by the wgpu pipeline.
+//!
+//! # Shader categories
+//!
+//! - **matmul** — matrix multiplication (naive, tiled, matrix-vector)
+//! - **elementwise** — add, mul, scale, `ReLU`, GELU, `SiLU`
+//! - **softmax** — row-wise softmax and log-softmax with shared-memory reduction
+//! - **`layer_norm`** — `LayerNorm` (gamma+beta) and RMS normalization (LLaMA-style)
+//! - **rope** — Rotary Position Embeddings
+
+pub mod elementwise;
+pub mod layer_norm;
+pub mod matmul;
+pub mod rope;
+pub mod softmax;
+
+/// Returns all shader sources as `(name, source)` pairs for bulk validation.
+pub fn all_shader_sources() -> Vec<(&'static str, &'static str)> {
+    vec![
+        // matmul
+        ("matmul_naive", matmul::MATMUL_NAIVE_SRC),
+        ("matmul_tiled", matmul::MATMUL_TILED_SRC),
+        ("matmul_vec", matmul::MATMUL_VEC_SRC),
+        // elementwise
+        ("add", elementwise::ADD_SRC),
+        ("mul", elementwise::MUL_SRC),
+        ("scale", elementwise::SCALE_SRC),
+        ("relu", elementwise::RELU_SRC),
+        ("gelu", elementwise::GELU_SRC),
+        ("silu", elementwise::SILU_SRC),
+        // softmax
+        ("softmax", softmax::SOFTMAX_SRC),
+        ("log_softmax", softmax::LOG_SOFTMAX_SRC),
+        // layer_norm
+        ("layer_norm", layer_norm::LAYER_NORM_SRC),
+        ("rms_norm", layer_norm::RMS_NORM_SRC),
+        // rope
+        ("rope", rope::ROPE_SRC),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use naga::front::wgsl;
+
+    fn validate_wgsl(source: &str) -> Result<(), String> {
+        let module = wgsl::parse_str(source).map_err(|e| format!("{e}"))?;
+        let mut validator = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        );
+        validator.validate(&module).map_err(|e| format!("{e}"))?;
+        Ok(())
+    }
+
+    // ── matmul ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_matmul_naive_valid() {
+        validate_wgsl(super::matmul::MATMUL_NAIVE_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_matmul_tiled_valid() {
+        validate_wgsl(super::matmul::MATMUL_TILED_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_matmul_vec_valid() {
+        validate_wgsl(super::matmul::MATMUL_VEC_SRC).unwrap();
+    }
+
+    // ── elementwise ─────────────────────────────────────────────
+
+    #[test]
+    fn test_add_valid() {
+        validate_wgsl(super::elementwise::ADD_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_mul_valid() {
+        validate_wgsl(super::elementwise::MUL_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_scale_valid() {
+        validate_wgsl(super::elementwise::SCALE_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_relu_valid() {
+        validate_wgsl(super::elementwise::RELU_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_gelu_valid() {
+        validate_wgsl(super::elementwise::GELU_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_silu_valid() {
+        validate_wgsl(super::elementwise::SILU_SRC).unwrap();
+    }
+
+    // ── softmax ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_softmax_valid() {
+        validate_wgsl(super::softmax::SOFTMAX_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_log_softmax_valid() {
+        validate_wgsl(super::softmax::LOG_SOFTMAX_SRC).unwrap();
+    }
+
+    // ── layer_norm ──────────────────────────────────────────────
+
+    #[test]
+    fn test_layer_norm_valid() {
+        validate_wgsl(super::layer_norm::LAYER_NORM_SRC).unwrap();
+    }
+
+    #[test]
+    fn test_rms_norm_valid() {
+        validate_wgsl(super::layer_norm::RMS_NORM_SRC).unwrap();
+    }
+
+    // ── rope ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_rope_valid() {
+        validate_wgsl(super::rope::ROPE_SRC).unwrap();
+    }
+
+    // ── bulk ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_all_shader_sources_validate() {
+        let sources = super::all_shader_sources();
+        assert_eq!(sources.len(), 14, "expected 14 shader sources");
+        for (name, source) in &sources {
+            validate_wgsl(source).unwrap_or_else(|e| {
+                panic!("shader '{name}' failed validation: {e}");
+            });
+        }
+    }
+
+    #[test]
+    fn test_all_shader_sources_non_empty() {
+        for (name, source) in super::all_shader_sources() {
+            assert!(!source.trim().is_empty(), "shader '{name}' is empty");
+        }
+    }
+
+    #[test]
+    fn test_shader_names_unique() {
+        let sources = super::all_shader_sources();
+        let names: Vec<_> = sources.iter().map(|(n, _)| *n).collect();
+        let mut deduped = names.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(names.len(), deduped.len(), "duplicate shader names found");
+    }
+}

--- a/crates/bitnet-wgpu-shaders/src/matmul.rs
+++ b/crates/bitnet-wgpu-shaders/src/matmul.rs
@@ -1,0 +1,135 @@
+//! Matrix multiplication WGSL compute shaders.
+//!
+//! Provides naive, tiled (shared-memory), and matrix-vector variants.
+
+/// Naive matrix multiplication: C = A × B (M×K · K×N → M×N).
+///
+/// Workgroup size: [16, 16, 1]. Each thread computes one output element.
+pub const MATMUL_NAIVE_SRC: &str = r"
+struct MatmulParams {
+    M: u32,
+    N: u32,
+    K: u32,
+}
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+@group(0) @binding(3) var<uniform> params: MatmulParams;
+
+@compute @workgroup_size(16, 16, 1)
+fn matmul_naive(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let row = gid.y;
+    let col = gid.x;
+
+    if row >= params.M || col >= params.N {
+        return;
+    }
+
+    var sum: f32 = 0.0;
+    for (var i: u32 = 0u; i < params.K; i = i + 1u) {
+        sum = sum + a[row * params.K + i] * b[i * params.N + col];
+    }
+    result[row * params.N + col] = sum;
+}
+";
+
+/// Tiled matrix multiplication using workgroup shared memory.
+///
+/// `TILE_SIZE` = 16. Workgroup size: [16, 16, 1].
+/// Uses `workgroupBarrier()` to synchronise shared-memory loads.
+pub const MATMUL_TILED_SRC: &str = r"
+struct MatmulParams {
+    M: u32,
+    N: u32,
+    K: u32,
+}
+
+const TILE_SIZE: u32 = 16u;
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+@group(0) @binding(3) var<uniform> params: MatmulParams;
+
+var<workgroup> tile_a: array<f32, 256>;
+var<workgroup> tile_b: array<f32, 256>;
+
+@compute @workgroup_size(16, 16, 1)
+fn matmul_tiled(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id) wgid: vec3<u32>,
+) {
+    let row = wgid.y * TILE_SIZE + lid.y;
+    let col = wgid.x * TILE_SIZE + lid.x;
+    let local_idx = lid.y * TILE_SIZE + lid.x;
+
+    var sum: f32 = 0.0;
+    let num_tiles = (params.K + TILE_SIZE - 1u) / TILE_SIZE;
+
+    for (var t: u32 = 0u; t < num_tiles; t = t + 1u) {
+        // Load tile from A
+        let a_col = t * TILE_SIZE + lid.x;
+        if row < params.M && a_col < params.K {
+            tile_a[local_idx] = a[row * params.K + a_col];
+        } else {
+            tile_a[local_idx] = 0.0;
+        }
+
+        // Load tile from B
+        let b_row = t * TILE_SIZE + lid.y;
+        if b_row < params.K && col < params.N {
+            tile_b[local_idx] = b[b_row * params.N + col];
+        } else {
+            tile_b[local_idx] = 0.0;
+        }
+
+        workgroupBarrier();
+
+        for (var i: u32 = 0u; i < TILE_SIZE; i = i + 1u) {
+            sum = sum + tile_a[lid.y * TILE_SIZE + i] * tile_b[i * TILE_SIZE + lid.x];
+        }
+
+        workgroupBarrier();
+    }
+
+    if row < params.M && col < params.N {
+        result[row * params.N + col] = sum;
+    }
+}
+";
+
+/// Matrix-vector multiplication: y = A × x (M×K · K → M).
+///
+/// Workgroup size: [256, 1, 1]. Each thread computes one output row.
+pub const MATMUL_VEC_SRC: &str = r"
+struct MatmulParams {
+    M: u32,
+    N: u32,
+    K: u32,
+}
+
+@group(0) @binding(0) var<storage, read> a: array<f32>;
+@group(0) @binding(1) var<storage, read> b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> result: array<f32>;
+@group(0) @binding(3) var<uniform> params: MatmulParams;
+
+@compute @workgroup_size(256, 1, 1)
+fn matmul_vec(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+) {
+    let row = gid.x;
+    if row >= params.M {
+        return;
+    }
+
+    var sum: f32 = 0.0;
+    for (var i: u32 = 0u; i < params.K; i = i + 1u) {
+        sum = sum + a[row * params.K + i] * b[i];
+    }
+    result[row] = sum;
+}
+";

--- a/crates/bitnet-wgpu-shaders/src/rope.rs
+++ b/crates/bitnet-wgpu-shaders/src/rope.rs
@@ -1,0 +1,58 @@
+//! Rotary Position Embedding (`RoPE`) WGSL compute shader.
+//!
+//! Applies rotary embeddings in-place to query/key tensors for
+//! transformer attention. Each thread handles one (position, `head_dim/2`) pair.
+
+/// Rotary Position Embedding.
+///
+/// Applies `RoPE` to an input tensor of shape [`seq_len`, `num_heads`, `head_dim`].
+/// The rotation is applied to consecutive pairs: (x[2i], x[2i+1]).
+///
+/// freq(i) = 1 / (theta ^ (2i / `head_dim`))
+/// x'[2i]   = x[2i]   * cos(pos * freq) - x[2i+1] * sin(pos * freq)
+/// x'[2i+1] = x[2i]   * sin(pos * freq) + x[2i+1] * cos(pos * freq)
+///
+/// Workgroup size: [256, 1, 1]. Dispatch with enough threads to cover
+/// `seq_len` * `num_heads` * (`head_dim` / 2).
+pub const ROPE_SRC: &str = r"
+struct RopeParams {
+    seq_len: u32,
+    num_heads: u32,
+    head_dim: u32,
+    theta: f32,
+}
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read> positions: array<u32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+@group(0) @binding(3) var<uniform> params: RopeParams;
+
+@compute @workgroup_size(256, 1, 1)
+fn rope(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let half_dim = params.head_dim / 2u;
+    let total = params.seq_len * params.num_heads * half_dim;
+    let idx = gid.x;
+    if idx >= total { return; }
+
+    // Decompose linear index into (seq_pos, head, pair_idx)
+    let pair_idx = idx % half_dim;
+    let remaining = idx / half_dim;
+    let head = remaining % params.num_heads;
+    let seq_pos = remaining / params.num_heads;
+
+    let pos = f32(positions[seq_pos]);
+    let freq_exp = 2.0 * f32(pair_idx) / f32(params.head_dim);
+    let freq = 1.0 / pow(params.theta, freq_exp);
+    let angle = pos * freq;
+    let cos_a = cos(angle);
+    let sin_a = sin(angle);
+
+    // Offset into the flattened [seq_len, num_heads, head_dim] tensor
+    let base = (seq_pos * params.num_heads + head) * params.head_dim + pair_idx * 2u;
+    let x0 = input[base];
+    let x1 = input[base + 1u];
+
+    output[base] = x0 * cos_a - x1 * sin_a;
+    output[base + 1u] = x0 * sin_a + x1 * cos_a;
+}
+";

--- a/crates/bitnet-wgpu-shaders/src/softmax.rs
+++ b/crates/bitnet-wgpu-shaders/src/softmax.rs
@@ -1,0 +1,174 @@
+//! Softmax WGSL compute shaders.
+//!
+//! Row-wise softmax and log-softmax with shared-memory reductions for
+//! numerical stability (online max subtraction).
+
+/// Row-wise softmax with online max subtraction.
+///
+/// Each workgroup processes one row. Workgroup size: [256, 1, 1].
+/// Uses shared memory for parallel max-reduction and sum-reduction.
+///
+/// `params.rows` = number of rows, `params.cols` = row width.
+/// Input layout is row-major: `input[row * cols + col]`.
+pub const SOFTMAX_SRC: &str = r"
+struct SoftmaxParams {
+    rows: u32,
+    cols: u32,
+}
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+@group(0) @binding(2) var<uniform> params: SoftmaxParams;
+
+const WG_SIZE: u32 = 256u;
+
+var<workgroup> shared_max: array<f32, 256>;
+var<workgroup> shared_sum: array<f32, 256>;
+
+@compute @workgroup_size(256, 1, 1)
+fn softmax(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id) wgid: vec3<u32>,
+) {
+    let row = wgid.x;
+    if row >= params.rows { return; }
+
+    let tid = lid.x;
+    let row_offset = row * params.cols;
+
+    // Phase 1: find row maximum via parallel reduction
+    var local_max: f32 = -3.402823466e+38;  // -FLT_MAX
+    var col = tid;
+    while col < params.cols {
+        local_max = max(local_max, input[row_offset + col]);
+        col = col + WG_SIZE;
+    }
+    shared_max[tid] = local_max;
+    workgroupBarrier();
+
+    // Tree reduction for max
+    var stride: u32 = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_max[tid] = max(shared_max[tid], shared_max[tid + stride]);
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+    let row_max = shared_max[0];
+    workgroupBarrier();
+
+    // Phase 2: compute exp(x - max) and sum
+    var local_sum: f32 = 0.0;
+    col = tid;
+    while col < params.cols {
+        let val = exp(input[row_offset + col] - row_max);
+        output[row_offset + col] = val;
+        local_sum = local_sum + val;
+        col = col + WG_SIZE;
+    }
+    shared_sum[tid] = local_sum;
+    workgroupBarrier();
+
+    // Tree reduction for sum
+    stride = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_sum[tid] = shared_sum[tid] + shared_sum[tid + stride];
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+    let row_sum = shared_sum[0];
+    workgroupBarrier();
+
+    // Phase 3: normalize
+    let inv_sum = 1.0 / row_sum;
+    col = tid;
+    while col < params.cols {
+        output[row_offset + col] = output[row_offset + col] * inv_sum;
+        col = col + WG_SIZE;
+    }
+}
+";
+
+/// Numerically stable log-softmax: log(softmax(x)).
+///
+/// Computed as `x[i] - max - log(sum(exp(x - max)))` to avoid
+/// separate softmax + log passes. Same layout/dispatch as `softmax`.
+pub const LOG_SOFTMAX_SRC: &str = r"
+struct SoftmaxParams {
+    rows: u32,
+    cols: u32,
+}
+
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+@group(0) @binding(2) var<uniform> params: SoftmaxParams;
+
+const WG_SIZE: u32 = 256u;
+
+var<workgroup> shared_max: array<f32, 256>;
+var<workgroup> shared_sum: array<f32, 256>;
+
+@compute @workgroup_size(256, 1, 1)
+fn log_softmax(
+    @builtin(local_invocation_id) lid: vec3<u32>,
+    @builtin(workgroup_id) wgid: vec3<u32>,
+) {
+    let row = wgid.x;
+    if row >= params.rows { return; }
+
+    let tid = lid.x;
+    let row_offset = row * params.cols;
+
+    // Phase 1: find row maximum
+    var local_max: f32 = -3.402823466e+38;
+    var col = tid;
+    while col < params.cols {
+        local_max = max(local_max, input[row_offset + col]);
+        col = col + WG_SIZE;
+    }
+    shared_max[tid] = local_max;
+    workgroupBarrier();
+
+    var stride: u32 = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_max[tid] = max(shared_max[tid], shared_max[tid + stride]);
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+    let row_max = shared_max[0];
+    workgroupBarrier();
+
+    // Phase 2: compute sum of exp(x - max)
+    var local_sum: f32 = 0.0;
+    col = tid;
+    while col < params.cols {
+        local_sum = local_sum + exp(input[row_offset + col] - row_max);
+        col = col + WG_SIZE;
+    }
+    shared_sum[tid] = local_sum;
+    workgroupBarrier();
+
+    stride = WG_SIZE / 2u;
+    while stride > 0u {
+        if tid < stride {
+            shared_sum[tid] = shared_sum[tid] + shared_sum[tid + stride];
+        }
+        workgroupBarrier();
+        stride = stride / 2u;
+    }
+    let log_sum_exp = log(shared_sum[0]);
+    workgroupBarrier();
+
+    // Phase 3: log_softmax = x - max - log(sum_exp)
+    col = tid;
+    while col < params.cols {
+        output[row_offset + col] = input[row_offset + col] - row_max - log_sum_exp;
+        col = col + WG_SIZE;
+    }
+}
+";


### PR DESCRIPTION
## Summary

Add `bitnet-wgpu-shaders` crate with embedded WGSL compute shader sources for WebGPU/wgpu-based BitNet inference. All shaders are exposed as `const &str` for runtime pipeline compilation.

## Shader Categories

| Category | Shaders | Workgroup |
|----------|---------|-----------|
| **matmul** | naive, tiled (shared memory), matrix-vector | [16,16,1] / [256,1,1] |
| **elementwise** | add, mul, scale, ReLU, GELU (tanh), SiLU | [256,1,1] |
| **softmax** | row-wise softmax, log-softmax | [256,1,1] per row |
| **layer_norm** | LayerNorm (gamma+beta), RMS norm (LLaMA) | [256,1,1] per row |
| **rope** | Rotary Position Embeddings | [256,1,1] |

## Validation

All 14 shader sources pass `naga` WGSL validation (17 tests total including bulk + uniqueness checks). The crate is registered as a workspace member but **not** in `default-members`.

## Test Results

```
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```