### PR TITLE
🛡️ Sentinel: [Security Improvement] Add HTTP Strict Transport Security (HSTS) header

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -439,6 +439,10 @@ pub async fn security_headers_middleware(request: Request, next: Next) -> Respon
         "Content-Security-Policy",
         "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'".parse().unwrap(),
     );
+    headers.insert(
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains".parse().unwrap(),
+    );
 
     response
 }

--- a/crates/bitnet-server/tests/server_security_tests.rs
+++ b/crates/bitnet-server/tests/server_security_tests.rs
@@ -282,6 +282,16 @@ async fn test_security_header_content_security_policy() {
     assert!(csp.contains("default-src 'self'"), "CSP must include default-src 'self'; got: {csp}");
 }
 
+#[tokio::test]
+async fn test_security_header_strict_transport_security() {
+    let headers = get_security_headers().await;
+    assert_eq!(
+        headers.get("strict-transport-security").unwrap(),
+        "max-age=31536000; includeSubDomains",
+        "Strict-Transport-Security must be 'max-age=31536000; includeSubDomains'"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Request validation tests
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 🛡️ Sentinel: Security Enhancement - Add HSTS Header

**Severity:** MEDIUM

**Vulnerability:** 
The application was missing the `Strict-Transport-Security` (HSTS) header in HTTP responses. Without this header, users remain vulnerable to man-in-the-middle attacks, SSL-stripping, and other downgrade attacks because browsers are not explicitly instructed to force HTTPS connections to the application and its subdomains.

**Fix:**
Added the `Strict-Transport-Security` header to the `security_headers_middleware` in `crates/bitnet-server/src/security.rs`. The header is set to `max-age=31536000; includeSubDomains` (1 year), establishing a long-lived policy that forces HTTPS.

**Verification:**
Added a unit test `test_security_header_strict_transport_security` in `crates/bitnet-server/tests/server_security_tests.rs` to verify the header is injected successfully. Local tests run and pass without regressions.

---
*PR created automatically by Jules for task [15411546440563701316](https://jules.google.com/task/15411546440563701316) started by @EffortlessSteven*