### PR TITLE
Extract download utility primitives into bitnet-download-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,16 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
  "reqwest",
+]
+
+[[package]]
+name = "bitnet-download-core"
+version = "0.2.1-dev"
+dependencies = [
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-core", # SRP: reusable download primitives core
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
@@ -151,6 +152,7 @@ default-members = [
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-core", # SRP: reusable download primitives core
 ]
 
 [package]

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-download-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Core SRP download primitives for offline mode, byte-range parsing, and atomic metadata writes"
+
+[dependencies]
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,0 +1,80 @@
+use std::{fs, path::Path};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Returns true when download logic should operate in offline mode.
+#[must_use]
+pub fn offline_enabled(cli_offline: bool) -> bool {
+    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,9 +10,9 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,20 +1,11 @@
+pub use bitnet_download_core::{
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
+};
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
-use thiserror::Error;
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DownloadValidationError {
-    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
-    Truncated { downloaded: u64, expected: u64 },
-}
-
-/// Returns true when download logic should operate in offline mode.
-#[must_use]
-pub fn offline_enabled(cli_offline: bool) -> bool {
-    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
-}
+use std::time::SystemTime;
 
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
@@ -27,51 +18,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
-#[must_use]
-pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
-}
-
-/// Ensure downloaded bytes match expected total when available.
-pub fn validate_downloaded_len(
-    downloaded: u64,
-    expected_total: Option<u64>,
-) -> Result<(), DownloadValidationError> {
-    if let Some(expected) = expected_total
-        && downloaded != expected
-    {
-        return Err(DownloadValidationError::Truncated { downloaded, expected });
-    }
-    Ok(())
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -120,21 +66,5 @@ mod tests {
         assert_eq!(exp_backoff_ms(2), 474);
         assert_eq!(exp_backoff_ms(3), 911);
         assert_eq!(exp_backoff_ms(10), 10_170);
-    }
-
-    #[test]
-    fn parses_content_range_total() {
-        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
-        assert_eq!(parse_content_range_total("invalid"), None);
-    }
-
-    #[test]
-    fn validates_downloaded_len() {
-        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
-        assert!(validate_downloaded_len(1024, None).is_ok());
-        assert!(matches!(
-            validate_downloaded_len(1, Some(2)),
-            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
-        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce coupling by moving download-related filesystem and parsing primitives out of the HTTP-bound crate so downstream code can depend on a minimal core API.
- Improve SRP adherence by making `bitnet-download` a thin HTTP/retry façade and placing pure utilities (metadata writes, byte-range parsing, validation, offline detection) into a reusable microcrate.

### Description
- Added a new microcrate `crates/bitnet-download-core` exposing `offline_enabled`, `parse_content_range_total`, `validate_downloaded_len`, `atomic_write`, and the `DownloadValidationError` type with unit tests moved into the new crate.
- Rewrote `crates/bitnet-download` as a thin façade that re-exports the core primitives and retains only HTTP header/retry behavior (`retry_after_secs`, `retry_after_secs_at`, and `exp_backoff_ms`).
- Updated `crates/bitnet-download/Cargo.toml` to depend on `bitnet-download-core` and added the new crate to the workspace `members`/`default-members` in the root `Cargo.toml`.
- Kept test coverage and examples unchanged; preserved semantics of the moved functions so downstream callers see no behavioral change.

### Testing
- Ran formatter with `cargo fmt` successfully.
- Ran unit tests with `cargo test -p bitnet-download-core -p bitnet-download` and all tests passed.
- Performed a lightweight build check with `cargo check -p bitnet-download -p bitnet-download-core` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98b3f1083339135d843b3a46c01)