### PR TITLE
Extract tensor utility SRP microcrate and delegate CLI tensor helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
  "bitnet-startup-contract-guard",
+ "bitnet-tensor-utils",
  "bitnet-tokenizer-discovery-core",
  "bitnet-tokenizers",
  "bitnet-validation",
@@ -1365,6 +1366,15 @@ dependencies = [
  "proptest",
  "thiserror 2.0.18",
  "xtask-build-helper",
+]
+
+[[package]]
+name = "bitnet-tensor-utils"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
+ "bitnet-common",
+ "candle-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-repl-core",     # SRP: reusable chat REPL state/command primitives
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
+  "crates/bitnet-tensor-utils",  # SRP: reusable tensor extraction/diagnostic helpers
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
@@ -142,6 +143,7 @@ default-members = [
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
   "crates/bitnet-logits",
+  "crates/bitnet-tensor-utils",
   "crates/bitnet-logits-filters",
   "crates/bitnet-generation",
   "crates/bitnet-generation-events-core",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -29,6 +29,7 @@ bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
+bitnet-tensor-utils = { path = "../bitnet-tensor-utils", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
 bitnet-repl-core = { path = "../bitnet-repl-core", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -12,7 +12,7 @@ use bitnet_common::Tensor;
 use bitnet_startup_contract_guard::{
     ContractPolicy, RuntimeComponent, evaluate_and_emit, feature_line,
 };
-use candle_core::{DType, IndexOp};
+use candle_core::DType;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use console::style;
@@ -1569,114 +1569,29 @@ async fn run_simple_generation(
 fn extract_last_token_hidden(
     tensor: &bitnet_common::ConcreteTensor,
 ) -> Result<bitnet_common::ConcreteTensor> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 3 {
-        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
-    }
-
-    let (batch_size, seq_len, hidden_size) = (shape[0], shape[1], shape[2]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            // Extract last token: [B, T, H] -> [B, H]
-            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?;
-            Ok(ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(last)))
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock hidden state [B, H]
-            Ok(ConcreteTensor::mock(vec![batch_size, hidden_size]))
-        }
-    }
+    bitnet_tensor_utils::extract_last_token_hidden(tensor)
 }
 
 /// Extract logits vector from 2D tensor \[B,V\] -> `Vec<f32>`
 fn extract_logits_2d(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 2 {
-        return Err(BitNetError::Validation("Expected 2D tensor".into()).into());
-    }
-
-    let (_batch, _vocab) = (shape[0], shape[1]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            // Extract first batch: [B, V] -> [V]
-            let batch_0 = candle.i(0)?;
-            let batch_0 =
-                if batch_0.dtype() != DType::F32 { batch_0.to_dtype(DType::F32)? } else { batch_0 };
-            Ok(batch_0.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock logits for testing
-            Ok(vec![0.1; 50257])
-        }
-    }
+    bitnet_tensor_utils::extract_logits_2d(tensor)
 }
 
 /// Extract logits vector from tensor (legacy function for compatibility)
 #[allow(dead_code)]
 fn extract_logits(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 3 {
-        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
-    }
-
-    let (_batch, seq_len, _vocab) = (shape[0], shape[1], shape[2]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?.i(0)?;
-            let last = if last.dtype() != DType::F32 { last.to_dtype(DType::F32)? } else { last };
-            Ok(last.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock logits for testing
-            Ok(vec![0.1; 50257])
-        }
-    }
+    bitnet_tensor_utils::extract_logits_3d_last_token(tensor)
 }
 
 /// Convert tensor to f32 vector for diagnostics
 fn tensor_to_vec(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::ConcreteTensor;
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            let candle_f32 = if candle.dtype() != DType::F32 {
-                candle.to_dtype(DType::F32)?
-            } else {
-                candle.clone()
-            };
-            // Flatten to 1D vector
-            let flattened = candle_f32.flatten_all()?;
-            Ok(flattened.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(mock) => {
-            // Return mock values - use shape from tensor
-            let size: usize = mock.shape().iter().product();
-            Ok(vec![0.1; size])
-        }
-    }
+    bitnet_tensor_utils::tensor_to_vec(tensor)
 }
 
 /// Compute RMS (root mean square) of a vector
 #[inline]
 fn compute_rms(xs: &[f32]) -> f32 {
-    if xs.is_empty() {
-        return 0.0;
-    }
-    let sum_sq: f32 = xs.iter().map(|x| x * x).sum();
-    (sum_sq / (xs.len() as f32)).sqrt()
+    bitnet_tensor_utils::compute_rms(xs)
 }
 
 /// Show system information

--- a/crates/bitnet-tensor-utils/Cargo.toml
+++ b/crates/bitnet-tensor-utils/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "bitnet-tensor-utils"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for extracting and inspecting BitNet tensors"
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+candle-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-tensor-utils/src/lib.rs
+++ b/crates/bitnet-tensor-utils/src/lib.rs
@@ -1,0 +1,124 @@
+//! Tensor extraction helpers shared across CLI/runtime crates.
+
+use anyhow::Result;
+use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
+use candle_core::{DType, IndexOp};
+
+/// Extract last token hidden state from 3D tensor `[B, T, H] -> [B, H]`.
+pub fn extract_last_token_hidden(tensor: &ConcreteTensor) -> Result<ConcreteTensor> {
+    let shape = tensor.shape();
+    if shape.len() != 3 {
+        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
+    }
+
+    let (batch_size, seq_len, hidden_size) = (shape[0], shape[1], shape[2]);
+
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?;
+            Ok(ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(last)))
+        }
+        ConcreteTensor::Mock(_) => Ok(ConcreteTensor::mock(vec![batch_size, hidden_size])),
+    }
+}
+
+/// Extract logits vector from 2D tensor `[B, V] -> Vec<f32>`.
+pub fn extract_logits_2d(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    let shape = tensor.shape();
+    if shape.len() != 2 {
+        return Err(BitNetError::Validation("Expected 2D tensor".into()).into());
+    }
+
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let batch_0 = candle.i(0)?;
+            let batch_0 =
+                if batch_0.dtype() != DType::F32 { batch_0.to_dtype(DType::F32)? } else { batch_0 };
+            Ok(batch_0.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(_) => Ok(vec![0.1; 50257]),
+    }
+}
+
+/// Extract logits vector from 3D tensor `[B, T, V] -> Vec<f32>` using the last token of batch 0.
+pub fn extract_logits_3d_last_token(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    let shape = tensor.shape();
+    if shape.len() != 3 {
+        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
+    }
+
+    let seq_len = shape[1];
+
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?.i(0)?;
+            let last = if last.dtype() != DType::F32 { last.to_dtype(DType::F32)? } else { last };
+            Ok(last.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(_) => Ok(vec![0.1; 50257]),
+    }
+}
+
+/// Convert any tensor shape to a flattened `Vec<f32>` for diagnostics.
+pub fn tensor_to_vec(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let candle_f32 = if candle.dtype() != DType::F32 {
+                candle.to_dtype(DType::F32)?
+            } else {
+                candle.clone()
+            };
+            let flattened = candle_f32.flatten_all()?;
+            Ok(flattened.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(mock) => {
+            let size: usize = mock.shape().iter().product();
+            Ok(vec![0.1; size])
+        }
+    }
+}
+
+/// Compute root-mean-square value for a slice.
+#[inline]
+pub fn compute_rms(xs: &[f32]) -> f32 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = xs.iter().map(|x| x * x).sum();
+    (sum_sq / (xs.len() as f32)).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_last_token_hidden_mock_shape() {
+        let t = ConcreteTensor::mock(vec![2, 4, 8]);
+        let out = extract_last_token_hidden(&t).expect("shape should be valid");
+        assert_eq!(out.shape(), &[2, 8]);
+    }
+
+    #[test]
+    fn extract_logits_2d_mock_size() {
+        let t = ConcreteTensor::mock(vec![1, 32]);
+        let out = extract_logits_2d(&t).expect("shape should be valid");
+        assert_eq!(out.len(), 50_257);
+    }
+
+    #[test]
+    fn tensor_to_vec_mock_uses_shape_product() {
+        let t = ConcreteTensor::mock(vec![2, 3, 5]);
+        let out = tensor_to_vec(&t).expect("mock tensor conversion should work");
+        assert_eq!(out.len(), 30);
+    }
+
+    #[test]
+    fn compute_rms_empty_is_zero() {
+        assert_eq!(compute_rms(&[]), 0.0);
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize small, non-CLI-specific tensor extraction and diagnostic helpers into an SRP microcrate so the logic is reusable outside the CLI and easier to test.
- Reduce duplication in `bitnet-cli` by delegating tensor helper functionality to a focused crate and keep the CLI focused on orchestration.

### Description

- Added a new microcrate `crates/bitnet-tensor-utils` with `Cargo.toml` and `src/lib.rs` implementing `extract_last_token_hidden`, `extract_logits_2d`, `extract_logits_3d_last_token`, `tensor_to_vec`, and `compute_rms`.
- Rewired the workspace `Cargo.toml` (members and `default-members`) to include `crates/bitnet-tensor-utils` and added `bitnet-tensor-utils` as a dependency in `crates/bitnet-cli/Cargo.toml`.
- Replaced the duplicated helper implementations in `crates/bitnet-cli/src/main.rs` with thin delegation wrappers that call the new microcrate APIs (preserving the public helper signatures used in the CLI).
- Added focused unit tests inside `crates/bitnet-tensor-utils` to validate shapes, flattened sizes, and `compute_rms` behavior.

### Testing

- Ran `cargo fmt --all` to ensure formatting changes were applied, and it completed successfully.
- Ran `cargo test -p bitnet-tensor-utils -- --nocapture` and all tests passed (4 passed, 0 failed).
- Built CLI tests with `cargo test -p bitnet-cli --no-run`, which compiled the CLI test targets successfully (no runtime test failures since tests were not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac061e28833394c997b83283d556)