### PR TITLE
refactor(cli): split CLI eval/scoring math into bitnet-eval-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "bitnet-common",
+ "bitnet-eval-core",
  "bitnet-ggml-ffi",
  "bitnet-inference",
  "bitnet-kernels",
@@ -599,6 +600,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "bitnet-eval-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-feature-contract"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
+  "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
   "crates/bitnet-cli",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -33,6 +33,7 @@ bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
+bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true

--- a/crates/bitnet-cli/src/commands/eval.rs
+++ b/crates/bitnet-cli/src/commands/eval.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 use tracing::{debug, info, warn};
 
+use bitnet_eval_core::{log_softmax_stable, topk_stable_indices};
 use bitnet_inference::InferenceEngine;
 use bitnet_models::ModelLoader;
 
@@ -183,46 +184,6 @@ pub struct EvalTiming {
     pub total: f64,
     pub per_line: f64,
     pub per_token: f64,
-}
-
-/// Small helper for deterministic, robust top-k on possibly quantized logits
-#[inline]
-fn topk_stable_indices(logits: &[f32], k: usize) -> Vec<usize> {
-    use core::cmp::Ordering;
-    if k == 0 {
-        return Vec::new();
-    }
-
-    let mut idx: Vec<usize> = (0..logits.len()).collect();
-
-    // Sort by logit descending, then by index ascending for ties
-    idx.sort_by(|&a, &b| {
-        match logits[b].partial_cmp(&logits[a]) {
-            Some(Ordering::Less) => Ordering::Less,
-            Some(Ordering::Greater) => Ordering::Greater,
-            _ => a.cmp(&b), // Deterministic tie-breaking
-        }
-    });
-
-    idx.truncate(k);
-    idx
-}
-
-/// Stable log-softmax computation
-#[inline]
-fn log_softmax_stable(xs: &[f32]) -> Vec<f32> {
-    let mut m = f32::NEG_INFINITY;
-    for &v in xs {
-        if v > m {
-            m = v;
-        }
-    }
-    let mut sum = 0.0f32;
-    for &v in xs {
-        sum += (v - m).exp();
-    }
-    let lse = m + sum.ln();
-    xs.iter().map(|&v| v - lse).collect()
 }
 
 impl EvalCommand {

--- a/crates/bitnet-cli/src/score.rs
+++ b/crates/bitnet-cli/src/score.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 use std::{fs, path::PathBuf, sync::Arc, time::Instant};
 
 use bitnet_common::Device as BNDevice;
+use bitnet_eval_core::log_softmax_stable;
 use bitnet_inference::InferenceEngine;
 use bitnet_models::{GgufReader, ModelLoader};
 use candle_core::Device;
@@ -154,20 +155,4 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
         println!("{}", serde_json::to_string_pretty(&out)?);
     }
     Ok(())
-}
-
-#[inline]
-fn log_softmax_stable(xs: &[f32]) -> Vec<f32> {
-    let mut m = f32::NEG_INFINITY;
-    for &v in xs {
-        if v > m {
-            m = v;
-        }
-    }
-    let mut sum = 0.0f32;
-    for &v in xs {
-        sum += (v - m).exp();
-    }
-    let lse = m + sum.ln();
-    xs.iter().map(|&v| v - lse).collect()
 }

--- a/crates/bitnet-eval-core/Cargo.toml
+++ b/crates/bitnet-eval-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitnet-eval-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP helpers for evaluation and scoring math"
+
+[lib]
+name = "bitnet_eval_core"
+path = "src/lib.rs"

--- a/crates/bitnet-eval-core/src/lib.rs
+++ b/crates/bitnet-eval-core/src/lib.rs
@@ -1,0 +1,60 @@
+//! Shared, deterministic evaluation helpers used by CLI scoring/eval commands.
+
+use core::cmp::Ordering;
+
+/// Deterministic top-k index selection over logits.
+///
+/// Sorts by logit descending and then by index ascending for ties.
+#[must_use]
+pub fn topk_stable_indices(logits: &[f32], k: usize) -> Vec<usize> {
+    if k == 0 {
+        return Vec::new();
+    }
+
+    let mut idx: Vec<usize> = (0..logits.len()).collect();
+    idx.sort_by(|&a, &b| match logits[b].partial_cmp(&logits[a]) {
+        Some(Ordering::Less) => Ordering::Less,
+        Some(Ordering::Greater) => Ordering::Greater,
+        _ => a.cmp(&b),
+    });
+
+    idx.truncate(k);
+    idx
+}
+
+/// Numerically stable log-softmax.
+#[must_use]
+pub fn log_softmax_stable(xs: &[f32]) -> Vec<f32> {
+    let mut m = f32::NEG_INFINITY;
+    for &v in xs {
+        if v > m {
+            m = v;
+        }
+    }
+    let mut sum = 0.0f32;
+    for &v in xs {
+        sum += (v - m).exp();
+    }
+    let lse = m + sum.ln();
+    xs.iter().map(|&v| v - lse).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{log_softmax_stable, topk_stable_indices};
+
+    #[test]
+    fn topk_is_deterministic_for_ties() {
+        let logits = vec![0.5f32, 1.0, 1.0, 0.2];
+        let top2 = topk_stable_indices(&logits, 2);
+        assert_eq!(top2, vec![1, 2]);
+    }
+
+    #[test]
+    fn log_softmax_outputs_normalized_distribution_when_expd() {
+        let logits = vec![1.0f32, 2.0, 3.0];
+        let logp = log_softmax_stable(&logits);
+        let p_sum: f32 = logp.iter().map(|v| v.exp()).sum();
+        assert!((p_sum - 1.0).abs() < 1e-5, "sum was {p_sum}");
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication and respect SRP by extracting pure, deterministic evaluation/scoring math from CLI command modules into a focused microcrate.
- Make deterministic helpers reusable by other frontends or services without pulling in CLI I/O/UX code.

### Description
- Added a new workspace member `crates/bitnet-eval-core` that exposes `topk_stable_indices` and `log_softmax_stable` with unit tests.
- Updated workspace `Cargo.toml` to register `bitnet-eval-core` and added a dependency from `crates/bitnet-cli` to `bitnet-eval-core`.
- Removed duplicated local implementations of `topk_stable_indices` and `log_softmax_stable` from `crates/bitnet-cli/src/commands/eval.rs` and `crates/bitnet-cli/src/score.rs`, and updated imports to use the new microcrate.
- Formatted code with `cargo fmt` and ensured the CLI compiles cleanly against the new microcrate.

### Testing
- Ran `cargo test -p bitnet-eval-core` and the crate's unit tests passed (`2 passed`).
- Ran `cargo fmt` with no remaining style issues.
- Ran `cargo check -p bitnet-cli` to verify the CLI builds against the new dependency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a490a19c7c8333b37a2312b4860d3e)