### PR TITLE
test(kernels): add kernel pipeline integration and numerical tests

### DIFF
--- a/crates/bitnet-kernels/tests/kernel_numerical_tests.rs
+++ b/crates/bitnet-kernels/tests/kernel_numerical_tests.rs
@@ -63,10 +63,7 @@ fn softmax_reference_sums_to_one_various_sizes() {
         let input = pseudo_random(size as u64, size);
         let sm = reference_softmax(&input);
         let sum: f32 = sm.iter().sum();
-        assert!(
-            (sum - 1.0).abs() < 1e-5,
-            "softmax sum={sum} for size={size}, expected ≈ 1.0"
-        );
+        assert!((sum - 1.0).abs() < 1e-5, "softmax sum={sum} for size={size}, expected ≈ 1.0");
     }
 }
 
@@ -139,10 +136,7 @@ fn attention_symmetric_input_symmetric_output() {
         for d in 0..head_dim {
             let first = output[d];
             let current = output[i * head_dim + d];
-            assert!(
-                (first - current).abs() < 1e-5,
-                "row0[{d}]={first} vs row{i}[{d}]={current}"
-            );
+            assert!((first - current).abs() < 1e-5, "row0[{d}]={first} vs row{i}[{d}]={current}");
         }
     }
 }

--- a/crates/bitnet-kernels/tests/kernel_pipeline_integration.rs
+++ b/crates/bitnet-kernels/tests/kernel_pipeline_integration.rs
@@ -82,8 +82,8 @@ fn pipeline_attention_to_projection() {
     let proj_dim = 16;
 
     let qkv = pseudo_random(7, seq_len * dim);
-    let attn_out = scaled_dot_product_attention(&qkv, &qkv, &qkv, seq_len, seq_len, dim, true)
-        .unwrap();
+    let attn_out =
+        scaled_dot_product_attention(&qkv, &qkv, &qkv, seq_len, seq_len, dim, true).unwrap();
     assert_eq!(attn_out.len(), seq_len * dim);
 
     let weight = pseudo_random(13, dim * proj_dim);
@@ -124,8 +124,7 @@ fn pipeline_full_embedding_attention_layernorm_projection() {
     assert_eq!(attn_out.len(), seq_len * embed_dim);
 
     // Step 3: Residual + LayerNorm
-    let residual: Vec<f32> =
-        embeddings.iter().zip(&attn_out).map(|(e, a)| e + a).collect();
+    let residual: Vec<f32> = embeddings.iter().zip(&attn_out).map(|(e, a)| e + a).collect();
     let gamma = vec![1.0f32; embed_dim];
     let config = LayerNormConfig::new(vec![embed_dim]);
     let normed = layer_norm(&residual, &gamma, None, &config).unwrap();
@@ -249,10 +248,9 @@ fn shape_attention_preserves_dimensions() {
     for seq_len in [1, 2, 8, 16] {
         let head_dim = 8;
         let data = vec![0.1f32; seq_len * head_dim];
-        let out = scaled_dot_product_attention(
-            &data, &data, &data, seq_len, seq_len, head_dim, false,
-        )
-        .unwrap();
+        let out =
+            scaled_dot_product_attention(&data, &data, &data, seq_len, seq_len, head_dim, false)
+                .unwrap();
         assert_eq!(out.len(), seq_len * head_dim, "attention shape mismatch for seq_len={seq_len}");
     }
 }
@@ -347,10 +345,9 @@ fn edge_large_sequence_attention() {
     let seq_len = 128;
     let head_dim = 8;
     let data = pseudo_random(1000, seq_len * head_dim);
-    let output = scaled_dot_product_attention(
-        &data, &data, &data, seq_len, seq_len, head_dim, true,
-    )
-    .unwrap();
+    let output =
+        scaled_dot_product_attention(&data, &data, &data, seq_len, seq_len, head_dim, true)
+            .unwrap();
     assert_eq!(output.len(), seq_len * head_dim);
     assert!(no_nan_inf(&output));
 }


### PR DESCRIPTION
## Summary

Add 38 new integration and numerical correctness tests for the CPU kernel pipeline across two new test files.

### kernel_pipeline_integration.rs (22 tests)
- **Kernel chaining**: embedding → attention → layernorm → projection pipeline works end-to-end
- **Determinism**: same input produces identical output across multiple invocations (matmul, attention, layernorm, quantization)
- **Shape propagation**: output dimensions match expectations through the pipeline
- **Numerical stability**: no NaN/Inf in outputs for reasonable inputs (large values, activations)
- **Edge cases**: single-element sequences, large sequences (128 tokens), zero input, causal mask structure, RoPE norm preservation

### kernel_numerical_tests.rs (16 tests)
- **Softmax sum-to-one**: verified via single-token attention pass-through and reference implementation
- **LayerNorm zero-mean**: output mean ≈ 0 with unit gamma, no beta
- **LayerNorm unit-variance**: output variance ≈ 1.0
- **RMSNorm unit-RMS**: output RMS ≈ 1.0
- **Attention symmetry**: identical input rows produce identical output rows (non-causal)
- **Quantize roundtrip**: i8 symmetric, u8 asymmetric, ternary sign preservation
- **Matmul identity**: A × I = A
- **Activation boundaries**: sigmoid(0)=0.5, silu(0)=0, gelu(0)=0
- **RoPE identity at position 0**: cos=1, sin=0 → no rotation

### Validation
- All 38 tests pass: `cargo test -p bitnet-kernels --no-default-features --features cpu`
- Clippy clean: `cargo clippy -p bitnet-kernels --no-default-features --features cpu -- -D warnings`