### PR TITLE
Extract GGUF metadata parsing into a dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-gguf-metadata-core"
+version = "0.2.1-dev"
+dependencies = [
+ "anyhow",
+ "bitnet-common",
+]
+
+[[package]]
 name = "bitnet-gpu-hal"
 version = "0.2.1-dev"
 dependencies = [
@@ -968,6 +976,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
+ "bitnet-gguf-metadata-core",
  "bitnet-quantization",
  "bitnet-st2gguf",
  "bitnet-test-fixtures-core",
@@ -1305,6 +1314,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",
+ "bitnet-gguf-metadata-core",
  "bitnet-inference",
  "bitnet-kernels",
  "bitnet-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-repl-core",     # SRP: reusable chat REPL state/command primitives
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser
+  "crates/bitnet-gguf-metadata-core", # SRP: GGUF metadata->shape/config extraction helpers
   "crates/bitnet-probability",  # SRP: probability normalization and categorical sampling primitives
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",

--- a/crates/bitnet-gguf-metadata-core/Cargo.toml
+++ b/crates/bitnet-gguf-metadata-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bitnet-gguf-metadata-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP GGUF metadata extraction helpers for BitNet model shape/config"
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-gguf-metadata-core/src/lib.rs
+++ b/crates/bitnet-gguf-metadata-core/src/lib.rs
@@ -1,0 +1,155 @@
+//! Reusable GGUF metadata extraction helpers for model-shape parsing.
+
+use anyhow::{Context, Result, anyhow};
+use bitnet_common::BitNetConfig;
+use std::collections::HashMap;
+
+/// Minimal model-shape fields extracted from GGUF key/value metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GgufModelShape {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_layers: usize,
+    pub num_heads: usize,
+    pub intermediate_size: usize,
+}
+
+/// Extract core model shape fields from GGUF metadata.
+///
+/// Supports both `bitnet-b1.58.*` and `llama.*` names for compatibility.
+pub fn extract_model_shape(metadata: &HashMap<String, String>) -> Result<GgufModelShape> {
+    Ok(GgufModelShape {
+        vocab_size: parse_required_usize(
+            metadata,
+            "vocab_size",
+            &["bitnet-b1.58.vocab_size", "llama.vocab_size"],
+        )?,
+        hidden_size: parse_required_usize(
+            metadata,
+            "hidden_size",
+            &["bitnet-b1.58.embedding_length", "llama.embedding_length", "llama.hidden_size"],
+        )?,
+        num_layers: parse_required_usize(
+            metadata,
+            "num_layers",
+            &["bitnet-b1.58.block_count", "llama.block_count", "llama.layer_count"],
+        )?,
+        num_heads: parse_required_usize(
+            metadata,
+            "num_heads",
+            &[
+                "bitnet-b1.58.attention.head_count",
+                "llama.attention.head_count",
+                "llama.head_count",
+            ],
+        )?,
+        intermediate_size: parse_optional_usize(
+            metadata,
+            "intermediate_size",
+            &["bitnet-b1.58.feed_forward_length", "llama.feed_forward_length"],
+        )?
+        .unwrap_or(0),
+    })
+}
+
+/// Build `BitNetConfig` from GGUF metadata, preserving defaults for absent optional fields.
+pub fn bitnet_config_from_metadata(metadata: &HashMap<String, String>) -> Result<BitNetConfig> {
+    let shape = extract_model_shape(metadata)?;
+    let mut config = BitNetConfig::default();
+    config.model.vocab_size = shape.vocab_size;
+    config.model.hidden_size = shape.hidden_size;
+    config.model.num_layers = shape.num_layers;
+    config.model.num_heads = shape.num_heads;
+
+    if shape.intermediate_size > 0 {
+        config.model.intermediate_size = shape.intermediate_size;
+    }
+
+    // BitNet default runtime assumptions for GGUF-hosted quantized checkpoints.
+    config.quantization.block_size = 128;
+
+    Ok(config)
+}
+
+fn parse_required_usize(
+    metadata: &HashMap<String, String>,
+    field: &str,
+    keys: &[&str],
+) -> Result<usize> {
+    parse_optional_usize(metadata, field, keys)?.ok_or_else(|| {
+        anyhow!("missing required GGUF field for {field} (tried: {})", keys.join(", "))
+    })
+}
+
+fn parse_optional_usize(
+    metadata: &HashMap<String, String>,
+    field: &str,
+    keys: &[&str],
+) -> Result<Option<usize>> {
+    for key in keys {
+        if let Some(value) = metadata.get(*key) {
+            let parsed = value
+                .parse::<usize>()
+                .with_context(|| format!("Failed to parse {field} from key '{key}'"))?;
+            return Ok(Some(parsed));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_model_shape_prefers_bitnet_keys_when_present() {
+        let metadata = HashMap::from([
+            ("bitnet-b1.58.vocab_size".to_string(), "32000".to_string()),
+            ("bitnet-b1.58.embedding_length".to_string(), "2048".to_string()),
+            ("bitnet-b1.58.block_count".to_string(), "24".to_string()),
+            ("bitnet-b1.58.attention.head_count".to_string(), "16".to_string()),
+            ("bitnet-b1.58.feed_forward_length".to_string(), "8192".to_string()),
+            ("llama.vocab_size".to_string(), "99999".to_string()),
+        ]);
+
+        let shape = extract_model_shape(&metadata).expect("shape should parse");
+
+        assert_eq!(shape.vocab_size, 32000);
+        assert_eq!(shape.hidden_size, 2048);
+        assert_eq!(shape.num_layers, 24);
+        assert_eq!(shape.num_heads, 16);
+        assert_eq!(shape.intermediate_size, 8192);
+    }
+
+    #[test]
+    fn extract_model_shape_uses_llama_fallbacks() {
+        let metadata = HashMap::from([
+            ("llama.vocab_size".to_string(), "128256".to_string()),
+            ("llama.embedding_length".to_string(), "4096".to_string()),
+            ("llama.block_count".to_string(), "32".to_string()),
+            ("llama.attention.head_count".to_string(), "32".to_string()),
+        ]);
+
+        let shape = extract_model_shape(&metadata).expect("shape should parse");
+        assert_eq!(shape.intermediate_size, 0);
+        assert_eq!(shape.num_layers, 32);
+    }
+
+    #[test]
+    fn bitnet_config_from_metadata_sets_quantization_defaults() {
+        let metadata = HashMap::from([
+            ("llama.vocab_size".to_string(), "32000".to_string()),
+            ("llama.embedding_length".to_string(), "4096".to_string()),
+            ("llama.block_count".to_string(), "32".to_string()),
+            ("llama.attention.head_count".to_string(), "32".to_string()),
+            ("llama.feed_forward_length".to_string(), "11008".to_string()),
+        ]);
+
+        let config = bitnet_config_from_metadata(&metadata).expect("config should parse");
+
+        assert_eq!(config.model.vocab_size, 32000);
+        assert_eq!(config.model.intermediate_size, 11008);
+        assert_eq!(config.quantization.block_size, 128);
+    }
+}

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -19,6 +19,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
+bitnet-gguf-metadata-core = { path = "../bitnet-gguf-metadata-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/gguf_parity.rs
+++ b/crates/bitnet-models/src/gguf_parity.rs
@@ -1,6 +1,7 @@
 //! GGUF model metadata and parity validation utilities
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
+use bitnet_gguf_metadata_core::extract_model_shape;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek};
@@ -54,30 +55,12 @@ pub fn read_gguf_metadata(path: &Path) -> Result<GgufMetadata> {
         metadata.insert(key, value);
     }
 
-    // Extract required fields — fail explicitly rather than use arbitrary defaults
-    let vocab_size = metadata
-        .get("llama.vocab_size")
-        .or_else(|| metadata.get("tokenizer.ggml.tokens"))
-        .and_then(|v| v.parse::<usize>().ok())
-        .ok_or_else(|| anyhow!("missing required GGUF field: llama.vocab_size"))?;
-
-    let hidden_size = metadata
-        .get("llama.embedding_length")
-        .or_else(|| metadata.get("llama.hidden_size"))
-        .and_then(|v| v.parse::<usize>().ok())
-        .ok_or_else(|| anyhow!("missing required GGUF field: llama.embedding_length"))?;
-
-    let num_layers = metadata
-        .get("llama.block_count")
-        .or_else(|| metadata.get("llama.layer_count"))
-        .and_then(|v| v.parse::<usize>().ok())
-        .ok_or_else(|| anyhow!("missing required GGUF field: llama.block_count"))?;
-
-    let num_heads = metadata
-        .get("llama.attention.head_count")
-        .or_else(|| metadata.get("llama.head_count"))
-        .and_then(|v| v.parse::<usize>().ok())
-        .ok_or_else(|| anyhow!("missing required GGUF field: llama.attention.head_count"))?;
+    // Extract required shape fields via SRP metadata helper.
+    let shape = extract_model_shape(&metadata)?;
+    let vocab_size = shape.vocab_size;
+    let hidden_size = shape.hidden_size;
+    let num_layers = shape.num_layers;
+    let num_heads = shape.num_heads;
 
     let tokenizer_type = metadata
         .get("tokenizer.ggml.model")

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -24,6 +24,7 @@ axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
+bitnet-gguf-metadata-core = { path = "../bitnet-gguf-metadata-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/model_loader.rs
+++ b/crates/bitnet-server/src/model_loader.rs
@@ -1,10 +1,10 @@
 //! Model loading utilities for the server
 
 use anyhow::{Context, Result};
+use bitnet_gguf_metadata_core::bitnet_config_from_metadata;
 use bitnet_common::Device;
 use bitnet_models::bitnet::BitNetModel;
 use bitnet_models::Model;
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -15,7 +15,7 @@ pub fn load_model_from_gguf(path: &Path, device: Device) -> Result<Arc<dyn Model
         .with_context(|| format!("Failed to load GGUF file: {}", path.display()))?;
 
     // Extract model configuration from metadata
-    let config = extract_config_from_metadata(&metadata)?;
+    let config = bitnet_config_from_metadata(&metadata)?;
 
     // Create the model
     let model = BitNetModel::from_gguf(config, tensors, device)?;
@@ -23,50 +23,13 @@ pub fn load_model_from_gguf(path: &Path, device: Device) -> Result<Arc<dyn Model
     Ok(Arc::new(model))
 }
 
-/// Extract BitNetConfig from GGUF metadata
-fn extract_config_from_metadata(metadata: &HashMap<String, String>) -> Result<bitnet_common::BitNetConfig> {
-    let mut config = bitnet_common::BitNetConfig::default();
-
-    // Parse key metadata fields
-    if let Some(vocab_size) = metadata.get("llama.vocab_size") {
-        config.model.vocab_size = vocab_size.parse()
-            .context("Failed to parse vocab_size")?;
-    }
-
-    if let Some(hidden_size) = metadata.get("llama.embedding_length") {
-        config.model.hidden_size = hidden_size.parse()
-            .context("Failed to parse hidden_size")?;
-    }
-
-    if let Some(num_layers) = metadata.get("llama.block_count") {
-        config.model.num_hidden_layers = num_layers.parse()
-            .context("Failed to parse num_hidden_layers")?;
-    }
-
-    if let Some(num_heads) = metadata.get("llama.attention.head_count") {
-        config.model.num_attention_heads = num_heads.parse()
-            .context("Failed to parse num_attention_heads")?;
-    }
-
-    if let Some(intermediate_size) = metadata.get("llama.feed_forward_length") {
-        config.model.intermediate_size = intermediate_size.parse()
-            .context("Failed to parse intermediate_size")?;
-    }
-
-    // Set quantization type based on tensor types found
-    config.quantization.bits = 2; // BitNet uses 2-bit quantization
-    config.quantization.group_size = 128; // Standard group size
-
-    Ok(config)
-}
-
 /// Load a dummy model for testing
 pub fn load_dummy_model(vocab_size: usize, hidden_size: usize, device: Device) -> Arc<dyn Model> {
     let mut config = bitnet_common::BitNetConfig::default();
     config.model.vocab_size = vocab_size;
     config.model.hidden_size = hidden_size;
-    config.model.num_hidden_layers = 12;
-    config.model.num_attention_heads = 12;
+    config.model.num_layers = 12;
+    config.model.num_heads = 12;
     config.model.intermediate_size = hidden_size * 4;
 
     let model = BitNetModel::new(config, device);


### PR DESCRIPTION
### Motivation
- Centralize and remove duplicate GGUF metadata parsing logic so multiple consumers share a single, well-tested extraction path.
- Follow SRP by exposing model-shape/config helpers for consistent construction of `BitNetConfig` from GGUF metadata across crates.

### Description
- Add a new microcrate `crates/bitnet-gguf-metadata-core` that provides `extract_model_shape` and `bitnet_config_from_metadata` plus unit tests for key precedence/fallbacks and defaults.
- Wire the new crate into the workspace `Cargo.toml` and add it as a dependency to `crates/bitnet-server` and `crates/bitnet-models` by updating their `Cargo.toml` files.
- Refactor `crates/bitnet-server/src/model_loader.rs` to call `bitnet_gguf_metadata_core::bitnet_config_from_metadata` and align dummy-model fields to the current `BitNetConfig` schema (`num_layers`/`num_heads`).
- Refactor `crates/bitnet-models/src/gguf_parity.rs` to reuse `bitnet_gguf_metadata_core::extract_model_shape` instead of duplicating required-field parsing logic.

### Testing
- Ran `cargo fmt` to normalize formatting and it completed successfully.
- Ran `cargo test -p bitnet-gguf-metadata-core` and all new crate unit tests passed (`3 passed; 0 failed`).
- Ran `cargo check` / `cargo test` on dependent crates with `cargo check -p bitnet-server --lib` and `cargo check -p bitnet-models --lib`, and both checks finished successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d259266c8333ae5986e427bdcea7)