### PR TITLE
Extract CLI tensor diagnostics helpers into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
  "bitnet-startup-contract-guard",
+ "bitnet-tensor-diagnostics-core",
  "bitnet-tokenizers",
  "bitnet-validation",
  "bytemuck",
@@ -1318,6 +1319,14 @@ dependencies = [
  "proptest",
  "thiserror 2.0.18",
  "xtask-build-helper",
+]
+
+[[package]]
+name = "bitnet-tensor-diagnostics-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-common",
+ "candle-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-tensor-diagnostics-core", # SRP: reusable tensor extraction/diagnostics helpers
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
@@ -138,6 +139,7 @@ default-members = [
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-tensor-diagnostics-core", # SRP: reusable tensor extraction/diagnostics helpers
 ]
 
 [package]

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -35,6 +35,7 @@ bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
+bitnet-tensor-diagnostics-core = { path = "../bitnet-tensor-diagnostics-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -12,7 +12,10 @@ use bitnet_common::Tensor;
 use bitnet_startup_contract_guard::{
     ContractPolicy, RuntimeComponent, evaluate_and_emit, feature_line,
 };
-use candle_core::{DType, IndexOp};
+use bitnet_tensor_diagnostics_core::{
+    compute_rms, extract_last_token_hidden, extract_logits_2d, tensor_to_vec,
+};
+use candle_core::DType;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use console::style;
@@ -1564,120 +1567,6 @@ async fn run_simple_generation(
     }
 
     Ok(())
-}
-
-/// Extract last token hidden state from 3D tensor \[B,T,H\] -> \[B,H\]
-fn extract_last_token_hidden(
-    tensor: &bitnet_common::ConcreteTensor,
-) -> Result<bitnet_common::ConcreteTensor> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 3 {
-        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
-    }
-
-    let (batch_size, seq_len, hidden_size) = (shape[0], shape[1], shape[2]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            // Extract last token: [B, T, H] -> [B, H]
-            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?;
-            Ok(ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(last)))
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock hidden state [B, H]
-            Ok(ConcreteTensor::mock(vec![batch_size, hidden_size]))
-        }
-    }
-}
-
-/// Extract logits vector from 2D tensor \[B,V\] -> `Vec<f32>`
-fn extract_logits_2d(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 2 {
-        return Err(BitNetError::Validation("Expected 2D tensor".into()).into());
-    }
-
-    let (_batch, _vocab) = (shape[0], shape[1]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            // Extract first batch: [B, V] -> [V]
-            let batch_0 = candle.i(0)?;
-            let batch_0 =
-                if batch_0.dtype() != DType::F32 { batch_0.to_dtype(DType::F32)? } else { batch_0 };
-            Ok(batch_0.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock logits for testing
-            Ok(vec![0.1; 50257])
-        }
-    }
-}
-
-/// Extract logits vector from tensor (legacy function for compatibility)
-#[allow(dead_code)]
-fn extract_logits(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::{BitNetError, ConcreteTensor, Tensor};
-
-    let shape = tensor.shape();
-    if shape.len() != 3 {
-        return Err(BitNetError::Validation("Expected 3D tensor".into()).into());
-    }
-
-    let (_batch, seq_len, _vocab) = (shape[0], shape[1], shape[2]);
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?.i(0)?;
-            let last = if last.dtype() != DType::F32 { last.to_dtype(DType::F32)? } else { last };
-            Ok(last.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(_) => {
-            // Return mock logits for testing
-            Ok(vec![0.1; 50257])
-        }
-    }
-}
-
-/// Convert tensor to f32 vector for diagnostics
-fn tensor_to_vec(tensor: &bitnet_common::ConcreteTensor) -> Result<Vec<f32>> {
-    use bitnet_common::ConcreteTensor;
-
-    match tensor {
-        ConcreteTensor::BitNet(t) => {
-            let candle = t.as_candle();
-            let candle_f32 = if candle.dtype() != DType::F32 {
-                candle.to_dtype(DType::F32)?
-            } else {
-                candle.clone()
-            };
-            // Flatten to 1D vector
-            let flattened = candle_f32.flatten_all()?;
-            Ok(flattened.to_vec1::<f32>()?)
-        }
-        ConcreteTensor::Mock(mock) => {
-            // Return mock values - use shape from tensor
-            let size: usize = mock.shape().iter().product();
-            Ok(vec![0.1; size])
-        }
-    }
-}
-
-/// Compute RMS (root mean square) of a vector
-#[inline]
-fn compute_rms(xs: &[f32]) -> f32 {
-    if xs.is_empty() {
-        return 0.0;
-    }
-    let sum_sq: f32 = xs.iter().map(|x| x * x).sum();
-    (sum_sq / (xs.len() as f32)).sqrt()
 }
 
 /// Show system information

--- a/crates/bitnet-tensor-diagnostics-core/Cargo.toml
+++ b/crates/bitnet-tensor-diagnostics-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-tensor-diagnostics-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for tensor extraction and diagnostics helpers"
+
+[dependencies]
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+candle-core.workspace = true

--- a/crates/bitnet-tensor-diagnostics-core/src/lib.rs
+++ b/crates/bitnet-tensor-diagnostics-core/src/lib.rs
@@ -1,0 +1,131 @@
+//! SRP microcrate for reusable tensor extraction and diagnostics helpers.
+
+use bitnet_common::{BitNetError, ConcreteTensor, Result, Tensor};
+use candle_core::IndexOp;
+
+/// Extract last token hidden state from a 3D tensor `[B, T, H] -> [B, H]`.
+pub fn extract_last_token_hidden(tensor: &ConcreteTensor) -> Result<ConcreteTensor> {
+    let shape = tensor.shape();
+    if shape.len() != 3 {
+        return Err(BitNetError::Validation("Expected 3D tensor".into()));
+    }
+
+    let (batch_size, seq_len, hidden_size) = (shape[0], shape[1], shape[2]);
+
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?;
+            Ok(ConcreteTensor::BitNet(bitnet_common::BitNetTensor::new(last)))
+        }
+        ConcreteTensor::Mock(_) => Ok(ConcreteTensor::mock(vec![batch_size, hidden_size])),
+    }
+}
+
+/// Extract logits vector from a 2D tensor `[B, V] -> Vec<f32>`.
+pub fn extract_logits_2d(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    let shape = tensor.shape();
+    if shape.len() != 2 {
+        return Err(BitNetError::Validation("Expected 2D tensor".into()));
+    }
+
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let batch_0 = candle.i(0)?;
+            let batch_0 = if batch_0.dtype() != candle_core::DType::F32 {
+                batch_0.to_dtype(candle_core::DType::F32)?
+            } else {
+                batch_0
+            };
+            Ok(batch_0.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(_) => Ok(vec![0.1; 50_257]),
+    }
+}
+
+/// Extract logits vector from a legacy 3D tensor `[B, T, V] -> Vec<f32>`.
+pub fn extract_logits_3d_legacy(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    let shape = tensor.shape();
+    if shape.len() != 3 {
+        return Err(BitNetError::Validation("Expected 3D tensor".into()));
+    }
+
+    let seq_len = shape[1];
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let last = candle.narrow(1, seq_len - 1, 1)?.squeeze(1)?.i(0)?;
+            let last = if last.dtype() != candle_core::DType::F32 {
+                last.to_dtype(candle_core::DType::F32)?
+            } else {
+                last
+            };
+            Ok(last.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(_) => Ok(vec![0.1; 50_257]),
+    }
+}
+
+/// Flatten a tensor to f32 values for diagnostics.
+pub fn tensor_to_vec(tensor: &ConcreteTensor) -> Result<Vec<f32>> {
+    match tensor {
+        ConcreteTensor::BitNet(t) => {
+            let candle = t.as_candle();
+            let candle_f32 = if candle.dtype() != candle_core::DType::F32 {
+                candle.to_dtype(candle_core::DType::F32)?
+            } else {
+                candle.clone()
+            };
+            Ok(candle_f32.flatten_all()?.to_vec1::<f32>()?)
+        }
+        ConcreteTensor::Mock(mock) => {
+            let size: usize = mock.shape().iter().product();
+            Ok(vec![0.1; size])
+        }
+    }
+}
+
+/// Compute RMS (root mean square) of values.
+#[inline]
+#[must_use]
+pub fn compute_rms(xs: &[f32]) -> f32 {
+    if xs.is_empty() {
+        return 0.0;
+    }
+    let sum_sq: f32 = xs.iter().map(|x| x * x).sum();
+    (sum_sq / (xs.len() as f32)).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_extract_last_token_hidden_returns_bxh_shape() {
+        let t = ConcreteTensor::mock(vec![2, 4, 8]);
+        let out = extract_last_token_hidden(&t).expect("extract should succeed");
+        assert_eq!(out.shape(), vec![2, 8]);
+    }
+
+    #[test]
+    fn extract_logits_2d_rejects_non_2d_shapes() {
+        let t = ConcreteTensor::mock(vec![2, 4, 8]);
+        let err = extract_logits_2d(&t).expect_err("expected validation error");
+        assert!(matches!(err, BitNetError::Validation(_)));
+    }
+
+    #[test]
+    fn tensor_to_vec_mock_uses_shape_product() {
+        let t = ConcreteTensor::mock(vec![2, 3, 5]);
+        let values = tensor_to_vec(&t).expect("flatten should succeed");
+        assert_eq!(values.len(), 30);
+    }
+
+    #[test]
+    fn compute_rms_handles_empty_and_non_empty() {
+        assert_eq!(compute_rms(&[]), 0.0);
+        let rms = compute_rms(&[3.0, 4.0]);
+        assert!((rms - 3.535534).abs() < 1e-5);
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove low-level tensor extraction/diagnostic helpers from the CLI entrypoint so they can be reused and maintained independently. 
- Improve single-responsibility boundaries by placing inference-agnostic tensor utilities into a focused microcrate.

### Description
- Added a new workspace crate `crates/bitnet-tensor-diagnostics-core` implementing `extract_last_token_hidden`, `extract_logits_2d`, `extract_logits_3d_legacy`, `tensor_to_vec`, and `compute_rms` with focused unit tests in `src/lib.rs`.
- Wired the new microcrate into the workspace by adding it to `members` and `default-members` in `Cargo.toml` and registering it in `Cargo.lock`.
- Updated `crates/bitnet-cli` to depend on `bitnet-tensor-diagnostics-core`, replaced the local implementations in `src/main.rs` with imports from the new crate, and removed the duplicated helper implementations.
- Added `candle-core` workspace dependency to the new crate and updated `crates/bitnet-cli/Cargo.toml` to include the new dependency.

### Testing
- Ran `cargo test -p bitnet-tensor-diagnostics-core` and all unit tests passed (4 passed, 0 failed).
- Ran `cargo check -p bitnet-cli` and the CLI crate checked cleanly (no errors).
- Ran `cargo test -p bitnet-cli --lib` and the CLI unit test suite passed (29 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b1fb92a08333895446151a0cccad)