### PR TITLE
Extract client IP header parsing into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-client-ip-core"
+version = "0.2.1-dev"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "bitnet-common"
 version = "0.2.1-dev"
 dependencies = [
@@ -1308,6 +1315,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bitnet-client-ip-core",
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
   "crates/bitnet-probability",  # SRP: probability normalization and categorical sampling primitives
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
+  "crates/bitnet-client-ip-core", # SRP: shared client-IP extraction from HTTP headers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server-health-types-core", # SRP: reusable server health endpoint contract types
   "crates/bitnet-server",
@@ -156,6 +157,7 @@ default-members = [
   "crates/bitnet-feature-contract",
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server-health-types-core",
+  "crates/bitnet-client-ip-core",
   "crates/bitnet-testing-policy-core",
   "crates/bitnet-testing-scenarios-core",
   "crates/bitnet-runtime-profile-core",

--- a/crates/bitnet-client-ip-core/Cargo.toml
+++ b/crates/bitnet-client-ip-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-client-ip-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP client IP extraction helpers for HTTP headers"
+
+[dependencies]
+http = "1.3.1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-client-ip-core/src/lib.rs
+++ b/crates/bitnet-client-ip-core/src/lib.rs
@@ -1,0 +1,67 @@
+//! SRP helpers for determining the client IP from HTTP headers.
+
+use http::HeaderMap;
+use std::net::IpAddr;
+
+/// Extract the client IP from common proxy headers.
+///
+/// Priority:
+/// 1. `x-forwarded-for` (first IP)
+/// 2. `x-real-ip`
+pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
+    if let Some(forwarded) = headers.get("x-forwarded-for")
+        && let Ok(forwarded_str) = forwarded.to_str()
+        && let Some(first_ip) = forwarded_str.split(',').next()
+        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    if let Some(real_ip) = headers.get("x-real-ip")
+        && let Ok(ip_str) = real_ip.to_str()
+        && let Ok(ip) = ip_str.parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_client_ip_from_headers;
+    use http::HeaderMap;
+    use std::net::IpAddr;
+
+    #[test]
+    fn prefers_x_forwarded_for_first_address() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.42, 10.0.0.1".parse().unwrap());
+        headers.insert("x-real-ip", "198.51.100.7".parse().unwrap());
+
+        let ip = extract_client_ip_from_headers(&headers);
+
+        assert_eq!(ip, Some(IpAddr::from([203, 0, 113, 42])));
+    }
+
+    #[test]
+    fn falls_back_to_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "198.51.100.7".parse().unwrap());
+
+        let ip = extract_client_ip_from_headers(&headers);
+
+        assert_eq!(ip, Some(IpAddr::from([198, 51, 100, 7])));
+    }
+
+    #[test]
+    fn returns_none_for_missing_or_invalid_headers() {
+        let mut headers = HeaderMap::new();
+        assert_eq!(extract_client_ip_from_headers(&headers), None);
+
+        headers.insert("x-forwarded-for", "not-an-ip".parse().unwrap());
+        headers.insert("x-real-ip", "also-not-an-ip".parse().unwrap());
+
+        assert_eq!(extract_client_ip_from_headers(&headers), None);
+    }
+}

--- a/crates/bitnet-inference/tests/model_config_tests.rs
+++ b/crates/bitnet-inference/tests/model_config_tests.rs
@@ -5,10 +5,8 @@
 //! head-count validation, context-length configs, hidden-dimension validation,
 //! SLM family configs (BitNet, Phi-4, LLaMA, Qwen), and edge cases.
 
-use bitnet_common::config::{
-    ActivationType, ModelConfig, NormType,
-};
 use bitnet_common::ArchitectureRegistry;
+use bitnet_common::config::{ActivationType, ModelConfig, NormType};
 use bitnet_inference::config::{GenerationConfig, InferenceConfig};
 use bitnet_models::config::{GgufModelConfig, GgufQuantizationConfig};
 
@@ -255,15 +253,10 @@ fn inference_config_reject_zero_batch_size() {
 
 #[test]
 fn architecture_detection_core_families() {
-    let core = [
-        "bitnet", "llama", "mistral", "phi", "qwen", "gemma",
-        "deepseek", "falcon", "gpt", "bert",
-    ];
+    let core =
+        ["bitnet", "llama", "mistral", "phi", "qwen", "gemma", "deepseek", "falcon", "gpt", "bert"];
     for name in &core {
-        assert!(
-            ArchitectureRegistry::is_known(name),
-            "core family '{name}' must be recognised"
-        );
+        assert!(ArchitectureRegistry::is_known(name), "core family '{name}' must be recognised");
     }
 }
 

--- a/crates/bitnet-kernels/tests/attention_correctness.rs
+++ b/crates/bitnet-kernels/tests/attention_correctness.rs
@@ -27,11 +27,7 @@ fn ref_softmax(row: &[f32]) -> Vec<f32> {
     let max = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
     let exps: Vec<f32> = row.iter().map(|&v| (v - max).exp()).collect();
     let sum: f32 = exps.iter().sum();
-    if sum == 0.0 {
-        vec![0.0; row.len()]
-    } else {
-        exps.iter().map(|&e| e / sum).collect()
-    }
+    if sum == 0.0 { vec![0.0; row.len()] } else { exps.iter().map(|&e| e / sum).collect() }
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -53,8 +49,7 @@ fn sdpa_identity_query_key_known_output() {
     let k = vec![1.0, 0.0, 0.0, 1.0]; // 2 keys
     let v = vec![10.0, 20.0, 30.0, 40.0]; // 2 values
 
-    let result =
-        scaled_dot_product_attention(&q, &k, &v, 2, 2, head_dim, false).unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, 2, 2, head_dim, false).unwrap();
 
     // scale = 1/√2 ≈ 0.7071
     let scale = 1.0 / (2.0_f32).sqrt();
@@ -82,10 +77,9 @@ fn sdpa_explicit_scale_overrides_default() {
     let v = vec![5.0; head_dim];
     let custom_scale = 0.25;
 
-    let result = AttentionKernel::scaled_dot_product(
-        &q, &k, &v, None, custom_scale, 1, 1, head_dim,
-    )
-    .unwrap();
+    let result =
+        AttentionKernel::scaled_dot_product(&q, &k, &v, None, custom_scale, 1, 1, head_dim)
+            .unwrap();
 
     // Single KV pair → softmax of single element = 1.0 → output = v
     for (i, &val) in result.iter().enumerate() {
@@ -101,8 +95,7 @@ fn sdpa_cross_attention_different_seq_lengths() {
     let k = vec![1.0, 0.0, 0.0, 1.0, 1.0, 1.0]; // 3 keys
     let v = vec![1.0, 0.0, 0.0, 1.0, 0.5, 0.5]; // 3 values
 
-    let result =
-        scaled_dot_product_attention(&q, &k, &v, 1, 3, head_dim, false).unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, 1, 3, head_dim, false).unwrap();
     assert_eq!(result.len(), head_dim);
 
     // Compute reference: scores = [q·k0, q·k1, q·k2] = [1, 0, 1], scale=1/√2
@@ -128,10 +121,8 @@ fn attention_weights_sum_to_one_uniform_scores() {
     let k = vec![1.0; seq_len * head_dim];
     let v = vec![1.0; seq_len * head_dim];
 
-    let result = scaled_dot_product_attention(
-        &q, &k, &v, seq_len, seq_len, head_dim, false,
-    )
-    .unwrap();
+    let result =
+        scaled_dot_product_attention(&q, &k, &v, seq_len, seq_len, head_dim, false).unwrap();
 
     // Output should be V (all 1.0) since uniform attention * uniform V = V
     for (i, &val) in result.iter().enumerate() {
@@ -148,8 +139,7 @@ fn attention_weights_sum_to_one_varying_scores() {
     let k = vec![1.0, 0.0, 0.0, 1.0, -1.0, 0.0]; // 3 keys
     let v = vec![0.0, 0.0, 10.0, 10.0, 5.0, 5.0]; // 3 values
 
-    let result =
-        scaled_dot_product_attention(&q, &k, &v, 1, 3, head_dim, false).unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, 1, 3, head_dim, false).unwrap();
 
     // Output must be in convex hull: each dim in [0, 10]
     for &val in &result {
@@ -198,20 +188,12 @@ fn causal_sdpa_first_token_attends_only_to_self() {
         }
     }
 
-    let result = scaled_dot_product_attention(
-        &q, &k, &v, seq, seq, head_dim, true,
-    )
-    .unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
 
     // First row (token 0): with causal mask, can only attend to position 0
     // → output should exactly equal V[0]
     for d in 0..head_dim {
-        assert!(
-            approx_eq(result[d], v[d]),
-            "token 0, dim {d}: got {} want {}",
-            result[d],
-            v[d]
-        );
+        assert!(approx_eq(result[d], v[d]), "token 0, dim {d}: got {} want {}", result[d], v[d]);
     }
 }
 
@@ -225,13 +207,10 @@ fn causal_sdpa_last_token_attends_to_all_preceding() {
     let v = vec![
         10.0, 0.0, // token 0
         0.0, 10.0, // token 1
-        5.0, 5.0,  // token 2
+        5.0, 5.0, // token 2
     ];
 
-    let result = scaled_dot_product_attention(
-        &q, &k, &v, seq, seq, head_dim, true,
-    )
-    .unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
 
     // Last token (index 2) attends uniformly to all 3 → average of V rows
     let expected_0 = (10.0 + 0.0 + 5.0) / 3.0;
@@ -285,10 +264,7 @@ fn multi_head_different_heads_produce_different_outputs() {
         30.0, 40.0, 30.0, 40.0,
     ];
 
-    let result = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, false,
-    )
-    .unwrap();
+    let result = multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, false).unwrap();
     assert_eq!(result.len(), seq_len * model_dim);
 
     // Head 0 output for token 0 (indices 0..2) should differ from
@@ -309,15 +285,9 @@ fn multi_head_single_head_equals_sdpa() {
     let k = vec![1.2, 1.1, 1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1];
     let v = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
 
-    let mha = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, false,
-    )
-    .unwrap();
+    let mha = multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, false).unwrap();
 
-    let sdpa = scaled_dot_product_attention(
-        &q, &k, &v, seq_len, seq_len, head_dim, false,
-    )
-    .unwrap();
+    let sdpa = scaled_dot_product_attention(&q, &k, &v, seq_len, seq_len, head_dim, false).unwrap();
 
     for (i, (&a, &b)) in mha.iter().zip(sdpa.iter()).enumerate() {
         assert!(approx_eq(a, b), "index {i}: mha={a} sdpa={b}");
@@ -341,28 +311,18 @@ fn multi_head_causal_preserves_causality() {
     let q = vec![1.0; seq_len * model_dim];
     let k = vec![1.0; seq_len * model_dim];
 
-    let causal_out = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, true,
-    )
-    .unwrap();
-    let non_causal_out = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, false,
-    )
-    .unwrap();
+    let causal_out =
+        multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, true).unwrap();
+    let non_causal_out =
+        multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, false).unwrap();
 
     // Token 0 with causal: attends only to self → equals V[0]
     // Token 0 without causal: attends to all → average of all V rows
     // These should differ (unless all V rows are identical, which they're not)
     let t0_causal = &causal_out[0..model_dim];
     let t0_non_causal = &non_causal_out[0..model_dim];
-    let differs = t0_causal
-        .iter()
-        .zip(t0_non_causal)
-        .any(|(a, b)| (a - b).abs() > EPS);
-    assert!(
-        differs,
-        "causal token 0 should differ from non-causal (different visible set)"
-    );
+    let differs = t0_causal.iter().zip(t0_non_causal).any(|(a, b)| (a - b).abs() > EPS);
+    assert!(differs, "causal token 0 should differ from non-causal (different visible set)");
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -373,13 +333,8 @@ fn multi_head_causal_preserves_causality() {
 fn kv_cache_append_and_readback() {
     let num_heads = 2;
     let head_dim = 4;
-    let cfg = KvCacheConfig {
-        num_layers: 1,
-        num_heads,
-        head_dim,
-        max_seq_len: 16,
-        dtype: KvDtype::F32,
-    };
+    let cfg =
+        KvCacheConfig { num_layers: 1, num_heads, head_dim, max_seq_len: 16, dtype: KvDtype::F32 };
     let mut cache = KvCache::new(cfg).unwrap();
     let te = num_heads * head_dim; // 8
 
@@ -447,10 +402,8 @@ fn attention_with_kv_cache_incremental_decoding() {
     let k1 = vec![1.0; head_dim];
     let v1 = vec![10.0; head_dim];
 
-    let out1 = attention_with_kv_cache(
-        &q1, &mut k_cache, &mut v_cache, &k1, &v1, head_dim,
-    )
-    .unwrap();
+    let out1 =
+        attention_with_kv_cache(&q1, &mut k_cache, &mut v_cache, &k1, &v1, head_dim).unwrap();
     assert_eq!(out1.len(), head_dim);
     // Only one KV → output = V
     for &val in &out1 {
@@ -463,10 +416,8 @@ fn attention_with_kv_cache_incremental_decoding() {
     let k2 = vec![1.0; head_dim];
     let v2 = vec![20.0; head_dim];
 
-    let out2 = attention_with_kv_cache(
-        &q2, &mut k_cache, &mut v_cache, &k2, &v2, head_dim,
-    )
-    .unwrap();
+    let out2 =
+        attention_with_kv_cache(&q2, &mut k_cache, &mut v_cache, &k2, &v2, head_dim).unwrap();
     assert_eq!(out2.len(), head_dim);
     assert_eq!(k_cache.len(), 2 * head_dim);
     // Uniform Q·K → equal attention → average of V: (10+20)/2 = 15
@@ -479,10 +430,8 @@ fn attention_with_kv_cache_incremental_decoding() {
     let k3 = vec![1.0; head_dim];
     let v3 = vec![30.0; head_dim];
 
-    let out3 = attention_with_kv_cache(
-        &q3, &mut k_cache, &mut v_cache, &k3, &v3, head_dim,
-    )
-    .unwrap();
+    let out3 =
+        attention_with_kv_cache(&q3, &mut k_cache, &mut v_cache, &k3, &v3, head_dim).unwrap();
     // 3 values → average = (10+20+30)/3 = 20
     for &val in &out3 {
         assert!(approx_eq(val, 20.0), "step3: got {val} want 20.0");
@@ -500,8 +449,7 @@ fn sdpa_seq_len_1_returns_value_unchanged() {
     let q = vec![0.5; head_dim];
     let k = vec![0.5; head_dim];
 
-    let result =
-        scaled_dot_product_attention(&q, &k, &v, 1, 1, head_dim, false).unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, 1, 1, head_dim, false).unwrap();
 
     // Single KV → softmax([score]) = [1.0] → output = V exactly
     for (i, (&got, &want)) in result.iter().zip(v.iter()).enumerate() {
@@ -516,8 +464,7 @@ fn sdpa_seq_len_1_causal_returns_value_unchanged() {
     let q = vec![1.0; head_dim];
     let k = vec![1.0; head_dim];
 
-    let result =
-        scaled_dot_product_attention(&q, &k, &v, 1, 1, head_dim, true).unwrap();
+    let result = scaled_dot_product_attention(&q, &k, &v, 1, 1, head_dim, true).unwrap();
 
     for (i, (&got, &want)) in result.iter().zip(v.iter()).enumerate() {
         assert!(approx_eq(got, want), "dim {i}: got {got} want {want}");
@@ -587,10 +534,8 @@ fn causal_attention_wrapper_matches_mha_causal() {
         scale: None,
     };
     let causal_result = causal_attention(&q, &k, &v, &cfg).unwrap();
-    let mha_causal = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, true,
-    )
-    .unwrap();
+    let mha_causal =
+        multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, true).unwrap();
 
     for (i, (&a, &b)) in causal_result.iter().zip(mha_causal.iter()).enumerate() {
         assert!(approx_eq(a, b), "index {i}: causal_attn={a} mha={b}");
@@ -622,10 +567,8 @@ fn gqa_1to1_equals_standard_mha() {
         scale: None,
     };
     let gqa_result = AttentionKernel::grouped_query_attention(&q, &k, &v, &gqa_cfg).unwrap();
-    let mha_result = multi_head_attention_cpu(
-        &q, &k, &v, num_heads, head_dim, seq_len, false,
-    )
-    .unwrap();
+    let mha_result =
+        multi_head_attention_cpu(&q, &k, &v, num_heads, head_dim, seq_len, false).unwrap();
 
     for (i, (&a, &b)) in gqa_result.iter().zip(mha_result.iter()).enumerate() {
         assert!(approx_eq(a, b), "index {i}: gqa={a} mha={b}");
@@ -645,18 +588,10 @@ fn gqa_multiple_queries_per_kv_head() {
 
     let q = vec![1.0; seq_len * q_dim];
     let k = vec![1.0; seq_len * kv_dim];
-    let v: Vec<f32> = (0..seq_len * kv_dim)
-        .map(|i| (i as f32) * 10.0)
-        .collect();
+    let v: Vec<f32> = (0..seq_len * kv_dim).map(|i| (i as f32) * 10.0).collect();
 
-    let cfg = GqaConfig {
-        num_q_heads,
-        num_kv_heads,
-        head_dim,
-        seq_len,
-        causal: false,
-        scale: None,
-    };
+    let cfg =
+        GqaConfig { num_q_heads, num_kv_heads, head_dim, seq_len, causal: false, scale: None };
     let result = AttentionKernel::grouped_query_attention(&q, &k, &v, &cfg).unwrap();
     assert_eq!(result.len(), seq_len * q_dim);
 
@@ -669,19 +604,13 @@ fn gqa_multiple_queries_per_kv_head() {
     let h0_t0 = &result[0..head_dim];
     let h1_t0 = &result[head_dim..2 * head_dim];
     for (i, (&a, &b)) in h0_t0.iter().zip(h1_t0.iter()).enumerate() {
-        assert!(
-            approx_eq(a, b),
-            "grouped heads 0,1 should match at dim {i}: {a} vs {b}"
-        );
+        assert!(approx_eq(a, b), "grouped heads 0,1 should match at dim {i}: {a} vs {b}");
     }
 
     let h2_t0 = &result[2 * head_dim..3 * head_dim];
     let h3_t0 = &result[3 * head_dim..4 * head_dim];
     for (i, (&a, &b)) in h2_t0.iter().zip(h3_t0.iter()).enumerate() {
-        assert!(
-            approx_eq(a, b),
-            "grouped heads 2,3 should match at dim {i}: {a} vs {b}"
-        );
+        assert!(approx_eq(a, b), "grouped heads 2,3 should match at dim {i}: {a} vs {b}");
     }
 
     // The two groups should differ (different KV heads → different V)
@@ -707,35 +636,19 @@ fn gqa_causal_masks_future() {
         }
     }
 
-    let cfg_causal = GqaConfig {
-        num_q_heads,
-        num_kv_heads,
-        head_dim,
-        seq_len,
-        causal: true,
-        scale: None,
-    };
-    let cfg_non_causal = GqaConfig {
-        num_q_heads,
-        num_kv_heads,
-        head_dim,
-        seq_len,
-        causal: false,
-        scale: None,
-    };
+    let cfg_causal =
+        GqaConfig { num_q_heads, num_kv_heads, head_dim, seq_len, causal: true, scale: None };
+    let cfg_non_causal =
+        GqaConfig { num_q_heads, num_kv_heads, head_dim, seq_len, causal: false, scale: None };
 
-    let causal_out =
-        AttentionKernel::grouped_query_attention(&q, &k, &v, &cfg_causal).unwrap();
+    let causal_out = AttentionKernel::grouped_query_attention(&q, &k, &v, &cfg_causal).unwrap();
     let non_causal_out =
         AttentionKernel::grouped_query_attention(&q, &k, &v, &cfg_non_causal).unwrap();
 
     // Token 0 should differ: causal sees only self, non-causal sees all
     let t0_causal = &causal_out[0..q_dim];
     let t0_non_causal = &non_causal_out[0..q_dim];
-    let differs = t0_causal
-        .iter()
-        .zip(t0_non_causal)
-        .any(|(a, b)| (a - b).abs() > EPS);
+    let differs = t0_causal.iter().zip(t0_non_causal).any(|(a, b)| (a - b).abs() > EPS);
     assert!(differs, "GQA causal should differ from non-causal at token 0");
 }
 
@@ -767,10 +680,8 @@ fn sdpa_deterministic_across_calls() {
     let k: Vec<f32> = (0..seq * head_dim).map(|i| (i as f32) * 0.02).collect();
     let v: Vec<f32> = (0..seq * head_dim).map(|i| (i as f32) * 0.07).collect();
 
-    let r1 =
-        scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
-    let r2 =
-        scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
+    let r1 = scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
+    let r2 = scaled_dot_product_attention(&q, &k, &v, seq, seq, head_dim, true).unwrap();
 
     assert_eq!(r1.len(), r2.len());
     for (i, (&a, &b)) in r1.iter().zip(r2.iter()).enumerate() {

--- a/crates/bitnet-kernels/tests/kernel_perf_smoke.rs
+++ b/crates/bitnet-kernels/tests/kernel_perf_smoke.rs
@@ -133,8 +133,7 @@ fn perf_smoke_attention_seq512() {
     let v = ones(n);
 
     let start = Instant::now();
-    let _out =
-        scaled_dot_product_attention(&q, &k, &v, seq_len, seq_len, head_dim, true).unwrap();
+    let _out = scaled_dot_product_attention(&q, &k, &v, seq_len, seq_len, head_dim, true).unwrap();
     assert_fast("attention(seq=512, head_dim=128, causal)", start.elapsed());
 }
 
@@ -159,15 +158,8 @@ fn perf_smoke_matmul_512() {
     let a = ones(m * k);
     let b = ones(k * n);
     let mut c = vec![0.0f32; m * n];
-    let cfg = SimdMatmulConfig {
-        m,
-        n,
-        k,
-        alpha: 1.0,
-        beta: 0.0,
-        transpose_a: false,
-        transpose_b: false,
-    };
+    let cfg =
+        SimdMatmulConfig { m, n, k, alpha: 1.0, beta: 0.0, transpose_a: false, transpose_b: false };
 
     let start = Instant::now();
     simd_matmul_f32(&a, &b, &mut c, &cfg).unwrap();

--- a/crates/bitnet-models/tests/gguf_loader_tests.rs
+++ b/crates/bitnet-models/tests/gguf_loader_tests.rs
@@ -108,10 +108,7 @@ fn header_zero_tensors() {
 fn metadata_architecture_string() {
     let buf = build_minimal_gguf("bitnet");
     let reader = GgufReader::new(&buf).expect("parse");
-    assert_eq!(
-        reader.get_string_metadata("general.architecture"),
-        Some("bitnet".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.architecture"), Some("bitnet".to_string()));
 }
 
 #[test]
@@ -139,14 +136,8 @@ fn metadata_f32_values() {
 fn metadata_string_values() {
     let buf = build_full_metadata_gguf();
     let reader = GgufReader::new(&buf).expect("parse");
-    assert_eq!(
-        reader.get_string_metadata("general.name"),
-        Some("test-llama-7b".to_string())
-    );
-    assert_eq!(
-        reader.get_string_metadata("general.description"),
-        Some("test model".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.name"), Some("test-llama-7b".to_string()));
+    assert_eq!(reader.get_string_metadata("general.description"), Some("test model".to_string()));
 }
 
 #[test]
@@ -248,30 +239,21 @@ fn tensor_type_preserved() {
 fn detect_llama_architecture() {
     let buf = build_minimal_gguf("llama");
     let reader = GgufReader::new(&buf).expect("parse");
-    assert_eq!(
-        reader.get_string_metadata("general.architecture"),
-        Some("llama".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.architecture"), Some("llama".to_string()));
 }
 
 #[test]
 fn detect_bitnet_architecture() {
     let buf = build_minimal_gguf("bitnet");
     let reader = GgufReader::new(&buf).expect("parse");
-    assert_eq!(
-        reader.get_string_metadata("general.architecture"),
-        Some("bitnet".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.architecture"), Some("bitnet".to_string()));
 }
 
 #[test]
 fn detect_phi_architecture() {
     let buf = build_minimal_gguf("phi");
     let reader = GgufReader::new(&buf).expect("parse");
-    assert_eq!(
-        reader.get_string_metadata("general.architecture"),
-        Some("phi".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.architecture"), Some("phi".to_string()));
 }
 
 #[test]
@@ -596,18 +578,12 @@ fn roundtrip_metadata_preserved() {
     let buf = cursor.into_inner();
     let reader = GgufReader::new(&buf).expect("parse");
 
-    assert_eq!(
-        reader.get_string_metadata("general.architecture"),
-        Some("bitnet".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("general.architecture"), Some("bitnet".to_string()));
     assert_eq!(
         reader.get_string_metadata("general.description"),
         Some("roundtrip test".to_string())
     );
-    assert_eq!(
-        reader.get_string_metadata("custom.author"),
-        Some("test-harness".to_string())
-    );
+    assert_eq!(reader.get_string_metadata("custom.author"), Some("test-harness".to_string()));
     assert_eq!(reader.get_u32_metadata("custom.version"), Some(42));
     let temp = reader.get_f32_metadata("custom.temperature").unwrap();
     assert!((temp - 0.7).abs() < f32::EPSILON);

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
+bitnet-client-ip-core = { path = "../bitnet-client-ip-core", version = "0.2.1-dev" }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -7,6 +7,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use bitnet_client_ip_core::extract_client_ip_from_headers as extract_ip_from_headers;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::net::IpAddr;
@@ -352,25 +353,8 @@ fn extract_client_ip(request: &Request) -> Option<IpAddr> {
 
 /// Extract client IP from headers (shared utility)
 pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    // Try X-Forwarded-For header first (for reverse proxies)
-    if let Some(forwarded) = headers.get("x-forwarded-for")
-        && let Ok(forwarded_str) = forwarded.to_str()
-        && let Some(first_ip) = forwarded_str.split(',').next()
-        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Try X-Real-IP header
-    if let Some(real_ip) = headers.get("x-real-ip")
-        && let Ok(ip_str) = real_ip.to_str()
-        && let Ok(ip) = ip_str.parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
     // Fall back to connection info (would need to be passed from the server)
-    None
+    extract_ip_from_headers(headers)
 }
 
 /// CORS middleware configuration

--- a/crates/bitnet-server/tests/handler_tests.rs
+++ b/crates/bitnet-server/tests/handler_tests.rs
@@ -396,8 +396,8 @@ fn config_builder_rejects_zero_max_prompt_length() {
 
 #[test]
 fn validator_accepts_valid_temperature() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -412,8 +412,8 @@ fn validator_accepts_valid_temperature() {
 
 #[test]
 fn validator_rejects_temperature_above_2() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -428,8 +428,8 @@ fn validator_rejects_temperature_above_2() {
 
 #[test]
 fn validator_rejects_negative_temperature() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -444,8 +444,8 @@ fn validator_rejects_negative_temperature() {
 
 #[test]
 fn validator_rejects_top_p_out_of_range() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -460,8 +460,8 @@ fn validator_rejects_top_p_out_of_range() {
 
 #[test]
 fn validator_rejects_top_k_zero() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -476,8 +476,8 @@ fn validator_rejects_top_k_zero() {
 
 #[test]
 fn validator_rejects_top_k_above_1000() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -492,8 +492,8 @@ fn validator_rejects_top_k_above_1000() {
 
 #[test]
 fn validator_rejects_repetition_penalty_out_of_range() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     let req = InferenceRequest {
         prompt: "hello".into(),
         max_tokens: None,
@@ -552,36 +552,36 @@ fn validator_rejects_max_tokens_exceeding_limit() {
 
 #[test]
 fn validator_rejects_empty_model_path() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     assert!(validator.validate_model_request("").is_err());
 }
 
 #[test]
 fn validator_rejects_path_traversal() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     assert!(validator.validate_model_request("../../etc/passwd.gguf").is_err());
 }
 
 #[test]
 fn validator_rejects_non_gguf_extension() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     assert!(validator.validate_model_request("/models/model.bin").is_err());
 }
 
 #[test]
 fn validator_accepts_gguf_extension() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     assert!(validator.validate_model_request("/models/model.gguf").is_ok());
 }
 
 #[test]
 fn validator_accepts_safetensors_extension() {
-    let validator = bitnet_server::security::SecurityValidator::new(SecurityConfig::default())
-        .unwrap();
+    let validator =
+        bitnet_server::security::SecurityValidator::new(SecurityConfig::default()).unwrap();
     assert!(validator.validate_model_request("/models/model.safetensors").is_ok());
 }
 
@@ -690,10 +690,7 @@ fn server_config_toml_round_trip() {
     let deserialized: ServerConfig = toml::from_str(&toml_str).unwrap();
     assert_eq!(deserialized.server.host, original.server.host);
     assert_eq!(deserialized.server.port, original.server.port);
-    assert_eq!(
-        deserialized.batch_engine.max_batch_size,
-        original.batch_engine.max_batch_size
-    );
+    assert_eq!(deserialized.batch_engine.max_batch_size, original.batch_engine.max_batch_size);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Isolate the single-responsibility task of extracting client IPs from proxy headers so it can be reused without dragging server security middleware dependencies. 
- Reduce coupling inside `bitnet-server` by moving header-parsing logic into a focused SRP microcrate for broader reuse across runtime/server components.

### Description
- Added a new crate `crates/bitnet-client-ip-core` implementing `extract_client_ip_from_headers` which parses `x-forwarded-for` (first entry) and `x-real-ip` and exposes unit tests.
- Wired the new crate into the workspace (`Cargo.toml`) and added a dependency on it from `crates/bitnet-server/Cargo.toml`.
- Refactored `crates/bitnet-server/src/security.rs` to delegate header parsing to the new crate while preserving the existing public helper `extract_client_ip_from_headers`.

### Testing
- Ran `cargo fmt` to ensure formatting; the command completed successfully.
- Ran `cargo test -p bitnet-client-ip-core` and all unit tests passed (`3 passed; 0 failed`).
- Started a wider `cargo check -p bitnet-server --lib` to validate integration; it began compiling dependencies but was not allowed to finish within the environment limits (no server-side test failures observed for the focused microcrate).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b98995b883339c6c23c4a8f5f9c2)