### PR TITLE
refactor: split server device config into bitnet-device-config-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-device-config-core"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
+ "bitnet-common",
+ "bitnet-kernels",
+ "serde",
+]
+
+[[package]]
 name = "bitnet-device-probe"
 version = "0.2.1-dev"
 dependencies = [
@@ -1222,6 +1232,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bitnet-common",
+ "bitnet-device-config-core",
  "bitnet-eval-core",
  "bitnet-inference",
  "bitnet-kernels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
   "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
+  "crates/bitnet-device-config-core", # SRP: shared device config parsing/resolution primitives
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-logits-filters", # SRP: reusable logits/probability filtering transforms
   "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events

--- a/crates/bitnet-device-config-core/Cargo.toml
+++ b/crates/bitnet-device-config-core/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bitnet-device-config-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for parsing and resolving BitNet device configuration"
+
+[dependencies]
+anyhow.workspace = true
+serde = { workspace = true, features = ["derive"] }
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
+
+[features]
+default = []
+cpu = []
+cuda = ["dep:bitnet-kernels"]
+gpu = ["cuda"]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -1,0 +1,79 @@
+use anyhow::Result;
+use bitnet_common::Device;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// Device configuration mode for server/CLI initialization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum DeviceConfig {
+    /// Automatically select the best available device (prefer GPU if available)
+    #[default]
+    Auto,
+    /// Force CPU execution
+    Cpu,
+    /// Force GPU execution on specific device ID
+    Gpu(usize),
+}
+
+impl FromStr for DeviceConfig {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(Self::Auto),
+            "cpu" => Ok(Self::Cpu),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(Self::Gpu(0)),
+            s if s.starts_with("gpu:") => parse_indexed_device(s, "gpu:"),
+            s if s.starts_with("cuda:") => parse_indexed_device(s, "cuda:"),
+            s if s.starts_with("vulkan:") => parse_indexed_device(s, "vulkan:"),
+            s if s.starts_with("opencl:") => parse_indexed_device(s, "opencl:"),
+            s if s.starts_with("ocl:") => parse_indexed_device(s, "ocl:"),
+            _ => anyhow::bail!("Unknown device config: {s}"),
+        }
+    }
+}
+
+fn parse_indexed_device(raw: &str, prefix: &str) -> Result<DeviceConfig, anyhow::Error> {
+    let id = raw[prefix.len()..].parse::<usize>()?;
+    Ok(DeviceConfig::Gpu(id))
+}
+
+impl DeviceConfig {
+    /// Resolve device configuration to actual runtime device.
+    pub fn resolve(&self) -> Device {
+        match self {
+            Self::Auto => {
+                #[cfg(any(feature = "gpu", feature = "cuda"))]
+                {
+                    use bitnet_kernels::device_features::gpu_available_runtime;
+                    if gpu_available_runtime() { Device::Cuda(0) } else { Device::Cpu }
+                }
+                #[cfg(not(any(feature = "gpu", feature = "cuda")))]
+                {
+                    Device::Cpu
+                }
+            }
+            Self::Cpu => Device::Cpu,
+            Self::Gpu(id) => Device::Cuda(*id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_aliases_and_indices() {
+        assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
+        assert_eq!("VULKAN:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+        assert_eq!("OPENCL:4".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(4));
+    }
+
+    #[test]
+    fn resolves_cpu_and_indexed_gpu() {
+        assert_eq!(DeviceConfig::Cpu.resolve(), Device::Cpu);
+        assert_eq!(DeviceConfig::Gpu(7).resolve(), Device::Cuda(7));
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
@@ -85,6 +86,7 @@ runtime-profile-core = [
   "bitnet-runtime-bootstrap/runtime-profile-quantization",
 ]
 cpu = [
+  "bitnet-device-config-core/cpu",
   "bitnet-inference/cpu",
   "bitnet-kernels/cpu",
   "runtime-profile-core",
@@ -92,6 +94,7 @@ cpu = [
   "bitnet-tokenizers/cpu",
 ]
 cuda = [
+  "bitnet-device-config-core/cuda",
   "dep:cudarc",
   "bitnet-inference/cuda",
   "bitnet-kernels/cuda",
@@ -102,6 +105,7 @@ crossval = ["runtime-profile-core", "bitnet-runtime-bootstrap/runtime-profile-cr
 default = ["prometheus", "server"]
 degraded-ok = []                                                                                                                                                                  # Map Degraded → 200 OK (default is fail-fast)
 gpu = [
+  "bitnet-device-config-core/gpu",
   "cuda",
   "bitnet-runtime-bootstrap/runtime-profile-gpu",
   "runtime-profile-core",

--- a/crates/bitnet-server/src/config.rs
+++ b/crates/bitnet-server/src/config.rs
@@ -1,13 +1,12 @@
 //! Configuration management with environment variable support
 
 use anyhow::Result;
-use bitnet_common::Device;
+pub use bitnet_device_config_core::DeviceConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::env;
 use std::net::IpAddr;
 use std::path::Path;
-use std::str::FromStr;
 use std::time::Duration;
 
 use crate::batch_engine::BatchEngineConfig;
@@ -16,78 +15,6 @@ use crate::execution_router::{DeviceSelectionStrategy, ExecutionRouterConfig};
 use crate::model_manager::ModelManagerConfig;
 use crate::monitoring::MonitoringConfig;
 use crate::security::SecurityConfig;
-
-/// Device configuration mode for server initialization
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub enum DeviceConfig {
-    /// Automatically select the best available device (prefer GPU if available)
-    #[default]
-    Auto,
-    /// Force CPU execution
-    Cpu,
-    /// Force GPU execution on specific device ID
-    Gpu(usize),
-}
-
-impl FromStr for DeviceConfig {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "auto" => Ok(DeviceConfig::Auto),
-            "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
-            s if s.starts_with("gpu:") => {
-                let id_str = &s[4..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("cuda:") => {
-                let id_str = &s[5..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("vulkan:") => {
-                let id_str = &s[7..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("opencl:") => {
-                let id_str = &s[7..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("ocl:") => {
-                let id_str = &s[4..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            _ => anyhow::bail!("Unknown device config: {}", s),
-        }
-    }
-}
-
-impl DeviceConfig {
-    /// Resolve device configuration to actual device
-    pub fn resolve(&self) -> Device {
-        match self {
-            DeviceConfig::Auto => {
-                // Auto: prefer GPU if available at runtime
-                #[cfg(any(feature = "gpu", feature = "cuda"))]
-                {
-                    use bitnet_kernels::device_features::gpu_available_runtime;
-                    if gpu_available_runtime() { Device::Cuda(0) } else { Device::Cpu }
-                }
-                #[cfg(not(any(feature = "gpu", feature = "cuda")))]
-                {
-                    Device::Cpu
-                }
-            }
-            DeviceConfig::Cpu => Device::Cpu,
-            DeviceConfig::Gpu(id) => Device::Cuda(*id),
-        }
-    }
-}
 
 /// Complete server configuration
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
### Motivation

- Device configuration parsing and resolution are reusable SRP logic that should be isolated from `bitnet-server` to reduce responsibilities and improve testability.
- Extracting this logic as a microcrate enables other crates to depend on the same parsing/resolution contracts without pulling in the entire server crate surface.

### Description

- Added a new microcrate `crates/bitnet-device-config-core` that implements `DeviceConfig`, its `FromStr` parsing, `resolve` logic, and focused unit tests (`src/lib.rs`).
- Registered the new crate as a workspace member in `Cargo.toml` and added the crate manifest `crates/bitnet-device-config-core/Cargo.toml`.
- Removed the inlined `DeviceConfig` implementation from `crates/bitnet-server/src/config.rs` and re-exported `DeviceConfig` from the new crate via `pub use bitnet_device_config_core::DeviceConfig;` to preserve server API compatibility.
- Wired the new crate into `crates/bitnet-server/Cargo.toml` dependencies and feature sets (`cpu`, `cuda`, `gpu`) so feature-driven runtime behavior remains consistent.

### Testing

- Ran formatting with `cargo fmt`, which completed successfully.
- Ran unit tests for the new microcrate with `cargo test -p bitnet-device-config-core`, and the tests passed (`2` tests passed, `0` failed).
- Attempted to run focused `bitnet-server` tests (e.g. `cargo test -p bitnet-server --test server_config_edge_cases`), but compilation and execution were long-running in this environment and could not be fully completed here; an earlier mis-invocation (`cargo test -p bitnet-server server_config_edge_cases config_builder_edge_cases`) produced an argument error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98eb02c83338905ce39aeac08d1)