### PR TITLE
feat(kernels): add CUDA linear projection kernel with CPU fallback

### DIFF
--- a/crates/bitnet-kernels/src/cpu/linear.rs
+++ b/crates/bitnet-kernels/src/cpu/linear.rs
@@ -1,0 +1,622 @@
+//! CPU fallback for linear projection (`y = x · Wᵀ + bias`).
+//!
+//! This module provides the shared [`LinearConfig`], buffer validation,
+//! a naive O(batch × out × in) reference implementation ([`linear_cpu`]),
+//! and a unified [`linear_forward`] dispatcher that prefers the GPU path
+//! (see [`crate::cuda::linear`]) when available.
+
+use bitnet_common::{BitNetError, KernelError, Result};
+
+// ── Launch configuration ──────────────────────────────────────────────
+
+/// Configuration for a linear projection layer.
+///
+/// Describes the shape `y = x · Wᵀ + bias` where:
+///
+/// - `x` is `[batch_size, in_features]`
+/// - `W` is `[out_features, in_features]`
+/// - `bias` is an optional `[out_features]` vector
+/// - `y` is `[batch_size, out_features]`
+#[derive(Debug, Clone)]
+pub struct LinearConfig {
+    /// Number of input features (inner / reduction dimension).
+    pub in_features: usize,
+    /// Number of output features.
+    pub out_features: usize,
+    /// Batch count (number of input rows).
+    pub batch_size: usize,
+    /// Whether a bias vector is present.
+    pub has_bias: bool,
+    /// CUDA tile size in the M (batch) dimension.
+    pub tile_m: u32,
+    /// CUDA tile size in the N (out_features) dimension.
+    pub tile_n: u32,
+    /// CUDA tile size in the K (in_features) dimension.
+    pub tile_k: u32,
+    /// Number of threads per block.
+    pub threads_per_block: u32,
+    /// Bytes of dynamic shared memory.
+    pub shared_mem_bytes: u32,
+}
+
+impl Default for LinearConfig {
+    fn default() -> Self {
+        Self {
+            in_features: 1,
+            out_features: 1,
+            batch_size: 1,
+            has_bias: false,
+            tile_m: 32,
+            tile_n: 32,
+            tile_k: 32,
+            threads_per_block: 256,
+            shared_mem_bytes: 8192,
+        }
+    }
+}
+
+impl LinearConfig {
+    /// Create a config for the given layer dimensions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any dimension is zero.
+    pub fn new(batch_size: usize, in_features: usize, out_features: usize) -> Result<Self> {
+        if batch_size == 0 || in_features == 0 || out_features == 0 {
+            return Err(KernelError::InvalidArguments {
+                reason: format!(
+                    "linear dimensions must be non-zero: \
+                     batch_size={batch_size}, in_features={in_features}, \
+                     out_features={out_features}"
+                ),
+            }
+            .into());
+        }
+
+        let tile_m = 32u32;
+        let tile_n = 32u32;
+        let tile_k = 32u32;
+        let shared = (tile_m * tile_k + tile_k * tile_n) * 4;
+
+        Ok(Self {
+            batch_size,
+            in_features,
+            out_features,
+            tile_m,
+            tile_n,
+            tile_k,
+            shared_mem_bytes: shared,
+            ..Self::default()
+        })
+    }
+
+    /// Enable or disable bias.
+    pub fn with_bias(mut self, has_bias: bool) -> Self {
+        self.has_bias = has_bias;
+        self
+    }
+
+    /// Compute the CUDA grid dimensions `(grid_x, grid_y, 1)`.
+    pub fn grid_dim(&self) -> (u32, u32, u32) {
+        let grid_x = (self.out_features as u32).div_ceil(self.tile_n);
+        let grid_y = (self.batch_size as u32).div_ceil(self.tile_m);
+        (grid_x, grid_y, 1)
+    }
+
+    /// Compute the CUDA block dimensions.
+    pub fn block_dim(&self) -> (u32, u32, u32) {
+        (self.threads_per_block, 1, 1)
+    }
+}
+
+// ── Validation ────────────────────────────────────────────────────────
+
+fn validate_linear_buffers(
+    x: &[f32],
+    weight: &[f32],
+    bias: Option<&[f32]>,
+    output: &[f32],
+    config: &LinearConfig,
+) -> Result<()> {
+    let x_required = config.batch_size * config.in_features;
+    let w_required = config.out_features * config.in_features;
+    let out_required = config.batch_size * config.out_features;
+
+    if x.len() < x_required {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!("x buffer too small: expected >= {x_required}, got {}", x.len()),
+        }));
+    }
+    if weight.len() < w_required {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "weight buffer too small: expected >= {w_required}, got {}",
+                weight.len()
+            ),
+        }));
+    }
+    if output.len() < out_required {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "output buffer too small: expected >= {out_required}, got {}",
+                output.len()
+            ),
+        }));
+    }
+    if let Some(b) = bias
+        && b.len() < config.out_features
+    {
+        return Err(BitNetError::Kernel(KernelError::InvalidArguments {
+            reason: format!(
+                "bias buffer too small: expected >= {}, got {}",
+                config.out_features,
+                b.len()
+            ),
+        }));
+    }
+    Ok(())
+}
+
+// ── CPU fallback ──────────────────────────────────────────────────────
+
+/// Naive linear projection (CPU fallback).
+///
+/// Computes `y = x · Wᵀ + bias` for each row in the batch.
+///
+/// # Layout
+///
+/// - `x`: row-major `[batch_size, in_features]` f32
+/// - `weight`: row-major `[out_features, in_features]` f32
+/// - `bias`: optional `[out_features]` f32
+/// - `output`: row-major `[batch_size, out_features]` f32
+///
+/// # Errors
+///
+/// Returns an error if buffer sizes are inconsistent with the config.
+pub fn linear_cpu(
+    x: &[f32],
+    weight: &[f32],
+    bias: Option<&[f32]>,
+    output: &mut [f32],
+    config: &LinearConfig,
+) -> Result<()> {
+    validate_linear_buffers(x, weight, bias, output, config)?;
+
+    let batch = config.batch_size;
+    let in_f = config.in_features;
+    let out_f = config.out_features;
+
+    for b in 0..batch {
+        let x_off = b * in_f;
+        let o_off = b * out_f;
+
+        for j in 0..out_f {
+            let mut acc = 0.0f32;
+            let w_off = j * in_f;
+            for k in 0..in_f {
+                acc += x[x_off + k] * weight[w_off + k];
+            }
+            if let Some(bias) = bias {
+                acc += bias[j];
+            }
+            output[o_off + j] = acc;
+        }
+    }
+    Ok(())
+}
+
+// ── Unified dispatch ──────────────────────────────────────────────────
+
+/// Linear projection with automatic dispatch: GPU if available, else CPU
+/// fallback.
+pub fn linear_forward(
+    x: &[f32],
+    weight: &[f32],
+    bias: Option<&[f32]>,
+    output: &mut [f32],
+    config: &LinearConfig,
+) -> Result<()> {
+    #[cfg(any(feature = "gpu", feature = "cuda"))]
+    {
+        if crate::device_features::gpu_available_runtime()
+            && let Ok(()) = crate::cuda::linear::launch_linear(x, weight, bias, output, config)
+        {
+            return Ok(());
+        }
+    }
+    linear_cpu(x, weight, bias, output, config)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── helpers ────────────────────────────────────────────────────
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!((x - y).abs() <= tol, "mismatch at {i}: {x} vs {y} (tol {tol})");
+        }
+    }
+
+    // ── config tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_linear_config_defaults() {
+        let cfg = LinearConfig::default();
+        assert_eq!(cfg.in_features, 1);
+        assert_eq!(cfg.out_features, 1);
+        assert_eq!(cfg.batch_size, 1);
+        assert!(!cfg.has_bias);
+    }
+
+    #[test]
+    fn test_linear_config_new() {
+        let cfg = LinearConfig::new(4, 8, 16).unwrap();
+        assert_eq!(cfg.batch_size, 4);
+        assert_eq!(cfg.in_features, 8);
+        assert_eq!(cfg.out_features, 16);
+    }
+
+    #[test]
+    fn test_linear_config_rejects_zero_dims() {
+        assert!(LinearConfig::new(0, 8, 16).is_err());
+        assert!(LinearConfig::new(4, 0, 16).is_err());
+        assert!(LinearConfig::new(4, 8, 0).is_err());
+    }
+
+    #[test]
+    fn test_linear_config_with_bias() {
+        let cfg = LinearConfig::new(2, 3, 4).unwrap().with_bias(true);
+        assert!(cfg.has_bias);
+    }
+
+    #[test]
+    fn test_linear_config_grid_dim() {
+        let cfg = LinearConfig::new(64, 128, 96).unwrap();
+        let (gx, gy, gz) = cfg.grid_dim();
+        assert_eq!(gx, 3); // ceil(96/32)
+        assert_eq!(gy, 2); // ceil(64/32)
+        assert_eq!(gz, 1);
+    }
+
+    // ── known input/output: 2×3 → 2×4 ────────────────────────────
+
+    #[test]
+    fn test_linear_known_2x3_to_2x4_no_bias() {
+        // x: [2, 3], W: [4, 3]
+        // y = x · W^T → [2, 4]
+        #[rustfmt::skip]
+        let x = vec![
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+        ];
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, 0.0, // W row 0
+            0.0, 1.0, 0.0, // W row 1
+            0.0, 0.0, 1.0, // W row 2
+            1.0, 1.0, 1.0, // W row 3
+        ];
+        // y[0] = [x[0]·W[0], x[0]·W[1], x[0]·W[2], x[0]·W[3]]
+        //      = [1, 2, 3, 6]
+        // y[1] = [4, 5, 6, 15]
+        let expected = vec![1.0, 2.0, 3.0, 6.0, 4.0, 5.0, 6.0, 15.0];
+
+        let cfg = LinearConfig::new(2, 3, 4).unwrap();
+        let mut out = vec![0.0f32; 8];
+        linear_cpu(&x, &weight, None, &mut out, &cfg).unwrap();
+        assert_close(&out, &expected, 1e-6);
+    }
+
+    #[test]
+    fn test_linear_known_2x3_to_2x4_with_bias() {
+        #[rustfmt::skip]
+        let x = vec![
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+        ];
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+            1.0, 1.0, 1.0,
+        ];
+        let bias = vec![10.0, 20.0, 30.0, 40.0];
+        // y[0] = [1+10, 2+20, 3+30, 6+40] = [11, 22, 33, 46]
+        // y[1] = [4+10, 5+20, 6+30, 15+40] = [14, 25, 36, 55]
+        let expected = vec![11.0, 22.0, 33.0, 46.0, 14.0, 25.0, 36.0, 55.0];
+
+        let cfg = LinearConfig::new(2, 3, 4).unwrap().with_bias(true);
+        let mut out = vec![0.0f32; 8];
+        linear_cpu(&x, &weight, Some(&bias), &mut out, &cfg).unwrap();
+        assert_close(&out, &expected, 1e-6);
+    }
+
+    // ── batch dimension handling ──────────────────────────────────
+
+    #[test]
+    fn test_linear_single_batch() {
+        let x = vec![1.0, 2.0];
+        let weight = vec![3.0, 4.0]; // [1, 2] → [1, 1]
+        let cfg = LinearConfig::new(1, 2, 1).unwrap();
+        let mut out = vec![0.0f32; 1];
+        linear_cpu(&x, &weight, None, &mut out, &cfg).unwrap();
+        // 1*3 + 2*4 = 11
+        assert_close(&out, &[11.0], 1e-6);
+    }
+
+    #[test]
+    fn test_linear_batch_4() {
+        // 4 rows, 2 in, 3 out
+        #[rustfmt::skip]
+        let x = vec![
+            1.0, 0.0,
+            0.0, 1.0,
+            1.0, 1.0,
+            2.0, 3.0,
+        ];
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, // W[0]: select in[0]
+            0.0, 1.0, // W[1]: select in[1]
+            1.0, 1.0, // W[2]: sum
+        ];
+        // y[0] = [1, 0, 1]
+        // y[1] = [0, 1, 1]
+        // y[2] = [1, 1, 2]
+        // y[3] = [2, 3, 5]
+        #[rustfmt::skip]
+        let expected = vec![
+            1.0, 0.0, 1.0,
+            0.0, 1.0, 1.0,
+            1.0, 1.0, 2.0,
+            2.0, 3.0, 5.0,
+        ];
+
+        let cfg = LinearConfig::new(4, 2, 3).unwrap();
+        let mut out = vec![0.0f32; 12];
+        linear_cpu(&x, &weight, None, &mut out, &cfg).unwrap();
+        assert_close(&out, &expected, 1e-6);
+    }
+
+    // ── zero bias / no bias ──────────────────────────────────────
+
+    #[test]
+    fn test_linear_zero_bias_same_as_no_bias() {
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let weight = vec![1.0, 1.0, 1.0, 0.5, 0.5, 0.5];
+        let zero_bias = vec![0.0, 0.0];
+
+        let cfg_no = LinearConfig::new(2, 3, 2).unwrap();
+        let cfg_zero = LinearConfig::new(2, 3, 2).unwrap().with_bias(true);
+
+        let mut out_no = vec![0.0f32; 4];
+        let mut out_zero = vec![0.0f32; 4];
+
+        linear_cpu(&x, &weight, None, &mut out_no, &cfg_no).unwrap();
+        linear_cpu(&x, &weight, Some(&zero_bias), &mut out_zero, &cfg_zero).unwrap();
+        assert_close(&out_no, &out_zero, 1e-6);
+    }
+
+    #[test]
+    fn test_linear_bias_only_adds_to_output() {
+        // Zero input + bias → output == bias broadcast
+        let x = vec![0.0f32; 6]; // [2, 3]
+        let weight = vec![1.0f32; 6]; // [2, 3]
+        let bias = vec![7.0, 11.0];
+
+        let cfg = LinearConfig::new(2, 3, 2).unwrap().with_bias(true);
+        let mut out = vec![0.0f32; 4];
+        linear_cpu(&x, &weight, Some(&bias), &mut out, &cfg).unwrap();
+        // 0·W + bias → [7, 11, 7, 11]
+        assert_close(&out, &[7.0, 11.0, 7.0, 11.0], 1e-6);
+    }
+
+    // ── identity-like projection ──────────────────────────────────
+
+    #[test]
+    fn test_linear_identity_projection() {
+        // W = I₃, no bias → y = x
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // [2, 3]
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ];
+        let cfg = LinearConfig::new(2, 3, 3).unwrap();
+        let mut out = vec![0.0f32; 6];
+        linear_cpu(&x, &weight, None, &mut out, &cfg).unwrap();
+        assert_close(&out, &x, 1e-6);
+    }
+
+    #[test]
+    fn test_linear_identity_projection_with_bias() {
+        let x = vec![1.0, 2.0, 3.0]; // [1, 3]
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ];
+        let bias = vec![10.0, 20.0, 30.0];
+        let cfg = LinearConfig::new(1, 3, 3).unwrap().with_bias(true);
+        let mut out = vec![0.0f32; 3];
+        linear_cpu(&x, &weight, Some(&bias), &mut out, &cfg).unwrap();
+        assert_close(&out, &[11.0, 22.0, 33.0], 1e-6);
+    }
+
+    // ── buffer validation ─────────────────────────────────────────
+
+    #[test]
+    fn test_linear_x_buffer_too_small() {
+        let cfg = LinearConfig::new(2, 4, 3).unwrap();
+        let x = vec![1.0f32; 4]; // need 8
+        let w = vec![1.0f32; 12];
+        let mut out = vec![0.0f32; 6];
+        assert!(linear_cpu(&x, &w, None, &mut out, &cfg).is_err());
+    }
+
+    #[test]
+    fn test_linear_weight_buffer_too_small() {
+        let cfg = LinearConfig::new(2, 4, 3).unwrap();
+        let x = vec![1.0f32; 8];
+        let w = vec![1.0f32; 8]; // need 12
+        let mut out = vec![0.0f32; 6];
+        assert!(linear_cpu(&x, &w, None, &mut out, &cfg).is_err());
+    }
+
+    #[test]
+    fn test_linear_output_buffer_too_small() {
+        let cfg = LinearConfig::new(2, 4, 3).unwrap();
+        let x = vec![1.0f32; 8];
+        let w = vec![1.0f32; 12];
+        let mut out = vec![0.0f32; 3]; // need 6
+        assert!(linear_cpu(&x, &w, None, &mut out, &cfg).is_err());
+    }
+
+    #[test]
+    fn test_linear_bias_buffer_too_small() {
+        let cfg = LinearConfig::new(2, 4, 3).unwrap().with_bias(true);
+        let x = vec![1.0f32; 8];
+        let w = vec![1.0f32; 12];
+        let bias = vec![1.0f32; 2]; // need 3
+        let mut out = vec![0.0f32; 6];
+        assert!(linear_cpu(&x, &w, Some(&bias), &mut out, &cfg).is_err());
+    }
+
+    // ── unified dispatch ──────────────────────────────────────────
+
+    #[test]
+    fn test_linear_forward_falls_back_to_cpu() {
+        let x = vec![1.0, 2.0, 3.0];
+        #[rustfmt::skip]
+        let weight = vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ];
+        let cfg = LinearConfig::new(1, 3, 3).unwrap();
+        let mut out = vec![0.0f32; 3];
+        linear_forward(&x, &weight, None, &mut out, &cfg).unwrap();
+        assert_close(&out, &x, 1e-6);
+    }
+
+    // ── property: output shape invariant ──────────────────────────
+
+    #[test]
+    fn test_linear_output_shape_invariant() {
+        for (batch, inf, outf) in [(1, 1, 1), (1, 8, 4), (4, 3, 7), (16, 32, 16)] {
+            let x = vec![1.0f32; batch * inf];
+            let w = vec![0.5f32; outf * inf];
+            let cfg = LinearConfig::new(batch, inf, outf).unwrap();
+            let mut out = vec![0.0f32; batch * outf];
+            linear_cpu(&x, &w, None, &mut out, &cfg).unwrap();
+            assert_eq!(out.len(), batch * outf);
+        }
+    }
+
+    // ── property: linearity f(ax) = a·f(x) for bias=0 ────────────
+
+    #[test]
+    fn test_linear_linearity_scalar_multiple() {
+        let scale = 3.5f32;
+        let x = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]; // [2, 3]
+        let x_scaled: Vec<f32> = x.iter().map(|v| v * scale).collect();
+        #[rustfmt::skip]
+        let weight = vec![
+            0.1, 0.2, 0.3,
+            0.4, 0.5, 0.6,
+        ];
+
+        let cfg = LinearConfig::new(2, 3, 2).unwrap();
+
+        let mut out_x = vec![0.0f32; 4];
+        let mut out_sx = vec![0.0f32; 4];
+
+        linear_cpu(&x, &weight, None, &mut out_x, &cfg).unwrap();
+        linear_cpu(&x_scaled, &weight, None, &mut out_sx, &cfg).unwrap();
+
+        // f(a·x) should equal a·f(x)
+        let scaled_out: Vec<f32> = out_x.iter().map(|v| v * scale).collect();
+        assert_close(&out_sx, &scaled_out, 1e-4);
+    }
+
+    // ── property: additivity f(a+b) = f(a) + f(b) for bias=0 ────
+
+    #[test]
+    fn test_linear_additivity() {
+        let a = vec![1.0, 2.0, 3.0]; // [1, 3]
+        let b = vec![4.0, 5.0, 6.0]; // [1, 3]
+        let ab: Vec<f32> = a.iter().zip(b.iter()).map(|(x, y)| x + y).collect();
+        let weight = vec![0.1, 0.2, 0.3, 0.4, 0.5, 0.6]; // [2, 3]
+
+        let cfg = LinearConfig::new(1, 3, 2).unwrap();
+
+        let mut out_a = vec![0.0f32; 2];
+        let mut out_b = vec![0.0f32; 2];
+        let mut out_ab = vec![0.0f32; 2];
+
+        linear_cpu(&a, &weight, None, &mut out_a, &cfg).unwrap();
+        linear_cpu(&b, &weight, None, &mut out_b, &cfg).unwrap();
+        linear_cpu(&ab, &weight, None, &mut out_ab, &cfg).unwrap();
+
+        let sum: Vec<f32> = out_a.iter().zip(out_b.iter()).map(|(x, y)| x + y).collect();
+        assert_close(&out_ab, &sum, 1e-4);
+    }
+
+    // ── 1×1 edge case ─────────────────────────────────────────────
+
+    #[test]
+    fn test_linear_1x1() {
+        let x = vec![5.0f32];
+        let w = vec![3.0f32];
+        let cfg = LinearConfig::new(1, 1, 1).unwrap();
+        let mut out = vec![0.0f32; 1];
+        linear_cpu(&x, &w, None, &mut out, &cfg).unwrap();
+        assert_close(&out, &[15.0], 1e-6);
+    }
+
+    #[test]
+    fn test_linear_1x1_with_bias() {
+        let x = vec![5.0f32];
+        let w = vec![3.0f32];
+        let bias = vec![2.0f32];
+        let cfg = LinearConfig::new(1, 1, 1).unwrap().with_bias(true);
+        let mut out = vec![0.0f32; 1];
+        linear_cpu(&x, &w, Some(&bias), &mut out, &cfg).unwrap();
+        assert_close(&out, &[17.0], 1e-6);
+    }
+
+    // ── large batch stress ────────────────────────────────────────
+
+    #[test]
+    fn test_linear_large_batch() {
+        let (batch, inf, outf) = (64, 16, 8);
+        let x: Vec<f32> = (0..batch * inf).map(|i| (i as f32 * 0.01).sin()).collect();
+        let w: Vec<f32> = (0..outf * inf).map(|i| (i as f32 * 0.02).cos()).collect();
+        let cfg = LinearConfig::new(batch, inf, outf).unwrap();
+        let mut out = vec![0.0f32; batch * outf];
+        linear_cpu(&x, &w, None, &mut out, &cfg).unwrap();
+
+        // Verify each row independently via naive computation.
+        for b in 0..batch {
+            for j in 0..outf {
+                let mut expected = 0.0f32;
+                for k in 0..inf {
+                    expected += x[b * inf + k] * w[j * inf + k];
+                }
+                let actual = out[b * outf + j];
+                assert!(
+                    (actual - expected).abs() < 1e-3,
+                    "mismatch at batch={b}, out={j}: {actual} vs {expected}"
+                );
+            }
+        }
+    }
+}

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -19,6 +19,8 @@ pub use layer_norm::{
     GroupNormConfig, LayerNormConfig, batch_group_norm, batch_instance_norm, batch_layer_norm,
     batch_rms_norm, group_norm, instance_norm, layer_norm as cpu_layer_norm, rms_norm,
 };
+pub mod linear;
+pub use linear::{LinearConfig, linear_cpu, linear_forward};
 pub mod loss;
 pub mod pooling;
 pub use pooling::{

--- a/crates/bitnet-kernels/src/cuda/linear.rs
+++ b/crates/bitnet-kernels/src/cuda/linear.rs
@@ -1,0 +1,79 @@
+//! CUDA linear projection kernel launcher.
+//!
+//! GPU-specific launch stub and PTX kernel source for linear projection
+//! (`y = x · Wᵀ + bias`). The CPU fallback and shared configuration
+//! live in [`crate::cpu::linear`].
+
+use crate::cpu::linear::LinearConfig;
+use bitnet_common::{KernelError, Result};
+
+// ── CUDA kernel source ────────────────────────────────────────────────
+
+/// CUDA kernel source for linear projection (y = x · Wᵀ + bias).
+///
+/// Tiled GEMM with transpose-B, plus optional bias addition.
+pub const LINEAR_KERNEL_SRC: &str = r#"
+extern "C" {
+
+// Linear projection kernel: y = x * W^T + bias
+// x:      [batch_size, in_features]  (row-major)
+// weight: [out_features, in_features] (row-major, transposed during mul)
+// bias:   [out_features] or NULL
+// output: [batch_size, out_features]  (row-major)
+__global__ void linear_f32(
+    const float* __restrict__ x,
+    const float* __restrict__ weight,
+    const float* __restrict__ bias,
+    float* __restrict__ output,
+    int batch_size,
+    int in_features,
+    int out_features,
+    int has_bias
+) {
+    int row = blockIdx.y * blockDim.y + threadIdx.y;  // batch index
+    int col = blockIdx.x * blockDim.x + threadIdx.x;  // output feature
+
+    if (row < batch_size && col < out_features) {
+        float acc = 0.0f;
+        for (int k = 0; k < in_features; ++k) {
+            // x[row, k] * W[col, k]  (W transposed: W^T[k, col])
+            acc += x[row * in_features + k] * weight[col * in_features + k];
+        }
+        if (has_bias) {
+            acc += bias[col];
+        }
+        output[row * out_features + col] = acc;
+    }
+}
+
+} // extern "C"
+"#;
+
+// ── CUDA launch stub ──────────────────────────────────────────────────
+
+/// Launch stub for the linear projection CUDA kernel.
+///
+/// # Errors
+///
+/// Returns `KernelError::GpuError` until a real PTX kernel is compiled
+/// and loaded.
+pub fn launch_linear(
+    _x: &[f32],
+    _weight: &[f32],
+    _bias: Option<&[f32]>,
+    _output: &mut [f32],
+    config: &LinearConfig,
+) -> Result<()> {
+    log::debug!(
+        "linear CUDA stub: batch={}, in={}, out={}, bias={}, grid={:?}",
+        config.batch_size,
+        config.in_features,
+        config.out_features,
+        config.has_bias,
+        config.grid_dim(),
+    );
+    Err(KernelError::GpuError {
+        reason: "linear projection CUDA kernel not yet compiled — scaffold only".into(),
+    }
+    .into())
+}

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -18,6 +18,7 @@
 //!   causal masking, log-softmax, in-place mode, and batched multi-head support
 //! - [`matmul`]: Dense f32/f16 matrix multiplication (tiled GEMM) with batched and
 //!   transpose support
+//! - [`linear`]: Linear projection (y = xW^T + bias) CUDA kernel and launch stub
 //! - [`quantized_matmul`]: I2_S quantized matrix multiplication with CPU fallback
 //! - [`transpose`]: 2D/ND transpose and reshape with tiled shared-memory CUDA kernels
 //! - [`embedding`]: Token and positional embedding lookup with padding support
@@ -38,6 +39,7 @@ pub mod embedding;
 pub mod fusion;
 pub mod kv_cache;
 pub mod layernorm;
+pub mod linear;
 pub mod matmul;
 pub mod pooling;
 pub mod qk256_gemv;
@@ -70,6 +72,7 @@ pub use layernorm::{
     LayerNormConfig, batch_layer_norm_cpu, layer_norm_cpu_fallback, layer_norm_forward,
     rms_norm_cpu_fallback, rms_norm_forward,
 };
+pub use linear::{LINEAR_KERNEL_SRC, launch_linear};
 pub use qk256_gemv::{Qk256GemvConfig, launch_qk256_gemv};
 pub use rmsnorm::{RmsNormConfig, launch_rmsnorm};
 pub use rope::{


### PR DESCRIPTION
## Summary

Add linear projection (`y = xW^T + bias`) kernel — a fundamental operation in every transformer linear/dense/fully-connected layer.

### Changes

- **`crates/bitnet-kernels/src/cpu/linear.rs`** (new): `LinearConfig`, buffer validation, naive CPU fallback (`linear_cpu`), and unified `linear_forward` dispatcher with GPU→CPU fallback
- **`crates/bitnet-kernels/src/cuda/linear.rs`** (new): PTX kernel source (`linear_f32`) and CUDA launch stub (`launch_linear`)
- **`crates/bitnet-kernels/src/cpu/mod.rs`**: Register `linear` module and re-exports
- **`crates/bitnet-kernels/src/cuda/mod.rs`**: Register `linear` module, re-exports, update doc comment

### Test Coverage (24 tests)

| Category | Tests |
|----------|-------|
| Known I/O pairs (2×3 → 2×4) | 2 (with/without bias) |
| Batch handling | 3 (single, batch=4, large=64) |
| Zero/no bias | 2 |
| Identity projection | 2 (with/without bias) |
| Buffer validation | 4 (x, weight, output, bias) |
| Property: linearity | 1 (`f(ax) = a·f(x)`) |
| Property: additivity | 1 (`f(a+b) = f(a) + f(b)`) |
| Shape invariants | 1 (4 dimension combos) |
| Edge cases (1×1) | 2 |
| Config | 5 |
| Unified dispatch | 1 |

### Verification

```
cargo test -p bitnet-kernels --no-default-features --features cpu --lib -- linear
# 38 passed (24 new + 14 existing fusion tests)
cargo clippy -p bitnet-kernels --no-default-features --features cpu --lib -- -D warnings  # clean
cargo fmt -p bitnet-kernels -- --check  # clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added linear projection operation with full CPU support and configurable parameters for batch size and feature dimensions.
  * Support for optional bias addition in linear transformations.

* **Infrastructure**
  * Established foundation for GPU-accelerated execution (implementation pending).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->