### PR TITLE
Extract NVIDIA probing into dedicated bitnet-nvidia microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,7 @@ version = "0.2.1-dev"
 dependencies = [
  "ash",
  "bitnet-common",
+ "bitnet-nvidia",
  "insta",
  "log",
  "opencl3",
@@ -787,6 +788,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
+ "bitnet-nvidia",
  "bitnet-quantization",
  "bitnet-test-support",
  "bitnet-tests",
@@ -874,6 +876,10 @@ dependencies = [
  "tracing",
  "url",
 ]
+
+[[package]]
+name = "bitnet-nvidia"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-opencl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-nvidia",       # SRP: NVIDIA vendor/runtime detection helpers
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
@@ -109,6 +110,7 @@ default-members = [
   "crates/bitnet-runtime-profile-core",
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
+  "crates/bitnet-nvidia",
   "crates/bitnet-logits",
   "crates/bitnet-generation",
   "crates/bitnet-engine-core",

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-nvidia = { path = "../bitnet-nvidia", version = "0.2.1-dev" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 opencl3 = { version = "0.9", optional = true }

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -220,7 +220,7 @@ fn cuda_available_runtime() -> bool {
         return fake.contains("cuda") || fake.contains("gpu");
     }
 
-    command_ok("nvidia-smi", &[])
+    bitnet_nvidia::cuda_runtime_available()
 }
 
 #[cfg(any(feature = "gpu", feature = "cuda", feature = "rocm"))]

--- a/crates/bitnet-device-probe/src/wgpu_probe.rs
+++ b/crates/bitnet-device-probe/src/wgpu_probe.rs
@@ -113,14 +113,9 @@ pub struct WgpuDeviceInfo {
     pub shader_f16: bool,
 }
 
-/// NVIDIA PCI vendor ID.
-const NVIDIA_VENDOR_ID: u32 = 0x10DE;
-
 /// Check whether a probed device is an NVIDIA GPU.
 pub fn is_nvidia(info: &WgpuDeviceInfo) -> bool {
-    info.vendor == NVIDIA_VENDOR_ID
-        || info.name.to_ascii_lowercase().contains("nvidia")
-        || info.driver.to_ascii_lowercase().contains("nvidia")
+    bitnet_nvidia::is_nvidia_device(info.vendor, &info.name, &info.driver)
 }
 
 /// Check whether a probed device uses the Vulkan backend.
@@ -283,7 +278,7 @@ mod tests {
 
     #[test]
     fn is_nvidia_by_vendor_id() {
-        let info = make_info(|i| i.vendor = NVIDIA_VENDOR_ID);
+        let info = make_info(|i| i.vendor = bitnet_nvidia::NVIDIA_VENDOR_ID);
         assert!(is_nvidia(&info));
     }
 

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-probe = { path = "../bitnet-device-probe", version = "0.2.1-dev" }
+bitnet-nvidia = { path = "../bitnet-nvidia", version = "0.2.1-dev" }
 thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true

--- a/crates/bitnet-kernels/src/gpu_utils.rs
+++ b/crates/bitnet-kernels/src/gpu_utils.rs
@@ -126,7 +126,8 @@ fn detect_real_gpu_info() -> GpuInfo {
             .map(|out| out.contains("Metal") || out.contains("Apple"))
             .unwrap_or(false);
 
-    let cuda = probe_command("nvidia-smi", &["--query-gpu=gpu_name", "--format=csv,noheader"]);
+    let cuda = bitnet_nvidia::cuda_runtime_available()
+        || probe_command("nvidia-smi", &["--query-gpu=gpu_name", "--format=csv,noheader"]);
 
     let cuda_version = if cuda { get_cuda_version() } else { None };
 

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitnet-nvidia"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "NVIDIA runtime/vendor detection helpers for BitNet GPU probing"
+rust-version.workspace = true
+
+[dependencies]
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-nvidia/src/lib.rs
+++ b/crates/bitnet-nvidia/src/lib.rs
@@ -1,0 +1,51 @@
+//! NVIDIA runtime/vendor detection helpers.
+//!
+//! This crate provides small, focused helpers that can be reused across
+//! backend crates without pulling in larger probing modules.
+
+/// NVIDIA PCI vendor ID.
+pub const NVIDIA_VENDOR_ID: u32 = 0x10DE;
+
+/// Return `true` if the vendor ID/name/driver tuple appears to be NVIDIA.
+#[must_use]
+pub fn is_nvidia_device(vendor: u32, name: &str, driver: &str) -> bool {
+    vendor == NVIDIA_VENDOR_ID
+        || name.to_ascii_lowercase().contains("nvidia")
+        || driver.to_ascii_lowercase().contains("nvidia")
+}
+
+/// Check whether CUDA runtime tooling is available by invoking `nvidia-smi`.
+#[must_use]
+pub fn cuda_runtime_available() -> bool {
+    std::process::Command::new("nvidia-smi")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nvidia_detected_by_vendor() {
+        assert!(is_nvidia_device(NVIDIA_VENDOR_ID, "Unknown", ""));
+    }
+
+    #[test]
+    fn nvidia_detected_by_name() {
+        assert!(is_nvidia_device(0, "NVIDIA RTX 4090", ""));
+    }
+
+    #[test]
+    fn nvidia_detected_by_driver() {
+        assert!(is_nvidia_device(0, "Generic GPU", "nvidia proprietary"));
+    }
+
+    #[test]
+    fn non_nvidia_not_detected() {
+        assert!(!is_nvidia_device(0x1002, "AMD Radeon", "amdgpu"));
+    }
+}


### PR DESCRIPTION
### Motivation

- Reduce duplication and tighten SRP by moving NVIDIA-specific vendor/runtime detection into a small reusable microcrate.
- Make CUDA/NVIDIA checks shareable across probing and kernel crates so future vendor-specific enhancements live in one place.

### Description

- Added a new crate `crates/bitnet-nvidia` that exposes `NVIDIA_VENDOR_ID`, `is_nvidia_device(vendor,name,driver)`, and `cuda_runtime_available()` which invokes `nvidia-smi`.
- Registered `bitnet-nvidia` in the workspace `Cargo.toml` and included it in `default-members` so it builds and tests with the workspace.
- Updated `crates/bitnet-device-probe` to depend on `bitnet-nvidia` and replaced local CUDA checks with `bitnet_nvidia::cuda_runtime_available()` and replaced the wgpu NVIDIA heuristic with `bitnet_nvidia::is_nvidia_device`.
- Updated `crates/bitnet-kernels` to depend on `bitnet-nvidia` and route initial CUDA detection in `gpu_utils::detect_real_gpu_info` through `bitnet_nvidia::cuda_runtime_available()` for consistent behavior.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p bitnet-nvidia` and all unit tests passed (`4` tests passed).
- Ran `cargo test -p bitnet-device-probe --features wgpu-probe --lib` and the library/unit tests passed; a full device-probe test run produced snapshot `.snap.new` files (snapshot expectations need review) so only lib-level checks were asserted as passing in this environment.
- Ran `cargo test -p bitnet-kernels --lib` and library tests passed (`1634` passed); a targeted integration test run earlier surfaced an unrelated pre-existing test/import mismatch in a separate test harness, not caused by this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4911ee770833380ad3a3c5cdffbb9)