### PR TITLE
fix(wgpu): replace redundant closures with function references

### DIFF
--- a/crates/bitnet-wgpu/src/buffer.rs
+++ b/crates/bitnet-wgpu/src/buffer.rs
@@ -84,7 +84,7 @@ impl GpuBuffer {
         });
         device.device().poll(wgpu::Maintain::Wait);
 
-        rx.recv().map_err(|e| WgpuError::mapping(e))?.map_err(|e| WgpuError::mapping(e))?;
+        rx.recv().map_err(WgpuError::mapping)?.map_err(WgpuError::mapping)?;
 
         let view = slice.get_mapped_range();
         let result: Vec<T> = bytemuck::cast_slice(&view).to_vec();

--- a/crates/bitnet-wgpu/src/device.rs
+++ b/crates/bitnet-wgpu/src/device.rs
@@ -80,7 +80,7 @@ impl WgpuDevice {
                 None,
             )
             .await
-            .map_err(|e| WgpuError::device(e))?;
+            .map_err(WgpuError::device)?;
 
         tracing::info!(
             adapter = %adapter.get_info().name,


### PR DESCRIPTION
Fixes `clippy::redundant_closure` warnings that were blocking Feature cpu CI check for all PRs.