### PR TITLE
Extract Intel GPU identification into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,9 @@ version = "0.2.1-dev"
 dependencies = [
  "ash",
  "bitnet-common",
+ "bitnet-intel-gpu-id",
  "insta",
+ "libloading 0.8.9",
  "log",
  "opencl3",
  "pollster",
@@ -777,6 +779,10 @@ dependencies = [
  "tracing",
  "wasm-bindgen-futures",
 ]
+
+[[package]]
+name = "bitnet-intel-gpu-id"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-kernels"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -13,9 +13,11 @@ rust-version.workspace = true
 
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-intel-gpu-id = { path = "../bitnet-intel-gpu-id", version = "0.2.1-dev" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 opencl3 = { version = "0.9", optional = true }
+libloading = { version = "0.8.9", optional = true }
 wgpu = { version = "24", features = ["vulkan-portability"], optional = true }
 pollster = { version = "0.4", optional = true }
 
@@ -34,7 +36,7 @@ rocm = []
 vulkan = ["dep:ash"]
 npu = ["oneapi"]
 oneapi = ["dep:opencl3"]
-opencl = ["dep:opencl3"]
+opencl = ["dep:opencl3", "dep:libloading"]
 wgpu-probe = ["dep:wgpu", "dep:pollster"]
 
 [[test]]

--- a/crates/bitnet-device-probe/src/opencl.rs
+++ b/crates/bitnet-device-probe/src/opencl.rs
@@ -6,6 +6,10 @@
 
 use std::fmt;
 
+use bitnet_intel_gpu_id::{
+    is_intel_arc_device as shared_is_intel_arc_device, is_intel_vendor as shared_is_intel_vendor,
+};
+
 // ── OpenCL C constants ──────────────────────────────────────────────────────
 
 const CL_SUCCESS: i32 = 0;
@@ -106,12 +110,12 @@ impl OpenClDeviceInfo {
 
     /// Returns `true` if vendor string contains "Intel" (case-insensitive).
     pub fn is_intel(&self) -> bool {
-        self.vendor.to_ascii_lowercase().contains("intel")
+        shared_is_intel_vendor(&self.vendor)
     }
 
     /// Returns `true` if this looks like an Intel Arc GPU.
     pub fn is_intel_arc(&self) -> bool {
-        self.is_intel() && self.is_gpu() && self.name.to_ascii_lowercase().contains("arc")
+        self.is_gpu() && shared_is_intel_arc_device(&self.vendor, &self.name)
     }
 }
 
@@ -168,42 +172,14 @@ impl ProbeResult {
 pub struct IntelArcDetector;
 
 impl IntelArcDetector {
-    /// Known Intel Arc device name patterns.
-    const ARC_PATTERNS: &[&str] = &[
-        "arc a",
-        "arc b",
-        "arc a770",
-        "arc a750",
-        "arc a580",
-        "arc a380",
-        "arc a310",
-        "arc b580",
-        "arc b570",
-        "arc pro",
-        "arc graphics",
-    ];
-
     /// Returns `true` if the vendor/device pair looks like an Intel Arc.
     pub fn is_arc(vendor: &str, device_name: &str) -> bool {
-        let vendor_lower = vendor.to_ascii_lowercase();
-        let device_lower = device_name.to_ascii_lowercase();
-
-        if !vendor_lower.contains("intel") {
-            return false;
-        }
-        // Check known patterns
-        for pattern in Self::ARC_PATTERNS {
-            if device_lower.contains(pattern) {
-                return true;
-            }
-        }
-        // Fallback: "arc" anywhere in the device name from Intel vendor
-        device_lower.contains("arc")
+        shared_is_intel_arc_device(vendor, device_name)
     }
 
     /// Returns `true` if the vendor looks like Intel (regardless of device).
     pub fn is_intel_vendor(vendor: &str) -> bool {
-        vendor.to_ascii_lowercase().contains("intel")
+        shared_is_intel_vendor(vendor)
     }
 }
 

--- a/crates/bitnet-intel-gpu-id/Cargo.toml
+++ b/crates/bitnet-intel-gpu-id/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-intel-gpu-id"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Intel GPU identification heuristics shared across BitNet GPU backends"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-intel-gpu-id/src/lib.rs
+++ b/crates/bitnet-intel-gpu-id/src/lib.rs
@@ -1,0 +1,70 @@
+//! Intel GPU identification helpers.
+//!
+//! This crate contains pure string-based heuristics for identifying Intel
+//! GPUs, with a focus on Intel Arc devices used by the OpenCL/oneAPI path.
+
+/// Known Intel Arc device name patterns.
+const ARC_PATTERNS: &[&str] = &[
+    "arc a",
+    "arc b",
+    "arc a770",
+    "arc a750",
+    "arc a580",
+    "arc a380",
+    "arc a310",
+    "arc b580",
+    "arc b570",
+    "arc pro",
+    "arc graphics",
+];
+
+/// Returns `true` if `vendor` looks like Intel.
+#[must_use]
+pub fn is_intel_vendor(vendor: &str) -> bool {
+    vendor.to_ascii_lowercase().contains("intel")
+}
+
+/// Returns `true` if `device_name` resembles an Intel Arc model.
+///
+/// This does not check vendor; use [`is_intel_arc_device`] for full matching.
+#[must_use]
+pub fn is_arc_name(device_name: &str) -> bool {
+    let device_lower = device_name.to_ascii_lowercase();
+    ARC_PATTERNS.iter().any(|pattern| device_lower.contains(pattern))
+        || device_lower.contains("arc")
+}
+
+/// Returns `true` if the vendor/device pair looks like an Intel Arc GPU.
+#[must_use]
+pub fn is_intel_arc_device(vendor: &str, device_name: &str) -> bool {
+    is_intel_vendor(vendor) && is_arc_name(device_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intel_vendor_detection_is_case_insensitive() {
+        assert!(is_intel_vendor("Intel(R) Corporation"));
+        assert!(is_intel_vendor("INTEL"));
+        assert!(is_intel_vendor("intel"));
+        assert!(!is_intel_vendor("NVIDIA"));
+        assert!(!is_intel_vendor("AMD"));
+    }
+
+    #[test]
+    fn arc_name_detection_accepts_known_models() {
+        assert!(is_arc_name("Intel Arc A770"));
+        assert!(is_arc_name("Intel Arc B580"));
+        assert!(is_arc_name("Intel Arc Pro A60M"));
+        assert!(is_arc_name("Some Future Arc Device"));
+    }
+
+    #[test]
+    fn intel_arc_detection_requires_intel_vendor() {
+        assert!(is_intel_arc_device("Intel", "Arc A770"));
+        assert!(!is_intel_arc_device("AMD", "Arc A770"));
+        assert!(!is_intel_arc_device("Intel", "Intel UHD Graphics 770"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Intel/Arc device-name heuristics are conceptually independent from OpenCL probing and were duplicated across backends, so extracting them follows SRP and enables reuse.
- Centralizing Intel GPU identification simplifies maintenance and makes it easier for other Intel-focused backends to share the same logic.
- The OpenCL code also required `libloading` to be exposed via the `opencl` feature for the runtime loader path to compile correctly.

### Description
- Adds a new workspace microcrate `crates/bitnet-intel-gpu-id` that implements `is_intel_vendor`, `is_arc_name`, and `is_intel_arc_device` with unit tests in `src/lib.rs`.
- Registers the new crate in the workspace `Cargo.toml` and adds a workspace dependency from `crates/bitnet-device-probe` to `bitnet-intel-gpu-id` in `crates/bitnet-device-probe/Cargo.toml`.
- Rewrites `crates/bitnet-device-probe/src/opencl.rs` to delegate Intel/vendor and Arc detection to the shared helpers (preserving the public detector API) and removes the duplicated ARC pattern table.
- Adds optional `libloading` to `crates/bitnet-device-probe/Cargo.toml` and enables it under the `opencl` feature so the dynamic OpenCL loader compiles, and updates `Cargo.lock` accordingly.

### Testing
- Ran `cargo fmt` successfully to format the workspace.
- Ran `cargo test -p bitnet-intel-gpu-id` and all unit tests passed (3 passed; 0 failed).
- Ran `cargo test -p bitnet-device-probe --features opencl --lib` and the OpenCL-related unit tests passed (all targeted tests passed); a broader `cargo test -p bitnet-device-probe` run hit unrelated snapshot mismatches (3 snapshot expectations differ from baseline) which pre-existed and are not introduced by this refactor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4911b07c8833399f2aec0033ca678)