### PR TITLE
feat(kernels): add gating mechanism kernels (SwiGLU, GeGLU, ReGLU)

### DIFF
--- a/crates/bitnet-kernels/src/cpu/gating.rs
+++ b/crates/bitnet-kernels/src/cpu/gating.rs
@@ -1,0 +1,488 @@
+//! CPU gating kernels for transformer FFN layers.
+//!
+//! Gating mechanisms combine two projections element-wise:
+//! `output = activation(gate) * up`
+//!
+//! Supported gating types:
+//! - **SwiGLU**: `SiLU(gate) * up` — used in LLaMA, Mistral, etc.
+//! - **GeGLU**: `GELU(gate) * up` — used in some GPT variants
+//! - **ReGLU**: `ReLU(gate) * up` — simpler alternative
+
+use bitnet_common::{KernelError, Result};
+
+// ── Gating type enum ────────────────────────────────────────────────
+
+/// Supported gating function types for FFN layers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatingType {
+    /// SwiGLU: `SiLU(gate) * up`
+    SwiGLU,
+    /// GeGLU: `GELU(gate) * up`
+    GeGLU,
+    /// ReGLU: `ReLU(gate) * up`
+    ReGLU,
+}
+
+// ── Scalar activation helpers ───────────────────────────────────────
+
+/// Scalar SiLU: `x / (1 + exp(-x))`.
+#[inline]
+fn silu(x: f32) -> f32 {
+    x / (1.0 + (-x).exp())
+}
+
+/// Scalar GELU (tanh approximation).
+#[inline]
+fn gelu(x: f32) -> f32 {
+    const SQRT_2_OVER_PI: f32 = 0.797_884_6;
+    const COEFF: f32 = 0.044_715;
+    let x3 = x * x * x;
+    let inner = SQRT_2_OVER_PI * (x + COEFF * x3);
+    0.5 * x * (1.0 + inner.tanh())
+}
+
+/// Scalar ReLU: `max(0, x)`.
+#[inline]
+fn relu(x: f32) -> f32 {
+    x.max(0.0)
+}
+
+// ── Input validation ────────────────────────────────────────────────
+
+/// Validate that `gate`, `up`, and `output` slices are compatible.
+fn validate_gating_buffers(gate: &[f32], up: &[f32], output: &[f32]) -> Result<usize> {
+    if gate.is_empty() {
+        return Err(KernelError::InvalidArguments {
+            reason: "gating input must be non-empty".into(),
+        }
+        .into());
+    }
+    if gate.len() != up.len() {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("gating gate length {} != up length {}", gate.len(), up.len(),),
+        }
+        .into());
+    }
+    if output.len() < gate.len() {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("gating output length {} < input length {}", output.len(), gate.len(),),
+        }
+        .into());
+    }
+    Ok(gate.len())
+}
+
+// ── Gating implementations ──────────────────────────────────────────
+
+/// SwiGLU gating: `output[i] = SiLU(gate[i]) * up[i]`.
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if slices are empty or
+/// have mismatched lengths.
+pub fn swiglu(gate: &[f32], up: &[f32], output: &mut [f32]) -> Result<()> {
+    let n = validate_gating_buffers(gate, up, output)?;
+    for i in 0..n {
+        output[i] = silu(gate[i]) * up[i];
+    }
+    Ok(())
+}
+
+/// GeGLU gating: `output[i] = GELU(gate[i]) * up[i]`.
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if slices are empty or
+/// have mismatched lengths.
+pub fn geglu(gate: &[f32], up: &[f32], output: &mut [f32]) -> Result<()> {
+    let n = validate_gating_buffers(gate, up, output)?;
+    for i in 0..n {
+        output[i] = gelu(gate[i]) * up[i];
+    }
+    Ok(())
+}
+
+/// ReGLU gating: `output[i] = ReLU(gate[i]) * up[i]`.
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if slices are empty or
+/// have mismatched lengths.
+pub fn reglu(gate: &[f32], up: &[f32], output: &mut [f32]) -> Result<()> {
+    let n = validate_gating_buffers(gate, up, output)?;
+    for i in 0..n {
+        output[i] = relu(gate[i]) * up[i];
+    }
+    Ok(())
+}
+
+/// Dispatch gating by [`GatingType`].
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if slices are empty or
+/// have mismatched lengths.
+pub fn apply_gating(
+    gating: GatingType,
+    gate: &[f32],
+    up: &[f32],
+    output: &mut [f32],
+) -> Result<()> {
+    match gating {
+        GatingType::SwiGLU => swiglu(gate, up, output),
+        GatingType::GeGLU => geglu(gate, up, output),
+        GatingType::ReGLU => reglu(gate, up, output),
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Validation tests ---------------------------------------------------
+
+    #[test]
+    fn test_gating_rejects_empty() {
+        let mut out = [0.0f32; 1];
+        assert!(swiglu(&[], &[], &mut out).is_err());
+        assert!(geglu(&[], &[], &mut out).is_err());
+        assert!(reglu(&[], &[], &mut out).is_err());
+    }
+
+    #[test]
+    fn test_gating_rejects_length_mismatch() {
+        let mut out = [0.0f32; 4];
+        assert!(swiglu(&[1.0, 2.0], &[1.0], &mut out).is_err());
+        assert!(geglu(&[1.0], &[1.0, 2.0], &mut out).is_err());
+        assert!(reglu(&[1.0, 2.0, 3.0], &[1.0, 2.0], &mut out).is_err());
+    }
+
+    #[test]
+    fn test_gating_rejects_short_output() {
+        let mut out = [0.0f32; 1];
+        assert!(swiglu(&[1.0, 2.0], &[1.0, 2.0], &mut out).is_err());
+    }
+
+    // -- SwiGLU known values ------------------------------------------------
+
+    #[test]
+    fn test_swiglu_zeros() {
+        let gate = [0.0f32; 4];
+        let up = [1.0, 2.0, 3.0, 4.0];
+        let mut out = [999.0f32; 4];
+        swiglu(&gate, &up, &mut out).unwrap();
+        // SiLU(0) = 0, so output is all zeros
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+    }
+
+    #[test]
+    fn test_swiglu_known_values() {
+        // SiLU(1) ≈ 0.7311, SiLU(-1) ≈ -0.2689
+        let gate = [1.0, -1.0, 2.0, 0.0];
+        let up = [1.0, 1.0, 0.5, 5.0];
+        let mut out = [0.0f32; 4];
+        swiglu(&gate, &up, &mut out).unwrap();
+
+        assert!((out[0] - 0.7311).abs() < 1e-3, "swiglu(1,1)={}", out[0]);
+        assert!((out[1] - (-0.2689)).abs() < 1e-3, "swiglu(-1,1)={}", out[1]);
+        // SiLU(2) ≈ 1.7616, * 0.5 ≈ 0.8808
+        assert!((out[2] - 0.8808).abs() < 1e-3, "swiglu(2,0.5)={}", out[2]);
+        // SiLU(0) = 0, * 5 = 0
+        assert!(out[3].abs() < 1e-7, "swiglu(0,5)={}", out[3]);
+    }
+
+    #[test]
+    fn test_swiglu_large_positive_gate() {
+        let gate = [100.0f32];
+        let up = [2.0f32];
+        let mut out = [0.0f32];
+        swiglu(&gate, &up, &mut out).unwrap();
+        // SiLU(100) ≈ 100, * 2 ≈ 200
+        assert!((out[0] - 200.0).abs() < 1e-2, "swiglu(100,2)={}", out[0]);
+    }
+
+    #[test]
+    fn test_swiglu_large_negative_gate() {
+        let gate = [-100.0f32];
+        let up = [2.0f32];
+        let mut out = [999.0f32];
+        swiglu(&gate, &up, &mut out).unwrap();
+        // SiLU(-100) ≈ 0
+        assert!(out[0].abs() < 1e-2, "swiglu(-100,2)={}", out[0]);
+    }
+
+    #[test]
+    fn test_swiglu_negative_up() {
+        let gate = [1.0f32];
+        let up = [-3.0f32];
+        let mut out = [0.0f32];
+        swiglu(&gate, &up, &mut out).unwrap();
+        // SiLU(1) ≈ 0.7311, * -3 ≈ -2.1933
+        assert!((out[0] - (-2.1933)).abs() < 1e-3, "swiglu(1,-3)={}", out[0]);
+    }
+
+    // -- GeGLU known values -------------------------------------------------
+
+    #[test]
+    fn test_geglu_zeros() {
+        let gate = [0.0f32; 4];
+        let up = [1.0, 2.0, 3.0, 4.0];
+        let mut out = [999.0f32; 4];
+        geglu(&gate, &up, &mut out).unwrap();
+        // GELU(0) = 0
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+    }
+
+    #[test]
+    fn test_geglu_known_values() {
+        // GELU(1) ≈ 0.8412, GELU(-1) ≈ -0.1588
+        let gate = [1.0, -1.0, 0.0];
+        let up = [1.0, 1.0, 5.0];
+        let mut out = [0.0f32; 3];
+        geglu(&gate, &up, &mut out).unwrap();
+
+        assert!((out[0] - 0.8412).abs() < 1e-3, "geglu(1,1)={}", out[0]);
+        assert!((out[1] - (-0.1588)).abs() < 1e-3, "geglu(-1,1)={}", out[1]);
+        assert!(out[2].abs() < 1e-7, "geglu(0,5)={}", out[2]);
+    }
+
+    #[test]
+    fn test_geglu_large_positive_gate() {
+        let gate = [10.0f32];
+        let up = [2.0f32];
+        let mut out = [0.0f32];
+        geglu(&gate, &up, &mut out).unwrap();
+        // GELU(10) ≈ 10, * 2 ≈ 20
+        assert!((out[0] - 20.0).abs() < 1e-2, "geglu(10,2)={}", out[0]);
+    }
+
+    #[test]
+    fn test_geglu_large_negative_gate() {
+        let gate = [-10.0f32];
+        let up = [2.0f32];
+        let mut out = [999.0f32];
+        geglu(&gate, &up, &mut out).unwrap();
+        // GELU(-10) ≈ 0
+        assert!(out[0].abs() < 1e-2, "geglu(-10,2)={}", out[0]);
+    }
+
+    // -- ReGLU known values -------------------------------------------------
+
+    #[test]
+    fn test_reglu_zeros() {
+        let gate = [0.0f32; 4];
+        let up = [1.0, 2.0, 3.0, 4.0];
+        let mut out = [999.0f32; 4];
+        reglu(&gate, &up, &mut out).unwrap();
+        // ReLU(0) = 0
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+    }
+
+    #[test]
+    fn test_reglu_known_values() {
+        let gate = [1.0, -1.0, 2.5, 0.0];
+        let up = [3.0, 3.0, 2.0, 5.0];
+        let mut out = [0.0f32; 4];
+        reglu(&gate, &up, &mut out).unwrap();
+
+        // ReLU(1)*3 = 3
+        assert!((out[0] - 3.0).abs() < 1e-7, "reglu(1,3)={}", out[0]);
+        // ReLU(-1)*3 = 0
+        assert!(out[1].abs() < 1e-7, "reglu(-1,3)={}", out[1]);
+        // ReLU(2.5)*2 = 5
+        assert!((out[2] - 5.0).abs() < 1e-7, "reglu(2.5,2)={}", out[2]);
+        // ReLU(0)*5 = 0
+        assert!(out[3].abs() < 1e-7, "reglu(0,5)={}", out[3]);
+    }
+
+    #[test]
+    fn test_reglu_all_negative_gate() {
+        let gate = [-1.0, -5.0, -100.0];
+        let up = [10.0, 20.0, 30.0];
+        let mut out = [999.0f32; 3];
+        reglu(&gate, &up, &mut out).unwrap();
+        for &v in &out[..3] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+    }
+
+    #[test]
+    fn test_reglu_all_positive_gate() {
+        let gate = [1.0, 2.0, 3.0];
+        let up = [4.0, 5.0, 6.0];
+        let mut out = [0.0f32; 3];
+        reglu(&gate, &up, &mut out).unwrap();
+        // ReLU is identity for positive inputs
+        assert!((out[0] - 4.0).abs() < 1e-7);
+        assert!((out[1] - 10.0).abs() < 1e-7);
+        assert!((out[2] - 18.0).abs() < 1e-7);
+    }
+
+    // -- apply_gating dispatch ----------------------------------------------
+
+    #[test]
+    fn test_apply_gating_dispatches_correctly() {
+        let gate = [1.0f32];
+        let up = [2.0f32];
+        let mut out_swi = [0.0f32];
+        let mut out_ge = [0.0f32];
+        let mut out_re = [0.0f32];
+
+        apply_gating(GatingType::SwiGLU, &gate, &up, &mut out_swi).unwrap();
+        apply_gating(GatingType::GeGLU, &gate, &up, &mut out_ge).unwrap();
+        apply_gating(GatingType::ReGLU, &gate, &up, &mut out_re).unwrap();
+
+        // SiLU(1)*2 ≈ 1.4622, GELU(1)*2 ≈ 1.6824, ReLU(1)*2 = 2.0
+        assert!((out_swi[0] - 1.4622).abs() < 1e-3);
+        assert!((out_ge[0] - 1.6824).abs() < 1e-3);
+        assert!((out_re[0] - 2.0).abs() < 1e-7);
+    }
+
+    // -- Property-style tests -----------------------------------------------
+
+    #[test]
+    fn test_gating_output_length_equals_input_length() {
+        for n in [1, 7, 64, 256, 1000] {
+            let gate: Vec<f32> = (0..n).map(|i| (i as f32) * 0.01 - 5.0).collect();
+            let up: Vec<f32> = (0..n).map(|i| (i as f32) * 0.02 - 3.0).collect();
+            let mut out = vec![0.0f32; n];
+
+            swiglu(&gate, &up, &mut out).unwrap();
+            // All n elements were written (none are the sentinel 999.0)
+            assert_eq!(out.len(), n);
+
+            geglu(&gate, &up, &mut out).unwrap();
+            assert_eq!(out.len(), n);
+
+            reglu(&gate, &up, &mut out).unwrap();
+            assert_eq!(out.len(), n);
+        }
+    }
+
+    #[test]
+    fn test_reglu_output_non_negative_when_up_non_negative() {
+        // ReLU(gate) >= 0, so if up >= 0, output >= 0
+        let gate: Vec<f32> = (-50..50).map(|i| i as f32 * 0.1).collect();
+        let up: Vec<f32> = (0..100).map(|i| i as f32 * 0.5).collect();
+        let mut out = vec![0.0f32; 100];
+        reglu(&gate, &up, &mut out).unwrap();
+        for (i, &v) in out.iter().enumerate() {
+            assert!(v >= 0.0, "reglu output[{i}] = {v} should be >= 0");
+        }
+    }
+
+    #[test]
+    fn test_swiglu_bounded_by_up_magnitude() {
+        // |SiLU(x)| <= |x| for all x, so |SwiGLU| <= |gate| * |up|
+        let gate: Vec<f32> = (-20..20).map(|i| i as f32 * 0.5).collect();
+        let up: Vec<f32> = (0..40).map(|i| (i as f32 - 20.0) * 0.3).collect();
+        let mut out = vec![0.0f32; 40];
+        swiglu(&gate, &up, &mut out).unwrap();
+        for i in 0..40 {
+            let bound = gate[i].abs() * up[i].abs();
+            assert!(
+                out[i].abs() <= bound + 1e-6,
+                "|swiglu[{i}]| = {} > |gate|*|up| = {bound}",
+                out[i].abs(),
+            );
+        }
+    }
+
+    // -- Numerical accuracy -------------------------------------------------
+
+    #[test]
+    fn test_swiglu_numerical_accuracy() {
+        // Compare against manually computed reference values
+        // gate=0.5: SiLU(0.5) = 0.5 * sigmoid(0.5) = 0.5 * 0.62246 = 0.31123
+        // up=1.0 -> output = 0.31123
+        let gate = [0.5f32];
+        let up = [1.0f32];
+        let mut out = [0.0f32];
+        swiglu(&gate, &up, &mut out).unwrap();
+        let sigmoid_half = 1.0 / (1.0 + (-0.5f32).exp());
+        let expected = 0.5 * sigmoid_half * 1.0;
+        assert!(
+            (out[0] - expected).abs() < 1e-6,
+            "swiglu(0.5,1) = {} expected {}",
+            out[0],
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_geglu_numerical_accuracy() {
+        // GELU(0.5) via tanh approx: 0.5 * 0.5 * (1 + tanh(sqrt(2/pi)*(0.5 + 0.044715*0.125)))
+        let gate = [0.5f32];
+        let up = [1.0f32];
+        let mut out = [0.0f32];
+        geglu(&gate, &up, &mut out).unwrap();
+        let expected = gelu(0.5) * 1.0;
+        assert!(
+            (out[0] - expected).abs() < 1e-6,
+            "geglu(0.5,1) = {} expected {}",
+            out[0],
+            expected,
+        );
+    }
+
+    #[test]
+    fn test_reglu_numerical_accuracy() {
+        let gate = [0.5f32, -0.5];
+        let up = [3.0f32, 3.0];
+        let mut out = [0.0f32; 2];
+        reglu(&gate, &up, &mut out).unwrap();
+        assert!((out[0] - 1.5).abs() < 1e-7, "reglu(0.5,3)={}", out[0]);
+        assert!(out[1].abs() < 1e-7, "reglu(-0.5,3)={}", out[1]);
+    }
+
+    #[test]
+    fn test_gating_single_element() {
+        let gate = [1.5f32];
+        let up = [2.0f32];
+        let mut out = [0.0f32];
+
+        swiglu(&gate, &up, &mut out).unwrap();
+        let expected_swiglu = silu(1.5) * 2.0;
+        assert!((out[0] - expected_swiglu).abs() < 1e-6);
+
+        geglu(&gate, &up, &mut out).unwrap();
+        let expected_geglu = gelu(1.5) * 2.0;
+        assert!((out[0] - expected_geglu).abs() < 1e-6);
+
+        reglu(&gate, &up, &mut out).unwrap();
+        assert!((out[0] - 3.0).abs() < 1e-7); // ReLU(1.5)*2 = 3
+    }
+
+    #[test]
+    fn test_gating_up_zeros() {
+        // When up is all zeros, output should be zero regardless of gate
+        let gate = [1.0, -1.0, 100.0, -100.0];
+        let up = [0.0f32; 4];
+        let mut out = [999.0f32; 4];
+
+        swiglu(&gate, &up, &mut out).unwrap();
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+
+        geglu(&gate, &up, &mut out).unwrap();
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+
+        reglu(&gate, &up, &mut out).unwrap();
+        for &v in &out[..4] {
+            assert!(v.abs() < 1e-7, "expected 0, got {v}");
+        }
+    }
+}

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -13,6 +13,7 @@ pub use conv2d::{Conv2dConfig, compute_output_size, conv2d, depthwise_conv2d, im
 pub mod embedding;
 pub mod fallback;
 pub mod fusion;
+pub mod gating;
 pub mod kv_cache;
 pub mod layer_norm;
 pub use layer_norm::{
@@ -51,6 +52,7 @@ pub use activations::{
 };
 pub use batch_norm::BatchNormConfig;
 pub use fallback::*;
+pub use gating::{GatingType, apply_gating, geglu, reglu, swiglu};
 pub use scatter_gather::{
     ScatterGatherConfig, ScatterReduce, gather_1d, gather_2d, index_select, scatter_1d, scatter_2d,
     scatter_add, scatter_max,

--- a/crates/bitnet-kernels/src/cuda/gating.rs
+++ b/crates/bitnet-kernels/src/cuda/gating.rs
@@ -1,0 +1,430 @@
+//! Gating CUDA kernels with CPU fallback for transformer FFN layers.
+//!
+//! Gating mechanisms combine two projections element-wise:
+//! `output = activation(gate) * up`
+//!
+//! Provides three fused gating operations:
+//! - **SwiGLU**: `SiLU(gate) * up` — used in LLaMA, Mistral, etc.
+//! - **GeGLU**: `GELU(gate) * up` — used in some GPT variants
+//! - **ReGLU**: `ReLU(gate) * up` — simpler alternative
+//!
+//! # Kernel strategy
+//!
+//! Each gating op is element-wise with no inter-element dependencies.
+//! CUDA kernels use grid-stride loops with 256 threads per block,
+//! matching the convention in [`super::activations`].
+//!
+//! # CPU fallback
+//!
+//! [`gating_cpu`] provides a pure-Rust scalar implementation that
+//! delegates to [`crate::cpu::gating`] for non-GPU environments.
+
+use bitnet_common::{KernelError, Result};
+
+// ---------------------------------------------------------------------------
+// PTX source (compiled at runtime via NVRTC when `gpu`/`cuda` is active)
+// ---------------------------------------------------------------------------
+
+/// Inline CUDA C source for fused gating kernels.
+///
+/// Contains three kernels: `swiglu_f32`, `geglu_f32`, `reglu_f32`.
+/// Each processes `n` elements using grid-stride loops, computing
+/// `output[i] = activation(gate[i]) * up[i]`.
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub const GATING_KERNEL_SRC: &str = r#"
+extern "C" __global__ void swiglu_f32(
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    float* __restrict__ output,
+    int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    for (int i = idx; i < n; i += blockDim.x * gridDim.x) {
+        float g = gate[i];
+        float silu_g = g / (1.0f + expf(-g));
+        output[i] = silu_g * up[i];
+    }
+}
+
+extern "C" __global__ void geglu_f32(
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    float* __restrict__ output,
+    int n)
+{
+    const float SQRT_2_OVER_PI = 0.7978845608f;
+    const float COEFF = 0.044715f;
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    for (int i = idx; i < n; i += blockDim.x * gridDim.x) {
+        float g = gate[i];
+        float g3 = g * g * g;
+        float inner = SQRT_2_OVER_PI * (g + COEFF * g3);
+        float gelu_g = 0.5f * g * (1.0f + tanhf(inner));
+        output[i] = gelu_g * up[i];
+    }
+}
+
+extern "C" __global__ void reglu_f32(
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    float* __restrict__ output,
+    int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    for (int i = idx; i < n; i += blockDim.x * gridDim.x) {
+        output[i] = fmaxf(0.0f, gate[i]) * up[i];
+    }
+}
+"#;
+
+// ---------------------------------------------------------------------------
+// Gating type selector
+// ---------------------------------------------------------------------------
+
+/// Selects which gating function to apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GatingType {
+    /// SwiGLU: `SiLU(gate) * up`
+    SwiGLU,
+    /// GeGLU: `GELU(gate) * up`
+    GeGLU,
+    /// ReGLU: `ReLU(gate) * up`
+    ReGLU,
+}
+
+impl GatingType {
+    /// CUDA kernel function name for this gating type.
+    pub fn kernel_name(&self) -> &'static str {
+        match self {
+            Self::SwiGLU => "swiglu_f32",
+            Self::GeGLU => "geglu_f32",
+            Self::ReGLU => "reglu_f32",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Launch configuration
+// ---------------------------------------------------------------------------
+
+/// Launch configuration for gating kernels.
+#[derive(Debug, Clone)]
+pub struct GatingConfig {
+    /// Total number of elements to process.
+    pub n: usize,
+    /// Threads per block (default 256).
+    pub threads_per_block: u32,
+    /// Which gating function to apply.
+    pub gating: GatingType,
+}
+
+impl GatingConfig {
+    /// Create a configuration for the given element count.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KernelError::InvalidArguments`] if `n` is zero.
+    pub fn new(n: usize, gating: GatingType) -> Result<Self> {
+        if n == 0 {
+            return Err(KernelError::InvalidArguments {
+                reason: "gating element count must be non-zero".into(),
+            }
+            .into());
+        }
+        Ok(Self { n, threads_per_block: 256, gating })
+    }
+
+    /// Compute the CUDA grid dimensions.
+    ///
+    /// Caps at 65 535 blocks; the grid-stride loop handles overflow.
+    pub fn grid_dim(&self) -> (u32, u32, u32) {
+        let blocks = (self.n as u32).div_ceil(self.threads_per_block);
+        (blocks.min(65_535), 1, 1)
+    }
+
+    /// Compute the CUDA block dimensions.
+    pub fn block_dim(&self) -> (u32, u32, u32) {
+        (self.threads_per_block, 1, 1)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+/// Validate buffers for gating kernels.
+fn validate_gating_buffers(gate: &[f32], up: &[f32], output: &[f32], n: usize) -> Result<()> {
+    if gate.len() < n {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("gating gate length {} < expected {n}", gate.len()),
+        }
+        .into());
+    }
+    if up.len() < n {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("gating up length {} < expected {n}", up.len()),
+        }
+        .into());
+    }
+    if output.len() < n {
+        return Err(KernelError::InvalidArguments {
+            reason: format!("gating output length {} < expected {n}", output.len()),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// CPU fallback
+// ---------------------------------------------------------------------------
+
+/// Gating on the CPU via [`crate::cpu::gating`].
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if buffer sizes are too small.
+pub fn gating_cpu(
+    gate: &[f32],
+    up: &[f32],
+    output: &mut [f32],
+    config: &GatingConfig,
+) -> Result<()> {
+    validate_gating_buffers(gate, up, output, config.n)?;
+    let cpu_gating = match config.gating {
+        GatingType::SwiGLU => crate::cpu::gating::GatingType::SwiGLU,
+        GatingType::GeGLU => crate::cpu::gating::GatingType::GeGLU,
+        GatingType::ReGLU => crate::cpu::gating::GatingType::ReGLU,
+    };
+    crate::cpu::gating::apply_gating(
+        cpu_gating,
+        &gate[..config.n],
+        &up[..config.n],
+        &mut output[..config.n],
+    )
+}
+
+// ---------------------------------------------------------------------------
+// CUDA dispatch (feature-gated)
+// ---------------------------------------------------------------------------
+
+/// Dispatch a gating kernel to the CUDA device via cudarc.
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub fn launch_gating_cuda(
+    gate: &[f32],
+    up: &[f32],
+    output: &mut [f32],
+    config: &GatingConfig,
+) -> Result<()> {
+    use cudarc::driver::{CudaContext, CudaSlice, LaunchConfig, PushKernelArg};
+    use cudarc::nvrtc::compile_ptx;
+
+    validate_gating_buffers(gate, up, output, config.n)?;
+
+    log::debug!(
+        "Gating CUDA dispatch: type={:?}, n={}, grid={:?}",
+        config.gating,
+        config.n,
+        config.grid_dim(),
+    );
+
+    let ctx = CudaContext::new(0).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to acquire CUDA device 0: {e:?}"),
+    })?;
+    let stream = ctx.default_stream();
+
+    let ptx = compile_ptx(GATING_KERNEL_SRC).map_err(|e| KernelError::GpuError {
+        reason: format!("NVRTC compilation failed: {e:?}"),
+    })?;
+    let module = ctx.load_module(ptx).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to load PTX module: {e:?}"),
+    })?;
+    let func =
+        module.load_function(config.gating.kernel_name()).map_err(|e| KernelError::GpuError {
+            reason: format!("{} function not found: {e:?}", config.gating.kernel_name()),
+        })?;
+
+    let gate_dev = stream.memcpy_stod(gate).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to copy gate to device: {e:?}"),
+    })?;
+    let up_dev = stream.memcpy_stod(up).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to copy up to device: {e:?}"),
+    })?;
+    let mut output_dev: CudaSlice<f32> = stream.alloc_zeros(config.n).map_err(|e| {
+        KernelError::GpuError { reason: format!("failed to allocate output on device: {e:?}") }
+    })?;
+
+    let (gx, gy, gz) = config.grid_dim();
+    let (bx, by, bz) = config.block_dim();
+    let launch_cfg =
+        LaunchConfig { grid_dim: (gx, gy, gz), block_dim: (bx, by, bz), shared_mem_bytes: 0 };
+    let n_arg = config.n as i32;
+
+    let mut builder = stream.launch_builder(&func);
+    builder.arg(&gate_dev);
+    builder.arg(&up_dev);
+    builder.arg(&mut output_dev);
+    builder.arg(&n_arg);
+
+    // Safety: kernel signature matches the CUDA source; buffers are
+    // correctly sized as validated above.
+    unsafe { builder.launch(launch_cfg) }.map_err(|e| KernelError::GpuError {
+        reason: format!("CUDA kernel launch failed: {e:?}"),
+    })?;
+
+    stream.synchronize().map_err(|e| KernelError::GpuError {
+        reason: format!("stream synchronize failed: {e:?}"),
+    })?;
+
+    let host: Vec<f32> = stream.memcpy_dtov(&output_dev).map_err(|e| KernelError::GpuError {
+        reason: format!("failed to copy output from device: {e:?}"),
+    })?;
+    output[..config.n].copy_from_slice(&host[..config.n]);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unified dispatch entry point
+// ---------------------------------------------------------------------------
+
+/// Launch a gating kernel with automatic CPU/GPU dispatch.
+///
+/// When compiled with `gpu` or `cuda` features **and** a CUDA device is
+/// available at runtime, the kernel runs on the GPU. Otherwise the CPU
+/// fallback is used.
+///
+/// # Arguments
+///
+/// * `gate`   — Gate projection tensor (FP32, at least `config.n` elements)
+/// * `up`     — Up projection tensor (FP32, at least `config.n` elements)
+/// * `output` — Output buffer (FP32, at least `config.n` elements)
+/// * `config` — Launch configuration including gating type
+///
+/// # Errors
+///
+/// Returns [`KernelError::InvalidArguments`] if buffer sizes are too small.
+pub fn launch_gating(
+    gate: &[f32],
+    up: &[f32],
+    output: &mut [f32],
+    config: &GatingConfig,
+) -> Result<()> {
+    #[cfg(any(feature = "gpu", feature = "cuda"))]
+    {
+        match launch_gating_cuda(gate, up, output, config) {
+            Ok(()) => {
+                log::debug!("Gating {:?} completed on CUDA (n={})", config.gating, config.n,);
+                return Ok(());
+            }
+            Err(e) => {
+                log::warn!("CUDA gating failed, falling back to CPU: {e}");
+            }
+        }
+    }
+
+    log::debug!("Gating {:?} CPU fallback (n={})", config.gating, config.n);
+    gating_cpu(gate, up, output, config)
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gating_config_basic() {
+        let cfg = GatingConfig::new(1024, GatingType::SwiGLU).unwrap();
+        assert_eq!(cfg.n, 1024);
+        assert_eq!(cfg.threads_per_block, 256);
+        assert_eq!(cfg.gating, GatingType::SwiGLU);
+    }
+
+    #[test]
+    fn test_gating_config_rejects_zero() {
+        assert!(GatingConfig::new(0, GatingType::SwiGLU).is_err());
+        assert!(GatingConfig::new(0, GatingType::GeGLU).is_err());
+        assert!(GatingConfig::new(0, GatingType::ReGLU).is_err());
+    }
+
+    #[test]
+    fn test_gating_config_grid_dim_small() {
+        let cfg = GatingConfig::new(100, GatingType::GeGLU).unwrap();
+        assert_eq!(cfg.grid_dim(), (1, 1, 1));
+        assert_eq!(cfg.block_dim(), (256, 1, 1));
+    }
+
+    #[test]
+    fn test_gating_config_grid_dim_large() {
+        let cfg = GatingConfig::new(20_000_000, GatingType::ReGLU).unwrap();
+        assert_eq!(cfg.grid_dim().0, 65_535);
+    }
+
+    #[test]
+    fn test_kernel_name_mapping() {
+        assert_eq!(GatingType::SwiGLU.kernel_name(), "swiglu_f32");
+        assert_eq!(GatingType::GeGLU.kernel_name(), "geglu_f32");
+        assert_eq!(GatingType::ReGLU.kernel_name(), "reglu_f32");
+    }
+
+    #[test]
+    fn test_gating_cpu_swiglu() {
+        let cfg = GatingConfig::new(2, GatingType::SwiGLU).unwrap();
+        let gate = [1.0f32, 0.0];
+        let up = [2.0f32, 5.0];
+        let mut out = [0.0f32; 2];
+        gating_cpu(&gate, &up, &mut out, &cfg).unwrap();
+        // SiLU(1)*2 ≈ 1.4622
+        assert!((out[0] - 1.4622).abs() < 1e-3);
+        // SiLU(0)*5 = 0
+        assert!(out[1].abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_gating_cpu_geglu() {
+        let cfg = GatingConfig::new(2, GatingType::GeGLU).unwrap();
+        let gate = [1.0f32, 0.0];
+        let up = [2.0f32, 5.0];
+        let mut out = [0.0f32; 2];
+        gating_cpu(&gate, &up, &mut out, &cfg).unwrap();
+        // GELU(1)*2 ≈ 1.6824
+        assert!((out[0] - 1.6824).abs() < 1e-3);
+        assert!(out[1].abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_gating_cpu_reglu() {
+        let cfg = GatingConfig::new(2, GatingType::ReGLU).unwrap();
+        let gate = [1.0f32, -1.0];
+        let up = [2.0f32, 5.0];
+        let mut out = [0.0f32; 2];
+        gating_cpu(&gate, &up, &mut out, &cfg).unwrap();
+        assert!((out[0] - 2.0).abs() < 1e-7);
+        assert!(out[1].abs() < 1e-7);
+    }
+
+    #[test]
+    fn test_gating_cpu_validation() {
+        let cfg = GatingConfig::new(4, GatingType::SwiGLU).unwrap();
+        let gate = [1.0f32, 2.0]; // too short
+        let up = [1.0f32, 2.0, 3.0, 4.0];
+        let mut out = [0.0f32; 4];
+        assert!(gating_cpu(&gate, &up, &mut out, &cfg).is_err());
+    }
+
+    #[test]
+    fn test_launch_gating_uses_cpu_fallback() {
+        let cfg = GatingConfig::new(3, GatingType::SwiGLU).unwrap();
+        let gate = [1.0f32, 0.0, -1.0];
+        let up = [1.0f32, 1.0, 1.0];
+        let mut out = [0.0f32; 3];
+        launch_gating(&gate, &up, &mut out, &cfg).unwrap();
+        // Just verify it runs without error and produces plausible output
+        assert!((out[0] - 0.7311).abs() < 1e-3);
+        assert!(out[1].abs() < 1e-7);
+        assert!((out[2] - (-0.2689)).abs() < 1e-3);
+    }
+}

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -36,6 +36,7 @@ pub mod conv1d;
 pub mod elementwise;
 pub mod embedding;
 pub mod fusion;
+pub mod gating;
 pub mod kv_cache;
 pub mod layernorm;
 pub mod matmul;
@@ -124,6 +125,11 @@ pub use embedding::{
     embedding_with_position_cpu, launch_embedding_lookup, launch_position_embedding,
     position_embedding_forward,
 };
+
+pub use gating::{GatingConfig, GatingType, gating_cpu, launch_gating};
+
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+pub use gating::{GATING_KERNEL_SRC, launch_gating_cuda};
 
 #[cfg(any(feature = "gpu", feature = "cuda"))]
 pub use embedding::{EMBEDDING_LOOKUP_KERNEL_SRC, EMBEDDING_WITH_POSITION_KERNEL_SRC};


### PR DESCRIPTION
## Summary

Add CPU and CUDA gating kernels for transformer FFN layers implementing three gating mechanisms commonly used in modern transformer architectures:

- **SwiGLU**: `SiLU(gate) * up` — used in LLaMA, Mistral, etc.
- **GeGLU**: `GELU(gate) * up` — used in some GPT variants
- **ReGLU**: `ReLU(gate) * up` — simpler alternative

## Changes

### CPU module (`crates/bitnet-kernels/src/cpu/gating.rs`)
- `swiglu`, `geglu`, `reglu` functions with input validation (non-empty, same-length)
- `GatingType` enum and `apply_gating` dispatcher
- 25 unit tests covering known values, edge cases, properties, and numerical accuracy

### CUDA module (`crates/bitnet-kernels/src/cuda/gating.rs`)
- `GATING_KERNEL_SRC` with grid-stride loop CUDA kernels for all three gating ops
- `GatingConfig` launch configuration (256 threads/block, 65535 block cap)
- `launch_gating` unified CPU/GPU dispatch with automatic fallback
- All GPU code behind `#[cfg(any(feature = "gpu", feature = "cuda"))]`

### Module registration
- Registered in both `cpu/mod.rs` and `cuda/mod.rs` with public re-exports

## Testing

```
cargo test -p bitnet-kernels --no-default-features --features cpu --lib -- gating
# 25 passed; 0 failed
```

Clippy clean: `cargo clippy -p bitnet-kernels --no-default-features --features cpu -- -D warnings`