### PR TITLE
Fix bitnet-opencl diagnostics test root imports

### DIFF
--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -12,18 +12,22 @@
 pub mod backend_dispatcher;
 pub mod backend_registry;
 pub mod context_pool;
+pub mod diagnostics;
 pub mod kv_cache;
 pub mod paged_attention;
+pub mod system_info;
 
 pub use backend_dispatcher::{
     BackendCapabilityMatrix, BackendDispatcher, BackendStatus, DispatchDecision, DispatchError,
     DispatchLog, DispatchStrategy, Operation,
 };
 pub use backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
+pub use diagnostics::{DiagnosticReport, GpuDiagnostics, format_json, format_report};
 pub mod quantized_kernels;
 pub mod quantized_ops;
 pub mod spirv;
 pub mod spirv_kernels;
+pub use system_info::collect_system_info;
 
 // Re-exports for convenience.
 pub use spirv::{


### PR DESCRIPTION
### Motivation
- Tests in `crates/bitnet-opencl/tests/diagnostics_tests.rs` import diagnostics symbols from the crate root, and a refactor removed those re-exports which caused unresolved import errors during `cargo test`.

### Description
- Added `pub mod diagnostics;` and `pub mod system_info;` to the crate root and re-exported the diagnostics helpers with `pub use diagnostics::{DiagnosticReport, GpuDiagnostics, format_json, format_report};`.
- Re-exported `collect_system_info` with `pub use system_info::collect_system_info;` so existing tests that import it from the crate root keep compiling without modification.

### Testing
- Ran `cargo test -p bitnet-opencl` and the entire `bitnet-opencl` test suite completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49d03193883338dd5bb49d8039743)