### PR TITLE
Extract feature-contract snapshot/drift logic into dedicated core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,11 +675,15 @@ version = "0.2.1-dev"
 name = "bitnet-feature-contract"
 version = "0.2.1-dev"
 dependencies = [
- "bitnet-bdd-grid",
+ "bitnet-feature-contract-core",
  "bitnet-feature-matrix",
  "insta",
  "proptest",
 ]
+
+[[package]]
+name = "bitnet-feature-contract-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-feature-matrix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
   "crates/bitnet-wasm-utils",
   "crates/bitnet-sys",
   "crates/bitnet-feature-contract",
+  "crates/bitnet-feature-contract-core", # SRP: policy/runtime feature contract snapshot + drift core
   "crates/bitnet-runtime-profile",
   "crates/bitnet-runtime-profile-core",
   "crates/bitnet-runtime-profile-contract",

--- a/crates/bitnet-feature-contract-core/Cargo.toml
+++ b/crates/bitnet-feature-contract-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-feature-contract-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core snapshot + drift contract types for policy/runtime feature alignment"
+include = ["src/**", "Cargo.toml"]
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-feature-contract-core/src/lib.rs
+++ b/crates/bitnet-feature-contract-core/src/lib.rs
@@ -1,0 +1,96 @@
+//! Core feature-contract snapshot and drift primitives.
+
+use std::collections::BTreeSet;
+
+/// Snapshot of policy-vs-runtime feature alignment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureContractSnapshot {
+    /// Features required/expected by policy profile resolution.
+    pub policy_features: Vec<String>,
+    /// Features active in the runtime feature stack.
+    pub runtime_features: Vec<String>,
+    /// Features expected by policy but not active at runtime.
+    pub missing_from_runtime: Vec<String>,
+    /// Features active at runtime but not expected by policy.
+    pub extra_from_runtime: Vec<String>,
+}
+
+impl FeatureContractSnapshot {
+    /// Returns true when policy/runtime feature views are aligned.
+    #[must_use]
+    pub fn is_consistent(&self) -> bool {
+        self.missing_from_runtime.is_empty() && self.extra_from_runtime.is_empty()
+    }
+}
+
+/// Build a normalized feature-contract comparison from explicit feature lists.
+pub fn feature_contract_snapshot<I, J, P, R>(
+    policy_features: I,
+    runtime_features: J,
+) -> FeatureContractSnapshot
+where
+    I: IntoIterator<Item = P>,
+    J: IntoIterator<Item = R>,
+    P: AsRef<str>,
+    R: AsRef<str>,
+{
+    let policy =
+        policy_features.into_iter().map(|value| value.as_ref().to_string()).collect::<Vec<_>>();
+    let runtime =
+        runtime_features.into_iter().map(|value| value.as_ref().to_string()).collect::<Vec<_>>();
+
+    let policy_set = policy.iter().cloned().collect::<BTreeSet<_>>();
+    let runtime_set = runtime.iter().cloned().collect::<BTreeSet<_>>();
+
+    let missing_from_runtime = policy_set.difference(&runtime_set).cloned().collect();
+    let extra_from_runtime = runtime_set.difference(&policy_set).cloned().collect();
+
+    FeatureContractSnapshot {
+        policy_features: policy,
+        runtime_features: runtime,
+        missing_from_runtime,
+        extra_from_runtime,
+    }
+}
+
+/// Return a drift snapshot only when policy/runtime feature views disagree.
+pub fn feature_contract_drift<I, J, P, R>(
+    policy_features: I,
+    runtime_features: J,
+) -> Option<FeatureContractSnapshot>
+where
+    I: IntoIterator<Item = P>,
+    J: IntoIterator<Item = R>,
+    P: AsRef<str>,
+    R: AsRef<str>,
+{
+    let snapshot = feature_contract_snapshot(policy_features, runtime_features);
+    if snapshot.is_consistent() { None } else { Some(snapshot) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FeatureContractSnapshot, feature_contract_drift, feature_contract_snapshot};
+
+    #[test]
+    fn feature_contract_snapshot_detects_missing_and_extra_features() {
+        let snapshot =
+            feature_contract_snapshot(vec!["inference", "kernels"], vec!["inference", "gpu"]);
+
+        assert_eq!(
+            snapshot,
+            FeatureContractSnapshot {
+                policy_features: vec!["inference".to_string(), "kernels".to_string()],
+                runtime_features: vec!["inference".to_string(), "gpu".to_string()],
+                missing_from_runtime: vec!["kernels".to_string()],
+                extra_from_runtime: vec!["gpu".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn feature_contract_drift_returns_none_when_aligned() {
+        let none = feature_contract_drift(vec!["inference", "gpu"], vec!["gpu", "inference"]);
+        assert!(none.is_none());
+    }
+}

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -13,7 +13,7 @@ description = "Compact feature and BDD profile contracts for BitNet tooling"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
-bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
+bitnet-feature-contract-core = { path = "../bitnet-feature-contract-core", version = "0.2.1-dev" }
 bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
 
 [dev-dependencies]

--- a/crates/bitnet-feature-contract/src/lib.rs
+++ b/crates/bitnet-feature-contract/src/lib.rs
@@ -4,103 +4,12 @@
 //! consumers while the source-of-truth feature-matrix behavior now lives in
 //! `bitnet-feature-matrix`.
 
-use std::collections::BTreeSet;
-
+pub use bitnet_feature_contract_core::{
+    FeatureContractSnapshot, feature_contract_drift, feature_contract_snapshot,
+};
 pub use bitnet_feature_matrix::{
     ActiveContext, ActiveProfile, BddCell, BddGrid, BitnetFeature, ExecutionEnvironment,
     FeatureSet, TestingScenario, active_features, active_profile, active_profile_for,
     active_profile_summary, active_profile_violation_labels, canonical_grid, feature_labels,
     feature_line, validate_active_profile, validate_active_profile_for,
 };
-
-/// Snapshot of policy-vs-runtime feature alignment.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FeatureContractSnapshot {
-    /// Features required/expected by policy profile resolution.
-    pub policy_features: Vec<String>,
-    /// Features active in the runtime feature stack.
-    pub runtime_features: Vec<String>,
-    /// Features expected by policy but not active at runtime.
-    pub missing_from_runtime: Vec<String>,
-    /// Features active at runtime but not expected by policy.
-    pub extra_from_runtime: Vec<String>,
-}
-
-impl FeatureContractSnapshot {
-    /// Returns true when policy/runtime feature views are aligned.
-    pub fn is_consistent(&self) -> bool {
-        self.missing_from_runtime.is_empty() && self.extra_from_runtime.is_empty()
-    }
-}
-
-/// Build a normalized feature-contract comparison from explicit feature lists.
-pub fn feature_contract_snapshot<I, J, P, R>(
-    policy_features: I,
-    runtime_features: J,
-) -> FeatureContractSnapshot
-where
-    I: IntoIterator<Item = P>,
-    J: IntoIterator<Item = R>,
-    P: AsRef<str>,
-    R: AsRef<str>,
-{
-    let policy =
-        policy_features.into_iter().map(|value| value.as_ref().to_string()).collect::<Vec<_>>();
-    let runtime =
-        runtime_features.into_iter().map(|value| value.as_ref().to_string()).collect::<Vec<_>>();
-
-    let policy_set = policy.iter().cloned().collect::<BTreeSet<_>>();
-    let runtime_set = runtime.iter().cloned().collect::<BTreeSet<_>>();
-
-    let missing_from_runtime = policy_set.difference(&runtime_set).cloned().collect();
-    let extra_from_runtime = runtime_set.difference(&policy_set).cloned().collect();
-
-    FeatureContractSnapshot {
-        policy_features: policy,
-        runtime_features: runtime,
-        missing_from_runtime,
-        extra_from_runtime,
-    }
-}
-
-/// Return a drift snapshot only when policy/runtime feature views disagree.
-pub fn feature_contract_drift<I, J, P, R>(
-    policy_features: I,
-    runtime_features: J,
-) -> Option<FeatureContractSnapshot>
-where
-    I: IntoIterator<Item = P>,
-    J: IntoIterator<Item = R>,
-    P: AsRef<str>,
-    R: AsRef<str>,
-{
-    let snapshot = feature_contract_snapshot(policy_features, runtime_features);
-    if snapshot.is_consistent() { None } else { Some(snapshot) }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{FeatureContractSnapshot, feature_contract_drift, feature_contract_snapshot};
-
-    #[test]
-    fn feature_contract_snapshot_detects_missing_and_extra_features() {
-        let snapshot =
-            feature_contract_snapshot(vec!["inference", "kernels"], vec!["inference", "gpu"]);
-
-        assert_eq!(
-            snapshot,
-            FeatureContractSnapshot {
-                policy_features: vec!["inference".to_string(), "kernels".to_string()],
-                runtime_features: vec!["inference".to_string(), "gpu".to_string()],
-                missing_from_runtime: vec!["kernels".to_string()],
-                extra_from_runtime: vec!["gpu".to_string()],
-            }
-        );
-    }
-
-    #[test]
-    fn feature_contract_drift_returns_none_when_aligned() {
-        let none = feature_contract_drift(vec!["inference", "gpu"], vec!["gpu", "inference"]);
-        assert!(none.is_none());
-    }
-}


### PR DESCRIPTION
### Motivation
- Isolate the pure policy/runtime feature-drift logic so it can be reused without pulling in matrix/profile surface area. 
- Improve SRP by moving snapshot/drift primitives into a minimal core microcrate for clearer ownership and easier consumption.

### Description
- Added a new crate `crates/bitnet-feature-contract-core` that owns `FeatureContractSnapshot`, `feature_contract_snapshot`, and `feature_contract_drift` with focused unit tests. 
- Rewrote `crates/bitnet-feature-contract/src/lib.rs` to become a thin compatibility shim that re-exports the new core primitives and continues to re-export `bitnet-feature-matrix` types/functions. 
- Wired the workspace and dependencies by adding the new crate to `Cargo.toml` members and updating `crates/bitnet-feature-contract/Cargo.toml` to depend on `bitnet-feature-contract-core`. 
- Included the new crate in the workspace lockfile changes (`Cargo.lock`) so the build graph resolves cleanly.

### Testing
- Ran `cargo test -p bitnet-feature-contract-core -p bitnet-feature-contract` and all unit and integration tests for those packages passed. 
- Ran `cargo fmt --all` to ensure formatting consistency and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6417dac83338e6bd95e5d629ba8)