### PR TITLE
Extract Qualcomm NPU env/runtime logic into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-math",
  "bitnet-models",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-rope",
  "bitnet-tests",
@@ -743,6 +744,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-receipts",
  "bitnet-rope",
@@ -787,6 +789,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-test-support",
  "bitnet-tests",
@@ -929,6 +932,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "bitnet-qualcomm"
+version = "0.2.1-dev"
+dependencies = [
+ "temp-env",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-qualcomm",      # SRP: Qualcomm NPU env/runtime selection helpers
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
@@ -169,6 +170,7 @@ bitnet-inference = { path = "crates/bitnet-inference", version = "0.2.1-dev", op
 bitnet-kernels = { path = "crates/bitnet-kernels", version = "0.2.1-dev", optional = true }
 bitnet-tokenizers = { path = "crates/bitnet-tokenizers", version = "0.2.1-dev", optional = true }
 bitnet-device-probe = { path = "crates/bitnet-device-probe", version = "0.2.1-dev", optional = true }
+bitnet-qualcomm = { path = "crates/bitnet-qualcomm", version = "0.2.1-dev", optional = true }
 
 [build-dependencies]
 vergen = { version = "9.0.6", features = ["build", "rustc", "cargo"] }
@@ -230,7 +232,7 @@ rocm = ["kernels", "inference", "tokenizers", "bitnet-kernels/rocm", "bitnet-inf
 vulkan = ["kernels", "inference", "tokenizers", "bitnet-kernels/vulkan", "bitnet-inference/gpu", "bitnet-quantization/gpu"]
 metal = ["kernels", "inference", "tokenizers", "bitnet-common/metal", "bitnet-inference/metal"]
 opencl = ["kernels", "inference", "tokenizers", "bitnet-kernels/opencl", "bitnet-inference/opencl", "bitnet-quantization/opencl"]
-npu = ["dep:bitnet-device-probe", "bitnet-device-probe/npu"]
+npu = ["dep:bitnet-device-probe", "dep:bitnet-qualcomm", "bitnet-device-probe/npu"]
 
 # Component features
 inference = ["dep:bitnet-inference", "kernels"]

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -19,6 +19,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
 bitnet-receipts = { path = "../bitnet-receipts", version = "0.2.1-dev" }

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use async_trait::async_trait;
 use bitnet_common::{ConcreteTensor, Device, Tensor};
 use bitnet_models::Model;
+use bitnet_qualcomm::BITNET_ENABLE_NPU as NPU_ENABLE_ENV;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
 use crate::cache::KVCache;
 
-const NPU_ENABLE_ENV: &str = "BITNET_ENABLE_NPU";
 const NPU_FALLBACK_ENV: &str = "BITNET_NPU_ALLOW_FALLBACK";
 
 /// Trait for inference backends

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -6,14 +6,12 @@
 
 use bitnet_common::Device;
 
-/// Environment variable used to enable NPU routing.
-pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
+pub use bitnet_qualcomm::BITNET_ENABLE_NPU;
+use bitnet_qualcomm::npu_enabled;
 
 /// Return `true` when the runtime should prefer NPU execution.
 pub fn npu_requested() -> bool {
-    std::env::var(BITNET_ENABLE_NPU)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    npu_enabled()
 }
 
 /// Map an external `--device` style token to an internal device preference.
@@ -24,5 +22,15 @@ pub fn map_device_token(token: &str) -> Option<Device> {
         "metal" | "npu" => Some(Device::Metal),
         "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_npu_alias() {
+        assert_eq!(map_device_token("npu"), Some(Device::Metal));
     }
 }

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true

--- a/crates/bitnet-kernels/src/npu/mod.rs
+++ b/crates/bitnet-kernels/src/npu/mod.rs
@@ -7,34 +7,20 @@
 //! bindings are wired in.
 
 use bitnet_common::{BitNetError, KernelError, QuantizationType, Result};
+use bitnet_qualcomm::{QualcommNpuBackend, npu_enabled};
 
 use crate::KernelProvider;
 
 /// NPU kernel provider for Qualcomm SDK integration points.
 #[derive(Debug, Clone, Default)]
 pub struct NpuKernel {
-    backend: NpuBackend,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NpuBackend {
-    Qnn,
-    Snpe,
-}
-
-impl Default for NpuBackend {
-    fn default() -> Self {
-        match std::env::var("BITNET_NPU_BACKEND") {
-            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
-            _ => Self::Qnn,
-        }
-    }
+    backend: QualcommNpuBackend,
 }
 
 impl NpuKernel {
     /// Create an NPU kernel provider.
     pub fn new() -> Self {
-        Self { backend: NpuBackend::default() }
+        Self { backend: QualcommNpuBackend::from_env() }
     }
 
     /// Whether NPU support was enabled for this build.
@@ -42,20 +28,11 @@ impl NpuKernel {
         cfg!(feature = "npu-backend")
     }
 
-    fn npu_enabled() -> bool {
-        std::env::var("BITNET_ENABLE_NPU")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    }
-
     fn unavailable_err(&self, op: &str) -> BitNetError {
         BitNetError::Kernel(KernelError::ExecutionFailed {
             reason: format!(
                 "NPU operation '{op}' is not yet wired to Qualcomm {} runtime",
-                match self.backend {
-                    NpuBackend::Qnn => "QNN",
-                    NpuBackend::Snpe => "SNPE",
-                }
+                self.backend.runtime_name()
             ),
         })
     }
@@ -63,14 +40,11 @@ impl NpuKernel {
 
 impl KernelProvider for NpuKernel {
     fn name(&self) -> &'static str {
-        match self.backend {
-            NpuBackend::Qnn => "npu-qnn",
-            NpuBackend::Snpe => "npu-snpe",
-        }
+        self.backend.provider_name()
     }
 
     fn is_available(&self) -> bool {
-        Self::compiled() && Self::npu_enabled()
+        Self::compiled() && npu_enabled()
     }
 
     fn matmul_i2s(

--- a/crates/bitnet-qualcomm/Cargo.toml
+++ b/crates/bitnet-qualcomm/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-qualcomm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Qualcomm NPU runtime selection and environment controls for BitNet"
+rust-version.workspace = true
+
+[dev-dependencies]
+temp-env.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-qualcomm/src/lib.rs
+++ b/crates/bitnet-qualcomm/src/lib.rs
@@ -1,0 +1,87 @@
+//! Qualcomm NPU environment and backend selection helpers.
+//!
+//! This microcrate centralizes env-var parsing shared by inference and kernel
+//! crates for the Qualcomm NPU integration path (QNN / SNPE).
+
+/// Environment variable used to enable NPU routing.
+pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
+
+/// Environment variable used to choose the Qualcomm backend implementation.
+pub const BITNET_NPU_BACKEND: &str = "BITNET_NPU_BACKEND";
+
+/// Qualcomm NPU runtime family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QualcommNpuBackend {
+    /// Qualcomm AI Engine Direct (QNN).
+    #[default]
+    Qnn,
+    /// Snapdragon Neural Processing Engine (SNPE).
+    Snpe,
+}
+
+impl QualcommNpuBackend {
+    /// Resolve backend from `BITNET_NPU_BACKEND`; defaults to [`Self::Qnn`].
+    #[must_use]
+    pub fn from_env() -> Self {
+        match std::env::var(BITNET_NPU_BACKEND) {
+            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
+            _ => Self::Qnn,
+        }
+    }
+
+    /// Provider name suffix used in kernel registration.
+    #[must_use]
+    pub const fn provider_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "npu-qnn",
+            Self::Snpe => "npu-snpe",
+        }
+    }
+
+    /// Human-readable runtime family.
+    #[must_use]
+    pub const fn runtime_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "QNN",
+            Self::Snpe => "SNPE",
+        }
+    }
+}
+
+/// Return `true` when the runtime should prefer Qualcomm NPU execution.
+#[must_use]
+pub fn npu_enabled() -> bool {
+    std::env::var(BITNET_ENABLE_NPU)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_defaults_to_qnn() {
+        temp_env::with_var_unset(BITNET_NPU_BACKEND, || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Qnn);
+        });
+    }
+
+    #[test]
+    fn backend_reads_snpe_case_insensitive() {
+        temp_env::with_var(BITNET_NPU_BACKEND, Some("SnPe"), || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Snpe);
+        });
+    }
+
+    #[test]
+    fn npu_enabled_accepts_true_and_one() {
+        temp_env::with_var(BITNET_ENABLE_NPU, Some("true"), || {
+            assert!(npu_enabled());
+        });
+
+        temp_env::with_var(BITNET_ENABLE_NPU, Some("1"), || {
+            assert!(npu_enabled());
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated Qualcomm NPU environment parsing and backend-selection logic spread across crates by centralizing it into a single SRP microcrate.
- Provide a stable, testable surface for QNN/SNPE selection and runtime enablement so kernel and inference crates can evolve independently of duplicated parsing code.

### Description
- Add a new microcrate `crates/bitnet-qualcomm` implementing shared constants and helpers (`BITNET_ENABLE_NPU`, `BITNET_NPU_BACKEND`, `QualcommNpuBackend`, `npu_enabled`) and unit tests in `src/lib.rs`.
- Register `bitnet-qualcomm` in the workspace `Cargo.toml` and wire it into the `npu` feature so feature selection uses the shared microcrate.
- Update `crates/bitnet-kernels/src/npu/mod.rs` to consume `bitnet_qualcomm::{QualcommNpuBackend, npu_enabled}` and replace local backend enum/parsing with the shared API, updating provider naming and runtime messages accordingly.
- Update `crates/bitnet-inference/src/npu.rs` and `crates/bitnet-inference/src/backends.rs` to reuse `bitnet-qualcomm` for `BITNET_ENABLE_NPU` and `npu` detection and add a focused test for the `npu` device token mapping.

### Testing
- Ran formatting with `cargo fmt --all` and the workspace formatting completed successfully.
- Ran unit tests for the new crate with `cargo test -p bitnet-qualcomm` and they passed (`3 passed`).
- Ran combined library tests with `cargo test -p bitnet-kernels -p bitnet-inference --lib` and the relevant `bitnet-kernels`/`bitnet-inference` library tests passed (NPU-related tests included).
- A full integrated `cargo test` invocation that compiled broader integration tests hit a pre-existing, unrelated `bitnet-kernels/tests/proptest_wave11.rs` import failure during a larger test job; re-running the targeted `--lib` tests confirmed the changes themselves do not fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4912c7ba483338c1b4c9a245d7228)