### PR TITLE
Extract chat REPL state/command logic into `bitnet-repl-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "bitnet-models",
  "bitnet-prompt-templates",
  "bitnet-quantization",
+ "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
  "bitnet-startup-contract-guard",
  "bitnet-tokenizers",
@@ -969,6 +970,14 @@ dependencies = [
  "rustc_version_runtime",
  "serde",
  "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "bitnet-repl-core"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
+  "crates/bitnet-repl-core",     # SRP: reusable chat REPL state/command primitives
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
@@ -112,6 +113,7 @@ default-members = [
   "crates/bitnet-logits",
   "crates/bitnet-generation",
   "crates/bitnet-engine-core",
+  "crates/bitnet-repl-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
 ]

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -30,6 +30,7 @@ bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
+bitnet-repl-core = { path = "../bitnet-repl-core", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/commands/chat.rs
+++ b/crates/bitnet-cli/src/commands/chat.rs
@@ -3,12 +3,14 @@
 //! Provides a streaming chat interface with conversation history.
 
 use anyhow::{Context, Result};
+use bitnet_repl_core::{
+    BoundedHistory, ChatMetrics, ReplInput, copy_receipt_if_present, parse_repl_input,
+};
 use console::style;
 use futures::StreamExt;
 use humantime::format_duration;
 use std::io::{self, IsTerminal, Write};
-use std::path::{Path, PathBuf};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 use tracing::{debug, error};
 
 use bitnet_inference::prompt_template::{ChatRole, ChatTurn};
@@ -18,45 +20,6 @@ use tracing::info;
 use super::inference::InferenceCommand;
 use super::template_util::looks_like_llama3_chat;
 use crate::config::CliConfig;
-
-/// Performance metrics for chat session
-#[derive(Debug, Default)]
-struct ChatMetrics {
-    total_tokens_generated: usize,
-    total_time_ms: u64,
-    num_exchanges: usize,
-}
-
-/// Copy receipt from effective receipt path to timestamped file in the specified directory
-fn copy_receipt_if_present(src: &Path, dir: &Path) -> Result<Option<PathBuf>> {
-    use std::fs;
-
-    if !src.exists() {
-        return Ok(None);
-    }
-
-    fs::create_dir_all(dir)?;
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
-    let dst = dir.join(format!("chat-{}.json", ts));
-    fs::copy(src, &dst)?;
-    Ok(Some(dst))
-}
-
-impl ChatMetrics {
-    fn add_exchange(&mut self, tokens: usize, elapsed_ms: u64) {
-        self.total_tokens_generated += tokens;
-        self.total_time_ms += elapsed_ms;
-        self.num_exchanges += 1;
-    }
-
-    fn average_tps(&self) -> f64 {
-        if self.total_time_ms > 0 {
-            (self.total_tokens_generated as f64) / (self.total_time_ms as f64 / 1000.0)
-        } else {
-            0.0
-        }
-    }
-}
 
 impl InferenceCommand {
     /// Run interactive chat mode with REPL
@@ -105,7 +68,8 @@ impl InferenceCommand {
         println!();
 
         // Conversation history: typed chat turns
-        let mut conversation_history: Vec<ChatTurn> = Vec::new();
+        let mut conversation_history: BoundedHistory<ChatTurn> =
+            BoundedHistory::new(self.chat_history_limit);
         let mut metrics = ChatMetrics::default();
 
         // Create generation config
@@ -134,122 +98,113 @@ impl InferenceCommand {
             match io::stdin().read_line(&mut input) {
                 Ok(0) => break, // EOF (Ctrl+D)
                 Ok(_) => {
-                    let line = input.trim();
-
-                    if line.is_empty() {
+                    let Some(parsed) = parse_repl_input(&input) else {
                         continue;
-                    }
+                    };
 
-                    // Handle commands
-                    match line {
-                        "/exit" | "/quit" => break,
-                        "/help" => {
+                    match parsed {
+                        ReplInput::Exit => break,
+                        ReplInput::Help => {
                             self.show_chat_help();
                             continue;
                         }
-                        "/clear" => {
+                        ReplInput::Clear => {
                             conversation_history.clear();
                             metrics = ChatMetrics::default();
                             println!("{}", style("Conversation cleared.").dim());
                             continue;
                         }
-                        "/metrics" => {
+                        ReplInput::Metrics => {
                             self.show_chat_metrics(&metrics);
                             continue;
                         }
-                        _ => {}
-                    }
+                        ReplInput::Message(line) => {
+                            // Format prompt with conversation history using library render_chat()
+                            // Build current turn history (all previous + current user input)
+                            let mut current_history = conversation_history.to_vec();
+                            current_history.push(ChatTurn::new(ChatRole::User, &line));
 
-                    // Format prompt with conversation history using library render_chat()
-                    // Build current turn history (all previous + current user input)
-                    let mut current_history = conversation_history.clone();
-                    current_history.push(ChatTurn::new(ChatRole::User, line));
+                            let formatted_prompt = template_type
+                                .render_chat(&current_history, self.system_prompt.as_deref())?;
 
-                    let formatted_prompt = template_type
-                        .render_chat(&current_history, self.system_prompt.as_deref())?;
-
-                    if self.verbose {
-                        debug!("Formatted prompt:\n{}", formatted_prompt);
-                    }
-
-                    // Run streaming inference
-                    let start_time = Instant::now();
-                    if is_tty {
-                        print!("{} ", style("assistant>").blue().bold());
-                    } else {
-                        print!("assistant> ");
-                    }
-
-                    // Handle BrokenPipe gracefully
-                    if let Err(e) = io::stdout().flush() {
-                        if e.kind() == io::ErrorKind::BrokenPipe {
-                            return Ok(());
-                        }
-                        return Err(e.into());
-                    }
-
-                    match self.run_chat_inference(&mut engine, &formatted_prompt, &gen_config).await
-                    {
-                        Ok((response_text, token_count)) => {
-                            println!(); // Newline after streaming
-
-                            let elapsed = start_time.elapsed();
-                            let elapsed_ms = elapsed.as_millis() as u64;
-
-                            // Update metrics
-                            metrics.add_exchange(token_count, elapsed_ms);
-
-                            // Add to conversation history: user turn and assistant turn
-                            conversation_history.push(ChatTurn::new(ChatRole::User, line));
-                            conversation_history
-                                .push(ChatTurn::new(ChatRole::Assistant, &response_text));
-
-                            // Enforce chat_history_limit if specified
-                            if let Some(limit) = self.chat_history_limit
-                                && conversation_history.len() > limit
-                            {
-                                let excess = conversation_history.len() - limit;
-                                conversation_history.drain(0..excess);
+                            if self.verbose {
+                                debug!("Formatted prompt:\n{}", formatted_prompt);
                             }
 
-                            // Copy receipt if directory specified
-                            if let Some(dir) = &self.emit_receipt_dir {
-                                let receipt_src = self.effective_receipt_path();
-                                match copy_receipt_if_present(receipt_src, dir) {
-                                    Ok(Some(path)) => {
-                                        debug!("Receipt saved: {}", path.display());
+                            // Run streaming inference
+                            let start_time = Instant::now();
+                            if is_tty {
+                                print!("{} ", style("assistant>").blue().bold());
+                            } else {
+                                print!("assistant> ");
+                            }
+
+                            // Handle BrokenPipe gracefully
+                            if let Err(e) = io::stdout().flush() {
+                                if e.kind() == io::ErrorKind::BrokenPipe {
+                                    return Ok(());
+                                }
+                                return Err(e.into());
+                            }
+
+                            match self
+                                .run_chat_inference(&mut engine, &formatted_prompt, &gen_config)
+                                .await
+                            {
+                                Ok((response_text, token_count)) => {
+                                    println!(); // Newline after streaming
+
+                                    let elapsed = start_time.elapsed();
+                                    let elapsed_ms = elapsed.as_millis() as u64;
+
+                                    // Update metrics
+                                    metrics.add_exchange(token_count, elapsed_ms);
+
+                                    // Add to conversation history: user turn and assistant turn
+                                    conversation_history.push(ChatTurn::new(ChatRole::User, &line));
+                                    conversation_history
+                                        .push(ChatTurn::new(ChatRole::Assistant, &response_text));
+
+                                    // Copy receipt if directory specified
+                                    if let Some(dir) = &self.emit_receipt_dir {
+                                        let receipt_src = self.effective_receipt_path();
+                                        match copy_receipt_if_present(receipt_src, dir) {
+                                            Ok(Some(path)) => {
+                                                debug!("Receipt saved: {}", path.display());
+                                            }
+                                            Ok(None) => {
+                                                debug!("No receipt found to copy");
+                                            }
+                                            Err(e) => {
+                                                debug!("Failed to copy receipt: {}", e);
+                                            }
+                                        }
                                     }
-                                    Ok(None) => {
-                                        debug!("No receipt found to copy");
+
+                                    // Show timing if metrics enabled
+                                    if self.metrics {
+                                        let tps = if elapsed.as_secs_f64() > 0.0 {
+                                            token_count as f64 / elapsed.as_secs_f64()
+                                        } else {
+                                            0.0
+                                        };
+                                        println!(
+                                            "  {} {} ({:.2} tok/s)",
+                                            style("Time:").dim(),
+                                            style(format_duration(elapsed)).dim(),
+                                            tps
+                                        );
                                     }
-                                    Err(e) => {
-                                        debug!("Failed to copy receipt: {}", e);
-                                    }
+
+                                    println!(); // Extra line for readability
+                                }
+                                Err(e) => {
+                                    println!();
+                                    error!("Inference failed: {}", e);
+                                    println!("{}", style(format!("Error: {}", e)).red());
+                                    println!();
                                 }
                             }
-
-                            // Show timing if metrics enabled
-                            if self.metrics {
-                                let tps = if elapsed.as_secs_f64() > 0.0 {
-                                    token_count as f64 / elapsed.as_secs_f64()
-                                } else {
-                                    0.0
-                                };
-                                println!(
-                                    "  {} {} ({:.2} tok/s)",
-                                    style("Time:").dim(),
-                                    style(format_duration(elapsed)).dim(),
-                                    tps
-                                );
-                            }
-
-                            println!(); // Extra line for readability
-                        }
-                        Err(e) => {
-                            println!();
-                            error!("Inference failed: {}", e);
-                            println!("{}", style(format!("Error: {}", e)).red());
-                            println!();
                         }
                     }
                 }

--- a/crates/bitnet-repl-core/Cargo.toml
+++ b/crates/bitnet-repl-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-repl-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for chat REPL state management"
+
+[dependencies]
+anyhow.workspace = true
+
+[dev-dependencies]
+tempfile = "3.23.0"

--- a/crates/bitnet-repl-core/src/lib.rs
+++ b/crates/bitnet-repl-core/src/lib.rs
@@ -1,0 +1,163 @@
+//! Core, reusable building blocks for chat-style REPL flows.
+
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Parsed result of one line entered into the REPL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplInput {
+    Exit,
+    Help,
+    Clear,
+    Metrics,
+    Message(String),
+}
+
+/// Parse a raw line from stdin into a REPL action.
+///
+/// Empty or whitespace-only lines are ignored and return `None`.
+pub fn parse_repl_input(line: &str) -> Option<ReplInput> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    Some(match line {
+        "/exit" | "/quit" => ReplInput::Exit,
+        "/help" => ReplInput::Help,
+        "/clear" => ReplInput::Clear,
+        "/metrics" => ReplInput::Metrics,
+        _ => ReplInput::Message(line.to_owned()),
+    })
+}
+
+/// Performance metrics for a chat session.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ChatMetrics {
+    pub total_tokens_generated: usize,
+    pub total_time_ms: u64,
+    pub num_exchanges: usize,
+}
+
+impl ChatMetrics {
+    pub fn add_exchange(&mut self, tokens: usize, elapsed_ms: u64) {
+        self.total_tokens_generated += tokens;
+        self.total_time_ms += elapsed_ms;
+        self.num_exchanges += 1;
+    }
+
+    pub fn average_tps(&self) -> f64 {
+        if self.total_time_ms > 0 {
+            self.total_tokens_generated as f64 / (self.total_time_ms as f64 / 1000.0)
+        } else {
+            0.0
+        }
+    }
+}
+
+/// FIFO history buffer with an optional max size.
+#[derive(Debug, Clone)]
+pub struct BoundedHistory<T> {
+    items: Vec<T>,
+    limit: Option<usize>,
+}
+
+impl<T> BoundedHistory<T> {
+    pub fn new(limit: Option<usize>) -> Self {
+        Self { items: Vec::new(), limit }
+    }
+
+    pub fn push(&mut self, item: T) {
+        self.items.push(item);
+        self.enforce_limit();
+    }
+
+    pub fn clear(&mut self) {
+        self.items.clear();
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.items.iter()
+    }
+
+    pub fn to_vec(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.items.clone()
+    }
+
+    fn enforce_limit(&mut self) {
+        if let Some(limit) = self.limit
+            && self.items.len() > limit
+        {
+            let excess = self.items.len() - limit;
+            self.items.drain(0..excess);
+        }
+    }
+}
+
+/// Copy receipt from effective receipt path to timestamped file in the target directory.
+pub fn copy_receipt_if_present(src: &Path, dir: &Path) -> Result<Option<PathBuf>> {
+    if !src.exists() {
+        return Ok(None);
+    }
+
+    fs::create_dir_all(dir)?;
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+    let dst = dir.join(format!("chat-{}.json", ts));
+    fs::copy(src, &dst)?;
+    Ok(Some(dst))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_commands_and_messages() {
+        assert_eq!(parse_repl_input("   "), None);
+        assert_eq!(parse_repl_input("/help"), Some(ReplInput::Help));
+        assert_eq!(parse_repl_input("/quit"), Some(ReplInput::Exit));
+        assert_eq!(parse_repl_input("hello"), Some(ReplInput::Message("hello".into())));
+    }
+
+    #[test]
+    fn bounded_history_trims_fifo() {
+        let mut history = BoundedHistory::new(Some(2));
+        history.push(1);
+        history.push(2);
+        history.push(3);
+
+        let items: Vec<_> = history.iter().copied().collect();
+        assert_eq!(items, vec![2, 3]);
+    }
+
+    #[test]
+    fn metrics_average_is_zero_without_time() {
+        let mut metrics = ChatMetrics::default();
+        metrics.add_exchange(5, 0);
+        assert_eq!(metrics.average_tps(), 0.0);
+    }
+
+    #[test]
+    fn copies_receipt_if_present() {
+        let src_dir = tempdir().expect("temp dir should be created");
+        let dst_dir = tempdir().expect("temp dir should be created");
+        let src = src_dir.path().join("receipt.json");
+        fs::write(&src, "{}\n").expect("receipt fixture should be written");
+
+        let copied = copy_receipt_if_present(&src, dst_dir.path())
+            .expect("copy should succeed")
+            .expect("receipt should be copied");
+
+        assert!(copied.exists());
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize and SRP-separate REPL/chat primitives that were embedded in the CLI so they can be reused and tested independently. 
- Reduce responsibility of `bitnet-cli` by moving parsing, history, metrics and receipt archival into a focused microcrate. 

### Description
- Add a new microcrate `bitnet-repl-core` that exposes `ReplInput`/`parse_repl_input`, `BoundedHistory<T>`, `ChatMetrics`, and `copy_receipt_if_present` for chat REPL flows. 
- Wire `bitnet-repl-core` into the workspace and into `bitnet-cli` by updating `Cargo.toml` and adding the dependency `bitnet-repl-core = { path = "../bitnet-repl-core", version = "0.2.1-dev" }`. 
- Refactor `crates/bitnet-cli/src/commands/chat.rs` to consume the new primitives (replace ad-hoc parsing, history Vec, metrics and receipt-copy logic with calls to `parse_repl_input`, `BoundedHistory<ChatTurn>`, `ChatMetrics`, and `copy_receipt_if_present`) while preserving the original interactive behaviour. 
- Add focused unit tests inside `crates/bitnet-repl-core/src/lib.rs` for parsing, FIFO trimming, metrics, and receipt copying. 

### Testing
- Ran formatting with `cargo fmt --all`, which completed successfully. 
- Ran unit tests for the new crate with `cargo test -p bitnet-repl-core`, all tests passed (`4 passed`). 
- Ran the CLI history tests with `cargo test -p bitnet-cli --test history_trim`, all tests passed (`12 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a491b589cc8333880a7d41e04127a3)