### PR TITLE
docs: publish local quantization benchmark snapshot

### DIFF
--- a/docs/benchmarks/BENCHMARK_SUMMARY.md
+++ b/docs/benchmarks/BENCHMARK_SUMMARY.md
@@ -142,3 +142,31 @@ cargo bench --bench kernel_benchmarks --no-default-features --features cpu,avx2 
 - **Scalar reference**: `crates/bitnet-models/src/quant/i2s.rs`
 - **Documentation**: `docs/benchmarks/qk256-dequant-benchmark.md`
 - **CLAUDE.md**: Project documentation
+
+
+## 2026-03-02 Quantization Ops Snapshot (CPU-only VM)
+
+Command executed:
+
+```bash
+cargo bench -p bitnet --no-default-features --features cpu,bench --bench quantization_ops -- --sample-size 10
+```
+
+Representative results from this run:
+
+| Benchmark | Time Range | Throughput Range |
+|---|---:|---:|
+| `i2s_roundtrip/quantize/4096` | 90.690–99.721 µs | 41.075–45.165 Melem/s |
+| `qk256_unpack/blocks/16` | 1.3990–1.4298 µs | 2.8647–2.9277 Gelem/s |
+| `qk256_gemv/full/16x4096` | 35.366–40.326 µs | 1.6252–1.8531 Gelem/s |
+| `tl1_lookup/roundtrip/4096` | 54.871–57.783 µs | 70.886–74.648 Melem/s |
+| `tl2_lookup/roundtrip/4096` | 41.458–49.130 µs | 83.371–98.800 Melem/s |
+
+Environment summary:
+- Linux 6.12.47 x86_64 (KVM VM)
+- Intel Xeon Platinum 8370C (3 vCPUs)
+- rustc 1.92.0 / cargo 1.92.0
+
+Interpretation:
+- Treat this as a "can run + baseline capture" pass in constrained CI-like hardware.
+- Outliers were reported by Criterion in several groups; focus on trend comparisons across repeated runs and same hardware class.

--- a/docs/performance-benchmarking.md
+++ b/docs/performance-benchmarking.md
@@ -30,6 +30,31 @@ python3 scripts/detect-performance-regression.py \
   --fail-on-regression
 ```
 
+
+## 🧪 Latest Local Benchmark Snapshot (2026-03-02)
+
+We ran the `bitnet` quantization micro-bench suite in this environment:
+
+```bash
+cargo bench -p bitnet --no-default-features --features cpu,bench --bench quantization_ops -- --sample-size 10
+```
+
+**Environment:**
+- OS: Linux 6.12.47 x86_64 (KVM VM)
+- CPU: Intel Xeon Platinum 8370C (3 vCPUs)
+- Toolchain: rustc 1.92.0 / cargo 1.92.0
+
+**Selected results (Criterion):**
+- `i2s_roundtrip/quantize/4096`: 90.690–99.721 µs (41.075–45.165 Melem/s)
+- `qk256_unpack/blocks/16`: 1.3990–1.4298 µs (2.8647–2.9277 Gelem/s)
+- `qk256_gemv/full/16x4096`: 35.366–40.326 µs (1.6252–1.8531 Gelem/s)
+- `tl1_lookup/roundtrip/4096`: 54.871–57.783 µs (70.886–74.648 Melem/s)
+- `tl2_lookup/roundtrip/4096`: 41.458–49.130 µs (83.371–98.800 Melem/s)
+
+> Notes:
+> - This is a VM-based, CPU-only run and should be treated as a reproducible smoke/perf baseline, not a hardware max-throughput claim.
+> - Criterion reported some outliers in multiple groups; compare deltas across runs rather than relying on single-point values.
+
 ## 📊 Architecture Overview
 
 The benchmarking infrastructure consists of several integrated components:


### PR DESCRIPTION
### Motivation

- Provide a concrete, reproducible CPU-only benchmark snapshot that can be run in constrained CI-like VMs so the project has an explicit local baseline to compare against. 
- Capture representative micro-benchmark results for the quantization code paths (I2S, QK256 unpack/GEMV, TL1, TL2) and make the constraints and caveats explicit in the docs.

### Description

- Ran a local Criterion micro-benchmark pass using `cargo bench -p bitnet --no-default-features --features cpu,bench --bench quantization_ops -- --sample-size 10` and captured representative ranges. 
- Added a new "Latest Local Benchmark Snapshot (2026-03-02)" section to `docs/performance-benchmarking.md` that documents the exact command, environment (OS/CPU/toolchain), selected Criterion results, and caveats about VM/outliers.
- Appended the same snapshot and a small result table to `docs/benchmarks/BENCHMARK_SUMMARY.md` as a quick baseline reference for I2S/QK256/TL1/TL2 paths.
- The documentation highlights that this is a VM-based, CPU-only run (Intel Xeon Platinum 8370C, 3 vCPUs, rustc 1.92.0 / cargo 1.92.0) and notes Criterion-reported outliers for interpretation guidance.

### Testing

- Executed the benchmark command `cargo bench -p bitnet --no-default-features --features cpu,bench --bench quantization_ops -- --sample-size 10`, which completed successfully and produced the reported Criterion ranges. 
- Collected system/tooling metadata via `uname -a`, `rustc --version`, `cargo --version`, and `lscpu` to include in the snapshot and all commands succeeded. 
- Verified that the selected representative metrics (I2S, QK256 unpack/GEMV, TL1, TL2 samples) were present in the Criterion output and were recorded into the two documentation files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d8c48c588333bb067a4e644457ba)