### PR TITLE
test(kernels): add property-based tests for OpenCL CPU reference implementations

### DIFF
--- a/crates/bitnet-kernels/tests/opencl_property_tests.rs
+++ b/crates/bitnet-kernels/tests/opencl_property_tests.rs
@@ -7,10 +7,10 @@
 use proptest::prelude::*;
 
 use bitnet_kernels::opencl_buffer::{
-    align_size, optimal_buffer_size, validate_alignment, AlignedBuffer, BufferAlignment, BufferPool,
+    AlignedBuffer, BufferAlignment, BufferPool, align_size, optimal_buffer_size, validate_alignment,
 };
 use bitnet_kernels::opencl_cache::{
-    CacheConfig, CacheSerializer, CacheStats, KernelCacheManager, KernelCacheEntry, KernelCacheKey,
+    CacheConfig, CacheSerializer, CacheStats, KernelCacheEntry, KernelCacheKey, KernelCacheManager,
     SourceHasher,
 };
 use bitnet_kernels::opencl_embedding::{
@@ -40,9 +40,7 @@ fn arb_f32_vec(min_len: usize, max_len: usize) -> impl Strategy<Value = Vec<f32>
 #[allow(dead_code)]
 fn arb_matrix(max_dim: usize) -> impl Strategy<Value = (Vec<f32>, usize, usize)> {
     (1..=max_dim, 1..=max_dim).prop_flat_map(|(rows, cols)| {
-        prop::collection::vec(-1.0f32..1.0f32, rows * cols).prop_map(move |data| {
-            (data, rows, cols)
-        })
+        prop::collection::vec(-1.0f32..1.0f32, rows * cols).prop_map(move |data| (data, rows, cols))
     })
 }
 


### PR DESCRIPTION
## Summary

Add 77 comprehensive property-based tests using \proptest\ covering all 7 publicly-exported \opencl_*\ modules in \itnet-kernels\.

## Test Coverage

| Module | Tests | Properties Verified |
|--------|-------|-------------------|
| \opencl_buffer\ | 10 | Alignment ≥ input, multiple-of, idempotent, overshoot bounded, cache-line aligned, pool alloc |
| \opencl_cache\ | 9 | Hash determinism, key filename format, serialize roundtrip, store/lookup/invalidate/clear |
| \opencl_embedding\ | 10 | Lookup correctness, OOV→zeros, padding→zeros, table↔ref equivalence, projection dimensions, identity weight passthrough, tied weights, position add, RMS norm stability |
| \opencl_kernel_sources\ | 5 | Registry non-empty, entry points valid, builtin IDs resolvable, sources have content, custom registration |
| \opencl_pipeline\ | 12 | Config zero-field rejection, tiny/2B validation, generation config validation, builder chains, forward returns vocab-size logits, empty-token rejection, reset reuse, finite logits |
| \opencl_work_size\ | 14 | Global ≥ elements, divisibility, efficiency ∈ (0,1], 2D/3D coverage, tiled matmul, reduction groups, local fits max, total items product, monotonicity |
| Deterministic edge cases | 17 | Zero alignment, panic on zero, large pages, tiny config values, attention not builtin, SIMD width, max work group, config validation, wrong weight sizes |

## Details

- Uses \ProptestConfig::with_cases(300)\ for thorough coverage
- All 77 tests pass (\cargo test --test opencl_property_tests\)
- Zero clippy warnings (\-D warnings\)
- Tests only publicly-exported APIs (7 of ~13 opencl modules are \pub mod\ in \lib.rs\)