### PR TITLE
docs: update CHANGELOG with A770 OpenCL waves 104-107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,33 @@ All notable changes to bitnet-rs will be documented in this file.
 
 - **PR #1063**: Closed destructive force-push that removed 813 lines from workspace config; superseded by fresh attention kernel (#1920)
 
+### Added — A770 OpenCL Inference Pipeline (Waves 105–107)
+
+- **Batch Inference**: Padding, scheduling, and batched operations for OpenCL inference pipeline, 51 tests (#1985)
+- **Reduction Kernels** (`reduction.cl`): argmax, sum, mean, L2 norm, log-sum-exp with tree reduction, 48 tests (#1986)
+- **Tensor Operations**: transpose, permute, concat, broadcast, gather for OpenCL tensors, 43 tests (#1987)
+- **Multi-Device Discovery**: Intel GPU multi-device discovery and selection with priority-based ranking, 43 tests (#1988)
+- **Cross-Validation Harness**: OpenCL vs CPU golden-vector cross-validation framework, 46 tests (#1989)
+- **Optimized Tiled MatMul**: 16×16 tiles with float4 vectorization and batched dispatch, 56 tests (#2005)
+- **Flash Attention** (`flash_attention.cl`): Memory-efficient block-tiled attention for long sequences, 40 tests (#1991)
+- **Fused Operations**: norm+linear, SwiGLU, bias+activation fused kernels for reduced memory traffic, 58 tests (#1993)
+- **Autoregressive Generation**: Token generation loop with sampling strategies for OpenCL backend, 61 tests (#1995)
+
+### Testing — A770 OpenCL (Waves 105–107)
+
+- **Property-Based Tests**: Property-based tests for OpenCL CPU reference implementations, 77 tests (#1999)
+
+### Added — A770 OpenCL Infrastructure (Wave 104)
+
+- **Device Warmup**: OpenCL device warmup module with kernel pre-compilation and buffer pre-allocation, 43 tests (#1957)
+- **Telemetry/Metrics**: Telemetry and metrics collection for OpenCL kernel execution, 44 tests (#1958)
+- **Intel GPU Architecture Docs**: Intel GPU architecture documentation for Xe-HPG optimization guidelines (#1959)
+- **Work Scheduler**: DAG-based task scheduling with dependency resolution and priority dispatch, 46 tests (#1960)
+
+### Testing — A770 OpenCL (Wave 104)
+
+- **E2E Integration Tests**: End-to-end integration tests for OpenCL compute kernels, 41 tests (#1967)
+
 ### Wave 99: Intel GPU Integration & Documentation
 
 - **Intel GPU architecture guide** (#1687): comprehensive Intel Arc backend design doc with architecture diagram, kernel categories, Xe-HPG optimization notes, and testing strategy


### PR DESCRIPTION
Update CHANGELOG.md to document waves 104-107 of the Intel Arc A770 OpenCL implementation.

## Wave 104
- #1957: Device warmup module (43 tests)
- #1958: Telemetry/metrics collection (44 tests)
- #1959: Intel GPU architecture documentation
- #1960: Work scheduler with DAG-based task scheduling (46 tests)
- #1967: E2E integration tests for OpenCL kernels (41 tests)

## Wave 105
- #1985: Batch inference support (51 tests)
- #1986: Reduction kernels (48 tests)
- #1987: Tensor operations (43 tests)
- #1988: Multi-device discovery (43 tests)
- #1989: Cross-validation harness (46 tests)
- #1999: Property-based tests (77 tests)
- #2005: Optimized tiled matmul (56 tests)

## Wave 106
- #1991: Flash attention (40 tests)
- #1993: Fused operations (58 tests)
- #1995: Autoregressive token generation (61 tests)