### PR TITLE
ci: add reproducible Nix flake workflow

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -42,10 +42,10 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v17
+        uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3  # v17
 
       - name: Configure Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v7
+        uses: DeterminateSystems/magic-nix-cache-action@b46e247b898aa56e6d2d2e728dc6df6c84fdb738  # v7
 
       - name: Validate flake metadata
         run: nix flake metadata --accept-flake-config


### PR DESCRIPTION
### Motivation

- Provide a reproducible CI lane that exercises the repository's Nix flake and produces the same build outputs as local development. 
- Catch flake metadata/check/build regressions early and surface deterministic, cache-enabled builds for primary artifacts. 

### Description

- Add a new GitHub Actions workflow at `/.github/workflows/nix-ci.yml` that triggers on PRs/pushes touching `flake.nix`, `flake.lock`, Cargo files, core sources, and the local CI script. 
- The job installs Nix via `DeterminateSystems/nix-installer-action`, configures binary caches via `DeterminateSystems/magic-nix-cache-action`, and runs `nix flake metadata` and `nix flake check`. 
- The workflow builds primary package outputs with `nix build --accept-flake-config --print-build-logs .#bitnet-server`, `.#bitnet-cli`, and `.#bitnet-st2gguf`. 
- Workflow-level hardening includes concurrency cancellation and least-privilege `contents: read` permissions.

### Testing

- Verified the workflow YAML by parsing `/.github/workflows/nix-ci.yml` with Python and `yaml.safe_load`, which succeeded. 
- Attempted to run `nix --version` in the local container but `nix` is not installed here, so `nix`-based commands were not executed locally and are expected to run in CI. 
- The workflow is designed to execute `nix flake check` and builds on GitHub Actions where Nix is installed and cache configuration is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a491869e40833397da7aba32eb3071)