### PR TITLE
Extract HIP/NPU loading policy into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
+ "bitnet-npu-support",
  "bitnet-quantization",
  "bitnet-st2gguf",
  "bitnet-test-support",
@@ -912,6 +913,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "bitnet-npu-support"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-npu-support",   # SRP: HIP/NPU support policy helpers
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-logits-filters", # SRP: reusable logits/probability filtering transforms
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
@@ -127,6 +128,7 @@ default-members = [
   "crates/bitnet-runtime-profile-core",
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
+  "crates/bitnet-npu-support",
   "crates/bitnet-logits",
   "crates/bitnet-logits-filters",
   "crates/bitnet-generation",

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -19,6 +19,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
+bitnet-npu-support = { path = "../bitnet-npu-support", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -8,6 +8,7 @@ use crate::{BitNetModel, Model};
 use bitnet_common::{
     BitNetConfig, BitNetError, CorrectionRecord, Device, ModelError, ModelMetadata, Result,
 };
+use bitnet_npu_support::model_loading_unsupported_message;
 use candle_core::{DType, Tensor};
 use std::path::Path;
 use tracing::{debug, info};
@@ -285,7 +286,9 @@ impl GgufLoader {
                     .to_string(),
             )),
             Device::Hip(_) | Device::Npu => Err(BitNetError::Validation(
-                "HIP/NPU devices are not yet supported for model loading".to_string(),
+                model_loading_unsupported_message(device)
+                    .unwrap_or("HIP/NPU devices are not yet supported for model loading")
+                    .to_string(),
             )),
             Device::OpenCL(_) => Ok(candle_core::Device::Cpu), // OpenCL uses its own buffer management
         }

--- a/crates/bitnet-models/src/formats/huggingface.rs
+++ b/crates/bitnet-models/src/formats/huggingface.rs
@@ -3,6 +3,7 @@
 use crate::loader::{FormatLoader, LoadConfig, MmapFile};
 use crate::{BitNetModel, Model};
 use bitnet_common::{BitNetConfig, BitNetError, Device, ModelError, ModelMetadata, Result};
+use bitnet_npu_support::model_loading_unsupported_message;
 use candle_core::Tensor;
 use safetensors::{Dtype as SafeDtype, SafeTensors};
 use serde_json::Value;
@@ -278,7 +279,9 @@ impl HuggingFaceLoader {
                     .to_string(),
             )),
             Device::Hip(_) | Device::Npu => Err(BitNetError::Validation(
-                "HIP/NPU devices are not yet supported for model loading".to_string(),
+                model_loading_unsupported_message(device)
+                    .unwrap_or("HIP/NPU devices are not yet supported for model loading")
+                    .to_string(),
             )),
             Device::OpenCL(_) => Ok(candle_core::Device::Cpu), // OpenCL uses its own buffer management
         }

--- a/crates/bitnet-models/src/formats/safetensors/loader.rs
+++ b/crates/bitnet-models/src/formats/safetensors/loader.rs
@@ -3,6 +3,7 @@
 use crate::loader::{FormatLoader, LoadConfig, MmapFile};
 use crate::{BitNetModel, Model};
 use bitnet_common::{BitNetConfig, BitNetError, Device, ModelError, ModelMetadata, Result};
+use bitnet_npu_support::model_loading_unsupported_message;
 use candle_core::Tensor;
 use safetensors::{Dtype as SafeDtype, SafeTensors};
 use std::collections::HashMap;
@@ -86,7 +87,9 @@ impl SafeTensorsLoader {
                     .to_string(),
             )),
             Device::Hip(_) | Device::Npu => Err(BitNetError::Validation(
-                "HIP/NPU devices are not yet supported for model loading".to_string(),
+                model_loading_unsupported_message(device)
+                    .unwrap_or("HIP/NPU devices are not yet supported for model loading")
+                    .to_string(),
             )),
             Device::OpenCL(_) => Ok(candle_core::Device::Cpu), // OpenCL uses its own buffer management
         }

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -3,6 +3,7 @@ use crate::loader::MmapFile;
 use crate::qk256_utils::{detect_qk256_orientation_by_bytes, expected_qk256_shape};
 use crate::quant::i2s_qk256::I2SQk256NoScale;
 use bitnet_common::{BitNetError, Device, QuantizationType, Result};
+use bitnet_npu_support::fallback_warning_message;
 use bitnet_quantization::{QuantizerTrait, TL1Quantizer, TL2Quantizer, qk256_tolerance_bytes};
 use candle_core::{DType, Device as CDevice, Tensor as CandleTensor};
 use std::collections::HashMap;
@@ -223,7 +224,11 @@ fn load_gguf_enhanced(
             CDevice::Cpu
         }
         Device::Hip(_) | Device::Npu => {
-            tracing::warn!("HIP/NPU device requested but not supported, falling back to CPU");
+            tracing::warn!(
+                "{}",
+                fallback_warning_message(&device)
+                    .unwrap_or("HIP/NPU device requested but not supported, falling back to CPU")
+            );
             CDevice::Cpu
         }
     };
@@ -567,7 +572,11 @@ fn load_gguf_minimal(path: &Path, device: Device) -> Result<GgufLoadResult> {
             CDevice::Cpu
         }
         Device::Hip(_) | Device::Npu => {
-            tracing::warn!("HIP/NPU device requested but not supported, falling back to CPU");
+            tracing::warn!(
+                "{}",
+                fallback_warning_message(&device)
+                    .unwrap_or("HIP/NPU device requested but not supported, falling back to CPU")
+            );
             CDevice::Cpu
         }
         Device::OpenCL(_) => {
@@ -1681,7 +1690,11 @@ fn create_mock_tensor_layout(device: Device) -> Result<GgufLoadResult> {
             CDevice::Cpu
         }
         Device::Hip(_) | Device::Npu => {
-            tracing::warn!("HIP/NPU device requested but not supported, fallback to CPU");
+            tracing::warn!(
+                "{}",
+                fallback_warning_message(&device)
+                    .unwrap_or("HIP/NPU device requested but not supported, falling back to CPU")
+            );
             CDevice::Cpu
         }
         Device::OpenCL(_) => {

--- a/crates/bitnet-npu-support/Cargo.toml
+++ b/crates/bitnet-npu-support/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bitnet-npu-support"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SRP helpers for NPU/HIP support policy and fallback behavior"
+
+[dependencies]
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-npu-support/src/lib.rs
+++ b/crates/bitnet-npu-support/src/lib.rs
@@ -1,0 +1,66 @@
+//! SRP microcrate for NPU/HIP backend support policy.
+//!
+//! Centralizes behavior used by model loaders and device routing while
+//! dedicated HIP/NPU backends are still being integrated.
+
+use bitnet_common::Device;
+
+/// Shared validation error text for model loading on unsupported accelerators.
+pub const MODEL_LOADING_UNSUPPORTED_MSG: &str =
+    "HIP/NPU devices are not yet supported for model loading";
+
+/// Returns true when the provided device is currently unsupported for direct
+/// model loading and should be routed through CPU fallback behavior.
+#[must_use]
+pub fn requires_cpu_fallback(device: &Device) -> bool {
+    matches!(device, Device::Hip(_) | Device::Npu)
+}
+
+/// Returns the canonical model-loading validation message when loading is
+/// requested on unsupported accelerators.
+#[must_use]
+pub fn model_loading_unsupported_message(device: &Device) -> Option<&'static str> {
+    if requires_cpu_fallback(device) { Some(MODEL_LOADING_UNSUPPORTED_MSG) } else { None }
+}
+
+/// Returns a warning message for CPU fallback flows.
+#[must_use]
+pub fn fallback_warning_message(device: &Device) -> Option<&'static str> {
+    if requires_cpu_fallback(device) {
+        Some("HIP/NPU device requested but not supported, falling back to CPU")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_unsupported_accelerators() {
+        assert!(requires_cpu_fallback(&Device::Hip(0)));
+        assert!(requires_cpu_fallback(&Device::Npu));
+        assert!(!requires_cpu_fallback(&Device::Cpu));
+        assert!(!requires_cpu_fallback(&Device::Cuda(0)));
+        assert!(!requires_cpu_fallback(&Device::OpenCL(0)));
+    }
+
+    #[test]
+    fn returns_expected_model_loading_message() {
+        assert_eq!(
+            model_loading_unsupported_message(&Device::Npu),
+            Some(MODEL_LOADING_UNSUPPORTED_MSG)
+        );
+        assert_eq!(model_loading_unsupported_message(&Device::Cpu), None);
+    }
+
+    #[test]
+    fn returns_expected_fallback_warning() {
+        assert_eq!(
+            fallback_warning_message(&Device::Hip(1)),
+            Some("HIP/NPU device requested but not supported, falling back to CPU")
+        );
+        assert_eq!(fallback_warning_message(&Device::Metal), None);
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplicated HIP/NPU policy strings and decision logic across model loaders by extracting a single-responsibility microcrate for NPU/HIP support policy. 
- Make loader error messages and fallback warnings consistent and easier to update as proper HIP/NPU backends are integrated. 

### Description
- Add a new microcrate `crates/bitnet-npu-support` that exposes `requires_cpu_fallback`, `model_loading_unsupported_message`, and `fallback_warning_message` and includes unit tests. 
- Wire the new crate into the workspace `Cargo.toml` and add it as a dependency of `crates/bitnet-models`. 
- Replace duplicated literal messages in GGUF, HuggingFace, and SafeTensors loaders to call `model_loading_unsupported_message(...)` for validation errors. 
- Replace repeated fallback warnings in the GGUF simple loader with `fallback_warning_message(...)` calls to centralize text and behavior. 

### Testing
- Ran code formatting with `cargo fmt` and the workspace was formatted without errors. 
- Ran unit tests for the new microcrate with `cargo test -p bitnet-npu-support -q`, which completed successfully (`3` tests passed). 
- Performed a workspace compile/check for the affected consumer with `cargo check -p bitnet-models --lib -q`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49213a9c88333b58dad90600bf3c6)