### PR TITLE
Extract performance metrics into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "bitnet-logits",
  "bitnet-math",
  "bitnet-models",
+ "bitnet-performance-metrics-core",
  "bitnet-quantization",
  "bitnet-rope",
  "bitnet-tests",
@@ -501,6 +502,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-math",
+ "bitnet-performance-metrics-core",
  "bitnet-test-support",
  "bitnet-warn-once",
  "bytemuck",
@@ -889,6 +891,14 @@ dependencies = [
  "temp-env",
  "tempfile",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "bitnet-performance-metrics-core"
+version = "0.2.1-dev"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "crates/bitnet-common",
   "crates/bitnet-math",
   "crates/bitnet-warn-once",
+  "crates/bitnet-performance-metrics-core", # SRP: shared performance metric + computation types
   "crates/bitnet-runtime-context",
   "crates/bitnet-runtime-context-core",
   "crates/bitnet-bdd-grid",
@@ -61,6 +62,7 @@ members = [
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-performance-metrics-core",
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
@@ -85,6 +87,7 @@ default-members = [
   "crates/bitnet-common",
   "crates/bitnet-math",
   "crates/bitnet-warn-once",
+  "crates/bitnet-performance-metrics-core", # SRP: shared performance metric + computation types
   "crates/bitnet-quantization",
   "crates/bitnet-rope",
   "crates/bitnet-transformer",
@@ -114,6 +117,7 @@ default-members = [
   "crates/bitnet-engine-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-performance-metrics-core",
 ]
 
 [package]
@@ -160,6 +164,7 @@ version = "0.2.1-dev"
 bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-performance-metrics-core = { path = "crates/bitnet-performance-metrics-core", version = "0.2.1-dev" }
 bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
 bitnet_ggml_ffi = { package = "bitnet-ggml-ffi", path = "crates/bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
@@ -321,6 +326,7 @@ required-features = ["cpu"]
 [workspace.dependencies]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-performance-metrics-core = { path = "crates/bitnet-performance-metrics-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-common/Cargo.toml
+++ b/crates/bitnet-common/Cargo.toml
@@ -18,6 +18,7 @@ include = [
 [dependencies]
 bitnet-math.workspace = true
 bitnet-warn-once.workspace = true
+bitnet-performance-metrics-core.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/bitnet-common/src/strict_mode.rs
+++ b/crates/bitnet-common/src/strict_mode.rs
@@ -4,6 +4,7 @@
 //! and ensure real quantized computation is used throughout the inference pipeline.
 
 use crate::{BitNetError, Result};
+pub use bitnet_performance_metrics_core::{ComputationType, PerformanceMetrics};
 use std::env;
 use std::sync::OnceLock;
 
@@ -280,30 +281,6 @@ pub struct MissingKernelScenario {
     pub quantization_type: crate::QuantizationType,
     pub device: crate::Device,
     pub fallback_available: bool,
-}
-
-/// Performance metrics for validation
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct PerformanceMetrics {
-    #[serde(default)]
-    pub tokens_per_second: f64,
-    #[serde(default)]
-    pub latency_ms: f64,
-    #[serde(default)]
-    pub memory_usage_mb: f64,
-    #[serde(default)]
-    pub computation_type: ComputationType,
-    #[serde(default)]
-    pub gpu_utilization: Option<f64>,
-}
-
-/// Computation type classification
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ComputationType {
-    #[default]
-    Real,
-    Mock,
 }
 
 #[cfg(test)]

--- a/crates/bitnet-performance-metrics-core/Cargo.toml
+++ b/crates/bitnet-performance-metrics-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-performance-metrics-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for shared performance metric types and computation classification"
+
+[dependencies]
+serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/bitnet-performance-metrics-core/src/lib.rs
+++ b/crates/bitnet-performance-metrics-core/src/lib.rs
@@ -1,0 +1,58 @@
+//! Shared performance telemetry primitives.
+//!
+//! This microcrate intentionally owns only the types needed to describe
+//! inference runtime metrics and whether the computation path was real or mock.
+
+/// Performance metrics for validation and telemetry.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct PerformanceMetrics {
+    #[serde(default)]
+    pub tokens_per_second: f64,
+    #[serde(default)]
+    pub latency_ms: f64,
+    #[serde(default)]
+    pub memory_usage_mb: f64,
+    #[serde(default)]
+    pub computation_type: ComputationType,
+    #[serde(default)]
+    pub gpu_utilization: Option<f64>,
+}
+
+/// Computation type classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputationType {
+    #[default]
+    Real,
+    Mock,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_real_computation() {
+        let metrics = PerformanceMetrics::default();
+        assert_eq!(metrics.computation_type, ComputationType::Real);
+        assert_eq!(metrics.tokens_per_second, 0.0);
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_fields() {
+        let metrics = PerformanceMetrics {
+            tokens_per_second: 42.0,
+            latency_ms: 10.0,
+            memory_usage_mb: 512.0,
+            computation_type: ComputationType::Mock,
+            gpu_utilization: Some(85.0),
+        };
+
+        let json = serde_json::to_string(&metrics).expect("serialize");
+        let deserialized: PerformanceMetrics = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(deserialized.tokens_per_second, 42.0);
+        assert_eq!(deserialized.computation_type, ComputationType::Mock);
+        assert_eq!(deserialized.gpu_utilization, Some(85.0));
+    }
+}


### PR DESCRIPTION
### Motivation
- Isolate the telemetry types (`PerformanceMetrics`, `ComputationType`) as a single-responsibility microcrate so other crates can depend on the types without pulling the broader `bitnet-common` surface.
- Reduce coupling and make the performance telemetry primitives reusable and easier to maintain across workspace crates.

### Description
- Added a new microcrate `crates/bitnet-performance-metrics-core` with `Cargo.toml` and `src/lib.rs` that defines `PerformanceMetrics` and `ComputationType` and includes focused unit tests.
- Wired the new crate into the workspace `members` and `default-members` and added a workspace dependency entry so it builds with the rest of the workspace.
- Updated `crates/bitnet-common/Cargo.toml` to depend on the new microcrate and removed the local `PerformanceMetrics` / `ComputationType` definitions from `crates/bitnet-common/src/strict_mode.rs`, instead re-exporting them via `pub use bitnet_performance_metrics_core::{ComputationType, PerformanceMetrics};` to preserve the existing public API.
- Ran `cargo fmt --all` to normalize formatting.

### Testing
- Ran `cargo test -p bitnet-performance-metrics-core` and all unit tests in the new crate passed.
- Ran `cargo test -p bitnet-common strict_mode --lib` and the strict-mode tests passed.
- Ran `cargo fmt --all` to ensure formatting changes were applied (completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a490a6aa948333a90c4be4d087e7ac)