### PR TITLE
Extract inference timing/throughput DTOs into bitnet-inference-metrics-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "bitnet-engine-core",
  "bitnet-generation",
  "bitnet-gguf",
+ "bitnet-inference-metrics-core",
  "bitnet-kernels",
  "bitnet-logits",
  "bitnet-models",
@@ -819,6 +820,13 @@ dependencies = [
  "tokio-test",
  "tracing",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "bitnet-inference-metrics-core"
+version = "0.2.1-dev"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",
   "crates/bitnet-inference",
+  "crates/bitnet-inference-metrics-core", # SRP: shared inference timing/throughput metric DTOs
   "crates/bitnet-rope",
   "crates/bitnet-tokenizers",
   "crates/bitnet-prompt-templates",
@@ -111,6 +112,7 @@ default-members = [
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",
   "crates/bitnet-inference",
+  "crates/bitnet-inference-metrics-core", # SRP: shared inference timing/throughput metric DTOs
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-receipts",

--- a/crates/bitnet-inference-metrics-core/Cargo.toml
+++ b/crates/bitnet-inference-metrics-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-inference-metrics-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Shared inference timing and throughput metric models"
+include = [
+  "src/**",
+  "Cargo.toml",
+]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-inference-metrics-core/src/lib.rs
+++ b/crates/bitnet-inference-metrics-core/src/lib.rs
@@ -1,0 +1,61 @@
+//! Shared DTOs for inference timing and throughput metrics.
+
+use serde::{Deserialize, Serialize};
+
+/// Enhanced timing metrics for detailed performance tracking.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct TimingMetrics {
+    /// Prefill latency in milliseconds
+    pub prefill_ms: Option<u64>,
+    /// Decode latency in milliseconds
+    pub decode_ms: Option<u64>,
+    /// Tokenization encode time in milliseconds
+    pub tokenization_encode_ms: Option<u64>,
+    /// Tokenization decode time in milliseconds
+    pub tokenization_decode_ms: Option<u64>,
+    /// End-to-end total time in milliseconds
+    pub total_ms: u64,
+}
+
+/// Enhanced throughput metrics for performance analysis.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ThroughputMetrics {
+    /// Prefill throughput in tokens per second
+    pub prefill_tokens_per_sec: Option<f64>,
+    /// Decode throughput in tokens per second
+    pub decode_tokens_per_sec: Option<f64>,
+    /// End-to-end throughput in tokens per second
+    pub end_to_end_tokens_per_sec: f64,
+    /// Total tokens generated
+    pub total_tokens: usize,
+}
+
+impl Default for ThroughputMetrics {
+    fn default() -> Self {
+        Self {
+            prefill_tokens_per_sec: None,
+            decode_tokens_per_sec: None,
+            end_to_end_tokens_per_sec: 0.0,
+            total_tokens: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ThroughputMetrics, TimingMetrics};
+
+    #[test]
+    fn timing_metrics_default_is_zeroed() {
+        assert_eq!(TimingMetrics::default().total_ms, 0);
+    }
+
+    #[test]
+    fn throughput_metrics_default_has_empty_phase_values() {
+        let metrics = ThroughputMetrics::default();
+        assert_eq!(metrics.prefill_tokens_per_sec, None);
+        assert_eq!(metrics.decode_tokens_per_sec, None);
+        assert_eq!(metrics.end_to_end_tokens_per_sec, 0.0);
+        assert_eq!(metrics.total_tokens, 0);
+    }
+}

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -27,6 +27,7 @@ bitnet-logits = { path = "../bitnet-logits", version = "0.2.1-dev" }
 bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
 bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
 bitnet-engine-core = { path = "../bitnet-engine-core", version = "0.2.1-dev" }
+bitnet-inference-metrics-core = { path = "../bitnet-inference-metrics-core", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-sys = { path = "../bitnet-sys", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-inference/src/lib.rs
+++ b/crates/bitnet-inference/src/lib.rs
@@ -47,6 +47,7 @@ pub(crate) use tensor_ext::TensorDeviceExt;
 
 pub use backends::{Backend, CpuBackend, GpuBackend};
 pub use batch::{BatchConfig, BatchRequest, BatchResult, BatchScheduler, SingleResult};
+pub use bitnet_inference_metrics_core::{ThroughputMetrics, TimingMetrics};
 pub use cache::{CacheConfig, KVCache};
 pub use config::{GenerationConfig, InferenceConfig};
 pub use engine::{InferenceEngine, InferenceResult};
@@ -73,7 +74,7 @@ pub use prefix_cache::{
 };
 pub use production_engine::{
     GenerationResult, PerformanceMetricsCollector, PrefillStrategy, ProductionInferenceConfig,
-    ProductionInferenceEngine, ThroughputMetrics, TimingMetrics,
+    ProductionInferenceEngine,
 };
 pub use prompt_template::{ChatRole, ChatTurn, PromptTemplate, TemplateType};
 pub use receipts::{

--- a/crates/bitnet-inference/src/production_engine.rs
+++ b/crates/bitnet-inference/src/production_engine.rs
@@ -16,9 +16,9 @@ use crate::{GenerationConfig, InferenceEngine};
 #[cfg(feature = "inference")]
 use bitnet_common::KernelCapabilities;
 use bitnet_common::{BackendStartupSummary, BitNetError, Device, InferenceError, Result};
+use bitnet_inference_metrics_core::{ThroughputMetrics, TimingMetrics};
 use bitnet_models::Model;
 use bitnet_tokenizers::Tokenizer;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
 #[cfg(feature = "inference")]
@@ -27,45 +27,6 @@ use tokio::sync::RwLock;
 use tracing::info;
 #[cfg(feature = "inference")]
 use tracing::{debug, instrument};
-
-/// Enhanced timing metrics for detailed performance tracking
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct TimingMetrics {
-    /// Prefill latency in milliseconds
-    pub prefill_ms: Option<u64>,
-    /// Decode latency in milliseconds
-    pub decode_ms: Option<u64>,
-    /// Tokenization encode time in milliseconds
-    pub tokenization_encode_ms: Option<u64>,
-    /// Tokenization decode time in milliseconds
-    pub tokenization_decode_ms: Option<u64>,
-    /// End-to-end total time in milliseconds
-    pub total_ms: u64,
-}
-
-/// Enhanced throughput metrics for performance analysis
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ThroughputMetrics {
-    /// Prefill throughput in tokens per second
-    pub prefill_tokens_per_sec: Option<f64>,
-    /// Decode throughput in tokens per second
-    pub decode_tokens_per_sec: Option<f64>,
-    /// End-to-end throughput in tokens per second
-    pub end_to_end_tokens_per_sec: f64,
-    /// Total tokens generated
-    pub total_tokens: usize,
-}
-
-impl Default for ThroughputMetrics {
-    fn default() -> Self {
-        Self {
-            prefill_tokens_per_sec: None,
-            decode_tokens_per_sec: None,
-            end_to_end_tokens_per_sec: 0.0,
-            total_tokens: 0,
-        }
-    }
-}
 
 /// Comprehensive performance metrics collector
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
### Motivation
- Reduce duplication and follow SRP by moving metric DTOs out of the large `production_engine.rs` file into a focused microcrate so metric schema is a single responsibility.
- Make timing/throughput models reusable across crates and easier to maintain without embedding data models inside runtime logic.
- Preserve the public API surface while enabling future metric-related integrations and cross-crate reuse.

### Description
- Added a new microcrate `crates/bitnet-inference-metrics-core` that defines `TimingMetrics` and `ThroughputMetrics`, their defaults, serde derives, and unit tests (new files: `crates/bitnet-inference-metrics-core/Cargo.toml` and `crates/bitnet-inference-metrics-core/src/lib.rs`).
- Wired the microcrate into the workspace `Cargo.toml` (added to `members` and `default-members`) and added it as a dependency of `crates/bitnet-inference/Cargo.toml`.
- Removed the local metric struct definitions from `crates/bitnet-inference/src/production_engine.rs` and imported the shared types from `bitnet_inference_metrics_core`; re-exported `TimingMetrics` and `ThroughputMetrics` from `bitnet-inference` root (`src/lib.rs`) to maintain downstream ergonomics.
- Formatted code and fixed unused imports affected by the extraction.

### Testing
- Ran formatter with `cargo fmt --all` and applied changes successfully.
- Executed unit tests for the new crate with `cargo test -p bitnet-inference-metrics-core`, which passed (`2 passed; 0 failed`).
- Ran the `bitnet-inference` library tests with `cargo test -p bitnet-inference --lib`, which completed successfully (all tests passed in the targeted test run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b2f1c69c8333ae6b1929dc5bc5a1)