### PR TITLE
Extract download validation into dedicated SRP core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,16 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-download-validate-core",
  "bitnet-http-retry",
  "httpdate",
  "reqwest",
+]
+
+[[package]]
+name = "bitnet-download-validate-core"
+version = "0.2.1-dev"
+dependencies = [
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-validate-core", # SRP: reusable download length/content-range validation core
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference
@@ -151,6 +152,7 @@ default-members = [
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
+  "crates/bitnet-download-validate-core", # SRP: reusable download length/content-range validation core
 ]
 
 [package]

--- a/crates/bitnet-download-validate-core/Cargo.toml
+++ b/crates/bitnet-download-validate-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-download-validate-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP core download validation primitives for content-range parsing and length checks"
+
+[dependencies]
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-download-validate-core/src/lib.rs
+++ b/crates/bitnet-download-validate-core/src/lib.rs
@@ -1,0 +1,47 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,9 +10,9 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-download-validate-core = { path = "../bitnet-download-validate-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,14 +1,10 @@
+pub use bitnet_download_validate_core::{
+    DownloadValidationError, parse_content_range_total, validate_downloaded_len,
+};
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
 use std::{fs, path::Path, time::SystemTime};
-use thiserror::Error;
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DownloadValidationError {
-    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
-    Truncated { downloaded: u64, expected: u64 },
-}
 
 /// Returns true when download logic should operate in offline mode.
 #[must_use]
@@ -27,25 +23,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
-#[must_use]
-pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
-}
-
-/// Ensure downloaded bytes match expected total when available.
-pub fn validate_downloaded_len(
-    downloaded: u64,
-    expected_total: Option<u64>,
-) -> Result<(), DownloadValidationError> {
-    if let Some(expected) = expected_total
-        && downloaded != expected
-    {
-        return Err(DownloadValidationError::Truncated { downloaded, expected });
-    }
-    Ok(())
 }
 
 /// Atomic write helper for small metadata files (etag/last-modified).
@@ -120,21 +97,5 @@ mod tests {
         assert_eq!(exp_backoff_ms(2), 474);
         assert_eq!(exp_backoff_ms(3), 911);
         assert_eq!(exp_backoff_ms(10), 10_170);
-    }
-
-    #[test]
-    fn parses_content_range_total() {
-        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
-        assert_eq!(parse_content_range_total("invalid"), None);
-    }
-
-    #[test]
-    fn validates_downloaded_len() {
-        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
-        assert!(validate_downloaded_len(1024, None).is_ok());
-        assert!(matches!(
-            validate_downloaded_len(1, Some(2)),
-            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
-        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Isolate pure download validation logic so `bitnet-download` focuses on orchestration (retry/offline/atomic writes) while validation rules remain dependency-light and reusable.
- Enable other crates to consume content-range/length validation without pulling in orchestration helpers or extra deps.

### Description
- Added a new microcrate `crates/bitnet-download-validate-core` that implements `DownloadValidationError`, `parse_content_range_total`, and `validate_downloaded_len` with unit tests.
- Updated `crates/bitnet-download` to depend on and re-export the moved symbols via `pub use bitnet_download_validate_core::{ DownloadValidationError, parse_content_range_total, validate_downloaded_len };` and removed the duplicated implementations.
- Wired the new crate into workspace `members` and `default-members` in `Cargo.toml` and updated `crates/bitnet-download/Cargo.toml` to reference the new crate.
- Cleaned up redundant `thiserror` usage inside `bitnet-download` and updated the workspace `Cargo.lock` entries to include the new crate.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran unit tests with `cargo test -p bitnet-download-validate-core -p bitnet-download` and all tests passed; `bitnet-download` tests (4) passed and `bitnet-download-validate-core` tests (2) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b9884eb48333b73bf1199b795e5e)