### PR TITLE
Extract GGUF alignment helpers into shared microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-gguf-layout"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-gpu-hal"
 version = "0.2.1-dev"
 dependencies = [
@@ -973,6 +977,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
+ "bitnet-gguf-layout",
  "bitnet-quantization",
  "bitnet-st2gguf",
  "bitnet-test-fixtures-core",
@@ -1398,6 +1403,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
+ "bitnet-gguf-layout",
  "bitnet-models",
  "bytemuck",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ members = [
   "tools/migrate-gen-config",   # AST migration tool for GenerationConfig
   "crates/bitnet-opencl",       # OpenCL GPU backend with KV cache & paged attention
   "crates/bitnet-wgpu-shaders-i2s", # WGSL compute shaders for I2_S 2-bit inference
+  "crates/bitnet-gguf-layout",
   "crates/bitnet-qk256-dispatch",
 ]
 resolver = "2"
@@ -385,6 +386,7 @@ harness = false
 required-features = ["cpu"]
 
 [workspace.dependencies]
+bitnet-gguf-layout = { path = "crates/bitnet-gguf-layout", version = "0.2.1-dev" }
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }

--- a/crates/bitnet-gguf-layout/Cargo.toml
+++ b/crates/bitnet-gguf-layout/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bitnet-gguf-layout"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SRP helpers for GGUF byte alignment and layout calculations"
+authors.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]

--- a/crates/bitnet-gguf-layout/src/lib.rs
+++ b/crates/bitnet-gguf-layout/src/lib.rs
@@ -1,0 +1,46 @@
+//! Helpers for GGUF byte alignment and layout computations.
+
+/// Align `value` up to the next multiple of `alignment`.
+///
+/// Returns `value` unchanged when `alignment == 0`.
+#[must_use]
+pub fn align_up_u64(value: u64, alignment: u64) -> u64 {
+    if alignment == 0 {
+        return value;
+    }
+    value.div_ceil(alignment) * alignment
+}
+
+/// Align `value` up to the next multiple of `alignment`.
+///
+/// Returns `value` unchanged when `alignment == 0`.
+#[must_use]
+pub fn align_up_usize(value: usize, alignment: usize) -> usize {
+    if alignment == 0 {
+        return value;
+    }
+    value.div_ceil(alignment) * alignment
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_up_u64_behaves() {
+        assert_eq!(align_up_u64(0, 32), 0);
+        assert_eq!(align_up_u64(1, 32), 32);
+        assert_eq!(align_up_u64(31, 32), 32);
+        assert_eq!(align_up_u64(32, 32), 32);
+        assert_eq!(align_up_u64(33, 32), 64);
+    }
+
+    #[test]
+    fn align_up_usize_behaves() {
+        assert_eq!(align_up_usize(0, 32), 0);
+        assert_eq!(align_up_usize(1, 32), 32);
+        assert_eq!(align_up_usize(31, 32), 32);
+        assert_eq!(align_up_usize(32, 32), 32);
+        assert_eq!(align_up_usize(33, 32), 64);
+    }
+}

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -19,6 +19,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
+bitnet-gguf-layout.workspace = true
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/formats/gguf/types.rs
+++ b/crates/bitnet-models/src/formats/gguf/types.rs
@@ -14,6 +14,7 @@
 //! - Resource limits to prevent memory bombs
 
 use bitnet_common::{BitNetError, ModelError, Result, SecurityError, SecurityLimits};
+use bitnet_gguf_layout::align_up_usize;
 
 /// Returns the smallest `x >= off` such that `x % align == 0`.
 /// Safe for any `align >= 1`.
@@ -23,7 +24,7 @@ pub fn align_up(off: usize, align: usize) -> usize {
         return off;
     }
     debug_assert!(align.is_power_of_two(), "alignment should be power-of-two");
-    (off + align - 1) & !(align - 1)
+    align_up_usize(off, align)
 }
 
 /// Parsed GGUF header (v2/v3).

--- a/crates/bitnet-models/src/gguf_writer.rs
+++ b/crates/bitnet-models/src/gguf_writer.rs
@@ -22,6 +22,7 @@ use std::io::{self, Seek, Write};
 use std::path::Path;
 
 use bitnet_gguf::GGUF_MAGIC;
+use bitnet_gguf_layout::align_up_u64 as gguf_align_up_u64;
 
 // ---------------------------------------------------------------------------
 // Tensor data type (write-side mirror of the read-side enum)
@@ -532,10 +533,7 @@ fn pad_to_alignment<W: Write + Seek>(w: &mut W, alignment: usize) -> io::Result<
 /// Smallest value ≥ `offset` that is a multiple of `alignment`.
 #[inline]
 fn align_up_u64(offset: u64, alignment: u64) -> u64 {
-    if alignment == 0 {
-        return offset;
-    }
-    (offset + alignment - 1) & !(alignment - 1)
+    gguf_align_up_u64(offset, alignment)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 # BitNet-rs internal crates
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-gguf-layout.workspace = true
 
 # Core dependencies
 anyhow.workspace = true
@@ -43,6 +44,7 @@ half = "2.6.0"
 
 [dev-dependencies]
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-gguf-layout.workspace = true
 tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true

--- a/crates/bitnet-st2gguf/src/writer.rs
+++ b/crates/bitnet-st2gguf/src/writer.rs
@@ -4,6 +4,7 @@
 //! It ensures proper alignment, metadata handling, and LayerNorm preservation.
 
 use anyhow::{Context, Result, anyhow};
+use bitnet_gguf_layout::align_up_u64;
 use std::fs::File;
 use std::io::{BufWriter, Seek, Write};
 use std::path::Path;
@@ -274,8 +275,7 @@ impl Default for GgufWriter {
 
 /// Align a value up to the specified alignment
 fn align_up(value: u64, alignment: u64) -> u64 {
-    let r = value % alignment;
-    if r == 0 { value } else { value + (alignment - r) }
+    align_up_u64(value, alignment)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Remove duplicated GGUF alignment/layout math scattered across crates and centralize it behind a single SRP microcrate for clarity and reuse.
- Tighten single-responsibility boundaries by extracting low-level byte-alignment helpers used by GGUF readers/writers.
- Make GGUF writer/reader code leaner and easier to reason about by delegating alignment logic to a tested utility crate.

### Description
- Added a new microcrate `crates/bitnet-gguf-layout` that exposes `align_up_u64` and `align_up_usize` with unit tests (`src/lib.rs`).
- Registered the new crate in the workspace and workspace dependencies (`Cargo.toml`) so other crates can depend on it.
- Replaced local alignment implementations with calls to the shared helpers in `crates/bitnet-models/src/formats/gguf/types.rs`, `crates/bitnet-models/src/gguf_writer.rs`, and `crates/bitnet-st2gguf/src/writer.rs`.
- Formatted code and updated `Cargo.toml`/`Cargo.lock` entries to reflect the new crate and wiring.

### Testing
- Ran `cargo test -p bitnet-gguf-layout`, and all unit tests passed (2 passed).
- Ran `cargo check -p bitnet-models --lib`, which completed successfully.
- Ran `cargo check -p bitnet-st2gguf`, which completed successfully.
- Ran `cargo fmt --all` to normalize formatting (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a491ba853c8333b6f64c9696abb60c)