### PR TITLE
Extract HTTP retry timing helpers into dedicated bitnet-http-retry microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-http-retry",
  "httpdate",
  "reqwest",
  "thiserror 2.0.18",
@@ -755,6 +756,13 @@ version = "0.2.1-dev"
 dependencies = [
  "insta",
  "proptest",
+]
+
+[[package]]
+name = "bitnet-http-retry"
+version = "0.2.1-dev"
+dependencies = [
+ "httpdate",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,9 +10,12 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }
-httpdate = "1.0.3"
 thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+httpdate = "1.0.3"

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,3 +1,5 @@
+pub use bitnet_http_retry::exp_backoff_ms;
+use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
 use std::{fs, path::Path, time::SystemTime};
 use thiserror::Error;
@@ -14,15 +16,6 @@ pub fn offline_enabled(cli_offline: bool) -> bool {
     cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
 }
 
-/// Safe exponential backoff helper with deterministic jitter.
-#[must_use]
-pub fn exp_backoff_ms(attempt: u32) -> u64 {
-    let shift = attempt.saturating_sub(1).min(20);
-    let base = (200u64).saturating_mul(1u64 << shift).min(10_000);
-    let jitter = (attempt as u64 * 37) % 200;
-    base.saturating_add(jitter)
-}
-
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -32,20 +25,8 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 /// Same as [`retry_after_secs`] but allows injecting the current time for deterministic tests.
 #[must_use]
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
-    let raw = match headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok()) {
-        Some(s) => s,
-        None => return 5,
-    };
-
-    if let Ok(s) = raw.parse::<u64>() {
-        return s.min(3600);
-    }
-
-    httpdate::parse_http_date(raw)
-        .ok()
-        .and_then(|when| when.duration_since(now).ok())
-        .map(|d| d.as_secs().clamp(1, 3600))
-        .unwrap_or(5)
+    let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
+    parse_retry_after_secs_at(retry_after, now)
 }
 
 /// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.

--- a/crates/bitnet-http-retry/Cargo.toml
+++ b/crates/bitnet-http-retry/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-http-retry"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP HTTP retry timing primitives (Retry-After parsing + exponential backoff)"
+
+[dependencies]
+httpdate = "1.0.3"
+
+[lints]
+workspace = true

--- a/crates/bitnet-http-retry/src/lib.rs
+++ b/crates/bitnet-http-retry/src/lib.rs
@@ -1,0 +1,77 @@
+use std::time::SystemTime;
+
+/// Safe exponential backoff helper with deterministic jitter.
+#[must_use]
+pub fn exp_backoff_ms(attempt: u32) -> u64 {
+    let shift = attempt.saturating_sub(1).min(20);
+    let base = (200u64).saturating_mul(1u64 << shift).min(10_000);
+    let jitter = (attempt as u64 * 37) % 200;
+    base.saturating_add(jitter)
+}
+
+/// Parse an HTTP `Retry-After` value (seconds or HTTP-date), capping to 1 hour.
+///
+/// If the value is missing or invalid, defaults to 5 seconds.
+#[must_use]
+pub fn retry_after_secs(value: Option<&str>) -> u64 {
+    retry_after_secs_at(value, SystemTime::now())
+}
+
+/// Same as [`retry_after_secs`] but allows injecting the current time for deterministic tests.
+#[must_use]
+pub fn retry_after_secs_at(value: Option<&str>, now: SystemTime) -> u64 {
+    let raw = match value {
+        Some(s) => s,
+        None => return 5,
+    };
+
+    if let Ok(s) = raw.parse::<u64>() {
+        return s.min(3600);
+    }
+
+    httpdate::parse_http_date(raw)
+        .ok()
+        .and_then(|when| when.duration_since(now).ok())
+        .map(|d| d.as_secs().clamp(1, 3600))
+        .unwrap_or(5)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn retry_after_seconds() {
+        assert_eq!(retry_after_secs(Some("10")), 10);
+    }
+
+    #[test]
+    fn retry_after_http_date() {
+        let now = SystemTime::now();
+        let future = now + Duration::from_secs(5);
+        let wait = retry_after_secs_at(Some(&httpdate::fmt_http_date(future)), now);
+        assert!((4..=6).contains(&wait));
+    }
+
+    #[test]
+    fn retry_after_past_date_falls_back() {
+        let now = SystemTime::now();
+        let past = now - Duration::from_secs(10);
+        assert_eq!(retry_after_secs_at(Some(&httpdate::fmt_http_date(past)), now), 5);
+    }
+
+    #[test]
+    fn retry_after_missing_or_invalid_falls_back() {
+        assert_eq!(retry_after_secs(None), 5);
+        assert_eq!(retry_after_secs(Some("not-a-date")), 5);
+    }
+
+    #[test]
+    fn exp_backoff_matches_contract() {
+        assert_eq!(exp_backoff_ms(1), 237);
+        assert_eq!(exp_backoff_ms(2), 474);
+        assert_eq!(exp_backoff_ms(3), 911);
+        assert_eq!(exp_backoff_ms(10), 10_170);
+    }
+}


### PR DESCRIPTION
### Motivation
- `bitnet-download` mixed generic HTTP retry timing logic with download/metadata responsibilities, violating SRP and reducing reuse potential. 
- Extracting the pure retry/backoff logic makes those primitives reusable and easier to maintain across crates. 

### Description
- Added a new microcrate `crates/bitnet-http-retry` that provides `exp_backoff_ms`, `retry_after_secs`, and `retry_after_secs_at` with unit tests. 
- Updated the workspace (`Cargo.toml`) to include `crates/bitnet-http-retry` as a member and wired it into the workspace dependency graph. 
- Updated `crates/bitnet-download` to depend on `bitnet-http-retry`, delegate Retry-After parsing to it, and re-export `exp_backoff_ms` to preserve the original API surface. 
- Kept `bitnet-download`’s download-specific helpers (`offline_enabled`, `parse_content_range_total`, `validate_downloaded_len`, `atomic_write`) intact and added a `dev-dependency` on `httpdate` for tests. 

### Testing
- Ran `cargo fmt` to normalize formatting and succeeded. 
- Ran `cargo test -p bitnet-http-retry -p bitnet-download` and all unit tests in both crates passed (`bitnet-http-retry`: 5 tests OK; `bitnet-download`: 6 tests OK). 
- Ran `cargo check -p xtask` to ensure workspace integration compiles and the check completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac14e2cc833389897064098b0b95)