### PR TITLE
Default root crate to CPU baseline and update feature-selection docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ rayon = "1.11.0"
 tracing = "0.1.41"
 
 [features]
-default = [] # Empty default features - must be explicitly enabled
+default = ["cpu"] # CPU is the ergonomic baseline; use --no-default-features for boundary checks
 
 # Test and development features (off by default)
 bench = []

--- a/docs/GPU_CONTRIBUTOR_GUIDE.md
+++ b/docs/GPU_CONTRIBUTOR_GUIDE.md
@@ -94,8 +94,8 @@ pub enum BackendRequest {
 ### How to Build
 
 ```bash
-# CPU-only (no GPU hardware required)
-cargo build --no-default-features --features cpu
+# CPU-only (no GPU hardware required; default root behavior)
+cargo build
 
 # GPU (CUDA)
 cargo build --no-default-features --features gpu
@@ -107,13 +107,13 @@ cargo build --no-default-features --features rocm
 cargo build --no-default-features --features vulkan
 ```
 
-> **Important**: Default features are empty. Always specify `--no-default-features --features <target>`.
+> **Important**: Root `bitnet` defaults to `cpu`; `bitnet-cli` defaults to `cpu,full-cli`. For non-default backend validation, use `--no-default-features --features <target>`.
 
 ### How to Test
 
 ```bash
 # CPU tests (always works, no hardware needed)
-cargo nextest run --workspace --no-default-features --features cpu
+cargo nextest run --workspace --features cpu
 
 # GPU tests (requires CUDA hardware + toolkit)
 cargo nextest run --workspace --no-default-features --features gpu
@@ -123,6 +123,10 @@ cargo test -p bitnet-kernels --no-default-features --features cpu
 
 # CI profile (4 threads, 5-min timeout)
 cargo nextest run --profile ci
+
+# Boundary check (feature gating hygiene)
+cargo check -p bitnet --no-default-features
+cargo check -p bitnet --features cpu
 ```
 
 ---

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -44,10 +44,17 @@ nvidia-smi
 
 ## 2) Build with GPU support
 
-Use explicit feature selection (default features are intentionally empty):
+CPU is the default baseline. Use explicit feature selection when targeting non-default backends:
 
 ```bash
 cargo build --no-default-features --features gpu
+```
+
+For feature-boundary validation, also run:
+
+```bash
+cargo check -p bitnet --no-default-features
+cargo check -p bitnet --features cpu
 ```
 
 Run GPU tests where hardware is available:


### PR DESCRIPTION
### Motivation

- The repository had drift between crate defaults and documentation, causing friction for the common CPU development path. 
- CPU is the practical baseline for day-to-day development so making it the ergonomic default reduces flags and surprise while preserving feature hygiene.
- Preserve explicit feature-boundary verification as a governance tool by keeping `--no-default-features` available for CI and validation.

### Description

- Set the workspace root `bitnet` crate default features to include `"cpu"` by changing `default = []` to `default = ["cpu"]` in `Cargo.toml`.
- Update `docs/GPU_SETUP.md` to state that CPU is the default baseline and add explicit feature-boundary validation commands using `cargo check -p bitnet --no-default-features` and `cargo check -p bitnet --features cpu`.
- Update `docs/GPU_CONTRIBUTOR_GUIDE.md` to reflect that the root crate defaults to `cpu` (and `bitnet-cli` defaults to `cpu,full-cli`), switch CPU build/test examples to the default-path commands, and add a short "Boundary check (feature gating hygiene)" section with the same validation commands.
- Files changed: `Cargo.toml`, `docs/GPU_SETUP.md`, and `docs/GPU_CONTRIBUTOR_GUIDE.md`.

### Testing

- Ran `cargo check -p bitnet --no-default-features` and it completed successfully. 
- Ran `cargo check -p bitnet --features cpu` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d236d8fc83339e1cee424b75d385)