### PR TITLE
Set root `bitnet` default feature to CPU and update feature-gating docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,7 +273,7 @@ rayon = "1.11.0"
 tracing = "0.1.41"
 
 [features]
-default = [] # Empty default features - must be explicitly enabled
+default = ["cpu"] # CPU-first default; use --no-default-features for boundary checks
 
 # Test and development features (off by default)
 bench = []

--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ BitNet-rs is a high-performance Rust inference engine for 1-bit BitNet LLMs.
 # 1. Download a model
 cargo run -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf
 
-# 2. Run inference  (always specify --no-default-features --features cpu|gpu)
-RUST_LOG=warn cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- run \
+# 2. Run inference (CPU defaults are enabled out of the box)
+RUST_LOG=warn cargo run -p bitnet-cli -- run \
   --model  models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
   --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
   --prompt "What is 2+2?" --max-tokens 8
 
 # 3. Interactive chat
-RUST_LOG=warn cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- chat \
+RUST_LOG=warn cargo run -p bitnet-cli -- chat \
   --model  models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
   --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json
 ```
 
-> Default features are **empty** by design — always pass `--no-default-features --features cpu` (or `gpu`).
+> Root `bitnet` now defaults to `cpu`; use `--no-default-features` for explicit feature-boundary checks and `--features gpu` (or another backend) when needed.
 
 ## Status
 
@@ -203,6 +203,17 @@ cargo fmt --all && cargo clippy --all-targets --no-default-features --features c
 The suite has 1000+ enabled tests spanning unit, property-based (proptest), snapshot (insta), fixture, fuzz (49 targets), and BDD grid categories. ~70 tests are intentionally `#[ignore]`-d — TDD scaffolding for tracked issues. See justification strings.
 
 See [docs/development/test-suite.md](docs/development/test-suite.md) for full details.
+
+
+### Feature-boundary checks
+
+```bash
+# Ensure minimal root crate build remains valid
+cargo check -p bitnet --no-default-features
+
+# Ensure explicit CPU feature path remains valid
+cargo check -p bitnet --no-default-features --features cpu
+```
 
 ## Contributing
 

--- a/docs/GPU_SETUP.md
+++ b/docs/GPU_SETUP.md
@@ -44,7 +44,7 @@ nvidia-smi
 
 ## 2) Build with GPU support
 
-Use explicit feature selection (default features are intentionally empty):
+Use explicit feature selection for GPU paths (root defaults to CPU):
 
 ```bash
 cargo build --no-default-features --features gpu

--- a/docs/explanation/FEATURES.md
+++ b/docs/explanation/FEATURES.md
@@ -4,12 +4,15 @@ This document provides comprehensive documentation for all feature flags availab
 
 ## Overview
 
-BitNet-rs uses Cargo feature flags to control compilation of optional functionality. **Default features are intentionally empty** to prevent unwanted dependencies and allow precise control over the build.
+BitNet-rs uses Cargo feature flags to control optional functionality. The root `bitnet` crate defaults to `cpu` for an ergonomic baseline, while `--no-default-features` remains available for strict feature-boundary validation.
 
 ## Quick Reference
 
 ```bash
-# CPU-only build (most common)
+# CPU-only build (most common, defaults)
+cargo build
+
+# CPU-only build (explicit boundary mode)
 cargo build --no-default-features --features cpu
 
 # GPU-enabled build


### PR DESCRIPTION
### Motivation

- Align crate defaults with current UX: the root `bitnet` crate should default to CPU because `bitnet-cli` already assumes CPU and day-to-day development is CPU-first. 
- Reduce friction by enabling the common developer path by default while preserving strict feature-boundary testing via `--no-default-features`.

### Description

- Change `Cargo.toml` top-level `[features]` `default = []` to `default = ["cpu"]`, making the root crate CPU-first. 
- Update `README.md` quickstart to use the new defaults and add a `Feature-boundary checks` snippet showing `cargo check -p bitnet --no-default-features` and `cargo check -p bitnet --no-default-features --features cpu`. 
- Revise `docs/explanation/FEATURES.md` to document the CPU-default ergonomics and add explicit examples for both default and `--no-default-features` modes. 
- Tweak `docs/GPU_SETUP.md` wording to clarify that explicit feature selection is required for GPU paths while the root crate defaults to CPU.

### Testing

- Ran `cargo check -p bitnet --no-default-features` and it completed successfully. 
- Ran `cargo check -p bitnet --features cpu` and it completed successfully. 
- Changes were committed after validation (`Cargo.toml`, `README.md`, `docs/explanation/FEATURES.md`, `docs/GPU_SETUP.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d236d8fc83339e1cee424b75d385)