### PR TITLE
fuzz(wave-21): add 6 CPU kernel fuzz targets

### DIFF
--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -63,6 +63,13 @@ jobs:
           - runtime_context_parse_no_panic
           - validation_no_panic
           - vocab_size_extraction
+          # Wave 21: CPU kernel modules
+          - fuzz_cpu_residual
+          - fuzz_cpu_concat
+          - fuzz_cpu_attention_mask
+          - fuzz_cpu_dequant
+          - fuzz_cpu_gating
+          - fuzz_cpu_fusion
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -61,6 +61,13 @@ jobs:
           - batch_norm_params
           - prefix_cache_ops
           - broadcast_shape_fuzz
+          # Wave 21: CPU kernel modules
+          - fuzz_cpu_residual
+          - fuzz_cpu_concat
+          - fuzz_cpu_attention_mask
+          - fuzz_cpu_dequant
+          - fuzz_cpu_gating
+          - fuzz_cpu_fusion
 
     steps:
       - name: Checkout

--- a/crates/bitnet-inference/src/cpu_opt.rs
+++ b/crates/bitnet-inference/src/cpu_opt.rs
@@ -732,16 +732,8 @@ mod tests {
     #[test]
     fn test_silu_numerical_stability_extremes() {
         let out = silu(&[100.0, -100.0]);
-        assert!(
-            (out[0] - 100.0).abs() < 1e-3,
-            "silu(100) should ≈ 100, got {}",
-            out[0]
-        );
-        assert!(
-            out[1].abs() < 1e-10,
-            "silu(-100) should ≈ 0, got {}",
-            out[1]
-        );
+        assert!((out[0] - 100.0).abs() < 1e-3, "silu(100) should ≈ 100, got {}", out[0]);
+        assert!(out[1].abs() < 1e-10, "silu(-100) should ≈ 0, got {}", out[1]);
         // No NaN or Inf
         for &v in &out {
             assert!(v.is_finite(), "silu output must be finite, got {v}");
@@ -768,11 +760,11 @@ mod tests {
     fn test_silu_known_reference_values() {
         let inputs = [0.0f32, 1.0, -1.0, 2.0, -2.0];
         let expected = [
-            0.0,      // silu(0) = 0
-            0.7311,   // silu(1) ≈ 0.7311
-            -0.2689,  // silu(-1) ≈ -0.2689
-            1.7616,   // silu(2) ≈ 1.7616
-            -0.2384,  // silu(-2) ≈ -0.2384
+            0.0,     // silu(0) = 0
+            0.7311,  // silu(1) ≈ 0.7311
+            -0.2689, // silu(-1) ≈ -0.2689
+            1.7616,  // silu(2) ≈ 1.7616
+            -0.2384, // silu(-2) ≈ -0.2384
         ];
         let out = silu(&inputs);
         for (i, (&got, &want)) in out.iter().zip(expected.iter()).enumerate() {
@@ -816,10 +808,7 @@ mod tests {
         rmsnorm(&input, &weight, &mut output, 1, dim, 1e-5).unwrap();
         // rms(1,1,1,1) = sqrt(1 + eps) ≈ 1.0, so output ≈ weight
         for (i, &v) in output.iter().enumerate() {
-            assert!(
-                (v - 1.0).abs() < 0.01,
-                "all-ones: output[{i}] = {v}, expected ≈ 1.0"
-            );
+            assert!((v - 1.0).abs() < 0.01, "all-ones: output[{i}] = {v}, expected ≈ 1.0");
         }
     }
 

--- a/crates/bitnet-models/src/safetensors_reader.rs
+++ b/crates/bitnet-models/src/safetensors_reader.rs
@@ -97,21 +97,15 @@ impl SafeTensorsReader {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file) }?;
 
-        let shard_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("model.safetensors")
-            .to_string();
+        let shard_name =
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("model.safetensors").to_string();
 
         let tensor_metadata = Self::extract_metadata_from_bytes(&mmap, &shard_name)?;
 
         let mut shards = HashMap::new();
         shards.insert(shard_name, mmap);
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// Open a sharded SafeTensors model from its index file.
@@ -174,10 +168,7 @@ impl SafeTensorsReader {
             );
         }
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// List all tensor names in the model, sorted alphabetically.
@@ -218,9 +209,7 @@ impl SafeTensorsReader {
         let st = SafeTensors::deserialize(mmap)
             .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
-        let view = st
-            .tensor(name)
-            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let data = view.data();
 
@@ -253,14 +242,12 @@ impl SafeTensorsReader {
         data: &[u8],
         shard_name: &str,
     ) -> Result<HashMap<String, TensorMeta>> {
-        let st =
-            SafeTensors::deserialize(data).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let st = SafeTensors::deserialize(data)
+            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let mut metadata = HashMap::new();
         for name in st.names() {
-            let view = st
-                .tensor(name)
-                .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+            let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
             metadata.insert(
                 name.to_string(),
                 TensorMeta {
@@ -286,9 +273,7 @@ fn read_f32_le(data: &[u8]) -> Vec<f32> {
 /// Read little-endian u16 values from a byte slice, handling potential
 /// alignment issues with memory-mapped data.
 fn read_u16_le(data: &[u8]) -> Vec<u16> {
-    data.chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect()
+    data.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
 }
 
 /// Deserialized shard index (`model.safetensors.index.json`).
@@ -305,9 +290,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     /// Helper: serialize tensors to a safetensors byte vector.
-    fn make_safetensors(
-        tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>,
-    ) -> Vec<u8> {
+    fn make_safetensors(tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>) -> Vec<u8> {
         let views: Vec<(String, TensorView)> = tensors
             .into_iter()
             .map(|(name, dtype, shape, data)| {
@@ -345,13 +328,10 @@ mod tests {
     #[test]
     fn bf16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![1.0, -2.5, 0.0, 42.0];
-        let bf16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::bf16::from_f32(f).to_le_bytes())
-            .collect();
+        let bf16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::bf16::from_f32(f).to_le_bytes()).collect();
 
-        let data =
-            make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
+        let data = make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -372,10 +352,8 @@ mod tests {
     #[test]
     fn f16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![0.5, -1.0, 3.14, 0.0];
-        let f16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::f16::from_f32(f).to_le_bytes())
-            .collect();
+        let f16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::f16::from_f32(f).to_le_bytes()).collect();
 
         let data = make_safetensors(vec![("proj", SafeDtype::F16, vec![2, 2], &f16_bytes)]);
 
@@ -401,14 +379,12 @@ mod tests {
         // Shard 1: embedding
         let embed_vals: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
         let embed_bytes: Vec<u8> = embed_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard1 =
-            make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
+        let shard1 = make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
 
         // Shard 2: projection
         let proj_vals: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let proj_bytes: Vec<u8> = proj_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard2 =
-            make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
+        let shard2 = make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
 
         std::fs::write(dir.path().join("shard-00001.safetensors"), &shard1).unwrap();
         std::fs::write(dir.path().join("shard-00002.safetensors"), &shard2).unwrap();
@@ -439,12 +415,8 @@ mod tests {
 
     #[test]
     fn error_missing_tensor() {
-        let data = make_safetensors(vec![(
-            "existing",
-            SafeDtype::F32,
-            vec![1],
-            &1.0f32.to_le_bytes(),
-        )]);
+        let data =
+            make_safetensors(vec![("existing", SafeDtype::F32, vec![1], &1.0f32.to_le_bytes())]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -465,12 +437,8 @@ mod tests {
     #[test]
     fn error_unsupported_dtype() {
         // I64 is not supported for F32 conversion
-        let i64_bytes: Vec<u8> = vec![1i64, 2i64]
-            .iter()
-            .flat_map(|i| i.to_le_bytes())
-            .collect();
-        let data =
-            make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
+        let i64_bytes: Vec<u8> = vec![1i64, 2i64].iter().flat_map(|i| i.to_le_bytes()).collect();
+        let data = make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -512,10 +480,7 @@ mod tests {
     #[test]
     fn multiple_tensors_single_file() {
         let w1: Vec<u8> = vec![1.0f32, 2.0].iter().flat_map(|f| f.to_le_bytes()).collect();
-        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0]
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let data = make_safetensors(vec![
             ("layer.0.weight", SafeDtype::F32, vec![2], &w1),
@@ -529,9 +494,6 @@ mod tests {
         let reader = SafeTensorsReader::from_file(file.path()).unwrap();
         assert_eq!(reader.tensor_count(), 2);
         assert_eq!(reader.load_tensor("layer.0.weight").unwrap(), vec![1.0, 2.0]);
-        assert_eq!(
-            reader.load_tensor("layer.1.weight").unwrap(),
-            vec![3.0, 4.0, 5.0]
-        );
+        assert_eq!(reader.load_tensor("layer.1.weight").unwrap(), vec![3.0, 4.0, 5.0]);
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -539,3 +539,39 @@ name = "fuzz_activation_elementwise"
 path = "fuzz_targets/fuzz_activation_elementwise.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_cpu_residual"
+path = "fuzz_targets/fuzz_cpu_residual.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_concat"
+path = "fuzz_targets/fuzz_cpu_concat.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_attention_mask"
+path = "fuzz_targets/fuzz_cpu_attention_mask.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_dequant"
+path = "fuzz_targets/fuzz_cpu_dequant.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_gating"
+path = "fuzz_targets/fuzz_cpu_gating.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_fusion"
+path = "fuzz_targets/fuzz_cpu_fusion.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_cpu_attention_mask.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_attention_mask.rs
@@ -1,0 +1,103 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::attention_mask::{
+    apply_mask, create_causal_mask, create_padding_mask, create_sliding_window_mask,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MaskInput {
+    seq_len: u8,
+    window: u8,
+    batch_size: u8,
+    lengths_raw: Vec<u8>,
+    scores_raw: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: MaskInput| {
+    let seq_len = (input.seq_len as usize % 16) + 1;
+    let n = seq_len * seq_len;
+
+    // --- create_causal_mask ---
+    {
+        let mask = create_causal_mask(seq_len);
+        assert_eq!(mask.len(), n);
+        // Verify lower-triangular structure
+        for i in 0..seq_len {
+            for j in 0..seq_len {
+                let v = mask[i * seq_len + j];
+                if j <= i {
+                    assert_eq!(v, 0.0, "causal mask [{i},{j}] should be 0.0");
+                } else {
+                    assert_eq!(v, f32::NEG_INFINITY, "causal mask [{i},{j}] should be -inf");
+                }
+            }
+        }
+    }
+
+    // --- create_sliding_window_mask ---
+    {
+        let window = input.window as usize % (seq_len + 2); // allow 0 and > seq_len
+        let mask = create_sliding_window_mask(seq_len, window);
+        assert_eq!(mask.len(), n);
+        for i in 0..seq_len {
+            for j in 0..seq_len {
+                let v = mask[i * seq_len + j];
+                assert!(v == 0.0 || v == f32::NEG_INFINITY, "unexpected mask value: {v}");
+                // Future positions must be blocked
+                if j > i {
+                    assert_eq!(v, f32::NEG_INFINITY);
+                }
+            }
+        }
+    }
+
+    // --- create_padding_mask ---
+    {
+        let batch = (input.batch_size as usize % 4) + 1;
+        let lengths: Vec<usize> =
+            input.lengths_raw.iter().take(batch).map(|&b| b as usize % (seq_len + 1)).collect();
+        if lengths.len() >= batch {
+            let mask = create_padding_mask(&lengths[..batch], seq_len);
+            assert_eq!(mask.len(), batch * seq_len);
+            for (b, &len) in lengths[..batch].iter().enumerate() {
+                let valid = len.min(seq_len);
+                for j in 0..seq_len {
+                    let v = mask[b * seq_len + j];
+                    if j < valid {
+                        assert_eq!(v, 0.0, "padding mask [{b},{j}] should be 0.0");
+                    } else {
+                        assert_eq!(v, f32::NEG_INFINITY, "padding mask [{b},{j}] should be -inf");
+                    }
+                }
+            }
+        }
+    }
+
+    // --- apply_mask ---
+    {
+        let scores = bytes_to_f32(&input.scores_raw, n);
+        if scores.len() >= n && scores[..n].iter().all(|x| x.is_finite()) {
+            let mask = create_causal_mask(seq_len);
+            let mut s = scores[..n].to_vec();
+            apply_mask(&mut s, &mask, seq_len);
+            // Masked positions should be -inf, unmasked should remain finite
+            for i in 0..seq_len {
+                for j in 0..seq_len {
+                    let v = s[i * seq_len + j];
+                    if j > i {
+                        assert_eq!(v, f32::NEG_INFINITY);
+                    }
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_concat.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_concat.rs
@@ -1,0 +1,84 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::concat::ConcatKernel;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ConcatInput {
+    rows_a: u8,
+    rows_b: u8,
+    cols: u8,
+    axis: u8,
+    num_splits: u8,
+    data_a: Vec<u8>,
+    data_b: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: ConcatInput| {
+    let rows_a = (input.rows_a as usize % 8) + 1;
+    let rows_b = (input.rows_b as usize % 8) + 1;
+    let cols = (input.cols as usize % 8) + 1;
+    let axis = input.axis as usize % 2; // 0 or 1 for 2D
+
+    let elems_a = rows_a * cols;
+    let elems_b = rows_b * cols;
+
+    let a = bytes_to_f32(&input.data_a, elems_a);
+    let b = bytes_to_f32(&input.data_b, elems_b);
+
+    // --- concat along axis 0 (stacking rows) ---
+    if axis == 0 && a.len() >= elems_a && b.len() >= elems_b {
+        let a_slice = &a[..elems_a];
+        let b_slice = &b[..elems_b];
+        let shape_a: &[usize] = &[rows_a, cols];
+        let shape_b: &[usize] = &[rows_b, cols];
+        let inputs: &[&[f32]] = &[a_slice, b_slice];
+        let shapes: &[&[usize]] = &[shape_a, shape_b];
+
+        if let Ok(out) = ConcatKernel::concat(inputs, shapes, 0) {
+            assert_eq!(out.len(), elems_a + elems_b);
+        }
+    }
+
+    // --- split ---
+    if a.len() >= elems_a && rows_a >= 2 {
+        let num_splits = ((input.num_splits as usize % rows_a) + 1).min(rows_a);
+        if rows_a % num_splits == 0 {
+            let shape: &[usize] = &[rows_a, cols];
+            if let Ok(parts) = ConcatKernel::split(&a[..elems_a], shape, 0, num_splits) {
+                assert_eq!(parts.len(), num_splits);
+                let total: usize = parts.iter().map(|p| p.len()).sum();
+                assert_eq!(total, elems_a);
+            }
+        }
+    }
+
+    // --- stack (same-shape tensors along new axis) ---
+    if a.len() >= cols && b.len() >= cols {
+        let a_row = &a[..cols];
+        let b_row = &b[..cols];
+        let shape_1d: &[usize] = &[cols];
+        let inputs: &[&[f32]] = &[a_row, b_row];
+
+        if let Ok(out) = ConcatKernel::stack(inputs, shape_1d, 0) {
+            assert_eq!(out.len(), 2 * cols);
+        }
+    }
+
+    // --- empty inputs should return empty ---
+    {
+        let empty: &[&[f32]] = &[];
+        let empty_shapes: &[&[usize]] = &[];
+        if let Ok(out) = ConcatKernel::concat(empty, empty_shapes, 0) {
+            assert!(out.is_empty());
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_dequant.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_dequant.rs
@@ -1,0 +1,110 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::dequant::{
+    dequant_i2s_block, dequant_i2s_row, dequant_ternary, pack_ternary,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct DequantInput {
+    block_size_hint: u8,
+    scale_raw: [u8; 4],
+    threshold_raw: [u8; 4],
+    packed_data: Vec<u8>,
+    float_data: Vec<u8>,
+    num_blocks_hint: u8,
+}
+
+fn bytes_to_f32_single(b: &[u8; 4]) -> f32 {
+    f32::from_le_bytes(*b)
+}
+
+fn bytes_to_f32_vec(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: DequantInput| {
+    let scale = bytes_to_f32_single(&input.scale_raw);
+    if !scale.is_finite() {
+        return;
+    }
+
+    // --- dequant_i2s_block ---
+    {
+        let block_size = (input.block_size_hint as usize % 64) + 1;
+        let bytes_needed = block_size.div_ceil(4);
+        if input.packed_data.len() >= bytes_needed {
+            match dequant_i2s_block(&input.packed_data[..bytes_needed], scale, block_size) {
+                Ok(out) => {
+                    assert_eq!(out.len(), block_size);
+                    // Each output must be in {-scale, 0, +scale}
+                    for (i, &v) in out.iter().enumerate() {
+                        assert!(
+                            v == 0.0 || v == scale || v == -scale,
+                            "dequant_i2s_block[{i}] = {v}, expected 0/{scale}/{s}",
+                            s = -scale,
+                        );
+                    }
+                }
+                Err(_) => {} // invalid input is fine
+            }
+        }
+
+        // Undersized packed data should fail
+        if bytes_needed > 0 && input.packed_data.len() < bytes_needed {
+            assert!(dequant_i2s_block(&input.packed_data, scale, block_size).is_err());
+        }
+    }
+
+    // --- dequant_ternary ---
+    if !input.packed_data.is_empty() {
+        let out = dequant_ternary(&input.packed_data, scale);
+        assert_eq!(out.len(), input.packed_data.len() * 4);
+        for (i, &v) in out.iter().enumerate() {
+            assert!(v == 0.0 || v == scale || v == -scale, "dequant_ternary[{i}] = {v}",);
+        }
+    }
+
+    // --- pack_ternary roundtrip ---
+    {
+        let floats = bytes_to_f32_vec(&input.float_data, 32);
+        if !floats.is_empty() && floats.iter().all(|x| x.is_finite()) {
+            let threshold = bytes_to_f32_single(&input.threshold_raw).abs();
+            if threshold.is_finite() {
+                let (packed, computed_scale) = pack_ternary(&floats, threshold);
+                assert!(computed_scale.is_finite());
+                assert!(computed_scale > 0.0);
+                // Roundtrip: dequantize what we just packed
+                let restored = dequant_ternary(&packed, computed_scale);
+                assert!(restored.len() >= floats.len());
+                // Each restored value must be ternary
+                for &v in &restored {
+                    assert!(
+                        v == 0.0 || v == computed_scale || v == -computed_scale,
+                        "roundtrip value {v} not ternary",
+                    );
+                }
+            }
+        }
+    }
+
+    // --- dequant_i2s_row ---
+    if !input.packed_data.is_empty() {
+        let block_size = (input.block_size_hint as usize % 32) + 1;
+        let total = input.packed_data.len() * 4;
+        let num_blocks = total.div_ceil(block_size);
+        let num_scales = (input.num_blocks_hint as usize % 16) + 1;
+        let scales = vec![scale; num_scales];
+
+        if num_scales >= num_blocks {
+            if let Ok(out) = dequant_i2s_row(&input.packed_data, &scales[..num_blocks], block_size)
+            {
+                assert_eq!(out.len(), total);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_fusion.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_fusion.rs
@@ -1,0 +1,128 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::fusion::{
+    fused_add_normalize, fused_gelu_linear, fused_rmsnorm_linear, fused_scale_add,
+    fused_softmax_mask,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct FusionInput {
+    n_hint: u8,
+    out_dim_hint: u8,
+    eps_raw: [u8; 4],
+    scale_raw: [u8; 4],
+    data_a: Vec<u8>,
+    data_b: Vec<u8>,
+    data_w: Vec<u8>,
+    data_gamma: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn bytes_to_f32_single(b: &[u8; 4]) -> f32 {
+    f32::from_le_bytes(*b)
+}
+
+fuzz_target!(|input: FusionInput| {
+    let n = (input.n_hint as usize % 32) + 1;
+    let out_dim = (input.out_dim_hint as usize % 8) + 1;
+
+    let a = bytes_to_f32(&input.data_a, n);
+    let b = bytes_to_f32(&input.data_b, n);
+    let gamma = bytes_to_f32(&input.data_gamma, n);
+    let weight = bytes_to_f32(&input.data_w, out_dim * n);
+
+    if a.len() < n || b.len() < n {
+        return;
+    }
+    if !a[..n].iter().chain(b[..n].iter()).all(|x| x.is_finite()) {
+        return;
+    }
+
+    // --- fused_scale_add ---
+    {
+        let scale = bytes_to_f32_single(&input.scale_raw);
+        if scale.is_finite() {
+            if let Ok(out) = fused_scale_add(&a[..n], &b[..n], scale) {
+                assert_eq!(out.len(), n);
+                for (i, &v) in out.iter().enumerate() {
+                    assert!(v.is_finite(), "fused_scale_add non-finite at {i}: {v}");
+                }
+            }
+        }
+    }
+
+    // --- fused_add_normalize ---
+    if gamma.len() >= n && gamma[..n].iter().all(|x| x.is_finite()) {
+        let eps = bytes_to_f32_single(&input.eps_raw).abs();
+        if eps.is_finite() && eps > 0.0 {
+            if let Ok(out) = fused_add_normalize(&a[..n], &b[..n], &gamma[..n], eps) {
+                assert_eq!(out.len(), n);
+            }
+        }
+    }
+
+    // --- fused_softmax_mask ---
+    {
+        // Use a and b as scores and mask
+        if let Ok(out) = fused_softmax_mask(&a[..n], &b[..n], 1.0) {
+            assert_eq!(out.len(), n);
+            // Softmax output should sum to ~1.0
+            let sum: f32 = out.iter().sum();
+            if sum.is_finite() {
+                assert!(
+                    (sum - 1.0).abs() < 1e-3 || sum == 0.0,
+                    "softmax sum = {sum}, expected ~1.0"
+                );
+            }
+            // All outputs should be >= 0
+            for (i, &v) in out.iter().enumerate() {
+                assert!(v >= 0.0, "softmax output[{i}] = {v} < 0");
+            }
+        }
+    }
+
+    // --- fused_rmsnorm_linear ---
+    if weight.len() >= out_dim * n
+        && gamma.len() >= n
+        && gamma[..n].iter().all(|x| x.is_finite())
+        && weight[..out_dim * n].iter().all(|x| x.is_finite())
+    {
+        let eps = bytes_to_f32_single(&input.eps_raw).abs();
+        if eps.is_finite() && eps > 0.0 {
+            if let Ok(out) = fused_rmsnorm_linear(&a[..n], &weight[..out_dim * n], &gamma[..n], eps)
+            {
+                assert_eq!(out.len(), out_dim);
+            }
+        }
+    }
+
+    // --- fused_gelu_linear ---
+    if weight.len() >= out_dim * n && weight[..out_dim * n].iter().all(|x| x.is_finite()) {
+        // Without bias
+        if let Ok(out) = fused_gelu_linear(&a[..n], &weight[..out_dim * n], &[]) {
+            assert_eq!(out.len(), out_dim);
+        }
+        // With bias
+        let bias = bytes_to_f32(&input.data_b, out_dim);
+        if bias.len() >= out_dim && bias[..out_dim].iter().all(|x| x.is_finite()) {
+            if let Ok(out) = fused_gelu_linear(&a[..n], &weight[..out_dim * n], &bias[..out_dim]) {
+                assert_eq!(out.len(), out_dim);
+            }
+        }
+    }
+
+    // --- empty input should error ---
+    {
+        let empty: &[f32] = &[];
+        assert!(fused_scale_add(empty, empty, 1.0).is_err());
+        assert!(fused_softmax_mask(empty, empty, 1.0).is_err());
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_gating.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_gating.rs
@@ -1,0 +1,92 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::gating::{GatingType, apply_gating, geglu, reglu, swiglu};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct GatingInput {
+    len_hint: u8,
+    gating_type: u8,
+    gate_raw: Vec<u8>,
+    up_raw: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: GatingInput| {
+    let n = (input.len_hint as usize % 64) + 1;
+    let gate = bytes_to_f32(&input.gate_raw, n);
+    let up = bytes_to_f32(&input.up_raw, n);
+
+    if gate.len() < n || up.len() < n {
+        return;
+    }
+    if !gate[..n].iter().chain(up[..n].iter()).all(|x| x.is_finite()) {
+        return;
+    }
+
+    let gate = &gate[..n];
+    let up = &up[..n];
+    let output = vec![0.0f32; n];
+
+    // --- swiglu ---
+    {
+        let mut out = output.clone();
+        if let Ok(()) = swiglu(gate, up, &mut out) {
+            assert_eq!(out.len(), n);
+            for (i, &v) in out.iter().enumerate() {
+                assert!(v.is_finite(), "swiglu non-finite at {i}: {v}");
+            }
+        }
+    }
+
+    // --- geglu ---
+    {
+        let mut out = output.clone();
+        if let Ok(()) = geglu(gate, up, &mut out) {
+            assert_eq!(out.len(), n);
+            for (i, &v) in out.iter().enumerate() {
+                assert!(v.is_finite(), "geglu non-finite at {i}: {v}");
+            }
+        }
+    }
+
+    // --- reglu ---
+    {
+        let mut out = output.clone();
+        if let Ok(()) = reglu(gate, up, &mut out) {
+            assert_eq!(out.len(), n);
+            for (i, &v) in out.iter().enumerate() {
+                assert!(v.is_finite(), "reglu non-finite at {i}: {v}");
+                // ReGLU output should be >= 0 when gate >= 0
+                // (ReLU(gate) * up >= 0 when both >= 0)
+            }
+        }
+    }
+
+    // --- apply_gating (dispatch by type) ---
+    {
+        let gating_type = match input.gating_type % 3 {
+            0 => GatingType::SwiGLU,
+            1 => GatingType::GeGLU,
+            _ => GatingType::ReGLU,
+        };
+        let mut out = output.clone();
+        if let Ok(()) = apply_gating(gating_type, gate, up, &mut out) {
+            assert_eq!(out.len(), n);
+        }
+    }
+
+    // --- mismatched lengths should error ---
+    if n > 1 {
+        let short_gate = &gate[..n - 1];
+        let mut out = vec![0.0f32; n];
+        assert!(swiglu(short_gate, up, &mut out).is_err());
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_residual.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_residual.rs
@@ -1,0 +1,76 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::residual::{add_residual, add_residual_scaled, add_residual_with_dropout};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ResidualInput {
+    len_hint: u8,
+    scale: u8,
+    a_raw: Vec<u8>,
+    b_raw: Vec<u8>,
+    mask_raw: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: ResidualInput| {
+    let n = (input.len_hint as usize % 64) + 1;
+    let a = bytes_to_f32(&input.a_raw, n);
+    let b = bytes_to_f32(&input.b_raw, n);
+
+    if a.len() < n || b.len() < n {
+        return;
+    }
+    if !a.iter().chain(b.iter()).all(|x| x.is_finite()) {
+        return;
+    }
+
+    // --- add_residual ---
+    {
+        let mut out = a[..n].to_vec();
+        if let Ok(()) = add_residual(&mut out, &b[..n]) {
+            assert_eq!(out.len(), n);
+            for (i, &v) in out.iter().enumerate() {
+                assert!(v.is_finite(), "add_residual non-finite at {i}: {v}");
+            }
+        }
+    }
+
+    // --- add_residual_scaled ---
+    {
+        let scale = (input.scale as f32 - 128.0) / 32.0;
+        if scale.is_finite() {
+            let mut out = a[..n].to_vec();
+            if let Ok(()) = add_residual_scaled(&mut out, &b[..n], scale) {
+                assert_eq!(out.len(), n);
+            }
+        }
+    }
+
+    // --- add_residual_with_dropout ---
+    {
+        let mask: Vec<bool> = input.mask_raw.iter().take(n).map(|&b| b & 1 != 0).collect();
+        if mask.len() >= n {
+            let mut out = a[..n].to_vec();
+            if let Ok(()) = add_residual_with_dropout(&mut out, &b[..n], &mask[..n]) {
+                assert_eq!(out.len(), n);
+                for (i, &v) in out.iter().enumerate() {
+                    assert!(v.is_finite(), "dropout residual non-finite at {i}: {v}");
+                }
+            }
+        }
+    }
+
+    // --- length mismatch should return Err ---
+    if n > 1 {
+        let mut short = vec![0.0f32; n - 1];
+        assert!(add_residual(&mut short, &b[..n]).is_err());
+    }
+});


### PR DESCRIPTION
## Wave 21: CPU Kernel Fuzz Targets

Add 6 new fuzz targets for recently merged CPU kernel modules, bringing the total from 78 to 84.

### New Targets

| Target | Module | What it fuzzes |
|--------|--------|----------------|
| `fuzz_cpu_residual` | `cpu::residual` | add_residual, scaled add, dropout masking |
| `fuzz_cpu_concat` | `cpu::concat` | ConcatKernel::concat/split/stack |
| `fuzz_cpu_attention_mask` | `cpu::attention_mask` | causal, padding, sliding-window masks |
| `fuzz_cpu_dequant` | `cpu::dequant` | I2_S block/row dequant, pack_ternary roundtrip |
| `fuzz_cpu_gating` | `cpu::gating` | SwiGLU, GeGLU, ReGLU FFN gating |
| `fuzz_cpu_fusion` | `cpu::fusion` | fused RMSNorm+linear, GELU+linear, softmax+mask, add+normalize, scale+add |

### Invariants Checked

- Output finiteness for all operations with finite inputs
- Correct output shapes (length assertions)
- Ternary value ranges (`{-scale, 0, +scale}`) for dequant
- Softmax outputs sum to ~1.0 and are non-negative
- Causal mask lower-triangular structure
- Error paths (empty inputs, length mismatches)

### CI

Registered in both `nightly-fuzz.yml` and `fuzz-nightly.yml` workflows.

### Validation

- `cargo check -p bitnet-fuzz` ✅ (zero warnings)
- TOML syntax validated ✅