### PR TITLE
fix(quantization): gate AVX2 imports behind x86_64, fix NEON unsafe blocks

### DIFF
--- a/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
@@ -27,6 +27,7 @@
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
 
+#[cfg(target_arch = "x86_64")]
 use crate::i2s_qk256::{QK256_BLOCK, QK256_PACKED_BYTES};
 use anyhow::Result;
 


### PR DESCRIPTION
## Summary

Fixes ARM/Apple Silicon build errors in `bitnet-quantization`:

1. **`i2s_qk256_avx2.rs`**: Gate `QK256_BLOCK` and `QK256_PACKED_BYTES` imports behind `#[cfg(target_arch = "x86_64")]` to fix unused import warnings on ARM targets
2. **`simd_ops.rs`**: Wrap NEON intrinsic calls in explicit `unsafe { }` blocks to comply with Rust 2024 edition's deny-by-default `unsafe_op_in_unsafe_fn` lint

## Testing

- `cargo clippy -p bitnet-quantization --lib --no-default-features --features cpu` passes cleanly on ARM64
- Full CI clippy command passes locally

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>