### PR TITLE
Extract download-core microcrate for validation and atomic metadata writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,17 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
  "reqwest",
+]
+
+[[package]]
+name = "bitnet-download-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-download-core"
+version = "0.2.1-dev"
+edition = "2024"
+description = "Core download validation and file helpers for BitNet"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/BitNet-Project/BitNet"
+
+[dependencies]
+thiserror = { workspace = true }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,0 +1,99 @@
+use std::{fs, path::Path};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Returns true when download logic should operate in offline mode.
+#[must_use]
+pub fn offline_enabled(cli_offline: bool) -> bool {
+    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+
+    #[test]
+    fn offline_env_var_enables_mode() {
+        unsafe {
+            std::env::set_var("BITNET_OFFLINE", "1");
+        }
+        assert!(offline_enabled(false));
+        unsafe {
+            std::env::remove_var("BITNET_OFFLINE");
+        }
+    }
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        let p = tmp.path().join("meta.txt");
+        atomic_write(&p, b"etag").expect("atomic write");
+        assert_eq!(std::fs::read_to_string(&p).expect("read output"), "etag");
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,9 +10,9 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,20 +1,11 @@
+pub use bitnet_download_core::{
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
+};
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
-use thiserror::Error;
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DownloadValidationError {
-    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
-    Truncated { downloaded: u64, expected: u64 },
-}
-
-/// Returns true when download logic should operate in offline mode.
-#[must_use]
-pub fn offline_enabled(cli_offline: bool) -> bool {
-    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
-}
+use std::time::SystemTime;
 
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
@@ -27,51 +18,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
-#[must_use]
-pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
-}
-
-/// Ensure downloaded bytes match expected total when available.
-pub fn validate_downloaded_len(
-    downloaded: u64,
-    expected_total: Option<u64>,
-) -> Result<(), DownloadValidationError> {
-    if let Some(expected) = expected_total
-        && downloaded != expected
-    {
-        return Err(DownloadValidationError::Truncated { downloaded, expected });
-    }
-    Ok(())
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -120,21 +66,5 @@ mod tests {
         assert_eq!(exp_backoff_ms(2), 474);
         assert_eq!(exp_backoff_ms(3), 911);
         assert_eq!(exp_backoff_ms(10), 10_170);
-    }
-
-    #[test]
-    fn parses_content_range_total() {
-        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
-        assert_eq!(parse_content_range_total("invalid"), None);
-    }
-
-    #[test]
-    fn validates_downloaded_len() {
-        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
-        assert!(validate_downloaded_len(1024, None).is_ok());
-        assert!(matches!(
-            validate_downloaded_len(1, Some(2)),
-            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
-        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Improve SRP by extracting transport-agnostic download invariants and filesystem helpers out of the HTTP-focused `bitnet-download` crate. 
- Make core download utilities reusable without pulling in `reqwest` or HTTP-specific dependencies.

### Description
- Add a new microcrate `crates/bitnet-download-core` that implements `DownloadValidationError`, `offline_enabled`, `parse_content_range_total`, `validate_downloaded_len`, and `atomic_write` and includes unit tests. 
- Rework `crates/bitnet-download` to depend on and re-export the core helpers while keeping HTTP `Retry-After` parsing and backoff logic (`retry_after_secs`, `retry_after_secs_at`, `exp_backoff_ms`).
- Wire the new crate into the workspace by adding `crates/bitnet-download-core` to `Cargo.toml` and update `crates/bitnet-download/Cargo.toml` to depend on `bitnet-download-core`.
- Run `cargo fmt` to normalize formatting and update manifests so the split compiles cleanly.

### Testing
- Ran `cargo fmt` successfully to format the workspace. 
- Ran `cargo test -p bitnet-download-core -p bitnet-download` which executed the unit tests (4 tests in `bitnet-download-core` and 4 tests in `bitnet-download`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98b3f1083339135d843b3a46c01)