### PR TITLE
Extract tokenizer discovery into SRP core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
  "bitnet-startup-contract-guard",
+ "bitnet-tokenizer-discovery-core",
  "bitnet-tokenizers",
  "bitnet-validation",
  "bytemuck",
@@ -1500,6 +1501,15 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "tokio",
+]
+
+[[package]]
+name = "bitnet-tokenizer-discovery-core"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/bitnet-inference",
   "crates/bitnet-rope",
   "crates/bitnet-tokenizers",
+  "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",
@@ -106,6 +107,7 @@ default-members = [
   "crates/bitnet-test-env",
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
+  "crates/bitnet-tokenizer-discovery-core",
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",
   "crates/bitnet-inference",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -29,6 +29,7 @@ bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
 bitnet-repl-core = { path = "../bitnet-repl-core", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/tokenizer_discovery.rs
+++ b/crates/bitnet-cli/src/tokenizer_discovery.rs
@@ -1,209 +1,19 @@
-//! Tokenizer auto-discovery for BitNet-rs CLI
-//!
-//! This module implements automatic tokenizer discovery with a fallback chain:
-//! 1. Explicit --tokenizer flag (highest priority)
-//! 2. GGUF embedded tokenizer metadata
-//! 3. Sibling tokenizer.json (same directory as model)
-//! 4. Parent directory tokenizer.json (one level up)
-//!
-//! AC:ID llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
+//! Tokenizer auto-discovery for BitNet-rs CLI.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::Result;
+use bitnet_tokenizer_discovery_core::resolve_tokenizer_with;
 use std::path::{Path, PathBuf};
-use tracing::debug;
 
-/// Tokenizer discovery engine
-///
-/// AC:ID llama3-tokenizer-api-contracts.md#cli-auto-discovery-v1
-pub struct TokenizerDiscovery {
-    model_path: PathBuf,
-}
-
-impl TokenizerDiscovery {
-    /// Create discovery engine from model path
-    ///
-    /// Preconditions:
-    /// - model_path must exist and be readable
-    /// - model_path must point to a file (not directory)
-    pub fn new(model_path: PathBuf) -> Self {
-        Self { model_path }
-    }
-
-    /// Discover tokenizer via fallback chain
-    ///
-    /// Discovery order:
-    /// 1. GGUF embedded tokenizer (tokenizer.ggml.model metadata)
-    /// 2. Sibling tokenizer.json (same directory as model)
-    /// 3. Parent directory tokenizer.json (one level up)
-    ///
-    /// Returns: Absolute path to valid tokenizer
-    /// Errors: If no tokenizer found in any location
-    pub fn discover(&self) -> Result<PathBuf> {
-        debug!("Starting tokenizer auto-discovery for model: {}", self.model_path.display());
-
-        // 1. Check GGUF embedded tokenizer
-        if let Some(path) = self.check_embedded_tokenizer()? {
-            debug!("Discovered embedded GGUF tokenizer");
-            return Ok(path);
-        }
-
-        // 2. Check sibling tokenizer.json
-        if let Some(path) = self.check_sibling_tokenizer()? {
-            debug!("Discovered sibling tokenizer: {}", path.display());
-            return Ok(path);
-        }
-
-        // 3. Check parent directory
-        if let Some(path) = self.check_parent_tokenizer()? {
-            debug!("Discovered parent tokenizer: {}", path.display());
-            return Ok(path);
-        }
-
-        // No tokenizer found - return actionable error
-        Err(self.discovery_failed_error())
-    }
-
-    /// Check for GGUF embedded tokenizer
-    ///
-    /// Returns: Some(PathBuf) if embedded tokenizer found and valid, None otherwise
-    fn check_embedded_tokenizer(&self) -> Result<Option<PathBuf>> {
-        // TODO: Implement GGUF embedded tokenizer extraction
-        // For now, return None as GGUF embedded tokenizers are not yet supported
-        debug!("Checking GGUF embedded tokenizer: Not present");
-        Ok(None)
-    }
-
-    /// Check for sibling tokenizer.json
-    ///
-    /// Returns: Some(PathBuf) if sibling exists and is valid, None otherwise
-    fn check_sibling_tokenizer(&self) -> Result<Option<PathBuf>> {
-        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
-        let sibling_path = model_dir.join("tokenizer.json");
-
-        debug!("Checking sibling tokenizer: {}", sibling_path.display());
-
-        if sibling_path.exists() && sibling_path.is_file() {
-            // Verify it's a valid tokenizer
-            if self.verify_tokenizer(&sibling_path)? {
-                // Return absolute path
-                return Ok(Some(sibling_path.canonicalize()?));
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Check for parent directory tokenizer.json
-    ///
-    /// Returns: Some(PathBuf) if parent tokenizer exists and is valid, None otherwise
-    fn check_parent_tokenizer(&self) -> Result<Option<PathBuf>> {
-        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
-
-        if let Some(parent_dir) = model_dir.parent() {
-            let parent_path = parent_dir.join("tokenizer.json");
-
-            debug!("Checking parent tokenizer: {}", parent_path.display());
-
-            if parent_path.exists() && parent_path.is_file() {
-                // Verify it's a valid tokenizer
-                if self.verify_tokenizer(&parent_path)? {
-                    // Return absolute path
-                    return Ok(Some(parent_path.canonicalize()?));
-                }
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Verify tokenizer file is valid
-    ///
-    /// Returns: true if valid, false otherwise
-    fn verify_tokenizer(&self, path: &Path) -> Result<bool> {
-        // Try to load tokenizer using bitnet-tokenizers
-        match bitnet_tokenizers::loader::load_tokenizer(path) {
-            Ok(_) => {
-                debug!("Tokenizer validation passed: {}", path.display());
-                Ok(true)
-            }
-            Err(e) => {
-                debug!("Tokenizer validation failed for {}: {}", path.display(), e);
-                Ok(false) // Return false instead of error for discovery chain
-            }
-        }
-    }
-
-    /// Generate actionable error when discovery fails
-    ///
-    /// AC:ID llama3-tokenizer-api-contracts.md#error-message-contract
-    fn discovery_failed_error(&self) -> anyhow::Error {
-        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
-        let sibling_path = model_dir.join("tokenizer.json");
-        let parent_path = model_dir
-            .parent()
-            .map(|p| p.join("tokenizer.json"))
-            .unwrap_or_else(|| PathBuf::from("N/A"));
-
-        anyhow!(
-            "Tokenizer not found for model: {}\n\
-             \n\
-             Tokenizer auto-discovery failed. Tried:\n\
-             1. GGUF embedded tokenizer: Not present\n\
-             2. Sibling tokenizer.json: {} (not found)\n\
-             3. Parent directory: {} (not found)\n\
-             \n\
-             Solution:\n\
-             1. Download LLaMA-3 tokenizer:\n\
-                cargo run -p xtask -- tokenizer --into {}\n\
-             2. Provide explicit tokenizer path:\n\
-                --tokenizer /path/to/tokenizer.json\n\
-             \n\
-             For more help, see: docs/quickstart.md#tokenizer-setup",
-            self.model_path.display(),
-            sibling_path.display(),
-            parent_path.display(),
-            model_dir.display()
-        )
-    }
-}
-
-/// Resolve tokenizer path with auto-discovery
-///
-/// This is the main entry point for tokenizer resolution.
+/// Resolve tokenizer path with auto-discovery.
 ///
 /// Priority:
-/// 1. Explicit path (if provided) - highest priority
-/// 2. Auto-discovery chain (GGUF → sibling → parent)
-///
-/// AC:ID llama3-tokenizer-api-contracts.md#cli-auto-discovery-v1
+/// 1. Explicit path (if provided).
+/// 2. Sibling tokenizer.json.
+/// 3. Parent tokenizer.json.
 pub fn resolve_tokenizer(model_path: &Path, explicit_path: Option<PathBuf>) -> Result<PathBuf> {
-    // Priority 1: Explicit path takes precedence
-    if let Some(path) = explicit_path {
-        debug!("Using explicit tokenizer path: {}", path.display());
-
-        // Verify explicit path exists
-        if !path.exists() {
-            anyhow::bail!(
-                "Explicit tokenizer path does not exist: {}\n\
-                 \n\
-                 Please provide a valid tokenizer.json file path.",
-                path.display()
-            );
-        }
-
-        // Verify it's a file
-        if !path.is_file() {
-            anyhow::bail!("Explicit tokenizer path is not a file: {}", path.display());
-        }
-
-        // Return absolute path
-        return path.canonicalize().context("Failed to canonicalize explicit tokenizer path");
-    }
-
-    // Priority 2: Auto-discovery
-    debug!("Starting tokenizer auto-discovery (no explicit path provided)");
-    let discovery = TokenizerDiscovery::new(model_path.to_path_buf());
-    discovery.discover()
+    resolve_tokenizer_with(model_path, explicit_path, |candidate| {
+        Ok(bitnet_tokenizers::loader::load_tokenizer(candidate).is_ok())
+    })
 }
 
 #[cfg(test)]
@@ -225,14 +35,12 @@ mod tests {
     }
 
     fn create_mock_gguf() -> Vec<u8> {
-        // Minimal GGUF header for testing
         b"GGUF\x03\x00\x00\x00".to_vec()
     }
 
     #[test]
-    fn test_explicit_path_takes_precedence() -> Result<()> {
+    fn explicit_path_takes_precedence() -> Result<()> {
         let temp_dir = TempDir::new()?;
-
         let model_path = temp_dir.path().join("model.gguf");
         let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
         let explicit_tokenizer = temp_dir.path().join("explicit_tokenizer.json");
@@ -242,107 +50,7 @@ mod tests {
         fs::write(&explicit_tokenizer, create_mock_tokenizer())?;
 
         let result = resolve_tokenizer(&model_path, Some(explicit_tokenizer.clone()))?;
-
         assert_eq!(result.canonicalize()?, explicit_tokenizer.canonicalize()?);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_discover_sibling_tokenizer() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-
-        let model_path = temp_dir.path().join("model.gguf");
-        let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
-
-        fs::write(&model_path, create_mock_gguf())?;
-        fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-
-        let result = resolve_tokenizer(&model_path, None)?;
-
-        assert_eq!(result.canonicalize()?, sibling_tokenizer.canonicalize()?);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_discover_parent_tokenizer() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let model_dir = temp_dir.path().join("models");
-        fs::create_dir(&model_dir)?;
-
-        let model_path = model_dir.join("model.gguf");
-        let parent_tokenizer = temp_dir.path().join("tokenizer.json");
-
-        fs::write(&model_path, create_mock_gguf())?;
-        fs::write(&parent_tokenizer, create_mock_tokenizer())?;
-
-        let result = resolve_tokenizer(&model_path, None)?;
-
-        assert_eq!(result.canonicalize()?, parent_tokenizer.canonicalize()?);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_fail_with_clear_error() {
-        let temp_dir = TempDir::new().unwrap();
-        let model_path = temp_dir.path().join("model.gguf");
-        fs::write(&model_path, create_mock_gguf()).unwrap();
-
-        let result = resolve_tokenizer(&model_path, None);
-
-        assert!(result.is_err());
-        let error_msg = result.unwrap_err().to_string();
-
-        assert!(error_msg.contains("Tokenizer not found"));
-        assert!(error_msg.contains("cargo run -p xtask -- tokenizer"));
-    }
-
-    #[test]
-    fn test_discovery_chain_order() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let model_dir = temp_dir.path().join("models");
-        fs::create_dir(&model_dir)?;
-
-        let model_path = model_dir.join("model.gguf");
-        fs::write(&model_path, create_mock_gguf())?;
-
-        // Test 1: No tokenizer anywhere - should fail
-        let result_none = resolve_tokenizer(&model_path, None);
-        assert!(result_none.is_err());
-
-        // Test 2: Parent tokenizer only
-        let parent_tokenizer = temp_dir.path().join("tokenizer.json");
-        fs::write(&parent_tokenizer, create_mock_tokenizer())?;
-
-        let result_parent = resolve_tokenizer(&model_path, None)?;
-        assert_eq!(result_parent.canonicalize()?, parent_tokenizer.canonicalize()?);
-
-        // Test 3: Sibling tokenizer (should take precedence over parent)
-        let sibling_tokenizer = model_dir.join("tokenizer.json");
-        fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-
-        let result_sibling = resolve_tokenizer(&model_path, None)?;
-        assert_eq!(result_sibling.canonicalize()?, sibling_tokenizer.canonicalize()?);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_discovery_returns_absolute_paths() -> Result<()> {
-        let temp_dir = TempDir::new()?;
-        let model_path = temp_dir.path().join("model.gguf");
-        let tokenizer_path = temp_dir.path().join("tokenizer.json");
-
-        fs::write(&model_path, create_mock_gguf())?;
-        fs::write(&tokenizer_path, create_mock_tokenizer())?;
-
-        let result = resolve_tokenizer(&model_path, None)?;
-
-        assert!(result.is_absolute());
-        assert_eq!(result, tokenizer_path.canonicalize()?);
-
         Ok(())
     }
 }

--- a/crates/bitnet-cli/tests/tokenizer_discovery_tests.rs
+++ b/crates/bitnet-cli/tests/tokenizer_discovery_tests.rs
@@ -1,437 +1,8 @@
-//! AC2: CLI auto-discovery tests
-//!
-//! Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-//! API contracts: llama3-tokenizer-api-contracts.md#cli-auto-discovery
-//!
-//! This test suite validates the automatic tokenizer discovery functionality including:
-//! - Explicit path takes precedence over discovery
-//! - Sibling tokenizer.json discovery
-//! - GGUF embedded tokenizer discovery
-//! - Clear error messages when discovery fails
-//! - Discovery chain order validation
-
 use anyhow::Result;
+use bitnet_cli::tokenizer_discovery::resolve_tokenizer;
 use std::fs;
-use std::path::PathBuf;
 use tempfile::TempDir;
 
-/// AC2:cli_auto_discovery:explicit
-/// Tests that explicit --tokenizer path takes precedence over auto-discovery
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_explicit_path_takes_precedence() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-
-    // Setup: Create model with sibling tokenizer
-    let model_path = temp_dir.path().join("model.gguf");
-    let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
-    let explicit_tokenizer = temp_dir.path().join("explicit_tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-    fs::write(&explicit_tokenizer, create_mock_tokenizer())?;
-
-    // Execute: Resolve tokenizer with explicit path provided
-    let result = resolve_tokenizer(&model_path, Some(explicit_tokenizer.clone()));
-
-    match result {
-        Ok(path) => {
-            // Verify: Explicit path was used, not sibling
-            assert_eq!(
-                path, explicit_tokenizer,
-                "Should use explicit path, not auto-discovered sibling"
-            );
-        }
-        Err(e) => {
-            // Test scaffolding - implementation pending
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Expected unimplemented error, got: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:sibling
-/// Tests discovery of sibling tokenizer.json in same directory as model
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_discover_sibling_tokenizer() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-
-    // Setup: Create model and sibling tokenizer.json
-    let model_path = temp_dir.path().join("model.gguf");
-    let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-
-    // Execute: Auto-discovery (no explicit path)
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(path) => {
-            // Verify: Discovered sibling tokenizer
-            assert_eq!(path, sibling_tokenizer, "Should discover sibling tokenizer.json");
-        }
-        Err(e) => {
-            // Test scaffolding
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Auto-discovery not implemented: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:gguf
-/// Tests discovery of GGUF embedded tokenizer metadata
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_discover_gguf_embedded() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-
-    // Setup: Create GGUF with embedded tokenizer metadata
-    let model_path = temp_dir.path().join("model_with_tokenizer.gguf");
-    fs::write(&model_path, create_mock_gguf_with_embedded_tokenizer())?;
-
-    // Execute: Auto-discovery
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(_path) => {
-            // Verify: Discovered embedded tokenizer
-            // Path might be virtual or extracted from GGUF
-        }
-        Err(e) => {
-            // Test scaffolding - GGUF embedded tokenizer support pending
-            assert!(
-                e.to_string().contains("not implemented")
-                    || e.to_string().contains("Tokenizer not found"),
-                "Expected unimplemented or not found, got: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:error_message
-/// Tests clear error message when discovery fails
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_fail_with_clear_error() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-
-    // Setup: Create model without any tokenizer
-    let model_path = temp_dir.path().join("model.gguf");
-    fs::write(&model_path, create_mock_gguf())?;
-
-    // Execute: Auto-discovery (should fail)
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(_) => {
-            panic!("Should fail when no tokenizer found");
-        }
-        Err(e) => {
-            let error_msg = e.to_string();
-
-            // Verify: Error message contains actionable guidance
-            let has_actionable_guidance = error_msg.contains("Tokenizer not found")
-                || error_msg.contains("cargo run -p xtask -- tokenizer")
-                || error_msg.contains("--tokenizer")
-                || error_msg.contains("not implemented");
-
-            assert!(
-                has_actionable_guidance,
-                "Error should provide actionable guidance, got: {}",
-                error_msg
-            );
-
-            // Verify: Error message lists discovery attempts
-            let lists_attempts = error_msg.contains("GGUF embedded")
-                || error_msg.contains("Sibling")
-                || error_msg.contains("Parent")
-                || error_msg.contains("not implemented");
-
-            assert!(lists_attempts, "Error should list discovery attempts, got: {}", error_msg);
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:chain
-/// Tests discovery chain order: GGUF → sibling → parent
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_discovery_chain_order() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let model_dir = temp_dir.path().join("models");
-    fs::create_dir(&model_dir)?;
-
-    // Setup: Create model in subdirectory
-    let model_path = model_dir.join("model.gguf");
-    fs::write(&model_path, create_mock_gguf())?;
-
-    // Test 1: No tokenizer anywhere - should fail
-    let result_none = resolve_tokenizer(&model_path, None);
-    assert!(result_none.is_err(), "Should fail when no tokenizer exists");
-
-    // Test 2: Parent tokenizer only
-    let parent_tokenizer = temp_dir.path().join("tokenizer.json");
-    fs::write(&parent_tokenizer, create_mock_tokenizer())?;
-
-    let result_parent = resolve_tokenizer(&model_path, None);
-    match result_parent {
-        Ok(path) => {
-            assert_eq!(path, parent_tokenizer, "Should discover parent tokenizer");
-        }
-        Err(e) => {
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Parent discovery not implemented: {}",
-                e
-            );
-        }
-    }
-
-    // Test 3: Sibling tokenizer (should take precedence over parent)
-    let sibling_tokenizer = model_dir.join("tokenizer.json");
-    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-
-    let result_sibling = resolve_tokenizer(&model_path, None);
-    match result_sibling {
-        Ok(path) => {
-            assert_eq!(path, sibling_tokenizer, "Sibling should take precedence over parent");
-        }
-        Err(e) => {
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Sibling discovery not implemented: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:parent_directory
-/// Tests discovery of tokenizer.json in parent directory
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_discover_parent_directory_tokenizer() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let model_dir = temp_dir.path().join("model-subdir");
-    fs::create_dir(&model_dir)?;
-
-    // Setup: Model in subdirectory, tokenizer in parent
-    let model_path = model_dir.join("model.gguf");
-    let parent_tokenizer = temp_dir.path().join("tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&parent_tokenizer, create_mock_tokenizer())?;
-
-    // Execute: Auto-discovery
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(path) => {
-            // Verify: Found parent directory tokenizer
-            assert_eq!(path, parent_tokenizer, "Should discover parent directory tokenizer");
-        }
-        Err(e) => {
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Parent discovery not implemented: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:debug_logging
-/// Tests that discovery attempts are logged at debug level
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-#[serial_test::serial(bitnet_env)]
-fn test_discovery_debug_logging() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let model_path = temp_dir.path().join("model.gguf");
-    let tokenizer_path = temp_dir.path().join("tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&tokenizer_path, create_mock_tokenizer())?;
-
-    // Execute: Auto-discovery with debug logging enabled
-    unsafe {
-        std::env::set_var("RUST_LOG", "debug");
-    }
-    let _result = resolve_tokenizer(&model_path, None);
-    unsafe {
-        std::env::remove_var("RUST_LOG");
-    }
-
-    // Test scaffolding: Actual implementation should emit debug logs like:
-    // "Checking GGUF embedded tokenizer..."
-    // "Checking sibling tokenizer: models/tokenizer.json"
-    // "Found tokenizer at: models/tokenizer.json"
-
-    // This test scaffolding verifies the structure exists
-    // Real implementation will validate log output
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:backward_compatibility
-/// Tests backward compatibility with explicit --tokenizer flag
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_backward_compatibility_explicit_flag() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-
-    // Setup: Create model and multiple tokenizers
-    let model_path = temp_dir.path().join("model.gguf");
-    let explicit_tokenizer = temp_dir.path().join("explicit.json");
-    let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&explicit_tokenizer, create_mock_tokenizer())?;
-    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
-
-    // Execute: Provide explicit tokenizer (backward compat)
-    let result = resolve_tokenizer(&model_path, Some(explicit_tokenizer.clone()));
-
-    match result {
-        Ok(path) => {
-            // Verify: Explicit path used, auto-discovery bypassed
-            assert_eq!(path, explicit_tokenizer, "Should use explicit path (backward compat)");
-        }
-        Err(e) => {
-            assert!(
-                e.to_string().contains("not implemented"),
-                "Explicit path handling not implemented: {}",
-                e
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:no_mock_fallback
-/// Tests that discovery fails fast without silent mock tokenizer fallback
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_no_mock_tokenizer_fallback() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let model_path = temp_dir.path().join("model.gguf");
-    fs::write(&model_path, create_mock_gguf())?;
-
-    // Execute: Auto-discovery without any tokenizer
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(_) => {
-            panic!("Should fail fast, not fall back to mock tokenizer");
-        }
-        Err(e) => {
-            let error_msg = e.to_string();
-
-            // Verify: No mention of mock/fallback tokenizer
-            assert!(
-                !error_msg.to_lowercase().contains("mock"),
-                "Should not use mock tokenizer fallback"
-            );
-            assert!(
-                !error_msg.to_lowercase().contains("fallback"),
-                "Should not use fallback tokenizer"
-            );
-        }
-    }
-
-    Ok(())
-}
-
-/// AC2:cli_auto_discovery:absolute_paths
-/// Tests that discovery returns absolute paths
-///
-/// Tests feature spec: llama3-tokenizer-fetching-spec.md#ac2-cli-auto-discovery
-#[test]
-fn test_discovery_returns_absolute_paths() -> Result<()> {
-    let temp_dir = TempDir::new()?;
-    let model_path = temp_dir.path().join("model.gguf");
-    let tokenizer_path = temp_dir.path().join("tokenizer.json");
-
-    fs::write(&model_path, create_mock_gguf())?;
-    fs::write(&tokenizer_path, create_mock_tokenizer())?;
-
-    // Execute: Auto-discovery
-    let result = resolve_tokenizer(&model_path, None);
-
-    match result {
-        Ok(path) => {
-            // Verify: Path is absolute
-            assert!(path.is_absolute(), "Discovery should return absolute path");
-            assert_eq!(
-                path.canonicalize()?,
-                tokenizer_path.canonicalize()?,
-                "Should return canonicalized absolute path"
-            );
-        }
-        Err(e) => {
-            assert!(e.to_string().contains("not implemented"), "Discovery not implemented: {}", e);
-        }
-    }
-
-    Ok(())
-}
-
-// Helper functions for test scaffolding
-
-/// Mock tokenizer resolution (auto-discovery)
-fn resolve_tokenizer(
-    _model_path: &std::path::Path,
-    _explicit_path: Option<PathBuf>,
-) -> Result<PathBuf> {
-    anyhow::bail!("not implemented: resolve_tokenizer (auto-discovery)")
-}
-
-/// Create mock GGUF file
-fn create_mock_gguf() -> Vec<u8> {
-    // Minimal GGUF header for testing
-    b"GGUF\x03\x00\x00\x00".to_vec()
-}
-
-/// Create mock GGUF with embedded tokenizer metadata
-fn create_mock_gguf_with_embedded_tokenizer() -> Vec<u8> {
-    // GGUF with tokenizer.ggml.model metadata
-    let mut data = create_mock_gguf();
-    data.extend_from_slice(b"TOKENIZER_METADATA");
-    data
-}
-
-/// Create mock tokenizer.json content
 fn create_mock_tokenizer() -> String {
     r#"{
   "version": "1.0",
@@ -442,4 +13,56 @@ fn create_mock_tokenizer() -> String {
   }
 }"#
     .to_string()
+}
+
+fn create_mock_gguf() -> Vec<u8> {
+    b"GGUF\x03\x00\x00\x00".to_vec()
+}
+
+#[test]
+fn explicit_path_takes_precedence() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let model_path = temp_dir.path().join("model.gguf");
+    let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
+    let explicit_tokenizer = temp_dir.path().join("explicit_tokenizer.json");
+
+    fs::write(&model_path, create_mock_gguf())?;
+    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
+    fs::write(&explicit_tokenizer, create_mock_tokenizer())?;
+
+    let result = resolve_tokenizer(&model_path, Some(explicit_tokenizer.clone()))?;
+    assert_eq!(result.canonicalize()?, explicit_tokenizer.canonicalize()?);
+    Ok(())
+}
+
+#[test]
+fn sibling_precedes_parent() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let model_dir = temp_dir.path().join("models");
+    fs::create_dir(&model_dir)?;
+
+    let model_path = model_dir.join("model.gguf");
+    let sibling_tokenizer = model_dir.join("tokenizer.json");
+    let parent_tokenizer = temp_dir.path().join("tokenizer.json");
+
+    fs::write(&model_path, create_mock_gguf())?;
+    fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
+    fs::write(&parent_tokenizer, create_mock_tokenizer())?;
+
+    let result = resolve_tokenizer(&model_path, None)?;
+    assert_eq!(result.canonicalize()?, sibling_tokenizer.canonicalize()?);
+    Ok(())
+}
+
+#[test]
+fn clear_error_when_not_found() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let model_path = temp_dir.path().join("model.gguf");
+    fs::write(&model_path, create_mock_gguf())?;
+
+    let error = resolve_tokenizer(&model_path, None).expect_err("should fail when no tokenizer");
+    let msg = error.to_string();
+    assert!(msg.contains("Tokenizer not found"));
+    assert!(msg.contains("--tokenizer /path/to/tokenizer.json"));
+    Ok(())
 }

--- a/crates/bitnet-tokenizer-discovery-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-discovery-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-tokenizer-discovery-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core crate for tokenizer path auto-discovery and resolution"
+
+[dependencies]
+anyhow.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/bitnet-tokenizer-discovery-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-discovery-core/src/lib.rs
@@ -1,0 +1,214 @@
+use anyhow::{Context, Result, anyhow};
+use std::path::{Path, PathBuf};
+use tracing::debug;
+
+/// Resolve tokenizer path with deterministic fallback ordering.
+///
+/// Priority:
+/// 1. Explicit path (if provided).
+/// 2. Sibling `tokenizer.json` next to model.
+/// 3. Parent-directory `tokenizer.json`.
+pub fn resolve_tokenizer_with<F>(
+    model_path: &Path,
+    explicit_path: Option<PathBuf>,
+    mut verifier: F,
+) -> Result<PathBuf>
+where
+    F: FnMut(&Path) -> Result<bool>,
+{
+    if let Some(path) = explicit_path {
+        debug!("Using explicit tokenizer path: {}", path.display());
+        return validate_explicit_path(path);
+    }
+
+    let discovery = TokenizerDiscovery::new(model_path.to_path_buf());
+    discovery.discover_with(&mut verifier)
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenizerDiscovery {
+    model_path: PathBuf,
+}
+
+impl TokenizerDiscovery {
+    #[must_use]
+    pub fn new(model_path: PathBuf) -> Self {
+        Self { model_path }
+    }
+
+    pub fn discover_with<F>(&self, verifier: &mut F) -> Result<PathBuf>
+    where
+        F: FnMut(&Path) -> Result<bool>,
+    {
+        debug!("Starting tokenizer auto-discovery for model: {}", self.model_path.display());
+
+        if let Some(path) = self.check_sibling_tokenizer(verifier)? {
+            debug!("Discovered sibling tokenizer: {}", path.display());
+            return Ok(path);
+        }
+
+        if let Some(path) = self.check_parent_tokenizer(verifier)? {
+            debug!("Discovered parent tokenizer: {}", path.display());
+            return Ok(path);
+        }
+
+        Err(self.discovery_failed_error())
+    }
+
+    fn check_sibling_tokenizer<F>(&self, verifier: &mut F) -> Result<Option<PathBuf>>
+    where
+        F: FnMut(&Path) -> Result<bool>,
+    {
+        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
+        let sibling_path = model_dir.join("tokenizer.json");
+
+        debug!("Checking sibling tokenizer: {}", sibling_path.display());
+
+        if sibling_path.exists() && sibling_path.is_file() && verifier(&sibling_path)? {
+            return Ok(Some(sibling_path.canonicalize()?));
+        }
+
+        Ok(None)
+    }
+
+    fn check_parent_tokenizer<F>(&self, verifier: &mut F) -> Result<Option<PathBuf>>
+    where
+        F: FnMut(&Path) -> Result<bool>,
+    {
+        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
+
+        if let Some(parent_dir) = model_dir.parent() {
+            let parent_path = parent_dir.join("tokenizer.json");
+
+            debug!("Checking parent tokenizer: {}", parent_path.display());
+
+            if parent_path.exists() && parent_path.is_file() && verifier(&parent_path)? {
+                return Ok(Some(parent_path.canonicalize()?));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn discovery_failed_error(&self) -> anyhow::Error {
+        let model_dir = self.model_path.parent().unwrap_or_else(|| Path::new("."));
+        let sibling_path = model_dir.join("tokenizer.json");
+        let parent_path = model_dir
+            .parent()
+            .map(|p| p.join("tokenizer.json"))
+            .unwrap_or_else(|| PathBuf::from("N/A"));
+
+        anyhow!(
+            "Tokenizer not found for model: {}\n\
+             \n\
+             Tokenizer auto-discovery failed. Tried:\n\
+             1. Sibling tokenizer.json: {} (not found/invalid)\n\
+             2. Parent directory: {} (not found/invalid)\n\
+             \n\
+             Solution:\n\
+             1. Download tokenizer:\n\
+                cargo run -p xtask -- tokenizer --into {}\n\
+             2. Provide explicit tokenizer path:\n\
+                --tokenizer /path/to/tokenizer.json",
+            self.model_path.display(),
+            sibling_path.display(),
+            parent_path.display(),
+            model_dir.display(),
+        )
+    }
+}
+
+fn validate_explicit_path(path: PathBuf) -> Result<PathBuf> {
+    if !path.exists() {
+        anyhow::bail!(
+            "Explicit tokenizer path does not exist: {}\n\
+             \n\
+             Please provide a valid tokenizer.json file path.",
+            path.display()
+        );
+    }
+
+    if !path.is_file() {
+        anyhow::bail!("Explicit tokenizer path is not a file: {}", path.display());
+    }
+
+    path.canonicalize().context("Failed to canonicalize explicit tokenizer path")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn always_valid(_path: &Path) -> Result<bool> {
+        Ok(true)
+    }
+
+    #[test]
+    fn explicit_path_takes_precedence() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let explicit_tokenizer = temp_dir.path().join("custom.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&explicit_tokenizer, b"{}")?;
+
+        let resolved =
+            resolve_tokenizer_with(&model_path, Some(explicit_tokenizer.clone()), always_valid)?;
+        assert_eq!(resolved, explicit_tokenizer.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn finds_sibling_first() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_dir = temp_dir.path().join("models");
+        fs::create_dir(&model_dir)?;
+
+        let model_path = model_dir.join("model.gguf");
+        let sibling = model_dir.join("tokenizer.json");
+        let parent = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+        fs::write(&parent, b"{}")?;
+
+        let resolved = resolve_tokenizer_with(&model_path, None, always_valid)?;
+        assert_eq!(resolved, sibling.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn falls_back_to_parent() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_dir = temp_dir.path().join("models");
+        fs::create_dir(&model_dir)?;
+
+        let model_path = model_dir.join("model.gguf");
+        let parent = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&parent, b"{}")?;
+
+        let resolved = resolve_tokenizer_with(&model_path, None, always_valid)?;
+        assert_eq!(resolved, parent.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn skips_invalid_tokenizer_candidates() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+
+        let mut called = 0usize;
+        let result = resolve_tokenizer_with(&model_path, None, |_path| {
+            called += 1;
+            Ok(false)
+        });
+
+        assert!(result.is_err());
+        assert_eq!(called, 1);
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Motivation
- Split tokenizer path resolution out of the CLI to follow SRP and make discovery logic reusable across binaries and tools.
- The discovery logic is pure orchestration (explicit path → sibling `tokenizer.json` → parent `tokenizer.json`) and does not need CLI concerns.
- Extracting it reduces coupling, simplifies the `bitnet-cli` surface, and centralizes actionable error messaging for missing tokenizers.

### Description
- Added a new workspace microcrate `crates/bitnet-tokenizer-discovery-core` that exposes `resolve_tokenizer_with` and `TokenizerDiscovery` for deterministic fallback resolution and clear failure diagnostics.
- Moved the sibling/parent/explicit-path resolution logic into the new crate and implemented `validate_explicit_path` + canonicalization behavior.
- Updated `crates/bitnet-cli/src/tokenizer_discovery.rs` to delegate to the new core crate and inject tokenizer validation using `bitnet-tokenizers::loader::load_tokenizer` as a thin adapter.
- Updated workspace and crate manifests (`Cargo.toml`, `crates/bitnet-cli/Cargo.toml`) and added focused unit/integration tests in both the new core crate and the CLI test suite.

### Testing
- Ran `cargo fmt --all` successfully to normalize formatting.
- Ran `cargo test -p bitnet-tokenizer-discovery-core` and all core unit tests passed (`4 passed, 0 failed`).
- Ran `cargo test -p bitnet-cli --test tokenizer_discovery_tests` and the CLI discovery tests passed (`3 passed, 0 failed`).
- Ran `cargo test -p bitnet-cli tokenizer_discovery` to exercise the CLI resolver and the test(s) for the discovery path passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac0b99208333918fd3d680ddbff9)