### PR TITLE
feat: default root bitnet crate to CPU and align quickstart guidance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ rayon = "1.11.0"
 tracing = "0.1.41"
 
 [features]
-default = [] # Empty default features - must be explicitly enabled
+default = ["cpu"] # CPU is the baseline; use --no-default-features for boundary validation
 
 # Test and development features (off by default)
 bench = []

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ BitNet-rs is a high-performance Rust inference engine for 1-bit BitNet LLMs.
 # 1. Download a model
 cargo run -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf
 
-# 2. Run inference  (always specify --no-default-features --features cpu|gpu)
-RUST_LOG=warn cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- run \
+# 2. Run inference (CPU baseline defaults are enabled)
+RUST_LOG=warn cargo run -p bitnet-cli -- run \
   --model  models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
   --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
   --prompt "What is 2+2?" --max-tokens 8
 
 # 3. Interactive chat
-RUST_LOG=warn cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- chat \
+RUST_LOG=warn cargo run -p bitnet-cli -- chat \
   --model  models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
   --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json
 ```
 
-> Default features are **empty** by design — always pass `--no-default-features --features cpu` (or `gpu`).
+> Default features include **CPU baseline**. Use `--no-default-features` for feature-boundary checks, or explicitly select alternatives such as `--features gpu`.
 
 ## Status
 


### PR DESCRIPTION
### Motivation
- Reduce ergonomic friction and docs drift by making the CPU path the workspace default because CPU is the intended baseline while preserving explicit feature-boundary testing.
- The workspace previously had `default = []` while `bitnet-cli` already defaulted to `["cpu", "full-cli"]`, causing inconsistent developer UX and inaccurate docs.

### Description
- Set `default = ["cpu"]` in the root `Cargo.toml` so the `bitnet` crate is CPU-enabled by default and added an inline note explaining `--no-default-features` remains available for boundary checks.
- Updated `README.md` Quick Start to remove the mandatory `--no-default-features --features cpu,full-cli` flags for the everyday CPU run/chat examples and replaced the “empty defaults” guidance with a note that CPU is the baseline.
- Left `bitnet-cli` crate defaults unchanged and clarified the recommended pattern: day-to-day use the CPU defaults and use `--no-default-features` when explicitly validating feature boundaries.

### Testing
- Ran `cargo check -p bitnet` which completed successfully.
- Ran `cargo check -p bitnet --no-default-features` which completed successfully.
- Ran `cargo check -p bitnet --features cpu` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d236d8fc83339e1cee424b75d385)