### PR TITLE
refactor(xtask): extract download mechanics into a dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-download"
+version = "0.2.1-dev"
+dependencies = [
+ "httpdate",
+ "reqwest",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bitnet-engine-core"
 version = "0.2.1-dev"
 dependencies = [
@@ -9336,6 +9345,7 @@ dependencies = [
  "bitnet-bdd-grid",
  "bitnet-common",
  "bitnet-crossval",
+ "bitnet-download",
  "bitnet-inference",
  "bitnet-kernels",
  "bitnet-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
@@ -114,6 +115,7 @@ default-members = [
   "crates/bitnet-engine-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-download",      # SRP: download mechanics primitives
 ]
 
 [package]

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-download"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
+
+[dependencies]
+reqwest = { workspace = true, features = ["blocking"] }
+httpdate = "1.0.3"
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,0 +1,159 @@
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use std::{fs, path::Path, time::SystemTime};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Returns true when download logic should operate in offline mode.
+#[must_use]
+pub fn offline_enabled(cli_offline: bool) -> bool {
+    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
+}
+
+/// Safe exponential backoff helper with deterministic jitter.
+#[must_use]
+pub fn exp_backoff_ms(attempt: u32) -> u64 {
+    let shift = attempt.saturating_sub(1).min(20);
+    let base = (200u64).saturating_mul(1u64 << shift).min(10_000);
+    let jitter = (attempt as u64 * 37) % 200;
+    base.saturating_add(jitter)
+}
+
+/// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
+#[must_use]
+pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
+    retry_after_secs_at(headers, SystemTime::now())
+}
+
+/// Same as [`retry_after_secs`] but allows injecting the current time for deterministic tests.
+#[must_use]
+pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
+    let raw = match headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok()) {
+        Some(s) => s,
+        None => return 5,
+    };
+
+    if let Ok(s) = raw.parse::<u64>() {
+        return s.min(3600);
+    }
+
+    httpdate::parse_http_date(raw)
+        .ok()
+        .and_then(|when| when.duration_since(now).ok())
+        .map(|d| d.as_secs().clamp(1, 3600))
+        .unwrap_or(5)
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::RETRY_AFTER;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn retry_after_seconds() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "10".parse().expect("valid retry-after seconds"));
+        assert_eq!(retry_after_secs(&headers), 10);
+    }
+
+    #[test]
+    fn retry_after_http_date() {
+        let now = SystemTime::now();
+        let future = now + Duration::from_secs(5);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            httpdate::fmt_http_date(future).parse().expect("valid retry-after date"),
+        );
+
+        let wait = retry_after_secs_at(&headers, now);
+        assert!((4..=6).contains(&wait));
+    }
+
+    #[test]
+    fn retry_after_past_date_falls_back() {
+        let now = SystemTime::now();
+        let past = now - Duration::from_secs(10);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            httpdate::fmt_http_date(past).parse().expect("valid retry-after date"),
+        );
+
+        assert_eq!(retry_after_secs_at(&headers, now), 5);
+    }
+
+    #[test]
+    fn exp_backoff_matches_contract() {
+        assert_eq!(exp_backoff_ms(1), 237);
+        assert_eq!(exp_backoff_ms(2), 474);
+        assert_eq!(exp_backoff_ms(3), 911);
+        assert_eq!(exp_backoff_ms(10), 10_170);
+    }
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+}

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -28,6 +28,7 @@ chrono = "0.4.42"
 bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
 bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev", default-features = false, features = ["cpu"] }
 bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev", default-features = false }
+bitnet-download = { path = "../crates/bitnet-download", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../crates/bitnet-tokenizers", version = "0.2.1-dev", default-features = false, features = ["spm"] }
 bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, optional = true }
 bitnet = { path = "..", version = "0.2.1-dev", default-features = false, features = ["cpu"], optional = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,18 +1,21 @@
 use anyhow::{Context, Result, anyhow, bail};
 use bitnet_common::Device;
+use bitnet_download::{
+    atomic_write, exp_backoff_ms, offline_enabled as bitnet_offline_enabled,
+    parse_content_range_total, retry_after_secs, validate_downloaded_len,
+};
 use bitnet_kernels::gpu_utils::get_gpu_info;
 use clap::{Parser, Subcommand, ValueEnum};
 use console::style;
 use fs2::FileExt;
 use fs2::available_space;
-use httpdate::parse_http_date;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use regex::Regex;
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
 use reqwest::header::{
     ACCEPT_ENCODING, ACCEPT_RANGES, AUTHORIZATION, CONTENT_LENGTH, CONTENT_RANGE, ETAG,
-    IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_RANGE, LAST_MODIFIED, RANGE, RETRY_AFTER,
+    IF_MODIFIED_SINCE, IF_NONE_MATCH, IF_RANGE, LAST_MODIFIED, RANGE,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -29,7 +32,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
     },
     thread,
-    time::{Duration, Instant, SystemTime},
+    time::{Duration, Instant},
 };
 use walkdir::WalkDir;
 
@@ -129,72 +132,6 @@ const EXIT_VERIFICATION_FAILED: i32 = 15;
 const EXIT_INFERENCE_FAILED: i32 = 16;
 const EXIT_BENCHMARK_FAILED: i32 = 17;
 const EXIT_INTERRUPTED: i32 = 130;
-
-// Safe exponential backoff helper with jitter
-#[inline]
-fn exp_backoff_ms(attempt: u32) -> u64 {
-    // 200ms, 400ms, 800ms… capped at 10s
-    let shift = attempt.saturating_sub(1).min(20);
-    let base = (200u64).saturating_mul(1u64 << shift).min(10_000);
-    // Add deterministic jitter: +0..199ms based on attempt
-    let jitter = (attempt as u64 * 37) % 200;
-    base.saturating_add(jitter)
-}
-
-// Parse Retry-After header (supports both seconds and HTTP-date)
-fn bitnet_offline_enabled(cli_offline: bool) -> bool {
-    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
-}
-
-fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> u64 {
-    let raw = match headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok()) {
-        Some(s) => s,
-        None => return 5, // Default to 5 seconds
-    };
-
-    // Try parsing as integer seconds first
-    if let Ok(s) = raw.parse::<u64>() {
-        return s.min(3600); // Cap at 1 hour
-    }
-
-    // Try parsing as HTTP-date
-    parse_http_date(raw)
-        .ok()
-        .and_then(|when| when.duration_since(SystemTime::now()).ok())
-        .map(|d| d.as_secs().clamp(1, 3600))
-        .unwrap_or(5) // Default to 5 seconds if parsing fails
-}
-
-fn validate_downloaded_len(downloaded: u64, expected_total: Option<u64>) -> Result<()> {
-    if let Some(total) = expected_total
-        && downloaded != total
-    {
-        bail!("download truncated: got {} bytes, expected {}", downloaded, total);
-    }
-    Ok(())
-}
-
-// Atomic write helper for metadata files
-fn atomic_write(path: &Path, bytes: &[u8]) -> Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-    fs::rename(&tmp, path)?;
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-    Ok(())
-}
 
 // Centralized defaults to avoid drift
 const DEFAULT_MODEL_ID: &str = "microsoft/bitnet-b1.58-2B-4T-gguf";
@@ -1646,7 +1583,7 @@ fn download_model_cmd(config: DownloadConfig) -> Result<()> {
                         .headers()
                         .get(CONTENT_RANGE)
                         .and_then(|h| h.to_str().ok())
-                        .and_then(|s| s.rsplit('/').next()?.parse::<u64>().ok())?;
+                        .and_then(parse_content_range_total)?;
                     Some(sz)
                 })
                 .map(|sz| (Some(sz), true))
@@ -6625,6 +6562,7 @@ fn run_inference_internal(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use reqwest::header::RETRY_AFTER;
     use std::net::TcpListener;
     use std::sync::{Arc, Mutex};
     use std::thread;


### PR DESCRIPTION
### Motivation

- The `xtask` download command mixed orchestration and low-level download mechanics, making reuse and testing harder. 
- Extracting these mechanics into a small SRP microcrate centralizes retry/backoff, offline handling, metadata, and validation so other crates can reuse them.

### Description

- Added a new microcrate `crates/bitnet-download` exposing helpers: `offline_enabled`, `exp_backoff_ms`, `retry_after_secs`/`retry_after_secs_at`, `parse_content_range_total`, `validate_downloaded_len`, and `atomic_write`.
- Rewired `xtask` to call into `bitnet-download` (replacing in-file helpers) and updated the `Content-Range` parsing and metadata writes to use the new crate.
- Registered `crates/bitnet-download` in the workspace and added it as a dependency in `xtask/Cargo.toml` and the workspace `Cargo.toml`.
- Added focused unit tests inside `crates/bitnet-download` for the core contracts and adjusted `xtask` tests to use the shared helpers.

### Testing

- Ran `cargo fmt --all` to normalize formatting, which completed successfully.
- Ran `cargo test -p bitnet-download` and all microcrate unit tests passed (`6 passed; 0 failed`).
- Ran targeted `xtask` tests without default GPU features via `cargo test -p xtask --no-default-features test_retry_after` and `cargo test -p xtask --no-default-features test_validate_downloaded_len_ok`, both of which passed in this environment.
- Attempting a full `cargo test -p xtask` with default features failed at link time due to missing system CUDA libraries (`-lcuda`, `-lnvrtc`, `-lcurand`, `-lcublas`), so full-feature integration tests were not run here due to the environment rather than code errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4913fdffc833395dfd12ba171d9d5)