### PR TITLE
Extract tokenizer byte vocabulary logic into dedicated core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-tokenizer-byte-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-tokenizer-discovery-core"
 version = "0.2.1-dev"
 dependencies = [
@@ -1711,6 +1715,7 @@ dependencies = [
  "bitnet-test-fixtures-core",
  "bitnet-test-support",
  "bitnet-tests",
+ "bitnet-tokenizer-byte-core",
  "bitnet-tokenizer-model-core",
  "dirs",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/bitnet-tokenizers",
   "crates/bitnet-tokenizer-model-core", # SRP: tokenizer model/vocabulary detection helpers
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
+  "crates/bitnet-tokenizer-byte-core", # SRP: byte-level tokenizer vocabulary lookup tables
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",
@@ -135,6 +136,7 @@ default-members = [
   "crates/bitnet-tokenizers",
   "crates/bitnet-tokenizer-model-core",
   "crates/bitnet-tokenizer-discovery-core",
+  "crates/bitnet-tokenizer-byte-core",
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",
   "crates/bitnet-inference",

--- a/crates/bitnet-tokenizer-byte-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-byte-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bitnet-tokenizer-byte-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Core byte-level vocabulary mapping utilities for tokenizers"
+
+[dependencies]

--- a/crates/bitnet-tokenizer-byte-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-byte-core/src/lib.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+
+/// Lookup tables derived from a token vocabulary for byte-level tokenization.
+#[derive(Debug, Clone)]
+pub struct ByteVocabulary {
+    vocab: HashMap<String, u32>,
+    reverse_vocab: HashMap<u32, String>,
+    byte_to_id: [Option<u32>; 256],
+    id_to_byte: HashMap<u32, u8>,
+}
+
+impl ByteVocabulary {
+    /// Build byte lookup tables from an ordered token list.
+    #[must_use]
+    pub fn from_tokens(tokens: &[String]) -> Self {
+        let mut vocab = HashMap::with_capacity(tokens.len());
+        let mut reverse_vocab = HashMap::with_capacity(tokens.len());
+        let mut byte_to_id = [None; 256];
+        let mut id_to_byte = HashMap::new();
+
+        for (i, token) in tokens.iter().enumerate() {
+            let id = i as u32;
+            vocab.insert(token.clone(), id);
+            reverse_vocab.insert(id, token.clone());
+
+            if token.len() == 6
+                && token.starts_with("<0x")
+                && token.ends_with('>')
+                && let Ok(byte) = u8::from_str_radix(&token[3..5], 16)
+            {
+                byte_to_id[byte as usize] = Some(id);
+                id_to_byte.insert(id, byte);
+            }
+        }
+
+        Self { vocab, reverse_vocab, byte_to_id, id_to_byte }
+    }
+
+    #[must_use]
+    pub fn vocab(&self) -> &HashMap<String, u32> {
+        &self.vocab
+    }
+
+    #[must_use]
+    pub fn reverse_vocab(&self) -> &HashMap<u32, String> {
+        &self.reverse_vocab
+    }
+
+    #[must_use]
+    pub fn byte_to_id(&self) -> &[Option<u32>; 256] {
+        &self.byte_to_id
+    }
+
+    #[must_use]
+    pub fn id_to_byte(&self) -> &HashMap<u32, u8> {
+        &self.id_to_byte
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ByteVocabulary;
+
+    #[test]
+    fn builds_vocab_and_reverse_vocab_from_tokens() {
+        let tokens = vec!["hello".to_string(), "world".to_string()];
+
+        let vocab = ByteVocabulary::from_tokens(&tokens);
+
+        assert_eq!(vocab.vocab().get("hello"), Some(&0));
+        assert_eq!(vocab.vocab().get("world"), Some(&1));
+        assert_eq!(vocab.reverse_vocab().get(&0), Some(&"hello".to_string()));
+        assert_eq!(vocab.reverse_vocab().get(&1), Some(&"world".to_string()));
+    }
+
+    #[test]
+    fn recognizes_hex_byte_tokens() {
+        let tokens = vec!["<0x41>".to_string(), "<0x00>".to_string(), "plain".to_string()];
+
+        let vocab = ByteVocabulary::from_tokens(&tokens);
+
+        assert_eq!(vocab.byte_to_id()[0x41], Some(0));
+        assert_eq!(vocab.byte_to_id()[0x00], Some(1));
+        assert_eq!(vocab.id_to_byte().get(&0), Some(&0x41));
+        assert_eq!(vocab.id_to_byte().get(&1), Some(&0x00));
+        assert!(!vocab.id_to_byte().contains_key(&2));
+    }
+
+    #[test]
+    fn ignores_malformed_hex_tokens() {
+        let tokens = vec!["<0xG1>".to_string(), "<0x1>".to_string(), "<0x414>".to_string()];
+
+        let vocab = ByteVocabulary::from_tokens(&tokens);
+
+        assert!(vocab.id_to_byte().is_empty());
+        assert!(vocab.byte_to_id().iter().all(Option::is_none));
+    }
+}

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -21,6 +21,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizer-model-core = { path = "../bitnet-tokenizer-model-core", version = "0.2.1-dev" }
+bitnet-tokenizer-byte-core = { path = "../bitnet-tokenizer-byte-core", version = "0.2.1-dev" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-tokenizers/src/gguf_tokenizer.rs
+++ b/crates/bitnet-tokenizers/src/gguf_tokenizer.rs
@@ -1,6 +1,7 @@
 use crate::Tokenizer;
 use bitnet_common::{BitNetError, ModelError, Result};
 use bitnet_models::{GgufReader, loader::MmapFile};
+use bitnet_tokenizer_byte_core::ByteVocabulary;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -20,24 +21,16 @@ impl GgufTokenizer {
         let (tokens, bos_token_id, eos_token_id) = read_gguf_metadata(path)?;
 
         // Extract vocabulary and byte-level mappings
-        let vocab = extract_vocab(&tokens);
-        let mut reverse_vocab: HashMap<u32, String> = HashMap::with_capacity(vocab.len());
-        let mut byte_to_id = [None; 256];
-        let mut id_to_byte = HashMap::new();
+        let byte_vocab = ByteVocabulary::from_tokens(&tokens);
 
-        for (token, &id) in &vocab {
-            reverse_vocab.insert(id, token.clone());
-            if token.len() == 6
-                && token.starts_with("<0x")
-                && token.ends_with('>')
-                && let Ok(byte) = u8::from_str_radix(&token[3..5], 16)
-            {
-                byte_to_id[byte as usize] = Some(id);
-                id_to_byte.insert(id, byte);
-            }
-        }
-
-        Ok(Self { vocab, reverse_vocab, byte_to_id, id_to_byte, bos_token_id, eos_token_id })
+        Ok(Self {
+            vocab: byte_vocab.vocab().clone(),
+            reverse_vocab: byte_vocab.reverse_vocab().clone(),
+            byte_to_id: *byte_vocab.byte_to_id(),
+            id_to_byte: byte_vocab.id_to_byte().clone(),
+            bos_token_id,
+            eos_token_id,
+        })
     }
 }
 
@@ -127,12 +120,4 @@ fn read_gguf_metadata(path: &Path) -> Result<(Vec<String>, Option<u32>, Option<u
     let eos = reader.get_u32_metadata("tokenizer.ggml.eos_token_id");
 
     Ok((tokens, bos, eos))
-}
-
-fn extract_vocab(tokens: &[String]) -> HashMap<String, u32> {
-    let mut vocab = HashMap::with_capacity(tokens.len());
-    for (i, token) in tokens.iter().enumerate() {
-        vocab.insert(token.clone(), i as u32);
-    }
-    vocab
 }


### PR DESCRIPTION
### Motivation
- Isolate byte-level vocabulary/table construction from tokenizer I/O to follow SRP and enable reuse across tokenizers.
- Reduce duplication and improve testability by moving `<0xHH>` byte mapping and token↔id lookup logic into a focused core crate.

### Description
- Added a new crate `crates/bitnet-tokenizer-byte-core` exposing `ByteVocabulary::from_tokens` plus accessors for `vocab`, `reverse_vocab`, `byte_to_id`, and `id_to_byte`.
- Refactored `crates/bitnet-tokenizers/src/gguf_tokenizer.rs` to use `ByteVocabulary::from_tokens` and removed the inline `extract_vocab`/byte-mapping code.
- Wired the new crate into the workspace and build graph by updating the top-level `Cargo.toml` (members and `default-members`) and `crates/bitnet-tokenizers/Cargo.toml` dependency list.
- Added unit tests in `bitnet-tokenizer-byte-core` covering normal vocab construction, valid hex byte token handling, and malformed token behavior.

### Testing
- Ran `cargo test -p bitnet-tokenizer-byte-core` and all unit tests passed (`3 passed; 0 failed`).
- Ran `cargo test -p bitnet-tokenizers --lib` and the tokenizer test-suite completed successfully (`70 passed; 0 failed`).
- Ran `cargo fmt` to ensure formatting was applied with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d259266c8333ae5986e427bdcea7)