### PR TITLE
test(kernels): add comprehensive batch normalization tests

### DIFF
--- a/crates/bitnet-kernels/src/cpu/batch_norm.rs
+++ b/crates/bitnet-kernels/src/cpu/batch_norm.rs
@@ -1091,7 +1091,7 @@ mod tests {
             /// All outputs should be finite for arbitrary finite inputs.
             #[test]
             fn prop_output_always_finite(
-                (batch, features, input) in bn_scenario()
+                (_batch, features, input) in bn_scenario()
             ) {
                 let cfg = BatchNormConfig {
                     num_features: features, eps: 1e-5, momentum: 0.1, training: true,


### PR DESCRIPTION
## Summary

Add 28 new tests to the `cpu/batch_norm` module in `bitnet-kernels`, bringing the total from 36 to 64 passing tests.

### Test Categories

| Category | Count | Description |
|----------|-------|-------------|
| Known-value forward pass | 3 | Single/multi channel, affine transform verification |
| Edge cases | 7 | All zeros, negatives, symmetric, single element, large batch/features, constant per-channel |
| Epsilon effects | 3 | Zero-variance sensitivity, magnitude impact, zero-mean preservation |
| Momentum effects | 4 | Zero/full momentum, convergence over 100 batches, interpolation |
| Numerical stability | 5 | Very large/small/mixed/subnormal values, large running variance |
| Property tests (proptest) | 6 | Output mean ≈ 0, variance ≈ 1, finite outputs, bounded running stats, eval determinism |

### Notes

- Tests target the `cpu::batch_norm` module which compiles with `--features cpu` (the `cuda` module is feature-gated behind `gpu`/`cuda` features)
- All 64 tests pass, fmt clean, clippy clean
- Property tests use `proptest` for randomized invariant checking across batch sizes 1–64 and feature counts 1–16

### Verification

```
cargo test -p bitnet-kernels --no-default-features --features cpu --lib -- batch_norm
# test result: ok. 64 passed; 0 failed; 0 ignored
```