### PR TITLE
feat(kernels): OpenCL telemetry module for A770 GPU inference monitoring

### DIFF
--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -22,12 +22,12 @@ pub mod metal_compute;
 #[cfg(feature = "npu-backend")]
 pub mod npu;
 pub mod opencl_buffer;
-pub mod opencl_telemetry;
 pub mod opencl_cache;
 pub mod opencl_context;
 pub mod opencl_embedding;
 pub mod opencl_kernel_sources;
 pub mod opencl_pipeline;
+pub mod opencl_telemetry;
 pub mod opencl_work_size;
 pub mod reduction;
 #[cfg(feature = "rocm")]

--- a/crates/bitnet-kernels/src/opencl_telemetry.rs
+++ b/crates/bitnet-kernels/src/opencl_telemetry.rs
@@ -79,13 +79,7 @@ impl MetricSample {
         value: f64,
         unit: impl Into<String>,
     ) -> Self {
-        Self {
-            metric_type,
-            name: name.into(),
-            value,
-            unit: unit.into(),
-            timestamp_ns: now_ns(),
-        }
+        Self { metric_type, name: name.into(), value, unit: unit.into(), timestamp_ns: now_ns() }
     }
 }
 
@@ -106,7 +100,13 @@ pub struct MetricAggregation {
 impl MetricAggregation {
     fn from_values(values: &[f64]) -> Self {
         if values.is_empty() {
-            return Self { count: 0, sum: 0.0, min: f64::INFINITY, max: f64::NEG_INFINITY, values: Vec::new() };
+            return Self {
+                count: 0,
+                sum: 0.0,
+                min: f64::INFINITY,
+                max: f64::NEG_INFINITY,
+                values: Vec::new(),
+            };
         }
         let count = values.len() as u64;
         let sum: f64 = values.iter().sum();
@@ -363,11 +363,7 @@ fn escape_json(s: &str) -> String {
 }
 
 fn format_f64(v: f64) -> String {
-    if v == v.floor() && v.abs() < 1e15 {
-        format!("{v:.1}")
-    } else {
-        format!("{v}")
-    }
+    if v == v.floor() && v.abs() < 1e15 { format!("{v:.1}") } else { format!("{v}") }
 }
 
 // ---------------------------------------------------------------------------
@@ -446,8 +442,13 @@ mod tests {
     fn ring_buffer_evicts_oldest() {
         let mut col = TelemetryCollector::new(3);
         for i in 0..5 {
-            col.record(MetricSample::new(MetricType::KernelExecution, format!("k{i}"), i as f64, "ms"))
-                .unwrap();
+            col.record(MetricSample::new(
+                MetricType::KernelExecution,
+                format!("k{i}"),
+                i as f64,
+                "ms",
+            ))
+            .unwrap();
         }
         assert_eq!(col.sample_count(), 3);
         assert_eq!(col.samples[0].name, "k2");


### PR DESCRIPTION
## Summary

Adds an OpenCL telemetry/metrics collection module for monitoring A770 GPU inference performance.

### New: \crates/bitnet-kernels/src/opencl_telemetry.rs\

- **MetricType** enum: KernelExecution, MemoryTransfer, BufferAllocation, QueueSubmit, CompilationTime, Throughput (with Display)
- **MetricSample** struct: individual metric data points with type, name, value, unit, timestamp
- **MetricAggregation** struct: count/sum/min/max with mean(), variance(), std_dev(), percentile_estimate(p)
- **TelemetryCollector** struct: ring-buffer collection with enable/disable, aggregate by type/name, samples_since, hand-rolled JSON export (no serde dep), human-readable summary
- **InferenceMetrics** struct: tokens_per_second(), gpu_utilization(), kernel_overhead_pct()
- **TelemetryError** enum with Display + std::error::Error

### Tests

44 unit tests covering:
- Record/retrieve samples, ring buffer eviction, aggregation (mean/min/max/stddev/variance)
- Aggregate by type and by name, JSON export format validation, summary formatting
- Enable/disable toggle, InferenceMetrics calculations, empty collector edge cases
- Clear resets state, concurrent-style recording patterns, percentile estimation, large sample sets

### Wiring

Module registered as \pub mod opencl_telemetry\ in \crates/bitnet-kernels/src/lib.rs\.