### PR TITLE
Extract reusable test-fixture helpers into `bitnet-test-fixtures-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "bitnet-gguf",
  "bitnet-quantization",
  "bitnet-st2gguf",
+ "bitnet-test-fixtures-core",
  "bitnet-test-support",
  "bitnet-trace",
  "bitnet-transformer",
@@ -1312,6 +1313,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-test-fixtures-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-test-support"
 version = "0.2.1-dev"
 dependencies = [
@@ -1512,6 +1517,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-models",
  "bitnet-quantization",
+ "bitnet-test-fixtures-core",
  "bitnet-test-support",
  "bitnet-tests",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
   "crates/bitnet-test-env",
+  "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
@@ -104,6 +105,7 @@ default-members = [
   "crates/bitnet-transformer",
   "crates/bitnet-test-support",
   "crates/bitnet-test-env",
+  "crates/bitnet-test-fixtures-core",
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -53,6 +53,7 @@ sha2 = "0.10.9"
 sysinfo = "0.37.2"
 bitnet-st2gguf = { path = "../bitnet-st2gguf", version = "0.2.1-dev" }
 bitnet-test-support.workspace = true
+bitnet-test-fixtures-core = { path = "../bitnet-test-fixtures-core", version = "0.2.1-dev" }
 insta.workspace = true
 
 [features]

--- a/crates/bitnet-models/tests/fixture_integrity_tests.rs
+++ b/crates/bitnet-models/tests/fixture_integrity_tests.rs
@@ -11,12 +11,18 @@
 //!
 //! See: SPEC-2025-006 (Fixture Contract and Validation)
 
-use std::path::PathBuf;
+use bitnet_test_fixtures_core::{
+    fixture_path_from_workspace, load_fixture_bytes, load_fixture_string,
+};
+use std::path::Path;
 
 /// Helper to get fixture paths relative to repository root
-fn fixture_path(filename: &str) -> PathBuf {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    PathBuf::from(manifest_dir).join("../../ci/fixtures/qk256").join(filename)
+fn fixture_path(filename: &str) -> std::path::PathBuf {
+    fixture_path_from_workspace(
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        2,
+        Path::new("ci/fixtures/qk256").join(filename),
+    )
 }
 
 /// Validate GGUF header structure (magic, version)
@@ -54,7 +60,7 @@ fn test_qk256_4x256_header_integrity() {
     let path = fixture_path("qk256_4x256.gguf");
     assert!(path.exists(), "Fixture qk256_4x256.gguf should exist at {:?}", path);
 
-    let bytes = std::fs::read(&path).expect("Should read qk256_4x256.gguf");
+    let bytes = load_fixture_bytes(&path).expect("Should read qk256_4x256.gguf");
     validate_gguf_header(&bytes, "qk256_4x256.gguf");
 
     // Verify expected size (from exploration: 10,816 bytes)
@@ -66,7 +72,7 @@ fn test_qk256_3x300_header_integrity() {
     let path = fixture_path("qk256_3x300.gguf");
     assert!(path.exists(), "Fixture qk256_3x300.gguf should exist at {:?}", path);
 
-    let bytes = std::fs::read(&path).expect("Should read qk256_3x300.gguf");
+    let bytes = load_fixture_bytes(&path).expect("Should read qk256_3x300.gguf");
     validate_gguf_header(&bytes, "qk256_3x300.gguf");
 
     // Verify expected size (from exploration: 10,696 bytes)
@@ -78,7 +84,7 @@ fn test_bitnet32_2x64_header_integrity() {
     let path = fixture_path("bitnet32_2x64.gguf");
     assert!(path.exists(), "Fixture bitnet32_2x64.gguf should exist at {:?}", path);
 
-    let bytes = std::fs::read(&path).expect("Should read bitnet32_2x64.gguf");
+    let bytes = load_fixture_bytes(&path).expect("Should read bitnet32_2x64.gguf");
     validate_gguf_header(&bytes, "bitnet32_2x64.gguf");
 
     // Verify expected size (from exploration: 8,832 bytes)
@@ -98,12 +104,15 @@ fn test_all_fixtures_present() {
 
 #[test]
 fn test_sha256sums_file_present() {
-    let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let sha256sums_path = PathBuf::from(manifest_dir).join("../../ci/fixtures/qk256/SHA256SUMS");
+    let sha256sums_path = fixture_path_from_workspace(
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        2,
+        "ci/fixtures/qk256/SHA256SUMS",
+    );
 
     assert!(sha256sums_path.exists(), "SHA256SUMS file should exist at {:?}", sha256sums_path);
 
-    let content = std::fs::read_to_string(&sha256sums_path).expect("Should read SHA256SUMS");
+    let content = load_fixture_string(&sha256sums_path).expect("Should read SHA256SUMS");
 
     // Verify it contains all three fixtures
     assert!(content.contains("qk256_4x256.gguf"), "SHA256SUMS should contain qk256_4x256.gguf");

--- a/crates/bitnet-models/tests/helpers/fixture_loader.rs
+++ b/crates/bitnet-models/tests/helpers/fixture_loader.rs
@@ -24,6 +24,7 @@
 //! file.write_all(&fixture_bytes).unwrap();
 //! ```
 
+use bitnet_test_fixtures_core::{fixture_path_from_workspace, load_fixture_bytes as load_bytes};
 use std::path::{Path, PathBuf};
 
 /// Get the absolute path to a fixture in `ci/fixtures/qk256/`
@@ -41,20 +42,13 @@ use std::path::{Path, PathBuf};
 /// Panics if the workspace root cannot be determined or fixture doesn't exist
 pub fn fixture_path(filename: &str) -> PathBuf {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-
-    // CARGO_MANIFEST_DIR points to crates/bitnet-models
-    // Navigate from crates/bitnet-models → workspace root
-    let workspace_root = manifest_dir
-        .parent() // crates
-        .and_then(|p| p.parent()) // workspace root
-        .expect("Failed to determine workspace root");
-
-    let fixture_path = workspace_root.join("ci/fixtures/qk256").join(filename);
+    let fixture_path =
+        fixture_path_from_workspace(manifest_dir, 2, Path::new("ci/fixtures/qk256").join(filename));
 
     if !fixture_path.exists() {
         panic!(
-            "Fixture not found: {}\nExpected path: {:?}\nWorkspace root: {:?}\nManifest dir: {:?}",
-            filename, fixture_path, workspace_root, manifest_dir
+            "Fixture not found: {}\nExpected path: {:?}\nManifest dir: {:?}",
+            filename, fixture_path, manifest_dir
         );
     }
 
@@ -76,7 +70,7 @@ pub fn fixture_path(filename: &str) -> PathBuf {
 /// Panics if the file cannot be read
 pub fn load_fixture_bytes(filename: &str) -> Vec<u8> {
     let path = fixture_path(filename);
-    std::fs::read(&path).unwrap_or_else(|e| {
+    load_bytes(&path).unwrap_or_else(|e| {
         panic!("Failed to read fixture {}: {}", filename, e);
     })
 }

--- a/crates/bitnet-test-fixtures-core/Cargo.toml
+++ b/crates/bitnet-test-fixtures-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bitnet-test-fixtures-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP helpers for resolving and loading test fixtures"
+
+[dependencies]

--- a/crates/bitnet-test-fixtures-core/src/lib.rs
+++ b/crates/bitnet-test-fixtures-core/src/lib.rs
@@ -1,0 +1,60 @@
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Resolve a fixture path relative to a crate manifest directory.
+pub fn fixture_path_from_manifest(
+    manifest_dir: impl AsRef<Path>,
+    relative_path: impl AsRef<Path>,
+) -> PathBuf {
+    manifest_dir.as_ref().join(relative_path)
+}
+
+/// Resolve a fixture path relative to the workspace root.
+///
+/// `levels_up` is how many parent traversals are needed to go from `manifest_dir`
+/// to workspace root (e.g. `2` for `crates/<name>`).
+pub fn fixture_path_from_workspace(
+    manifest_dir: impl AsRef<Path>,
+    levels_up: usize,
+    relative_path: impl AsRef<Path>,
+) -> PathBuf {
+    let root = workspace_root(manifest_dir, levels_up);
+    root.join(relative_path)
+}
+
+/// Load fixture bytes from a path.
+pub fn load_fixture_bytes(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
+    std::fs::read(path)
+}
+
+/// Load fixture text from a path.
+pub fn load_fixture_string(path: impl AsRef<Path>) -> io::Result<String> {
+    std::fs::read_to_string(path)
+}
+
+fn workspace_root(manifest_dir: impl AsRef<Path>, levels_up: usize) -> PathBuf {
+    let mut current = manifest_dir.as_ref();
+    for _ in 0..levels_up {
+        current = current.parent().expect("Failed to determine workspace root from manifest dir");
+    }
+    current.to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_manifest_relative_paths() {
+        let manifest = Path::new("/tmp/project/crates/demo");
+        let path = fixture_path_from_manifest(manifest, "tests/fixtures/a.bin");
+        assert_eq!(path, PathBuf::from("/tmp/project/crates/demo/tests/fixtures/a.bin"));
+    }
+
+    #[test]
+    fn resolves_workspace_relative_paths() {
+        let manifest = Path::new("/tmp/project/crates/demo");
+        let path = fixture_path_from_workspace(manifest, 2, "ci/fixtures/a.bin");
+        assert_eq!(path, PathBuf::from("/tmp/project/ci/fixtures/a.bin"));
+    }
+}

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -63,5 +63,6 @@ temp-env = "0.3.6"
 serial_test.workspace = true
 bitnet-tests = { path = "../../tests", version = "0.2.1-dev" }
 bitnet-test-support.workspace = true
+bitnet-test-fixtures-core = { path = "../bitnet-test-fixtures-core", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }

--- a/crates/bitnet-tokenizers/tests/fixtures/mod.rs
+++ b/crates/bitnet-tokenizers/tests/fixtures/mod.rs
@@ -12,11 +12,18 @@ pub mod tokenizer_fixtures;
 #[cfg(feature = "cpu")]
 pub mod mock;
 
-use std::path::PathBuf;
+use bitnet_test_fixtures_core::{
+    fixture_path_from_manifest, load_fixture_bytes as load_bytes,
+    load_fixture_string as load_string,
+};
+use std::path::Path;
 
 /// Get the path to a test fixture file
-pub fn fixture_path(relative_path: &str) -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("fixtures").join(relative_path)
+pub fn fixture_path(relative_path: &str) -> std::path::PathBuf {
+    fixture_path_from_manifest(
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        Path::new("tests/fixtures").join(relative_path),
+    )
 }
 
 /// Check if a fixture exists
@@ -28,11 +35,11 @@ pub fn fixture_exists(relative_path: &str) -> bool {
 /// Load fixture contents as bytes
 #[allow(dead_code)]
 pub fn load_fixture_bytes(relative_path: &str) -> std::io::Result<Vec<u8>> {
-    std::fs::read(fixture_path(relative_path))
+    load_bytes(fixture_path(relative_path))
 }
 
 /// Load fixture contents as string
 #[allow(dead_code)]
 pub fn load_fixture_string(relative_path: &str) -> std::io::Result<String> {
-    std::fs::read_to_string(fixture_path(relative_path))
+    load_string(fixture_path(relative_path))
 }


### PR DESCRIPTION
### Motivation

- Remove duplicated fixture-path resolution and file I/O logic that lived in multiple test modules by centralizing this responsibility in a single SRP microcrate.
- Keep fixture-loading behavior consistent across test suites and make workspace-relative and manifest-relative resolution explicit and reusable.
- Make test helpers easier to maintain and reuse across crates (e.g. `bitnet-models` and `bitnet-tokenizers`).

### Description

- Added a new microcrate `crates/bitnet-test-fixtures-core` implementing `fixture_path_from_manifest`, `fixture_path_from_workspace`, `load_fixture_bytes`, and `load_fixture_string` with focused unit tests.
- Wired the new crate into the workspace members and `default-members` in `Cargo.toml` and added it as a `dev-dependency` to `crates/bitnet-models` and `crates/bitnet-tokenizers`.
- Replaced duplicated logic in `crates/bitnet-models/tests/helpers/fixture_loader.rs`, `crates/bitnet-models/tests/fixture_integrity_tests.rs`, and `crates/bitnet-tokenizers/tests/fixtures/mod.rs` to call the new microcrate and swapped direct `std::fs` usage for the new helper functions.
- Ran `cargo fmt --all` to normalize formatting after the refactor.

### Testing

- Ran `cargo fmt --all` and it completed successfully.
- Ran `cargo test -p bitnet-test-fixtures-core` and the microcrate unit tests passed (`2` tests passed).
- Ran `cargo test -p bitnet-models --test fixture_integrity_tests -- --test-threads=1` which compiled successfully but several fixture-presence/assertion tests failed (`test_qk256_4x256_header_integrity`, `test_qk256_3x300_header_integrity`, `test_bitnet32_2x64_header_integrity`, `test_all_fixtures_present`) because the required GGUF fixture files under `ci/fixtures/qk256` were not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac10c408833381052809b4c58eb2)