### PR TITLE
refactor(server): extract DeviceConfig into reusable core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-device-config-core"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
+ "bitnet-common",
+ "bitnet-kernels",
+ "serde",
+]
+
+[[package]]
 name = "bitnet-device-probe"
 version = "0.2.1-dev"
 dependencies = [
@@ -1222,6 +1232,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bitnet-common",
+ "bitnet-device-config-core",
  "bitnet-eval-core",
  "bitnet-inference",
  "bitnet-kernels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-device-config-core", # SRP: shared device config parsing + resolution core
   "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-logits-filters", # SRP: reusable logits/probability filtering transforms

--- a/crates/bitnet-device-config-core/Cargo.toml
+++ b/crates/bitnet-device-config-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "bitnet-device-config-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP core device configuration parsing and resolution"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
+serde.workspace = true
+
+[features]
+default = []
+cuda = ["dep:bitnet-kernels", "bitnet-kernels/cuda"]
+gpu = ["cuda", "bitnet-kernels/gpu"]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -1,0 +1,79 @@
+//! Core device configuration parsing and runtime resolution.
+
+use anyhow::Result;
+use bitnet_common::Device;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+/// Device configuration mode for runtime initialization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum DeviceConfig {
+    /// Automatically select the best available device (prefer GPU if available).
+    #[default]
+    Auto,
+    /// Force CPU execution.
+    Cpu,
+    /// Force GPU execution on specific device ID.
+    Gpu(usize),
+}
+
+impl FromStr for DeviceConfig {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "auto" => Ok(DeviceConfig::Auto),
+            "cpu" => Ok(DeviceConfig::Cpu),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            s if s.starts_with("gpu:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("cuda:") => Ok(DeviceConfig::Gpu(s[5..].parse::<usize>()?)),
+            s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
+            s if s.starts_with("opencl:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
+            s if s.starts_with("ocl:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            _ => anyhow::bail!("Unknown device config: {}", s),
+        }
+    }
+}
+
+impl DeviceConfig {
+    /// Resolve configuration to an executable device choice.
+    #[must_use]
+    pub fn resolve(&self) -> Device {
+        match self {
+            DeviceConfig::Auto => {
+                #[cfg(any(feature = "gpu", feature = "cuda"))]
+                {
+                    use bitnet_kernels::device_features::gpu_available_runtime;
+                    if gpu_available_runtime() { Device::Cuda(0) } else { Device::Cpu }
+                }
+                #[cfg(not(any(feature = "gpu", feature = "cuda")))]
+                {
+                    Device::Cpu
+                }
+            }
+            DeviceConfig::Cpu => Device::Cpu,
+            DeviceConfig::Gpu(id) => Device::Cuda(*id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DeviceConfig;
+
+    #[test]
+    fn parses_supported_aliases() {
+        assert_eq!("cpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Cpu);
+        assert_eq!("auto".parse::<DeviceConfig>().unwrap(), DeviceConfig::Auto);
+        assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
+        assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+    }
+
+    #[test]
+    fn rejects_invalid_values() {
+        assert!("unknown".parse::<DeviceConfig>().is_err());
+        assert!("gpu:".parse::<DeviceConfig>().is_err());
+        assert!("gpu:abc".parse::<DeviceConfig>().is_err());
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
@@ -93,6 +94,7 @@ cpu = [
 ]
 cuda = [
   "dep:cudarc",
+  "bitnet-device-config-core/cuda",
   "bitnet-inference/cuda",
   "bitnet-kernels/cuda",
   "runtime-profile-core",
@@ -103,6 +105,7 @@ default = ["prometheus", "server"]
 degraded-ok = []                                                                                                                                                                  # Map Degraded → 200 OK (default is fail-fast)
 gpu = [
   "cuda",
+  "bitnet-device-config-core/gpu",
   "bitnet-runtime-bootstrap/runtime-profile-gpu",
   "runtime-profile-core",
 ]

--- a/crates/bitnet-server/src/config.rs
+++ b/crates/bitnet-server/src/config.rs
@@ -1,14 +1,14 @@
 //! Configuration management with environment variable support
 
 use anyhow::Result;
-use bitnet_common::Device;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::env;
 use std::net::IpAddr;
 use std::path::Path;
-use std::str::FromStr;
 use std::time::Duration;
+
+pub use bitnet_device_config_core::DeviceConfig;
 
 use crate::batch_engine::BatchEngineConfig;
 use crate::concurrency::ConcurrencyConfig;
@@ -16,78 +16,6 @@ use crate::execution_router::{DeviceSelectionStrategy, ExecutionRouterConfig};
 use crate::model_manager::ModelManagerConfig;
 use crate::monitoring::MonitoringConfig;
 use crate::security::SecurityConfig;
-
-/// Device configuration mode for server initialization
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
-pub enum DeviceConfig {
-    /// Automatically select the best available device (prefer GPU if available)
-    #[default]
-    Auto,
-    /// Force CPU execution
-    Cpu,
-    /// Force GPU execution on specific device ID
-    Gpu(usize),
-}
-
-impl FromStr for DeviceConfig {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "auto" => Ok(DeviceConfig::Auto),
-            "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
-            s if s.starts_with("gpu:") => {
-                let id_str = &s[4..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("cuda:") => {
-                let id_str = &s[5..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("vulkan:") => {
-                let id_str = &s[7..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("opencl:") => {
-                let id_str = &s[7..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            s if s.starts_with("ocl:") => {
-                let id_str = &s[4..];
-                let id = id_str.parse::<usize>()?;
-                Ok(DeviceConfig::Gpu(id))
-            }
-            _ => anyhow::bail!("Unknown device config: {}", s),
-        }
-    }
-}
-
-impl DeviceConfig {
-    /// Resolve device configuration to actual device
-    pub fn resolve(&self) -> Device {
-        match self {
-            DeviceConfig::Auto => {
-                // Auto: prefer GPU if available at runtime
-                #[cfg(any(feature = "gpu", feature = "cuda"))]
-                {
-                    use bitnet_kernels::device_features::gpu_available_runtime;
-                    if gpu_available_runtime() { Device::Cuda(0) } else { Device::Cpu }
-                }
-                #[cfg(not(any(feature = "gpu", feature = "cuda")))]
-                {
-                    Device::Cpu
-                }
-            }
-            DeviceConfig::Cpu => Device::Cpu,
-            DeviceConfig::Gpu(id) => Device::Cuda(*id),
-        }
-    }
-}
 
 /// Complete server configuration
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -499,6 +427,7 @@ pub fn generate_example_config() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitnet_common::Device;
     use std::env;
 
     #[test]


### PR DESCRIPTION
### Motivation
- Reduce single-responsibility burden in the server crate by extracting device configuration parsing and runtime resolution into a dedicated microcrate. 
- Make `DeviceConfig` logic reusable by other crates (e.g. device probe, runtimes) without pulling server internals.
- Preserve existing public API and feature-driven runtime behavior while improving modularity.

### Description
- Added a new SRP microcrate `crates/bitnet-device-config-core` that implements `DeviceConfig` (enum, `FromStr` parsing aliases, and `resolve()` runtime logic) and unit tests in `src/lib.rs`.
- Registered the new crate in the workspace `Cargo.toml` and added `bitnet-device-config-core` as a dependency of `crates/bitnet-server` in its `Cargo.toml`.
- Forwarded `cuda`/`gpu` feature flags from `bitnet-server` to `bitnet-device-config-core` so `DeviceConfig::Auto` remains feature-consistent across builds.
- Removed the duplicated `DeviceConfig` implementation from `crates/bitnet-server/src/config.rs` and re-exported the type with `pub use bitnet_device_config_core::DeviceConfig;` to keep the server API stable.

### Testing
- Ran unit tests for the new crate with `cargo test -p bitnet-device-config-core`, which passed (`2` tests passed).
- Ran server tests that exercise device config behavior with `cargo test -p bitnet-server --test device_config_test`, which passed (`6` tests passed).
- Ran broader server config tests with `cargo test -p bitnet-server --test config_builder_edge_cases`, which passed (`36` tests passed).
- Ran `cargo fmt`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98995b883339c6c23c4a8f5f9c2)