### PR TITLE
Extract NVIDIA tuning heuristics into a dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-nvidia"
+version = "0.1.0"
+
+[[package]]
 name = "bitnet-opencl"
 version = "0.2.1-dev"
 dependencies = [
@@ -1729,6 +1733,7 @@ dependencies = [
 name = "bitnet-wgpu"
 version = "0.1.0"
 dependencies = [
+ "bitnet-nvidia",
  "bytemuck",
  "pollster",
  "proptest",
@@ -1743,7 +1748,11 @@ name = "bitnet-wgpu-bench"
 version = "0.1.0"
 dependencies = [
  "bitnet-bench-receipts",
+ "bitnet-nvidia",
  "proptest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
+  "crates/bitnet-nvidia",        # SRP: NVIDIA-specific tuning heuristics
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
     "crates/bitnet-rocm",          # HIP compute kernels for AMD ROCm backend",

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bitnet-nvidia"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92.0"
+description = "NVIDIA-specific GPU tuning heuristics shared across BitNet backends"
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/crates/bitnet-nvidia/src/lib.rs
+++ b/crates/bitnet-nvidia/src/lib.rs
@@ -1,0 +1,58 @@
+//! NVIDIA-focused GPU tuning helpers.
+//!
+//! This crate intentionally stays tiny so NVIDIA-specific heuristics can be
+//! shared across backend/runtime crates without pulling in larger dependencies.
+
+/// Threads per warp on NVIDIA hardware.
+pub const NVIDIA_WARP_SIZE: u32 = 32;
+
+/// Canonical 1-D workgroup candidate sizes for NVIDIA tuning sweeps.
+pub const NVIDIA_1D_WORKGROUP_CANDIDATES: [u32; 4] = [64, 128, 256, 512];
+
+/// Returns `true` if the workgroup size is aligned to warp boundaries.
+#[must_use]
+pub const fn is_warp_aligned(workgroup_size: u32) -> bool {
+    workgroup_size != 0 && workgroup_size.is_multiple_of(NVIDIA_WARP_SIZE)
+}
+
+/// Return an NVIDIA-tuned workgroup size for 1-D dispatches.
+///
+/// Heuristics:
+/// - Always warp-aligned (multiple of 32).
+/// - Prefer 256 for Blackwell / Ada / Ampere (good occupancy).
+/// - Fall back to 128 for small workloads, 64 for tiny workloads.
+#[must_use]
+pub const fn optimal_workgroup_size_1d(elements: u32) -> u32 {
+    if elements == 0 {
+        return NVIDIA_WARP_SIZE;
+    }
+    if elements <= 64 {
+        NVIDIA_WARP_SIZE * 2 // 64
+    } else if elements <= 256 {
+        128
+    } else {
+        256
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidates_are_warp_aligned() {
+        for candidate in NVIDIA_1D_WORKGROUP_CANDIDATES {
+            assert!(is_warp_aligned(candidate));
+        }
+    }
+
+    #[test]
+    fn heuristic_thresholds() {
+        assert_eq!(optimal_workgroup_size_1d(0), 32);
+        assert_eq!(optimal_workgroup_size_1d(1), 64);
+        assert_eq!(optimal_workgroup_size_1d(64), 64);
+        assert_eq!(optimal_workgroup_size_1d(65), 128);
+        assert_eq!(optimal_workgroup_size_1d(256), 128);
+        assert_eq!(optimal_workgroup_size_1d(257), 256);
+    }
+}

--- a/crates/bitnet-wgpu-bench/Cargo.toml
+++ b/crates/bitnet-wgpu-bench/Cargo.toml
@@ -8,6 +8,10 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }
+bitnet-nvidia = { path = "../bitnet-nvidia" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/bitnet-wgpu-bench/src/workgroup_tuner.rs
+++ b/crates/bitnet-wgpu-bench/src/workgroup_tuner.rs
@@ -1,5 +1,7 @@
 //! Workgroup size tuning grid for wgpu compute kernel dispatch.
 
+use bitnet_nvidia::NVIDIA_1D_WORKGROUP_CANDIDATES;
+
 /// A candidate workgroup configuration for kernel dispatch.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkgroupConfig {
@@ -39,14 +41,11 @@ impl TuningGrid {
 
     /// NVIDIA-optimized defaults: warp-aligned sizes (multiples of 32).
     pub fn nvidia_defaults() -> Self {
-        Self {
-            candidates: vec![
-                WorkgroupConfig::new([64, 1, 1], "nvidia_64"),
-                WorkgroupConfig::new([128, 1, 1], "nvidia_128"),
-                WorkgroupConfig::new([256, 1, 1], "nvidia_256"),
-                WorkgroupConfig::new([512, 1, 1], "nvidia_512"),
-            ],
-        }
+        let candidates = NVIDIA_1D_WORKGROUP_CANDIDATES
+            .iter()
+            .map(|&size| WorkgroupConfig::new([size, 1, 1], format!("nvidia_{size}")))
+            .collect();
+        Self { candidates }
     }
 
     /// Number of candidates in the grid.

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -7,6 +7,7 @@ description = "wgpu-based GPU compute backend for BitNet inference (Vulkan/Metal
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+bitnet-nvidia = { path = "../bitnet-nvidia" }
 wgpu = { version = "24", features = ["vulkan-portability"] }
 bytemuck = { version = "1", features = ["derive"] }
 pollster = "0.4"

--- a/crates/bitnet-wgpu/src/dispatch.rs
+++ b/crates/bitnet-wgpu/src/dispatch.rs
@@ -1,5 +1,6 @@
 //! Workgroup dispatch helpers and NVIDIA-tuned sizing.
 
+use bitnet_nvidia::optimal_workgroup_size_1d;
 use std::fmt;
 
 /// Configuration for a single compute dispatch.
@@ -42,9 +43,6 @@ pub fn compute_dispatch_size(total_elements: u32, workgroup_size: u32) -> u32 {
     total_elements.div_ceil(workgroup_size)
 }
 
-/// NVIDIA warp size (threads per warp on all NVIDIA architectures).
-const NVIDIA_WARP_SIZE: u32 = 32;
-
 /// Return an NVIDIA-tuned workgroup size for 1-D dispatches.
 ///
 /// Heuristics:
@@ -52,19 +50,7 @@ const NVIDIA_WARP_SIZE: u32 = 32;
 /// - Prefer 256 for Blackwell / Ada / Ampere (good occupancy).
 /// - Fall back to 128 for very small workloads, 64 for tiny ones.
 pub fn optimal_workgroup_size_nvidia(elements: u32) -> u32 {
-    if elements == 0 {
-        return NVIDIA_WARP_SIZE;
-    }
-    if elements <= 64 {
-        // Tiny: one or two warps.
-        NVIDIA_WARP_SIZE * 2 // 64
-    } else if elements <= 256 {
-        // Small: four warps.
-        128
-    } else {
-        // Default: eight warps — best occupancy on Blackwell / RTX 5070 Ti.
-        256
-    }
+    optimal_workgroup_size_1d(elements)
 }
 
 /// Records dispatches for profiling / diagnostics.
@@ -152,7 +138,7 @@ mod tests {
     #[test]
     fn nvidia_workgroup_zero_elements() {
         let ws = optimal_workgroup_size_nvidia(0);
-        assert_eq!(ws, NVIDIA_WARP_SIZE);
+        assert_eq!(ws, bitnet_nvidia::NVIDIA_WARP_SIZE);
     }
 
     #[test]
@@ -180,7 +166,11 @@ mod tests {
     fn nvidia_workgroup_always_warp_aligned() {
         for n in [0, 1, 32, 33, 64, 65, 128, 256, 257, 512, 100_000] {
             let ws = optimal_workgroup_size_nvidia(n);
-            assert_eq!(ws % NVIDIA_WARP_SIZE, 0, "ws={ws} not warp-aligned for n={n}");
+            assert_eq!(
+                ws % bitnet_nvidia::NVIDIA_WARP_SIZE,
+                0,
+                "ws={ws} not warp-aligned for n={n}"
+            );
         }
     }
 


### PR DESCRIPTION
### Motivation
- Remove duplicated NVIDIA-specific tuning constants/heuristics from multiple crates and centralize them behind a small SRP microcrate so backends can share a single source of truth.

### Description
- Add a new microcrate `crates/bitnet-nvidia` exposing `NVIDIA_WARP_SIZE`, `NVIDIA_1D_WORKGROUP_CANDIDATES`, `is_warp_aligned`, and `optimal_workgroup_size_1d` with unit tests.
- Register the new crate in the workspace `Cargo.toml` and add `bitnet-nvidia` as a dependency to `crates/bitnet-wgpu` and `crates/bitnet-wgpu-bench`.
- Update `crates/bitnet-wgpu/src/dispatch.rs` to delegate `optimal_workgroup_size_nvidia` to `bitnet_nvidia::optimal_workgroup_size_1d` and reference the shared `NVIDIA_WARP_SIZE` in tests.
- Update `crates/bitnet-wgpu-bench/src/workgroup_tuner.rs` to build its NVIDIA tuning grid from `NVIDIA_1D_WORKGROUP_CANDIDATES` instead of hard-coded literals.

### Testing
- Ran `cargo test -p bitnet-nvidia -p bitnet-wgpu -p bitnet-wgpu-bench` and all selected unit tests passed successfully (GPU-runtime-only tests are still ignored as expected).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49120e35c8333bd4d0a2e49e4e9db)