### PR TITLE
Extract scoring primitives into new bitnet-scoring-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
+ "bitnet-scoring-core",
  "bitnet-startup-contract-guard",
  "bitnet-tokenizer-discovery-core",
  "bitnet-tokenizers",
@@ -1211,6 +1212,13 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "tracing",
+]
+
+[[package]]
+name = "bitnet-scoring-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-eval-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server",
   "crates/bitnet-cli-sampling-core", # SRP: reusable CLI sampling primitives
+  "crates/bitnet-scoring-core", # SRP: reusable NLL/logit scoring primitives
   "crates/bitnet-cli",
   "crates/bitnet-st2gguf",      # SafeTensors to GGUF converter
   "crates/bitnet-safetensors-ln", # SRP: shared SafeTensors LayerNorm utilities
@@ -129,6 +130,7 @@ default-members = [
   "crates/bitnet-sampling",
   "crates/bitnet-cli-sampling-core", # SRP: reusable CLI sampling primitives
   "crates/bitnet-cli",
+  "crates/bitnet-scoring-core",
   "crates/bitnet-server",
   "crates/bitnet-st2gguf",
   # Testing infrastructure crates (always built/tested by default)

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -37,6 +37,7 @@ bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", ver
 bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-cli-sampling-core = { path = "../bitnet-cli-sampling-core", version = "0.2.1-dev" }
+bitnet-scoring-core = { path = "../bitnet-scoring-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true
 anyhow.workspace = true

--- a/crates/bitnet-cli/src/commands/eval.rs
+++ b/crates/bitnet-cli/src/commands/eval.rs
@@ -6,31 +6,12 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 use tracing::{debug, info, warn};
 
-use bitnet_eval_core::{log_softmax_stable, topk_stable_indices};
+use bitnet_eval_core::topk_stable_indices;
 use bitnet_inference::InferenceEngine;
 use bitnet_models::ModelLoader;
+use bitnet_scoring_core::{NllStats, observe_target_nll, sanitize_logits_in_place};
 
 use crate::config::CliConfig;
-
-/// Running sum of NLL and the number of predicted tokens (T-1)
-#[derive(Clone, Copy, Debug, Default)]
-struct NllStats {
-    sum: f64,      // total negative log-likelihood over predicted tokens
-    tokens: usize, // number of predicted tokens (T-1), padding excluded
-}
-
-impl NllStats {
-    #[inline]
-    fn mean(self) -> f64 {
-        if self.tokens > 0 { self.sum / self.tokens as f64 } else { 0.0 }
-    }
-
-    #[inline]
-    fn add(&mut self, other: NllStats) {
-        self.sum += other.sum;
-        self.tokens += other.tokens;
-    }
-}
 
 /// Evaluate model perplexity and performance
 #[derive(Debug, Args)]
@@ -419,12 +400,8 @@ impl EvalCommand {
             let mut logits =
                 engine.eval_ids(&prefix).await.context("eval_ids in teacher-forcing")?;
 
-            // Demote NaNs for robustness
-            for v in &mut logits {
-                if !v.is_finite() {
-                    *v = f32::NEG_INFINITY;
-                }
-            }
+            // Demote non-finite values for robustness
+            sanitize_logits_in_place(&mut logits);
 
             // Skip padding tokens if specified
             if let Some(pid) = pad_id
@@ -434,15 +411,11 @@ impl EvalCommand {
                 continue;
             }
 
-            // Compute log probabilities
-            let logp = log_softmax_stable(&logits);
             let target = current_token as usize;
-            let lp = *logp
-                .get(target)
-                .ok_or_else(|| anyhow::anyhow!("target index {} out of bounds", target))?;
-
-            stats.sum -= lp as f64;
-            stats.tokens += 1;
+            if target >= logits.len() {
+                anyhow::bail!("target index {} out of bounds", target);
+            }
+            observe_target_nll(&mut stats, &logits, target);
 
             prefix.push(current_token);
         }
@@ -489,7 +462,7 @@ impl EvalCommand {
         let elapsed = start.elapsed();
         let elapsed_ms = elapsed.as_secs_f64() * 1000.0;
         let mean_nll = agg.mean();
-        let perplexity = mean_nll.exp();
+        let perplexity = agg.perplexity();
         let predicted = agg.tokens.max(1); // T-1 token count
 
         Ok(EvalResults {
@@ -538,7 +511,7 @@ impl EvalCommand {
         };
 
         let mean_nll = stats.mean();
-        let perplexity = mean_nll.exp();
+        let perplexity = stats.perplexity();
         let predicted = stats.tokens.max(1);
 
         // Optional logits dump (teacher-forced)
@@ -548,12 +521,8 @@ impl EvalCommand {
                 for (step, t) in (0..(tf_ids.len() - 1)).take(steps).enumerate() {
                     let mut logits: Vec<f32> = engine.eval_ids(&tf_ids[..=t]).await?;
 
-                    // Demote NaNs to -inf
-                    for v in &mut logits {
-                        if !v.is_finite() {
-                            *v = f32::NEG_INFINITY;
-                        }
-                    }
+                    // Demote non-finite values to -inf
+                    sanitize_logits_in_place(&mut logits);
 
                     let k = self.logits_topk.min(logits.len());
                     let idx = topk_stable_indices(&logits, k);

--- a/crates/bitnet-cli/src/score.rs
+++ b/crates/bitnet-cli/src/score.rs
@@ -4,9 +4,9 @@ use serde_json::json;
 use std::{fs, path::PathBuf, sync::Arc, time::Instant};
 
 use bitnet_common::Device as BNDevice;
-use bitnet_eval_core::log_softmax_stable;
 use bitnet_inference::InferenceEngine;
 use bitnet_models::{GgufReader, ModelLoader};
+use bitnet_scoring_core::{NllStats, observe_target_nll, sanitize_logits_in_place};
 use candle_core::Device;
 
 #[derive(Args, Debug)]
@@ -84,8 +84,7 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
     let lines: Vec<&str> = data.lines().filter(|l| !l.trim().is_empty()).collect();
 
     let start = Instant::now();
-    let mut total_tokens: usize = 0; // predicted tokens (T-1)
-    let mut total_nll: f64 = 0.0;
+    let mut stats = NllStats::default();
 
     'outer: for chunk in lines.chunks(args.batch_size) {
         for line in chunk {
@@ -95,7 +94,7 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
             }
 
             let max_steps = if args.max_tokens > 0 {
-                args.max_tokens.saturating_sub(total_tokens).min(ids.len() - 1)
+                args.max_tokens.saturating_sub(stats.tokens).min(ids.len() - 1)
             } else {
                 ids.len() - 1
             };
@@ -104,17 +103,14 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
             prefix.push(ids[0]);
             for t in 0..max_steps {
                 let mut logits = engine.eval_ids(&prefix).await?;
-                for v in &mut logits {
-                    if !v.is_finite() {
-                        *v = f32::NEG_INFINITY;
-                    }
-                }
-                let logp = log_softmax_stable(&logits);
+                sanitize_logits_in_place(&mut logits);
                 let target = ids[t + 1] as usize;
-                total_nll -= logp[target] as f64;
-                total_tokens += 1;
+                if target >= logits.len() {
+                    anyhow::bail!("target index {} out of bounds", target);
+                }
+                observe_target_nll(&mut stats, &logits, target);
                 prefix.push(ids[t + 1]);
-                if args.max_tokens > 0 && total_tokens >= args.max_tokens {
+                if args.max_tokens > 0 && stats.tokens >= args.max_tokens {
                     break 'outer;
                 }
             }
@@ -123,15 +119,15 @@ pub async fn run_score(args: &ScoreArgs) -> Result<()> {
 
     let tokenizer_origin = if args.tokenizer.is_some() { "external" } else { "embedded" };
 
-    let mean_nll = if total_tokens > 0 { total_nll / total_tokens as f64 } else { 0.0 };
-    let ppl = mean_nll.exp();
+    let mean_nll = stats.mean();
+    let ppl = stats.perplexity();
     let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
 
     let out = json!({
         "type": "score",
         "model": args.model.display().to_string(),
         "dataset": args.file.display().to_string(),
-        "tokens": total_tokens,
+        "tokens": stats.tokens,
         "mean_nll": mean_nll,
         "ppl": ppl,
         "latency": { "total_ms": latency_ms },

--- a/crates/bitnet-scoring-core/Cargo.toml
+++ b/crates/bitnet-scoring-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-scoring-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP scoring primitives extracted from bitnet-cli"
+
+[dependencies]
+bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-scoring-core/src/lib.rs
+++ b/crates/bitnet-scoring-core/src/lib.rs
@@ -1,0 +1,92 @@
+//! Shared scoring primitives for negative log-likelihood evaluation.
+
+/// Running sum of NLL and the number of predicted tokens (T-1).
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct NllStats {
+    /// Total negative log-likelihood over predicted tokens.
+    pub sum: f64,
+    /// Number of predicted tokens (T-1), padding excluded.
+    pub tokens: usize,
+}
+
+impl NllStats {
+    /// Mean negative log-likelihood.
+    #[must_use]
+    #[inline]
+    pub fn mean(self) -> f64 {
+        if self.tokens > 0 { self.sum / self.tokens as f64 } else { 0.0 }
+    }
+
+    /// Perplexity computed as `exp(mean_nll)`.
+    #[must_use]
+    #[inline]
+    pub fn perplexity(self) -> f64 {
+        self.mean().exp()
+    }
+
+    /// Accumulate another stats sample.
+    #[inline]
+    pub fn add(&mut self, other: NllStats) {
+        self.sum += other.sum;
+        self.tokens += other.tokens;
+    }
+
+    /// Add one observed log-probability for a target token.
+    #[inline]
+    pub fn observe_logprob(&mut self, log_prob: f32) {
+        self.sum -= log_prob as f64;
+        self.tokens += 1;
+    }
+}
+
+/// Replaces any non-finite logit value with `NEG_INFINITY`.
+#[inline]
+pub fn sanitize_logits_in_place(logits: &mut [f32]) {
+    for v in logits {
+        if !v.is_finite() {
+            *v = f32::NEG_INFINITY;
+        }
+    }
+}
+
+/// Accumulate NLL from a target token index using stable log-softmax.
+#[inline]
+pub fn observe_target_nll(stats: &mut NllStats, logits: &[f32], target: usize) {
+    let logp = bitnet_eval_core::log_softmax_stable(logits);
+    stats.observe_logprob(logp[target]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nll_stats_mean_and_perplexity_are_stable_on_empty() {
+        let stats = NllStats::default();
+        assert_eq!(stats.mean(), 0.0);
+        assert_eq!(stats.perplexity(), 1.0);
+    }
+
+    #[test]
+    fn nll_stats_accumulates_observations() {
+        let mut stats = NllStats::default();
+        stats.observe_logprob(-0.5);
+        stats.observe_logprob(-1.5);
+
+        assert_eq!(stats.tokens, 2);
+        assert!((stats.sum - 2.0).abs() < 1e-9);
+        assert!((stats.mean() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn sanitize_logits_maps_nan_and_infinity_to_neg_inf() {
+        let mut logits = vec![1.0, f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -2.0];
+        sanitize_logits_in_place(&mut logits);
+
+        assert_eq!(logits[0], 1.0);
+        assert_eq!(logits[1], f32::NEG_INFINITY);
+        assert_eq!(logits[2], f32::NEG_INFINITY);
+        assert_eq!(logits[3], f32::NEG_INFINITY);
+        assert_eq!(logits[4], -2.0);
+    }
+}


### PR DESCRIPTION
### Motivation
- Eliminate duplicated/ad-hoc scoring logic in the CLI by extracting NLL/logit scoring helpers into a single SRP microcrate.
- Provide a small, well-tested API (`NllStats`, logit sanitization, target-NLL observation) that other crates can reuse.

### Description
- Add new workspace crate `crates/bitnet-scoring-core` that exposes `NllStats`, `sanitize_logits_in_place`, and `observe_target_nll` and includes unit tests.
- Wire the new crate into the workspace `Cargo.toml` and add it as a dependency of `crates/bitnet-cli`.
- Refactor `crates/bitnet-cli/src/commands/eval.rs` to remove the local `NllStats`/sanitization logic and call the shared `bitnet-scoring-core` helpers instead, including using `NllStats::perplexity()`.
- Refactor `crates/bitnet-cli/src/score.rs` to use the shared scoring primitives for sanitization and NLL accumulation and to report totals from `NllStats`.

### Testing
- Ran `cargo fmt --all` to normalize formatting and it completed successfully.
- Ran `cargo test -p bitnet-scoring-core` and all unit tests in the new crate passed (3 passed, 0 failed).
- Ran `cargo test -p bitnet-cli --no-run` to ensure the CLI tests and binary build; compilation completed (tests compile with existing deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98b3f1083339135d843b3a46c01)