### PR TITLE
Extract weight-name drift normalization into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "bitnet-test-support",
  "bitnet-trace",
  "bitnet-transformer",
+ "bitnet-weight-name-normalization",
  "bytemuck",
  "candle-core",
  "candle-nn",
@@ -1656,6 +1657,10 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
+
+[[package]]
+name = "bitnet-weight-name-normalization"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-wgpu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-weight-name-normalization", # SRP: exporter tensor-name drift normalization
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
   "crates/bitnet-metal",         # MSL compute kernels for Apple Silicon
@@ -138,6 +139,7 @@ default-members = [
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-weight-name-normalization", # SRP: exporter tensor-name drift normalization
 ]
 
 [package]

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -21,6 +21,7 @@ bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
+bitnet-weight-name-normalization = { path = "../bitnet-weight-name-normalization", version = "0.2.1-dev" }
 anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true

--- a/crates/bitnet-models/src/weight_mapper.rs
+++ b/crates/bitnet-models/src/weight_mapper.rs
@@ -2,7 +2,6 @@ use bitnet_common::Result;
 use candle_core::{DType, Device, Tensor};
 use regex::Regex;
 /// Weight mapping utilities for loading model weights from various formats
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::OnceLock;
 
@@ -256,21 +255,8 @@ pub fn remap_gguf_weights(tensors: &HashMap<String, Tensor>) -> Result<HashMap<S
 }
 
 /// Normalize exporter name drift to our canonical names.
-/// Known drifts:
-///  - attn_sub_norm <-> attention_sub_norm
-///  - ffn_sub_norm  <-> mlp_sub_layernorm
-fn normalize_name(name: &str) -> Cow<'_, str> {
-    if name.contains("attention_sub_norm") {
-        // Map Microsoft's variation to our canonical name
-        let s = name.replace("attention_sub_norm", "attn_sub_norm");
-        return Cow::Owned(s);
-    }
-    if name.contains("mlp_sub_layernorm") {
-        // Map to our canonical FFN sub norm
-        let s = name.replace("mlp_sub_layernorm", "ffn_sub_norm");
-        return Cow::Owned(s);
-    }
-    Cow::Borrowed(name)
+fn normalize_name(name: &str) -> std::borrow::Cow<'_, str> {
+    bitnet_weight_name_normalization::normalize_exporter_name_drift(name)
 }
 
 /// Helper to get 2D tensor dimensions

--- a/crates/bitnet-models/tests/weight_name_normalization_integration.rs
+++ b/crates/bitnet-models/tests/weight_name_normalization_integration.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use bitnet_models::weight_mapper::remap_gguf_weights_with_options;
+use candle_core::{Device, Tensor};
+
+#[test]
+fn remap_normalizes_exporter_drift_for_attention_sub_norm() {
+    let device = Device::Cpu;
+    let tensor = Tensor::zeros((2, 2), candle_core::DType::F32, &device).expect("tensor");
+    let mut tensors = HashMap::new();
+    tensors.insert("blk.0.attention_sub_norm.weight".to_string(), tensor);
+
+    let mapped = remap_gguf_weights_with_options(&tensors, false).expect("remap succeeds");
+
+    assert!(mapped.contains_key("layers.0.attention.sub_layernorm.weight"));
+}
+
+#[test]
+fn remap_normalizes_exporter_drift_for_mlp_sub_layernorm() {
+    let device = Device::Cpu;
+    let tensor = Tensor::zeros((2, 2), candle_core::DType::F32, &device).expect("tensor");
+    let mut tensors = HashMap::new();
+    tensors.insert("blk.0.mlp_sub_layernorm.weight".to_string(), tensor);
+
+    let mapped = remap_gguf_weights_with_options(&tensors, false).expect("remap succeeds");
+
+    assert!(mapped.contains_key("layers.0.feed_forward.sub_layernorm.weight"));
+}

--- a/crates/bitnet-weight-name-normalization/Cargo.toml
+++ b/crates/bitnet-weight-name-normalization/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bitnet-weight-name-normalization"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for exporter weight-name drift normalization"
+
+[dependencies]
+

--- a/crates/bitnet-weight-name-normalization/src/lib.rs
+++ b/crates/bitnet-weight-name-normalization/src/lib.rs
@@ -1,0 +1,32 @@
+//! Exporter weight-name drift normalization helpers.
+//!
+//! This crate has a single responsibility: normalize known vendor-specific
+//! naming drift to canonical internal names before mapping.
+
+use std::borrow::Cow;
+
+const DEFAULT_DRIFT_RULES: [(&str, &str); 2] =
+    [("attention_sub_norm", "attn_sub_norm"), ("mlp_sub_layernorm", "ffn_sub_norm")];
+
+/// Normalize exporter-specific tensor-name drift to canonical names.
+///
+/// Returns [`Cow::Borrowed`] when no rule matches and [`Cow::Owned`] when a
+/// replacement was applied.
+pub fn normalize_exporter_name_drift(name: &str) -> Cow<'_, str> {
+    normalize_with_rules(name, &DEFAULT_DRIFT_RULES)
+}
+
+/// Normalize using custom replacement rules, applied in order.
+///
+/// Rules are `(from, to)` replacement pairs and use `str::replace` semantics.
+pub fn normalize_with_rules<'a>(name: &'a str, rules: &[(&str, &str)]) -> Cow<'a, str> {
+    let mut normalized = Cow::Borrowed(name);
+
+    for (from, to) in rules {
+        if normalized.contains(from) {
+            normalized = Cow::Owned(normalized.replace(from, to));
+        }
+    }
+
+    normalized
+}

--- a/crates/bitnet-weight-name-normalization/tests/normalization_tests.rs
+++ b/crates/bitnet-weight-name-normalization/tests/normalization_tests.rs
@@ -1,0 +1,28 @@
+use bitnet_weight_name_normalization::{normalize_exporter_name_drift, normalize_with_rules};
+
+#[test]
+fn default_rules_normalize_microsoft_attention_alias() {
+    let normalized = normalize_exporter_name_drift("blk.0.attention_sub_norm.weight");
+    assert_eq!(normalized, "blk.0.attn_sub_norm.weight");
+}
+
+#[test]
+fn default_rules_normalize_ffn_alias() {
+    let normalized = normalize_exporter_name_drift("blk.0.mlp_sub_layernorm.weight");
+    assert_eq!(normalized, "blk.0.ffn_sub_norm.weight");
+}
+
+#[test]
+fn default_rules_no_match_keeps_borrowed_input() {
+    let source = "blk.0.attn_norm.weight";
+    let normalized = normalize_exporter_name_drift(source);
+    assert_eq!(normalized, source);
+    assert!(matches!(normalized, std::borrow::Cow::Borrowed(_)));
+}
+
+#[test]
+fn custom_rules_apply_in_order() {
+    let rules = [("foo", "bar"), ("bar", "baz")];
+    let normalized = normalize_with_rules("foo.weight", &rules);
+    assert_eq!(normalized, "baz.weight");
+}


### PR DESCRIPTION
### Motivation
- Remove hardcoded exporter name-drift logic from the GGUF weight remapper to enforce single-responsibility and make rules extensible.
- Provide a small, reusable microcrate that can be shared by other crates that need to normalize vendor-specific tensor-name drift.
- Make future rule additions or configuration-based mappings easier without changing `weight_mapper` internals.

### Description
- Added a new SRP microcrate `crates/bitnet-weight-name-normalization` exposing `normalize_exporter_name_drift` and `normalize_with_rules` to apply ordered replacement rules.
- Replaced the inline `normalize_name` implementation in `crates/bitnet-models/src/weight_mapper.rs` with a call to the new microcrate, preserving the public remapping flow.
- Added unit tests for the new microcrate (`tests/normalization_tests.rs`) and integration tests in `crates/bitnet-models/tests/weight_name_normalization_integration.rs` that exercise remapping end-to-end for the drift cases.
- Registered the new crate in top-level `Cargo.toml` and `crates/bitnet-models/Cargo.toml` so it is built and tested as part of the workspace.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p bitnet-weight-name-normalization` and all unit tests passed (`4` tests passed).
- Ran `cargo test -p bitnet-models --test weight_name_normalization_integration` and the integration tests passed (`2` tests passed).
- Ran `cargo test -p bitnet-models --test weight_mapper_edge_cases` and the existing edge-case suite passed (`50` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b2f2ac388333b4a8a071b6811669)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weight name normalization for exporter drift, mapping non-standard tensor names to canonical formats.

* **Tests**
  * Added integration and unit tests to validate weight name normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->