### PR TITLE
Fix Docker CI workspace copy and export diagnostics API from bitnet-opencl

### DIFF
--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -12,6 +12,9 @@
 pub mod backend_dispatcher;
 pub mod backend_registry;
 pub mod context_pool;
+pub mod diagnostics;
+pub mod system_info;
+
 pub mod kv_cache;
 pub mod paged_attention;
 
@@ -20,6 +23,8 @@ pub use backend_dispatcher::{
     DispatchLog, DispatchStrategy, Operation,
 };
 pub use backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
+pub use diagnostics::{DiagnosticReport, GpuDiagnostics, format_json, format_report};
+pub use system_info::collect_system_info;
 pub mod quantized_kernels;
 pub mod quantized_ops;
 pub mod spirv;

--- a/docker/Dockerfile.intel-gpu
+++ b/docker/Dockerfile.intel-gpu
@@ -27,8 +27,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Copy workspace
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
+COPY crossval/ ./crossval/
+COPY tests/ ./tests/
+COPY tests-new/ ./tests-new/
+COPY xtask/ ./xtask/
+COPY xtask-build-helper/ ./xtask-build-helper/
+COPY fuzz/ ./fuzz/
+COPY tools/ ./tools/
 
 # Compile check with oneapi feature (validates Intel backend wiring)
 RUN cargo check --workspace --locked --no-default-features --features cpu,oneapi \

--- a/docker/Dockerfile.nvidia-gpu
+++ b/docker/Dockerfile.nvidia-gpu
@@ -22,8 +22,16 @@ ENV PATH=/root/.cargo/bin:$PATH
 WORKDIR /app
 
 # Copy workspace
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
+COPY crossval/ ./crossval/
+COPY tests/ ./tests/
+COPY tests-new/ ./tests-new/
+COPY xtask/ ./xtask/
+COPY xtask-build-helper/ ./xtask-build-helper/
+COPY fuzz/ ./fuzz/
+COPY tools/ ./tools/
 
 # Build with GPU feature
 RUN cargo build --locked --no-default-features --features gpu

--- a/docker/Dockerfile.test-matrix
+++ b/docker/Dockerfile.test-matrix
@@ -15,8 +15,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
+COPY crossval/ ./crossval/
+COPY tests/ ./tests/
+COPY tests-new/ ./tests-new/
+COPY xtask/ ./xtask/
+COPY xtask-build-helper/ ./xtask-build-helper/
+COPY fuzz/ ./fuzz/
+COPY tools/ ./tools/
 
 # ── CPU feature build + test ─────────────────────────────────────
 FROM base AS test-cpu


### PR DESCRIPTION
### Motivation
- Docker-based CI images were missing the workspace root sources and other workspace-member directories, causing Cargo to fail to locate the root `bitnet` lib target in Docker lanes.
- MSRV/all-targets checks compile integration tests that expect `bitnet-opencl` to expose diagnostics/system-info symbols, but `crates/bitnet-opencl/src/lib.rs` did not re-export them.

### Description
- Updated `docker/Dockerfile.test-matrix`, `docker/Dockerfile.intel-gpu`, and `docker/Dockerfile.nvidia-gpu` to copy the workspace root and other workspace-member directories into the build context by adding `build.rs`, `src/`, `crossval/`, `tests/`, `tests-new/`, `xtask/`, `xtask-build-helper/`, `fuzz/`, and `tools/` to the `COPY` section.
- Declared `pub mod diagnostics;` and `pub mod system_info;` in `crates/bitnet-opencl/src/lib.rs` and re-exported the test-expected API with `pub use diagnostics::{DiagnosticReport, GpuDiagnostics, format_json, format_report};` and `pub use system_info::collect_system_info;`.

### Testing
- Ran `cargo check -p bitnet-opencl --tests --locked --no-default-features --features cpu` and it completed successfully.
- Ran `cargo check --workspace --all-targets --locked --no-default-features --features cpu` which surfaced unrelated preexisting failures in `tests-new` (missing `KernelCapabilities` fields) and therefore did not fully pass; these failures are not introduced by this change.
- Attempted to validate Docker builds with `docker build -f docker/Dockerfile.test-matrix --target test-cpu .`, `docker build -f docker/Dockerfile.intel-gpu --target builder .`, and `docker build -f docker/Dockerfile.nvidia-gpu --target builder .` but could not run them in this environment because `docker` is not available (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a492aa6a688333927bf9917fa29eed)