### PR TITLE
feat(wgpu): add bitnet-wgpu microcrate foundation (device, buffer, pipeline, dispatch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-wgpu"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "pollster",
+ "proptest",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wgpu",
+]
+
+[[package]]
 name = "bitnet-wgpu-bench"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
     "crates/bitnet-rocm",          # HIP compute kernels for AMD ROCm backend",
   "crates/bitnet-vulkan",        # Vulkan GLSL compute shaders for GPU inference
+  "crates/bitnet-wgpu",          # WebGPU compute backend for cross-platform GPU inference
   "crates/bitnet-wgpu-bench",    # Benchmarking and profiling harness for wgpu compute kernels
   "crossval",
   "tests",

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitnet-wgpu"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92.0"
+description = "wgpu-based GPU compute backend for BitNet inference (Vulkan/Metal/DX12)"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+wgpu = { version = "24", features = ["vulkan-portability"] }
+bytemuck = { version = "1", features = ["derive"] }
+pollster = "0.4"
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "macros"] }
+proptest = "1"
+
+[features]
+default = []

--- a/crates/bitnet-wgpu/src/buffer.rs
+++ b/crates/bitnet-wgpu/src/buffer.rs
@@ -1,0 +1,350 @@
+//! GPU buffer management and pool-based allocation.
+
+use wgpu::BufferUsages;
+
+use crate::device::WgpuDevice;
+use crate::error::WgpuError;
+
+/// Metadata-rich wrapper around a `wgpu::Buffer`.
+pub struct GpuBuffer {
+    inner: wgpu::Buffer,
+    size: u64,
+    usage: BufferUsages,
+    label: String,
+}
+
+impl GpuBuffer {
+    /// Create a storage buffer (read/write from shaders, copy-src for readback).
+    pub fn new_storage(device: &WgpuDevice, size: u64, label: &str) -> Self {
+        let usage = BufferUsages::STORAGE | BufferUsages::COPY_DST | BufferUsages::COPY_SRC;
+        let inner = device.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage,
+            mapped_at_creation: false,
+        });
+        Self { inner, size, usage, label: label.to_string() }
+    }
+
+    /// Create a uniform buffer (read-only from shaders).
+    pub fn new_uniform(device: &WgpuDevice, size: u64, label: &str) -> Self {
+        let usage = BufferUsages::UNIFORM | BufferUsages::COPY_DST;
+        let inner = device.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage,
+            mapped_at_creation: false,
+        });
+        Self { inner, size, usage, label: label.to_string() }
+    }
+
+    /// Create a buffer with explicit usage flags.
+    pub fn new_with_usage(
+        device: &WgpuDevice,
+        size: u64,
+        usage: BufferUsages,
+        label: &str,
+    ) -> Self {
+        let inner = device.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage,
+            mapped_at_creation: false,
+        });
+        Self { inner, size, usage, label: label.to_string() }
+    }
+
+    /// Write data from the host into this buffer.
+    pub fn write<T: bytemuck::Pod>(&self, queue: &wgpu::Queue, data: &[T]) {
+        queue.write_buffer(&self.inner, 0, bytemuck::cast_slice(data));
+    }
+
+    /// Asynchronously read buffer contents back to the host.
+    pub async fn read_async<T: bytemuck::Pod>(
+        &self,
+        device: &WgpuDevice,
+    ) -> Result<Vec<T>, WgpuError> {
+        let staging = device.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("readback-staging"),
+            size: self.size,
+            usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder = device.device().create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("readback-encoder"),
+        });
+        encoder.copy_buffer_to_buffer(&self.inner, 0, &staging, 0, self.size);
+        device.queue().submit(std::iter::once(encoder.finish()));
+
+        let slice = staging.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        device.device().poll(wgpu::Maintain::Wait);
+
+        rx.recv().map_err(|e| WgpuError::mapping(e))?.map_err(|e| WgpuError::mapping(e))?;
+
+        let view = slice.get_mapped_range();
+        let result: Vec<T> = bytemuck::cast_slice(&view).to_vec();
+        drop(view);
+        staging.unmap();
+        Ok(result)
+    }
+
+    /// Blocking read-back wrapper.
+    pub fn read_blocking<T: bytemuck::Pod>(
+        &self,
+        device: &WgpuDevice,
+    ) -> Result<Vec<T>, WgpuError> {
+        pollster::block_on(self.read_async(device))
+    }
+
+    /// Buffer size in bytes.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    /// Buffer usage flags.
+    pub fn usage(&self) -> BufferUsages {
+        self.usage
+    }
+
+    /// Human-readable label.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Access the underlying `wgpu::Buffer`.
+    pub fn inner(&self) -> &wgpu::Buffer {
+        &self.inner
+    }
+}
+
+impl std::fmt::Debug for GpuBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GpuBuffer")
+            .field("label", &self.label)
+            .field("size", &self.size)
+            .field("usage", &self.usage)
+            .finish()
+    }
+}
+
+/// Statistics for the buffer pool.
+#[derive(Debug, Clone, Default)]
+pub struct PoolStats {
+    /// Total buffers allocated (including reused).
+    pub allocations: u64,
+    /// Buffers served from the free list.
+    pub reuses: u64,
+    /// Buffers currently in the free list.
+    pub free_count: usize,
+    /// Buffers currently checked out.
+    pub active_count: usize,
+}
+
+impl PoolStats {
+    /// Fraction of allocations served from the free list (0.0–1.0).
+    pub fn reuse_rate(&self) -> f64 {
+        if self.allocations == 0 { 0.0 } else { self.reuses as f64 / self.allocations as f64 }
+    }
+}
+
+/// Pool of reusable GPU buffers keyed by (size, usage).
+#[derive(Default)]
+pub struct BufferPool {
+    /// Free buffers available for reuse, keyed by (size, usage-bits).
+    free: Vec<(u64, BufferUsages, GpuBuffer)>,
+    stats: PoolStats,
+}
+
+impl BufferPool {
+    /// Create an empty pool.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate (or reuse) a buffer with the given size and usage.
+    pub fn allocate(&mut self, device: &WgpuDevice, size: u64, usage: BufferUsages) -> GpuBuffer {
+        self.stats.allocations += 1;
+
+        // Try to reuse a matching buffer.
+        if let Some(idx) = self.free.iter().position(|(s, u, _)| *s >= size && *u == usage) {
+            self.stats.reuses += 1;
+            self.stats.free_count -= 1;
+            self.stats.active_count += 1;
+            let (_, _, buf) = self.free.swap_remove(idx);
+            return buf;
+        }
+
+        self.stats.active_count += 1;
+        GpuBuffer::new_with_usage(device, size, usage, "pool-buffer")
+    }
+
+    /// Return a buffer to the pool for future reuse.
+    pub fn release(&mut self, buffer: GpuBuffer) {
+        let size = buffer.size();
+        let usage = buffer.usage();
+        self.stats.active_count = self.stats.active_count.saturating_sub(1);
+        self.stats.free_count += 1;
+        self.free.push((size, usage, buffer));
+    }
+
+    /// Current pool statistics.
+    pub fn stats(&self) -> &PoolStats {
+        &self.stats
+    }
+}
+
+impl std::fmt::Debug for BufferPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferPool")
+            .field("free", &self.free.len())
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── GPU-gated tests ──────────────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn buffer_new_storage() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let buf = GpuBuffer::new_storage(&dev, 1024, "test-storage");
+        assert_eq!(buf.size(), 1024);
+        assert!(buf.usage().contains(BufferUsages::STORAGE));
+        assert_eq!(buf.label(), "test-storage");
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn buffer_new_uniform() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let buf = GpuBuffer::new_uniform(&dev, 256, "test-uniform");
+        assert_eq!(buf.size(), 256);
+        assert!(buf.usage().contains(BufferUsages::UNIFORM));
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn buffer_write_read_roundtrip_f32() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+        let buf = GpuBuffer::new_storage(&dev, (data.len() * 4) as u64, "roundtrip");
+        buf.write(dev.queue(), &data);
+        let read_back: Vec<f32> = buf.read_blocking(&dev).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn buffer_write_read_roundtrip_u32() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let data: Vec<u32> = vec![0xDEAD, 0xBEEF, 0xCAFE, 0xBABE];
+        let buf = GpuBuffer::new_storage(&dev, (data.len() * 4) as u64, "roundtrip-u32");
+        buf.write(dev.queue(), &data);
+        let read_back: Vec<u32> = buf.read_blocking(&dev).unwrap();
+        assert_eq!(read_back, data);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn buffer_debug_output() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let buf = GpuBuffer::new_storage(&dev, 64, "dbg-test");
+        let dbg = format!("{buf:?}");
+        assert!(dbg.contains("GpuBuffer"));
+        assert!(dbg.contains("dbg-test"));
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pool_allocate_returns_buffer() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let mut pool = BufferPool::new();
+        let buf = pool.allocate(&dev, 512, BufferUsages::STORAGE);
+        assert!(buf.size() >= 512);
+        assert_eq!(pool.stats().allocations, 1);
+        assert_eq!(pool.stats().active_count, 1);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pool_reuse_after_release() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let mut pool = BufferPool::new();
+        let buf = pool.allocate(&dev, 512, BufferUsages::STORAGE);
+        pool.release(buf);
+        assert_eq!(pool.stats().free_count, 1);
+
+        let _buf2 = pool.allocate(&dev, 512, BufferUsages::STORAGE);
+        assert_eq!(pool.stats().reuses, 1);
+        assert_eq!(pool.stats().free_count, 0);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pool_no_reuse_for_different_usage() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let mut pool = BufferPool::new();
+        let buf = pool.allocate(&dev, 512, BufferUsages::STORAGE);
+        pool.release(buf);
+
+        // Request UNIFORM — should not reuse the STORAGE buffer.
+        let _buf2 = pool.allocate(&dev, 512, BufferUsages::UNIFORM);
+        assert_eq!(pool.stats().reuses, 0);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pool_reuse_larger_buffer() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let mut pool = BufferPool::new();
+        let buf = pool.allocate(&dev, 1024, BufferUsages::STORAGE);
+        pool.release(buf);
+
+        // Requesting 512 — should reuse the 1024 buffer.
+        let reused = pool.allocate(&dev, 512, BufferUsages::STORAGE);
+        assert!(reused.size() >= 512);
+        assert_eq!(pool.stats().reuses, 1);
+    }
+
+    // ── Non-GPU tests ────────────────────────────────────────────────
+
+    #[test]
+    fn pool_stats_initial() {
+        let pool = BufferPool::new();
+        let stats = pool.stats();
+        assert_eq!(stats.allocations, 0);
+        assert_eq!(stats.reuses, 0);
+        assert_eq!(stats.free_count, 0);
+        assert_eq!(stats.active_count, 0);
+    }
+
+    #[test]
+    fn pool_stats_reuse_rate_empty() {
+        let stats = PoolStats::default();
+        assert_eq!(stats.reuse_rate(), 0.0);
+    }
+
+    #[test]
+    fn pool_stats_reuse_rate_computed() {
+        let stats = PoolStats { allocations: 10, reuses: 3, free_count: 0, active_count: 0 };
+        let rate = stats.reuse_rate();
+        assert!((rate - 0.3).abs() < 1e-9);
+    }
+
+    #[test]
+    fn pool_debug_output() {
+        let pool = BufferPool::new();
+        let dbg = format!("{pool:?}");
+        assert!(dbg.contains("BufferPool"));
+    }
+}

--- a/crates/bitnet-wgpu/src/device.rs
+++ b/crates/bitnet-wgpu/src/device.rs
@@ -1,0 +1,247 @@
+//! GPU device initialization and adapter discovery.
+
+use crate::error::WgpuError;
+
+/// Configuration for wgpu device creation.
+#[derive(Debug, Clone)]
+pub struct WgpuDeviceConfig {
+    /// Power preference hint for adapter selection.
+    pub power_preference: wgpu::PowerPreference,
+    /// Backend API filter (e.g. Vulkan-only).
+    pub backend_bits: wgpu::Backends,
+    /// Features required on the device.
+    pub required_features: wgpu::Features,
+    /// Limits required on the device.
+    pub required_limits: wgpu::Limits,
+}
+
+impl Default for WgpuDeviceConfig {
+    fn default() -> Self {
+        Self {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            backend_bits: wgpu::Backends::VULKAN,
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::default(),
+        }
+    }
+}
+
+/// Summary information about the selected adapter.
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+    /// Human-readable adapter name (e.g. "NVIDIA RTX 5070 Ti").
+    pub name: String,
+    /// Backend API in use (Vulkan, Metal, DX12, …).
+    pub backend: wgpu::Backend,
+    /// Driver description reported by the adapter.
+    pub driver: String,
+    /// Driver-info string (version, etc.).
+    pub driver_info: String,
+    /// Device type (discrete GPU, integrated, CPU, …).
+    pub device_type: wgpu::DeviceType,
+    /// Vendor ID.
+    pub vendor: u32,
+    /// Negotiated device limits.
+    pub limits: wgpu::Limits,
+}
+
+/// A wgpu device handle with adapter metadata.
+pub struct WgpuDevice {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    adapter: wgpu::Adapter,
+}
+
+impl WgpuDevice {
+    /// Create a new device asynchronously.
+    pub async fn new(config: &WgpuDeviceConfig) -> Result<Self, WgpuError> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: config.backend_bits,
+            ..Default::default()
+        });
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: config.power_preference,
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            })
+            .await
+            .ok_or_else(|| WgpuError::device("no suitable GPU adapter found"))?;
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("bitnet-wgpu"),
+                    required_features: config.required_features,
+                    required_limits: config.required_limits.clone(),
+                    ..Default::default()
+                },
+                None,
+            )
+            .await
+            .map_err(|e| WgpuError::device(e))?;
+
+        tracing::info!(
+            adapter = %adapter.get_info().name,
+            backend = ?adapter.get_info().backend,
+            "wgpu device created"
+        );
+
+        Ok(Self { device, queue, adapter })
+    }
+
+    /// Blocking wrapper around [`Self::new`] using `pollster`.
+    pub fn new_blocking(config: &WgpuDeviceConfig) -> Result<Self, WgpuError> {
+        pollster::block_on(Self::new(config))
+    }
+
+    /// Query adapter and device information.
+    pub fn info(&self) -> DeviceInfo {
+        let info = self.adapter.get_info();
+        DeviceInfo {
+            name: info.name.clone(),
+            backend: info.backend,
+            driver: info.driver.clone(),
+            driver_info: info.driver_info.clone(),
+            device_type: info.device_type,
+            vendor: info.vendor,
+            limits: self.device.limits(),
+        }
+    }
+
+    /// PCI vendor ID for NVIDIA.
+    const NVIDIA_VENDOR_ID: u32 = 0x10DE;
+
+    /// Returns `true` if the adapter is an NVIDIA GPU.
+    pub fn is_nvidia(&self) -> bool {
+        self.adapter.get_info().vendor == Self::NVIDIA_VENDOR_ID
+    }
+
+    /// Returns `true` if the device supports subgroup (warp/wave) operations.
+    pub fn supports_subgroup_ops(&self) -> bool {
+        self.device.features().contains(wgpu::Features::SUBGROUP)
+    }
+
+    /// Access the underlying `wgpu::Device`.
+    pub fn device(&self) -> &wgpu::Device {
+        &self.device
+    }
+
+    /// Access the underlying `wgpu::Queue`.
+    pub fn queue(&self) -> &wgpu::Queue {
+        &self.queue
+    }
+
+    /// Access the underlying `wgpu::Adapter`.
+    pub fn adapter(&self) -> &wgpu::Adapter {
+        &self.adapter
+    }
+}
+
+impl std::fmt::Debug for WgpuDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let info = self.adapter.get_info();
+        f.debug_struct("WgpuDevice")
+            .field("name", &info.name)
+            .field("backend", &info.backend)
+            .field("vendor", &info.vendor)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── GPU-gated tests ──────────────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_creation_default_config() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default());
+        assert!(dev.is_ok(), "device creation failed: {:?}", dev.err());
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_info_populated() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        let info = dev.info();
+        assert!(!info.name.is_empty(), "adapter name should not be empty");
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_backend_is_vulkan_by_default() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        let info = dev.info();
+        assert_eq!(info.backend, wgpu::Backend::Vulkan);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_is_nvidia_on_nvidia_hw() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        // This may or may not be true depending on HW; just verify no panic.
+        let _ = dev.is_nvidia();
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_supports_subgroup_query() {
+        let config =
+            WgpuDeviceConfig { required_features: wgpu::Features::SUBGROUP, ..Default::default() };
+        // This may fail if the adapter doesn't support subgroups — that's OK.
+        if let Ok(dev) = WgpuDevice::new_blocking(&config) {
+            assert!(dev.supports_subgroup_ops());
+        }
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_debug_output() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        let dbg = format!("{dev:?}");
+        assert!(dbg.contains("WgpuDevice"), "debug output malformed");
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_accessors() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        // Just verify accessors don't panic.
+        let _ = dev.device();
+        let _ = dev.queue();
+        let _ = dev.adapter();
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn device_limits_populated() {
+        let dev = WgpuDevice::new_blocking(&WgpuDeviceConfig::default()).unwrap();
+        let info = dev.info();
+        assert!(info.limits.max_compute_workgroup_size_x > 0, "max workgroup size x should be > 0");
+    }
+
+    // ── Non-GPU tests ────────────────────────────────────────────────
+
+    #[test]
+    fn default_config_is_vulkan_high_perf() {
+        let cfg = WgpuDeviceConfig::default();
+        assert_eq!(cfg.power_preference, wgpu::PowerPreference::HighPerformance);
+        assert!(cfg.backend_bits.contains(wgpu::Backends::VULKAN));
+    }
+
+    #[test]
+    fn device_info_is_clone_and_debug() {
+        fn assert_clone_debug<T: Clone + std::fmt::Debug>() {}
+        assert_clone_debug::<DeviceInfo>();
+    }
+
+    #[test]
+    fn config_is_clone_and_debug() {
+        fn assert_clone_debug<T: Clone + std::fmt::Debug>() {}
+        assert_clone_debug::<WgpuDeviceConfig>();
+    }
+}

--- a/crates/bitnet-wgpu/src/dispatch.rs
+++ b/crates/bitnet-wgpu/src/dispatch.rs
@@ -1,0 +1,233 @@
+//! Workgroup dispatch helpers and NVIDIA-tuned sizing.
+
+use std::fmt;
+
+/// Configuration for a single compute dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DispatchConfig {
+    /// Workgroup size declared in the shader (x, y, z).
+    pub workgroup_size: [u32; 3],
+    /// Number of workgroups to dispatch (x, y, z).
+    pub dispatch_size: [u32; 3],
+}
+
+impl DispatchConfig {
+    /// Total number of threads launched across all workgroups.
+    pub fn total_threads(&self) -> u64 {
+        let wg: u64 = self.workgroup_size.iter().map(|&v| v as u64).product();
+        let ds: u64 = self.dispatch_size.iter().map(|&v| v as u64).product();
+        wg * ds
+    }
+}
+
+impl fmt::Display for DispatchConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "workgroup[{}×{}×{}] dispatch[{}×{}×{}]",
+            self.workgroup_size[0],
+            self.workgroup_size[1],
+            self.workgroup_size[2],
+            self.dispatch_size[0],
+            self.dispatch_size[1],
+            self.dispatch_size[2],
+        )
+    }
+}
+
+/// Compute the number of workgroups needed to cover `total_elements`,
+/// rounding up so no element is missed.
+pub fn compute_dispatch_size(total_elements: u32, workgroup_size: u32) -> u32 {
+    assert!(workgroup_size > 0, "workgroup_size must be > 0");
+    total_elements.div_ceil(workgroup_size)
+}
+
+/// NVIDIA warp size (threads per warp on all NVIDIA architectures).
+const NVIDIA_WARP_SIZE: u32 = 32;
+
+/// Return an NVIDIA-tuned workgroup size for 1-D dispatches.
+///
+/// Heuristics:
+/// - Always warp-aligned (multiple of 32).
+/// - Prefer 256 for Blackwell / Ada / Ampere (good occupancy).
+/// - Fall back to 128 for very small workloads, 64 for tiny ones.
+pub fn optimal_workgroup_size_nvidia(elements: u32) -> u32 {
+    if elements == 0 {
+        return NVIDIA_WARP_SIZE;
+    }
+    if elements <= 64 {
+        // Tiny: one or two warps.
+        NVIDIA_WARP_SIZE * 2 // 64
+    } else if elements <= 256 {
+        // Small: four warps.
+        128
+    } else {
+        // Default: eight warps — best occupancy on Blackwell / RTX 5070 Ti.
+        256
+    }
+}
+
+/// Records dispatches for profiling / diagnostics.
+#[derive(Debug, Default)]
+pub struct DispatchRecorder {
+    entries: Vec<DispatchEntry>,
+}
+
+/// A single recorded dispatch.
+#[derive(Debug, Clone)]
+pub struct DispatchEntry {
+    /// Human-readable label (e.g. kernel name).
+    pub label: String,
+    /// The dispatch configuration used.
+    pub config: DispatchConfig,
+}
+
+impl DispatchRecorder {
+    /// Create an empty recorder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a dispatch.
+    pub fn record(&mut self, label: impl Into<String>, config: DispatchConfig) {
+        self.entries.push(DispatchEntry { label: label.into(), config });
+    }
+
+    /// Number of recorded dispatches.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the recorder is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate over recorded entries.
+    pub fn entries(&self) -> &[DispatchEntry] {
+        &self.entries
+    }
+
+    /// Total threads across all recorded dispatches.
+    pub fn total_threads(&self) -> u64 {
+        self.entries.iter().map(|e| e.config.total_threads()).sum()
+    }
+
+    /// Clear all entries.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dispatch_size_exact_multiple() {
+        assert_eq!(compute_dispatch_size(256, 256), 1);
+        assert_eq!(compute_dispatch_size(512, 256), 2);
+        assert_eq!(compute_dispatch_size(1024, 256), 4);
+    }
+
+    #[test]
+    fn dispatch_size_rounds_up() {
+        assert_eq!(compute_dispatch_size(1, 256), 1);
+        assert_eq!(compute_dispatch_size(257, 256), 2);
+        assert_eq!(compute_dispatch_size(513, 256), 3);
+    }
+
+    #[test]
+    fn dispatch_size_single_element() {
+        assert_eq!(compute_dispatch_size(1, 1), 1);
+        assert_eq!(compute_dispatch_size(1, 64), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "workgroup_size must be > 0")]
+    fn dispatch_size_zero_workgroup_panics() {
+        compute_dispatch_size(100, 0);
+    }
+
+    #[test]
+    fn nvidia_workgroup_zero_elements() {
+        let ws = optimal_workgroup_size_nvidia(0);
+        assert_eq!(ws, NVIDIA_WARP_SIZE);
+    }
+
+    #[test]
+    fn nvidia_workgroup_tiny() {
+        assert_eq!(optimal_workgroup_size_nvidia(1), 64);
+        assert_eq!(optimal_workgroup_size_nvidia(32), 64);
+        assert_eq!(optimal_workgroup_size_nvidia(64), 64);
+    }
+
+    #[test]
+    fn nvidia_workgroup_small() {
+        assert_eq!(optimal_workgroup_size_nvidia(65), 128);
+        assert_eq!(optimal_workgroup_size_nvidia(128), 128);
+        assert_eq!(optimal_workgroup_size_nvidia(256), 128);
+    }
+
+    #[test]
+    fn nvidia_workgroup_large() {
+        assert_eq!(optimal_workgroup_size_nvidia(257), 256);
+        assert_eq!(optimal_workgroup_size_nvidia(1024), 256);
+        assert_eq!(optimal_workgroup_size_nvidia(1_000_000), 256);
+    }
+
+    #[test]
+    fn nvidia_workgroup_always_warp_aligned() {
+        for n in [0, 1, 32, 33, 64, 65, 128, 256, 257, 512, 100_000] {
+            let ws = optimal_workgroup_size_nvidia(n);
+            assert_eq!(ws % NVIDIA_WARP_SIZE, 0, "ws={ws} not warp-aligned for n={n}");
+        }
+    }
+
+    #[test]
+    fn dispatch_config_total_threads() {
+        let cfg = DispatchConfig { workgroup_size: [256, 1, 1], dispatch_size: [4, 1, 1] };
+        assert_eq!(cfg.total_threads(), 1024);
+    }
+
+    #[test]
+    fn dispatch_config_total_threads_3d() {
+        let cfg = DispatchConfig { workgroup_size: [8, 8, 4], dispatch_size: [2, 2, 2] };
+        // 8*8*4 = 256 threads per WG, 2*2*2 = 8 WGs → 2048
+        assert_eq!(cfg.total_threads(), 2048);
+    }
+
+    #[test]
+    fn dispatch_config_display() {
+        let cfg = DispatchConfig { workgroup_size: [256, 1, 1], dispatch_size: [4, 2, 1] };
+        let s = cfg.to_string();
+        assert!(s.contains("256"), "display should contain workgroup x");
+        assert!(s.contains("dispatch"), "display should contain 'dispatch'");
+    }
+
+    #[test]
+    fn recorder_basic_usage() {
+        let mut rec = DispatchRecorder::new();
+        assert!(rec.is_empty());
+        assert_eq!(rec.len(), 0);
+
+        let cfg = DispatchConfig { workgroup_size: [256, 1, 1], dispatch_size: [4, 1, 1] };
+        rec.record("matmul", cfg);
+        assert_eq!(rec.len(), 1);
+        assert!(!rec.is_empty());
+        assert_eq!(rec.entries()[0].label, "matmul");
+        assert_eq!(rec.total_threads(), 1024);
+    }
+
+    #[test]
+    fn recorder_clear() {
+        let mut rec = DispatchRecorder::new();
+        let cfg = DispatchConfig { workgroup_size: [64, 1, 1], dispatch_size: [1, 1, 1] };
+        rec.record("a", cfg);
+        rec.record("b", cfg);
+        assert_eq!(rec.len(), 2);
+        rec.clear();
+        assert!(rec.is_empty());
+        assert_eq!(rec.total_threads(), 0);
+    }
+}

--- a/crates/bitnet-wgpu/src/error.rs
+++ b/crates/bitnet-wgpu/src/error.rs
@@ -1,0 +1,132 @@
+//! Error types for the bitnet-wgpu backend.
+
+use std::fmt;
+
+/// Errors produced by the wgpu compute backend.
+#[derive(Debug, thiserror::Error)]
+pub enum WgpuError {
+    /// Failed to create a GPU device or adapter.
+    #[error("device creation failed: {0}")]
+    DeviceCreation(String),
+
+    /// Buffer allocation failure.
+    #[error("buffer allocation failed: {0}")]
+    BufferAllocation(String),
+
+    /// Shader module compilation failure.
+    #[error("shader compilation failed: {0}")]
+    ShaderCompilation(String),
+
+    /// Compute pipeline creation failure.
+    #[error("pipeline creation failed: {0}")]
+    PipelineCreation(String),
+
+    /// Buffer mapping (readback) failure.
+    #[error("buffer mapping failed: {0}")]
+    BufferMapping(String),
+
+    /// Dispatch or submission error.
+    #[error("dispatch failed: {0}")]
+    Dispatch(String),
+
+    /// Internal / unexpected error.
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl WgpuError {
+    /// Convenience constructor for device creation errors.
+    pub fn device(msg: impl fmt::Display) -> Self {
+        Self::DeviceCreation(msg.to_string())
+    }
+
+    /// Convenience constructor for shader compilation errors.
+    pub fn shader(msg: impl fmt::Display) -> Self {
+        Self::ShaderCompilation(msg.to_string())
+    }
+
+    /// Convenience constructor for pipeline creation errors.
+    pub fn pipeline(msg: impl fmt::Display) -> Self {
+        Self::PipelineCreation(msg.to_string())
+    }
+
+    /// Convenience constructor for buffer mapping errors.
+    pub fn mapping(msg: impl fmt::Display) -> Self {
+        Self::BufferMapping(msg.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_device_creation() {
+        let err = WgpuError::DeviceCreation("no adapter found".into());
+        assert_eq!(err.to_string(), "device creation failed: no adapter found");
+    }
+
+    #[test]
+    fn error_display_buffer_allocation() {
+        let err = WgpuError::BufferAllocation("out of memory".into());
+        assert_eq!(err.to_string(), "buffer allocation failed: out of memory");
+    }
+
+    #[test]
+    fn error_display_shader_compilation() {
+        let err = WgpuError::ShaderCompilation("syntax error at line 5".into());
+        assert_eq!(err.to_string(), "shader compilation failed: syntax error at line 5");
+    }
+
+    #[test]
+    fn error_display_pipeline_creation() {
+        let err = WgpuError::PipelineCreation("bind group mismatch".into());
+        assert_eq!(err.to_string(), "pipeline creation failed: bind group mismatch");
+    }
+
+    #[test]
+    fn error_display_buffer_mapping() {
+        let err = WgpuError::BufferMapping("map async failed".into());
+        assert_eq!(err.to_string(), "buffer mapping failed: map async failed");
+    }
+
+    #[test]
+    fn error_display_dispatch() {
+        let err = WgpuError::Dispatch("command encoder error".into());
+        assert_eq!(err.to_string(), "dispatch failed: command encoder error");
+    }
+
+    #[test]
+    fn error_display_internal() {
+        let err = WgpuError::Internal("unexpected state".into());
+        assert_eq!(err.to_string(), "internal error: unexpected state");
+    }
+
+    #[test]
+    fn error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<WgpuError>();
+    }
+
+    #[test]
+    fn error_source_chain() {
+        let err = WgpuError::device("adapter not found");
+        // WgpuError has no source — verify the trait impl exists and returns None.
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[test]
+    fn convenience_constructors() {
+        let e1 = WgpuError::device("d");
+        assert!(matches!(e1, WgpuError::DeviceCreation(_)));
+
+        let e2 = WgpuError::shader("s");
+        assert!(matches!(e2, WgpuError::ShaderCompilation(_)));
+
+        let e3 = WgpuError::pipeline("p");
+        assert!(matches!(e3, WgpuError::PipelineCreation(_)));
+
+        let e4 = WgpuError::mapping("m");
+        assert!(matches!(e4, WgpuError::BufferMapping(_)));
+    }
+}

--- a/crates/bitnet-wgpu/src/lib.rs
+++ b/crates/bitnet-wgpu/src/lib.rs
@@ -1,0 +1,29 @@
+//! `bitnet-wgpu` — wgpu-based GPU compute backend for BitNet inference.
+//!
+//! This crate provides the foundational infrastructure for running BitNet
+//! inference on Vulkan, Metal, and DX12 via [wgpu](https://wgpu.rs/):
+//!
+//! - **Device management** — adapter discovery, device creation, capability queries
+//! - **Buffer management** — typed GPU buffers with pool-based allocation
+//! - **Pipeline infrastructure** — shader compilation and pipeline caching
+//! - **Dispatch helpers** — workgroup sizing with NVIDIA-tuned heuristics
+//!
+//! # Status
+//!
+//! Foundation crate only — no compute shaders yet.  This establishes the seam
+//! for future kernel implementations (matmul, quantization, attention).
+
+pub mod buffer;
+pub mod device;
+pub mod dispatch;
+pub mod error;
+pub mod pipeline;
+
+pub use buffer::{BufferPool, GpuBuffer, PoolStats};
+pub use device::{DeviceInfo, WgpuDevice, WgpuDeviceConfig};
+pub use dispatch::{
+    DispatchConfig, DispatchEntry, DispatchRecorder, compute_dispatch_size,
+    optimal_workgroup_size_nvidia,
+};
+pub use error::WgpuError;
+pub use pipeline::{CacheStats, ComputePipeline, PipelineCache};

--- a/crates/bitnet-wgpu/src/pipeline.rs
+++ b/crates/bitnet-wgpu/src/pipeline.rs
@@ -1,0 +1,329 @@
+//! Compute pipeline creation and shader module caching.
+
+use std::collections::HashMap;
+
+use crate::device::WgpuDevice;
+use crate::error::WgpuError;
+
+/// A compiled compute pipeline with metadata.
+pub struct ComputePipeline {
+    inner: wgpu::ComputePipeline,
+    entry_point: String,
+    bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl ComputePipeline {
+    /// Compile a WGSL shader and create a compute pipeline.
+    ///
+    /// `bind_group_entries` describes the bind group layout entries for bind
+    /// group 0.  The caller is responsible for matching entries to the shader.
+    pub fn new(
+        device: &WgpuDevice,
+        shader_src: &str,
+        entry_point: &str,
+        bind_group_entries: &[wgpu::BindGroupLayoutEntry],
+    ) -> Result<Self, WgpuError> {
+        let module = device.device().create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("bitnet-shader"),
+            source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+        });
+
+        let bind_group_layout =
+            device.device().create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("bitnet-bgl"),
+                entries: bind_group_entries,
+            });
+
+        let pipeline_layout =
+            device.device().create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("bitnet-pipeline-layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+
+        let inner = device.device().create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("bitnet-compute-pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &module,
+            entry_point: Some(entry_point),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        Ok(Self { inner, entry_point: entry_point.to_string(), bind_group_layout })
+    }
+
+    /// Access the underlying `wgpu::ComputePipeline`.
+    pub fn inner(&self) -> &wgpu::ComputePipeline {
+        &self.inner
+    }
+
+    /// The entry point function name.
+    pub fn entry_point(&self) -> &str {
+        &self.entry_point
+    }
+
+    /// The bind group layout for bind group 0.
+    pub fn bind_group_layout(&self) -> &wgpu::BindGroupLayout {
+        &self.bind_group_layout
+    }
+}
+
+impl std::fmt::Debug for ComputePipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ComputePipeline").field("entry_point", &self.entry_point).finish()
+    }
+}
+
+/// Cache statistics.
+#[derive(Debug, Clone, Default)]
+pub struct CacheStats {
+    /// Number of cache lookups.
+    pub lookups: u64,
+    /// Number of cache hits.
+    pub hits: u64,
+    /// Number of shader compilations (cache misses).
+    pub compilations: u64,
+}
+
+impl CacheStats {
+    /// Cache hit rate (0.0–1.0).
+    pub fn hit_rate(&self) -> f64 {
+        if self.lookups == 0 { 0.0 } else { self.hits as f64 / self.lookups as f64 }
+    }
+}
+
+/// Caches compiled compute pipelines keyed by a hash of the shader source
+/// and entry point.
+pub struct PipelineCache {
+    entries: HashMap<u64, ComputePipeline>,
+    stats: CacheStats,
+}
+
+impl PipelineCache {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self { entries: HashMap::new(), stats: CacheStats::default() }
+    }
+
+    /// Compute a simple hash key for a (shader_src, entry_point) pair.
+    fn cache_key(shader_src: &str, entry_point: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        shader_src.hash(&mut hasher);
+        entry_point.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Look up a cached pipeline or compile a new one.
+    ///
+    /// Returns a reference to the cached pipeline.  The `bind_group_entries`
+    /// are only used on a cache miss (first compilation).
+    pub fn get_or_create(
+        &mut self,
+        device: &WgpuDevice,
+        shader_src: &str,
+        entry_point: &str,
+        bind_group_entries: &[wgpu::BindGroupLayoutEntry],
+    ) -> Result<&ComputePipeline, WgpuError> {
+        let key = Self::cache_key(shader_src, entry_point);
+        self.stats.lookups += 1;
+
+        if self.entries.contains_key(&key) {
+            self.stats.hits += 1;
+            return Ok(self.entries.get(&key).unwrap());
+        }
+
+        let pipeline = ComputePipeline::new(device, shader_src, entry_point, bind_group_entries)?;
+        self.stats.compilations += 1;
+        self.entries.insert(key, pipeline);
+        Ok(self.entries.get(&key).unwrap())
+    }
+
+    /// Current cache statistics.
+    pub fn stats(&self) -> &CacheStats {
+        &self.stats
+    }
+
+    /// Number of cached pipelines.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Clear all cached pipelines.
+    pub fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+impl Default for PipelineCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for PipelineCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PipelineCache")
+            .field("entries", &self.entries.len())
+            .field("stats", &self.stats)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── GPU-gated tests ──────────────────────────────────────────────
+
+    /// Minimal WGSL shader for pipeline creation tests.
+    #[cfg(test)]
+    const TRIVIAL_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read_write> data: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    data[gid.x] = data[gid.x] + 1.0;
+}
+"#;
+
+    #[cfg(test)]
+    fn trivial_bind_group_entries() -> Vec<wgpu::BindGroupLayoutEntry> {
+        vec![wgpu::BindGroupLayoutEntry {
+            binding: 0,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }]
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pipeline_creation_trivial_shader() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let entries = trivial_bind_group_entries();
+        let pipe = ComputePipeline::new(&dev, TRIVIAL_SHADER, "main", &entries);
+        assert!(pipe.is_ok());
+        assert_eq!(pipe.unwrap().entry_point(), "main");
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn pipeline_debug_output() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let entries = trivial_bind_group_entries();
+        let pipe = ComputePipeline::new(&dev, TRIVIAL_SHADER, "main", &entries).unwrap();
+        let dbg = format!("{pipe:?}");
+        assert!(dbg.contains("main"));
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn cache_miss_then_hit() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let entries = trivial_bind_group_entries();
+        let mut cache = PipelineCache::new();
+
+        // First lookup — miss.
+        let _p1 = cache.get_or_create(&dev, TRIVIAL_SHADER, "main", &entries).unwrap();
+        assert_eq!(cache.stats().compilations, 1);
+        assert_eq!(cache.stats().hits, 0);
+
+        // Second lookup — hit.
+        let _p2 = cache.get_or_create(&dev, TRIVIAL_SHADER, "main", &entries).unwrap();
+        assert_eq!(cache.stats().compilations, 1);
+        assert_eq!(cache.stats().hits, 1);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn cache_different_entry_points() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let entries = trivial_bind_group_entries();
+        let mut cache = PipelineCache::new();
+
+        let _p1 = cache.get_or_create(&dev, TRIVIAL_SHADER, "main", &entries).unwrap();
+
+        // Different shader source with same entry point name compiles separately.
+        let other_shader = r#"
+@group(0) @binding(0) var<storage, read_write> data: array<f32>;
+
+@compute @workgroup_size(128)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    data[gid.x] = data[gid.x] * 2.0;
+}
+"#;
+        let _p2 = cache.get_or_create(&dev, other_shader, "main", &entries).unwrap();
+        assert_eq!(cache.stats().compilations, 2);
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime"]
+    fn cache_clear_resets() {
+        let dev = WgpuDevice::new_blocking(&Default::default()).unwrap();
+        let entries = trivial_bind_group_entries();
+        let mut cache = PipelineCache::new();
+
+        let _ = cache.get_or_create(&dev, TRIVIAL_SHADER, "main", &entries).unwrap();
+        assert_eq!(cache.len(), 1);
+        cache.clear();
+        assert!(cache.is_empty());
+    }
+
+    // ── Non-GPU tests ────────────────────────────────────────────────
+
+    #[test]
+    fn cache_stats_initial() {
+        let cache = PipelineCache::new();
+        let stats = cache.stats();
+        assert_eq!(stats.lookups, 0);
+        assert_eq!(stats.hits, 0);
+        assert_eq!(stats.compilations, 0);
+        assert_eq!(stats.hit_rate(), 0.0);
+    }
+
+    #[test]
+    fn cache_stats_hit_rate_computed() {
+        let stats = CacheStats { lookups: 10, hits: 7, compilations: 3 };
+        assert!((stats.hit_rate() - 0.7).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cache_empty_initial() {
+        let cache = PipelineCache::new();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn cache_debug_output() {
+        let cache = PipelineCache::new();
+        let dbg = format!("{cache:?}");
+        assert!(dbg.contains("PipelineCache"));
+    }
+
+    #[test]
+    fn cache_key_deterministic() {
+        let k1 = PipelineCache::cache_key("shader_a", "main");
+        let k2 = PipelineCache::cache_key("shader_a", "main");
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn cache_key_varies_on_source() {
+        let k1 = PipelineCache::cache_key("shader_a", "main");
+        let k2 = PipelineCache::cache_key("shader_b", "main");
+        assert_ne!(k1, k2);
+    }
+}


### PR DESCRIPTION
## Summary

Foundation crate for wgpu-based GPU compute targeting Vulkan (NVIDIA RTX 5070 Ti).
This is infrastructure only — no compute shaders yet.

## Modules

| Module | Purpose |
|--------|---------|
| `device` | `WgpuDevice` with async/blocking init, adapter info, NVIDIA vendor detection, subgroup ops query |
| `buffer` | `GpuBuffer` (storage/uniform), host ↔ GPU write/read, `BufferPool` with reuse tracking |
| `pipeline` | `ComputePipeline` from WGSL, `PipelineCache` with hash-keyed dedup and hit-rate stats |
| `dispatch` | `DispatchConfig`, `compute_dispatch_size`, NVIDIA-tuned workgroup sizing (warp-aligned, prefer 256 for Blackwell) |
| `error` | `WgpuError` enum with 7 variants and convenience constructors |

## Tests

- **37 non-GPU unit tests passing** — dispatch math, error display, pool stats, cache keys
- **22 GPU-gated tests** with `#[ignore = "requires GPU runtime"]` — device creation, buffer roundtrip, pipeline compilation, pool reuse

## Integration

- Registered in workspace `members` (not `default-members` — opt-in only)
- No changes to existing crates
- MSRV 1.92.0, edition 2024