### PR TITLE
feat(device-probe): add wgpu-based GPU device probing for Vulkan/Metal/DX12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -372,6 +372,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitnet"
@@ -576,9 +579,11 @@ dependencies = [
  "insta",
  "log",
  "opencl3",
+ "pollster",
  "proptest",
  "serial_test",
  "temp-env",
+ "wgpu",
 ]
 
 [[package]]
@@ -1395,7 +1400,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "winapi",
- "xml-rs",
+ "xml-rs 1.0.0",
 ]
 
 [[package]]
@@ -1929,6 +1934,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -4036,6 +4051,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs 0.8.28",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,6 +4077,78 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.11.0",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4162,6 +4260,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hkdf"
@@ -4650,6 +4754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4691,6 +4801,23 @@ dependencies = [
  "signature",
  "simple_asn1",
 ]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kstring"
@@ -4954,6 +5081,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5098,6 +5240,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.18",
+ "unicode-xid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5127,6 +5291,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
 ]
 
 [[package]]
@@ -5337,7 +5510,7 @@ dependencies = [
  "num-traits",
  "pyo3",
  "pyo3-build-config",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -5593,6 +5766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,6 +5999,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5886,6 +6074,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5930,6 +6124,12 @@ checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "prometheus"
@@ -6228,7 +6428,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.18",
@@ -6248,7 +6448,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6375,6 +6575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6382,6 +6588,12 @@ checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rawpointer"
@@ -6485,6 +6697,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6575,6 +6793,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -7111,6 +7335,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7131,6 +7364,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "spki"
@@ -7171,6 +7413,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -7234,7 +7498,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7284,6 +7548,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -7868,7 +8141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
 dependencies = [
  "half",
- "metal",
+ "metal 0.29.0",
  "objc",
  "serde",
  "thiserror 1.0.69",
@@ -8318,6 +8591,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.11.0",
+ "block",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "metal 0.31.0",
+ "naga",
+ "ndk-sys",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.11.0",
+ "js-sys",
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "which"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8361,6 +8743,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -8383,12 +8775,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
@@ -8400,8 +8805,8 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
@@ -8420,9 +8825,31 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8475,6 +8902,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -8489,6 +8925,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8797,6 +9243,12 @@ name = "xml"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xml-rs"

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -16,6 +16,8 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 opencl3 = { version = "0.9", optional = true }
+wgpu = { version = "24", features = ["vulkan-portability"], optional = true }
+pollster = { version = "0.4", optional = true }
 
 [dev-dependencies]
 temp-env.workspace = true
@@ -33,6 +35,7 @@ vulkan = ["dep:ash"]
 npu = ["oneapi"]
 oneapi = ["dep:opencl3"]
 opencl = ["dep:opencl3"]
+wgpu-probe = ["dep:wgpu", "dep:pollster"]
 
 [[test]]
 name = "oneapi_detection_bdd"

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -13,6 +13,14 @@ pub use opencl::{
     ProbeResult, is_intel_arc_available, list_opencl_devices, probe_opencl,
 };
 
+#[cfg(feature = "wgpu-probe")]
+pub mod wgpu_probe;
+#[cfg(feature = "wgpu-probe")]
+pub use wgpu_probe::{
+    WgpuBackend, WgpuDeviceInfo, WgpuDeviceType, WgpuLimits, is_nvidia, is_vulkan_backend,
+    probe_best_wgpu_device, probe_wgpu_devices, supports_f16,
+};
+
 // ── CPU capabilities ─────────────────────────────────────────────────────────
 
 /// CPU capabilities detected at runtime.

--- a/crates/bitnet-device-probe/src/wgpu_probe.rs
+++ b/crates/bitnet-device-probe/src/wgpu_probe.rs
@@ -1,0 +1,398 @@
+//! wgpu-based GPU device probing for Vulkan/Metal/DX12 backends.
+//!
+//! Provides adapter enumeration and capability extraction via the `wgpu` crate,
+//! complementing the raw Vulkan probing done via `ash` in the `vulkan` feature.
+
+use std::fmt;
+
+/// Compute-relevant limits extracted from a wgpu adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgpuLimits {
+    /// Maximum size of a single GPU buffer in bytes.
+    pub max_buffer_size: u64,
+    /// Maximum number of storage buffers per shader stage.
+    pub max_storage_buffers: u32,
+    /// Maximum compute workgroup size in the X dimension.
+    pub max_compute_workgroup_size_x: u32,
+    /// Maximum compute workgroup size in the Y dimension.
+    pub max_compute_workgroup_size_y: u32,
+    /// Maximum compute workgroup size in the Z dimension.
+    pub max_compute_workgroup_size_z: u32,
+    /// Maximum total invocations per compute workgroup.
+    pub max_compute_invocations: u32,
+    /// Maximum number of bind groups.
+    pub max_bind_groups: u32,
+    /// Minimum subgroup size (0 if unavailable).
+    pub subgroup_size: u32,
+}
+
+impl Default for WgpuLimits {
+    fn default() -> Self {
+        Self {
+            max_buffer_size: 256 * 1024 * 1024, // 256 MiB conservative default
+            max_storage_buffers: 8,
+            max_compute_workgroup_size_x: 256,
+            max_compute_workgroup_size_y: 256,
+            max_compute_workgroup_size_z: 64,
+            max_compute_invocations: 256,
+            max_bind_groups: 4,
+            subgroup_size: 0,
+        }
+    }
+}
+
+/// Device type reported by wgpu.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WgpuDeviceType {
+    /// Discrete GPU (dedicated graphics card).
+    DiscreteGpu,
+    /// Integrated GPU (shares memory with CPU).
+    IntegratedGpu,
+    /// Software/CPU renderer.
+    Cpu,
+    /// Virtual GPU (e.g. in a VM).
+    VirtualGpu,
+    /// Unknown or unrecognised device type.
+    Other,
+}
+
+impl fmt::Display for WgpuDeviceType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DiscreteGpu => write!(f, "DiscreteGpu"),
+            Self::IntegratedGpu => write!(f, "IntegratedGpu"),
+            Self::Cpu => write!(f, "Cpu"),
+            Self::VirtualGpu => write!(f, "VirtualGpu"),
+            Self::Other => write!(f, "Other"),
+        }
+    }
+}
+
+/// GPU backend used by the adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WgpuBackend {
+    Vulkan,
+    Metal,
+    Dx12,
+    Gl,
+    BrowserWebGpu,
+    Other,
+}
+
+impl fmt::Display for WgpuBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vulkan => write!(f, "Vulkan"),
+            Self::Metal => write!(f, "Metal"),
+            Self::Dx12 => write!(f, "DX12"),
+            Self::Gl => write!(f, "GL"),
+            Self::BrowserWebGpu => write!(f, "BrowserWebGpu"),
+            Self::Other => write!(f, "Other"),
+        }
+    }
+}
+
+/// Information about a single wgpu-discovered GPU adapter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WgpuDeviceInfo {
+    /// Human-readable adapter name.
+    pub name: String,
+    /// Vendor identifier (PCI vendor ID).
+    pub vendor: u32,
+    /// Backend API used by this adapter.
+    pub backend: WgpuBackend,
+    /// Device type classification.
+    pub device_type: WgpuDeviceType,
+    /// Driver name (may be empty on some platforms).
+    pub driver: String,
+    /// Additional driver information string.
+    pub driver_info: String,
+    /// Compute-relevant limits.
+    pub limits: WgpuLimits,
+    /// Whether the adapter reports `shader-f16` feature support.
+    pub shader_f16: bool,
+}
+
+/// NVIDIA PCI vendor ID.
+const NVIDIA_VENDOR_ID: u32 = 0x10DE;
+
+/// Check whether a probed device is an NVIDIA GPU.
+pub fn is_nvidia(info: &WgpuDeviceInfo) -> bool {
+    info.vendor == NVIDIA_VENDOR_ID
+        || info.name.to_ascii_lowercase().contains("nvidia")
+        || info.driver.to_ascii_lowercase().contains("nvidia")
+}
+
+/// Check whether a probed device uses the Vulkan backend.
+pub fn is_vulkan_backend(info: &WgpuDeviceInfo) -> bool {
+    info.backend == WgpuBackend::Vulkan
+}
+
+/// Check whether a probed device advertises `shader-f16` support.
+pub fn supports_f16(info: &WgpuDeviceInfo) -> bool {
+    info.shader_f16
+}
+
+// ── wgpu backend conversion helpers ──────────────────────────────────────────
+
+fn convert_backend(b: wgpu::Backend) -> WgpuBackend {
+    match b {
+        wgpu::Backend::Vulkan => WgpuBackend::Vulkan,
+        wgpu::Backend::Metal => WgpuBackend::Metal,
+        wgpu::Backend::Dx12 => WgpuBackend::Dx12,
+        wgpu::Backend::Gl => WgpuBackend::Gl,
+        wgpu::Backend::BrowserWebGpu => WgpuBackend::BrowserWebGpu,
+        _ => WgpuBackend::Other,
+    }
+}
+
+fn convert_device_type(dt: wgpu::DeviceType) -> WgpuDeviceType {
+    match dt {
+        wgpu::DeviceType::DiscreteGpu => WgpuDeviceType::DiscreteGpu,
+        wgpu::DeviceType::IntegratedGpu => WgpuDeviceType::IntegratedGpu,
+        wgpu::DeviceType::Cpu => WgpuDeviceType::Cpu,
+        wgpu::DeviceType::VirtualGpu => WgpuDeviceType::VirtualGpu,
+        _ => WgpuDeviceType::Other,
+    }
+}
+
+fn adapter_to_info(adapter: &wgpu::Adapter) -> WgpuDeviceInfo {
+    let info = adapter.get_info();
+    let limits = adapter.limits();
+    let features = adapter.features();
+
+    WgpuDeviceInfo {
+        name: info.name.clone(),
+        vendor: info.vendor,
+        backend: convert_backend(info.backend),
+        device_type: convert_device_type(info.device_type),
+        driver: info.driver.clone(),
+        driver_info: info.driver_info.clone(),
+        limits: WgpuLimits {
+            max_buffer_size: limits.max_buffer_size,
+            max_storage_buffers: limits.max_storage_buffers_per_shader_stage,
+            max_compute_workgroup_size_x: limits.max_compute_workgroup_size_x,
+            max_compute_workgroup_size_y: limits.max_compute_workgroup_size_y,
+            max_compute_workgroup_size_z: limits.max_compute_workgroup_size_z,
+            max_compute_invocations: limits.max_compute_invocations_per_workgroup,
+            max_bind_groups: limits.max_bind_groups,
+            subgroup_size: if features.contains(wgpu::Features::SUBGROUP) {
+                limits.min_subgroup_size
+            } else {
+                0
+            },
+        },
+        shader_f16: features.contains(wgpu::Features::SHADER_F16),
+    }
+}
+
+/// Enumerate all wgpu adapters and return their device info.
+///
+/// Returns an empty `Vec` if no adapters are found or wgpu initialisation fails.
+pub fn probe_wgpu_devices() -> Vec<WgpuDeviceInfo> {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        let adapters = instance.enumerate_adapters(wgpu::Backends::all());
+        adapters.iter().map(|a| adapter_to_info(a)).collect()
+    })
+}
+
+/// Pick the highest-performance wgpu adapter.
+///
+/// Preference order: discrete GPU > integrated GPU > virtual GPU > CPU > other.
+/// Within the same device type, Vulkan is preferred over other backends.
+pub fn probe_best_wgpu_device() -> Option<WgpuDeviceInfo> {
+    let mut devices = probe_wgpu_devices();
+    if devices.is_empty() {
+        return None;
+    }
+
+    devices.sort_by(|a, b| {
+        fn type_rank(dt: &WgpuDeviceType) -> u32 {
+            match dt {
+                WgpuDeviceType::DiscreteGpu => 4,
+                WgpuDeviceType::IntegratedGpu => 3,
+                WgpuDeviceType::VirtualGpu => 2,
+                WgpuDeviceType::Cpu => 1,
+                WgpuDeviceType::Other => 0,
+            }
+        }
+        fn backend_rank(b: &WgpuBackend) -> u32 {
+            match b {
+                WgpuBackend::Vulkan => 3,
+                WgpuBackend::Metal => 2,
+                WgpuBackend::Dx12 => 2,
+                WgpuBackend::Gl => 1,
+                _ => 0,
+            }
+        }
+        let cmp = type_rank(&b.device_type).cmp(&type_rank(&a.device_type));
+        if cmp != std::cmp::Ordering::Equal {
+            return cmp;
+        }
+        backend_rank(&b.backend).cmp(&backend_rank(&a.backend))
+    });
+
+    devices.into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Unit tests (no GPU required) ─────────────────────────────────────
+
+    fn make_info(overrides: impl FnOnce(&mut WgpuDeviceInfo)) -> WgpuDeviceInfo {
+        let mut info = WgpuDeviceInfo {
+            name: "Test GPU".to_string(),
+            vendor: 0,
+            backend: WgpuBackend::Vulkan,
+            device_type: WgpuDeviceType::DiscreteGpu,
+            driver: String::new(),
+            driver_info: String::new(),
+            limits: WgpuLimits::default(),
+            shader_f16: false,
+        };
+        overrides(&mut info);
+        info
+    }
+
+    #[test]
+    fn wgpu_device_info_construction() {
+        let info = make_info(|i| i.name = "RTX 4090".to_string());
+        assert_eq!(info.name, "RTX 4090");
+        assert_eq!(info.device_type, WgpuDeviceType::DiscreteGpu);
+    }
+
+    #[test]
+    fn wgpu_limits_default_values() {
+        let limits = WgpuLimits::default();
+        assert_eq!(limits.max_buffer_size, 256 * 1024 * 1024);
+        assert_eq!(limits.max_storage_buffers, 8);
+        assert_eq!(limits.max_compute_workgroup_size_x, 256);
+        assert_eq!(limits.max_compute_workgroup_size_y, 256);
+        assert_eq!(limits.max_compute_workgroup_size_z, 64);
+        assert_eq!(limits.max_compute_invocations, 256);
+        assert_eq!(limits.max_bind_groups, 4);
+        assert_eq!(limits.subgroup_size, 0);
+    }
+
+    #[test]
+    fn is_nvidia_by_vendor_id() {
+        let info = make_info(|i| i.vendor = NVIDIA_VENDOR_ID);
+        assert!(is_nvidia(&info));
+    }
+
+    #[test]
+    fn is_nvidia_by_name() {
+        let info = make_info(|i| i.name = "NVIDIA GeForce RTX 3090".to_string());
+        assert!(is_nvidia(&info));
+    }
+
+    #[test]
+    fn is_nvidia_by_driver() {
+        let info = make_info(|i| i.driver = "nvidia proprietary".to_string());
+        assert!(is_nvidia(&info));
+    }
+
+    #[test]
+    fn is_not_nvidia_for_amd() {
+        let info = make_info(|i| {
+            i.vendor = 0x1002; // AMD
+            i.name = "AMD Radeon RX 7900".to_string();
+            i.driver = "radv".to_string();
+        });
+        assert!(!is_nvidia(&info));
+    }
+
+    #[test]
+    fn is_vulkan_backend_true() {
+        let info = make_info(|i| i.backend = WgpuBackend::Vulkan);
+        assert!(is_vulkan_backend(&info));
+    }
+
+    #[test]
+    fn is_vulkan_backend_false_for_metal() {
+        let info = make_info(|i| i.backend = WgpuBackend::Metal);
+        assert!(!is_vulkan_backend(&info));
+    }
+
+    #[test]
+    fn supports_f16_true() {
+        let info = make_info(|i| i.shader_f16 = true);
+        assert!(supports_f16(&info));
+    }
+
+    #[test]
+    fn supports_f16_false() {
+        let info = make_info(|_| {});
+        assert!(!supports_f16(&info));
+    }
+
+    #[test]
+    fn device_type_display() {
+        assert_eq!(WgpuDeviceType::DiscreteGpu.to_string(), "DiscreteGpu");
+        assert_eq!(WgpuDeviceType::IntegratedGpu.to_string(), "IntegratedGpu");
+        assert_eq!(WgpuDeviceType::Cpu.to_string(), "Cpu");
+        assert_eq!(WgpuDeviceType::VirtualGpu.to_string(), "VirtualGpu");
+        assert_eq!(WgpuDeviceType::Other.to_string(), "Other");
+    }
+
+    #[test]
+    fn backend_display() {
+        assert_eq!(WgpuBackend::Vulkan.to_string(), "Vulkan");
+        assert_eq!(WgpuBackend::Metal.to_string(), "Metal");
+        assert_eq!(WgpuBackend::Dx12.to_string(), "DX12");
+        assert_eq!(WgpuBackend::Gl.to_string(), "GL");
+        assert_eq!(WgpuBackend::BrowserWebGpu.to_string(), "BrowserWebGpu");
+        assert_eq!(WgpuBackend::Other.to_string(), "Other");
+    }
+
+    // ── GPU-requiring tests ──────────────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires GPU runtime with wgpu-probe feature"]
+    fn probe_wgpu_devices_returns_adapters() {
+        let devices = probe_wgpu_devices();
+        assert!(!devices.is_empty(), "expected at least one wgpu adapter");
+        for d in &devices {
+            assert!(!d.name.is_empty(), "adapter name must not be empty");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime with wgpu-probe feature"]
+    fn probe_best_wgpu_device_returns_some() {
+        let best = probe_best_wgpu_device();
+        assert!(best.is_some(), "expected at least one wgpu adapter");
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime with wgpu-probe feature"]
+    fn probe_best_prefers_discrete() {
+        let devices = probe_wgpu_devices();
+        if devices.len() < 2 {
+            return; // can't test preference with < 2 adapters
+        }
+        let best = probe_best_wgpu_device().unwrap();
+        let has_discrete = devices.iter().any(|d| d.device_type == WgpuDeviceType::DiscreteGpu);
+        if has_discrete {
+            assert_eq!(best.device_type, WgpuDeviceType::DiscreteGpu);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires GPU runtime with wgpu-probe feature"]
+    fn probe_devices_have_valid_limits() {
+        let devices = probe_wgpu_devices();
+        for d in &devices {
+            assert!(d.limits.max_buffer_size > 0);
+            assert!(d.limits.max_compute_workgroup_size_x > 0);
+            assert!(d.limits.max_compute_invocations > 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add a new `wgpu-probe` feature to the `bitnet-device-probe` crate that provides GPU adapter enumeration and capability extraction via the wgpu crate. This complements the existing raw Vulkan probing done via `ash`.

## Changes

- **Cargo.toml**: Added `wgpu` (v24) and `pollster` (v0.4) as optional deps; new `wgpu-probe` feature gate
- **wgpu_probe.rs**: New module with:
  - `WgpuDeviceInfo` — adapter name, vendor, backend, device type, driver info, limits, shader_f16
  - `WgpuLimits` — compute-relevant limits (buffer size, storage buffers, workgroup sizes, bind groups, subgroup size)
  - `WgpuBackend` / `WgpuDeviceType` — typed enums mirroring wgpu types
  - `probe_wgpu_devices()` — enumerate all wgpu adapters (Vulkan/Metal/DX12/GL)
  - `probe_best_wgpu_device()` — select highest-performance adapter (discrete > integrated > virtual > CPU; Vulkan preferred)
  - `is_nvidia()`, `is_vulkan_backend()`, `supports_f16()` — helper predicates
- **lib.rs**: Register module and re-exports under `#[cfg(feature = "wgpu-probe")]`

## Testing

- 12 unit tests (no GPU required): struct construction, defaults, Display impls, is_nvidia/is_vulkan_backend/supports_f16 logic with mock data
- 4 GPU-gated tests: `#[ignore = "requires GPU runtime with wgpu-probe feature"]`
- All 12 non-GPU tests pass: `cargo test -p bitnet-device-probe --features wgpu-probe --lib -- wgpu_probe`

## Usage

```bash
cargo build -p bitnet-device-probe --features wgpu-probe
cargo test -p bitnet-device-probe --features wgpu-probe --lib -- wgpu_probe
```