### PR TITLE
ci: improve ROCm smoke workflow coverage and safety

### DIFF
--- a/.github/workflows/rocm-smoke.yml
+++ b/.github/workflows/rocm-smoke.yml
@@ -1,6 +1,14 @@
 name: ROCm Smoke Tests
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/rocm-smoke.yml'
+      - 'crates/bitnet-kernels/**'
+      - 'crates/bitnet-cli/**'
+      - 'crates/bitnet/**'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
   workflow_dispatch:
     inputs:
       run_parity:
@@ -16,10 +24,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   RUST_LOG: warn
+  CARGO_INCREMENTAL: 0
 
 jobs:
   # Always-on compile check (no ROCm runtime required)
@@ -88,6 +100,11 @@ jobs:
 
       - name: Build ROCm release
         run: cargo build --release --no-default-features --features rocm,cpu --locked
+
+      - name: Verify ROCm runtime availability
+        run: |
+          command -v rocm-smi
+          rocm-smi --showproductname --showdriverversion | head -20
 
       - name: ROCm kernel smoke (${{ matrix.test }})
         if: matrix.test == 'kernel-smoke'


### PR DESCRIPTION
### Motivation

- Ensure ROCm-related changes get CI feedback during PRs without requiring ROCm hardware by adding targeted compile-time checks.
- Reduce CI blast-radius by using least-privilege workflow permissions and make builds more deterministic.
- Fail early on misconfigured self-hosted ROCm runners by verifying runtime availability before running runtime smoke tests.

### Description

- Add a `pull_request` trigger with focused path filters for `.github/workflows/rocm-smoke.yml`, `crates/bitnet-kernels/**`, `crates/bitnet-cli/**`, `crates/bitnet/**`, `Cargo.lock`, and `Cargo.toml` so relevant PRs run ROCm compile validation.
- Set workflow `permissions` to `contents: read` to tighten default privileges.
- Set `CARGO_INCREMENTAL: 0` in the workflow `env` to disable incremental compilation for more deterministic CI outputs.
- Add a `Verify ROCm runtime availability` step that runs `command -v rocm-smi` and `rocm-smi --showproductname --showdriverversion` before runtime smoke tests.
- Preserve the runtime ROCm job behavior to run only on self-hosted ROCm runners and only for manual/scheduled dispatches.

### Testing

- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/rocm-smoke.yml'); puts 'YAML parse OK'"`, which returned `YAML parse OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a490d0411c8333ac4fbb3d851ea5a0)