### PR TITLE
Extract Qualcomm NPU controls into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-math",
  "bitnet-models",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-rope",
  "bitnet-tests",
@@ -743,6 +744,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-receipts",
  "bitnet-rope",
@@ -787,6 +789,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-test-support",
  "bitnet-tests",
@@ -929,6 +932,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "bitnet-qualcomm"
+version = "0.2.1-dev"
+dependencies = [
+ "temp-env",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ members = [
   "tools/migrate-gen-config",   # AST migration tool for GenerationConfig
   "crates/bitnet-opencl",       # OpenCL GPU backend with KV cache & paged attention
   "crates/bitnet-wgpu-shaders-i2s", # WGSL compute shaders for I2_S 2-bit inference
+  "crates/bitnet-qualcomm",          # SRP: Qualcomm NPU backend/env controls
 ]
 resolver = "2"
 # Build & test these by default. Others (root `bitnet`, `tests`, `xtask`,
@@ -114,6 +115,7 @@ default-members = [
   "crates/bitnet-engine-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-qualcomm",      # SRP: Qualcomm NPU backend/env controls
 ]
 
 [package]
@@ -160,6 +162,7 @@ version = "0.2.1-dev"
 bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "crates/bitnet-qualcomm", version = "0.2.1-dev" }
 bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
 bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
@@ -321,6 +324,7 @@ required-features = ["cpu"]
 [workspace.dependencies]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "crates/bitnet-qualcomm", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -27,6 +27,7 @@ bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
 bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
 bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
 bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-sys = { path = "../bitnet-sys", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -1,20 +1,11 @@
 //! NPU integration utilities for inference.
 //!
-//! This module centralizes environment-driven controls for the NPU path so the
-//! engine and CLI can expose a stable "npu" target while backend wiring to
-//! Qualcomm QNN/SNPE matures.
+//! This module centralizes device-token mapping for the NPU path while runtime
+//! enablement controls are sourced from the `bitnet-qualcomm` microcrate.
 
 use bitnet_common::Device;
 
-/// Environment variable used to enable NPU routing.
-pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
-
-/// Return `true` when the runtime should prefer NPU execution.
-pub fn npu_requested() -> bool {
-    std::env::var(BITNET_ENABLE_NPU)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
+pub use bitnet_qualcomm::{BITNET_ENABLE_NPU, npu_requested};
 
 /// Map an external `--device` style token to an internal device preference.
 pub fn map_device_token(token: &str) -> Option<Device> {
@@ -24,5 +15,15 @@ pub fn map_device_token(token: &str) -> Option<Device> {
         "metal" | "npu" => Some(Device::Metal),
         "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npu_alias_maps_to_metal_path() {
+        assert_eq!(map_device_token("npu"), Some(Device::Metal));
     }
 }

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true

--- a/crates/bitnet-kernels/src/npu/mod.rs
+++ b/crates/bitnet-kernels/src/npu/mod.rs
@@ -7,34 +7,20 @@
 //! bindings are wired in.
 
 use bitnet_common::{BitNetError, KernelError, QuantizationType, Result};
+use bitnet_qualcomm::{QualcommNpuBackend, npu_requested};
 
 use crate::KernelProvider;
 
 /// NPU kernel provider for Qualcomm SDK integration points.
 #[derive(Debug, Clone, Default)]
 pub struct NpuKernel {
-    backend: NpuBackend,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NpuBackend {
-    Qnn,
-    Snpe,
-}
-
-impl Default for NpuBackend {
-    fn default() -> Self {
-        match std::env::var("BITNET_NPU_BACKEND") {
-            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
-            _ => Self::Qnn,
-        }
-    }
+    backend: QualcommNpuBackend,
 }
 
 impl NpuKernel {
     /// Create an NPU kernel provider.
     pub fn new() -> Self {
-        Self { backend: NpuBackend::default() }
+        Self { backend: QualcommNpuBackend::from_env() }
     }
 
     /// Whether NPU support was enabled for this build.
@@ -42,20 +28,11 @@ impl NpuKernel {
         cfg!(feature = "npu-backend")
     }
 
-    fn npu_enabled() -> bool {
-        std::env::var("BITNET_ENABLE_NPU")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    }
-
     fn unavailable_err(&self, op: &str) -> BitNetError {
         BitNetError::Kernel(KernelError::ExecutionFailed {
             reason: format!(
                 "NPU operation '{op}' is not yet wired to Qualcomm {} runtime",
-                match self.backend {
-                    NpuBackend::Qnn => "QNN",
-                    NpuBackend::Snpe => "SNPE",
-                }
+                self.backend.runtime_name()
             ),
         })
     }
@@ -63,14 +40,11 @@ impl NpuKernel {
 
 impl KernelProvider for NpuKernel {
     fn name(&self) -> &'static str {
-        match self.backend {
-            NpuBackend::Qnn => "npu-qnn",
-            NpuBackend::Snpe => "npu-snpe",
-        }
+        self.backend.provider_name()
     }
 
     fn is_available(&self) -> bool {
-        Self::compiled() && Self::npu_enabled()
+        Self::compiled() && npu_requested()
     }
 
     fn matmul_i2s(

--- a/crates/bitnet-qualcomm/Cargo.toml
+++ b/crates/bitnet-qualcomm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitnet-qualcomm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Qualcomm NPU runtime selection and environment controls"
+include = [
+  "src/**",
+  "Cargo.toml",
+]
+
+[dependencies]
+
+[dev-dependencies]
+temp-env.workspace = true

--- a/crates/bitnet-qualcomm/src/lib.rs
+++ b/crates/bitnet-qualcomm/src/lib.rs
@@ -1,0 +1,94 @@
+//! Qualcomm runtime configuration helpers.
+//!
+//! This crate centralizes environment-driven controls for Qualcomm NPU runtime
+//! selection so kernel and inference crates can share one source of truth.
+
+/// Environment variable used to enable NPU routing.
+pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
+
+/// Environment variable used to pick the Qualcomm backend implementation.
+pub const BITNET_NPU_BACKEND: &str = "BITNET_NPU_BACKEND";
+
+/// Qualcomm NPU backend selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QualcommNpuBackend {
+    /// Qualcomm AI Engine Direct (QNN).
+    #[default]
+    Qnn,
+    /// Snapdragon Neural Processing Engine (SNPE).
+    Snpe,
+}
+
+impl QualcommNpuBackend {
+    /// Parse backend from runtime environment.
+    #[must_use]
+    pub fn from_env() -> Self {
+        match std::env::var(BITNET_NPU_BACKEND) {
+            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
+            _ => Self::Qnn,
+        }
+    }
+
+    /// Stable provider name used by kernel registration.
+    #[must_use]
+    pub const fn provider_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "npu-qnn",
+            Self::Snpe => "npu-snpe",
+        }
+    }
+
+    /// Human-readable runtime name.
+    #[must_use]
+    pub const fn runtime_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "QNN",
+            Self::Snpe => "SNPE",
+        }
+    }
+}
+
+/// Return `true` when the runtime should prefer NPU execution.
+#[must_use]
+pub fn npu_requested() -> bool {
+    std::env::var(BITNET_ENABLE_NPU)
+        .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_qnn() {
+        temp_env::with_var_unset(BITNET_NPU_BACKEND, || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Qnn);
+        });
+    }
+
+    #[test]
+    fn reads_snpe_backend_case_insensitive() {
+        temp_env::with_var(BITNET_NPU_BACKEND, Some("SnPe"), || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Snpe);
+        });
+    }
+
+    #[test]
+    fn npu_requested_supports_true_and_one() {
+        temp_env::with_var(BITNET_ENABLE_NPU, Some("true"), || {
+            assert!(npu_requested());
+        });
+        temp_env::with_var(BITNET_ENABLE_NPU, Some("1"), || {
+            assert!(npu_requested());
+        });
+    }
+
+    #[test]
+    fn provider_and_runtime_names_are_stable() {
+        assert_eq!(QualcommNpuBackend::Qnn.provider_name(), "npu-qnn");
+        assert_eq!(QualcommNpuBackend::Qnn.runtime_name(), "QNN");
+        assert_eq!(QualcommNpuBackend::Snpe.provider_name(), "npu-snpe");
+        assert_eq!(QualcommNpuBackend::Snpe.runtime_name(), "SNPE");
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidate Qualcomm-specific NPU runtime controls (env vars and backend selection) into a single SRP microcrate to remove duplication and provide a single source of truth. 
- Prepare a stable integration point for Qualcomm QNN/SNPE wiring without changing current conservative runtime behavior.

### Description
- Added a new crate `crates/bitnet-qualcomm` that exports `BITNET_ENABLE_NPU`, `BITNET_NPU_BACKEND`, `QualcommNpuBackend` (with `from_env`, `provider_name`, and `runtime_name`) and `npu_requested`, plus focused unit tests; also added `temp-env` as a dev-dependency for tests. 
- Wired the new microcrate into the workspace and workspace dependencies by adding it to `Cargo.toml` members, default-members, and workspace dependencies. 
- Updated `crates/bitnet-kernels/src/npu/mod.rs` to consume `bitnet-qualcomm` for backend selection and enablement checks, replacing the previous local enum and env parsing with calls to the microcrate. 
- Updated `crates/bitnet-inference/src/npu.rs` to re-export `BITNET_ENABLE_NPU` and `npu_requested` from `bitnet-qualcomm` and keep only device-token mapping and a small unit test. 

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo test -p bitnet-qualcomm` and all unit tests passed (4 passed, 0 failed). 
- Ran `cargo check -p bitnet-kernels --lib` which completed successfully. 
- Ran `cargo check -p bitnet-inference --lib` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4912ad890833381b3ac568b9bc866)