### PR TITLE
test(kernels): add snapshot wave 14 for CPU kernel modules

### DIFF
--- a/crates/bitnet-inference/src/cpu_opt.rs
+++ b/crates/bitnet-inference/src/cpu_opt.rs
@@ -732,16 +732,8 @@ mod tests {
     #[test]
     fn test_silu_numerical_stability_extremes() {
         let out = silu(&[100.0, -100.0]);
-        assert!(
-            (out[0] - 100.0).abs() < 1e-3,
-            "silu(100) should ≈ 100, got {}",
-            out[0]
-        );
-        assert!(
-            out[1].abs() < 1e-10,
-            "silu(-100) should ≈ 0, got {}",
-            out[1]
-        );
+        assert!((out[0] - 100.0).abs() < 1e-3, "silu(100) should ≈ 100, got {}", out[0]);
+        assert!(out[1].abs() < 1e-10, "silu(-100) should ≈ 0, got {}", out[1]);
         // No NaN or Inf
         for &v in &out {
             assert!(v.is_finite(), "silu output must be finite, got {v}");
@@ -768,11 +760,11 @@ mod tests {
     fn test_silu_known_reference_values() {
         let inputs = [0.0f32, 1.0, -1.0, 2.0, -2.0];
         let expected = [
-            0.0,      // silu(0) = 0
-            0.7311,   // silu(1) ≈ 0.7311
-            -0.2689,  // silu(-1) ≈ -0.2689
-            1.7616,   // silu(2) ≈ 1.7616
-            -0.2384,  // silu(-2) ≈ -0.2384
+            0.0,     // silu(0) = 0
+            0.7311,  // silu(1) ≈ 0.7311
+            -0.2689, // silu(-1) ≈ -0.2689
+            1.7616,  // silu(2) ≈ 1.7616
+            -0.2384, // silu(-2) ≈ -0.2384
         ];
         let out = silu(&inputs);
         for (i, (&got, &want)) in out.iter().zip(expected.iter()).enumerate() {
@@ -816,10 +808,7 @@ mod tests {
         rmsnorm(&input, &weight, &mut output, 1, dim, 1e-5).unwrap();
         // rms(1,1,1,1) = sqrt(1 + eps) ≈ 1.0, so output ≈ weight
         for (i, &v) in output.iter().enumerate() {
-            assert!(
-                (v - 1.0).abs() < 0.01,
-                "all-ones: output[{i}] = {v}, expected ≈ 1.0"
-            );
+            assert!((v - 1.0).abs() < 0.01, "all-ones: output[{i}] = {v}, expected ≈ 1.0");
         }
     }
 

--- a/crates/bitnet-kernels/tests/snapshot_wave14.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave14.rs
@@ -1,0 +1,334 @@
+//! Wave 14 snapshot tests for `bitnet-kernels` — CPU kernel output and
+//! error-message snapshots for modules added after wave 11.
+//!
+//! Covers: residual, concat, dequant, attention_mask, gating.
+
+// =========================================================================
+// Section 1 — Residual connection snapshots
+// =========================================================================
+
+mod residual_snapshots {
+    use bitnet_kernels::cpu::residual::{
+        add_residual, add_residual_scaled, add_residual_with_dropout,
+    };
+
+    #[test]
+    fn residual_add_basic_result() {
+        let mut output = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let residual = vec![0.5, -0.5, 1.0, -1.0];
+        add_residual(&mut output, &residual).unwrap();
+        insta::assert_debug_snapshot!(output);
+    }
+
+    #[test]
+    fn residual_scaled_result() {
+        let mut output = vec![0.0_f32; 4];
+        let residual = vec![1.0, 2.0, 3.0, 4.0];
+        add_residual_scaled(&mut output, &residual, 0.5).unwrap();
+        insta::assert_debug_snapshot!(output);
+    }
+
+    #[test]
+    fn residual_with_dropout_result() {
+        let mut output = vec![1.0_f32, 2.0, 3.0, 4.0];
+        let residual = vec![10.0, 20.0, 30.0, 40.0];
+        let mask = vec![true, false, true, false];
+        add_residual_with_dropout(&mut output, &residual, &mask).unwrap();
+        insta::assert_debug_snapshot!(output);
+    }
+
+    #[test]
+    fn residual_length_mismatch_error() {
+        let mut output = vec![1.0_f32, 2.0];
+        let err = add_residual(&mut output, &[1.0]).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn residual_scaled_length_mismatch_error() {
+        let mut output = vec![1.0_f32];
+        let err = add_residual_scaled(&mut output, &[1.0, 2.0], 1.0).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn residual_dropout_mask_mismatch_error() {
+        let mut output = vec![1.0_f32, 2.0];
+        let err = add_residual_with_dropout(&mut output, &[1.0, 2.0], &[true]).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+}
+
+// =========================================================================
+// Section 2 — Concat kernel output-shape snapshots
+// =========================================================================
+
+mod concat_snapshots {
+    use bitnet_kernels::cpu::concat::ConcatKernel;
+
+    #[test]
+    fn concat_output_shape_axis0() {
+        let s1: &[usize] = &[2, 3];
+        let s2: &[usize] = &[4, 3];
+        let shape = ConcatKernel::concat_output_shape(&[s1, s2], 0).unwrap();
+        insta::assert_debug_snapshot!(shape);
+    }
+
+    #[test]
+    fn concat_output_shape_axis1() {
+        let s1: &[usize] = &[2, 3];
+        let s2: &[usize] = &[2, 5];
+        let shape = ConcatKernel::concat_output_shape(&[s1, s2], 1).unwrap();
+        insta::assert_debug_snapshot!(shape);
+    }
+
+    #[test]
+    fn stack_output_shape_axis0() {
+        let shape = ConcatKernel::stack_output_shape(&[3, 4], 0, 5).unwrap();
+        insta::assert_debug_snapshot!(shape);
+    }
+
+    #[test]
+    fn stack_output_shape_axis1() {
+        let shape = ConcatKernel::stack_output_shape(&[3, 4], 1, 2).unwrap();
+        insta::assert_debug_snapshot!(shape);
+    }
+
+    #[test]
+    fn split_output_shapes_even() {
+        let shapes = ConcatKernel::split_output_shapes(&[6, 4], 0, 3).unwrap();
+        insta::assert_debug_snapshot!(shapes);
+    }
+
+    #[test]
+    fn concat_axis_out_of_range_error() {
+        let s1: &[usize] = &[2, 3];
+        let err = ConcatKernel::concat_output_shape(&[s1], 5).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn concat_2d_values_axis0() {
+        let a = [1.0_f32, 2.0, 3.0, 4.0];
+        let b = [5.0_f32, 6.0, 7.0, 8.0];
+        let sa: &[usize] = &[2, 2];
+        let sb: &[usize] = &[2, 2];
+        let result = ConcatKernel::concat(&[&a, &b], &[sa, sb], 0).unwrap();
+        insta::assert_debug_snapshot!(result);
+    }
+}
+
+// =========================================================================
+// Section 3 — Dequantization snapshots
+// =========================================================================
+
+mod dequant_snapshots {
+    use bitnet_kernels::cpu::dequant::{
+        dequant_i2s_block, dequant_i2s_row, dequant_ternary, pack_ternary,
+    };
+
+    fn pack4(vals: [i8; 4]) -> u8 {
+        let mut byte = 0u8;
+        for (i, &v) in vals.iter().enumerate() {
+            let code: u8 = match v {
+                1 => 0b01,
+                -1 => 0b11,
+                _ => 0b00,
+            };
+            byte |= code << (i * 2);
+        }
+        byte
+    }
+
+    #[test]
+    fn dequant_i2s_block_mixed_values() {
+        let packed = vec![pack4([1, -1, 0, 1])];
+        let result = dequant_i2s_block(&packed, 2.0, 4).unwrap();
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn dequant_ternary_two_bytes() {
+        let packed = vec![pack4([1, -1, 0, 1]), pack4([-1, 0, -1, 1])];
+        let result = dequant_ternary(&packed, 1.5);
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn dequant_i2s_row_multi_block() {
+        let packed = vec![pack4([1, -1, 0, 1]), pack4([-1, 1, 1, 0])];
+        let scales = vec![2.0, 3.0];
+        let result = dequant_i2s_row(&packed, &scales, 4).unwrap();
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn pack_ternary_round_trip_snapshot() {
+        let values = vec![1.0_f32, -0.8, 0.05, 0.9, -1.2];
+        let (packed, scale) = pack_ternary(&values, 0.1);
+        let deq = dequant_ternary(&packed, scale);
+        insta::assert_debug_snapshot!("packed_bytes", &packed);
+        insta::assert_snapshot!("scale", format!("{scale:.6}"));
+        insta::assert_debug_snapshot!("round_trip_values", &deq);
+    }
+
+    #[test]
+    fn dequant_i2s_block_insufficient_bytes_error() {
+        let err = dequant_i2s_block(&[0u8], 1.0, 8).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn dequant_i2s_row_zero_block_size_error() {
+        let err = dequant_i2s_row(&[0u8; 4], &[1.0], 0).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn dequant_i2s_row_insufficient_scales_error() {
+        let err = dequant_i2s_row(&[0u8; 4], &[1.0, 2.0], 4).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+}
+
+// =========================================================================
+// Section 4 — Attention mask output snapshots
+// =========================================================================
+
+mod attention_mask_snapshots {
+    use bitnet_kernels::cpu::attention_mask::{
+        combine_masks, create_causal_mask, create_padding_mask, create_sliding_window_mask,
+    };
+
+    /// Replace -inf with a readable string for snapshot stability.
+    fn mask_display(mask: &[f32], cols: usize) -> String {
+        mask.chunks(cols)
+            .map(|row| {
+                row.iter()
+                    .map(|&v| {
+                        if v == f32::NEG_INFINITY {
+                            " -inf".to_string()
+                        } else {
+                            format!("{v:5.1}")
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn causal_mask_4x4() {
+        let mask = create_causal_mask(4);
+        insta::assert_snapshot!(mask_display(&mask, 4));
+    }
+
+    #[test]
+    fn padding_mask_batch3() {
+        let mask = create_padding_mask(&[2, 4, 0], 4);
+        insta::assert_snapshot!(mask_display(&mask, 4));
+    }
+
+    #[test]
+    fn sliding_window_mask_4x4_window2() {
+        let mask = create_sliding_window_mask(4, 2);
+        insta::assert_snapshot!(mask_display(&mask, 4));
+    }
+
+    #[test]
+    fn sliding_window_mask_4x4_window1() {
+        let mask = create_sliding_window_mask(4, 1);
+        insta::assert_snapshot!(mask_display(&mask, 4));
+    }
+
+    #[test]
+    fn combine_causal_and_padding() {
+        let causal = create_causal_mask(3);
+        let mut pad = vec![0.0_f32; 9];
+        // Block column 2 in all rows (simulates padding at position 2).
+        for i in 0..3 {
+            pad[i * 3 + 2] = f32::NEG_INFINITY;
+        }
+        let combined = combine_masks(&causal, &pad, 3);
+        insta::assert_snapshot!(mask_display(&combined, 3));
+    }
+}
+
+// =========================================================================
+// Section 5 — Gating kernel snapshots
+// =========================================================================
+
+mod gating_snapshots {
+    use bitnet_kernels::cpu::gating::{GatingType, apply_gating, geglu, reglu, swiglu};
+
+    #[test]
+    fn gating_type_all_variants_debug() {
+        let types = [GatingType::SwiGLU, GatingType::GeGLU, GatingType::ReGLU];
+        insta::assert_debug_snapshot!(types);
+    }
+
+    #[test]
+    fn swiglu_known_output() {
+        let gate = [0.0_f32, 1.0, -1.0, 2.0];
+        let up = [1.0_f32, 1.0, 1.0, 0.5];
+        let mut out = [0.0_f32; 4];
+        swiglu(&gate, &up, &mut out).unwrap();
+        let rounded: Vec<String> = out.iter().map(|v| format!("{v:.4}")).collect();
+        insta::assert_debug_snapshot!(rounded);
+    }
+
+    #[test]
+    fn geglu_known_output() {
+        let gate = [0.0_f32, 1.0, -1.0, 2.0];
+        let up = [1.0_f32, 1.0, 1.0, 0.5];
+        let mut out = [0.0_f32; 4];
+        geglu(&gate, &up, &mut out).unwrap();
+        let rounded: Vec<String> = out.iter().map(|v| format!("{v:.4}")).collect();
+        insta::assert_debug_snapshot!(rounded);
+    }
+
+    #[test]
+    fn reglu_known_output() {
+        let gate = [0.0_f32, 1.0, -1.0, 2.0];
+        let up = [1.0_f32, 1.0, 1.0, 0.5];
+        let mut out = [0.0_f32; 4];
+        reglu(&gate, &up, &mut out).unwrap();
+        insta::assert_debug_snapshot!(out);
+    }
+
+    #[test]
+    fn apply_gating_dispatch_results() {
+        let gate = [1.0_f32];
+        let up = [2.0_f32];
+        let mut results = Vec::new();
+        for gtype in [GatingType::SwiGLU, GatingType::GeGLU, GatingType::ReGLU] {
+            let mut out = [0.0_f32];
+            apply_gating(gtype, &gate, &up, &mut out).unwrap();
+            results.push(format!("{:?}: {:.4}", gtype, out[0]));
+        }
+        insta::assert_debug_snapshot!(results);
+    }
+
+    #[test]
+    fn gating_empty_input_error() {
+        let mut out = [0.0_f32; 1];
+        let err = swiglu(&[], &[], &mut out).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn gating_length_mismatch_error() {
+        let mut out = [0.0_f32; 4];
+        let err = geglu(&[1.0, 2.0], &[1.0], &mut out).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+
+    #[test]
+    fn gating_output_too_short_error() {
+        let mut out = [0.0_f32; 1];
+        let err = reglu(&[1.0, 2.0], &[1.0, 2.0], &mut out).unwrap_err();
+        insta::assert_snapshot!(err.to_string());
+    }
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__causal_mask_4x4.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__causal_mask_4x4.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 215
+expression: "mask_display(&mask, 4)"
+---
+  0.0  -inf  -inf  -inf
+  0.0   0.0  -inf  -inf
+  0.0   0.0   0.0  -inf
+  0.0   0.0   0.0   0.0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__combine_causal_and_padding.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__combine_causal_and_padding.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 245
+expression: "mask_display(&combined, 3)"
+---
+  0.0  -inf  -inf
+  0.0   0.0  -inf
+  0.0   0.0  -inf

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__padding_mask_batch3.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__padding_mask_batch3.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 221
+expression: "mask_display(&mask, 4)"
+---
+  0.0   0.0  -inf  -inf
+  0.0   0.0   0.0   0.0
+ -inf  -inf  -inf  -inf

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__sliding_window_mask_4x4_window1.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__sliding_window_mask_4x4_window1.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 233
+expression: "mask_display(&mask, 4)"
+---
+  0.0  -inf  -inf  -inf
+ -inf   0.0  -inf  -inf
+ -inf  -inf   0.0  -inf
+ -inf  -inf  -inf   0.0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__sliding_window_mask_4x4_window2.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__attention_mask_snapshots__sliding_window_mask_4x4_window2.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 227
+expression: "mask_display(&mask, 4)"
+---
+  0.0  -inf  -inf  -inf
+  0.0   0.0  -inf  -inf
+ -inf   0.0   0.0  -inf
+ -inf  -inf   0.0   0.0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_2d_values_axis0.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_2d_values_axis0.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 115
+expression: result
+---
+[
+    1.0,
+    2.0,
+    3.0,
+    4.0,
+    5.0,
+    6.0,
+    7.0,
+    8.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_axis_out_of_range_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_axis_out_of_range_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 105
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: axis 5 out of range for 2-dimensional tensor

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_output_shape_axis0.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_output_shape_axis0.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 72
+expression: shape
+---
+[
+    6,
+    3,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_output_shape_axis1.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__concat_output_shape_axis1.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 80
+expression: shape
+---
+[
+    2,
+    8,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__split_output_shapes_even.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__split_output_shapes_even.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 98
+expression: shapes
+---
+[
+    [
+        2,
+        4,
+    ],
+    [
+        2,
+        4,
+    ],
+    [
+        2,
+        4,
+    ],
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__stack_output_shape_axis0.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__stack_output_shape_axis0.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 86
+expression: shape
+---
+[
+    5,
+    3,
+    4,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__stack_output_shape_axis1.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__concat_snapshots__stack_output_shape_axis1.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 92
+expression: shape
+---
+[
+    3,
+    2,
+    4,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_block_insufficient_bytes_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_block_insufficient_bytes_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 174
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: dequant_i2s_block: need 2 bytes for block_size=8, got 1

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_block_mixed_values.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_block_mixed_values.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 143
+expression: result
+---
+[
+    2.0,
+    -2.0,
+    0.0,
+    2.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_insufficient_scales_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_insufficient_scales_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 186
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: dequant_i2s_row: need 4 scales for 16 elements (block_size=4), got 2

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_multi_block.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_multi_block.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 158
+expression: result
+---
+[
+    2.0,
+    -2.0,
+    0.0,
+    2.0,
+    -3.0,
+    3.0,
+    3.0,
+    0.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_zero_block_size_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_i2s_row_zero_block_size_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 180
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: dequant_i2s_row: block_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_ternary_two_bytes.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__dequant_ternary_two_bytes.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 150
+expression: result
+---
+[
+    1.5,
+    -1.5,
+    0.0,
+    1.5,
+    -1.5,
+    0.0,
+    -1.5,
+    1.5,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__packed_bytes.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__packed_bytes.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 166
+expression: "&packed"
+---
+[
+    77,
+    3,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__round_trip_values.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__round_trip_values.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 168
+expression: "&deq"
+---
+[
+    0.97499996,
+    -0.97499996,
+    0.0,
+    0.97499996,
+    -0.97499996,
+    0.0,
+    0.0,
+    0.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__scale.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__dequant_snapshots__scale.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 167
+expression: "format!(\"{scale:.6}\")"
+---
+0.975000

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__apply_gating_dispatch_results.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__apply_gating_dispatch_results.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 301
+expression: results
+---
+[
+    "SwiGLU: 1.4621",
+    "GeGLU: 1.6824",
+    "ReGLU: 2.0000",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_empty_input_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_empty_input_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 308
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: gating input must be non-empty

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_length_mismatch_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_length_mismatch_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 315
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: gating gate length 2 != up length 1

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_output_too_short_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_output_too_short_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 322
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: gating output length 1 < input length 2

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_type_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__gating_type_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 259
+expression: types
+---
+[
+    SwiGLU,
+    GeGLU,
+    ReGLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__geglu_known_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__geglu_known_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 279
+expression: rounded
+---
+[
+    "0.0000",
+    "0.8412",
+    "-0.1588",
+    "0.9773",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__reglu_known_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__reglu_known_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 288
+expression: out
+---
+[
+    0.0,
+    1.0,
+    0.0,
+    1.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__swiglu_known_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__gating_snapshots__swiglu_known_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 269
+expression: rounded
+---
+[
+    "0.0000",
+    "0.7311",
+    "-0.2689",
+    "0.8808",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_add_basic_result.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_add_basic_result.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 18
+expression: output
+---
+[
+    1.5,
+    1.5,
+    4.0,
+    3.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_dropout_mask_mismatch_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_dropout_mask_mismatch_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 56
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: output length (2) must equal dropout_mask length (1)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_length_mismatch_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_length_mismatch_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 42
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: output length (2) must equal residual length (1)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_scaled_length_mismatch_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_scaled_length_mismatch_error.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 49
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: output length (1) must equal residual length (2)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_scaled_result.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_scaled_result.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 26
+expression: output
+---
+[
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_with_dropout_result.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave14__residual_snapshots__residual_with_dropout_result.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave14.rs
+assertion_line: 35
+expression: output
+---
+[
+    11.0,
+    2.0,
+    33.0,
+    4.0,
+]

--- a/crates/bitnet-models/src/safetensors_reader.rs
+++ b/crates/bitnet-models/src/safetensors_reader.rs
@@ -97,21 +97,15 @@ impl SafeTensorsReader {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file) }?;
 
-        let shard_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("model.safetensors")
-            .to_string();
+        let shard_name =
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("model.safetensors").to_string();
 
         let tensor_metadata = Self::extract_metadata_from_bytes(&mmap, &shard_name)?;
 
         let mut shards = HashMap::new();
         shards.insert(shard_name, mmap);
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// Open a sharded SafeTensors model from its index file.
@@ -174,10 +168,7 @@ impl SafeTensorsReader {
             );
         }
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// List all tensor names in the model, sorted alphabetically.
@@ -218,9 +209,7 @@ impl SafeTensorsReader {
         let st = SafeTensors::deserialize(mmap)
             .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
-        let view = st
-            .tensor(name)
-            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let data = view.data();
 
@@ -253,14 +242,12 @@ impl SafeTensorsReader {
         data: &[u8],
         shard_name: &str,
     ) -> Result<HashMap<String, TensorMeta>> {
-        let st =
-            SafeTensors::deserialize(data).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let st = SafeTensors::deserialize(data)
+            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let mut metadata = HashMap::new();
         for name in st.names() {
-            let view = st
-                .tensor(name)
-                .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+            let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
             metadata.insert(
                 name.to_string(),
                 TensorMeta {
@@ -286,9 +273,7 @@ fn read_f32_le(data: &[u8]) -> Vec<f32> {
 /// Read little-endian u16 values from a byte slice, handling potential
 /// alignment issues with memory-mapped data.
 fn read_u16_le(data: &[u8]) -> Vec<u16> {
-    data.chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect()
+    data.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
 }
 
 /// Deserialized shard index (`model.safetensors.index.json`).
@@ -305,9 +290,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     /// Helper: serialize tensors to a safetensors byte vector.
-    fn make_safetensors(
-        tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>,
-    ) -> Vec<u8> {
+    fn make_safetensors(tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>) -> Vec<u8> {
         let views: Vec<(String, TensorView)> = tensors
             .into_iter()
             .map(|(name, dtype, shape, data)| {
@@ -345,13 +328,10 @@ mod tests {
     #[test]
     fn bf16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![1.0, -2.5, 0.0, 42.0];
-        let bf16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::bf16::from_f32(f).to_le_bytes())
-            .collect();
+        let bf16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::bf16::from_f32(f).to_le_bytes()).collect();
 
-        let data =
-            make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
+        let data = make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -372,10 +352,8 @@ mod tests {
     #[test]
     fn f16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![0.5, -1.0, 3.14, 0.0];
-        let f16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::f16::from_f32(f).to_le_bytes())
-            .collect();
+        let f16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::f16::from_f32(f).to_le_bytes()).collect();
 
         let data = make_safetensors(vec![("proj", SafeDtype::F16, vec![2, 2], &f16_bytes)]);
 
@@ -401,14 +379,12 @@ mod tests {
         // Shard 1: embedding
         let embed_vals: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
         let embed_bytes: Vec<u8> = embed_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard1 =
-            make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
+        let shard1 = make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
 
         // Shard 2: projection
         let proj_vals: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let proj_bytes: Vec<u8> = proj_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard2 =
-            make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
+        let shard2 = make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
 
         std::fs::write(dir.path().join("shard-00001.safetensors"), &shard1).unwrap();
         std::fs::write(dir.path().join("shard-00002.safetensors"), &shard2).unwrap();
@@ -439,12 +415,8 @@ mod tests {
 
     #[test]
     fn error_missing_tensor() {
-        let data = make_safetensors(vec![(
-            "existing",
-            SafeDtype::F32,
-            vec![1],
-            &1.0f32.to_le_bytes(),
-        )]);
+        let data =
+            make_safetensors(vec![("existing", SafeDtype::F32, vec![1], &1.0f32.to_le_bytes())]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -465,12 +437,8 @@ mod tests {
     #[test]
     fn error_unsupported_dtype() {
         // I64 is not supported for F32 conversion
-        let i64_bytes: Vec<u8> = vec![1i64, 2i64]
-            .iter()
-            .flat_map(|i| i.to_le_bytes())
-            .collect();
-        let data =
-            make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
+        let i64_bytes: Vec<u8> = vec![1i64, 2i64].iter().flat_map(|i| i.to_le_bytes()).collect();
+        let data = make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -512,10 +480,7 @@ mod tests {
     #[test]
     fn multiple_tensors_single_file() {
         let w1: Vec<u8> = vec![1.0f32, 2.0].iter().flat_map(|f| f.to_le_bytes()).collect();
-        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0]
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let data = make_safetensors(vec![
             ("layer.0.weight", SafeDtype::F32, vec![2], &w1),
@@ -529,9 +494,6 @@ mod tests {
         let reader = SafeTensorsReader::from_file(file.path()).unwrap();
         assert_eq!(reader.tensor_count(), 2);
         assert_eq!(reader.load_tensor("layer.0.weight").unwrap(), vec![1.0, 2.0]);
-        assert_eq!(
-            reader.load_tensor("layer.1.weight").unwrap(),
-            vec![3.0, 4.0, 5.0]
-        );
+        assert_eq!(reader.load_tensor("layer.1.weight").unwrap(), vec![3.0, 4.0, 5.0]);
     }
 }


### PR DESCRIPTION
## Snapshot Wave 14

Adds **33 insta snapshot tests** (35 .snap files) covering 5 CPU kernel modules in `bitnet-kernels` that lacked snapshot coverage:

### Modules covered

| Module | Tests | Coverage |
|--------|-------|----------|
| **residual** | 6 | add/scaled/dropout results + error messages |
| **concat** | 7 | output shapes, split shapes, concat values + errors |
| **dequant** | 9 | I2_S block/row/ternary output, pack round-trip + errors |
| **attention_mask** | 5 | causal/padding/sliding-window mask layouts |
| **gating** | 8 | GatingType Debug, SwiGLU/GeGLU/ReGLU output + errors |

### Test types

### Verification
```
cargo test -p bitnet-kernels --test snapshot_wave14 --no-default-features --features cpu
# test result: ok. 33 passed; 0 failed
```