### PR TITLE
refactor: extract L2 divergence into bitnet-eval-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,6 +1162,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bitnet-common",
+ "bitnet-eval-core",
  "bitnet-inference",
  "bitnet-kernels",
  "bitnet-models",

--- a/crates/bitnet-eval-core/src/lib.rs
+++ b/crates/bitnet-eval-core/src/lib.rs
@@ -39,9 +39,24 @@ pub fn log_softmax_stable(xs: &[f32]) -> Vec<f32> {
     xs.iter().map(|&v| v - lse).collect()
 }
 
+/// L2 divergence (Euclidean distance) between two vectors.
+///
+/// Returns `f64::INFINITY` when vector lengths do not match.
+#[must_use]
+pub fn l2_divergence(baseline: &[f32], canary: &[f32]) -> f64 {
+    if baseline.len() != canary.len() {
+        return f64::INFINITY;
+    }
+
+    let sum_sq: f64 =
+        baseline.iter().zip(canary.iter()).map(|(a, b)| ((*a as f64) - (*b as f64)).powi(2)).sum();
+
+    sum_sq.sqrt()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{log_softmax_stable, topk_stable_indices};
+    use super::{l2_divergence, log_softmax_stable, topk_stable_indices};
 
     #[test]
     fn topk_is_deterministic_for_ties() {
@@ -56,5 +71,16 @@ mod tests {
         let logp = log_softmax_stable(&logits);
         let p_sum: f32 = logp.iter().map(|v| v.exp()).sum();
         assert!((p_sum - 1.0).abs() < 1e-5, "sum was {p_sum}");
+    }
+
+    #[test]
+    fn l2_divergence_zero_for_identical_vectors() {
+        let a = vec![0.1f32, -2.5, 3.0, 9.75];
+        assert_eq!(l2_divergence(&a, &a), 0.0);
+    }
+
+    #[test]
+    fn l2_divergence_returns_infinity_for_mismatched_lengths() {
+        assert!(l2_divergence(&[1.0f32, 2.0], &[1.0]).is_infinite());
     }
 }

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/canary.rs
+++ b/crates/bitnet-server/src/canary.rs
@@ -5,6 +5,7 @@
 //! outputs within a tolerance, tracks error rates, and automatically rolls
 //! back if the canary exceeds an error threshold.
 
+use bitnet_eval_core::l2_divergence;
 use std::fmt;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -77,12 +78,7 @@ pub struct ComparisonResult {
 
 /// Compare two output vectors and return the L2 divergence.
 pub fn compute_divergence(baseline: &[f32], canary: &[f32]) -> f64 {
-    if baseline.len() != canary.len() {
-        return f64::INFINITY;
-    }
-    let sum_sq: f64 =
-        baseline.iter().zip(canary.iter()).map(|(a, b)| ((*a as f64) - (*b as f64)).powi(2)).sum();
-    sum_sq.sqrt()
+    l2_divergence(baseline, canary)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Remove duplicated numeric comparison logic by centralizing L2 divergence calculation in a shared SRP microcrate for reuse and easier testing.

### Description

- Added `l2_divergence` to `crates/bitnet-eval-core/src/lib.rs` as a reusable, documented helper that returns `f64::INFINITY` for mismatched lengths.
- Replaced the local divergence math in `crates/bitnet-server/src/canary.rs` with a call to `bitnet_eval_core::l2_divergence` via `compute_divergence`.
- Wired the dependency by adding `bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }` to `crates/bitnet-server/Cargo.toml`.
- Added focused unit tests for `l2_divergence` in `crates/bitnet-eval-core` and ran `rustfmt` to keep formatting consistent.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p bitnet-eval-core` which passed (4 tests: topk/log-softmax and the two new `l2_divergence` tests).
- Ran `cargo test -p bitnet-server --test snapshot_wave9 compute_divergence` which passed (3 tests covering the canary divergence snapshots).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac0da8648333805cf47f1f5f0677)