### PR TITLE
test: add proptest wave 13 (kernel, sampling, type properties)

### DIFF
--- a/crates/bitnet-common/tests/proptest_wave13.rs
+++ b/crates/bitnet-common/tests/proptest_wave13.rs
@@ -1,0 +1,315 @@
+//! Wave 13 property tests: common type safety, shape arithmetic, tensor
+//! validation, backend selection, and kernel registry invariants.
+//!
+//! Key invariants tested (12 properties):
+//! - Broadcast: reflexive (a⊕a = a), commutative, can_broadcast consistent
+//! - Matmul shapes: compatible shapes produce correct output dimensions
+//! - Reshape: matching element counts always succeed
+//! - Transpose: identity permutation is no-op, output shape permuted correctly
+//! - C-contiguous strides: last stride is 1, product matches element count
+//! - KernelCapabilities: from_compile_time is idempotent, cpu_rust always present
+//! - ArchitectureRegistry: known architectures are non-empty strings
+
+use bitnet_common::arch_registry::ArchitectureRegistry;
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities};
+use bitnet_common::tensor_validation::{
+    broadcast_shape, c_contiguous_strides, can_broadcast, validate_matmul_shapes, validate_reshape,
+    validate_transpose_axes,
+};
+use bitnet_common::types::Device;
+use proptest::prelude::*;
+
+// -------------------------------------------------------------------
+// Strategy helpers
+// -------------------------------------------------------------------
+
+/// Small shape vector (1-4 dims, each dim 1..=8).
+fn small_shape(max_dims: usize) -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(1usize..=8, 1..=max_dims)
+}
+
+// ===================================================================
+// 1. Broadcast shape arithmetic
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Broadcasting a shape with itself always succeeds and returns the same shape.
+    #[test]
+    fn prop_broadcast_reflexive(shape in small_shape(4)) {
+        let result = broadcast_shape(&shape, &shape).unwrap();
+        prop_assert_eq!(&result, &shape, "broadcast(a,a) should equal a");
+    }
+
+    /// Broadcasting is commutative: broadcast(a,b) == broadcast(b,a) when both succeed.
+    #[test]
+    fn prop_broadcast_commutative(
+        a in small_shape(3),
+        b in small_shape(3),
+    ) {
+        let ab = broadcast_shape(&a, &b);
+        let ba = broadcast_shape(&b, &a);
+        match (ab, ba) {
+            (Ok(r1), Ok(r2)) => prop_assert_eq!(r1, r2, "broadcast must be commutative"),
+            (Err(_), Err(_)) => {} // both fail — fine
+            (Ok(_), Err(_)) | (Err(_), Ok(_)) => {
+                prop_assert!(false, "broadcast symmetry broken: one succeeded, other failed");
+            }
+        }
+    }
+
+    /// can_broadcast is consistent with broadcast_shape.
+    #[test]
+    fn prop_can_broadcast_consistent(
+        a in small_shape(3),
+        b in small_shape(3),
+    ) {
+        let result = broadcast_shape(&a, &b);
+        let can = can_broadcast(&a, &b);
+        prop_assert_eq!(result.is_ok(), can, "can_broadcast inconsistent with broadcast_shape");
+    }
+
+    /// Broadcasting with a scalar (empty shape) always succeeds.
+    #[test]
+    fn prop_broadcast_with_scalar(shape in small_shape(4)) {
+        let result = broadcast_shape(&shape, &[]).unwrap();
+        prop_assert_eq!(&result, &shape, "broadcast(a, []) should equal a");
+    }
+}
+
+// ===================================================================
+// 2. Matmul shape validation
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// 2D matmul with compatible inner dimensions produces correct output shape.
+    #[test]
+    fn prop_matmul_2d_compatible(
+        m in 1usize..=16,
+        k in 1usize..=16,
+        n in 1usize..=16,
+    ) {
+        let result = validate_matmul_shapes(&[m, k], &[k, n]).unwrap();
+        prop_assert_eq!(result, vec![m, n], "expected [m,n] output shape");
+    }
+
+    /// 2D matmul with incompatible inner dimensions fails.
+    #[test]
+    fn prop_matmul_2d_incompatible(
+        m in 1usize..=16,
+        k1 in 1usize..=16,
+        k2 in 1usize..=16,
+        n in 1usize..=16,
+    ) {
+        prop_assume!(k1 != k2);
+        let result = validate_matmul_shapes(&[m, k1], &[k2, n]);
+        prop_assert!(result.is_err(), "mismatched inner dims should fail");
+    }
+
+    /// 1D dot product of same-length vectors succeeds with scalar output.
+    #[test]
+    fn prop_matmul_1d_dot_product(k in 1usize..=32) {
+        let result = validate_matmul_shapes(&[k], &[k]).unwrap();
+        prop_assert!(result.is_empty(), "1D dot product should produce scalar (empty shape)");
+    }
+}
+
+// ===================================================================
+// 3. Reshape validation
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Reshape with matching element counts always succeeds.
+    #[test]
+    fn prop_reshape_matching_counts(
+        a in 1usize..=8,
+        b in 1usize..=8,
+    ) {
+        let total = a * b;
+        let result = validate_reshape(&[a, b], &[total]);
+        prop_assert!(result.is_ok(), "matching element counts should succeed");
+    }
+
+    /// Reshape with mismatched element counts always fails.
+    #[test]
+    fn prop_reshape_mismatched_counts(
+        a in 2usize..=8,
+        b in 2usize..=8,
+    ) {
+        let total = a * b;
+        let result = validate_reshape(&[a, b], &[total + 1]);
+        prop_assert!(result.is_err(), "mismatched element counts should fail");
+    }
+}
+
+// ===================================================================
+// 4. Transpose validation
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Identity permutation [0,1,...,n-1] returns the original shape.
+    #[test]
+    fn prop_transpose_identity_permutation(shape in small_shape(4)) {
+        let axes: Vec<usize> = (0..shape.len()).collect();
+        let result = validate_transpose_axes(&shape, &axes).unwrap();
+        prop_assert_eq!(&result, &shape, "identity permutation should return original shape");
+    }
+
+    /// Reversing axes on a 2D shape swaps dimensions.
+    #[test]
+    fn prop_transpose_2d_swap(
+        a in 1usize..=16,
+        b in 1usize..=16,
+    ) {
+        let result = validate_transpose_axes(&[a, b], &[1, 0]).unwrap();
+        prop_assert_eq!(result, vec![b, a], "transposing [a,b] with [1,0] should give [b,a]");
+    }
+
+    /// Transpose with wrong number of axes fails.
+    #[test]
+    fn prop_transpose_wrong_axes_count(shape in small_shape(3)) {
+        let wrong_axes: Vec<usize> = (0..shape.len() + 1).collect();
+        let result = validate_transpose_axes(&shape, &wrong_axes);
+        prop_assert!(result.is_err(), "wrong axes count should fail");
+    }
+}
+
+// ===================================================================
+// 5. C-contiguous strides
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Last stride is always 1 for non-empty shapes.
+    #[test]
+    fn prop_c_strides_last_is_one(shape in small_shape(4)) {
+        let strides = c_contiguous_strides(&shape);
+        prop_assert_eq!(strides.len(), shape.len());
+        prop_assert_eq!(*strides.last().unwrap(), 1, "last stride must be 1");
+    }
+
+    /// First stride equals the product of all dimensions except the first.
+    #[test]
+    fn prop_c_strides_first_matches_trailing_product(shape in small_shape(4)) {
+        let strides = c_contiguous_strides(&shape);
+        let trailing_product: usize = shape[1..].iter().product();
+        prop_assert_eq!(
+            strides[0], trailing_product,
+            "first stride should be product of trailing dims"
+        );
+    }
+
+    /// stride[i] = stride[i+1] * shape[i+1] for all i.
+    #[test]
+    fn prop_c_strides_recurrence(
+        shape in prop::collection::vec(1usize..=8, 2..=5),
+    ) {
+        let strides = c_contiguous_strides(&shape);
+        for i in 0..shape.len() - 1 {
+            prop_assert_eq!(
+                strides[i],
+                strides[i + 1] * shape[i + 1],
+                "stride[{}] should be stride[{}] * shape[{}]", i, i + 1, i + 1
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 6. KernelCapabilities and KernelBackend
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// from_compile_time is idempotent: calling twice gives same result.
+    #[test]
+    fn prop_kernel_caps_compile_time_idempotent(_dummy in 0..1i32) {
+        let c1 = KernelCapabilities::from_compile_time();
+        let c2 = KernelCapabilities::from_compile_time();
+        let b1 = c1.compiled_backends();
+        let b2 = c2.compiled_backends();
+        prop_assert_eq!(b1, b2, "from_compile_time should be deterministic");
+    }
+
+    /// CpuRust backend is always in compiled backends.
+    #[test]
+    fn prop_kernel_caps_always_has_cpu_rust(_dummy in 0..1i32) {
+        let caps = KernelCapabilities::from_compile_time();
+        let backends = caps.compiled_backends();
+        prop_assert!(
+            backends.contains(&KernelBackend::CpuRust),
+            "CpuRust should always be compiled"
+        );
+    }
+
+    /// CpuRust does not require GPU.
+    #[test]
+    fn prop_cpu_rust_does_not_require_gpu(_dummy in 0..1i32) {
+        prop_assert!(!KernelBackend::CpuRust.requires_gpu());
+    }
+
+    /// KernelBackend::is_compiled returns true for CpuRust.
+    #[test]
+    fn prop_cpu_rust_is_compiled(_dummy in 0..1i32) {
+        prop_assert!(KernelBackend::CpuRust.is_compiled());
+    }
+}
+
+// ===================================================================
+// 7. ArchitectureRegistry
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+
+    /// All known architecture strings are non-empty.
+    #[test]
+    fn prop_known_architectures_non_empty(_dummy in 0..1i32) {
+        let archs = ArchitectureRegistry::known_architectures();
+        prop_assert!(!archs.is_empty(), "should have at least one known architecture");
+        for arch in archs {
+            prop_assert!(!arch.is_empty(), "architecture name should be non-empty");
+        }
+    }
+
+    /// Looking up a known architecture always returns Some.
+    #[test]
+    fn prop_known_architecture_lookup_succeeds(_dummy in 0..1i32) {
+        let archs = ArchitectureRegistry::known_architectures();
+        for arch in archs {
+            let result = ArchitectureRegistry::lookup(arch);
+            prop_assert!(
+                result.is_some(),
+                "lookup({arch}) should succeed for known architecture"
+            );
+        }
+    }
+
+    /// is_known is consistent with lookup for known architectures.
+    #[test]
+    fn prop_is_known_consistent_with_lookup(_dummy in 0..1i32) {
+        let archs = ArchitectureRegistry::known_architectures();
+        for arch in archs {
+            prop_assert_eq!(
+                ArchitectureRegistry::is_known(arch),
+                ArchitectureRegistry::lookup(arch).is_some()
+            );
+        }
+    }
+
+    /// Device::Cpu is the default device.
+    #[test]
+    fn prop_default_device_is_cpu(_dummy in 0..1i32) {
+        let d = Device::default();
+        prop_assert!(d.is_cpu(), "default device should be CPU");
+    }
+}

--- a/crates/bitnet-kernels/tests/proptest_wave13.rs
+++ b/crates/bitnet-kernels/tests/proptest_wave13.rs
@@ -1,0 +1,390 @@
+//! Wave 13 property tests: kernel mathematical invariants for activations,
+//! quantization, layer normalization, attention, RoPE, fusion, and SIMD math.
+//!
+//! Key invariants tested (15 properties):
+//! - Activations: sigmoid output range [0,1], relu/silu continuity at zero,
+//!   activate + activate_inplace equivalence
+//! - Quantization: ternary values always in {-1,0,1}, binary values always
+//!   in {-1,1}, symmetric i8 roundtrip error bounded, scale factor non-negative
+//! - Layer norm: RMS norm output finite and scaled, layer norm idempotent
+//!   on unit-variance input
+//! - Attention: causal mask diagonal is zero, causal mask upper triangle
+//!   is neg-infinity
+//! - RoPE: frequency array length matches config, frequencies are positive
+//! - Fusion: fused_scale_add matches unfused, fused_add_normalize preserves length
+//! - SIMD math: vector scale by 1.0 is identity, dot product self is non-negative
+
+use bitnet_kernels::cpu::activations::{
+    ActivationType, activate, activate_inplace, gelu, hard_sigmoid, relu, sigmoid, silu,
+};
+use bitnet_kernels::cpu::attention::causal_mask;
+use bitnet_kernels::cpu::fusion::{fused_add_normalize, fused_scale_add};
+use bitnet_kernels::cpu::layer_norm::{LayerNormConfig, layer_norm, rms_norm};
+use bitnet_kernels::cpu::quantize::{
+    compute_quantization_error, dequantize_symmetric_i8, quantize_binary, quantize_symmetric_i8,
+    quantize_ternary,
+};
+use bitnet_kernels::cpu::rope::{RopeConfig, compute_frequencies};
+use bitnet_kernels::cpu::simd_math::{simd_dot_product, simd_vector_scale};
+use proptest::prelude::*;
+
+// -------------------------------------------------------------------
+// Strategy helpers
+// -------------------------------------------------------------------
+
+/// Non-empty f32 vector with finite values in [-10, 10].
+fn finite_f32_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-10.0f32..10.0f32, 1..=max_len)
+}
+
+// ===================================================================
+// 1. Activations
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// sigmoid output is always in [0, 1].
+    #[test]
+    fn prop_sigmoid_output_in_unit_interval(x in -50.0f32..50.0f32) {
+        let y = sigmoid(x);
+        prop_assert!((0.0..=1.0).contains(&y), "sigmoid({x}) = {y} not in [0,1]");
+    }
+
+    /// hard_sigmoid output is always in [0, 1].
+    #[test]
+    fn prop_hard_sigmoid_output_in_unit_interval(x in -50.0f32..50.0f32) {
+        let y = hard_sigmoid(x);
+        prop_assert!((0.0..=1.0).contains(&y), "hard_sigmoid({x}) = {y} not in [0,1]");
+    }
+
+    /// relu of any value is non-negative.
+    #[test]
+    fn prop_relu_output_nonneg(x in -100.0f32..100.0f32) {
+        prop_assert!(relu(x) >= 0.0);
+    }
+
+    /// silu(0) == 0 (since silu(x) = x * sigmoid(x)).
+    #[test]
+    fn prop_silu_zero_at_origin(_dummy in 0..1i32) {
+        let y = silu(0.0);
+        prop_assert!((y - 0.0).abs() < 1e-7, "silu(0) = {y}, expected 0");
+    }
+
+    /// activate and activate_inplace produce identical results.
+    #[test]
+    fn prop_activate_matches_inplace(input in finite_f32_vec(64)) {
+        let allocated = activate(&input, ActivationType::GELU);
+        let mut inplace = input.clone();
+        activate_inplace(&mut inplace, ActivationType::GELU);
+        for (i, (&a, &b)) in allocated.iter().zip(inplace.iter()).enumerate() {
+            prop_assert!(
+                (a - b).abs() < 1e-6,
+                "mismatch at index {i}: activate={a}, inplace={b}"
+            );
+        }
+    }
+
+    /// gelu is bounded below by a known lower bound: gelu(x) > -0.17 for all x
+    /// (global minimum ≈ -0.1699).
+    #[test]
+    fn prop_gelu_bounded_below(x in -50.0f32..50.0f32) {
+        let y = gelu(x);
+        prop_assert!(y > -0.18, "gelu({x}) = {y} below expected minimum");
+    }
+}
+
+// ===================================================================
+// 2. Quantization: ternary values, binary values, roundtrip error
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Ternary quantization produces only {-1, 0, 1}.
+    #[test]
+    fn prop_ternary_values_in_set(
+        input in finite_f32_vec(128),
+        threshold in 0.0f32..5.0f32,
+    ) {
+        let q = quantize_ternary(&input, threshold);
+        for (i, &v) in q.iter().enumerate() {
+            prop_assert!(
+                v == -1 || v == 0 || v == 1,
+                "ternary[{i}] = {v}, expected {{-1,0,1}}"
+            );
+        }
+    }
+
+    /// Binary quantization produces only {-1, 1}.
+    #[test]
+    fn prop_binary_values_in_set(input in finite_f32_vec(128)) {
+        let q = quantize_binary(&input);
+        for (i, &v) in q.iter().enumerate() {
+            prop_assert!(
+                v == -1 || v == 1,
+                "binary[{i}] = {v}, expected {{-1,1}}"
+            );
+        }
+    }
+
+    /// Symmetric i8 quantization scale is non-negative.
+    #[test]
+    fn prop_symmetric_i8_scale_nonneg(
+        input in finite_f32_vec(64),
+        bits in 2u8..=8u8,
+    ) {
+        let (_, scale) = quantize_symmetric_i8(&input, bits);
+        prop_assert!(scale >= 0.0, "scale={scale} is negative");
+    }
+
+    /// Symmetric i8 roundtrip error is bounded: max_abs_error <= scale + eps.
+    #[test]
+    fn prop_symmetric_i8_roundtrip_error_bounded(
+        input in prop::collection::vec(-5.0f32..5.0f32, 2..=64),
+        bits in 2u8..=8u8,
+    ) {
+        let (q, scale) = quantize_symmetric_i8(&input, bits);
+        let deq = dequantize_symmetric_i8(&q, scale);
+        let err = compute_quantization_error(&input, &deq);
+        prop_assert!(
+            err.max_abs_error <= scale + 1e-5,
+            "max_abs_error={} > scale={}", err.max_abs_error, scale
+        );
+    }
+
+    /// Symmetric i8 quantization preserves length.
+    #[test]
+    fn prop_symmetric_i8_preserves_length(
+        input in finite_f32_vec(128),
+        bits in 2u8..=8u8,
+    ) {
+        let (q, _) = quantize_symmetric_i8(&input, bits);
+        prop_assert_eq!(q.len(), input.len());
+    }
+}
+
+// ===================================================================
+// 3. Layer normalization
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// RMS norm output has the same length as input and all values are finite.
+    #[test]
+    fn prop_rms_norm_output_finite_same_length(
+        norm_size in 1usize..=32,
+        batch_size in 1usize..=8,
+    ) {
+        let n = batch_size * norm_size;
+        let input: Vec<f32> = (0..n).map(|i| (i as f32) * 0.1 - 1.0).collect();
+        let gamma = vec![1.0f32; norm_size];
+        let config = LayerNormConfig::new(vec![norm_size]);
+
+        let output = rms_norm(&input, &gamma, &config).unwrap();
+        prop_assert_eq!(output.len(), n, "output length mismatch");
+        for (i, &v) in output.iter().enumerate() {
+            prop_assert!(v.is_finite(), "rms_norm output[{i}] = {v} is not finite");
+        }
+    }
+
+    /// Layer norm with identity affine (gamma=1, beta=0) produces zero-mean output.
+    #[test]
+    fn prop_layer_norm_identity_affine_zero_mean(
+        norm_size in 2usize..=32,
+        batch_size in 1usize..=4,
+    ) {
+        let n = batch_size * norm_size;
+        let input: Vec<f32> = (0..n).map(|i| (i as f32) * 0.3 - 5.0).collect();
+        let gamma = vec![1.0f32; norm_size];
+        let beta = vec![0.0f32; norm_size];
+        let config = LayerNormConfig::new(vec![norm_size]);
+
+        let output = layer_norm(&input, &gamma, Some(&beta), &config).unwrap();
+        for b in 0..batch_size {
+            let start = b * norm_size;
+            let slice = &output[start..start + norm_size];
+            let mean: f32 = slice.iter().sum::<f32>() / norm_size as f32;
+            prop_assert!(
+                mean.abs() < 1e-4,
+                "batch {b}: mean = {mean}, expected ~0"
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 4. Attention: causal mask properties
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Causal mask diagonal is always 0.0 (token can attend to itself).
+    #[test]
+    fn prop_causal_mask_diagonal_zero(seq_len in 1usize..=32) {
+        let mask = causal_mask(seq_len);
+        for i in 0..seq_len {
+            let val = mask[i * seq_len + i];
+            prop_assert!(
+                val == 0.0,
+                "mask[{i},{i}] = {val}, expected 0.0"
+            );
+        }
+    }
+
+    /// Causal mask upper triangle is NEG_INFINITY (future tokens masked).
+    #[test]
+    fn prop_causal_mask_upper_neg_inf(seq_len in 2usize..=32) {
+        let mask = causal_mask(seq_len);
+        for i in 0..seq_len {
+            for j in (i + 1)..seq_len {
+                let val = mask[i * seq_len + j];
+                prop_assert!(
+                    val == f32::NEG_INFINITY,
+                    "mask[{i},{j}] = {val}, expected NEG_INFINITY"
+                );
+            }
+        }
+    }
+
+    /// Causal mask lower triangle is 0.0 (past tokens visible).
+    #[test]
+    fn prop_causal_mask_lower_zero(seq_len in 2usize..=32) {
+        let mask = causal_mask(seq_len);
+        for i in 1..seq_len {
+            for j in 0..i {
+                let val = mask[i * seq_len + j];
+                prop_assert!(
+                    val == 0.0,
+                    "mask[{i},{j}] = {val}, expected 0.0"
+                );
+            }
+        }
+    }
+}
+
+// ===================================================================
+// 5. RoPE: frequency array properties
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// compute_frequencies returns max_seq_len * head_dim values, all finite.
+    #[test]
+    fn prop_rope_frequencies_finite_and_correct_length(
+        head_dim in prop::sample::select(vec![2usize, 4, 8, 16, 32, 64]),
+    ) {
+        let max_seq = 16usize;
+        let config = RopeConfig::new(head_dim, max_seq);
+        let freqs = compute_frequencies(&config);
+        prop_assert_eq!(
+            freqs.len(),
+            max_seq * head_dim,
+            "expected max_seq_len * head_dim elements"
+        );
+        for (i, &f) in freqs.iter().enumerate() {
+            prop_assert!(f.is_finite(), "freq[{}] = {} is not finite", i, f);
+        }
+    }
+
+    /// RoPE cos/sin values are bounded in [-1, 1].
+    #[test]
+    fn prop_rope_frequencies_bounded(
+        head_dim in prop::sample::select(vec![4usize, 8, 16, 32, 64]),
+    ) {
+        let config = RopeConfig::new(head_dim, 16);
+        let freqs = compute_frequencies(&config);
+        for (i, &f) in freqs.iter().enumerate() {
+            prop_assert!(
+                (-1.0..=1.0).contains(&f),
+                "freq[{}]={} out of [-1, 1] (cos/sin range)",
+                i, f
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 6. Fusion: fused_scale_add identity, length preservation
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// fused_scale_add with scale=1.0 is equivalent to vector addition.
+    #[test]
+    fn prop_fused_scale_add_identity_scale(
+        len in 1usize..=64,
+    ) {
+        let a: Vec<f32> = (0..len).map(|i| i as f32 * 0.5).collect();
+        let b: Vec<f32> = (0..len).map(|i| i as f32 * -0.3).collect();
+        let result = fused_scale_add(&a, &b, 1.0).unwrap();
+        for i in 0..len {
+            let expected = a[i] + b[i];
+            prop_assert!(
+                (result[i] - expected).abs() < 1e-6,
+                "index {i}: result={}, expected={}", result[i], expected
+            );
+        }
+    }
+
+    /// fused_add_normalize output has same length as input.
+    #[test]
+    fn prop_fused_add_normalize_preserves_length(
+        norm_size in 1usize..=16,
+        batch_size in 1usize..=4,
+    ) {
+        let n = norm_size * batch_size;
+        let a: Vec<f32> = (0..n).map(|i| i as f32 * 0.1).collect();
+        let b: Vec<f32> = (0..n).map(|i| i as f32 * -0.05).collect();
+        let gamma = vec![1.0f32; norm_size];
+        let eps = 1e-5;
+        let result = fused_add_normalize(&a, &b, &gamma, eps);
+        match result {
+            Ok(out) => prop_assert_eq!(out.len(), n),
+            Err(_) => { /* dimension validation may reject — that's fine */ }
+        }
+    }
+}
+
+// ===================================================================
+// 7. SIMD math: scale identity, dot product self non-negative
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Scaling a vector by 1.0 returns the original values.
+    #[test]
+    fn prop_simd_vector_scale_identity(input in finite_f32_vec(128)) {
+        let result = simd_vector_scale(&input, 1.0);
+        for (i, (&orig, &scaled)) in input.iter().zip(result.iter()).enumerate() {
+            prop_assert!(
+                (orig - scaled).abs() < 1e-6,
+                "index {i}: orig={orig}, scaled={scaled}"
+            );
+        }
+    }
+
+    /// Dot product of a vector with itself is non-negative.
+    #[test]
+    fn prop_simd_dot_self_nonneg(input in finite_f32_vec(128)) {
+        let dot = simd_dot_product(&input, &input);
+        prop_assert!(dot >= -1e-6, "dot(x,x) = {dot} is negative");
+    }
+
+    /// Scaling by 0.0 produces all zeros.
+    #[test]
+    fn prop_simd_vector_scale_zero(input in finite_f32_vec(64)) {
+        let result = simd_vector_scale(&input, 0.0);
+        for (i, &v) in result.iter().enumerate() {
+            prop_assert!(
+                v == 0.0,
+                "index {i}: expected 0.0, got {v}"
+            );
+        }
+    }
+}

--- a/crates/bitnet-sampling/tests/proptest_wave13.rs
+++ b/crates/bitnet-sampling/tests/proptest_wave13.rs
@@ -1,0 +1,432 @@
+//! Wave 13 property tests: sampling strategy invariants for temperature
+//! scaling, top-k/top-p filtering, repetition penalty, min-p, typical,
+//! mirostat, and sampler chain composition.
+//!
+//! Key invariants tested (15 properties):
+//! - Temperature: higher temperature increases entropy of softmax output
+//! - Top-k: after apply_top_k, at most k entries are finite
+//! - Top-p: surviving probabilities sum to >= top_p
+//! - Repetition penalty: penalty > 1 reduces positive logit of penalized token
+//! - Min-p: all surviving probabilities >= min_p * max_prob
+//! - Mirostat: sample output is always a valid token index
+//! - SamplerChain: builder produces correct stage count, sample in range
+//! - RepetitionPenaltyConfig: frequency penalty reduces logit proportionally
+//! - SamplingStrategy: greedy with same seed is deterministic, output in range
+
+use bitnet_logits::{
+    apply_min_p, apply_repetition_penalty, apply_temperature, apply_top_k, apply_top_p, argmax,
+    softmax_in_place,
+};
+use bitnet_sampling::{
+    MinPSampler, MirostatSampler, RepetitionPenaltyConfig, SamplerChain, SamplingConfig,
+    SamplingStrategy, TypicalSampler,
+};
+use proptest::prelude::*;
+
+// -------------------------------------------------------------------
+// Strategy helpers
+// -------------------------------------------------------------------
+
+/// Non-empty f32 vector with finite values in [-5, 5] for logits.
+fn logits_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-5.0f32..5.0f32, 2..=max_len)
+}
+
+/// Probability-like vector (non-negative, sums roughly to 1).
+fn prob_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(0.01f32..1.0f32, 2..=max_len).prop_map(|v| {
+        let sum: f32 = v.iter().sum();
+        v.into_iter().map(|x| x / sum).collect::<Vec<f32>>()
+    })
+}
+
+// ===================================================================
+// 1. Temperature scaling: higher temp → more uniform distribution
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Higher temperature produces a more uniform (higher entropy) distribution.
+    #[test]
+    fn prop_higher_temp_higher_entropy(
+        logits in logits_vec(32),
+    ) {
+        let mut low = logits.clone();
+        apply_temperature(&mut low, 0.5);
+        softmax_in_place(&mut low);
+        let entropy_low: f32 = low.iter()
+            .filter(|&&p| p > 0.0)
+            .map(|&p| -p * p.ln())
+            .sum();
+
+        let mut high = logits.clone();
+        apply_temperature(&mut high, 2.0);
+        softmax_in_place(&mut high);
+        let entropy_high: f32 = high.iter()
+            .filter(|&&p| p > 0.0)
+            .map(|&p| -p * p.ln())
+            .sum();
+
+        prop_assert!(
+            entropy_high >= entropy_low - 1e-5,
+            "entropy_high={entropy_high} < entropy_low={entropy_low}"
+        );
+    }
+
+    /// Temperature 1.0 is a no-op on logits.
+    #[test]
+    fn prop_temperature_one_noop(logits in logits_vec(32)) {
+        let mut buf = logits.clone();
+        apply_temperature(&mut buf, 1.0);
+        for (i, (&orig, &after)) in logits.iter().zip(buf.iter()).enumerate() {
+            prop_assert!(
+                (orig - after).abs() < 1e-6,
+                "index {i}: orig={orig}, after={after}"
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 2. Top-k: at most k entries remain finite
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// After apply_top_k, the number of finite entries is at most k.
+    #[test]
+    fn prop_top_k_keeps_at_most_k(
+        logits in logits_vec(32),
+        k in 1usize..=10,
+    ) {
+        let mut buf = logits.clone();
+        let kept = apply_top_k(&mut buf, k);
+        prop_assert!(
+            kept <= k,
+            "kept={kept} > k={k}"
+        );
+        let finite_count = buf.iter().filter(|x| x.is_finite()).count();
+        prop_assert!(
+            finite_count <= k,
+            "finite_count={finite_count} > k={k}"
+        );
+    }
+
+    /// Top-k with k >= len is a no-op (all entries preserved).
+    #[test]
+    fn prop_top_k_large_k_noop(logits in logits_vec(16)) {
+        let mut buf = logits.clone();
+        let kept = apply_top_k(&mut buf, logits.len() + 10);
+        prop_assert_eq!(kept, logits.len());
+        for (i, (&orig, &after)) in logits.iter().zip(buf.iter()).enumerate() {
+            prop_assert!(
+                (orig - after).abs() < 1e-6,
+                "index {i}: changed from {orig} to {after}"
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 3. Top-p: surviving mass >= top_p
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// After apply_top_p, the sum of surviving probabilities >= top_p.
+    #[test]
+    fn prop_top_p_surviving_mass(
+        probs in prob_vec(16),
+        top_p in 0.1f32..0.99f32,
+    ) {
+        let mut buf = probs.clone();
+        apply_top_p(&mut buf, top_p);
+        let surviving_sum: f32 = buf.iter().sum();
+        prop_assert!(
+            surviving_sum >= top_p - 1e-5,
+            "surviving_sum={surviving_sum} < top_p={top_p}"
+        );
+    }
+
+    /// apply_top_p with top_p=1.0 is a no-op.
+    #[test]
+    fn prop_top_p_one_noop(probs in prob_vec(16)) {
+        let mut buf = probs.clone();
+        apply_top_p(&mut buf, 1.0);
+        for (i, (&orig, &after)) in probs.iter().zip(buf.iter()).enumerate() {
+            prop_assert!(
+                (orig - after).abs() < 1e-6,
+                "index {i}: changed from {orig} to {after}"
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 4. Repetition penalty: penalized tokens get reduced logits
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// apply_repetition_penalty with penalty > 1 reduces positive logits.
+    #[test]
+    fn prop_repetition_penalty_reduces_positive(
+        logits in prop::collection::vec(0.1f32..5.0f32, 4..=16),
+        penalty in 1.1f32..3.0f32,
+    ) {
+        let token_id = 0u32;
+        let orig = logits[0];
+        let mut buf = logits.clone();
+        apply_repetition_penalty(&mut buf, &[token_id], penalty);
+        prop_assert!(
+            buf[0] < orig + 1e-6,
+            "penalized logit {} not reduced from original {}", buf[0], orig
+        );
+    }
+
+    /// RepetitionPenaltyConfig frequency penalty is proportional to count.
+    #[test]
+    fn prop_rep_config_frequency_proportional(
+        base_logit in 1.0f32..5.0f32,
+        freq_penalty in 0.1f32..1.0f32,
+    ) {
+        let config = RepetitionPenaltyConfig {
+            frequency_penalty: freq_penalty,
+            presence_penalty: 0.0,
+            count_penalty: 1.0,
+        };
+        let mut logits1 = vec![base_logit; 4];
+        let mut logits2 = vec![base_logit; 4];
+        config.apply(&mut logits1, &[(0, 1)]);
+        config.apply(&mut logits2, &[(0, 2)]);
+        prop_assert!(
+            logits2[0] < logits1[0] + 1e-6,
+            "count=2 logit {} not less than count=1 logit {}", logits2[0], logits1[0]
+        );
+    }
+}
+
+// ===================================================================
+// 5. Min-p: surviving probabilities above threshold
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// After apply_min_p, all surviving probabilities >= min_p * max_prob.
+    #[test]
+    fn prop_min_p_threshold_respected(
+        probs in prob_vec(16),
+        min_p in 0.01f32..0.5f32,
+    ) {
+        let max_prob = probs.iter().copied().fold(0.0f32, f32::max);
+        let threshold = min_p * max_prob;
+        let mut buf = probs.clone();
+        apply_min_p(&mut buf, min_p);
+        for (i, &p) in buf.iter().enumerate() {
+            if p > 0.0 {
+                prop_assert!(
+                    p >= threshold - 1e-6,
+                    "probs[{i}]={p} < threshold={threshold}"
+                );
+            }
+        }
+    }
+
+    /// MinPSampler.filter zeroes the same entries as apply_min_p.
+    #[test]
+    fn prop_min_p_sampler_matches_raw(
+        probs in prob_vec(16),
+        min_p in 0.01f32..0.5f32,
+    ) {
+        let sampler = MinPSampler::new(min_p);
+        let mut via_sampler = probs.clone();
+        sampler.filter(&mut via_sampler);
+        let mut via_raw = probs.clone();
+        apply_min_p(&mut via_raw, min_p);
+        for (i, (&a, &b)) in via_sampler.iter().zip(via_raw.iter()).enumerate() {
+            prop_assert!(
+                (a - b).abs() < 1e-6,
+                "index {i}: sampler={a}, raw={b}"
+            );
+        }
+    }
+}
+
+// ===================================================================
+// 6. Mirostat: output is always a valid token index
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// MirostatSampler always returns an index within vocab size.
+    #[test]
+    fn prop_mirostat_output_in_range(
+        logits in logits_vec(32),
+        tau in 1.0f32..10.0f32,
+    ) {
+        let mut sampler = MirostatSampler::new(tau, 0.1, Some(42));
+        let token = sampler.sample(&logits).unwrap();
+        prop_assert!(
+            (token as usize) < logits.len(),
+            "token={token} >= vocab_size={}", logits.len()
+        );
+    }
+
+    /// MirostatSampler.reset restores mu to 2*tau.
+    #[test]
+    fn prop_mirostat_reset_restores_mu(
+        tau in 1.0f32..10.0f32,
+    ) {
+        let mut sampler = MirostatSampler::new(tau, 0.1, Some(0));
+        let logits = vec![1.0, 2.0, 0.5, -1.0];
+        let _ = sampler.sample(&logits);
+        let _ = sampler.sample(&logits);
+        sampler.reset();
+        prop_assert!(
+            (sampler.mu - 2.0 * tau).abs() < 1e-6,
+            "mu={} != 2*tau={}", sampler.mu, 2.0 * tau
+        );
+    }
+}
+
+// ===================================================================
+// 7. TypicalSampler: at least one token survives
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// TypicalSampler.filter keeps at least one non-zero probability.
+    #[test]
+    fn prop_typical_keeps_at_least_one(
+        probs in prob_vec(16),
+        typical_p in 0.1f32..0.99f32,
+    ) {
+        let sampler = TypicalSampler::new(typical_p);
+        let mut buf = probs.clone();
+        sampler.filter(&mut buf);
+        let nonzero = buf.iter().filter(|&&p| p > 0.0).count();
+        prop_assert!(
+            nonzero >= 1,
+            "typical filter zeroed all probabilities"
+        );
+    }
+}
+
+// ===================================================================
+// 8. SamplerChain: builder, sample in range
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// SamplerChain.sample always returns an index within vocab size.
+    #[test]
+    fn prop_sampler_chain_output_in_range(
+        logits in logits_vec(32),
+    ) {
+        let chain = SamplerChain::builder()
+            .temperature(0.8)
+            .top_k(10)
+            .top_p(0.9)
+            .build(Some(42));
+        let token = chain.sample(&logits).unwrap();
+        prop_assert!(
+            (token as usize) < logits.len(),
+            "token={token} >= vocab_size={}", logits.len()
+        );
+    }
+
+    /// SamplerChain builder accumulates stages correctly.
+    #[test]
+    fn prop_sampler_chain_stage_count(
+        use_top_k in proptest::bool::ANY,
+        use_min_p in proptest::bool::ANY,
+    ) {
+        let mut builder = SamplerChain::builder().temperature(0.7);
+        let mut expected = 1; // temperature
+        if use_top_k {
+            builder = builder.top_k(10);
+            expected += 1;
+        }
+        if use_min_p {
+            builder = builder.min_p(0.05);
+            expected += 1;
+        }
+        let chain = builder.build(Some(42));
+        prop_assert_eq!(
+            chain.stages().len(),
+            expected,
+            "expected {} stages", expected
+        );
+    }
+}
+
+// ===================================================================
+// 9. SamplingStrategy: determinism, output range
+// ===================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// SamplingStrategy with same seed produces same token.
+    #[test]
+    fn prop_sampling_strategy_deterministic_with_seed(
+        logits in logits_vec(16),
+        seed in 0u64..1000,
+    ) {
+        let config1 = SamplingConfig {
+            temperature: 0.7,
+            seed: Some(seed),
+            ..Default::default()
+        };
+        let config2 = SamplingConfig {
+            temperature: 0.7,
+            seed: Some(seed),
+            ..Default::default()
+        };
+        let mut s1 = SamplingStrategy::new(config1);
+        let mut s2 = SamplingStrategy::new(config2);
+        let t1 = s1.sample(&logits, &[]).unwrap();
+        let t2 = s2.sample(&logits, &[]).unwrap();
+        prop_assert_eq!(t1, t2, "same seed should produce same token");
+    }
+
+    /// SamplingStrategy output is always within vocab range.
+    #[test]
+    fn prop_sampling_strategy_output_in_range(
+        logits in logits_vec(16),
+    ) {
+        let config = SamplingConfig {
+            temperature: 0.7,
+            seed: Some(42),
+            ..Default::default()
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&logits, &[]).unwrap();
+        prop_assert!(
+            (token as usize) < logits.len(),
+            "token={token} >= vocab_size={}", logits.len()
+        );
+    }
+
+    /// Greedy sampling (temp=0) always returns argmax.
+    #[test]
+    fn prop_greedy_returns_argmax(logits in logits_vec(16)) {
+        let config = SamplingConfig {
+            temperature: 0.0,
+            seed: Some(0),
+            ..Default::default()
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&logits, &[]).unwrap();
+        let expected = argmax(&logits) as u32;
+        prop_assert_eq!(token, expected, "greedy should pick argmax");
+    }
+}


### PR DESCRIPTION
## Proptest Wave 13

Adds **64 property-based tests** across 3 crates:

### bitnet-kernels (23 properties)
- **Activations**: sigmoid/hard_sigmoid range, relu nonneg, silu zero, gelu bound
- **Quantization**: ternary/binary value sets, i8 scale/roundtrip/length
- **Layer norm**: rms_norm finite, layer_norm zero mean
- **Attention**: causal mask diagonal/upper/lower triangular
- **RoPE**: frequency array length/finiteness, cos/sin bounds
- **Fusion**: fused_scale_add identity, fused_add_normalize length
- **SIMD math**: scale identity/zero, dot self nonneg

### bitnet-sampling (18 properties)
- **Temperature**: entropy ordering, identity at 1.0
- **Top-k**: at most k survivors, large k noop
- **Top-p**: surviving mass threshold, identity at 1.0
- **Repetition penalty**: reduces positive logits, frequency proportional
- **Min-p**: threshold respected, sampler parity
- **Mirostat**: output range, reset restores mu
- **Typical**: keeps at least one token
- **Sampler chain**: output range, stage count
- **Sampling strategy**: deterministic seeds, output range, greedy argmax

### bitnet-common (23 properties)
- **Broadcast**: reflexive, commutative, scalar, consistency
- **Matmul shapes**: 2D compatible/incompatible, 1D dot product
- **Reshape**: matching/mismatched element counts
- **Transpose**: identity permutation, 2D swap, wrong axes
- **C-contiguous strides**: last=1, first=trailing product, recurrence
- **Kernel capabilities**: compile_time idempotent, cpu_rust presence
- **Architecture registry**: known non-empty, lookup succeeds, is_known
- **Device**: default is CPU

All 64 tests pass locally.