### PR TITLE
feat(fuzz): add wave 20 — 6 new fuzz targets (84 total)

### DIFF
--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -113,6 +113,13 @@ jobs:
           - runtime_context_parse_no_panic
           - validation_no_panic
           - vocab_size_extraction
+          # Wave 20: attention, pipeline, KV eviction, sampling, embedding, GGUF
+          - fuzz_attention_mask
+          - fuzz_pipeline_config
+          - fuzz_kv_cache_eviction
+          - fuzz_token_sampling
+          - fuzz_embedding_lookup
+          - fuzz_gguf_header
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -63,6 +63,13 @@ jobs:
           - runtime_context_parse_no_panic
           - validation_no_panic
           - vocab_size_extraction
+          # Wave 20: attention, pipeline, KV eviction, sampling, embedding, GGUF
+          - fuzz_attention_mask
+          - fuzz_pipeline_config
+          - fuzz_kv_cache_eviction
+          - fuzz_token_sampling
+          - fuzz_embedding_lookup
+          - fuzz_gguf_header
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -61,6 +61,12 @@ jobs:
           - batch_norm_params
           - prefix_cache_ops
           - broadcast_shape_fuzz
+          - fuzz_attention_mask
+          - fuzz_pipeline_config
+          - fuzz_kv_cache_eviction
+          - fuzz_token_sampling
+          - fuzz_embedding_lookup
+          - fuzz_gguf_header
 
     steps:
       - name: Checkout

--- a/crates/bitnet-inference/src/cpu_opt.rs
+++ b/crates/bitnet-inference/src/cpu_opt.rs
@@ -732,16 +732,8 @@ mod tests {
     #[test]
     fn test_silu_numerical_stability_extremes() {
         let out = silu(&[100.0, -100.0]);
-        assert!(
-            (out[0] - 100.0).abs() < 1e-3,
-            "silu(100) should ≈ 100, got {}",
-            out[0]
-        );
-        assert!(
-            out[1].abs() < 1e-10,
-            "silu(-100) should ≈ 0, got {}",
-            out[1]
-        );
+        assert!((out[0] - 100.0).abs() < 1e-3, "silu(100) should ≈ 100, got {}", out[0]);
+        assert!(out[1].abs() < 1e-10, "silu(-100) should ≈ 0, got {}", out[1]);
         // No NaN or Inf
         for &v in &out {
             assert!(v.is_finite(), "silu output must be finite, got {v}");
@@ -768,11 +760,11 @@ mod tests {
     fn test_silu_known_reference_values() {
         let inputs = [0.0f32, 1.0, -1.0, 2.0, -2.0];
         let expected = [
-            0.0,      // silu(0) = 0
-            0.7311,   // silu(1) ≈ 0.7311
-            -0.2689,  // silu(-1) ≈ -0.2689
-            1.7616,   // silu(2) ≈ 1.7616
-            -0.2384,  // silu(-2) ≈ -0.2384
+            0.0,     // silu(0) = 0
+            0.7311,  // silu(1) ≈ 0.7311
+            -0.2689, // silu(-1) ≈ -0.2689
+            1.7616,  // silu(2) ≈ 1.7616
+            -0.2384, // silu(-2) ≈ -0.2384
         ];
         let out = silu(&inputs);
         for (i, (&got, &want)) in out.iter().zip(expected.iter()).enumerate() {
@@ -816,10 +808,7 @@ mod tests {
         rmsnorm(&input, &weight, &mut output, 1, dim, 1e-5).unwrap();
         // rms(1,1,1,1) = sqrt(1 + eps) ≈ 1.0, so output ≈ weight
         for (i, &v) in output.iter().enumerate() {
-            assert!(
-                (v - 1.0).abs() < 0.01,
-                "all-ones: output[{i}] = {v}, expected ≈ 1.0"
-            );
+            assert!((v - 1.0).abs() < 0.01, "all-ones: output[{i}] = {v}, expected ≈ 1.0");
         }
     }
 

--- a/crates/bitnet-models/src/safetensors_reader.rs
+++ b/crates/bitnet-models/src/safetensors_reader.rs
@@ -97,21 +97,15 @@ impl SafeTensorsReader {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file) }?;
 
-        let shard_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("model.safetensors")
-            .to_string();
+        let shard_name =
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("model.safetensors").to_string();
 
         let tensor_metadata = Self::extract_metadata_from_bytes(&mmap, &shard_name)?;
 
         let mut shards = HashMap::new();
         shards.insert(shard_name, mmap);
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// Open a sharded SafeTensors model from its index file.
@@ -174,10 +168,7 @@ impl SafeTensorsReader {
             );
         }
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// List all tensor names in the model, sorted alphabetically.
@@ -218,9 +209,7 @@ impl SafeTensorsReader {
         let st = SafeTensors::deserialize(mmap)
             .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
-        let view = st
-            .tensor(name)
-            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let data = view.data();
 
@@ -253,14 +242,12 @@ impl SafeTensorsReader {
         data: &[u8],
         shard_name: &str,
     ) -> Result<HashMap<String, TensorMeta>> {
-        let st =
-            SafeTensors::deserialize(data).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let st = SafeTensors::deserialize(data)
+            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let mut metadata = HashMap::new();
         for name in st.names() {
-            let view = st
-                .tensor(name)
-                .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+            let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
             metadata.insert(
                 name.to_string(),
                 TensorMeta {
@@ -286,9 +273,7 @@ fn read_f32_le(data: &[u8]) -> Vec<f32> {
 /// Read little-endian u16 values from a byte slice, handling potential
 /// alignment issues with memory-mapped data.
 fn read_u16_le(data: &[u8]) -> Vec<u16> {
-    data.chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect()
+    data.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
 }
 
 /// Deserialized shard index (`model.safetensors.index.json`).
@@ -305,9 +290,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     /// Helper: serialize tensors to a safetensors byte vector.
-    fn make_safetensors(
-        tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>,
-    ) -> Vec<u8> {
+    fn make_safetensors(tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>) -> Vec<u8> {
         let views: Vec<(String, TensorView)> = tensors
             .into_iter()
             .map(|(name, dtype, shape, data)| {
@@ -345,13 +328,10 @@ mod tests {
     #[test]
     fn bf16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![1.0, -2.5, 0.0, 42.0];
-        let bf16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::bf16::from_f32(f).to_le_bytes())
-            .collect();
+        let bf16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::bf16::from_f32(f).to_le_bytes()).collect();
 
-        let data =
-            make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
+        let data = make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -372,10 +352,8 @@ mod tests {
     #[test]
     fn f16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![0.5, -1.0, 3.14, 0.0];
-        let f16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::f16::from_f32(f).to_le_bytes())
-            .collect();
+        let f16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::f16::from_f32(f).to_le_bytes()).collect();
 
         let data = make_safetensors(vec![("proj", SafeDtype::F16, vec![2, 2], &f16_bytes)]);
 
@@ -401,14 +379,12 @@ mod tests {
         // Shard 1: embedding
         let embed_vals: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
         let embed_bytes: Vec<u8> = embed_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard1 =
-            make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
+        let shard1 = make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
 
         // Shard 2: projection
         let proj_vals: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let proj_bytes: Vec<u8> = proj_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard2 =
-            make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
+        let shard2 = make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
 
         std::fs::write(dir.path().join("shard-00001.safetensors"), &shard1).unwrap();
         std::fs::write(dir.path().join("shard-00002.safetensors"), &shard2).unwrap();
@@ -439,12 +415,8 @@ mod tests {
 
     #[test]
     fn error_missing_tensor() {
-        let data = make_safetensors(vec![(
-            "existing",
-            SafeDtype::F32,
-            vec![1],
-            &1.0f32.to_le_bytes(),
-        )]);
+        let data =
+            make_safetensors(vec![("existing", SafeDtype::F32, vec![1], &1.0f32.to_le_bytes())]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -465,12 +437,8 @@ mod tests {
     #[test]
     fn error_unsupported_dtype() {
         // I64 is not supported for F32 conversion
-        let i64_bytes: Vec<u8> = vec![1i64, 2i64]
-            .iter()
-            .flat_map(|i| i.to_le_bytes())
-            .collect();
-        let data =
-            make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
+        let i64_bytes: Vec<u8> = vec![1i64, 2i64].iter().flat_map(|i| i.to_le_bytes()).collect();
+        let data = make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -512,10 +480,7 @@ mod tests {
     #[test]
     fn multiple_tensors_single_file() {
         let w1: Vec<u8> = vec![1.0f32, 2.0].iter().flat_map(|f| f.to_le_bytes()).collect();
-        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0]
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let data = make_safetensors(vec![
             ("layer.0.weight", SafeDtype::F32, vec![2], &w1),
@@ -529,9 +494,6 @@ mod tests {
         let reader = SafeTensorsReader::from_file(file.path()).unwrap();
         assert_eq!(reader.tensor_count(), 2);
         assert_eq!(reader.load_tensor("layer.0.weight").unwrap(), vec![1.0, 2.0]);
-        assert_eq!(
-            reader.load_tensor("layer.1.weight").unwrap(),
-            vec![3.0, 4.0, 5.0]
-        );
+        assert_eq!(reader.load_tensor("layer.1.weight").unwrap(), vec![3.0, 4.0, 5.0]);
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -539,3 +539,39 @@ name = "fuzz_activation_elementwise"
 path = "fuzz_targets/fuzz_activation_elementwise.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_attention_mask"
+path = "fuzz_targets/fuzz_attention_mask.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_pipeline_config"
+path = "fuzz_targets/fuzz_pipeline_config.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_kv_cache_eviction"
+path = "fuzz_targets/fuzz_kv_cache_eviction.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_token_sampling"
+path = "fuzz_targets/fuzz_token_sampling.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_embedding_lookup"
+path = "fuzz_targets/fuzz_embedding_lookup.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_gguf_header"
+path = "fuzz_targets/fuzz_gguf_header.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_attention_mask.rs
+++ b/fuzz/fuzz_targets/fuzz_attention_mask.rs
@@ -1,0 +1,157 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MaskInput {
+    /// Sequence lengths for each batch entry.
+    seq_lens: Vec<u8>,
+    /// Maximum sequence length override.
+    max_seq_len: u8,
+    /// Whether to apply causal masking.
+    causal: bool,
+    /// Whether to apply padding masking.
+    padding: bool,
+}
+
+/// Build a causal mask: position j > i is masked (set to NEG_INFINITY).
+fn build_causal_mask(seq_len: usize) -> Vec<f32> {
+    let mut mask = vec![0.0f32; seq_len * seq_len];
+    for i in 0..seq_len {
+        for j in (i + 1)..seq_len {
+            mask[i * seq_len + j] = f32::NEG_INFINITY;
+        }
+    }
+    mask
+}
+
+/// Build a padding mask: positions beyond `actual_len` are masked.
+fn build_padding_mask(actual_len: usize, max_len: usize) -> Vec<f32> {
+    let mut mask = vec![0.0f32; max_len];
+    for j in actual_len..max_len {
+        mask[j] = f32::NEG_INFINITY;
+    }
+    mask
+}
+
+/// Combine causal and padding masks into a 2-D attention mask.
+fn build_attention_mask(
+    actual_len: usize,
+    max_len: usize,
+    causal: bool,
+    padding: bool,
+) -> Vec<f32> {
+    let mut mask = vec![0.0f32; max_len * max_len];
+
+    if causal {
+        let causal_m = build_causal_mask(max_len);
+        for (i, v) in causal_m.iter().enumerate() {
+            if *v == f32::NEG_INFINITY {
+                mask[i] = f32::NEG_INFINITY;
+            }
+        }
+    }
+
+    if padding {
+        let pad_m = build_padding_mask(actual_len, max_len);
+        for i in 0..max_len {
+            for j in 0..max_len {
+                if pad_m[j] == f32::NEG_INFINITY {
+                    mask[i * max_len + j] = f32::NEG_INFINITY;
+                }
+            }
+        }
+    }
+
+    mask
+}
+
+fuzz_target!(|input: MaskInput| {
+    let seq_lens: Vec<usize> =
+        input.seq_lens.iter().take(16).map(|&s| (s as usize % 32) + 1).collect();
+    if seq_lens.is_empty() {
+        return;
+    }
+
+    let max_len = ((input.max_seq_len as usize) % 32) + 1;
+
+    for &actual_len in &seq_lens {
+        let actual = actual_len.min(max_len);
+
+        // --- Causal mask invariants ---
+        let causal = build_causal_mask(max_len);
+        assert_eq!(causal.len(), max_len * max_len, "causal mask size mismatch");
+
+        // Invariant 1: Diagonal is always unmasked.
+        for i in 0..max_len {
+            assert_eq!(causal[i * max_len + i], 0.0, "diagonal position ({i},{i}) should be 0.0");
+        }
+
+        // Invariant 2: Lower triangle (j <= i) is unmasked.
+        for i in 0..max_len {
+            for j in 0..=i {
+                assert_eq!(causal[i * max_len + j], 0.0, "lower-tri ({i},{j}) should be 0.0");
+            }
+        }
+
+        // Invariant 3: Upper triangle (j > i) is masked.
+        for i in 0..max_len {
+            for j in (i + 1)..max_len {
+                assert_eq!(
+                    causal[i * max_len + j],
+                    f32::NEG_INFINITY,
+                    "upper-tri ({i},{j}) should be -inf"
+                );
+            }
+        }
+
+        // --- Padding mask invariants ---
+        let pad = build_padding_mask(actual, max_len);
+        assert_eq!(pad.len(), max_len, "padding mask size mismatch");
+
+        // Invariant 4: Positions < actual_len are unmasked.
+        for j in 0..actual {
+            assert_eq!(pad[j], 0.0, "padding mask position {j} should be 0.0 (actual={actual})");
+        }
+
+        // Invariant 5: Positions >= actual_len are masked.
+        for j in actual..max_len {
+            assert_eq!(
+                pad[j],
+                f32::NEG_INFINITY,
+                "padding mask position {j} should be -inf (actual={actual})"
+            );
+        }
+
+        // --- Combined mask invariants ---
+        let combined = build_attention_mask(actual, max_len, input.causal, input.padding);
+        assert_eq!(combined.len(), max_len * max_len, "combined mask size mismatch");
+
+        // Invariant 6: No NaN values in the mask.
+        for (idx, &v) in combined.iter().enumerate() {
+            assert!(!v.is_nan(), "combined mask has NaN at index {idx}");
+        }
+
+        // Invariant 7: Mask values are only 0.0 or NEG_INFINITY.
+        for (idx, &v) in combined.iter().enumerate() {
+            assert!(
+                v == 0.0 || v == f32::NEG_INFINITY,
+                "combined mask has unexpected value {v} at index {idx}"
+            );
+        }
+
+        // Invariant 8: With both causal and padding, padded future positions are masked.
+        if input.causal && input.padding && actual < max_len {
+            for j in actual..max_len {
+                for i in 0..max_len {
+                    assert_eq!(
+                        combined[i * max_len + j],
+                        f32::NEG_INFINITY,
+                        "padded column {j} in row {i} should be masked"
+                    );
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_embedding_lookup.rs
+++ b/fuzz/fuzz_targets/fuzz_embedding_lookup.rs
@@ -1,0 +1,127 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct EmbeddingLookupInput {
+    vocab_size: u8,
+    embed_dim: u8,
+    table_data: Vec<u8>,
+    /// Token IDs as u32 to cover a wider OOB range.
+    token_ids: Vec<u32>,
+    /// Whether to test gather (batch lookup with possible duplicates).
+    test_gather: bool,
+}
+
+struct EmbeddingTable {
+    data: Vec<f32>,
+    vocab_size: usize,
+    embed_dim: usize,
+}
+
+impl EmbeddingTable {
+    fn new(data: Vec<f32>, vocab_size: usize, embed_dim: usize) -> Self {
+        Self { data, vocab_size, embed_dim }
+    }
+
+    fn lookup(&self, token_id: usize) -> Option<&[f32]> {
+        if token_id >= self.vocab_size {
+            return None;
+        }
+        let start = token_id * self.embed_dim;
+        let end = start + self.embed_dim;
+        if end > self.data.len() {
+            return None;
+        }
+        Some(&self.data[start..end])
+    }
+
+    fn gather(&self, ids: &[usize]) -> Vec<f32> {
+        let mut out = Vec::with_capacity(ids.len() * self.embed_dim);
+        for &id in ids {
+            if let Some(emb) = self.lookup(id) {
+                out.extend_from_slice(emb);
+            }
+        }
+        out
+    }
+
+    /// Compute L2 norm of an embedding vector.
+    fn l2_norm(&self, token_id: usize) -> Option<f32> {
+        self.lookup(token_id).map(|emb| emb.iter().map(|x| x * x).sum::<f32>().sqrt())
+    }
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: EmbeddingLookupInput| {
+    let vocab_size = (input.vocab_size as usize % 64) + 1;
+    let embed_dim = (input.embed_dim as usize % 32) + 1;
+    let required = vocab_size * embed_dim;
+
+    let mut table = bytes_to_f32(&input.table_data, required);
+    table.resize(required, 0.0);
+
+    let emb = EmbeddingTable::new(table, vocab_size, embed_dim);
+
+    let ids: Vec<usize> = input.token_ids.iter().take(128).map(|&t| t as usize).collect();
+
+    // Invariant 1: Valid lookups return correct dimension.
+    for &tid in &ids {
+        match emb.lookup(tid) {
+            Some(vec) => {
+                assert!(tid < vocab_size, "OOB token {tid} returned Some");
+                assert_eq!(vec.len(), embed_dim, "wrong dim for token {tid}");
+            }
+            None => {
+                assert!(tid >= vocab_size, "valid token {tid} returned None");
+            }
+        }
+    }
+
+    // Invariant 2: Same token ID always yields identical embedding.
+    for &tid in &ids {
+        if let (Some(a), Some(b)) = (emb.lookup(tid), emb.lookup(tid)) {
+            assert_eq!(a, b, "lookup should be deterministic for token {tid}");
+        }
+    }
+
+    // Invariant 3: Gather output dimension is correct.
+    let valid_ids: Vec<usize> = ids.iter().copied().filter(|&t| t < vocab_size).collect();
+    let gathered = emb.gather(&valid_ids);
+    assert_eq!(gathered.len(), valid_ids.len() * embed_dim, "gather output dim mismatch");
+
+    // Invariant 4: Gather with duplicates produces repeated embeddings.
+    if let Some(&first_valid) = valid_ids.first() {
+        let dup_ids = vec![first_valid; 3];
+        let dup_gathered = emb.gather(&dup_ids);
+        assert_eq!(dup_gathered.len(), 3 * embed_dim);
+        let e0 = &dup_gathered[..embed_dim];
+        let e1 = &dup_gathered[embed_dim..2 * embed_dim];
+        let e2 = &dup_gathered[2 * embed_dim..3 * embed_dim];
+        assert_eq!(e0, e1, "duplicate gather entries should match");
+        assert_eq!(e1, e2, "duplicate gather entries should match");
+    }
+
+    // Invariant 5: All-OOB gather produces empty output.
+    let oob_ids: Vec<usize> = ids.iter().copied().filter(|&t| t >= vocab_size).take(8).collect();
+    let oob_gathered = emb.gather(&oob_ids);
+    assert!(oob_gathered.is_empty(), "all-OOB gather should be empty");
+
+    // Invariant 6: L2 norm is non-negative for valid tokens.
+    if input.test_gather {
+        for &tid in &valid_ids {
+            if let Some(norm) = emb.l2_norm(tid) {
+                assert!(norm >= 0.0 || norm.is_nan(), "L2 norm must be non-negative");
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_gguf_header.rs
+++ b/fuzz/fuzz_targets/fuzz_gguf_header.rs
@@ -1,0 +1,141 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_gguf::{GgufValueType, check_magic, parse_header, read_version};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct GgufHeaderInput {
+    /// Base data that may be valid or corrupted GGUF bytes.
+    data: Vec<u8>,
+    /// Corruption operations to apply.
+    corruptions: Vec<Corruption>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum Corruption {
+    /// Flip a single byte at the given position.
+    FlipByte { pos: u16, mask: u8 },
+    /// Zero out a range of bytes.
+    ZeroRange { start: u16, len: u8 },
+    /// Overwrite magic bytes with garbage.
+    CorruptMagic { replacement: [u8; 4] },
+    /// Set version field to an extreme value.
+    CorruptVersion { value: u32 },
+    /// Truncate to a specific length.
+    Truncate { len: u16 },
+    /// Append random bytes.
+    Extend { extra: Vec<u8> },
+}
+
+/// Build a minimal valid GGUF header for corruption testing.
+fn build_valid_gguf_header(n_kv: u64, n_tensors: u64) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(b"GGUF"); // magic
+    buf.extend_from_slice(&3u32.to_le_bytes()); // version 3
+    buf.extend_from_slice(&n_tensors.to_le_bytes()); // tensor count
+    buf.extend_from_slice(&n_kv.to_le_bytes()); // metadata kv count
+    buf
+}
+
+fn apply_corruptions(data: &mut Vec<u8>, corruptions: &[Corruption]) {
+    for corruption in corruptions.iter().take(16) {
+        match corruption {
+            Corruption::FlipByte { pos, mask } => {
+                let idx = *pos as usize;
+                if idx < data.len() {
+                    data[idx] ^= mask;
+                }
+            }
+            Corruption::ZeroRange { start, len } => {
+                let s = *start as usize;
+                let l = (*len as usize).min(32);
+                for i in s..data.len().min(s + l) {
+                    data[i] = 0;
+                }
+            }
+            Corruption::CorruptMagic { replacement } => {
+                if data.len() >= 4 {
+                    data[..4].copy_from_slice(replacement);
+                }
+            }
+            Corruption::CorruptVersion { value } => {
+                if data.len() >= 8 {
+                    data[4..8].copy_from_slice(&value.to_le_bytes());
+                }
+            }
+            Corruption::Truncate { len } => {
+                let l = *len as usize;
+                if l < data.len() {
+                    data.truncate(l);
+                }
+            }
+            Corruption::Extend { extra } => {
+                data.extend_from_slice(&extra[..extra.len().min(64)]);
+            }
+        }
+    }
+}
+
+fuzz_target!(|input: GgufHeaderInput| {
+    // --- Phase 1: Parse fully arbitrary bytes ---
+    let _ = check_magic(&input.data);
+    let _ = read_version(&input.data);
+    let _ = parse_header(&input.data);
+
+    // Exercise GgufValueType discriminant.
+    for chunk in input.data.windows(4) {
+        let disc = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let _ = GgufValueType::from_u32(disc);
+    }
+
+    // --- Phase 2: Build valid header then corrupt it ---
+    let valid = build_valid_gguf_header(0, 0);
+
+    // Invariant 1: Uncorrupted valid header passes magic check.
+    assert!(check_magic(&valid), "valid GGUF header should pass magic check");
+
+    // Invariant 2: Uncorrupted valid header has version 3.
+    assert_eq!(read_version(&valid), Some(3), "valid GGUF header should have version 3");
+
+    // Invariant 3: Uncorrupted valid header parses successfully.
+    assert!(parse_header(&valid).is_ok(), "valid GGUF header should parse");
+
+    // Now corrupt and ensure no panics.
+    let mut corrupted = valid.clone();
+    apply_corruptions(&mut corrupted, &input.corruptions);
+
+    let magic_ok = check_magic(&corrupted);
+    let version = read_version(&corrupted);
+    let parsed = parse_header(&corrupted);
+
+    // Invariant 4: If magic is corrupted, check_magic should fail.
+    if corrupted.len() >= 4 && &corrupted[..4] != b"GGUF" {
+        assert!(!magic_ok, "corrupted magic should fail check");
+    }
+
+    // Invariant 5: If version is corrupted beyond [1,3], read_version returns value or None.
+    if let Some(ver) = version {
+        // Version is a u32 — no constraint on range, just no panic.
+        let _ = ver;
+    }
+
+    // Invariant 6: Parse result is either Ok or Err — never panic.
+    let _ = parsed;
+
+    // --- Phase 3: Progressive truncation of valid header ---
+    for trim in 1..valid.len() {
+        let truncated = &valid[..valid.len() - trim];
+        let _ = check_magic(truncated);
+        let _ = read_version(truncated);
+        let _ = parse_header(truncated);
+    }
+
+    // --- Phase 4: Various tensor/kv counts ---
+    for &n_kv in &[0u64, 1, 100, u64::MAX] {
+        for &n_tensors in &[0u64, 1, 1000, u64::MAX] {
+            let header = build_valid_gguf_header(n_kv, n_tensors);
+            let _ = parse_header(&header);
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_kv_cache_eviction.rs
+++ b/fuzz/fuzz_targets/fuzz_kv_cache_eviction.rs
@@ -1,0 +1,223 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct EvictionInput {
+    n_layers: u8,
+    n_heads: u8,
+    head_dim: u8,
+    capacity: u8,
+    ops: Vec<EvictionOp>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum EvictionOp {
+    Append { layer: u8, data: Vec<u8> },
+    EvictOldest { layer: u8, count: u8 },
+    EvictRange { layer: u8, start: u8, end: u8 },
+    ReadSeqLen { layer: u8 },
+    ReadSlice { layer: u8, start: u8, end: u8 },
+    Reset,
+}
+
+struct EvictableKvCache {
+    n_layers: usize,
+    n_heads: usize,
+    head_dim: usize,
+    capacity: usize,
+    keys: Vec<Vec<f32>>,
+    values: Vec<Vec<f32>>,
+    seq_lens: Vec<usize>,
+}
+
+impl EvictableKvCache {
+    fn new(n_layers: usize, n_heads: usize, head_dim: usize, capacity: usize) -> Self {
+        Self {
+            n_layers,
+            n_heads,
+            head_dim,
+            capacity,
+            keys: vec![Vec::new(); n_layers],
+            values: vec![Vec::new(); n_layers],
+            seq_lens: vec![0; n_layers],
+        }
+    }
+
+    fn step_size(&self) -> usize {
+        self.n_heads * self.head_dim
+    }
+
+    fn append(&mut self, layer: usize, k: &[f32], v: &[f32]) -> bool {
+        if layer >= self.n_layers {
+            return false;
+        }
+        let step = self.step_size();
+        if k.len() != step || v.len() != step {
+            return false;
+        }
+        // Evict oldest if at capacity.
+        if self.seq_lens[layer] >= self.capacity && self.capacity > 0 {
+            self.keys[layer].drain(..step);
+            self.values[layer].drain(..step);
+            self.seq_lens[layer] -= 1;
+        }
+        self.keys[layer].extend_from_slice(k);
+        self.values[layer].extend_from_slice(v);
+        self.seq_lens[layer] += 1;
+        true
+    }
+
+    fn evict_oldest(&mut self, layer: usize, count: usize) -> usize {
+        if layer >= self.n_layers {
+            return 0;
+        }
+        let actual = count.min(self.seq_lens[layer]);
+        let step = self.step_size();
+        let remove = actual * step;
+        self.keys[layer].drain(..remove);
+        self.values[layer].drain(..remove);
+        self.seq_lens[layer] -= actual;
+        actual
+    }
+
+    fn evict_range(&mut self, layer: usize, start: usize, end: usize) -> usize {
+        if layer >= self.n_layers || start >= end || start >= self.seq_lens[layer] {
+            return 0;
+        }
+        let clamped_end = end.min(self.seq_lens[layer]);
+        let count = clamped_end - start;
+        let step = self.step_size();
+        let byte_start = start * step;
+        let byte_end = clamped_end * step;
+        self.keys[layer].drain(byte_start..byte_end);
+        self.values[layer].drain(byte_start..byte_end);
+        self.seq_lens[layer] -= count;
+        count
+    }
+
+    fn seq_len(&self, layer: usize) -> usize {
+        if layer >= self.n_layers { 0 } else { self.seq_lens[layer] }
+    }
+
+    fn read_slice(&self, layer: usize, start: usize, end: usize) -> Option<(&[f32], &[f32])> {
+        if layer >= self.n_layers || start >= end || end > self.seq_lens[layer] {
+            return None;
+        }
+        let step = self.step_size();
+        let s = start * step;
+        let e = end * step;
+        Some((&self.keys[layer][s..e], &self.values[layer][s..e]))
+    }
+
+    fn reset(&mut self) {
+        for l in 0..self.n_layers {
+            self.keys[l].clear();
+            self.values[l].clear();
+            self.seq_lens[l] = 0;
+        }
+    }
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: EvictionInput| {
+    let n_layers = (input.n_layers as usize % 4) + 1;
+    let n_heads = (input.n_heads as usize % 4) + 1;
+    let head_dim = (input.head_dim as usize % 16) + 1;
+    let capacity = (input.capacity as usize % 32) + 1;
+    let step = n_heads * head_dim;
+
+    let mut cache = EvictableKvCache::new(n_layers, n_heads, head_dim, capacity);
+
+    for op in input.ops.into_iter().take(256) {
+        match op {
+            EvictionOp::Append { layer, data } => {
+                let layer_idx = layer as usize % n_layers;
+                let kv = bytes_to_f32(&data, step * 2);
+                if kv.len() >= step * 2 {
+                    let prev = cache.seq_len(layer_idx);
+                    let ok = cache.append(layer_idx, &kv[..step], &kv[step..step * 2]);
+                    if ok {
+                        let new_len = cache.seq_len(layer_idx);
+                        // Invariant 1: After append, seq_len is at most capacity.
+                        assert!(
+                            new_len <= capacity,
+                            "seq_len {} exceeds capacity {}",
+                            new_len,
+                            capacity
+                        );
+                        // Invariant 2: seq_len increments or stays same (eviction case).
+                        assert!(
+                            new_len == prev + 1 || new_len == prev,
+                            "unexpected seq_len transition {prev} -> {new_len}"
+                        );
+                    }
+                }
+            }
+            EvictionOp::EvictOldest { layer, count } => {
+                let layer_idx = layer as usize % n_layers;
+                let prev = cache.seq_len(layer_idx);
+                let evicted = cache.evict_oldest(layer_idx, count as usize);
+                let new_len = cache.seq_len(layer_idx);
+
+                // Invariant 3: Evicted count never exceeds previous length.
+                assert!(evicted <= prev, "evicted {evicted} > prev len {prev}");
+
+                // Invariant 4: New length is prev - evicted.
+                assert_eq!(new_len, prev - evicted, "seq_len after eviction mismatch");
+
+                // Invariant 5: Buffer sizes are consistent.
+                assert_eq!(cache.keys[layer_idx].len(), new_len * step);
+                assert_eq!(cache.values[layer_idx].len(), new_len * step);
+            }
+            EvictionOp::EvictRange { layer, start, end } => {
+                let layer_idx = layer as usize % n_layers;
+                let prev = cache.seq_len(layer_idx);
+                let s = start as usize;
+                let e = end as usize;
+                let evicted = cache.evict_range(layer_idx, s, e);
+                let new_len = cache.seq_len(layer_idx);
+
+                // Invariant 6: Evicted count never exceeds previous length.
+                assert!(evicted <= prev);
+                assert_eq!(new_len, prev - evicted);
+                assert_eq!(cache.keys[layer_idx].len(), new_len * step);
+            }
+            EvictionOp::ReadSeqLen { layer } => {
+                let layer_idx = layer as usize % n_layers;
+                let len = cache.seq_len(layer_idx);
+                // Invariant 7: seq_len matches actual buffer size / step.
+                assert_eq!(cache.keys[layer_idx].len(), len * step);
+                assert_eq!(cache.values[layer_idx].len(), len * step);
+            }
+            EvictionOp::ReadSlice { layer, start, end } => {
+                let layer_idx = layer as usize % n_layers;
+                let s = start as usize;
+                let e = end as usize;
+                if let Some((k, v)) = cache.read_slice(layer_idx, s, e) {
+                    let expected = (e - s) * step;
+                    // Invariant 8: Slice sizes match expected.
+                    assert_eq!(k.len(), expected);
+                    assert_eq!(v.len(), expected);
+                }
+            }
+            EvictionOp::Reset => {
+                cache.reset();
+                for l in 0..n_layers {
+                    assert_eq!(cache.seq_len(l), 0);
+                    assert!(cache.keys[l].is_empty());
+                    assert!(cache.values[l].is_empty());
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pipeline_config.rs
+++ b/fuzz/fuzz_targets/fuzz_pipeline_config.rs
@@ -1,0 +1,190 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct PipelineConfigInput {
+    hidden_size: u32,
+    n_heads: u16,
+    n_kv_heads: u16,
+    n_layers: u16,
+    intermediate_size: u32,
+    head_dim: u16,
+    vocab_size: u32,
+    max_seq_len: u32,
+    rms_norm_eps: f32,
+    rope_theta: f32,
+}
+
+/// Minimal transformer layer config for validation fuzzing.
+#[derive(Debug)]
+struct TransformerLayerConfig {
+    hidden_size: usize,
+    n_heads: usize,
+    n_kv_heads: usize,
+    n_layers: usize,
+    intermediate_size: usize,
+    head_dim: usize,
+    vocab_size: usize,
+    max_seq_len: usize,
+    rms_norm_eps: f32,
+    rope_theta: f32,
+}
+
+#[derive(Debug)]
+enum ConfigError {
+    ZeroField,
+    HeadDimMismatch,
+    KvHeadsExceedHeads,
+    HeadsDivisibility,
+    InvalidEps,
+    InvalidTheta,
+    TooLarge,
+}
+
+impl TransformerLayerConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.hidden_size == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+        if self.n_heads == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+        if self.n_kv_heads == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+        if self.n_layers == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+        if self.vocab_size == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+        if self.max_seq_len == 0 {
+            return Err(ConfigError::ZeroField);
+        }
+
+        // Head dimension must divide hidden_size evenly.
+        let expected_head_dim = self.hidden_size / self.n_heads;
+        if expected_head_dim == 0 || self.hidden_size % self.n_heads != 0 {
+            return Err(ConfigError::HeadDimMismatch);
+        }
+        if self.head_dim != expected_head_dim {
+            return Err(ConfigError::HeadDimMismatch);
+        }
+
+        // KV heads must not exceed attention heads.
+        if self.n_kv_heads > self.n_heads {
+            return Err(ConfigError::KvHeadsExceedHeads);
+        }
+
+        // n_heads must be divisible by n_kv_heads (GQA constraint).
+        if self.n_heads % self.n_kv_heads != 0 {
+            return Err(ConfigError::HeadsDivisibility);
+        }
+
+        // Epsilon must be positive and finite.
+        if !self.rms_norm_eps.is_finite() || self.rms_norm_eps <= 0.0 {
+            return Err(ConfigError::InvalidEps);
+        }
+
+        // Rope theta must be positive and finite.
+        if !self.rope_theta.is_finite() || self.rope_theta <= 0.0 {
+            return Err(ConfigError::InvalidTheta);
+        }
+
+        // Sanity bounds.
+        if self.hidden_size > 65536 {
+            return Err(ConfigError::TooLarge);
+        }
+        if self.n_layers > 1024 {
+            return Err(ConfigError::TooLarge);
+        }
+
+        Ok(())
+    }
+
+    /// Compute the total parameter count estimate for the transformer stack.
+    fn estimated_params(&self) -> u64 {
+        let hs = self.hidden_size as u64;
+        let ff = self.intermediate_size as u64;
+        let nl = self.n_layers as u64;
+        let vs = self.vocab_size as u64;
+        // Rough estimate: embedding + n_layers * (4*hs*hs + 2*hs*ff) + output
+        vs * hs + nl * (4 * hs * hs + 2 * hs * ff) + vs * hs
+    }
+}
+
+fuzz_target!(|input: PipelineConfigInput| {
+    let config = TransformerLayerConfig {
+        hidden_size: input.hidden_size as usize,
+        n_heads: input.n_heads as usize,
+        n_kv_heads: input.n_kv_heads as usize,
+        n_layers: input.n_layers as usize,
+        intermediate_size: input.intermediate_size as usize,
+        head_dim: input.head_dim as usize,
+        vocab_size: input.vocab_size as usize,
+        max_seq_len: input.max_seq_len as usize,
+        rms_norm_eps: input.rms_norm_eps,
+        rope_theta: input.rope_theta,
+    };
+
+    match config.validate() {
+        Ok(()) => {
+            // Invariant 1: Valid config has non-zero fields.
+            assert!(config.hidden_size > 0);
+            assert!(config.n_heads > 0);
+            assert!(config.n_kv_heads > 0);
+            assert!(config.n_layers > 0);
+            assert!(config.vocab_size > 0);
+
+            // Invariant 2: hidden_size divisible by n_heads.
+            assert_eq!(
+                config.hidden_size % config.n_heads,
+                0,
+                "hidden_size must be divisible by n_heads"
+            );
+
+            // Invariant 3: head_dim matches hidden_size / n_heads.
+            assert_eq!(config.head_dim, config.hidden_size / config.n_heads, "head_dim mismatch");
+
+            // Invariant 4: GQA constraint — n_heads divisible by n_kv_heads.
+            assert_eq!(
+                config.n_heads % config.n_kv_heads,
+                0,
+                "n_heads must be divisible by n_kv_heads"
+            );
+
+            // Invariant 5: n_kv_heads <= n_heads.
+            assert!(config.n_kv_heads <= config.n_heads);
+
+            // Invariant 6: Param estimate is non-zero for valid config.
+            let params = config.estimated_params();
+            assert!(params > 0, "valid config should have non-zero estimated params");
+
+            // Invariant 7: eps and theta are positive finite.
+            assert!(config.rms_norm_eps > 0.0 && config.rms_norm_eps.is_finite());
+            assert!(config.rope_theta > 0.0 && config.rope_theta.is_finite());
+        }
+        Err(_) => {
+            // Validation error is expected for bad inputs — no panic.
+        }
+    }
+
+    // Also fuzz the BitNetConfig builder with the same dimensions.
+    let result = bitnet_common::BitNetConfig::builder()
+        .hidden_size(input.hidden_size as usize)
+        .num_heads(input.n_heads as usize)
+        .num_key_value_heads(input.n_kv_heads as usize)
+        .num_layers(input.n_layers as usize)
+        .vocab_size(input.vocab_size as usize)
+        .max_length(input.max_seq_len as usize)
+        .build();
+
+    match result {
+        Ok(cfg) => {
+            let _ = cfg.validate();
+        }
+        Err(_) => {}
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_token_sampling.rs
+++ b/fuzz/fuzz_targets/fuzz_token_sampling.rs
@@ -1,0 +1,136 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_sampling::{SamplingConfig, SamplingStrategy};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct TokenSamplingInput {
+    /// Raw bytes interpreted as little-endian f32 logits.
+    raw_logits: Vec<u8>,
+    /// Context token IDs for repetition penalty.
+    context_tokens: Vec<u8>,
+    /// Strategy selector: 0=greedy, 1=top-k, 2=nucleus, 3=combined.
+    strategy: u8,
+    /// Top-k value.
+    top_k: u16,
+    /// Top-p value.
+    top_p_raw: u8,
+    /// Repetition penalty (raw byte scaled to [0.5, 2.0]).
+    rep_penalty_raw: u8,
+    /// Random seed.
+    seed: u64,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: TokenSamplingInput| {
+    let logits = bytes_to_f32(&input.raw_logits, 32_768);
+    if logits.is_empty() {
+        return;
+    }
+    let vocab_size = logits.len();
+
+    let context_tokens: Vec<u32> =
+        input.context_tokens.iter().take(256).map(|&b| (b as u32) % vocab_size as u32).collect();
+
+    // Map top_p_raw (0..255) to [0.0, 1.0].
+    let top_p = input.top_p_raw as f32 / 255.0;
+    // Map rep_penalty_raw to [0.5, 2.0].
+    let rep_penalty = 0.5 + (input.rep_penalty_raw as f32 / 255.0) * 1.5;
+
+    let configs = match input.strategy % 4 {
+        // Greedy: temperature=0, no top-k/top-p.
+        0 => vec![SamplingConfig {
+            temperature: 0.0,
+            top_k: 0,
+            top_p: 1.0,
+            repetition_penalty: rep_penalty,
+            seed: Some(input.seed),
+        }],
+        // Top-k only.
+        1 => vec![SamplingConfig {
+            temperature: 1.0,
+            top_k: (input.top_k as u32).min(vocab_size as u32),
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(input.seed),
+        }],
+        // Nucleus (top-p) only.
+        2 => vec![SamplingConfig {
+            temperature: 1.0,
+            top_k: 0,
+            top_p,
+            repetition_penalty: 1.0,
+            seed: Some(input.seed),
+        }],
+        // Combined: top-k + top-p + repetition penalty.
+        _ => vec![SamplingConfig {
+            temperature: 0.7,
+            top_k: (input.top_k as u32).min(vocab_size as u32),
+            top_p,
+            repetition_penalty: rep_penalty,
+            seed: Some(input.seed),
+        }],
+    };
+
+    for config in configs {
+        let mut strategy = SamplingStrategy::new(config);
+
+        match strategy.sample(&logits, &context_tokens) {
+            Ok(token_id) => {
+                // Invariant 1: Token ID is within vocabulary bounds.
+                assert!(
+                    (token_id as usize) < vocab_size,
+                    "sampled token {token_id} >= vocab_size {vocab_size}"
+                );
+            }
+            Err(_) => {
+                // Errors are expected for degenerate inputs (all-NaN, empty after filtering).
+            }
+        }
+    }
+
+    // Invariant 2: Greedy sampling is deterministic — same seed, same input, same result.
+    let greedy_cfg = SamplingConfig {
+        temperature: 0.0,
+        top_k: 0,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+        seed: Some(42),
+    };
+    let result1 = SamplingStrategy::new(greedy_cfg.clone()).sample(&logits, &context_tokens);
+    let result2 = SamplingStrategy::new(greedy_cfg).sample(&logits, &context_tokens);
+    match (result1, result2) {
+        (Ok(a), Ok(b)) => {
+            assert_eq!(a, b, "greedy sampling must be deterministic");
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("greedy sampling inconsistency: one succeeded, one failed"),
+    }
+
+    // Invariant 3: Same seed produces same result for stochastic sampling.
+    let seeded_cfg = SamplingConfig {
+        temperature: 0.7,
+        top_k: 50,
+        top_p: 0.9,
+        repetition_penalty: 1.0,
+        seed: Some(input.seed),
+    };
+    let r1 = SamplingStrategy::new(seeded_cfg.clone()).sample(&logits, &context_tokens);
+    let r2 = SamplingStrategy::new(seeded_cfg).sample(&logits, &context_tokens);
+    match (r1, r2) {
+        (Ok(a), Ok(b)) => {
+            assert_eq!(a, b, "seeded sampling must be reproducible");
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("seeded sampling inconsistency"),
+    }
+});


### PR DESCRIPTION
## Fuzz Wave 20

Add 6 new fuzz targets bringing the total from 78 to 84.

### New Targets

| Target | Description |
|--------|-------------|
| `fuzz_attention_mask` | Causal/padding mask creation with random seq_lens; validates mask shape, diagonal, triangle, and value invariants |
| `fuzz_pipeline_config` | TransformerLayerConfig validation with random dimensions + BitNetConfig builder; checks head_dim, GQA, eps/theta constraints |
| `fuzz_kv_cache_eviction` | KV cache append/evict with capacity limits, range eviction, slice reads; verifies capacity bounds and buffer consistency |
| `fuzz_token_sampling` | Greedy, top-k, nucleus sampling strategies via `bitnet-sampling`; tests determinism, reproducibility, OOB invariants |
| `fuzz_embedding_lookup` | Embedding table lookup with OOB indices, batch gather, duplicate gather, L2 norm; checks dimension and determinism |
| `fuzz_gguf_header` | GGUF header parsing with corrupted/truncated bytes via `bitnet-gguf`; validates magic, version, progressive truncation |

### Notes
- `fuzz_kv_cache_ops` already existed (wave prior); created `fuzz_kv_cache_eviction` with eviction-policy focus instead
- All 6 targets registered in `fuzz/Cargo.toml` and all three fuzz CI workflows (`nightly-fuzz.yml`, `fuzz-ci.yml`, `fuzz-nightly.yml`)
- All compile cleanly with zero warnings
- TOML validated