### PR TITLE
refactor(download): extract reusable download primitives into bitnet-download-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,9 +623,17 @@ dependencies = [
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
  "reqwest",
+]
+
+[[package]]
+name = "bitnet-download-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-download-core", # SRP: reusable download/offline/content-range core helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
@@ -150,6 +151,7 @@ default-members = [
   "crates/bitnet-repl-core",
   "crates/bitnet-gguf",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-download-core", # SRP: reusable download/offline/content-range core helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
 ]
 

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bitnet-download-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "Core SRP download helpers for offline toggles, content-range parsing, validation, and atomic metadata writes"
+
+[dependencies]
+thiserror.workspace = true
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,0 +1,93 @@
+use std::{fs, path::Path};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DownloadValidationError {
+    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
+    Truncated { downloaded: u64, expected: u64 },
+}
+
+/// Returns true when download logic should operate in offline mode.
+#[must_use]
+pub fn offline_enabled(cli_offline: bool) -> bool {
+    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
+}
+
+/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
+#[must_use]
+pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
+    content_range.rsplit('/').next()?.parse::<u64>().ok()
+}
+
+/// Ensure downloaded bytes match expected total when available.
+pub fn validate_downloaded_len(
+    downloaded: u64,
+    expected_total: Option<u64>,
+) -> Result<(), DownloadValidationError> {
+    if let Some(expected) = expected_total
+        && downloaded != expected
+    {
+        return Err(DownloadValidationError::Truncated { downloaded, expected });
+    }
+    Ok(())
+}
+
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_content_range_total() {
+        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
+        assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    fn validates_downloaded_len() {
+        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
+        assert!(validate_downloaded_len(1024, None).is_ok());
+        assert!(matches!(
+            validate_downloaded_len(1, Some(2)),
+            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
+        ));
+    }
+
+    #[test]
+    fn atomic_write_replaces_file_contents() {
+        let dir = tempdir().expect("temp dir");
+        let path = dir.path().join("etag.txt");
+
+        atomic_write(&path, b"first").expect("first write");
+        atomic_write(&path, b"second").expect("second write");
+
+        let bytes = std::fs::read(path).expect("read metadata file");
+        assert_eq!(bytes, b"second");
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,9 +10,9 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }
-thiserror.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,20 +1,11 @@
+pub use bitnet_download_core::{
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
+};
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
-use thiserror::Error;
-
-#[derive(Debug, Error, PartialEq, Eq)]
-pub enum DownloadValidationError {
-    #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
-    Truncated { downloaded: u64, expected: u64 },
-}
-
-/// Returns true when download logic should operate in offline mode.
-#[must_use]
-pub fn offline_enabled(cli_offline: bool) -> bool {
-    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
-}
+use std::time::SystemTime;
 
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
@@ -27,51 +18,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
-#[must_use]
-pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
-}
-
-/// Ensure downloaded bytes match expected total when available.
-pub fn validate_downloaded_len(
-    downloaded: u64,
-    expected_total: Option<u64>,
-) -> Result<(), DownloadValidationError> {
-    if let Some(expected) = expected_total
-        && downloaded != expected
-    {
-        return Err(DownloadValidationError::Truncated { downloaded, expected });
-    }
-    Ok(())
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
@@ -120,21 +66,5 @@ mod tests {
         assert_eq!(exp_backoff_ms(2), 474);
         assert_eq!(exp_backoff_ms(3), 911);
         assert_eq!(exp_backoff_ms(10), 10_170);
-    }
-
-    #[test]
-    fn parses_content_range_total() {
-        assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
-        assert_eq!(parse_content_range_total("invalid"), None);
-    }
-
-    #[test]
-    fn validates_downloaded_len() {
-        assert!(validate_downloaded_len(1024, Some(1024)).is_ok());
-        assert!(validate_downloaded_len(1024, None).is_ok());
-        assert!(matches!(
-            validate_downloaded_len(1, Some(2)),
-            Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
-        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Isolate pure download/metadata/validation concerns from HTTP/header parsing so the core logic is SRP-friendly and easier to reuse across other download pipelines.
- Reduce coupling in `bitnet-download` by moving file/validation/offline helpers into a small focused microcrate suitable for other teams to consume.

### Description
- Added a new microcrate `crates/bitnet-download-core` that implements and tests `offline_enabled`, `parse_content_range_total`, `validate_downloaded_len` (with `DownloadValidationError`), and `atomic_write` in `src/lib.rs`.
- Updated `crates/bitnet-download` to depend on `bitnet-download-core` and re-export the core APIs so existing call sites remain compatible while keeping `retry_after_*` header parsing local to `bitnet-download`.
- Wired the new crate into the workspace by adding `crates/bitnet-download-core` to `members` and `default-members` in `Cargo.toml` and updated dependency wiring in `crates/bitnet-download/Cargo.toml`.
- Moved unit tests for the extracted behavior into `bitnet-download-core` and retained retry/backoff tests in `bitnet-download`; updated `Cargo.lock` accordingly.

### Testing
- Ran `cargo test -p bitnet-download-core -p bitnet-download` and both crates' test suites passed (`bitnet-download-core`: 3 tests passed; `bitnet-download`: 4 tests passed).
- Ran `cargo fmt --all` to normalize formatting and the formatting step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98eb02c83338905ce39aeac08d1)