### PR TITLE
test: proptest wave 16 — 134 properties across 5 crates

### DIFF
--- a/crates/bitnet-common/tests/proptest_wave16.rs
+++ b/crates/bitnet-common/tests/proptest_wave16.rs
@@ -1,0 +1,409 @@
+//! Property-based tests — wave 16.
+//!
+//! Tensor shape validation: broadcasting, matmul, reshape, transpose,
+//! attention shapes, and KernelCapabilities invariants.
+
+use bitnet_common::{
+    kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel},
+    tensor_validation::{
+        broadcast_shape, can_broadcast, validate_attention_shapes, validate_matmul_shapes,
+        validate_reshape, validate_transpose_axes,
+    },
+    types::{Device, GenerationConfig, PerformanceMetrics, QuantizationType},
+};
+use proptest::prelude::*;
+
+// ── Broadcasting properties ─────────────────────────────────────────────────
+
+proptest! {
+    /// Broadcasting is reflexive: any shape broadcasts with itself.
+    #[test]
+    fn broadcast_reflexive(
+        shape in prop::collection::vec(1usize..8, 1..4),
+    ) {
+        let result = broadcast_shape(&shape, &shape);
+        prop_assert!(result.is_ok(), "shape {:?} should broadcast with itself", shape);
+        prop_assert_eq!(result.unwrap(), shape);
+    }
+
+    /// Broadcasting is symmetric: broadcast(a, b) == broadcast(b, a).
+    #[test]
+    fn broadcast_symmetric(
+        a in prop::collection::vec(1usize..4, 1..3),
+        b in prop::collection::vec(1usize..4, 1..3),
+    ) {
+        let ab = broadcast_shape(&a, &b);
+        let ba = broadcast_shape(&b, &a);
+        match (ab, ba) {
+            (Ok(ab), Ok(ba)) => prop_assert_eq!(ab, ba),
+            (Err(_), Err(_)) => {} // both fail — OK
+            (ab, ba) => prop_assert!(false,
+                "asymmetric broadcast: a={:?} b={:?} → {:?} vs {:?}", a, b, ab, ba),
+        }
+    }
+
+    /// can_broadcast agrees with broadcast_shape.
+    #[test]
+    fn can_broadcast_agrees(
+        a in prop::collection::vec(1usize..4, 1..3),
+        b in prop::collection::vec(1usize..4, 1..3),
+    ) {
+        let ok = broadcast_shape(&a, &b).is_ok();
+        prop_assert_eq!(can_broadcast(&a, &b), ok);
+    }
+
+    /// Broadcasting with [1] never changes the other shape.
+    #[test]
+    fn broadcast_with_ones(
+        shape in prop::collection::vec(1usize..8, 1..4),
+    ) {
+        let ones = vec![1usize; shape.len()];
+        let result = broadcast_shape(&shape, &ones).unwrap();
+        prop_assert_eq!(result, shape);
+    }
+
+    /// Broadcast output ndim = max(a.ndim, b.ndim).
+    #[test]
+    fn broadcast_output_ndim(
+        a in prop::collection::vec(1usize..4, 1..4),
+        b in prop::collection::vec(1usize..4, 1..4),
+    ) {
+        if let Ok(out) = broadcast_shape(&a, &b) {
+            prop_assert_eq!(out.len(), a.len().max(b.len()));
+        }
+    }
+}
+
+// ── Matmul shape validation ─────────────────────────────────────────────────
+
+proptest! {
+    /// 2D matmul [M,K] × [K,N] → [M,N].
+    #[test]
+    fn matmul_2d_output_shape(
+        m in 1usize..16,
+        k in 1usize..16,
+        n in 1usize..16,
+    ) {
+        let out = validate_matmul_shapes(&[m, k], &[k, n]).unwrap();
+        prop_assert_eq!(out, vec![m, n]);
+    }
+
+    /// 1D dot product [K] × [K] → [].
+    #[test]
+    fn matmul_1d_dot_product(k in 1usize..32) {
+        let out = validate_matmul_shapes(&[k], &[k]).unwrap();
+        prop_assert!(out.is_empty(), "dot product should produce scalar shape");
+    }
+
+    /// Mismatched inner dims always fail.
+    #[test]
+    fn matmul_inner_mismatch_fails(
+        m in 1usize..8,
+        k1 in 1usize..8,
+        k2 in 1usize..8,
+        n in 1usize..8,
+    ) {
+        prop_assume!(k1 != k2);
+        prop_assert!(validate_matmul_shapes(&[m, k1], &[k2, n]).is_err());
+    }
+
+    /// Empty shapes always fail.
+    #[test]
+    fn matmul_empty_shapes_fail(_dummy in 0u8..1) {
+        prop_assert!(validate_matmul_shapes(&[], &[4]).is_err());
+        prop_assert!(validate_matmul_shapes(&[4], &[]).is_err());
+        prop_assert!(validate_matmul_shapes(&[], &[]).is_err());
+    }
+}
+
+// ── Reshape validation ──────────────────────────────────────────────────────
+
+proptest! {
+    /// Reshape to same element count always succeeds.
+    #[test]
+    fn reshape_same_elements_ok(
+        d0 in 1usize..16,
+        d1 in 1usize..16,
+    ) {
+        let n = d0 * d1;
+        prop_assert!(validate_reshape(&[d0, d1], &[n]).is_ok());
+        prop_assert!(validate_reshape(&[n], &[d0, d1]).is_ok());
+    }
+
+    /// Reshape to different element count always fails.
+    #[test]
+    fn reshape_different_elements_fail(
+        a in 2usize..64,
+        b in 2usize..64,
+    ) {
+        prop_assume!(a != b);
+        prop_assert!(validate_reshape(&[a], &[b]).is_err());
+    }
+
+    /// Reshape is reflexive: any shape reshapes to itself.
+    #[test]
+    fn reshape_reflexive(
+        shape in prop::collection::vec(1usize..8, 1..4),
+    ) {
+        prop_assert!(validate_reshape(&shape, &shape).is_ok());
+    }
+}
+
+// ── Transpose validation ────────────────────────────────────────────────────
+
+proptest! {
+    /// Identity permutation always succeeds and preserves shape.
+    #[test]
+    fn transpose_identity(
+        shape in prop::collection::vec(1usize..8, 1..5),
+    ) {
+        let axes: Vec<usize> = (0..shape.len()).collect();
+        let result = validate_transpose_axes(&shape, &axes).unwrap();
+        prop_assert_eq!(result, shape);
+    }
+
+    /// Double transpose is identity.
+    #[test]
+    fn transpose_double_is_identity(
+        d0 in 1usize..8,
+        d1 in 1usize..8,
+    ) {
+        let shape = vec![d0, d1];
+        let perm = vec![1, 0];
+        let first = validate_transpose_axes(&shape, &perm).unwrap();
+        let second = validate_transpose_axes(&first, &perm).unwrap();
+        prop_assert_eq!(second, shape);
+    }
+
+    /// Transpose preserves total element count.
+    #[test]
+    fn transpose_preserves_elements(
+        d0 in 1usize..8,
+        d1 in 1usize..8,
+        d2 in 1usize..8,
+    ) {
+        let shape = vec![d0, d1, d2];
+        let perm = vec![2, 0, 1];
+        let result = validate_transpose_axes(&shape, &perm).unwrap();
+        let orig_elems: usize = shape.iter().product();
+        let new_elems: usize = result.iter().product();
+        prop_assert_eq!(orig_elems, new_elems);
+    }
+
+    /// Out-of-range axis always fails.
+    #[test]
+    fn transpose_out_of_range_fails(
+        ndim in 1usize..5,
+    ) {
+        let shape = vec![2; ndim];
+        let mut axes: Vec<usize> = (0..ndim).collect();
+        axes[0] = ndim; // out of range
+        prop_assert!(validate_transpose_axes(&shape, &axes).is_err());
+    }
+
+    /// Wrong number of axes always fails.
+    #[test]
+    fn transpose_wrong_axes_count_fails(
+        ndim in 2usize..5,
+    ) {
+        let shape = vec![2; ndim];
+        let axes: Vec<usize> = (0..ndim - 1).collect();
+        prop_assert!(validate_transpose_axes(&shape, &axes).is_err());
+    }
+}
+
+// ── Attention shape validation ──────────────────────────────────────────────
+
+proptest! {
+    /// Valid attention shapes pass validation.
+    #[test]
+    fn attention_valid_shapes(
+        batch in 1usize..4,
+        heads in 1usize..8,
+        seq_len in 1usize..16,
+        kv_len in 1usize..16,
+        head_dim in 1usize..16,
+        v_dim in 1usize..16,
+    ) {
+        let q = vec![batch, heads, seq_len, head_dim];
+        let k = vec![batch, heads, kv_len, head_dim];
+        let v = vec![batch, heads, kv_len, v_dim];
+        prop_assert!(validate_attention_shapes(&q, &k, &v).is_ok());
+    }
+
+    /// GQA: Q heads must be a multiple of KV heads.
+    #[test]
+    fn attention_gqa_heads(
+        batch in 1usize..4,
+        kv_heads in 1usize..4,
+        multiplier in 1usize..4,
+        seq_len in 1usize..8,
+        head_dim in 1usize..8,
+    ) {
+        let q_heads = kv_heads * multiplier;
+        let q = vec![batch, q_heads, seq_len, head_dim];
+        let k = vec![batch, kv_heads, seq_len, head_dim];
+        let v = vec![batch, kv_heads, seq_len, head_dim];
+        prop_assert!(validate_attention_shapes(&q, &k, &v).is_ok());
+    }
+
+    /// Non-4D tensors always fail.
+    #[test]
+    fn attention_non_4d_fails(
+        ndim in 1usize..4,
+    ) {
+        prop_assume!(ndim != 4);
+        let shape = vec![2; ndim];
+        let valid = vec![2; 4];
+        prop_assert!(validate_attention_shapes(&shape, &valid, &valid).is_err());
+        prop_assert!(validate_attention_shapes(&valid, &shape, &valid).is_err());
+        prop_assert!(validate_attention_shapes(&valid, &valid, &shape).is_err());
+    }
+
+    /// Mismatched batch dims always fail.
+    #[test]
+    fn attention_batch_mismatch_fails(
+        b1 in 1usize..4,
+        b2 in 1usize..4,
+    ) {
+        prop_assume!(b1 != b2);
+        let q = vec![b1, 2, 4, 8];
+        let k = vec![b2, 2, 4, 8];
+        let v = vec![b2, 2, 4, 8];
+        prop_assert!(validate_attention_shapes(&q, &k, &v).is_err());
+    }
+}
+
+// ── KernelCapabilities properties ───────────────────────────────────────────
+
+proptest! {
+    /// compiled_backends always includes CpuRust when cpu_rust is true.
+    #[test]
+    fn capabilities_cpu_rust_in_backends(_dummy in 0u8..1) {
+        let caps = KernelCapabilities::from_compile_time();
+        let backends = caps.compiled_backends();
+        // cpu feature is always on when testing with --features cpu
+        prop_assert!(backends.contains(&KernelBackend::CpuRust));
+    }
+
+    /// best_available never returns a backend that requires GPU without runtime.
+    #[test]
+    fn capabilities_best_no_gpu_without_runtime(_dummy in 0u8..1) {
+        let caps = KernelCapabilities::from_compile_time();
+        if let Some(best) = caps.best_available()
+            && best.requires_gpu()
+        {
+            let backends = caps.compiled_backends();
+            prop_assert!(backends.contains(&best));
+        }
+    }
+
+    /// summary is non-empty.
+    #[test]
+    fn capabilities_summary_non_empty(_dummy in 0u8..1) {
+        let caps = KernelCapabilities::from_compile_time();
+        prop_assert!(!caps.summary().is_empty());
+    }
+}
+
+// ── SimdLevel ordering ──────────────────────────────────────────────────────
+
+proptest! {
+    /// SimdLevel ordering: Scalar < Sse42 < Avx2 < Avx512.
+    #[test]
+    fn simd_level_ordering(_dummy in 0u8..1) {
+        prop_assert!(SimdLevel::Scalar < SimdLevel::Sse42);
+        prop_assert!(SimdLevel::Sse42 < SimdLevel::Avx2);
+        prop_assert!(SimdLevel::Avx2 < SimdLevel::Avx512);
+    }
+
+    /// SimdLevel ordering is reflexive.
+    #[test]
+    fn simd_level_reflexive(
+        level in prop_oneof![
+            Just(SimdLevel::Scalar),
+            Just(SimdLevel::Sse42),
+            Just(SimdLevel::Avx2),
+            Just(SimdLevel::Avx512),
+            Just(SimdLevel::Neon),
+        ]
+    ) {
+        prop_assert!(level <= level);
+        prop_assert!(level >= level);
+    }
+}
+
+// ── GenerationConfig defaults ───────────────────────────────────────────────
+
+proptest! {
+    /// Default GenerationConfig has sane values.
+    #[test]
+    fn gen_config_defaults_sane(_dummy in 0u8..1) {
+        let cfg = GenerationConfig::default();
+        prop_assert!(cfg.max_new_tokens > 0);
+        prop_assert!(cfg.temperature > 0.0);
+        prop_assert!(cfg.temperature.is_finite());
+        prop_assert!(cfg.repetition_penalty >= 1.0);
+    }
+
+    /// PerformanceMetrics default is all zeros.
+    #[test]
+    fn perf_metrics_default_zero(_dummy in 0u8..1) {
+        let m = PerformanceMetrics::default();
+        prop_assert_eq!(m.tokens_per_second, 0.0);
+        prop_assert_eq!(m.latency_ms, 0.0);
+        prop_assert_eq!(m.memory_usage_mb, 0.0);
+        prop_assert_eq!(m.gpu_utilization, None);
+    }
+}
+
+// ── Device type properties ──────────────────────────────────────────────────
+
+proptest! {
+    /// All device variants have mutually exclusive predicates.
+    #[test]
+    fn device_predicates_exclusive(idx in 0usize..4) {
+        let devices = vec![
+            Device::Cpu,
+            Device::Cuda(idx),
+            Device::OpenCL(idx),
+        ];
+        for d in &devices {
+            let count = [d.is_cpu(), d.is_cuda(), d.is_opencl()].iter()
+                .filter(|&&x| x).count();
+            prop_assert_eq!(count, 1,
+                "device {:?} has {} true predicates, expected exactly 1", d, count);
+        }
+    }
+
+    /// Device Clone produces equal copy.
+    #[test]
+    fn device_clone_eq(idx in 0usize..4) {
+        let d = Device::Cuda(idx);
+        let d2 = d;
+        prop_assert_eq!(d, d2);
+    }
+}
+
+// ── QuantizationType properties ─────────────────────────────────────────────
+
+proptest! {
+    /// All QuantizationType variants have distinct Display output.
+    #[test]
+    fn quantization_type_display_distinct(_dummy in 0u8..1) {
+        let variants = [
+            QuantizationType::I2S,
+            QuantizationType::TL1,
+            QuantizationType::TL2,
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                prop_assert_ne!(
+                    variants[i].to_string(),
+                    variants[j].to_string(),
+                    "{:?} and {:?} have same Display", variants[i], variants[j]
+                );
+            }
+        }
+    }
+}

--- a/crates/bitnet-kernels/tests/proptest_wave16.rs
+++ b/crates/bitnet-kernels/tests/proptest_wave16.rs
@@ -1,0 +1,415 @@
+//! Property-based tests — wave 16.
+//!
+//! Activation function bounds, layer norm shape preservation, causal mask
+//! invariants, RoPE frequency properties, embedding lookup shapes, and
+//! reduction kernel consistency.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_kernels::cpu::activations::{
+    elu, gelu, gelu_tanh, hard_sigmoid, hard_swish, leaky_relu, mish, quick_gelu, relu, selu,
+    sigmoid, silu, softplus, swish, tanh_act,
+};
+use bitnet_kernels::cpu::attention::causal_mask;
+use bitnet_kernels::cpu::embedding::embedding_lookup;
+use bitnet_kernels::cpu::layer_norm::{LayerNormConfig, layer_norm, rms_norm};
+use bitnet_kernels::cpu::reduction::ReductionKernel;
+use bitnet_kernels::cpu::rope::{RopeConfig, compute_frequencies};
+use proptest::prelude::*;
+
+// ── Activation function bounds ──────────────────────────────────────────────
+
+proptest! {
+    /// relu(x) >= 0 for all x.
+    #[test]
+    fn relu_non_negative(x in -100.0f32..100.0) {
+        prop_assert!(relu(x) >= 0.0);
+    }
+
+    /// relu is idempotent: relu(relu(x)) == relu(x).
+    #[test]
+    fn relu_idempotent(x in -100.0f32..100.0) {
+        let r = relu(x);
+        prop_assert_eq!(relu(r), r);
+    }
+
+    /// sigmoid output in (0, 1) for moderate inputs.
+    #[test]
+    fn sigmoid_bounded(x in -10.0f32..10.0) {
+        let s = sigmoid(x);
+        prop_assert!(s > 0.0 && s < 1.0,
+            "sigmoid({}) = {} not in (0,1)", x, s);
+    }
+
+    /// sigmoid is monotonically non-decreasing.
+    #[test]
+    fn sigmoid_monotone(a in -50.0f32..50.0, b in -50.0f32..50.0) {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        prop_assert!(sigmoid(lo) <= sigmoid(hi) + 1e-6);
+    }
+
+    /// sigmoid(0) ≈ 0.5.
+    #[test]
+    fn sigmoid_zero_is_half(_dummy in 0u8..1) {
+        prop_assert!((sigmoid(0.0) - 0.5).abs() < 1e-6);
+    }
+
+    /// tanh output in (-1, 1) for moderate inputs.
+    #[test]
+    fn tanh_bounded(x in -8.0f32..8.0) {
+        let t = tanh_act(x);
+        prop_assert!(t > -1.0 && t < 1.0,
+            "tanh({}) = {} not in (-1,1)", x, t);
+    }
+
+    /// hard_sigmoid output in [0, 1].
+    #[test]
+    fn hard_sigmoid_bounded(x in -100.0f32..100.0) {
+        let hs = hard_sigmoid(x);
+        prop_assert!((0.0..=1.0).contains(&hs),
+            "hard_sigmoid({}) = {} not in [0,1]", x, hs);
+    }
+
+    /// silu(0) == 0.
+    #[test]
+    fn silu_zero(_dummy in 0u8..1) {
+        prop_assert!((silu(0.0)).abs() < 1e-6);
+    }
+
+    /// gelu(x) >= -0.2 (known lower bound approximation).
+    #[test]
+    fn gelu_lower_bound(x in -100.0f32..100.0) {
+        let g = gelu(x);
+        prop_assert!(g >= -0.2,
+            "gelu({}) = {} below -0.2", x, g);
+    }
+
+    /// gelu_tanh(x) >= -0.2.
+    #[test]
+    fn gelu_tanh_lower_bound(x in -100.0f32..100.0) {
+        let g = gelu_tanh(x);
+        prop_assert!(g >= -0.2,
+            "gelu_tanh({}) = {} below -0.2", x, g);
+    }
+
+    /// leaky_relu(x, alpha) for alpha >= 0: positive x unchanged, negative scaled.
+    #[test]
+    fn leaky_relu_lower_bound(x in -100.0f32..100.0, alpha in 0.0f32..1.0) {
+        let lr = leaky_relu(x, alpha);
+        if x >= 0.0 {
+            prop_assert_eq!(lr, x);
+        } else {
+            prop_assert!((lr - alpha * x).abs() < 1e-4,
+                "leaky_relu({}, {}) = {} != {}", x, alpha, lr, alpha * x);
+        }
+    }
+
+    /// softplus(x) > 0 for moderate finite x.
+    #[test]
+    fn softplus_positive(x in -10.0f32..50.0) {
+        prop_assert!(softplus(x) > 0.0);
+    }
+
+    /// softplus is monotonically non-decreasing.
+    #[test]
+    fn softplus_monotone(a in -50.0f32..50.0, b in -50.0f32..50.0) {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        prop_assert!(softplus(lo) <= softplus(hi) + 1e-6);
+    }
+
+    /// elu(x, alpha) == x for x >= 0.
+    #[test]
+    fn elu_positive_identity(x in 0.0f32..100.0, alpha in 0.01f32..2.0) {
+        prop_assert_eq!(elu(x, alpha), x);
+    }
+
+    /// selu output is finite for bounded input.
+    #[test]
+    fn selu_finite(x in -50.0f32..50.0) {
+        let s = selu(x);
+        prop_assert!(s.is_finite(), "selu({}) = {} not finite", x, s);
+    }
+
+    /// quick_gelu(0) == 0.
+    #[test]
+    fn quick_gelu_zero(_dummy in 0u8..1) {
+        prop_assert!((quick_gelu(0.0)).abs() < 1e-6);
+    }
+
+    /// swish(x, 1.0) == silu(x).
+    #[test]
+    fn swish_beta1_equals_silu(x in -50.0f32..50.0) {
+        let s = swish(x, 1.0);
+        let si = silu(x);
+        prop_assert!((s - si).abs() < 1e-5,
+            "swish({}, 1.0)={} != silu({})={}", x, s, x, si);
+    }
+
+    /// mish output is finite for bounded input.
+    #[test]
+    fn mish_finite(x in -50.0f32..50.0) {
+        let m = mish(x);
+        prop_assert!(m.is_finite(), "mish({}) = {} not finite", x, m);
+    }
+
+    /// hard_swish output is finite.
+    #[test]
+    fn hard_swish_finite(x in -100.0f32..100.0) {
+        let hs = hard_swish(x);
+        prop_assert!(hs.is_finite(), "hard_swish({}) not finite", x);
+    }
+}
+
+// ── Causal mask properties ──────────────────────────────────────────────────
+
+proptest! {
+    /// Causal mask has size seq_len².
+    #[test]
+    fn causal_mask_size(seq_len in 1usize..32) {
+        let mask = causal_mask(seq_len);
+        prop_assert_eq!(mask.len(), seq_len * seq_len);
+    }
+
+    /// Diagonal is always zero (token can attend to itself).
+    #[test]
+    fn causal_mask_diagonal_zero(seq_len in 1usize..32) {
+        let mask = causal_mask(seq_len);
+        for i in 0..seq_len {
+            prop_assert_eq!(mask[i * seq_len + i], 0.0,
+                "diagonal position ({},{}) should be 0", i, i);
+        }
+    }
+
+    /// Lower triangle (i >= j) is always zero.
+    #[test]
+    fn causal_mask_lower_triangle_zero(seq_len in 1usize..16) {
+        let mask = causal_mask(seq_len);
+        for i in 0..seq_len {
+            for j in 0..=i {
+                prop_assert_eq!(mask[i * seq_len + j], 0.0,
+                    "lower triangle ({},{}) should be 0", i, j);
+            }
+        }
+    }
+
+    /// Upper triangle (j > i) is -inf.
+    #[test]
+    fn causal_mask_upper_triangle_neg_inf(seq_len in 2usize..16) {
+        let mask = causal_mask(seq_len);
+        for i in 0..seq_len {
+            for j in (i + 1)..seq_len {
+                prop_assert_eq!(mask[i * seq_len + j], f32::NEG_INFINITY,
+                    "upper triangle ({},{}) should be -inf", i, j);
+            }
+        }
+    }
+
+    /// Causal mask is idempotent under element-wise min.
+    #[test]
+    fn causal_mask_idempotent_min(seq_len in 1usize..16) {
+        let mask = causal_mask(seq_len);
+        let min_mask: Vec<f32> = mask.iter().zip(&mask)
+            .map(|(&a, &b)| a.min(b))
+            .collect();
+        prop_assert_eq!(mask, min_mask);
+    }
+}
+
+// ── Layer norm shape preservation ───────────────────────────────────────────
+
+proptest! {
+    /// layer_norm output has same length as input.
+    #[test]
+    fn layer_norm_preserves_length(
+        batch in 1usize..4,
+        dim in 2usize..32,
+    ) {
+        let n = batch * dim;
+        let input: Vec<f32> = (0..n).map(|i| (i as f32) * 0.1).collect();
+        let gamma = vec![1.0f32; dim];
+        let config = LayerNormConfig::new(vec![dim]);
+        let output = layer_norm(&input, &gamma, None, &config).unwrap();
+        prop_assert_eq!(output.len(), input.len());
+    }
+
+    /// layer_norm output is finite for finite input.
+    #[test]
+    fn layer_norm_output_finite(
+        dim in 2usize..16,
+    ) {
+        let input: Vec<f32> = (0..dim).map(|i| (i as f32 - dim as f32 / 2.0) * 0.5).collect();
+        let gamma = vec![1.0f32; dim];
+        let config = LayerNormConfig::new(vec![dim]);
+        let output = layer_norm(&input, &gamma, None, &config).unwrap();
+        for (i, &v) in output.iter().enumerate() {
+            prop_assert!(v.is_finite(), "output[{}] = {} not finite", i, v);
+        }
+    }
+
+    /// rms_norm output has same length as input.
+    #[test]
+    fn rms_norm_preserves_length(
+        batch in 1usize..4,
+        dim in 2usize..32,
+    ) {
+        let n = batch * dim;
+        let input: Vec<f32> = (0..n).map(|i| (i as f32) * 0.1 + 0.01).collect();
+        let gamma = vec![1.0f32; dim];
+        let config = LayerNormConfig::new(vec![dim]);
+        let output = rms_norm(&input, &gamma, &config).unwrap();
+        prop_assert_eq!(output.len(), input.len());
+    }
+
+    /// rms_norm with gamma=1 does not change zero input.
+    #[test]
+    fn rms_norm_zero_input(dim in 2usize..16) {
+        let input = vec![0.0f32; dim];
+        let gamma = vec![1.0f32; dim];
+        let config = LayerNormConfig::new(vec![dim]);
+        let output = rms_norm(&input, &gamma, &config).unwrap();
+        for &v in &output {
+            prop_assert!(v.abs() < 1e-6, "rms_norm(zeros) should be ~0, got {}", v);
+        }
+    }
+}
+
+// ── RoPE frequency properties ───────────────────────────────────────────────
+
+proptest! {
+    /// Frequency table length = max_seq_len * head_dim.
+    #[test]
+    fn rope_freq_length(head_dim in (1usize..8).prop_map(|x| x * 2)) {
+        let max_seq_len = 32;
+        let config = RopeConfig::new(head_dim, max_seq_len);
+        let freqs = compute_frequencies(&config);
+        prop_assert_eq!(freqs.len(), max_seq_len * head_dim);
+    }
+
+    /// All frequencies are finite.
+    #[test]
+    fn rope_freq_finite(head_dim in (1usize..8).prop_map(|x| x * 2)) {
+        let config = RopeConfig::new(head_dim, 32);
+        let freqs = compute_frequencies(&config);
+        for (i, &f) in freqs.iter().enumerate() {
+            prop_assert!(f.is_finite(),
+                "freq[{}] = {} not finite", i, f);
+        }
+    }
+
+    /// Position 0 cosines are 1.0 and sines are 0.0.
+    #[test]
+    fn rope_freq_position_zero(head_dim in (1usize..8).prop_map(|x| x * 2)) {
+        let config = RopeConfig::new(head_dim, 32);
+        let freqs = compute_frequencies(&config);
+        let half_dim = head_dim / 2;
+        for i in 0..half_dim {
+            let cos_val = freqs[i * 2];
+            let sin_val = freqs[i * 2 + 1];
+            prop_assert!((cos_val - 1.0).abs() < 1e-5,
+                "position 0 cos[{}] = {}, expected 1.0", i, cos_val);
+            prop_assert!(sin_val.abs() < 1e-5,
+                "position 0 sin[{}] = {}, expected 0.0", i, sin_val);
+        }
+    }
+}
+
+// ── Embedding lookup shape ──────────────────────────────────────────────────
+
+proptest! {
+    /// Output length = num_indices * embedding_dim.
+    #[test]
+    fn embedding_lookup_output_shape(
+        vocab in 10usize..100,
+        dim in 2usize..16,
+        n_idx in 1usize..8,
+    ) {
+        let table: Vec<f32> = (0..(vocab * dim)).map(|i| i as f32 * 0.01).collect();
+        let indices: Vec<u32> = (0..n_idx).map(|i| (i % vocab) as u32).collect();
+        let output = embedding_lookup(&table, &indices, dim).unwrap();
+        prop_assert_eq!(output.len(), n_idx * dim);
+    }
+
+    /// Out-of-bounds indices produce an error.
+    #[test]
+    fn embedding_lookup_oob_error(
+        vocab in 10usize..50,
+        dim in 2usize..8,
+    ) {
+        let table = vec![0.0f32; vocab * dim];
+        let indices = vec![vocab as u32]; // OOB
+        prop_assert!(embedding_lookup(&table, &indices, dim).is_err());
+    }
+}
+
+// ── Reduction kernel properties ─────────────────────────────────────────────
+
+proptest! {
+    /// sum of all-ones = length.
+    #[test]
+    fn reduction_sum_ones(n in 1usize..64) {
+        let data = vec![1.0f32; n];
+        let sum = ReductionKernel::sum(&data).unwrap();
+        prop_assert!((sum - n as f32).abs() < 1e-4,
+            "sum of {} ones = {}", n, sum);
+    }
+
+    /// mean is bounded by min and max of data.
+    #[test]
+    fn reduction_mean_bounded(
+        data in prop::collection::vec(-100.0f32..100.0, 1..64),
+    ) {
+        let mean = ReductionKernel::mean(&data).unwrap();
+        let min = data.iter().cloned().fold(f32::INFINITY, f32::min);
+        let max = data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        prop_assert!(mean >= min - 1e-4 && mean <= max + 1e-4,
+            "mean {} not in [{}, {}]", mean, min, max);
+    }
+
+    /// max value >= all elements.
+    #[test]
+    fn reduction_max_is_upper_bound(
+        data in prop::collection::vec(-100.0f32..100.0, 1..64),
+    ) {
+        let result = ReductionKernel::max(&data).unwrap();
+        for &v in &data {
+            prop_assert!(result.value >= v - 1e-6);
+        }
+    }
+
+    /// min value <= all elements.
+    #[test]
+    fn reduction_min_is_lower_bound(
+        data in prop::collection::vec(-100.0f32..100.0, 1..64),
+    ) {
+        let result = ReductionKernel::min(&data).unwrap();
+        for &v in &data {
+            prop_assert!(result.value <= v + 1e-6);
+        }
+    }
+
+    /// l2_norm is non-negative.
+    #[test]
+    fn reduction_l2_norm_non_negative(
+        data in prop::collection::vec(-100.0f32..100.0, 1..64),
+    ) {
+        let norm = ReductionKernel::l2_norm(&data).unwrap();
+        prop_assert!(norm >= 0.0);
+    }
+
+    /// l1_norm is non-negative.
+    #[test]
+    fn reduction_l1_norm_non_negative(
+        data in prop::collection::vec(-100.0f32..100.0, 1..64),
+    ) {
+        let norm = ReductionKernel::l1_norm(&data).unwrap();
+        prop_assert!(norm >= 0.0);
+    }
+
+    /// l2_norm of zeros is zero.
+    #[test]
+    fn reduction_l2_norm_zeros(n in 1usize..32) {
+        let data = vec![0.0f32; n];
+        let norm = ReductionKernel::l2_norm(&data).unwrap();
+        prop_assert!(norm.abs() < 1e-6);
+    }
+}

--- a/crates/bitnet-models/tests/proptest_wave16.rs
+++ b/crates/bitnet-models/tests/proptest_wave16.rs
@@ -1,0 +1,252 @@
+//! Property-based tests — wave 16.
+//!
+//! GGUF tensor type invariants, naming predicate consistency, model config
+//! properties, and qk256 tolerance re-export identity.
+
+#![cfg(all(test, feature = "cpu"))]
+
+use bitnet_gguf::{GGUF_MAGIC, check_magic, read_version};
+use bitnet_models::formats::gguf::GgufTensorType;
+use bitnet_models::names::{is_layernorm_weight, is_projection_weight};
+use bitnet_models::{QK256_SIZE_TOLERANCE_PERCENT, qk256_tolerance_bytes};
+use proptest::prelude::*;
+
+/// Strategy that produces every known `GgufTensorType` variant.
+fn any_tensor_type() -> impl Strategy<Value = GgufTensorType> {
+    prop_oneof![
+        Just(GgufTensorType::F32),
+        Just(GgufTensorType::F16),
+        Just(GgufTensorType::F64),
+        Just(GgufTensorType::Q4_0),
+        Just(GgufTensorType::Q4_1),
+        Just(GgufTensorType::Q5_0),
+        Just(GgufTensorType::Q5_1),
+        Just(GgufTensorType::Q8_0),
+        Just(GgufTensorType::Q8_1),
+        Just(GgufTensorType::Q2_K),
+        Just(GgufTensorType::Q3_K),
+        Just(GgufTensorType::Q4_K),
+        Just(GgufTensorType::Q5_K),
+        Just(GgufTensorType::Q6_K),
+        Just(GgufTensorType::Q8_K),
+        Just(GgufTensorType::IQ2_S),
+        Just(GgufTensorType::I2_S),
+    ]
+}
+
+/// Strategy for quantized-only types.
+fn quantized_tensor_type() -> impl Strategy<Value = GgufTensorType> {
+    prop_oneof![
+        Just(GgufTensorType::Q4_0),
+        Just(GgufTensorType::Q4_1),
+        Just(GgufTensorType::Q5_0),
+        Just(GgufTensorType::Q5_1),
+        Just(GgufTensorType::Q8_0),
+        Just(GgufTensorType::Q8_1),
+        Just(GgufTensorType::Q2_K),
+        Just(GgufTensorType::Q3_K),
+        Just(GgufTensorType::Q4_K),
+        Just(GgufTensorType::Q5_K),
+        Just(GgufTensorType::Q6_K),
+        Just(GgufTensorType::Q8_K),
+        Just(GgufTensorType::IQ2_S),
+        Just(GgufTensorType::I2_S),
+    ]
+}
+
+// ── GgufTensorType size invariants ──────────────────────────────────────────
+
+proptest! {
+    /// element_size is always > 0 for all known tensor types.
+    #[test]
+    fn gguf_tensor_type_element_size_positive(t in any_tensor_type()) {
+        let size = t.element_size();
+        prop_assert!(size > 0, "{:?} element_size is 0", t);
+    }
+
+    /// F32 element_size is 4 bytes.
+    #[test]
+    fn gguf_f32_is_4_bytes(_dummy in 0u8..1) {
+        prop_assert_eq!(GgufTensorType::F32.element_size(), 4);
+    }
+
+    /// F16 element_size is 2 bytes.
+    #[test]
+    fn gguf_f16_is_2_bytes(_dummy in 0u8..1) {
+        prop_assert_eq!(GgufTensorType::F16.element_size(), 2);
+    }
+
+    /// F64 element_size is 8 bytes.
+    #[test]
+    fn gguf_f64_is_8_bytes(_dummy in 0u8..1) {
+        prop_assert_eq!(GgufTensorType::F64.element_size(), 8);
+    }
+
+    /// block_size >= 1 for all types.
+    #[test]
+    fn gguf_block_size_positive(t in any_tensor_type()) {
+        let bs = t.block_size();
+        prop_assert!(bs >= 1, "{:?} block_size is {}", t, bs);
+    }
+
+    /// Quantized types have block_size > 1.
+    #[test]
+    fn gguf_quantized_block_size_gt1(t in quantized_tensor_type()) {
+        prop_assert!(t.block_size() > 1, "{:?} block_size should be > 1", t);
+    }
+
+    /// For unquantized types, block_size == 1.
+    #[test]
+    fn gguf_unquantized_block_size_one(
+        t in prop_oneof![
+            Just(GgufTensorType::F32),
+            Just(GgufTensorType::F16),
+            Just(GgufTensorType::F64),
+        ]
+    ) {
+        prop_assert_eq!(t.block_size(), 1, "{:?} block_size should be 1", t);
+    }
+
+    /// is_quantized is true iff block_size > 1.
+    #[test]
+    fn gguf_is_quantized_matches_block_size(t in any_tensor_type()) {
+        prop_assert_eq!(t.is_quantized(), t.block_size() > 1,
+            "{:?}: is_quantized={} but block_size={}",
+            t, t.is_quantized(), t.block_size());
+    }
+}
+
+// ── Naming predicate properties ─────────────────────────────────────────────
+
+proptest! {
+    /// Random alphabetic strings are neither LN nor projection.
+    #[test]
+    fn random_alpha_not_ln_or_proj(name in "[a-zA-Z]{1,30}") {
+        prop_assert!(!is_layernorm_weight(&name),
+            "random string '{}' wrongly classified as LN", name);
+        prop_assert!(!is_projection_weight(&name),
+            "random string '{}' wrongly classified as projection", name);
+    }
+
+    /// Predicates are stable: calling twice gives the same answer.
+    #[test]
+    fn naming_predicates_stable(name in "\\PC{0,80}") {
+        let ln1 = is_layernorm_weight(&name);
+        let ln2 = is_layernorm_weight(&name);
+        prop_assert_eq!(ln1, ln2);
+
+        let proj1 = is_projection_weight(&name);
+        let proj2 = is_projection_weight(&name);
+        prop_assert_eq!(proj1, proj2);
+    }
+
+    /// LN and projection are always mutually exclusive.
+    #[test]
+    fn ln_proj_mutually_exclusive(name in "\\PC{0,80}") {
+        let is_ln = is_layernorm_weight(&name);
+        let is_proj = is_projection_weight(&name);
+        prop_assert!(!(is_ln && is_proj),
+            "'{}' classified as both LN and projection", name);
+    }
+}
+
+// ── qk256 tolerance re-export identity ──────────────────────────────────────
+
+proptest! {
+    /// Re-exported qk256_tolerance_bytes matches the quantization crate.
+    #[test]
+    fn qk256_tolerance_reexport_identity(n in 0usize..10_000_000) {
+        let models_val = qk256_tolerance_bytes(n);
+        let quant_val = bitnet_quantization::qk256_tolerance_bytes(n);
+        prop_assert_eq!(models_val, quant_val);
+    }
+
+    /// Re-exported QK256_SIZE_TOLERANCE_PERCENT matches.
+    #[test]
+    fn qk256_percent_reexport_identity(_dummy in 0u8..1) {
+        prop_assert_eq!(
+            QK256_SIZE_TOLERANCE_PERCENT,
+            bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT
+        );
+    }
+}
+
+// ── GGUF magic and version ──────────────────────────────────────────────────
+
+proptest! {
+    /// check_magic passes for the real GGUF magic bytes.
+    #[test]
+    fn gguf_magic_valid(_dummy in 0u8..1) {
+        let mut data = Vec::new();
+        data.extend_from_slice(&GGUF_MAGIC);
+        data.extend_from_slice(&3u32.to_le_bytes());
+        data.extend_from_slice(&[0u8; 100]);
+        prop_assert!(check_magic(&data));
+    }
+
+    /// check_magic rejects random non-magic bytes.
+    #[test]
+    fn gguf_magic_random_fails(
+        b0 in 0u8..=255u8,
+        b1 in 0u8..=255u8,
+        b2 in 0u8..=255u8,
+        b3 in 0u8..=255u8,
+    ) {
+        let bytes = [b0, b1, b2, b3];
+        prop_assume!(bytes != GGUF_MAGIC);
+        let mut data = Vec::from(bytes);
+        data.extend_from_slice(&[0u8; 100]);
+        prop_assert!(!check_magic(&data));
+    }
+
+    /// read_version succeeds for version 3.
+    #[test]
+    fn gguf_version_3_valid(_dummy in 0u8..1) {
+        let mut data = Vec::new();
+        data.extend_from_slice(&GGUF_MAGIC);
+        data.extend_from_slice(&3u32.to_le_bytes());
+        let version = read_version(&data).unwrap();
+        prop_assert_eq!(version, 3);
+    }
+
+    /// read_version returns None for data shorter than 8 bytes.
+    #[test]
+    fn gguf_version_short_data(len in 0usize..8) {
+        let data = vec![0u8; len];
+        prop_assert!(read_version(&data).is_none());
+    }
+}
+
+// ── GgufTensorType Display / Debug ──────────────────────────────────────────
+
+proptest! {
+    /// Debug output is non-empty for all tensor types.
+    #[test]
+    fn gguf_tensor_type_debug_non_empty(t in any_tensor_type()) {
+        let s = format!("{:?}", t);
+        prop_assert!(!s.is_empty());
+    }
+
+    /// Clone produces equal value.
+    #[test]
+    fn gguf_tensor_type_clone_eq(t in any_tensor_type()) {
+        let t2 = t;
+        prop_assert_eq!(t, t2);
+    }
+
+    /// from_quant_string roundtrips for canonical names.
+    #[test]
+    fn gguf_from_quant_string_known(
+        (name, expected) in prop_oneof![
+            Just(("i2_s", GgufTensorType::I2_S)),
+            Just(("iq2_s", GgufTensorType::IQ2_S)),
+            Just(("q4_0", GgufTensorType::Q4_0)),
+            Just(("q4_1", GgufTensorType::Q4_1)),
+            Just(("q8_0", GgufTensorType::Q8_0)),
+            Just(("q8_1", GgufTensorType::Q8_1)),
+        ]
+    ) {
+        let parsed = GgufTensorType::from_quant_string(name);
+        prop_assert_eq!(parsed, Some(expected), "parsing '{}' failed", name);
+    }
+}

--- a/crates/bitnet-quantization/tests/proptest_wave16.rs
+++ b/crates/bitnet-quantization/tests/proptest_wave16.rs
@@ -1,0 +1,402 @@
+//! Property-based tests — wave 16.
+//!
+//! New invariants for quantization utilities, I2S layout, QuantizedTensor,
+//! grouped scales, MSE/SNR metrics, and optimal block size calculation.
+
+#![cfg(feature = "cpu")]
+
+use bitnet_quantization::utils::{
+    calculate_grouped_scales, calculate_mse, calculate_optimal_block_size, calculate_scale,
+    calculate_snr, dequantize_value, dequantize_value_with_offset, pack_unsigned_2bit_values,
+    quantize_value, quantize_value_with_offset, unpack_unsigned_2bit_values, validate_shapes,
+};
+use bitnet_quantization::{I2SLayout, QuantizedTensor};
+
+use bitnet_common::QuantizationType;
+use proptest::prelude::*;
+
+// ── I2SLayout invariants ────────────────────────────────────────────────────
+
+proptest! {
+    /// bytes_per_block = data_bytes + scale_bytes for any block size.
+    #[test]
+    fn i2s_layout_bytes_sum(block_size in 4usize..512) {
+        let layout = I2SLayout::with_block_size(block_size);
+        prop_assert_eq!(
+            layout.bytes_per_block,
+            layout.data_bytes_per_block + layout.scale_bytes_per_block,
+            "bytes_per_block must equal data + scale bytes"
+        );
+    }
+
+    /// Scale bytes is always 2 (f16).
+    #[test]
+    fn i2s_layout_scale_always_2(block_size in 4usize..512) {
+        let layout = I2SLayout::with_block_size(block_size);
+        prop_assert_eq!(layout.scale_bytes_per_block, 2);
+    }
+
+    /// data_bytes >= ceil(block_size * 2 / 8) — enough bits for 2-bit values.
+    #[test]
+    fn i2s_layout_data_bytes_sufficient(block_size in 4usize..512) {
+        let layout = I2SLayout::with_block_size(block_size);
+        let min_bytes = (block_size * 2).div_ceil(8);
+        prop_assert!(
+            layout.data_bytes_per_block >= min_bytes,
+            "data_bytes {} < min {} for block_size {}",
+            layout.data_bytes_per_block, min_bytes, block_size
+        );
+    }
+
+    /// Monotonicity: larger block_size → more data bytes.
+    #[test]
+    fn i2s_layout_data_bytes_monotone(
+        a in 4usize..256,
+        b in 4usize..256,
+    ) {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let la = I2SLayout::with_block_size(lo);
+        let lb = I2SLayout::with_block_size(hi);
+        prop_assert!(
+            la.data_bytes_per_block <= lb.data_bytes_per_block,
+            "data bytes not monotone: {} (bs={}) > {} (bs={})",
+            la.data_bytes_per_block, lo, lb.data_bytes_per_block, hi
+        );
+    }
+
+    /// Default layout has block_size 32.
+    #[test]
+    fn i2s_layout_default_block_size(_dummy in 0u8..1) {
+        let layout = I2SLayout::default();
+        prop_assert_eq!(layout.block_size, 32);
+        prop_assert_eq!(layout.bytes_per_block, 10);
+        prop_assert_eq!(layout.data_bytes_per_block, 8);
+    }
+}
+
+// ── QuantizedTensor properties ──────────────────────────────────────────────
+
+proptest! {
+    /// numel equals product of shape dimensions.
+    #[test]
+    fn quantized_tensor_numel(
+        d0 in 1usize..16,
+        d1 in 1usize..16,
+    ) {
+        let shape = vec![d0, d1];
+        let numel = d0 * d1;
+        let qt = QuantizedTensor::new(
+            vec![0u8; numel / 4 + 1],
+            vec![1.0f32; 1],
+            shape.clone(),
+            QuantizationType::I2S,
+        );
+        prop_assert_eq!(qt.numel(), numel);
+    }
+
+    /// compression_ratio >= 1.0 (never expands).
+    #[test]
+    fn quantized_tensor_compression_ratio_ge_one(
+        n in 32usize..1024,
+    ) {
+        let qt = QuantizedTensor::new(
+            vec![0u8; n / 4],
+            vec![1.0f32; n / 32],
+            vec![n],
+            QuantizationType::I2S,
+        );
+        prop_assert!(
+            qt.compression_ratio() >= 1.0,
+            "compression_ratio {} < 1.0", qt.compression_ratio()
+        );
+    }
+
+    /// new_with_params preserves all fields.
+    #[test]
+    fn quantized_tensor_new_with_params(
+        block_size in 4usize..128,
+    ) {
+        let data = vec![0xABu8; 16];
+        let scales = vec![0.5f32; 4];
+        let zp = vec![1i32; 4];
+        let shape = vec![64];
+        let qt = QuantizedTensor::new_with_params(
+            data.clone(),
+            scales.clone(),
+            Some(zp.clone()),
+            shape.clone(),
+            QuantizationType::TL2,
+            block_size,
+        );
+        prop_assert_eq!(&qt.data, &data);
+        prop_assert_eq!(&qt.scales, &scales);
+        prop_assert_eq!(qt.zero_points.as_ref().unwrap(), &zp);
+        prop_assert_eq!(&qt.shape, &shape);
+        prop_assert_eq!(qt.qtype, QuantizationType::TL2);
+        prop_assert_eq!(qt.block_size, block_size);
+    }
+}
+
+// ── Grouped scales properties ───────────────────────────────────────────────
+
+proptest! {
+    /// Number of grouped scales = ceil(data.len() / block_size).
+    #[test]
+    fn grouped_scales_count(
+        data in prop::collection::vec(-10.0f32..10.0, 1..256),
+        block_size in 1usize..64,
+    ) {
+        let scales = calculate_grouped_scales(&data, block_size, 2);
+        let expected = data.len().div_ceil(block_size);
+        prop_assert_eq!(
+            scales.len(), expected,
+            "expected {} scales, got {}", expected, scales.len()
+        );
+    }
+
+    /// All grouped scales are positive and finite for finite data.
+    #[test]
+    fn grouped_scales_positive_finite(
+        data in prop::collection::vec(-100.0f32..100.0, 1..128),
+        block_size in 1usize..32,
+    ) {
+        let scales = calculate_grouped_scales(&data, block_size, 2);
+        for (i, &s) in scales.iter().enumerate() {
+            prop_assert!(s.is_finite(), "scale[{}] is not finite: {}", i, s);
+            prop_assert!(s > 0.0, "scale[{}] is not positive: {}", i, s);
+        }
+    }
+
+    /// Grouped scales with block_size == data.len() equals single-block scale.
+    #[test]
+    fn grouped_scales_single_block(
+        data in prop::collection::vec(-10.0f32..10.0, 1..64),
+    ) {
+        let scales = calculate_grouped_scales(&data, data.len(), 2);
+        prop_assert_eq!(scales.len(), 1);
+        let single = calculate_scale(&data, 2);
+        prop_assert!(
+            (scales[0] - single).abs() < 1e-10,
+            "single-block scale mismatch: {} vs {}", scales[0], single
+        );
+    }
+}
+
+// ── quantize_value / dequantize_value roundtrip ─────────────────────────────
+
+proptest! {
+    /// Quantize→dequantize produces a result within ±scale/2 of the clamped
+    /// representable range. For values that saturate the quantized range, the
+    /// error may be large, so we only check within the representable domain.
+    #[test]
+    fn quantize_dequantize_bounded_error(
+        value in -5.0f32..5.0,
+        scale in 0.1f32..5.0,
+        bits in 2u8..8,
+    ) {
+        let max_q = (1i32 << (bits - 1)) - 1;
+        let min_q = -(1i32 << (bits - 1));
+        let max_representable = max_q as f32 * scale;
+        let min_representable = min_q as f32 * scale;
+        // Only check error bound if value is within representable range
+        if value >= min_representable && value <= max_representable {
+            let q = quantize_value(value, scale, bits);
+            let dq = dequantize_value(q, scale);
+            let err = (value - dq).abs();
+            prop_assert!(
+                err <= scale / 2.0 + 1e-6,
+                "error {} > scale/2 {} for value={}, q={}, dq={}",
+                err, scale / 2.0, value, q, dq
+            );
+        }
+    }
+
+    /// Quantized values stay within the signed bit range.
+    #[test]
+    fn quantize_value_range(
+        value in -100.0f32..100.0,
+        scale in 0.01f32..10.0,
+        bits in 2u8..8,
+    ) {
+        let q = quantize_value(value, scale, bits);
+        let max_val = (1i8 << (bits - 1)) - 1;
+        let min_val = -(1i8 << (bits - 1));
+        prop_assert!(q >= min_val && q <= max_val,
+            "q={} outside [{}, {}] for bits={}", q, min_val, max_val, bits);
+    }
+
+    /// Order preservation: if a > b then quantize(a) >= quantize(b) with same scale.
+    #[test]
+    fn quantize_preserves_order(
+        a in -10.0f32..10.0,
+        b in -10.0f32..10.0,
+        scale in 0.01f32..5.0,
+    ) {
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let qlo = quantize_value(lo, scale, 8);
+        let qhi = quantize_value(hi, scale, 8);
+        prop_assert!(qlo <= qhi,
+            "order not preserved: q({})={} > q({})={}", lo, qlo, hi, qhi);
+    }
+
+    /// dequantize of zero is always zero.
+    #[test]
+    fn dequantize_zero_is_zero(scale in -100.0f32..100.0) {
+        let dq = dequantize_value(0, scale);
+        prop_assert_eq!(dq, 0.0);
+    }
+}
+
+// ── Asymmetric quantize/dequantize ──────────────────────────────────────────
+
+proptest! {
+    /// With offset=0, asymmetric functions match symmetric ones.
+    #[test]
+    fn asymmetric_zero_offset_matches_symmetric(
+        value in -10.0f32..10.0,
+        scale in 0.01f32..5.0,
+        bits in 2u8..8,
+    ) {
+        let q_sym = quantize_value(value, scale, bits);
+        let q_asym = quantize_value_with_offset(value, scale, 0, bits);
+        prop_assert_eq!(q_sym, q_asym);
+
+        let dq_sym = dequantize_value(q_sym, scale);
+        let dq_asym = dequantize_value_with_offset(q_asym, scale, 0);
+        prop_assert!(
+            (dq_sym - dq_asym).abs() < 1e-10,
+            "dequantize mismatch: {} vs {}", dq_sym, dq_asym
+        );
+    }
+}
+
+// ── Unsigned 2-bit pack/unpack roundtrip ────────────────────────────────────
+
+proptest! {
+    /// Unsigned pack→unpack is identity for values in [0, 3].
+    #[test]
+    fn unsigned_pack_unpack_roundtrip(
+        values in prop::collection::vec(0i8..=3i8, 4..64),
+    ) {
+        let packed = pack_unsigned_2bit_values(&values);
+        let unpacked = unpack_unsigned_2bit_values(&packed, values.len());
+        prop_assert_eq!(&unpacked, &values);
+    }
+
+    /// Unsigned packed length is ceil(n / 4).
+    #[test]
+    fn unsigned_packed_length(n in 1usize..256) {
+        let values = vec![0i8; n];
+        let packed = pack_unsigned_2bit_values(&values);
+        prop_assert_eq!(packed.len(), n.div_ceil(4));
+    }
+}
+
+// ── MSE / SNR properties ────────────────────────────────────────────────────
+
+proptest! {
+    /// MSE of identical vectors is zero.
+    #[test]
+    fn mse_identical_is_zero(
+        data in prop::collection::vec(-10.0f32..10.0, 1..64),
+    ) {
+        let mse = calculate_mse(&data, &data).unwrap();
+        prop_assert!(mse.abs() < 1e-10, "MSE of identical data should be ~0, got {}", mse);
+    }
+
+    /// MSE is always non-negative.
+    #[test]
+    fn mse_non_negative(
+        a in prop::collection::vec(-10.0f32..10.0, 1..64),
+        b in prop::collection::vec(-10.0f32..10.0, 1..64),
+    ) {
+        if a.len() == b.len() {
+            let mse = calculate_mse(&a, &b).unwrap();
+            prop_assert!(mse >= 0.0, "MSE must be non-negative, got {}", mse);
+        }
+    }
+
+    /// MSE is symmetric: MSE(a, b) == MSE(b, a).
+    #[test]
+    fn mse_symmetric(
+        a in prop::collection::vec(-10.0f32..10.0, 8..32),
+    ) {
+        let b: Vec<f32> = a.iter().map(|x| x + 0.1).collect();
+        let mse_ab = calculate_mse(&a, &b).unwrap();
+        let mse_ba = calculate_mse(&b, &a).unwrap();
+        prop_assert!(
+            (mse_ab - mse_ba).abs() < 1e-6,
+            "MSE not symmetric: {} vs {}", mse_ab, mse_ba
+        );
+    }
+
+    /// MSE returns error for mismatched lengths.
+    #[test]
+    fn mse_mismatched_lengths_error(
+        a_len in 1usize..32,
+        b_len in 1usize..32,
+    ) {
+        prop_assume!(a_len != b_len);
+        let a = vec![0.0f32; a_len];
+        let b = vec![0.0f32; b_len];
+        prop_assert!(calculate_mse(&a, &b).is_err());
+    }
+
+    /// SNR of identical vectors is infinite.
+    #[test]
+    fn snr_identical_is_infinite(
+        data in prop::collection::vec(1.0f32..10.0, 2..32),
+    ) {
+        let snr = calculate_snr(&data, &data).unwrap();
+        prop_assert!(snr.is_infinite() && snr > 0.0,
+            "SNR of identical data should be +inf, got {}", snr);
+    }
+}
+
+// ── validate_shapes ─────────────────────────────────────────────────────────
+
+proptest! {
+    /// Identical shapes always validate.
+    #[test]
+    fn validate_shapes_identical_ok(
+        shape in prop::collection::vec(1usize..16, 1..4),
+    ) {
+        prop_assert!(validate_shapes(&shape, &shape).is_ok());
+    }
+
+    /// Different shapes always fail.
+    #[test]
+    fn validate_shapes_different_err(
+        a in prop::collection::vec(1usize..16, 1..4),
+        b in prop::collection::vec(1usize..16, 1..4),
+    ) {
+        prop_assume!(a != b);
+        prop_assert!(validate_shapes(&a, &b).is_err());
+    }
+}
+
+// ── calculate_optimal_block_size ────────────────────────────────────────────
+
+proptest! {
+    /// Result is always a power of two.
+    #[test]
+    fn optimal_block_size_power_of_two(
+        tensor_size in 16usize..10_000,
+        target_blocks in 1usize..100,
+    ) {
+        let bs = calculate_optimal_block_size(tensor_size, target_blocks);
+        prop_assert!(bs.is_power_of_two(),
+            "block_size {} is not a power of two", bs);
+    }
+
+    /// Result is clamped to [16, 1024].
+    #[test]
+    fn optimal_block_size_clamped(
+        tensor_size in 1usize..100_000,
+        target_blocks in 1usize..1000,
+    ) {
+        let bs = calculate_optimal_block_size(tensor_size, target_blocks);
+        prop_assert!((16..=1024).contains(&bs),
+            "block_size {} outside [16, 1024]", bs);
+    }
+}

--- a/crates/bitnet-tokenizers/tests/proptest_wave16.rs
+++ b/crates/bitnet-tokenizers/tests/proptest_wave16.rs
@@ -1,0 +1,204 @@
+//! Property-based tests — wave 16.
+//!
+//! BasicTokenizer encode/decode roundtrip, config field preservation,
+//! EOS/BOS token handling, and vocabulary bounds.
+
+use bitnet_tokenizers::{BasicTokenizer, Tokenizer, TokenizerConfig};
+use proptest::prelude::*;
+
+// ── Encode/decode roundtrip ─────────────────────────────────────────────────
+
+proptest! {
+    /// Encoding then decoding ASCII text recovers the original.
+    #[test]
+    fn encode_decode_roundtrip_ascii(text in "[a-zA-Z]{1,30}") {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        let decoded = t.decode(&tokens).expect("decode");
+        prop_assert_eq!(decoded.trim(), text.trim(),
+            "roundtrip failed for '{}'", text);
+    }
+
+    /// Encoding non-empty text produces at least one token.
+    #[test]
+    fn encode_non_empty_text_non_empty_tokens(text in "[a-zA-Z0-9 ]{1,50}") {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        prop_assert!(!tokens.is_empty(),
+            "encoding '{}' produced empty tokens", text);
+    }
+
+    /// Decoding empty tokens produces empty string.
+    #[test]
+    fn decode_empty_tokens(_dummy in 0u8..1) {
+        let t = BasicTokenizer::new();
+        let decoded = t.decode(&[]).expect("decode");
+        prop_assert!(decoded.is_empty(),
+            "decoding empty tokens should give empty string, got '{}'", decoded);
+    }
+}
+
+// ── BOS / EOS token handling ────────────────────────────────────────────────
+
+proptest! {
+    /// add_bos prepends the BOS token ID.
+    #[test]
+    fn encode_bos_prepends_token(
+        text in "[a-z]{1,20}",
+        bos_id in 0u32..256,
+    ) {
+        let t = BasicTokenizer::with_config(50257, Some(bos_id), None, None);
+        let tokens = t.encode(&text, true, false).expect("encode with bos");
+        prop_assert_eq!(tokens[0], bos_id,
+            "first token should be BOS {}", bos_id);
+    }
+
+    /// add_special appends the EOS token ID.
+    #[test]
+    fn encode_add_special_appends_eos(
+        text in "[a-z]{1,20}",
+        eos_id in 256u32..500,
+    ) {
+        let t = BasicTokenizer::with_config(50257, None, Some(eos_id), None);
+        let tokens = t.encode(&text, false, true).expect("encode with eos");
+        prop_assert_eq!(*tokens.last().unwrap(), eos_id,
+            "last token should be EOS {}", eos_id);
+    }
+
+    /// BOS + add_special together add exactly 2 extra tokens (BOS + EOS).
+    #[test]
+    fn encode_bos_eos_adds_two(
+        text in "[a-z]{1,20}",
+        bos_id in 0u32..256,
+        eos_id in 256u32..500,
+    ) {
+        let t = BasicTokenizer::with_config(50257, Some(bos_id), Some(eos_id), None);
+        let bare = t.encode(&text, false, false).expect("bare");
+        let both = t.encode(&text, true, true).expect("both");
+        prop_assert_eq!(both.len(), bare.len() + 2);
+        prop_assert_eq!(both[0], bos_id);
+        prop_assert_eq!(*both.last().unwrap(), eos_id);
+    }
+
+    /// Without bos_token_id set, add_bos is a no-op.
+    #[test]
+    fn encode_bos_noop_when_unset(text in "[a-z]{1,20}") {
+        let t = BasicTokenizer::with_config(50257, None, None, None);
+        let without = t.encode(&text, false, false).expect("without bos");
+        let with = t.encode(&text, true, false).expect("with bos");
+        prop_assert_eq!(without, with);
+    }
+}
+
+// ── Token ID bounds ─────────────────────────────────────────────────────────
+
+proptest! {
+    /// All token IDs from encode are within [0, vocab_size).
+    #[test]
+    fn encode_ids_within_vocab(text in "[a-zA-Z ]{1,30}") {
+        let t = BasicTokenizer::new(); // vocab_size = 50257
+        let vocab_size = t.vocab_size();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        for &id in &tokens {
+            prop_assert!((id as usize) < vocab_size,
+                "token id {} >= vocab_size {}", id, vocab_size);
+        }
+    }
+
+    /// vocab_size is preserved by with_config.
+    #[test]
+    fn vocab_size_preserved(vocab_size in 256usize..200_000) {
+        let t = BasicTokenizer::with_config(vocab_size, None, None, None);
+        prop_assert_eq!(t.vocab_size(), vocab_size);
+    }
+
+    /// Byte-level encoding fails when vocab_size is too small for the byte.
+    #[test]
+    fn encode_small_vocab_fails(vocab_size in 1usize..97) {
+        let t = BasicTokenizer::with_config(vocab_size, None, None, None);
+        // 'a' = 97, so any vocab_size < 97 must reject it
+        let result = t.encode("a", false, false);
+        prop_assert!(result.is_err());
+    }
+}
+
+// ── TokenizerConfig properties ──────────────────────────────────────────────
+
+proptest! {
+    /// Config Default has sane initial values.
+    #[test]
+    fn config_default_sane(_dummy in 0u8..1) {
+        let cfg = TokenizerConfig::new();
+        prop_assert_eq!(cfg.vocab_size, 0);
+        prop_assert!(!cfg.add_bos);
+        prop_assert!(!cfg.add_eos);
+    }
+
+    /// Config struct preserves all fields via construction.
+    #[test]
+    fn config_fields_roundtrip(
+        vocab_size in 1usize..100_000,
+        add_bos in any::<bool>(),
+        add_eos in any::<bool>(),
+        bos_id in proptest::option::of(0u32..1000),
+        eos_id in proptest::option::of(0u32..1000),
+    ) {
+        let cfg = TokenizerConfig {
+            model_type: "test".to_string(),
+            vocab_size,
+            add_bos,
+            add_eos,
+            bos_token_id: bos_id,
+            eos_token_id: eos_id,
+            ..Default::default()
+        };
+        prop_assert_eq!(cfg.model_type, "test");
+        prop_assert_eq!(cfg.vocab_size, vocab_size);
+        prop_assert_eq!(cfg.add_bos, add_bos);
+        prop_assert_eq!(cfg.add_eos, add_eos);
+        prop_assert_eq!(cfg.bos_token_id, bos_id);
+        prop_assert_eq!(cfg.eos_token_id, eos_id);
+    }
+
+    /// model_type string is preserved.
+    #[test]
+    fn config_model_type_preserved(model_type in "[a-z]{1,20}") {
+        let cfg = TokenizerConfig {
+            model_type: model_type.clone(),
+            ..Default::default()
+        };
+        prop_assert_eq!(cfg.model_type, model_type);
+    }
+}
+
+// ── Encoding idempotency (same input → same output) ────────────────────────
+
+proptest! {
+    /// Encoding the same text twice gives the same tokens (deterministic).
+    #[test]
+    fn encode_deterministic(text in "[a-zA-Z0-9 ]{1,30}") {
+        let t = BasicTokenizer::new();
+        let t1 = t.encode(&text, false, false).expect("encode 1");
+        let t2 = t.encode(&text, false, false).expect("encode 2");
+        prop_assert_eq!(t1, t2);
+    }
+
+    /// token_to_piece returns Some for all byte-range tokens.
+    #[test]
+    fn token_to_piece_byte_range(id in 0u32..256) {
+        let t = BasicTokenizer::new();
+        let piece = t.token_to_piece(id);
+        prop_assert!(piece.is_some(),
+            "token_to_piece({}) should return Some", id);
+    }
+
+    /// token_to_piece is non-empty for all IDs.
+    #[test]
+    fn token_to_piece_non_empty(id in 0u32..1000) {
+        let t = BasicTokenizer::new();
+        if let Some(piece) = t.token_to_piece(id) {
+            prop_assert!(!piece.is_empty(),
+                "token_to_piece({}) returned empty string", id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add **134 property-based tests** across 5 crates as part of the ongoing proptest coverage expansion.

### Test Breakdown

| Crate | Properties | Focus Areas |
|-------|-----------|-------------|
| `bitnet-quantization` | 27 | I2SLayout invariants, QuantizedTensor shape/block, grouped scales, quantize/dequantize roundtrip, unsigned pack/unpack, MSE/SNR, validate_shapes, optimal_block_size |
| `bitnet-common` | 31 | Broadcast shape algebra, matmul shapes, reshape, transpose, attention shapes, KernelCapabilities, SimdLevel ordering, GenerationConfig, Device, QuantizationType |
| `bitnet-kernels` | 40 | 20 activation functions (relu, sigmoid, tanh, hard_sigmoid, silu, gelu, etc.), causal mask, layer_norm/rms_norm, RoPE frequencies, embedding lookup, reduction kernels |
| `bitnet-models` | 20 | GgufTensorType invariants, naming predicates, qk256 tolerance re-export, GGUF magic/version, from_quant_string |
| `bitnet-tokenizers` | 16 | Encode/decode roundtrip, BOS/EOS handling, token ID bounds, vocab_size, TokenizerConfig, determinism, token_to_piece |

### Validation

- All 134 tests pass with `--no-default-features --features cpu`
- `cargo fmt --all` clean
- `cargo clippy -- -D warnings` clean on all 5 crates
- No Cargo.toml changes needed (proptest already a dev-dependency in all crates)