### PR TITLE
refactor(server): extract IP header parsing into bitnet-server-security-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-runtime-bootstrap",
+ "bitnet-server-security-core",
  "bitnet-startup-contract-guard",
  "bitnet-tokenizers",
  "chrono",
@@ -1222,6 +1223,13 @@ dependencies = [
  "uuid",
  "vergen-gix",
  "walkdir",
+]
+
+[[package]]
+name = "bitnet-server-security-core"
+version = "0.2.1-dev"
+dependencies = [
+ "http",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
+  "crates/bitnet-server-security-core",
   "crates/bitnet-cli",
   "crates/bitnet-st2gguf",      # SafeTensors to GGUF converter
   "crates/bitnet-st-tools",     # SafeTensors inspection & merge utilities
@@ -118,6 +119,7 @@ default-members = [
   "crates/bitnet-sampling",
   "crates/bitnet-cli",
   "crates/bitnet-server",
+  "crates/bitnet-server-security-core",
   "crates/bitnet-st2gguf",
   # Testing infrastructure crates (always built/tested by default)
   "crates/bitnet-bdd-grid",

--- a/crates/bitnet-server-security-core/Cargo.toml
+++ b/crates/bitnet-server-security-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-server-security-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP microcrate for server-side security header/IP parsing primitives"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+http = "1.3.1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-server-security-core/src/lib.rs
+++ b/crates/bitnet-server-security-core/src/lib.rs
@@ -1,0 +1,64 @@
+//! Shared security parsing primitives for server transports.
+
+use http::HeaderMap;
+use std::net::IpAddr;
+
+/// Extract a client IP from common proxy headers.
+///
+/// Priority:
+/// 1. `x-forwarded-for` (first comma-separated entry)
+/// 2. `x-real-ip`
+#[must_use]
+pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
+    // Try X-Forwarded-For header first (for reverse proxies)
+    if let Some(forwarded) = headers.get("x-forwarded-for")
+        && let Ok(forwarded_str) = forwarded.to_str()
+        && let Some(first_ip) = forwarded_str.split(',').next()
+        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    // Try X-Real-IP header
+    if let Some(real_ip) = headers.get("x-real-ip")
+        && let Ok(ip_str) = real_ip.to_str()
+        && let Ok(ip) = ip_str.parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn takes_first_x_forwarded_for_entry() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.7, 198.51.100.2".parse().unwrap());
+        headers.insert("x-real-ip", "198.51.100.2".parse().unwrap());
+
+        let parsed = extract_client_ip_from_headers(&headers);
+        assert_eq!(parsed, Some("203.0.113.7".parse().unwrap()));
+    }
+
+    #[test]
+    fn falls_back_to_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "203.0.113.10".parse().unwrap());
+
+        let parsed = extract_client_ip_from_headers(&headers);
+        assert_eq!(parsed, Some("203.0.113.10".parse().unwrap()));
+    }
+
+    #[test]
+    fn invalid_values_return_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "invalid-ip".parse().unwrap());
+
+        let parsed = extract_client_ip_from_headers(&headers);
+        assert_eq!(parsed, None);
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -27,6 +27,7 @@ bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+bitnet-server-security-core = { path = "../bitnet-server-security-core", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true
 clap.workspace = true

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -13,6 +13,8 @@ use std::net::IpAddr;
 use std::sync::Arc;
 use tracing::{debug, warn};
 
+pub use bitnet_server_security_core::extract_client_ip_from_headers;
+
 /// Security configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SecurityConfig {
@@ -348,29 +350,6 @@ pub async fn ip_blocking_middleware(
 /// Extract client IP from request
 fn extract_client_ip(request: &Request) -> Option<IpAddr> {
     extract_client_ip_from_headers(request.headers())
-}
-
-/// Extract client IP from headers (shared utility)
-pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    // Try X-Forwarded-For header first (for reverse proxies)
-    if let Some(forwarded) = headers.get("x-forwarded-for")
-        && let Ok(forwarded_str) = forwarded.to_str()
-        && let Some(first_ip) = forwarded_str.split(',').next()
-        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Try X-Real-IP header
-    if let Some(real_ip) = headers.get("x-real-ip")
-        && let Ok(ip_str) = real_ip.to_str()
-        && let Ok(ip) = ip_str.parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Fall back to connection info (would need to be passed from the server)
-    None
 }
 
 /// CORS middleware configuration


### PR DESCRIPTION
### Motivation
- Isolate the transport/header parsing concern behind a small SRP microcrate so IP-parsing can be reused and tested independently of Axum middleware orchestration. 
- Reduce duplication and improve separation of concerns by moving `extract_client_ip_from_headers` out of the `bitnet-server` module.

### Description
- Add new microcrate `crates/bitnet-server-security-core` providing `extract_client_ip_from_headers` and focused unit tests (`crates/bitnet-server-security-core/Cargo.toml` and `src/lib.rs`).
- Remove the in-module implementation from `crates/bitnet-server/src/security.rs` and make `bitnet-server` depend on and re-export the extracted function with `pub use bitnet_server_security_core::extract_client_ip_from_headers;` so existing call-sites remain compatible.
- Wire the new crate into the workspace and default build set by updating the root `Cargo.toml` and the server `Cargo.toml`, and add the new entry to `Cargo.lock`.

### Testing
- Ran `cargo fmt` to ensure formatting changes were applied successfully.
- Ran `cargo test -p bitnet-server-security-core` and all unit tests passed (3 passed, 0 failed).
- Attempted `cargo test -p bitnet-server server_security_tests`; compilation began successfully but the full server test run was long-running in this environment and thus inconclusive within the session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b2f5baac8333bd55c4475ee4041b)