### PR TITLE
Extract runtime fingerprint collection into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
+ "bitnet-runtime-fingerprint-core",
  "bitnet-startup-contract-guard",
  "bitnet-tokenizer-discovery-core",
  "bitnet-tokenizers",
@@ -1076,10 +1077,10 @@ dependencies = [
  "bitnet-common",
  "bitnet-honest-compute",
  "bitnet-kernels",
+ "bitnet-runtime-fingerprint-core",
  "chrono",
  "insta",
  "proptest",
- "rustc_version_runtime",
  "serde",
  "serde_json",
  "tempfile",
@@ -1153,6 +1154,15 @@ dependencies = [
  "insta",
  "proptest",
  "serde_json",
+]
+
+[[package]]
+name = "bitnet-runtime-fingerprint-core"
+version = "0.2.1-dev"
+dependencies = [
+ "rustc_version_runtime",
+ "serial_test",
+ "temp-env",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ members = [
   "crates/bitnet-runtime-profile-core",
   "crates/bitnet-runtime-profile-contract",
   "crates/bitnet-runtime-profile-contract-core",
+  "crates/bitnet-runtime-fingerprint-core",
   "crates/bitnet-testing-profile",
   "crates/bitnet-testing-scenarios",
   "crates/bitnet-testing-policy-core",
@@ -139,6 +140,7 @@ default-members = [
   "crates/bitnet-testing-policy-core",
   "crates/bitnet-testing-scenarios-core",
   "crates/bitnet-runtime-profile-core",
+  "crates/bitnet-runtime-fingerprint-core",
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
   "crates/bitnet-logits",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -37,6 +37,7 @@ bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", ver
 bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-cli-sampling-core = { path = "../bitnet-cli-sampling-core", version = "0.2.1-dev" }
+bitnet-runtime-fingerprint-core = { path = "../bitnet-runtime-fingerprint-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true

--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -59,6 +59,7 @@ use tracing::{debug, error, info, warn};
 
 use bitnet_inference::{InferenceEngine, KernelRecorder, SamplingConfig, TemplateType};
 use bitnet_models::ModelLoader;
+use bitnet_runtime_fingerprint_core::collect_runtime_fingerprint;
 use bitnet_tokenizers::Tokenizer;
 use candle_core::Device;
 
@@ -977,15 +978,6 @@ impl InferenceCommand {
         // Determine backend from device
         let backend = self.device.as_deref().unwrap_or("cpu");
 
-        // Capture runtime environment (similar to xtask benchmark)
-        let rust_version = std::process::Command::new("rustc")
-            .arg("--version")
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default();
-
         // Build receipt JSON (matching xtask format)
         // Capture actual kernel IDs from engine telemetry
         let mut kernels = if let Some(recorder) = engine.kernel_recorder() {
@@ -1021,11 +1013,7 @@ impl InferenceCommand {
             "deterministic": self.deterministic || self.greedy,
             "tokens_generated": tokens_generated,
             "kernels": kernels,
-            "environment": {
-                "BITNET_VERSION": env!("CARGO_PKG_VERSION"),
-                "OS": format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
-                "RUST_VERSION": rust_version,
-            },
+            "environment": collect_runtime_fingerprint(env!("CARGO_PKG_VERSION")),
             "model": {
                 "path": self.model.as_ref().map(|p| p.display().to_string()).unwrap_or_default()
             }

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.1-dev" }
+bitnet-runtime-fingerprint-core = { path = "../bitnet-runtime-fingerprint-core", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
-rustc_version_runtime = "0.3.0"
 
 [features]
 gpu = ["dep:bitnet-kernels", "bitnet-kernels/gpu"]

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -19,6 +19,7 @@ use bitnet_honest_compute::{
     classify_compute_path, validate_compute_path as validate_honest_compute_path,
     validate_kernel_ids as validate_honest_kernel_ids,
 };
+use bitnet_runtime_fingerprint_core::collect_runtime_fingerprint;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -288,34 +289,9 @@ impl InferenceReceipt {
 
     /// Collect relevant environment variables
     fn collect_env_vars() -> HashMap<String, String> {
-        let mut env_vars = HashMap::new();
+        let mut env_vars = collect_runtime_fingerprint(env!("CARGO_PKG_VERSION"));
 
-        // Determinism variables
-        if let Ok(val) = std::env::var("BITNET_DETERMINISTIC") {
-            env_vars.insert("BITNET_DETERMINISTIC".to_string(), val);
-        }
-        if let Ok(val) = std::env::var("BITNET_SEED") {
-            env_vars.insert("BITNET_SEED".to_string(), val);
-        }
-        if let Ok(val) = std::env::var("RAYON_NUM_THREADS") {
-            env_vars.insert("RAYON_NUM_THREADS".to_string(), val);
-        }
-
-        // Model path
-        if let Ok(val) = std::env::var("BITNET_GGUF") {
-            env_vars.insert("BITNET_GGUF".to_string(), val);
-        }
-
-        // System info
-        env_vars.insert("RUST_VERSION".to_string(), rustc_version_runtime::version().to_string());
-        env_vars.insert("BITNET_VERSION".to_string(), env!("CARGO_PKG_VERSION").to_string());
-        env_vars.insert(
-            "OS".to_string(),
-            format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
-        );
-
-        // Add CPU and GPU fingerprints (best-effort)
-        env_vars.insert("CPU_BRAND".to_string(), detect_cpu_brand());
+        // Add GPU fingerprints (best-effort)
         if let Some(gpu_info) = detect_gpu_info() {
             env_vars.insert("GPU_INFO".to_string(), gpu_info);
         }
@@ -573,22 +549,6 @@ impl InferenceReceipt {
 
 /// Detect CPU brand string (best-effort).
 /// Linux: reads `/proc/cpuinfo` model name; otherwise returns arch.
-fn detect_cpu_brand() -> String {
-    #[cfg(target_os = "linux")]
-    {
-        if let Ok(content) = std::fs::read_to_string("/proc/cpuinfo") {
-            for line in content.lines() {
-                if line.starts_with("model name")
-                    && let Some(brand) = line.split(':').nth(1)
-                {
-                    return brand.trim().to_string();
-                }
-            }
-        }
-    }
-    std::env::consts::ARCH.to_string()
-}
-
 /// Detect GPU information (best-effort)
 ///
 /// Uses bitnet-kernels GPU utilities to detect available GPUs.

--- a/crates/bitnet-runtime-fingerprint-core/Cargo.toml
+++ b/crates/bitnet-runtime-fingerprint-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-runtime-fingerprint-core"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SRP microcrate for collecting runtime environment fingerprints"
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+rustc_version_runtime = "0.3.0"
+
+[dev-dependencies]
+temp-env = { workspace = true }
+serial_test = { workspace = true }

--- a/crates/bitnet-runtime-fingerprint-core/src/lib.rs
+++ b/crates/bitnet-runtime-fingerprint-core/src/lib.rs
@@ -1,0 +1,85 @@
+//! Runtime fingerprint helpers shared by receipts and CLI tools.
+
+use std::collections::HashMap;
+
+/// Collect common runtime variables used in inference receipts.
+///
+/// Includes deterministic knobs when present and always reports Rust/BitNet/OS/CPU identity.
+pub fn collect_runtime_fingerprint(bitnet_version: &str) -> HashMap<String, String> {
+    let mut env_vars = HashMap::new();
+
+    for key in ["BITNET_DETERMINISTIC", "BITNET_SEED", "RAYON_NUM_THREADS", "BITNET_GGUF"] {
+        if let Ok(val) = std::env::var(key) {
+            env_vars.insert(key.to_string(), val);
+        }
+    }
+
+    env_vars.insert("RUST_VERSION".to_string(), rustc_version_runtime::version().to_string());
+    env_vars.insert("BITNET_VERSION".to_string(), bitnet_version.to_string());
+    env_vars
+        .insert("OS".to_string(), format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH));
+    env_vars.insert("CPU_BRAND".to_string(), detect_cpu_brand());
+
+    env_vars
+}
+
+/// Detect CPU brand/model string (best-effort).
+pub fn detect_cpu_brand() -> String {
+    if cfg!(target_os = "linux") {
+        if let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo") {
+            for line in cpuinfo.lines() {
+                if let Some(brand) = line.strip_prefix("model name\t: ") {
+                    return brand.trim().to_string();
+                }
+            }
+        }
+    }
+
+    if cfg!(target_os = "macos") {
+        if let Ok(output) =
+            std::process::Command::new("sysctl").args(["-n", "machdep.cpu.brand_string"]).output()
+            && output.status.success()
+            && let Ok(brand) = String::from_utf8(output.stdout)
+        {
+            return brand.trim().to_string();
+        }
+    }
+
+    std::env::consts::ARCH.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial(bitnet_env)]
+    fn includes_required_static_keys() {
+        let vars = collect_runtime_fingerprint("9.9.9-test");
+        assert!(vars.contains_key("RUST_VERSION"));
+        assert_eq!(vars.get("BITNET_VERSION"), Some(&"9.9.9-test".to_string()));
+        assert!(vars.contains_key("OS"));
+        assert!(vars.contains_key("CPU_BRAND"));
+    }
+
+    #[test]
+    #[serial(bitnet_env)]
+    fn includes_optional_env_when_present() {
+        temp_env::with_vars(
+            [
+                ("BITNET_DETERMINISTIC", Some("1")),
+                ("BITNET_SEED", Some("42")),
+                ("RAYON_NUM_THREADS", Some("8")),
+                ("BITNET_GGUF", Some("/tmp/model.gguf")),
+            ],
+            || {
+                let vars = collect_runtime_fingerprint("0.0.0");
+                assert_eq!(vars.get("BITNET_DETERMINISTIC"), Some(&"1".to_string()));
+                assert_eq!(vars.get("BITNET_SEED"), Some(&"42".to_string()));
+                assert_eq!(vars.get("RAYON_NUM_THREADS"), Some(&"8".to_string()));
+                assert_eq!(vars.get("BITNET_GGUF"), Some(&"/tmp/model.gguf".to_string()));
+            },
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce duplication by moving runtime/receipt environment fingerprint logic into a single SRP microcrate so multiple consumers (CLI, receipts) share a single implementation.
- Improve single-responsibility separation for small, well-scoped helpers that are useful across crates (BITNET_*/RAYON vars, Rust/BitNet/OS/CPU identity).
- Make receipts and CLI use a consistent environment snapshot to simplify validation and downstream baselines.

### Description
- Add a new microcrate `crates/bitnet-runtime-fingerprint-core` providing `collect_runtime_fingerprint` and `detect_cpu_brand` to centralize runtime/environment fingerprint collection.
- Wire `crates/bitnet-receipts-core` to call `collect_runtime_fingerprint` and keep only GPU augmentation locally, removing duplicated env collection and `rustc_version_runtime` usage.
- Update `crates/bitnet-cli` to use `collect_runtime_fingerprint` for receipt emission and remove the local `rustc --version` probing path.
- Register the new microcrate in the workspace `Cargo.toml` (members and `default-members`) and add the dependency entries in affected crate `Cargo.toml` files.

### Testing
- Ran formatting with `cargo fmt` and the tree was formatted successfully.
- Executed `cargo test -p bitnet-runtime-fingerprint-core` which passed all unit tests (2 passed).
- Executed `cargo test -p bitnet-receipts-core` which passed the full test suite for that crate (30 passed).
- Ran `cargo check -p bitnet-cli` which completed successfully with no compile errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98b3f1083339135d843b3a46c01)