### PR TITLE
refactor(kernels): extract CPU SIMD detection into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-cpu-detect"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-crossval"
 version = "0.2.1-dev"
 dependencies = [
@@ -816,6 +820,7 @@ dependencies = [
  "bindgen",
  "bitnet-common",
  "bitnet-cpu-activations",
+ "bitnet-cpu-detect",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
  "bitnet-quantization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   ".",                          # Main library crate
   "crates/bitnet-common",
+  "crates/bitnet-cpu-detect",
   "crates/bitnet-math",
   "crates/bitnet-simd",
   "crates/bitnet-warn-once",
@@ -96,6 +97,7 @@ resolver = "2"
 # wasm/py/ffi, etc.) remain workspace members but are opt-in.
 default-members = [
   "crates/bitnet-common",
+  "crates/bitnet-cpu-detect",
   "crates/bitnet-math",
   "crates/bitnet-simd",
   "crates/bitnet-warn-once",

--- a/crates/bitnet-cpu-detect/Cargo.toml
+++ b/crates/bitnet-cpu-detect/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bitnet-cpu-detect"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "CPU SIMD capability detection helpers for BitNet runtime kernel selection"
+include = [
+  "src/**",
+  "Cargo.toml",
+]
+
+[dependencies]
+
+[features]
+default = []
+avx2 = []
+avx512 = []
+neon = []

--- a/crates/bitnet-cpu-detect/src/lib.rs
+++ b/crates/bitnet-cpu-detect/src/lib.rs
@@ -1,0 +1,114 @@
+//! CPU capability detection for kernel provider selection.
+
+/// Detected CPU execution tier in descending performance preference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CpuExecutionTier {
+    Avx512,
+    Avx2,
+    Neon,
+    Scalar,
+}
+
+impl CpuExecutionTier {
+    /// Lower is better (higher priority).
+    pub const fn priority(self) -> u8 {
+        match self {
+            Self::Avx512 => 0,
+            Self::Avx2 => 1,
+            Self::Neon => 2,
+            Self::Scalar => 3,
+        }
+    }
+}
+
+/// Returns true when AVX-512 is both compiled and available at runtime.
+#[must_use]
+pub fn avx512_available() -> bool {
+    #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+    {
+        return is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw");
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Returns true when AVX2 is both compiled and available at runtime.
+#[must_use]
+pub fn avx2_available() -> bool {
+    #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
+    {
+        return is_x86_feature_detected!("avx2");
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Returns true when NEON is both compiled and available at runtime.
+#[must_use]
+pub fn neon_available() -> bool {
+    #[cfg(all(target_arch = "aarch64", feature = "neon"))]
+    {
+        return std::arch::is_aarch64_feature_detected!("neon");
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+/// Detect all available CPU tiers ordered by preference.
+#[must_use]
+pub fn available_tiers() -> Vec<CpuExecutionTier> {
+    let mut tiers = vec![CpuExecutionTier::Scalar];
+
+    if avx512_available() {
+        tiers.insert(0, CpuExecutionTier::Avx512);
+    }
+
+    if avx2_available() {
+        let insert_pos = tiers.len().saturating_sub(1);
+        tiers.insert(insert_pos, CpuExecutionTier::Avx2);
+    }
+
+    if neon_available() {
+        let insert_pos = tiers.len().saturating_sub(1);
+        tiers.insert(insert_pos, CpuExecutionTier::Neon);
+    }
+
+    tiers.sort_by_key(|tier| tier.priority());
+    tiers.dedup();
+    tiers
+}
+
+/// Detects the best available tier for the current process.
+#[must_use]
+pub fn best_tier() -> CpuExecutionTier {
+    available_tiers().into_iter().next().unwrap_or(CpuExecutionTier::Scalar)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CpuExecutionTier, available_tiers, best_tier};
+
+    #[test]
+    fn scalar_tier_is_always_present() {
+        let tiers = available_tiers();
+        assert!(tiers.contains(&CpuExecutionTier::Scalar));
+    }
+
+    #[test]
+    fn available_tiers_are_sorted_by_priority() {
+        let tiers = available_tiers();
+        for pair in tiers.windows(2) {
+            assert!(pair[0].priority() <= pair[1].priority());
+        }
+    }
+
+    #[test]
+    fn best_tier_matches_first_available_tier() {
+        let tiers = available_tiers();
+        let first = tiers.first().copied().unwrap_or(CpuExecutionTier::Scalar);
+        assert_eq!(best_tier(), first);
+    }
+}

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-cpu-activations = { path = "../bitnet-cpu-activations", version = "0.2.1-dev" }
+bitnet-cpu-detect = { path = "../bitnet-cpu-detect", version = "0.2.1-dev", default-features = false }
 bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
 bitnet-simd = { path = "../bitnet-simd", version = "0.2.1-dev" }
 thiserror.workspace = true
@@ -70,9 +71,9 @@ npu-backend = []
 cpu = ["cpu-fallback"]
 cpu-fallback = []
 cpu-optimized = ["avx512", "avx2", "neon"]
-avx2 = []
-avx512 = []
-neon = []
+avx2 = ["bitnet-cpu-detect/avx2"]
+avx512 = ["bitnet-cpu-detect/avx512"]
+neon = ["bitnet-cpu-detect/neon"]
 cuda = ["dep:cudarc", "dep:half", "bitnet-device-probe/cuda"]
 rocm = ["bitnet-device-probe/rocm"]
 hip = ["rocm"]

--- a/crates/bitnet-kernels/src/device_aware.rs
+++ b/crates/bitnet-kernels/src/device_aware.rs
@@ -7,6 +7,10 @@
 use crate::gpu;
 use crate::{KernelProvider, cpu};
 use bitnet_common::{Device, KernelError, QuantizationType, Result};
+#[cfg(all(target_arch = "x86_64", feature = "avx2"))]
+use bitnet_cpu_detect::avx2_available;
+#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+use bitnet_cpu_detect::neon_available;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use sysinfo;
@@ -91,7 +95,7 @@ impl DeviceAwareQuantizer {
         // Try optimized CPU kernels first
         #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            if avx2_available() {
                 log::debug!("Using AVX2 CPU kernel for fallback");
                 return Ok(Box::new(cpu::Avx2Kernel));
             }
@@ -99,7 +103,7 @@ impl DeviceAwareQuantizer {
 
         #[cfg(all(target_arch = "aarch64", feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            if neon_available() {
                 log::debug!("Using NEON CPU kernel for fallback");
                 return Ok(Box::new(cpu::NeonKernel));
             }
@@ -703,7 +707,7 @@ mod tests {
         // On x86_64, we should either get AVX2 or fallback
         #[cfg(feature = "avx2")]
         {
-            if is_x86_feature_detected!("avx2") {
+            if avx2_available() {
                 assert!(
                     provider_name.contains("avx2"),
                     "Should use AVX2 kernel when feature is available: {}",
@@ -738,7 +742,7 @@ mod tests {
         // On aarch64, we should either get NEON or fallback
         #[cfg(feature = "neon")]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            if neon_available() {
                 assert!(
                     provider_name.contains("neon"),
                     "Should use NEON kernel when feature is available: {}",

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -1,6 +1,12 @@
 //! High-performance compute kernels for BitNet
 
 use bitnet_common::{QuantizationType, Result};
+#[cfg(all(target_arch = "x86_64", feature = "avx2"))]
+use bitnet_cpu_detect::avx2_available;
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+use bitnet_cpu_detect::avx512_available;
+#[cfg(all(target_arch = "aarch64", feature = "neon"))]
+use bitnet_cpu_detect::neon_available;
 use std::sync::OnceLock;
 
 pub mod benchmarks;
@@ -123,7 +129,7 @@ impl KernelManager {
         // Add optimized CPU kernels in order of preference (best first)
         #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
         {
-            if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw") {
+            if avx512_available() {
                 let insert_pos = if providers.is_empty() { 0 } else { providers.len() - 1 };
                 providers.insert(insert_pos, Box::new(cpu::Avx512Kernel));
             }
@@ -131,7 +137,7 @@ impl KernelManager {
 
         #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
         {
-            if is_x86_feature_detected!("avx2") {
+            if avx2_available() {
                 let insert_pos = if providers.len() > 1 { providers.len() - 1 } else { 0 };
                 providers.insert(insert_pos, Box::new(cpu::Avx2Kernel));
             }
@@ -139,7 +145,7 @@ impl KernelManager {
 
         #[cfg(all(target_arch = "aarch64", feature = "neon"))]
         {
-            if std::arch::is_aarch64_feature_detected!("neon") {
+            if neon_available() {
                 let insert_pos = if providers.len() > 1 { providers.len() - 1 } else { 0 };
                 providers.insert(insert_pos, Box::new(cpu::NeonKernel));
             }
@@ -214,14 +220,14 @@ pub fn select_cpu_kernel() -> Result<Box<dyn KernelProvider>> {
 
     #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
     {
-        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512bw") {
+        if avx512_available() {
             providers.insert(0, Box::new(cpu::Avx512Kernel));
         }
     }
 
     #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
     {
-        if is_x86_feature_detected!("avx2") {
+        if avx2_available() {
             let insert_pos = if providers.is_empty() { 0 } else { providers.len() - 1 };
             providers.insert(insert_pos, Box::new(cpu::Avx2Kernel));
         }
@@ -229,7 +235,7 @@ pub fn select_cpu_kernel() -> Result<Box<dyn KernelProvider>> {
 
     #[cfg(all(target_arch = "aarch64", feature = "neon"))]
     {
-        if std::arch::is_aarch64_feature_detected!("neon") {
+        if neon_available() {
             providers.insert(0, Box::new(cpu::NeonKernel));
         }
     }


### PR DESCRIPTION
### Motivation
- Reduce duplicated CPU SIMD feature-detection logic scattered in kernel selection code by centralizing runtime detection and tiering in a small SRP microcrate.
- Make CPU-path kernel selection consistent and easier to test, evolve, and forward-feature-manage from the workspace.

### Description
- Added a new microcrate `crates/bitnet-cpu-detect` that exposes `avx512_available()`, `avx2_available()`, `neon_available()`, `available_tiers()`, `best_tier()` and `CpuExecutionTier` utilities (including unit tests in the new crate).
- Wired the new crate into the workspace and default-members, and added it as a dependency of `crates/bitnet-kernels` with `default-features = false`.
- Forwarded `bitnet-kernels` feature flags to the detector crate by changing `avx2`, `avx512`, and `neon` features to depend on `bitnet-cpu-detect/*`.
- Replaced inline runtime checks with the shared API in `bitnet-kernels` at the CPU selection sites: `KernelManager::new`, `select_cpu_kernel`, and `DeviceAwareQuantizer::create_best_cpu_provider` (files changed: `crates/bitnet-kernels/src/lib.rs`, `crates/bitnet-kernels/src/device_aware.rs`, `crates/bitnet-kernels/Cargo.toml`, plus the new crate files and workspace `Cargo.toml`).

### Testing
- Ran `cargo fmt --all` successfully to format workspace sources.
- Ran unit tests for the new crate with `CARGO_TARGET_DIR=target-cpu-detect cargo test -p bitnet-cpu-detect`, and all tests passed.
- Performed targeted `cargo check`/`cargo test` attempts for `bitnet-kernels`; a full workspace build/check for `bitnet-kernels` without defaults was attempted but is heavy and did not fully complete in this environment run (partial compilation steps were observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49132cae88333a315c1e97963b595)