### PR TITLE
refactor(download): extract bitnet-download-core SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,14 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
- "bitnet-http-retry",
+ "bitnet-download-core",
+ "tempfile",
+]
+
+[[package]]
+name = "bitnet-download-core"
+version = "0.2.1-dev"
+dependencies = [
  "httpdate",
  "reqwest",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-core", # SRP: pure download retry/header/validation core
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
@@ -155,6 +156,7 @@ default-members = [
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-core", # SRP: pure download retry/header/validation core
 ]
 
 [package]

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-download-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP download primitives for retry/header parsing and payload validation"
+
+[dependencies]
+reqwest = { workspace = true }
+httpdate = "1.0.3"
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,0 +1,127 @@
+use reqwest::header::{HeaderMap, RETRY_AFTER};
+use std::time::SystemTime;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Safe exponential backoff helper with deterministic jitter.
+#[must_use]
+pub fn exp_backoff_ms(attempt: u32) -> u64 {
+    let shift = attempt.saturating_sub(1).min(20);
+    let base = (200u64).saturating_mul(1u64 << shift).min(10_000);
+    let jitter = (attempt as u64 * 37) % 200;
+    base.saturating_add(jitter)
+}
+
+/// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
+#[must_use]
+pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
+    retry_after_secs_at(headers, SystemTime::now())
+}
+
+/// Same as [`retry_after_secs`] but allows injecting the current time for deterministic tests.
+#[must_use]
+pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
+    let raw = match headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok()) {
+        Some(s) => s,
+        None => return 5,
+    };
+
+    if let Ok(s) = raw.parse::<u64>() {
+        return s.min(3600);
+    }
+
+    httpdate::parse_http_date(raw)
+        .ok()
+        .and_then(|when| when.duration_since(now).ok())
+        .map(|d| d.as_secs().clamp(1, 3600))
+        .unwrap_or(5)
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::RETRY_AFTER;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn retry_after_seconds() {
+        let mut headers = HeaderMap::new();
+        headers.insert(RETRY_AFTER, "10".parse().expect("valid retry-after seconds"));
+        assert_eq!(retry_after_secs(&headers), 10);
+    }
+
+    #[test]
+    fn retry_after_http_date() {
+        let now = SystemTime::now();
+        let future = now + Duration::from_secs(5);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            httpdate::fmt_http_date(future).parse().expect("valid retry-after date"),
+        );
+
+        let wait = retry_after_secs_at(&headers, now);
+        assert!((4..=6).contains(&wait));
+    }
+
+    #[test]
+    fn retry_after_past_date_falls_back() {
+        let now = SystemTime::now();
+        let past = now - Duration::from_secs(10);
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            RETRY_AFTER,
+            httpdate::fmt_http_date(past).parse().expect("valid retry-after date"),
+        );
+
+        assert_eq!(retry_after_secs_at(&headers, now), 5);
+    }
+
+    #[test]
+    fn exp_backoff_matches_contract() {
+        assert_eq!(exp_backoff_ms(1), 237);
+        assert_eq!(exp_backoff_ms(2), 474);
+        assert_eq!(exp_backoff_ms(3), 911);
+        assert_eq!(exp_backoff_ms(10), 10_170);
+    }
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,12 +10,10 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
-bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
-reqwest = { workspace = true, features = ["blocking"] }
-thiserror.workspace = true
+bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-httpdate = "1.0.3"

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,51 +1,14 @@
-pub use bitnet_http_retry::exp_backoff_ms;
-use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
-use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
-use thiserror::Error;
+use std::{fs, path::Path};
 
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DownloadValidationError {
-    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
-    Truncated { downloaded: u64, expected: u64 },
-}
+pub use bitnet_download_core::{
+    DownloadValidationError, exp_backoff_ms, parse_content_range_total, retry_after_secs,
+    retry_after_secs_at, validate_downloaded_len,
+};
 
 /// Returns true when download logic should operate in offline mode.
 #[must_use]
 pub fn offline_enabled(cli_offline: bool) -> bool {
     cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
-}
-
-/// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
-#[must_use]
-pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
-    retry_after_secs_at(headers, SystemTime::now())
-}
-
-/// Same as [`retry_after_secs`] but allows injecting the current time for deterministic tests.
-#[must_use]
-pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
-    let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
-    parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
-#[must_use]
-pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
-}
-
-/// Ensure downloaded bytes match expected total when available.
-pub fn validate_downloaded_len(
-    downloaded: u64,
-    expected_total: Option<u64>,
-) -> Result<(), DownloadValidationError> {
-    if let Some(expected) = expected_total
-        && downloaded != expected
-    {
-        return Err(DownloadValidationError::Truncated { downloaded, expected });
-    }
-    Ok(())
 }
 
 /// Atomic write helper for small metadata files (etag/last-modified).
@@ -77,64 +40,42 @@ pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest::header::RETRY_AFTER;
-    use std::time::{Duration, SystemTime};
+    use std::io::Read;
 
     #[test]
-    fn retry_after_seconds() {
-        let mut headers = HeaderMap::new();
-        headers.insert(RETRY_AFTER, "10".parse().expect("valid retry-after seconds"));
-        assert_eq!(retry_after_secs(&headers), 10);
+    fn offline_enabled_obeys_cli_and_env() {
+        let key = "BITNET_OFFLINE";
+
+        assert!(offline_enabled(true));
+
+        unsafe {
+            std::env::remove_var(key);
+        }
+        assert!(!offline_enabled(false));
+
+        unsafe {
+            std::env::set_var(key, "1");
+        }
+        assert!(offline_enabled(false));
+
+        unsafe {
+            std::env::remove_var(key);
+        }
     }
 
     #[test]
-    fn retry_after_http_date() {
-        let now = SystemTime::now();
-        let future = now + Duration::from_secs(5);
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            RETRY_AFTER,
-            httpdate::fmt_http_date(future).parse().expect("valid retry-after date"),
-        );
+    fn atomic_write_replaces_file_contents() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("meta.etag");
 
-        let wait = retry_after_secs_at(&headers, now);
-        assert!((4..=6).contains(&wait));
-    }
+        atomic_write(&path, b"old").expect("initial write");
+        atomic_write(&path, b"new").expect("replacement write");
 
-    #[test]
-    fn retry_after_past_date_falls_back() {
-        let now = SystemTime::now();
-        let past = now - Duration::from_secs(10);
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            RETRY_AFTER,
-            httpdate::fmt_http_date(past).parse().expect("valid retry-after date"),
-        );
+        let mut file = std::fs::File::open(&path).expect("open written file");
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf).expect("read file");
 
-        assert_eq!(retry_after_secs_at(&headers, now), 5);
-    }
-
-    #[test]
-    fn exp_backoff_matches_contract() {
-        assert_eq!(exp_backoff_ms(1), 237);
-        assert_eq!(exp_backoff_ms(2), 474);
-        assert_eq!(exp_backoff_ms(3), 911);
-        assert_eq!(exp_backoff_ms(10), 10_170);
-    }
-
-    #[test]
-    fn parses_content_range_total() {
-        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
-        assert_eq!(parse_content_range_total("invalid"), None);
-    }
-
-    #[test]
-    fn validates_downloaded_len() {
-        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
-        assert!(validate_downloaded_len(1024, None).is_ok());
-        assert!(matches!(
-            validate_downloaded_len(1, Some(2)),
-            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
-        ));
+        assert_eq!(buf, b"new");
+        assert!(!path.with_extension("tmp").exists());
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce a monolithic utility crate by extracting pure parsing/validation/backoff logic into a single-responsibility microcrate for easier reuse and testing.
- Keep filesystem and environment concerns (`offline_enabled`, `atomic_write`) separated from HTTP header parsing and validation to clarify ownership and dependencies.
- Make the retry/Retry-After/Content-Range helpers available to other crates without pulling in filesystem/test helpers.

### Description
- Add new crate `crates/bitnet-download-core` which implements `exp_backoff_ms`, `retry_after_secs`/`retry_after_secs_at`, `parse_content_range_total`, `validate_downloaded_len`, and `DownloadValidationError` with unit tests in `src/lib.rs`.
- Update `crates/bitnet-download` to focus on environment/filesystem behavior (`offline_enabled`, `atomic_write`) and re-export the moved APIs from `bitnet-download-core` via `pub use bitnet_download_core::{ ... }` for backward compatibility.
- Wire the new microcrate into the workspace by adding `crates/bitnet-download-core` to `Cargo.toml` members and `default-members`, and update `crates/bitnet-download/Cargo.toml` to depend on `bitnet-download-core`.
- Preserve and reorganize unit coverage by moving parsing/backoff/validation tests into `bitnet-download-core` and keeping env/fs tests in `bitnet-download`.

### Testing
- Ran `cargo test -p bitnet-download-core -p bitnet-download` and all unit tests passed (`bitnet-download-core`: 6 tests passed; `bitnet-download`: 2 tests passed).
- Ran `cargo fmt --all` to ensure formatting consistency and no formatting failures were reported.
- Verified the library compiles and unit tests run under the workspace test profile with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b1fb92a08333895446151a0cccad)