### PR TITLE
test(snapshot): add wave 8 snapshot tests (59 tests)

### DIFF
--- a/crates/bitnet-common/tests/snapshot_error_display.rs
+++ b/crates/bitnet-common/tests/snapshot_error_display.rs
@@ -1,0 +1,236 @@
+//! Wave 8 snapshot tests — error type Display implementations.
+//!
+//! Pins the user-facing error messages so that accidental changes to
+//! Display formatting are caught at review time.
+
+use bitnet_common::backend_selection::BackendRequest;
+use bitnet_common::kernel_registry::KernelBackend;
+use bitnet_common::tensor_validation::TensorValidationError;
+use bitnet_common::{
+    BackendSelectionError, InferenceError, KernelError, ModelError, QuantizationError,
+    SecurityError,
+};
+
+// ---------------------------------------------------------------------------
+// ModelError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_error_not_found_display() {
+    let err = ModelError::NotFound { path: "/models/missing.gguf".into() };
+    insta::assert_snapshot!("model_error_not_found", err.to_string());
+}
+
+#[test]
+fn model_error_invalid_format_display() {
+    let err = ModelError::InvalidFormat { format: "safetensors-v3".into() };
+    insta::assert_snapshot!("model_error_invalid_format", err.to_string());
+}
+
+#[test]
+fn model_error_loading_failed_display() {
+    let err = ModelError::LoadingFailed { reason: "corrupted header at offset 0x42".into() };
+    insta::assert_snapshot!("model_error_loading_failed", err.to_string());
+}
+
+#[test]
+fn model_error_unsupported_version_display() {
+    let err = ModelError::UnsupportedVersion { version: "4.0".into() };
+    insta::assert_snapshot!("model_error_unsupported_version", err.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantization_error_all_variants_display() {
+    let errors: Vec<QuantizationError> = vec![
+        QuantizationError::UnsupportedType { qtype: "Q4_K_M".into() },
+        QuantizationError::QuantizationFailed { reason: "scale underflow".into() },
+        QuantizationError::InvalidBlockSize { size: 7 },
+        QuantizationError::ResourceLimit { reason: "exceeded 4GB allocation".into() },
+        QuantizationError::InvalidInput { reason: "shape [0, 128] has zero dim".into() },
+        QuantizationError::MemoryAllocation { reason: "out of memory".into() },
+    ];
+    let displays: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    insta::assert_debug_snapshot!("quantization_error_all_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// KernelError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn kernel_error_all_variants_display() {
+    let errors: Vec<KernelError> = vec![
+        KernelError::NoProvider,
+        KernelError::ExecutionFailed { reason: "CUDA out of memory".into() },
+        KernelError::UnsupportedArchitecture { arch: "riscv64".into() },
+        KernelError::GpuError { reason: "device lost".into() },
+        KernelError::UnsupportedHardware { required: "AVX2".into(), available: "SSE4.2".into() },
+        KernelError::InvalidArguments { reason: "batch size must be > 0".into() },
+        KernelError::QuantizationFailed { reason: "invalid block alignment".into() },
+        KernelError::MatmulFailed { reason: "dimension mismatch: 128 vs 256".into() },
+    ];
+    let displays: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    insta::assert_debug_snapshot!("kernel_error_all_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// InferenceError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inference_error_all_variants_display() {
+    let errors: Vec<InferenceError> = vec![
+        InferenceError::GenerationFailed { reason: "KV cache overflow".into() },
+        InferenceError::InvalidInput { reason: "empty prompt".into() },
+        InferenceError::ContextLengthExceeded { length: 8192 },
+        InferenceError::TokenizationFailed { reason: "unknown byte sequence".into() },
+    ];
+    let displays: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    insta::assert_debug_snapshot!("inference_error_all_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// SecurityError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn security_error_all_variants_display() {
+    let errors: Vec<SecurityError> = vec![
+        SecurityError::InputValidation { reason: "prompt exceeds 1MB".into() },
+        SecurityError::MemoryBomb { reason: "tensor claims 999TB".into() },
+        SecurityError::ResourceLimit {
+            resource: "memory".into(),
+            value: 5_000_000_000,
+            limit: 4_000_000_000,
+        },
+        SecurityError::MalformedData { reason: "negative tensor dimension".into() },
+        SecurityError::UnsafeOperation {
+            operation: "mmap".into(),
+            reason: "file from untrusted source".into(),
+        },
+    ];
+    let displays: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    insta::assert_debug_snapshot!("security_error_all_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// BackendSelectionError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn backend_selection_error_no_backend_display() {
+    let err = BackendSelectionError::NoBackendAvailable;
+    insta::assert_snapshot!("backend_selection_error_no_backend", err.to_string());
+}
+
+#[test]
+fn backend_selection_error_unavailable_display() {
+    let err = BackendSelectionError::RequestedUnavailable {
+        requested: BackendRequest::Gpu,
+        available: vec![KernelBackend::CpuRust],
+    };
+    insta::assert_snapshot!("backend_selection_error_unavailable", err.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// TensorValidationError Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tensor_validation_error_all_variants_display() {
+    let errors: Vec<TensorValidationError> = vec![
+        TensorValidationError::ZeroDimension { axis: 1, shape: vec![32, 0, 64] },
+        TensorValidationError::TotalElementsExceeded { total: 2_000_000_000, max: 1_000_000_000 },
+        TensorValidationError::DimensionsExceeded { ndim: 9, max: 8 },
+        TensorValidationError::NanDetected { index: 42 },
+        TensorValidationError::InfDetected { index: 7, value: f32::INFINITY },
+        TensorValidationError::ValueOutOfRange { index: 3, value: 999.0, min: -1.0, max: 1.0 },
+        TensorValidationError::StrideInconsistent { axis: 2, expected: 64, actual: 128 },
+        TensorValidationError::AlignmentViolation { required: 32, actual: 4 },
+    ];
+    let displays: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    insta::assert_debug_snapshot!("tensor_validation_error_all_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// Error source chains (std::error::Error::source)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_error_wraps_in_bitnet_error() {
+    let inner = ModelError::NotFound { path: "/missing.gguf".into() };
+    let outer = bitnet_common::BitNetError::Model(inner);
+    insta::assert_snapshot!("bitnet_error_model_wrapper", outer.to_string());
+}
+
+#[test]
+fn quantization_error_wraps_in_bitnet_error() {
+    let inner = QuantizationError::InvalidBlockSize { size: 0 };
+    let outer = bitnet_common::BitNetError::Quantization(inner);
+    insta::assert_snapshot!("bitnet_error_quantization_wrapper", outer.to_string());
+}
+
+#[test]
+fn kernel_error_wraps_in_bitnet_error() {
+    let inner = KernelError::NoProvider;
+    let outer = bitnet_common::BitNetError::Kernel(inner);
+    insta::assert_snapshot!("bitnet_error_kernel_wrapper", outer.to_string());
+}
+
+#[test]
+fn inference_error_wraps_in_bitnet_error() {
+    let inner = InferenceError::ContextLengthExceeded { length: 4096 };
+    let outer = bitnet_common::BitNetError::Inference(inner);
+    insta::assert_snapshot!("bitnet_error_inference_wrapper", outer.to_string());
+}
+
+#[test]
+fn security_error_wraps_in_bitnet_error() {
+    let inner = SecurityError::MemoryBomb { reason: "oversized allocation".into() };
+    let outer = bitnet_common::BitNetError::Security(inner);
+    insta::assert_snapshot!("bitnet_error_security_wrapper", outer.to_string());
+}
+
+#[test]
+fn config_error_display() {
+    let err = bitnet_common::BitNetError::Config("missing required field 'model_path'".into());
+    insta::assert_snapshot!("bitnet_error_config", err.to_string());
+}
+
+#[test]
+fn validation_error_display() {
+    let err = bitnet_common::BitNetError::Validation("LayerNorm gamma RMS out of range".into());
+    insta::assert_snapshot!("bitnet_error_validation", err.to_string());
+}
+
+#[test]
+fn strict_mode_error_display() {
+    let err = bitnet_common::BitNetError::StrictMode("mock inference rejected".into());
+    insta::assert_snapshot!("bitnet_error_strict_mode", err.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// Error source() chain verification
+// ---------------------------------------------------------------------------
+
+#[test]
+fn model_error_source_chain() {
+    use std::error::Error;
+    let inner = ModelError::NotFound { path: "/model.gguf".into() };
+    let outer = bitnet_common::BitNetError::Model(inner);
+    let source = outer.source().map(|s| s.to_string()).unwrap_or_default();
+    insta::assert_snapshot!("bitnet_error_model_source", source);
+}
+
+#[test]
+fn kernel_error_source_chain() {
+    use std::error::Error;
+    let inner = KernelError::ExecutionFailed { reason: "timeout".into() };
+    let outer = bitnet_common::BitNetError::Kernel(inner);
+    let source = outer.source().map(|s| s.to_string()).unwrap_or_default();
+    insta::assert_snapshot!("bitnet_error_kernel_source", source);
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__backend_selection_error_no_backend.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__backend_selection_error_no_backend.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+no kernel backend is compiled; build with --features cpu or --features gpu

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__backend_selection_error_unavailable.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__backend_selection_error_unavailable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+requested backend 'gpu' is not available; compiled backends: [cpu-rust]

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_config.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_config.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Configuration error: missing required field 'model_path'

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_inference_wrapper.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_inference_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: outer.to_string()
+---
+Inference error: Context length exceeded: 4096

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_kernel_source.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_kernel_source.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: source
+---
+Kernel execution failed: timeout

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_kernel_wrapper.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_kernel_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: outer.to_string()
+---
+Kernel error: No available kernel provider

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_model_source.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_model_source.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: source
+---
+Model not found: /model.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_model_wrapper.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_model_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: outer.to_string()
+---
+Model error: Model not found: /missing.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_quantization_wrapper.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_quantization_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: outer.to_string()
+---
+Quantization error: Invalid block size: 0

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_security_wrapper.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_security_wrapper.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: outer.to_string()
+---
+Security error: Memory allocation attack detected: oversized allocation

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_strict_mode.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_strict_mode.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Strict mode violation: mock inference rejected

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_validation.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__bitnet_error_validation.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Validation error: LayerNorm gamma RMS out of range

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__inference_error_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__inference_error_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: displays
+---
+[
+    "Generation failed: KV cache overflow",
+    "Invalid input: empty prompt",
+    "Context length exceeded: 8192",
+    "Tokenization failed: unknown byte sequence",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__kernel_error_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__kernel_error_all_variants.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: displays
+---
+[
+    "No available kernel provider",
+    "Kernel execution failed: CUDA out of memory",
+    "Unsupported architecture: riscv64",
+    "GPU error: device lost",
+    "Unsupported hardware: required AVX2, available SSE4.2",
+    "Invalid arguments: batch size must be > 0",
+    "Quantization failed: invalid block alignment",
+    "Matrix multiplication failed: dimension mismatch: 128 vs 256",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_invalid_format.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_invalid_format.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Invalid model format: safetensors-v3

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_loading_failed.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_loading_failed.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Model loading failed: corrupted header at offset 0x42

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_not_found.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_not_found.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Model not found: /models/missing.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_unsupported_version.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__model_error_unsupported_version.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: err.to_string()
+---
+Unsupported model version: 4.0

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__quantization_error_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__quantization_error_all_variants.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: displays
+---
+[
+    "Unsupported quantization type: Q4_K_M",
+    "Quantization failed: scale underflow",
+    "Invalid block size: 7",
+    "Resource limit exceeded: exceeded 4GB allocation",
+    "Invalid input dimensions: shape [0, 128] has zero dim",
+    "Memory allocation failed: out of memory",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__security_error_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__security_error_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: displays
+---
+[
+    "Input validation failed: prompt exceeds 1MB",
+    "Memory allocation attack detected: tensor claims 999TB",
+    "Resource limit exceeded: memory = 5000000000 exceeds limit 4000000000",
+    "Malformed data structure: negative tensor dimension",
+    "Unsafe operation blocked: mmap - file from untrusted source",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_error_display__tensor_validation_error_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_error_display__tensor_validation_error_all_variants.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-common/tests/snapshot_error_display.rs
+expression: displays
+---
+[
+    "zero dimension at axis 1 in shape [32, 0, 64]",
+    "total elements 2000000000 exceeds maximum 1000000000",
+    "9 dimensions exceeds maximum 8",
+    "NaN detected at index 42",
+    "Inf detected at index 7, value=inf",
+    "value 999 at index 3 outside range [-1, 1]",
+    "stride mismatch at axis 2: expected 64 (C-contiguous), got 128",
+    "alignment 4 does not meet required 32",
+]

--- a/crates/bitnet-inference/tests/snapshot_generation_config.rs
+++ b/crates/bitnet-inference/tests/snapshot_generation_config.rs
@@ -1,0 +1,188 @@
+//! Wave 8 snapshot tests — GenerationConfig and sampling presets.
+//!
+//! Extends the existing snapshot_tests.rs and snapshot_wave5.rs by pinning
+//! builder edge-cases, validation error messages, stop-token configuration,
+//! and the SamplingStrategy preset surfaces.
+
+use bitnet_inference::config::{GenerationConfig, InferenceConfig};
+use bitnet_inference::generation::sampling::{SamplingConfig, SamplingStrategy};
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — stop-token configuration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_with_stop_sequences_snapshot() {
+    let cfg = GenerationConfig::default()
+        .with_stop_sequence("</s>".into())
+        .with_stop_sequence("\n\nQ:".into());
+    insta::assert_snapshot!("gen_config_stop_sequences", format!("{:?}", cfg.stop_sequences));
+}
+
+#[test]
+fn generation_config_with_stop_token_ids_snapshot() {
+    let cfg =
+        GenerationConfig::default().with_stop_token_ids(vec![128009, 128001]).with_stop_token_id(2);
+    insta::assert_snapshot!("gen_config_stop_token_ids", format!("{:?}", cfg.stop_token_ids));
+}
+
+#[test]
+fn generation_config_stop_string_window_default() {
+    let cfg = GenerationConfig::default();
+    insta::assert_snapshot!(
+        "gen_config_stop_window_default",
+        format!("{}", cfg.stop_string_window)
+    );
+}
+
+#[test]
+fn generation_config_custom_stop_window() {
+    let cfg = GenerationConfig::default().with_stop_string_window(256);
+    insta::assert_snapshot!("gen_config_stop_window_custom", format!("{}", cfg.stop_string_window));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — EOS and special token handling
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_eos_token_id_snapshot() {
+    let cfg = GenerationConfig::default().with_eos_token_id(Some(128001));
+    insta::assert_snapshot!(
+        "gen_config_eos_token_id",
+        format!("eos_token_id={:?}", cfg.eos_token_id)
+    );
+}
+
+#[test]
+fn generation_config_skip_special_tokens_default() {
+    let cfg = GenerationConfig::default();
+    insta::assert_snapshot!(
+        "gen_config_skip_special_default",
+        format!("skip_special_tokens={}", cfg.skip_special_tokens)
+    );
+}
+
+#[test]
+fn generation_config_add_bos_override() {
+    let cfg = GenerationConfig::default().with_add_bos(true);
+    insta::assert_snapshot!("gen_config_add_bos_true", format!("add_bos={}", cfg.add_bos));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — logits tap configuration
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_logits_tap_defaults() {
+    let cfg = GenerationConfig::default();
+    insta::assert_snapshot!(
+        "gen_config_logits_tap_defaults",
+        format!("tap_steps={}, topk={}", cfg.logits_tap_steps, cfg.logits_topk)
+    );
+}
+
+#[test]
+fn generation_config_logits_tap_custom() {
+    let cfg = GenerationConfig::default().with_logits_tap_steps(10).with_logits_topk(5);
+    insta::assert_snapshot!(
+        "gen_config_logits_tap_custom",
+        format!("tap_steps={}, topk={}", cfg.logits_tap_steps, cfg.logits_topk)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — validation error messages
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_validate_zero_repetition_penalty() {
+    let cfg = GenerationConfig::default().with_repetition_penalty(0.0);
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!("gen_config_validate_zero_rep_penalty", err);
+}
+
+#[test]
+fn generation_config_validate_negative_repetition_penalty() {
+    let cfg = GenerationConfig::default().with_repetition_penalty(-1.0);
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!("gen_config_validate_neg_rep_penalty", err);
+}
+
+#[test]
+fn generation_config_validate_top_p_over_one() {
+    let cfg = GenerationConfig::default().with_top_p(1.5);
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!("gen_config_validate_top_p_over_one", err);
+}
+
+#[test]
+fn generation_config_validate_ok_snapshot() {
+    let cfg = GenerationConfig::balanced();
+    let result = cfg.validate();
+    insta::assert_snapshot!("gen_config_validate_ok", format!("{result:?}"));
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig — JSON round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generation_config_greedy_json_snapshot() {
+    let cfg = GenerationConfig::greedy().with_max_tokens(16).with_seed(42);
+    insta::assert_json_snapshot!("gen_config_greedy_json", cfg);
+}
+
+#[test]
+fn generation_config_creative_json_snapshot() {
+    let cfg = GenerationConfig::creative().with_max_tokens(256);
+    insta::assert_json_snapshot!("gen_config_creative_json", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// InferenceConfig — field stability
+// ---------------------------------------------------------------------------
+
+#[test]
+fn inference_config_default_json_snapshot() {
+    let cfg = InferenceConfig { num_threads: 0, ..Default::default() };
+    insta::assert_json_snapshot!("inference_config_default_json", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// SamplingConfig — presets
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sampling_config_default_snapshot() {
+    let cfg = SamplingConfig::default();
+    insta::assert_debug_snapshot!("sampling_config_default", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// SamplingStrategy — preset Debug snapshots
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sampling_strategy_deterministic_snapshot() {
+    let strat = SamplingStrategy::deterministic();
+    insta::assert_debug_snapshot!("sampling_strategy_deterministic", strat);
+}
+
+#[test]
+fn sampling_strategy_creative_snapshot() {
+    let strat = SamplingStrategy::creative();
+    insta::assert_debug_snapshot!("sampling_strategy_creative", strat);
+}
+
+#[test]
+fn sampling_strategy_balanced_snapshot() {
+    let strat = SamplingStrategy::balanced();
+    insta::assert_debug_snapshot!("sampling_strategy_balanced", strat);
+}
+
+#[test]
+fn sampling_strategy_conservative_snapshot() {
+    let strat = SamplingStrategy::conservative();
+    insta::assert_debug_snapshot!("sampling_strategy_conservative", strat);
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_add_bos_true.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_add_bos_true.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"add_bos={}\", cfg.add_bos)"
+---
+add_bos=true

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_creative_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_creative_json.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: cfg
+---
+{
+  "max_new_tokens": 256,
+  "temperature": 0.9,
+  "top_k": 100,
+  "top_p": 0.95,
+  "repetition_penalty": 1.1,
+  "stop_sequences": [],
+  "stop_token_ids": [],
+  "stop_string_window": 64,
+  "seed": null,
+  "skip_special_tokens": true,
+  "eos_token_id": null,
+  "logits_tap_steps": 0,
+  "logits_topk": 10,
+  "add_bos": false
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_eos_token_id.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_eos_token_id.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"eos_token_id={:?}\", cfg.eos_token_id)"
+---
+eos_token_id=Some(128001)

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_greedy_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_greedy_json.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: cfg
+---
+{
+  "max_new_tokens": 16,
+  "temperature": 0.0,
+  "top_k": 1,
+  "top_p": 1.0,
+  "repetition_penalty": 1.0,
+  "stop_sequences": [],
+  "stop_token_ids": [],
+  "stop_string_window": 64,
+  "seed": 42,
+  "skip_special_tokens": true,
+  "eos_token_id": null,
+  "logits_tap_steps": 0,
+  "logits_topk": 10,
+  "add_bos": false
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_logits_tap_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_logits_tap_custom.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"tap_steps={}, topk={}\", cfg.logits_tap_steps, cfg.logits_topk)"
+---
+tap_steps=10, topk=5

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_logits_tap_defaults.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_logits_tap_defaults.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"tap_steps={}, topk={}\", cfg.logits_tap_steps, cfg.logits_topk)"
+---
+tap_steps=0, topk=10

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_skip_special_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_skip_special_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"skip_special_tokens={}\", cfg.skip_special_tokens)"
+---
+skip_special_tokens=true

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_sequences.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_sequences.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"{:?}\", cfg.stop_sequences)"
+---
+["</s>", "\n\nQ:"]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_token_ids.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_token_ids.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"{:?}\", cfg.stop_token_ids)"
+---
+[128009, 128001, 2]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_window_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_window_custom.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"{}\", cfg.stop_string_window)"
+---
+256

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_window_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_stop_window_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"{}\", cfg.stop_string_window)"
+---
+64

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_neg_rep_penalty.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_neg_rep_penalty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: err
+---
+repetition_penalty must be positive

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_ok.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_ok.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: "format!(\"{result:?}\")"
+---
+Ok(())

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_top_p_over_one.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_top_p_over_one.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: err
+---
+top_p must be in range (0.0, 1.0]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_zero_rep_penalty.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__gen_config_validate_zero_rep_penalty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: err
+---
+repetition_penalty must be positive

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__inference_config_default_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__inference_config_default_json.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: cfg
+---
+{
+  "max_context_length": 2048,
+  "num_threads": 0,
+  "batch_size": 1,
+  "mixed_precision": false,
+  "memory_pool_size": 536870912
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_config_default.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_balanced.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_balanced.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: strat
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 0.8,
+        top_k: Some(
+            50,
+        ),
+        top_p: Some(
+            0.95,
+        ),
+        repetition_penalty: 1.1,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_conservative.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_conservative.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: strat
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 0.3,
+        top_k: Some(
+            20,
+        ),
+        top_p: Some(
+            0.8,
+        ),
+        repetition_penalty: 1.05,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.05,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_creative.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_creative.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: strat
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 1.2,
+        top_k: Some(
+            100,
+        ),
+        top_p: Some(
+            0.9,
+        ),
+        repetition_penalty: 1.2,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.2,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_deterministic.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_generation_config__sampling_strategy_deterministic.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_generation_config.rs
+expression: strat
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 1.0,
+        top_k: None,
+        top_p: None,
+        repetition_penalty: 1.0,
+        do_sample: false,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.0,
+}

--- a/crates/bitnet-quantization/tests/snapshot_quant_params.rs
+++ b/crates/bitnet-quantization/tests/snapshot_quant_params.rs
@@ -1,0 +1,208 @@
+//! Wave 8 snapshot tests — quantization parameters and layouts.
+//!
+//! Pins the configuration defaults and scale-factor arithmetic so that
+//! any silent change to block sizes, byte layouts, or numeric constants
+//! is caught at review time.
+
+use bitnet_common::QuantizationType;
+use bitnet_quantization::I2SLayout;
+use bitnet_quantization::tl1::TL1Config;
+use bitnet_quantization::tl2::TL2Config;
+use bitnet_quantization::utils::{calculate_grouped_scales, calculate_scale};
+
+// ---------------------------------------------------------------------------
+// I2SLayout defaults and custom sizes
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i2s_layout_default_snapshot() {
+    let l = I2SLayout::default();
+    insta::assert_snapshot!(
+        "i2s_layout_default",
+        format!(
+            "block_size={} bytes_per_block={} data={} scale={}",
+            l.block_size, l.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,
+        )
+    );
+}
+
+#[test]
+fn i2s_layout_block_64_snapshot() {
+    let l = I2SLayout::with_block_size(64);
+    insta::assert_snapshot!(
+        "i2s_layout_block_64",
+        format!(
+            "block_size={} bytes_per_block={} data={} scale={}",
+            l.block_size, l.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,
+        )
+    );
+}
+
+#[test]
+fn i2s_layout_block_256_snapshot() {
+    let l = I2SLayout::with_block_size(256);
+    insta::assert_snapshot!(
+        "i2s_layout_block_256",
+        format!(
+            "block_size={} bytes_per_block={} data={} scale={}",
+            l.block_size, l.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,
+        )
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TL1Config defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tl1_config_default_snapshot() {
+    let config = TL1Config::default();
+    insta::assert_debug_snapshot!("tl1_config_default", config);
+}
+
+// ---------------------------------------------------------------------------
+// TL2Config defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tl2_config_default_snapshot() {
+    let config = TL2Config::default();
+    // Redact runtime-detected SIMD fields that differ per machine.
+    insta::assert_snapshot!(
+        "tl2_config_default",
+        format!(
+            "TL2Config {{ block_size: {}, lookup_table_size: {}, precision_bits: {}, vectorized_tables: {} }}",
+            config.block_size,
+            config.lookup_table_size,
+            config.precision_bits,
+            config.vectorized_tables,
+        )
+    );
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationConfig (from bitnet-common)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quantization_config_default_snapshot() {
+    let config = bitnet_common::config::QuantizationConfig::default();
+    insta::assert_debug_snapshot!("quantization_config_default", config);
+}
+
+#[test]
+fn quantization_config_per_type_snapshot() {
+    let configs: Vec<_> = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2]
+        .iter()
+        .map(|&qt| {
+            let cfg = bitnet_common::config::QuantizationConfig {
+                quantization_type: qt,
+                ..Default::default()
+            };
+            format!("{}: block_size={}, precision={}", qt, cfg.block_size, cfg.precision)
+        })
+        .collect();
+    insta::assert_debug_snapshot!("quantization_config_per_type", configs);
+}
+
+// ---------------------------------------------------------------------------
+// Scale factor computation — known inputs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scale_factor_uniform_ones_2bit() {
+    let data = vec![1.0f32; 32];
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_uniform_ones_2bit", format!("{scale:.6}"));
+}
+
+#[test]
+fn scale_factor_mixed_values_2bit() {
+    let data: Vec<f32> = (0..32).map(|i| (i as f32 - 16.0) / 16.0).collect();
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_mixed_values_2bit", format!("{scale:.6}"));
+}
+
+#[test]
+fn scale_factor_all_zeros() {
+    let data = vec![0.0f32; 64];
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_all_zeros", format!("{scale:.6}"));
+}
+
+#[test]
+fn scale_factor_contains_nan() {
+    let mut data = vec![1.0f32; 32];
+    data[5] = f32::NAN;
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_with_nan", format!("{scale:.6}"));
+}
+
+#[test]
+fn scale_factor_contains_inf() {
+    let mut data = vec![0.5f32; 32];
+    data[10] = f32::INFINITY;
+    let scale = calculate_scale(&data, 2);
+    insta::assert_snapshot!("scale_with_inf", format!("{scale:.6}"));
+}
+
+// ---------------------------------------------------------------------------
+// Grouped scale factors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn grouped_scales_two_blocks() {
+    // Two blocks of 4 elements each with distinct max values.
+    let data = vec![1.0, 0.5, -1.0, 0.25, 2.0, -2.0, 0.0, 0.5];
+    let scales = calculate_grouped_scales(&data, 4, 2);
+    let formatted: Vec<String> = scales.iter().map(|s| format!("{s:.6}")).collect();
+    insta::assert_debug_snapshot!("grouped_scales_two_blocks", formatted);
+}
+
+#[test]
+fn grouped_scales_partial_last_block() {
+    // 6 elements with block_size=4 → 2 blocks, second is partial.
+    let data = vec![3.0, -1.0, 0.0, 0.5, 0.25, -0.25];
+    let scales = calculate_grouped_scales(&data, 4, 2);
+    let formatted: Vec<String> = scales.iter().map(|s| format!("{s:.6}")).collect();
+    insta::assert_debug_snapshot!("grouped_scales_partial_block", formatted);
+}
+
+// ---------------------------------------------------------------------------
+// Block layout descriptions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn i2s_layout_byte_budget_description() {
+    let layout = I2SLayout::default();
+    let description = format!(
+        "I2S block: {} elements → {} total bytes (data={}, scale={})",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block,
+    );
+    insta::assert_snapshot!("i2s_block_byte_budget", description);
+}
+
+#[test]
+fn i2s_compression_ratio() {
+    let layout = I2SLayout::default();
+    // Original: block_size elements × 4 bytes (f32)
+    let original_bytes = layout.block_size * 4;
+    let ratio = original_bytes as f64 / layout.bytes_per_block as f64;
+    insta::assert_snapshot!("i2s_compression_ratio", format!("{ratio:.2}x"));
+}
+
+#[test]
+fn i2s_layout_block_256_byte_budget() {
+    let layout = I2SLayout::with_block_size(256);
+    let description = format!(
+        "I2S block: {} elements → {} total bytes (data={}, scale={})",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block,
+    );
+    insta::assert_snapshot!("i2s_block_256_byte_budget", description);
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__grouped_scales_partial_block.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__grouped_scales_partial_block.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: formatted
+---
+[
+    "3.000000",
+    "0.250000",
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__grouped_scales_two_blocks.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__grouped_scales_two_blocks.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: formatted
+---
+[
+    "1.000000",
+    "2.000000",
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_block_256_byte_budget.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_block_256_byte_budget.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: description
+---
+I2S block: 256 elements → 66 total bytes (data=64, scale=2)

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_block_byte_budget.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_block_byte_budget.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: description
+---
+I2S block: 32 elements → 10 total bytes (data=8, scale=2)

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_compression_ratio.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_compression_ratio.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{ratio:.2}x\")"
+---
+12.80x

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_block_256.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_block_256.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"block_size={} bytes_per_block={} data={} scale={}\", l.block_size,\nl.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,)"
+---
+block_size=256 bytes_per_block=66 data=64 scale=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_block_64.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_block_64.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"block_size={} bytes_per_block={} data={} scale={}\", l.block_size,\nl.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,)"
+---
+block_size=64 bytes_per_block=18 data=16 scale=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__i2s_layout_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"block_size={} bytes_per_block={} data={} scale={}\", l.block_size,\nl.bytes_per_block, l.data_bytes_per_block, l.scale_bytes_per_block,)"
+---
+block_size=32 bytes_per_block=10 data=8 scale=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__quantization_config_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__quantization_config_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: config
+---
+QuantizationConfig {
+    quantization_type: I2S,
+    block_size: 64,
+    precision: 0.0001,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__quantization_config_per_type.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__quantization_config_per_type.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: configs
+---
+[
+    "I2_S: block_size=64, precision=0.0001",
+    "TL1: block_size=64, precision=0.0001",
+    "TL2: block_size=64, precision=0.0001",
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_all_zeros.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_all_zeros.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_mixed_values_2bit.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_mixed_values_2bit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_uniform_ones_2bit.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_uniform_ones_2bit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_with_inf.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_with_inf.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{scale:.6}\")"
+---
+0.500000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_with_nan.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__scale_with_nan.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"{scale:.6}\")"
+---
+1.000000

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__tl1_config_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__tl1_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: config
+---
+TL1Config {
+    block_size: 64,
+    lookup_table_size: 256,
+    use_asymmetric: false,
+    precision_bits: 2,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__tl2_config_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_quant_params__tl2_config_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_quant_params.rs
+expression: "format!(\"TL2Config {{ block_size: {}, lookup_table_size: {}, precision_bits: {}, vectorized_tables: {} }}\",\nconfig.block_size, config.lookup_table_size, config.precision_bits,\nconfig.vectorized_tables,)"
+---
+TL2Config { block_size: 128, lookup_table_size: 256, precision_bits: 2, vectorized_tables: true }


### PR DESCRIPTION
## Snapshot Wave 8

Adds **59 new snapshot tests** targeting under-tested areas across 3 crates:

### `bitnet-common` — `snapshot_error_display.rs` (21 tests)
- Pin Display output for all error types: ModelError, QuantizationError, KernelError, InferenceError, SecurityError, BackendSelectionError, TensorValidationError
- Error chain wrapping in BitNetError (Model, Quantization, Kernel, Inference, Security, Config, Validation, StrictMode)
- `std::error::Error::source()` chain verification

### `bitnet-quantization` — `snapshot_quant_params.rs` (17 tests)
- I2SLayout defaults and custom block sizes (32, 64, 256)
- TL1Config and TL2Config defaults (SIMD fields redacted for portability)
- QuantizationConfig per QuantizationType variant
- Scale factor computation: uniform, mixed, zeros, NaN, Inf edge cases
- Grouped scale factors with full and partial blocks
- Block byte-budget descriptions and compression ratios

### `bitnet-inference` — `snapshot_generation_config.rs` (21 tests)
- Stop-token configuration: sequences, token IDs, string window
- EOS and special token handling
- Logits tap configuration defaults and custom
- Validation error messages: zero/negative repetition penalty, top_p > 1.0
- JSON round-trip for greedy and creative presets
- InferenceConfig defaults (num_threads redacted)
- All SamplingStrategy presets: deterministic, creative, balanced, conservative

### Verification
- All 59 tests pass with `--no-default-features --features cpu`
- Clippy clean (`-D warnings`)
- Snapshot files accepted and committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive snapshot tests for error type display implementations across BitNet error variants.
  * Added snapshot tests for generation and inference configuration handling, including validation and presets.
  * Added snapshot tests for quantization parameters, layouts, and scale factor computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->