### PR TITLE
Extract benchmark receipt contracts into new core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,16 @@ dependencies = [
 name = "bitnet-bench-receipts"
 version = "0.1.0"
 dependencies = [
+ "bitnet-bench-receipts-core",
+ "tempfile",
+]
+
+[[package]]
+name = "bitnet-bench-receipts-core"
+version = "0.1.0"
+dependencies = [
  "serde",
  "serde_json",
- "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
   "crates/bitnet-vulkan-shaders",# SRP: embedded Vulkan GLSL shader source catalog
   "crates/bitnet-wgpu",          # WebGPU compute backend for cross-platform GPU inference
   "crates/bitnet-dispatch-core", # SRP: backend-agnostic compute dispatch sizing/contracts
+  "crates/bitnet-bench-receipts-core", # SRP: benchmark receipt contract DTOs + serde
   "crates/bitnet-bench-receipts", # SRP: benchmark receipt model + JSONL persistence
   "crates/bitnet-wgpu-bench",    # Benchmarking and profiling harness for wgpu compute kernels
   "crates/bitnet-wgpu-runner",   # WebGPU kernel runner for GPU compute dispatch

--- a/crates/bitnet-bench-receipts-core/Cargo.toml
+++ b/crates/bitnet-bench-receipts-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bitnet-bench-receipts-core"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92.0"
+description = "Core benchmark receipt contracts and JSON serialization"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/crates/bitnet-bench-receipts-core/src/lib.rs
+++ b/crates/bitnet-bench-receipts-core/src/lib.rs
@@ -1,0 +1,132 @@
+//! Core benchmark receipt contracts.
+
+use serde::{Deserialize, Serialize};
+
+/// Errors from receipt serialization and deserialization.
+#[derive(Debug, thiserror::Error)]
+pub enum ReceiptError {
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// A single benchmark measurement for a compute-kernel dispatch.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BenchReceipt {
+    pub kernel_name: String,
+    pub workgroup_size: [u32; 3],
+    pub dispatch_size: [u32; 3],
+    pub elapsed_us: u64,
+    pub throughput_gflops: f64,
+    pub timestamp: u64,
+    pub device_name: String,
+    pub backend: String,
+}
+
+impl BenchReceipt {
+    /// Create a new benchmark receipt.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        kernel_name: impl Into<String>,
+        workgroup_size: [u32; 3],
+        dispatch_size: [u32; 3],
+        elapsed_us: u64,
+        throughput_gflops: f64,
+        timestamp: u64,
+        device_name: impl Into<String>,
+        backend: impl Into<String>,
+    ) -> Self {
+        Self {
+            kernel_name: kernel_name.into(),
+            workgroup_size,
+            dispatch_size,
+            elapsed_us,
+            throughput_gflops,
+            timestamp,
+            device_name: device_name.into(),
+            backend: backend.into(),
+        }
+    }
+
+    /// Serialize to a JSON string.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).expect("BenchReceipt is always serializable")
+    }
+
+    /// Deserialize from a JSON string.
+    pub fn from_json(s: &str) -> Result<Self, ReceiptError> {
+        Ok(serde_json::from_str(s)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_receipt(name: &str, elapsed_us: u64) -> BenchReceipt {
+        BenchReceipt::new(
+            name,
+            [256, 1, 1],
+            [1024, 1, 1],
+            elapsed_us,
+            42.0,
+            1_700_000_000,
+            "Test GPU",
+            "vulkan",
+        )
+    }
+
+    #[test]
+    fn test_new_sets_all_fields() {
+        let r = sample_receipt("matmul", 500);
+        assert_eq!(r.kernel_name, "matmul");
+        assert_eq!(r.workgroup_size, [256, 1, 1]);
+        assert_eq!(r.dispatch_size, [1024, 1, 1]);
+        assert_eq!(r.elapsed_us, 500);
+        assert_eq!(r.device_name, "Test GPU");
+        assert_eq!(r.backend, "vulkan");
+    }
+
+    #[test]
+    fn test_to_json_produces_valid_json() {
+        let r = sample_receipt("softmax", 100);
+        let json = r.to_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["kernel_name"], "softmax");
+    }
+
+    #[test]
+    fn test_from_json_roundtrip() {
+        let r = sample_receipt("rms_norm", 250);
+        let json = r.to_json();
+        let r2 = BenchReceipt::from_json(&json).unwrap();
+        assert_eq!(r, r2);
+    }
+
+    #[test]
+    fn test_from_json_invalid_returns_error() {
+        let result = BenchReceipt::from_json("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_json_missing_field() {
+        let result = BenchReceipt::from_json(r#"{"kernel_name":"x"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_serialization_preserves_workgroup_array() {
+        let r = sample_receipt("conv", 300);
+        let json = r.to_json();
+        assert!(json.contains("[256,1,1]"));
+    }
+
+    #[test]
+    fn test_throughput_precision() {
+        let r = BenchReceipt::new("k", [1, 1, 1], [1, 1, 1], 1, 3.141_592_653_589_793, 0, "", "");
+        let r2 = BenchReceipt::from_json(&r.to_json()).unwrap();
+        assert!((r2.throughput_gflops - std::f64::consts::PI).abs() < 1e-10);
+    }
+}

--- a/crates/bitnet-bench-receipts/Cargo.toml
+++ b/crates/bitnet-bench-receipts/Cargo.toml
@@ -7,9 +7,7 @@ description = "Receipt model and JSONL store for benchmark result tracking"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-thiserror = "2"
+bitnet-bench-receipts-core = { path = "../bitnet-bench-receipts-core" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/bitnet-bench-receipts/src/lib.rs
+++ b/crates/bitnet-bench-receipts/src/lib.rs
@@ -1,66 +1,11 @@
 //! Benchmark receipts for tracking kernel performance over time.
+//!
+//! This crate provides filesystem persistence over the core receipt contracts
+//! from `bitnet-bench-receipts-core`.
 
-use serde::{Deserialize, Serialize};
+pub use bitnet_bench_receipts_core::{BenchReceipt, ReceiptError};
 use std::io::{BufRead, Write};
 use std::path::Path;
-
-/// Errors from receipt I/O and serialization.
-#[derive(Debug, thiserror::Error)]
-pub enum ReceiptError {
-    #[error("JSON error: {0}")]
-    Json(#[from] serde_json::Error),
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
-
-/// A single benchmark measurement for a compute-kernel dispatch.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct BenchReceipt {
-    pub kernel_name: String,
-    pub workgroup_size: [u32; 3],
-    pub dispatch_size: [u32; 3],
-    pub elapsed_us: u64,
-    pub throughput_gflops: f64,
-    pub timestamp: u64,
-    pub device_name: String,
-    pub backend: String,
-}
-
-impl BenchReceipt {
-    /// Create a new benchmark receipt.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        kernel_name: impl Into<String>,
-        workgroup_size: [u32; 3],
-        dispatch_size: [u32; 3],
-        elapsed_us: u64,
-        throughput_gflops: f64,
-        timestamp: u64,
-        device_name: impl Into<String>,
-        backend: impl Into<String>,
-    ) -> Self {
-        Self {
-            kernel_name: kernel_name.into(),
-            workgroup_size,
-            dispatch_size,
-            elapsed_us,
-            throughput_gflops,
-            timestamp,
-            device_name: device_name.into(),
-            backend: backend.into(),
-        }
-    }
-
-    /// Serialize to a JSON string.
-    pub fn to_json(&self) -> String {
-        serde_json::to_string(self).expect("BenchReceipt is always serializable")
-    }
-
-    /// Deserialize from a JSON string.
-    pub fn from_json(s: &str) -> Result<Self, ReceiptError> {
-        Ok(serde_json::from_str(s)?)
-    }
-}
 
 /// Append-only JSON-lines store for benchmark receipts.
 pub struct ReceiptStore;
@@ -109,52 +54,6 @@ mod tests {
     }
 
     #[test]
-    fn test_new_sets_all_fields() {
-        let r = sample_receipt("matmul", 500);
-        assert_eq!(r.kernel_name, "matmul");
-        assert_eq!(r.workgroup_size, [256, 1, 1]);
-        assert_eq!(r.dispatch_size, [1024, 1, 1]);
-        assert_eq!(r.elapsed_us, 500);
-        assert_eq!(r.device_name, "Test GPU");
-        assert_eq!(r.backend, "vulkan");
-    }
-
-    #[test]
-    fn test_to_json_produces_valid_json() {
-        let r = sample_receipt("softmax", 100);
-        let json = r.to_json();
-        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed["kernel_name"], "softmax");
-    }
-
-    #[test]
-    fn test_from_json_roundtrip() {
-        let r = sample_receipt("rms_norm", 250);
-        let json = r.to_json();
-        let r2 = BenchReceipt::from_json(&json).unwrap();
-        assert_eq!(r, r2);
-    }
-
-    #[test]
-    fn test_from_json_invalid_returns_error() {
-        let result = BenchReceipt::from_json("not json");
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_from_json_missing_field() {
-        let result = BenchReceipt::from_json(r#"{"kernel_name":"x"}"#);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_serialization_preserves_workgroup_array() {
-        let r = sample_receipt("conv", 300);
-        let json = r.to_json();
-        assert!(json.contains("[256,1,1]"));
-    }
-
-    #[test]
     fn test_store_append_and_load() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("receipts.jsonl");
@@ -199,13 +98,6 @@ mod tests {
 
         let loaded = ReceiptStore::load(&path).unwrap();
         assert_eq!(loaded.len(), 2);
-    }
-
-    #[test]
-    fn test_throughput_precision() {
-        let r = BenchReceipt::new("k", [1, 1, 1], [1, 1, 1], 1, 3.141_592_653_589_793, 0, "", "");
-        let r2 = BenchReceipt::from_json(&r.to_json()).unwrap();
-        assert!((r2.throughput_gflops - std::f64::consts::PI).abs() < 1e-10);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Separate the pure DTO/serde logic for benchmark receipts from filesystem persistence to follow SRP and enable reuse across crates.
- Reduce coupling so other components can depend on receipt contracts without pulling in file I/O and test helpers.
- Keep the public API stable while allowing the persistence layer to evolve independently.

### Description
- Introduced a new microcrate `crates/bitnet-bench-receipts-core` that defines `BenchReceipt`, `ReceiptError`, and contract-focused serialization helpers and tests.
- Refactored `crates/bitnet-bench-receipts` to focus on JSONL persistence via `ReceiptStore` and to re-export the core types with `pub use bitnet_bench_receipts_core::{BenchReceipt, ReceiptError}` for backwards compatibility.
- Wired the new crate into the workspace by adding the member to `Cargo.toml` and updated `crates/bitnet-bench-receipts/Cargo.toml` to depend on the core crate.
- Kept tests that exercise persistence in `bitnet-bench-receipts` and moved contract/unit tests into the core crate to preserve test coverage.

### Testing
- Ran `cargo test -p bitnet-bench-receipts-core -p bitnet-bench-receipts` and all unit tests completed successfully.
- Ran `cargo fmt --all --check` and formatting checks passed.
- Verified the workspace `Cargo.toml` was updated and the new crate builds cleanly as part of the default members.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6417dac83338e6bd95e5d629ba8)