### PR TITLE
refactor(tokenizers): extract ModelTypeDetector into dedicated microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-tokenizer-model-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-common",
+]
+
+[[package]]
 name = "bitnet-tokenizers"
 version = "0.2.1-dev"
 dependencies = [
@@ -1597,6 +1604,7 @@ dependencies = [
  "bitnet-test-fixtures-core",
  "bitnet-test-support",
  "bitnet-tests",
+ "bitnet-tokenizer-model-core",
  "dirs",
  "futures-util",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "crates/bitnet-inference",
   "crates/bitnet-rope",
   "crates/bitnet-tokenizers",
+  "crates/bitnet-tokenizer-model-core", # SRP: tokenizer model/vocabulary detection helpers
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
@@ -118,6 +119,7 @@ default-members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
+  "crates/bitnet-tokenizer-model-core",
   "crates/bitnet-tokenizer-discovery-core",
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",

--- a/crates/bitnet-tokenizer-model-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-model-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitnet-tokenizer-model-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Core model/vocabulary detection helpers for tokenizers"
+
+[dependencies]
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+

--- a/crates/bitnet-tokenizer-model-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-model-core/src/lib.rs
@@ -1,0 +1,74 @@
+use bitnet_common::{BitNetError, Result};
+
+/// Model type detection utilities for neural-network tokenizers.
+pub struct ModelTypeDetector;
+
+impl ModelTypeDetector {
+    /// Detect model type from vocabulary size.
+    #[must_use]
+    pub fn detect_from_vocab_size(vocab_size: usize) -> String {
+        match vocab_size {
+            32000 => "llama2".to_string(),
+            128256 => "llama3".to_string(),
+            32016 => "codellama".to_string(),
+            50257 => "gpt2".to_string(),
+            _ => "unknown".to_string(),
+        }
+    }
+
+    /// Check if vocabulary size indicates a model that usually benefits from GPU acceleration.
+    #[must_use]
+    pub fn requires_gpu_acceleration(vocab_size: usize) -> bool {
+        vocab_size > 65536
+    }
+
+    /// Validate vocabulary size for tokenizer usage.
+    pub fn validate_vocab_size(vocab_size: usize) -> Result<()> {
+        if vocab_size == 0 {
+            return Err(BitNetError::Config("Vocabulary size cannot be zero".to_string()));
+        }
+
+        if vocab_size > 2_000_000 {
+            return Err(BitNetError::Config(format!(
+                "Vocabulary size {} exceeds reasonable limit (2M)",
+                vocab_size
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Expected vocabulary sizes for common model families.
+    #[must_use]
+    pub fn expected_vocab_size(model_type: &str) -> Option<usize> {
+        match model_type {
+            "llama2" => Some(32000),
+            "llama3" => Some(128256),
+            "codellama" => Some(32016),
+            "gpt2" => Some(50257),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModelTypeDetector;
+
+    #[test]
+    fn detects_known_vocab_sizes() {
+        assert_eq!(ModelTypeDetector::detect_from_vocab_size(32000), "llama2");
+        assert_eq!(ModelTypeDetector::detect_from_vocab_size(128256), "llama3");
+        assert_eq!(ModelTypeDetector::detect_from_vocab_size(32016), "codellama");
+        assert_eq!(ModelTypeDetector::detect_from_vocab_size(50257), "gpt2");
+        assert_eq!(ModelTypeDetector::detect_from_vocab_size(42), "unknown");
+    }
+
+    #[test]
+    fn validates_vocab_bounds() {
+        assert!(ModelTypeDetector::validate_vocab_size(1).is_ok());
+        assert!(ModelTypeDetector::validate_vocab_size(2_000_000).is_ok());
+        assert!(ModelTypeDetector::validate_vocab_size(0).is_err());
+        assert!(ModelTypeDetector::validate_vocab_size(2_000_001).is_err());
+    }
+}

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -20,6 +20,7 @@ include = [
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
+bitnet-tokenizer-model-core = { path = "../bitnet-tokenizer-model-core", version = "0.2.1-dev" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-tokenizers/src/discovery.rs
+++ b/crates/bitnet-tokenizers/src/discovery.rs
@@ -4,8 +4,8 @@
 //! Supports GGUF metadata parsing, smart downloading, and device-aware tokenization for production-scale models.
 
 use crate::{
-    Tokenizer,
-    error_handling::{CacheManager, ModelTypeDetector, TokenizerErrorHandler},
+    ModelTypeDetector, Tokenizer,
+    error_handling::{CacheManager, TokenizerErrorHandler},
 };
 use bitnet_common::{BitNetError, Result};
 use bitnet_models::GgufReader;
@@ -1200,7 +1200,7 @@ mod tests {
     use super::{ModelCompatibilityMatrix, TokenizerDiscovery};
     #[cfg(any(feature = "cpu", feature = "gpu"))]
     #[allow(unused_imports)]
-    use crate::error_handling::ModelTypeDetector;
+    use crate::ModelTypeDetector;
     #[cfg(feature = "cpu")]
     use crate::{BitNetError, CacheManager, TokenizerDownloadInfo, TokenizerStrategy};
     #[cfg(feature = "cpu")]

--- a/crates/bitnet-tokenizers/src/error_handling.rs
+++ b/crates/bitnet-tokenizers/src/error_handling.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result as AnyhowResult;
 use bitnet_common::{BitNetError, ModelError, Result};
+pub use bitnet_tokenizer_model_core::ModelTypeDetector;
 use std::path::{Path, PathBuf};
 use tracing::warn;
 //use crate::{CacheManager, ModelTypeDetector};
@@ -204,56 +205,6 @@ impl CacheManager {
             Ok(model_cache.join(format!("vocab_{}", size)))
         } else {
             Ok(model_cache)
-        }
-    }
-}
-
-/// Model type detection utilities for neural network tokenizers
-pub struct ModelTypeDetector;
-
-impl ModelTypeDetector {
-    /// Detect model type from vocabulary size and metadata
-    pub fn detect_from_vocab_size(vocab_size: usize) -> String {
-        match vocab_size {
-            32000 => "llama2".to_string(),
-            128256 => "llama3".to_string(),
-            32016 => "codellama".to_string(),
-            50257 => "gpt2".to_string(),
-            _ => "unknown".to_string(),
-        }
-    }
-
-    /// Check if vocabulary size indicates large model requiring GPU acceleration
-    pub fn requires_gpu_acceleration(vocab_size: usize) -> bool {
-        vocab_size > 65536
-    }
-
-    /// Validate vocabulary size is reasonable for neural network inference
-    pub fn validate_vocab_size(vocab_size: usize) -> Result<()> {
-        if vocab_size == 0 {
-            return Err(TokenizerErrorHandler::config_error(
-                "Vocabulary size cannot be zero".to_string(),
-            ));
-        }
-
-        if vocab_size > 2_000_000 {
-            return Err(TokenizerErrorHandler::config_error(format!(
-                "Vocabulary size {} exceeds reasonable limit (2M)",
-                vocab_size
-            )));
-        }
-
-        Ok(())
-    }
-
-    /// Get expected vocabulary size for known model types
-    pub fn expected_vocab_size(model_type: &str) -> Option<usize> {
-        match model_type {
-            "llama2" => Some(32000),
-            "llama3" => Some(128256),
-            "codellama" => Some(32016),
-            "gpt2" => Some(50257),
-            _ => None,
         }
     }
 }

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -46,9 +46,10 @@ pub use gguf_loader::{GgufTokKind, RustTokenizer};
 // BasicTokenizer is defined below in this module
 
 // New tokenizer discovery and strategy exports
+pub use bitnet_tokenizer_model_core::ModelTypeDetector;
 pub use discovery::{TokenizerDiscovery, TokenizerDownloadInfo, TokenizerStrategy};
 pub use download::{DownloadProgress, SmartTokenizerDownload};
-pub use error_handling::{CacheManager, ModelTypeDetector, TokenizerErrorHandler};
+pub use error_handling::{CacheManager, TokenizerErrorHandler};
 pub use fallback::TokenizerFallbackChain;
 pub use strategy::{
     BitNetTokenizerWrapper, Gpt2TokenizerWrapper, LlamaTokenizerWrapper, TokenizerStrategyResolver,

--- a/crates/bitnet-tokenizers/src/strategy.rs
+++ b/crates/bitnet-tokenizers/src/strategy.rs
@@ -4,10 +4,10 @@
 //! and BitNet models with proper special token handling and neural network-specific configurations.
 
 use crate::{
-    Tokenizer,
+    ModelTypeDetector, Tokenizer,
     discovery::{TokenizerDiscovery, TokenizerStrategy},
     download::SmartTokenizerDownload,
-    error_handling::{ModelTypeDetector, TokenizerErrorHandler},
+    error_handling::TokenizerErrorHandler,
 };
 use bitnet_common::QuantizationType;
 use bitnet_common::{BitNetError, Result};


### PR DESCRIPTION
### Motivation
- Separate reusable model/vocabulary detection logic from the larger tokenizer error/cache module to follow SRP and make detection utilities independently testable.
- Reduce coupling inside the tokenizer subsystem so other crates can depend on a focused microcrate for model-type heuristics.

### Description
- Added a new microcrate `crates/bitnet-tokenizer-model-core` that contains `ModelTypeDetector` and focused unit tests for detection and validation.
- Wired the new crate into the workspace and added it as a dependency of `crates/bitnet-tokenizers`, and updated `Cargo.toml` default-members accordingly.
- Removed the inline `ModelTypeDetector` implementation from `crates/bitnet-tokenizers/src/error_handling.rs` and re-export `ModelTypeDetector` from the tokenizer crate root so existing call sites remain compatible.
- Updated tokenizer modules (`discovery`, `strategy`, and `lib`) to import `ModelTypeDetector` from the crate root/re-export and applied `cargo fmt` for formatting.

### Testing
- Ran `cargo fmt` to normalize formatting and the command completed successfully.
- Ran `cargo test -p bitnet-tokenizer-model-core` and the crate's unit tests passed (`2 passed`).
- Ran `cargo test -p bitnet-tokenizers --test tokenizer_types_edge_cases -- --nocapture` and the tokenizer subsystem tests passed (`44 passed`).
- Ran `cargo test -p bitnet-tokenizers --test tokenizer_error_cache_edge_cases model_type_detector_roundtrip` which completed successfully (no tests matched the filter but the run finished without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b9884eb48333b73bf1199b795e5e)