### PR TITLE
Extract probability-domain helpers into new SRP microcrate (bitnet-probability)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-probability"
+version = "0.2.1-dev"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
 name = "bitnet-prompt-templates"
 version = "0.2.1-dev"
 dependencies = [
@@ -1208,6 +1215,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-logits",
+ "bitnet-probability",
  "insta",
  "proptest",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-repl-core",     # SRP: reusable chat REPL state/command primitives
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
+  "crates/bitnet-probability",  # SRP: probability normalization and categorical sampling primitives
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
@@ -142,6 +143,7 @@ default-members = [
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
   "crates/bitnet-logits",
+  "crates/bitnet-probability",
   "crates/bitnet-logits-filters",
   "crates/bitnet-generation",
   "crates/bitnet-generation-events-core",

--- a/crates/bitnet-probability/Cargo.toml
+++ b/crates/bitnet-probability/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitnet-probability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for probability normalization and categorical sampling primitives"
+rust-version.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-probability/src/lib.rs
+++ b/crates/bitnet-probability/src/lib.rs
@@ -1,0 +1,93 @@
+//! Probability-domain primitives for decode-time sampling.
+//!
+//! This crate intentionally provides small pure functions that can be reused
+//! across sampling implementations.
+
+/// Renormalize a probability vector in place so it sums to exactly 1.0.
+///
+/// Returns `true` when normalization was applied, and `false` if `probs`
+/// could not be normalized (empty or non-positive sum).
+pub fn renormalize_in_place(probs: &mut [f32]) -> bool {
+    if probs.is_empty() {
+        return false;
+    }
+
+    let sum: f32 = probs.iter().sum();
+    if sum <= 0.0 || !sum.is_finite() {
+        return false;
+    }
+
+    let inv_sum = 1.0 / sum;
+    for p in probs.iter_mut() {
+        *p *= inv_sum;
+    }
+
+    true
+}
+
+/// Sample a categorical distribution using a pre-generated random value.
+///
+/// `random_value` is expected in `[0.0, 1.0)`. Values outside this range are
+/// safely clamped.
+///
+/// Returns `None` when `probabilities` is empty.
+pub fn sample_categorical(probabilities: &[f32], random_value: f32) -> Option<usize> {
+    if probabilities.is_empty() {
+        return None;
+    }
+
+    let rv = random_value.clamp(0.0, 1.0 - f32::EPSILON);
+
+    let mut cumulative = 0.0_f32;
+    for (i, &prob) in probabilities.iter().enumerate() {
+        cumulative += prob;
+        if rv <= cumulative {
+            return Some(i);
+        }
+    }
+
+    // In case of floating-point accumulation error, pick the last token.
+    Some(probabilities.len() - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn renormalize_success() {
+        let mut probs = vec![2.0_f32, 3.0, 5.0];
+        assert!(renormalize_in_place(&mut probs));
+        let sum: f32 = probs.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn renormalize_rejects_empty_or_zero_sum() {
+        let mut empty: Vec<f32> = vec![];
+        assert!(!renormalize_in_place(&mut empty));
+
+        let mut zeros = vec![0.0_f32, 0.0];
+        assert!(!renormalize_in_place(&mut zeros));
+    }
+
+    #[test]
+    fn categorical_returns_last_on_rounding_tail() {
+        let probs = vec![0.1_f32, 0.2, 0.3, 0.4];
+        assert_eq!(sample_categorical(&probs, 0.999_999_94), Some(3));
+    }
+
+    proptest! {
+        #[test]
+        fn categorical_always_returns_valid_index(
+            values in prop::collection::vec(0.0f32..10.0f32, 1..128),
+            random in 0.0f32..1.0f32,
+        ) {
+            let mut probs = values;
+            prop_assume!(renormalize_in_place(&mut probs));
+            let idx = sample_categorical(&probs, random).unwrap();
+            prop_assert!(idx < probs.len());
+        }
+    }
+}

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 rand = "0.9.2"
 rand_chacha = "0.9.0"
 bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
+bitnet-probability = { path = "../bitnet-probability", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -17,6 +17,7 @@ pub use strategies::{
 };
 
 use anyhow::{Context, Result};
+use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::collections::HashMap;
@@ -180,13 +181,7 @@ impl SamplingStrategy {
         }
 
         // Re-normalize after top-p (top-p zeroes entries without renormalizing).
-        let sum: f32 = buf.iter().sum();
-        if sum > 0.0 {
-            let inv_sum = 1.0 / sum;
-            for p in buf.iter_mut() {
-                *p *= inv_sum;
-            }
-        }
+        let _ = renormalize_in_place(&mut buf);
 
         let token = self.sample_from_distribution(&buf)?;
         *self.token_counts.entry(token).or_insert(0) += 1;
@@ -243,26 +238,11 @@ impl SamplingStrategy {
             return Ok(idx as u32);
         }
 
-        // Sample using cumulative distribution
+        // Sample using cumulative distribution.
         let random_value: f32 = self.rng.random();
-        let mut cumulative = 0.0;
-
-        for (i, &prob) in probabilities.iter().enumerate() {
-            cumulative += prob;
-            if random_value <= cumulative {
-                // Ensure token ID is within vocabulary bounds
-                debug_assert!(
-                    i < vocab_size,
-                    "Sampled token {} exceeds vocab size {}",
-                    i,
-                    vocab_size
-                );
-                return Ok(i as u32);
-            }
-        }
-
-        // Fallback to last valid token (clamped to vocab size)
-        Ok((vocab_size - 1) as u32)
+        let idx = sample_categorical(probabilities, random_value).expect("non-empty checked above");
+        debug_assert!(idx < vocab_size, "Sampled token {} exceeds vocab size {}", idx, vocab_size);
+        Ok(idx as u32)
     }
 
     /// Reset token counts for a new sequence.


### PR DESCRIPTION
### Motivation
- Reduce responsibilities in `bitnet-sampling` by extracting small, reusable probability primitives into their own SRP microcrate to improve reuse and testability.
- Move renormalization and categorical sampling logic out of strategy orchestration so other components can reuse these pure functions without pulling sampling state.

### Description
- Added a new crate `crates/bitnet-probability` providing `renormalize_in_place` and `sample_categorical` with unit and property tests in `src/lib.rs`.
- Updated workspace `Cargo.toml` to register `crates/bitnet-probability` and added it to `default-members` so it is built/tested by default.
- Wired `bitnet-sampling` to depend on `bitnet-probability` and replaced inline code with calls to `renormalize_in_place` and `sample_categorical` in `crates/bitnet-sampling/src/lib.rs`.

### Testing
- Ran formatting with `cargo fmt` and executed `cargo test -p bitnet-probability -p bitnet-sampling` as the primary validation commands.
- All automated tests for the two crates passed (unit/property/doc tests in `bitnet-probability` and `bitnet-sampling` completed successfully).
- Ran the test run twice after formatting to ensure stability and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac03d7c08333b92fb7e82c020753)