### PR TITLE
Extract Qualcomm NPU policy into bitnet-qualcomm microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-receipts",
  "bitnet-rope",
@@ -787,6 +788,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
+ "bitnet-qualcomm",
  "bitnet-quantization",
  "bitnet-test-support",
  "bitnet-tests",
@@ -929,6 +931,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "bitnet-qualcomm"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-common",
+ "temp-env",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
+  "crates/bitnet-qualcomm",      # SRP: Qualcomm NPU env/runtime policy helpers
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
   "crates/bitnet-feature-matrix",
@@ -111,6 +112,7 @@ default-members = [
   "crates/bitnet-device-probe",
   "crates/bitnet-logits",
   "crates/bitnet-generation",
+  "crates/bitnet-qualcomm",
   "crates/bitnet-engine-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -28,6 +28,7 @@ bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
 bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
 bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 bitnet-sys = { path = "../bitnet-sys", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true
 futures.workspace = true

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -10,10 +10,11 @@ use bitnet_models::Model;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::cache::KVCache;
+use bitnet_qualcomm::{
+    BITNET_ENABLE_NPU, BITNET_NPU_ALLOW_FALLBACK, allow_cpu_fallback, npu_requested,
+};
 
-const NPU_ENABLE_ENV: &str = "BITNET_ENABLE_NPU";
-const NPU_FALLBACK_ENV: &str = "BITNET_NPU_ALLOW_FALLBACK";
+use crate::cache::KVCache;
 
 /// Trait for inference backends
 #[async_trait]
@@ -160,7 +161,7 @@ impl NpuBackend {
     pub fn new(model: Arc<dyn Model>, device: Device) -> Result<Self> {
         if !Self::is_available() {
             return Err(anyhow::anyhow!(
-                "NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and compile with metal support on macOS"
+                "NPU backend unavailable. Set {BITNET_ENABLE_NPU}=1 and compile with metal support on macOS"
             ));
         }
 
@@ -168,9 +169,7 @@ impl NpuBackend {
             return Err(anyhow::anyhow!("NPU backend currently requires Device::Metal"));
         }
 
-        let allow_cpu_fallback = std::env::var(NPU_FALLBACK_ENV)
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+        let allow_cpu_fallback = allow_cpu_fallback();
 
         info!(
             "Created NPU backend (device={:?}, allow_cpu_fallback={})",
@@ -182,11 +181,7 @@ impl NpuBackend {
 
     /// Check if NPU backend is available in current build/runtime.
     pub fn is_available() -> bool {
-        let enabled = std::env::var(NPU_ENABLE_ENV)
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
-
-        enabled && cfg!(target_os = "macos")
+        npu_requested() && cfg!(target_os = "macos")
     }
 
     fn ensure_npu_tensor(&self, input: &ConcreteTensor) -> Result<ConcreteTensor> {
@@ -206,7 +201,7 @@ impl NpuBackend {
         }
 
         Err(anyhow::anyhow!(
-            "NPU tensor transfer is not available and fallback is disabled via {NPU_FALLBACK_ENV}=0"
+            "NPU tensor transfer is not available and fallback is disabled via {BITNET_NPU_ALLOW_FALLBACK}=0"
         ))
     }
 }

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -1,28 +1,6 @@
 //! NPU integration utilities for inference.
 //!
-//! This module centralizes environment-driven controls for the NPU path so the
-//! engine and CLI can expose a stable "npu" target while backend wiring to
-//! Qualcomm QNN/SNPE matures.
+//! This module keeps the historical `bitnet_inference::npu` import path while
+//! re-exporting Qualcomm-focused policy helpers from the dedicated SRP crate.
 
-use bitnet_common::Device;
-
-/// Environment variable used to enable NPU routing.
-pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
-
-/// Return `true` when the runtime should prefer NPU execution.
-pub fn npu_requested() -> bool {
-    std::env::var(BITNET_ENABLE_NPU)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
-/// Map an external `--device` style token to an internal device preference.
-pub fn map_device_token(token: &str) -> Option<Device> {
-    match token {
-        "cpu" => Some(Device::Cpu),
-        "cuda" | "gpu" => Some(Device::Cuda(0)),
-        "metal" | "npu" => Some(Device::Metal),
-        "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
-        _ => None,
-    }
-}
+pub use bitnet_qualcomm::{BITNET_ENABLE_NPU, map_device_token, npu_requested};

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-qualcomm = { path = "../bitnet-qualcomm", version = "0.2.1-dev" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true

--- a/crates/bitnet-kernels/src/npu/mod.rs
+++ b/crates/bitnet-kernels/src/npu/mod.rs
@@ -7,34 +7,20 @@
 //! bindings are wired in.
 
 use bitnet_common::{BitNetError, KernelError, QuantizationType, Result};
+use bitnet_qualcomm::{QualcommNpuBackend, npu_requested};
 
 use crate::KernelProvider;
 
 /// NPU kernel provider for Qualcomm SDK integration points.
 #[derive(Debug, Clone, Default)]
 pub struct NpuKernel {
-    backend: NpuBackend,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NpuBackend {
-    Qnn,
-    Snpe,
-}
-
-impl Default for NpuBackend {
-    fn default() -> Self {
-        match std::env::var("BITNET_NPU_BACKEND") {
-            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
-            _ => Self::Qnn,
-        }
-    }
+    backend: QualcommNpuBackend,
 }
 
 impl NpuKernel {
     /// Create an NPU kernel provider.
     pub fn new() -> Self {
-        Self { backend: NpuBackend::default() }
+        Self { backend: QualcommNpuBackend::from_env() }
     }
 
     /// Whether NPU support was enabled for this build.
@@ -42,20 +28,11 @@ impl NpuKernel {
         cfg!(feature = "npu-backend")
     }
 
-    fn npu_enabled() -> bool {
-        std::env::var("BITNET_ENABLE_NPU")
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
-    }
-
     fn unavailable_err(&self, op: &str) -> BitNetError {
         BitNetError::Kernel(KernelError::ExecutionFailed {
             reason: format!(
                 "NPU operation '{op}' is not yet wired to Qualcomm {} runtime",
-                match self.backend {
-                    NpuBackend::Qnn => "QNN",
-                    NpuBackend::Snpe => "SNPE",
-                }
+                self.backend.runtime_name(),
             ),
         })
     }
@@ -63,14 +40,11 @@ impl NpuKernel {
 
 impl KernelProvider for NpuKernel {
     fn name(&self) -> &'static str {
-        match self.backend {
-            NpuBackend::Qnn => "npu-qnn",
-            NpuBackend::Snpe => "npu-snpe",
-        }
+        self.backend.kernel_name()
     }
 
     fn is_available(&self) -> bool {
-        Self::compiled() && Self::npu_enabled()
+        Self::compiled() && npu_requested()
     }
 
     fn matmul_i2s(

--- a/crates/bitnet-qualcomm/Cargo.toml
+++ b/crates/bitnet-qualcomm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitnet-qualcomm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Qualcomm NPU runtime selection and environment policy helpers for BitNet"
+include = [
+  "src/**",
+  "Cargo.toml",
+]
+
+[dependencies]
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[dev-dependencies]
+temp-env.workspace = true

--- a/crates/bitnet-qualcomm/src/lib.rs
+++ b/crates/bitnet-qualcomm/src/lib.rs
@@ -1,0 +1,109 @@
+//! Qualcomm NPU integration helpers.
+//!
+//! This crate centralizes environment policy for Qualcomm-oriented NPU routing
+//! so kernel and inference crates can share the same runtime behavior.
+
+use bitnet_common::Device;
+
+/// Environment variable used to enable NPU routing.
+pub const BITNET_ENABLE_NPU: &str = "BITNET_ENABLE_NPU";
+
+/// Environment variable selecting the Qualcomm NPU backend implementation.
+pub const BITNET_NPU_BACKEND: &str = "BITNET_NPU_BACKEND";
+
+/// Environment variable controlling CPU fallback behavior for NPU inference.
+pub const BITNET_NPU_ALLOW_FALLBACK: &str = "BITNET_NPU_ALLOW_FALLBACK";
+
+/// Qualcomm NPU backend selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QualcommNpuBackend {
+    /// Qualcomm Neural Network SDK backend.
+    #[default]
+    Qnn,
+    /// Snapdragon Neural Processing Engine backend.
+    Snpe,
+}
+
+impl QualcommNpuBackend {
+    /// Parse backend selection from `BITNET_NPU_BACKEND`.
+    pub fn from_env() -> Self {
+        match std::env::var(BITNET_NPU_BACKEND) {
+            Ok(value) if value.eq_ignore_ascii_case("snpe") => Self::Snpe,
+            _ => Self::Qnn,
+        }
+    }
+
+    /// Canonical kernel provider name.
+    pub fn kernel_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "npu-qnn",
+            Self::Snpe => "npu-snpe",
+        }
+    }
+
+    /// Human-readable Qualcomm runtime name.
+    pub fn runtime_name(self) -> &'static str {
+        match self {
+            Self::Qnn => "QNN",
+            Self::Snpe => "SNPE",
+        }
+    }
+}
+
+/// Return `true` when NPU execution is explicitly enabled.
+pub fn npu_requested() -> bool {
+    std::env::var(BITNET_ENABLE_NPU)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Return `true` when CPU fallback should be allowed for NPU operations.
+pub fn allow_cpu_fallback() -> bool {
+    std::env::var(BITNET_NPU_ALLOW_FALLBACK)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(true)
+}
+
+/// Map an external `--device` style token to an internal device preference.
+pub fn map_device_token(token: &str) -> Option<Device> {
+    match token {
+        "cpu" => Some(Device::Cpu),
+        "cuda" | "gpu" => Some(Device::Cuda(0)),
+        "metal" | "npu" => Some(Device::Metal),
+        "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_defaults_to_qnn() {
+        temp_env::with_var_unset(BITNET_NPU_BACKEND, || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Qnn);
+        });
+    }
+
+    #[test]
+    fn backend_parses_snpe() {
+        temp_env::with_var(BITNET_NPU_BACKEND, Some("snpe"), || {
+            assert_eq!(QualcommNpuBackend::from_env(), QualcommNpuBackend::Snpe);
+        });
+    }
+
+    #[test]
+    fn npu_requested_uses_enable_env() {
+        temp_env::with_var(BITNET_ENABLE_NPU, Some("true"), || {
+            assert!(npu_requested());
+        });
+    }
+
+    #[test]
+    fn fallback_defaults_enabled() {
+        temp_env::with_var_unset(BITNET_NPU_ALLOW_FALLBACK, || {
+            assert!(allow_cpu_fallback());
+        });
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated Qualcomm-specific environment parsing and runtime naming from multiple crates and centralize Qualcomm NPU policy behind a single SRP microcrate to follow SRP and simplify future wiring for QNN/SNPE.
- Provide a small, well-tested surface for backend selection, enable flags, fallback policy, and device-token mapping so kernels and inference can rely on one source-of-truth.

### Description
- Add a new crate `crates/bitnet-qualcomm` that exposes `BITNET_ENABLE_NPU`, `BITNET_NPU_BACKEND`, `BITNET_NPU_ALLOW_FALLBACK`, `QualcommNpuBackend`, `npu_requested()`, `allow_cpu_fallback()`, and `map_device_token()` with unit tests. (`crates/bitnet-qualcomm/src/lib.rs`, `crates/bitnet-qualcomm/Cargo.toml`).
- Wire `bitnet-qualcomm` into the workspace and `default-members` so it builds and is available to dependents (`Cargo.toml`).
- Update `crates/bitnet-kernels` to depend on `bitnet-qualcomm` and refactor `npu::NpuKernel` to use `QualcommNpuBackend` and `npu_requested()` instead of duplicating env parsing/runtime naming (`crates/bitnet-kernels/src/npu/mod.rs`, `crates/bitnet-kernels/Cargo.toml`).
- Update `crates/bitnet-inference` to depend on `bitnet-qualcomm`, turn `bitnet_inference::npu` into a compatibility re-export, and update `NpuBackend` to use `npu_requested()` and `allow_cpu_fallback()` (string messages updated to reference the shared constants) (`crates/bitnet-inference/src/npu.rs`, `crates/bitnet-inference/src/backends.rs`, `crates/bitnet-inference/Cargo.toml`).

### Testing
- Ran `cargo fmt` successfully across the workspace.
- Ran `cargo test -p bitnet-qualcomm` and all crate unit tests passed (4 passed).
- Ran `cargo test -p bitnet-kernels --lib npu::tests::npu_kernel_reports_name --features npu-backend` and the targeted NPU kernel test passed.
- Ran `cargo test -p bitnet-inference --test opencl_backend_selection -- --nocapture` and the OpenCL/oneAPI selection tests passed.
- Attempted a broader `cargo test` for `bitnet-kernels` which failed due to pre-existing unrelated borrow-check errors in `crates/bitnet-kernels/tests/metal_kernel_validation.rs` (errors surfaced from existing tests, not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4912a1840833394a691630bb4614f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized NPU runtime configuration and environment variable handling for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->