### PR TITLE
feat(kernels): add OpenCL device warmup module for A770 GPU init

### DIFF
--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -22,12 +22,12 @@ pub mod metal_compute;
 #[cfg(feature = "npu-backend")]
 pub mod npu;
 pub mod opencl_buffer;
-pub mod opencl_warmup;
 pub mod opencl_cache;
 pub mod opencl_context;
 pub mod opencl_embedding;
 pub mod opencl_kernel_sources;
 pub mod opencl_pipeline;
+pub mod opencl_warmup;
 pub mod opencl_work_size;
 pub mod reduction;
 #[cfg(feature = "rocm")]

--- a/crates/bitnet-kernels/src/opencl_warmup.rs
+++ b/crates/bitnet-kernels/src/opencl_warmup.rs
@@ -112,7 +112,9 @@ impl WarmupConfig {
     /// Validate the config, returning an error if invalid.
     pub fn validate(&self) -> Result<(), WarmupError> {
         if self.dry_run_matmul && self.dry_run_size == 0 {
-            return Err(WarmupError::InvalidConfig("dry_run_size must be > 0 when dry_run_matmul is enabled".into()));
+            return Err(WarmupError::InvalidConfig(
+                "dry_run_size must be > 0 when dry_run_matmul is enabled".into(),
+            ));
         }
         if self.timeout_ms == 0 {
             return Err(WarmupError::InvalidConfig("timeout_ms must be > 0".into()));
@@ -147,10 +149,7 @@ impl WarmupReport {
     pub fn summary(&self) -> String {
         let ok = self.results.iter().filter(|r| r.success).count();
         let total = self.results.len();
-        format!(
-            "Warmup: {ok}/{total} phases succeeded in {ms}ms",
-            ms = self.total_duration_ms,
-        )
+        format!("Warmup: {ok}/{total} phases succeeded in {ms}ms", ms = self.total_duration_ms,)
     }
 
     /// Return phases that failed.
@@ -647,17 +646,14 @@ mod tests {
 
     #[test]
     fn test_error_display_phase_failed() {
-        let e = WarmupError::PhaseFailed {
-            phase: WarmupPhase::MemoryAllocation,
-            reason: "OOM".into(),
-        };
+        let e =
+            WarmupError::PhaseFailed { phase: WarmupPhase::MemoryAllocation, reason: "OOM".into() };
         assert_eq!(e.to_string(), "warmup phase MemoryAllocation failed: OOM");
     }
 
     #[test]
     fn test_error_is_std_error() {
-        let e: Box<dyn std::error::Error> =
-            Box::new(WarmupError::InvalidConfig("x".into()));
+        let e: Box<dyn std::error::Error> = Box::new(WarmupError::InvalidConfig("x".into()));
         assert!(!e.to_string().is_empty());
     }
 


### PR DESCRIPTION
## Summary

Add opencl_warmup module to itnet-kernels for managing A770 GPU warmup routines that reduce first-use latency from JIT compilation and device initialization.

## Changes

- **WarmupPhase** enum: DeviceInit, KernelCompilation, MemoryAllocation, DryRun, Complete with Display
- **WarmupConfig** with ast(), 	horough(), minimal() presets and validation
- **WarmupResult** / **WarmupReport** with summary(), ailed_phases(), slowest_phase()
- **DeviceWarmer** with un_warmup(), is_warmed(), stimated_warmup_time_ms()
- **WarmupError** enum with Display + Error
- Wired into lib.rs as pub mod opencl_warmup

## Testing

43 unit tests covering config presets, phase ordering, report methods, state tracking, error display, timeout handling, idempotency, and edge cases.