### PR TITLE
feat(kernels): add CUDA RoPE kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cuda/rope.rs
+++ b/crates/bitnet-kernels/src/cuda/rope.rs
@@ -1070,6 +1070,7 @@ mod tests {
 
     #[test]
     #[ignore = "requires CUDA runtime — run with --features gpu on GPU hardware"]
+    #[allow(unused_variables, unused_mut)]
     fn test_cuda_rope_launch() {
         let cfg = RopeConfig::for_shape(128, 32, 64).unwrap();
         let total = 32 * 64 * 128;
@@ -1081,6 +1082,7 @@ mod tests {
 
     #[test]
     #[ignore = "requires CUDA runtime — run with --features gpu on GPU hardware"]
+    #[allow(unused_variables, unused_mut)]
     fn test_cuda_rope_backward_launch() {
         let cfg = RopeConfig::for_shape(128, 32, 64).unwrap();
         let total = 32 * 64 * 128;
@@ -1441,6 +1443,7 @@ mod tests {
 
     #[test]
     #[ignore = "requires CUDA runtime — compile-check for kernel source strings"]
+    #[allow(unused_variables, unused_mut)]
     fn test_cuda_kernel_sources_compile() {
         #[cfg(any(feature = "gpu", feature = "cuda"))]
         {


### PR DESCRIPTION
## Summary

Adds `#[allow(unused_variables, unused_mut)]` attributes to GPU-gated tests in
`crates/bitnet-kernels/src/cuda/rope.rs` for consistency with project conventions.

### Existing implementation (already on main)

The CUDA RoPE kernel module provides:

- **`RopeConfig`** with `head_dim`, `max_seq_len`, `base` (default 10000.0), `interleaved` flag
- **`compute_sincos_table`** / **`build_rope_freqs`**: precomputed cos/sin frequency tables
- **`rope_forward_cpu`**: CPU fallback applying RoPE to query/key tensors
- **`ROPE_FORWARD_KERNEL_SRC`** / **`ROPE_BACKWARD_KERNEL_SRC`**: CUDA kernel source strings
- **`rope_forward`**: automatic GPU→CPU dispatch
- **`apply_rope`** / **`apply_rope_batched`**: explicit-position and batched APIs
- **`rope_backward_cpu`** / **`rope_backward`**: backward pass with dispatch

### Tests (58 total)

- Config construction and validation (12 tests)
- Sin/cos table generation and correctness (6 tests)
- CPU forward: identity at pos-0, norm preservation, basic rotation, position offset, multi-head, various dims/seq lengths, buffer mismatch, custom base, scaling factor (14 tests)
- Property tests: zero input preserved, different positions differ, norm preservation (3 tests)
- Inverse frequency table verification (1 test)
- Runtime dispatch (1 test)
- GPU-gated launch stubs with `#[ignore]` (3 tests)
- Interleaved layout (5 tests)
- `build_rope_freqs` standalone API (4 tests)
- `apply_rope` explicit positions (4 tests)
- `apply_rope_batched` (3 tests)
- Backward pass correctness and roundtrip (6 tests)

### Registered in `cuda/mod.rs`

`pub mod rope;` with full re-exports of all public items.