### PR TITLE
refactor(download): extract atomic metadata write helper into download-core

### DIFF
--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,3 +1,4 @@
+use std::{fs, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -31,9 +32,36 @@ pub fn validate_downloaded_len(
     Ok(())
 }
 
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn parses_content_range_total() {
@@ -49,5 +77,22 @@ mod tests {
             validate_downloaded_len(1, Some(2)),
             Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
         ));
+    }
+
+    #[test]
+    fn atomic_write_persists_file_contents() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock should be monotonic")
+            .as_nanos();
+        let temp_path = std::env::temp_dir().join(format!("bitnet-download-core-{unique}.txt"));
+
+        atomic_write(&temp_path, b"v1").expect("first write should succeed");
+        assert_eq!(std::fs::read(&temp_path).expect("file should be readable"), b"v1");
+
+        atomic_write(&temp_path, b"v2").expect("second write should succeed");
+        assert_eq!(std::fs::read(&temp_path).expect("file should be readable"), b"v2");
+
+        std::fs::remove_file(&temp_path).expect("temp file cleanup should succeed");
     }
 }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Consolidate low-level download file persistence logic into the SRP microcrate so core download primitives (validation and file mechanics) live together.
- Reduce surface area of the higher-level `bitnet-download` crate so it focuses on HTTP/retry helpers while delegating file system behavior to `bitnet-download-core`.

### Description
- Added `atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()>` to `crates/bitnet-download-core/src/lib.rs` to provide an atomic metadata write helper.
- Removed the duplicate `atomic_write` implementation from `crates/bitnet-download/src/lib.rs` and re-exported the core implementation from `bitnet-download` to preserve the existing public API (`pub use bitnet_download_core::{..., atomic_write, ...}`).
- Added the unit test `atomic_write_persists_file_contents` to `bitnet-download-core` to validate repeated atomic writes and file content persistence.
- Cleaned up imports (removed local `fs`/`Path` usage from `bitnet-download`) and kept APIs stable via re-export.

### Testing
- Ran `cargo fmt --all` successfully.
- Ran `cargo test -p bitnet-download-core -p bitnet-download` and all tests passed (download crate tests and core download tests including the new `atomic_write` test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6417dac83338e6bd95e5d629ba8)