### PR TITLE
Extract LLaMA-3 template detection into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "bitnet-sampling",
  "bitnet-scoring-core",
  "bitnet-startup-contract-guard",
+ "bitnet-template-detect-core",
  "bitnet-tokenizer-discovery-core",
  "bitnet-tokenizers",
  "bitnet-validation",
@@ -1467,6 +1468,13 @@ dependencies = [
  "proptest",
  "thiserror 2.0.18",
  "xtask-build-helper",
+]
+
+[[package]]
+name = "bitnet-template-detect-core"
+version = "0.2.1-dev"
+dependencies = [
+ "proptest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "crates/bitnet-tokenizers",
   "crates/bitnet-tokenizer-model-core", # SRP: tokenizer model/vocabulary detection helpers
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
+  "crates/bitnet-template-detect-core", # SRP: prompt-template family detection heuristics
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -30,6 +30,7 @@ bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
+bitnet-template-detect-core = { path = "../bitnet-template-detect-core", version = "0.2.1-dev" }
 bitnet-prompt-templates = { path = "../bitnet-prompt-templates", version = "0.2.1-dev" }
 bitnet-repl-core = { path = "../bitnet-repl-core", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/commands/template_util.rs
+++ b/crates/bitnet-cli/src/commands/template_util.rs
@@ -1,18 +1,3 @@
 //! Template selection utilities (shared by chat + tests)
 
-/// Return true only when we can be confident the model expects LLaMA-3 chat formatting.
-pub fn looks_like_llama3_chat(
-    tokenizer_name: Option<&str>,
-    chat_template_jinja: Option<&str>,
-) -> bool {
-    let name_hit = tokenizer_name
-        .map(|s| s.to_ascii_lowercase())
-        .map(|n| n.contains("llama") && n.contains("3"))
-        .unwrap_or(false);
-
-    let tmpl_hit = chat_template_jinja
-        .map(|j| j.contains("<|start_header_id|>") && j.contains("<|eot_id|>"))
-        .unwrap_or(false);
-
-    name_hit || tmpl_hit
-}
+pub use bitnet_template_detect_core::looks_like_llama3_chat;

--- a/crates/bitnet-template-detect-core/Cargo.toml
+++ b/crates/bitnet-template-detect-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-template-detect-core"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SRP prompt-template family detection helpers"
+categories.workspace = true
+keywords.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/crates/bitnet-template-detect-core/src/lib.rs
+++ b/crates/bitnet-template-detect-core/src/lib.rs
@@ -1,0 +1,42 @@
+//! Prompt-template auto-detection primitives shared across crates.
+
+/// Return true only when we can be confident the model expects LLaMA-3 chat formatting.
+#[must_use]
+pub fn looks_like_llama3_chat(
+    tokenizer_name: Option<&str>,
+    chat_template_jinja: Option<&str>,
+) -> bool {
+    let name_hit = tokenizer_name
+        .map(|s| s.to_ascii_lowercase())
+        .map(|n| n.contains("llama") && n.contains('3'))
+        .unwrap_or(false);
+
+    let tmpl_hit = chat_template_jinja
+        .map(|j| j.contains("<|start_header_id|>") && j.contains("<|eot_id|>"))
+        .unwrap_or(false);
+
+    name_hit || tmpl_hit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::looks_like_llama3_chat;
+
+    #[test]
+    fn detects_llama3_from_tokenizer_name() {
+        assert!(looks_like_llama3_chat(Some("meta-llama-3.1"), None));
+    }
+
+    #[test]
+    fn detects_llama3_from_chat_template_tokens() {
+        assert!(looks_like_llama3_chat(
+            None,
+            Some("<|start_header_id|>user<|end_header_id|>x<|eot_id|>")
+        ));
+    }
+
+    #[test]
+    fn ignores_non_llama_templates() {
+        assert!(!looks_like_llama3_chat(Some("mistral"), Some("{{ prompt }}")));
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve separation of concerns by moving prompt-template family detection out of the CLI crate and into a focused SRP microcrate so detection logic can be reused and tested in isolation.
- Reduce coupling of `bitnet-cli` internals and make prompt-template heuristics easier to maintain and evolve independently.

### Description
- Add a new microcrate `bitnet-template-detect-core` containing the `looks_like_llama3_chat` helper and focused unit tests in `crates/bitnet-template-detect-core/src/lib.rs`.
- Register the new crate in the workspace (`Cargo.toml`) so it builds as a first-class workspace member.
- Wire `bitnet-cli` to depend on the new crate (added dependency in `crates/bitnet-cli/Cargo.toml`) and re-export the helper from `crates/bitnet-cli/src/commands/template_util.rs` to preserve existing call sites.
- Update lockfile and workspace dependencies to include the new microcrate and its dev-dependency (`proptest`).

### Testing
- Ran `cargo test -p bitnet-template-detect-core` and all unit tests in the new crate passed (3 tests, all ok).
- Ran `cargo test -p bitnet-cli test_detect_llama3_from_jinja` and the relevant CLI auto-detection test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d6417dac83338e6bd95e5d629ba8)