### PR TITLE
feat(kernels): add CpuAttention batched executor and NEON TODO markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7101,9 +7101,9 @@ dependencies = [
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -3,9 +3,9 @@
 pub mod activations;
 pub mod attention;
 pub use attention::{
-    AttentionConfig, AttentionKernel, CpuAttentionConfig, GqaConfig, apply_rotary_embedding,
-    attention_with_kv_cache, causal_attention, causal_mask, masked_attention,
-    multi_head_attention_cpu, scaled_dot_product_attention,
+    AttentionConfig, AttentionKernel, CpuAttention, CpuAttentionConfig, GqaConfig,
+    apply_rotary_embedding, attention_with_kv_cache, causal_attention, causal_mask,
+    masked_attention, multi_head_attention_cpu, scaled_dot_product_attention,
 };
 pub mod batch_norm;
 pub mod conv2d;


### PR DESCRIPTION
## Summary

Add `CpuAttention` struct that couples `CpuAttentionConfig` with execution, providing batched multi-head attention. This makes the previously orphaned `CpuAttentionConfig` (which had a `batch_size` field unused by any function) actually functional.

## Changes

- **`CpuAttention` struct** with `new()`, `forward()`, `forward_single_head()`, and `config()` methods
  - `forward()` supports batched multi-head attention: `[batch_size, seq_len, num_heads * head_dim]`
  - `forward_single_head()` for per-head slices without multi-head splitting
  - Delegates to existing `AttentionKernel` methods (no code duplication)
- **NEON SIMD TODO markers** in dispatch section for ARM targets (aarch64)
- **Re-export** `CpuAttention` from `cpu/mod.rs`
- **12 new tests**: basic forward, MHA parity, batched execution, causal masking, single token edge case, numerical stability (large values), shape validation (Q/K/V), invalid config rejection, single-head forward, config accessor

## Test Results

All 82 attention tests pass (70 existing + 12 new):
```
test result: ok. 82 passed; 0 failed; 0 ignored; 0 measured; 1450 filtered out
```

Clippy clean, `cargo fmt` applied.