### PR TITLE
Extract generation config into dedicated core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,12 +748,20 @@ dependencies = [
 name = "bitnet-generation"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-generation-config-core",
  "bitnet-generation-events-core",
  "bitnet-generation-stop-core",
  "insta",
  "proptest",
- "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitnet-generation-config-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-generation-stop-core",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ members = [
   "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
   "crates/bitnet-logits",        # SRP: pure logits transform functions
   "crates/bitnet-logits-filters", # SRP: reusable logits/probability filtering transforms
-  "crates/bitnet-generation",    # SRP: decode-loop stopping logic & generation events
+  "crates/bitnet-generation",    # SRP: decode-loop stopping logic + generation contract re-exports
+  "crates/bitnet-generation-config-core", # SRP: reusable generation request config contract
   "crates/bitnet-generation-events-core", # SRP: reusable generation stream event/stat contracts
   "crates/bitnet-generation-stop-core", # SRP: reusable stop criteria/check core
   "crates/bitnet-kv-cache-policy-core", # SRP: KV-cache sequence transition decision policy
@@ -165,6 +166,7 @@ default-members = [
   "crates/bitnet-probability",
   "crates/bitnet-logits-filters",
   "crates/bitnet-generation",
+  "crates/bitnet-generation-config-core",
   "crates/bitnet-generation-events-core",
   "crates/bitnet-generation-stop-core",
   "crates/bitnet-kv-cache-policy-core",

--- a/crates/bitnet-generation-config-core/Cargo.toml
+++ b/crates/bitnet-generation-config-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bitnet-generation-config-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Reusable generation request config contract for BitNet inference"
+rust-version.workspace = true
+
+[dependencies]
+bitnet-generation-stop-core = { path = "../bitnet-generation-stop-core", version = "0.2.1-dev" }
+serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-generation-config-core/src/lib.rs
+++ b/crates/bitnet-generation-config-core/src/lib.rs
@@ -1,0 +1,33 @@
+//! Reusable generation request configuration contract for `BitNet` inference.
+
+use bitnet_generation_stop_core::StopCriteria;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for a single generation request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerationConfig {
+    /// Maximum number of new tokens to generate.
+    pub max_new_tokens: usize,
+    /// Random seed for reproducible generation (None = random).
+    pub seed: Option<u64>,
+    /// Stopping criteria.
+    pub stop_criteria: StopCriteria,
+}
+
+impl Default for GenerationConfig {
+    fn default() -> Self {
+        Self { max_new_tokens: 128, seed: None, stop_criteria: StopCriteria::default() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_config_defaults_are_sensible() {
+        let cfg = GenerationConfig::default();
+        assert_eq!(cfg.max_new_tokens, 128);
+        assert!(cfg.seed.is_none());
+    }
+}

--- a/crates/bitnet-generation/Cargo.toml
+++ b/crates/bitnet-generation/Cargo.toml
@@ -12,9 +12,9 @@ description = "Decode-loop stopping logic and generation event types for BitNet 
 rust-version.workspace = true
 
 [dependencies]
+bitnet-generation-config-core = { path = "../bitnet-generation-config-core", version = "0.2.1-dev" }
 bitnet-generation-stop-core = { path = "../bitnet-generation-stop-core", version = "0.2.1-dev" }
 bitnet-generation-events-core = { path = "../bitnet-generation-events-core", version = "0.2.1-dev" }
-serde.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-generation/src/lib.rs
+++ b/crates/bitnet-generation/src/lib.rs
@@ -1,46 +1,12 @@
 //! Decode-loop generation contracts for `BitNet` inference.
 //!
 //! This crate provides orchestration-facing generation types:
-//! - generation config
+//! - generation config (via `bitnet-generation-config-core`)
 //! - stream events (via `bitnet-generation-events-core`)
-//! - generation stats (via `bitnet-generation-events-core`)
 //!
 //! Decode-loop stop criteria and stop-check logic live in
 //! `bitnet-generation-stop-core` and are re-exported here.
 
+pub use bitnet_generation_config_core::GenerationConfig;
 pub use bitnet_generation_events_core::{GenerationStats, StreamEvent, TokenEvent};
 pub use bitnet_generation_stop_core::{StopCriteria, StopReason, check_stop};
-use serde::{Deserialize, Serialize};
-
-// ---------------------------------------------------------------------------
-// Generation config
-// ---------------------------------------------------------------------------
-
-/// Configuration for a single generation request.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GenerationConfig {
-    /// Maximum number of new tokens to generate.
-    pub max_new_tokens: usize,
-    /// Random seed for reproducible generation (None = random).
-    pub seed: Option<u64>,
-    /// Stopping criteria.
-    pub stop_criteria: StopCriteria,
-}
-
-impl Default for GenerationConfig {
-    fn default() -> Self {
-        Self { max_new_tokens: 128, seed: None, stop_criteria: StopCriteria::default() }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn generation_config_defaults_are_sensible() {
-        let cfg = GenerationConfig::default();
-        assert_eq!(cfg.max_new_tokens, 128);
-        assert!(cfg.seed.is_none());
-    }
-}


### PR DESCRIPTION
### Motivation
- Separate the request-configuration contract from decode-loop orchestration to follow SRP and enable reuse of the generation request type.
- Make `bitnet-generation` a small façade that re-exports focused SRP components rather than owning the `GenerationConfig` implementation.
- Prepare the codebase for incremental microcrate extraction and clearer dependency boundaries for downstream teams.

### Description
- Added a new microcrate `crates/bitnet-generation-config-core` that defines `GenerationConfig`, its `Default` impl, serde derives, and unit test in `src/lib.rs` and a corresponding `Cargo.toml`.
- Removed the `GenerationConfig` implementation from `crates/bitnet-generation/src/lib.rs` and replaced it with a re-export `pub use bitnet_generation_config_core::GenerationConfig;`.
- Updated `crates/bitnet-generation/Cargo.toml` to depend on `bitnet-generation-config-core` and updated the workspace `Cargo.toml` to include the new crate in `members` and `default-members`.
- Ran `cargo fmt --all` to apply formatting changes.

### Testing
- Ran `cargo fmt --all` and the formatter completed successfully.
- Ran `cargo test -p bitnet-generation-config-core -p bitnet-generation` and the test suites for both crates completed with all tests passing (unit, property and integration tests for `bitnet-generation` and the `GenerationConfig` unit test in `bitnet-generation-config-core`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d259266c8333ae5986e427bdcea7)