### PR TITLE
Fix misleading cross-validation PR summary when lanes are skipped

### DIFF
--- a/.github/workflows/crossval.yml
+++ b/.github/workflows/crossval.yml
@@ -575,8 +575,23 @@ jobs:
 
           ## Key Findings
 
+          EOF
+
+          if [[ "${{ needs.check-trigger.outputs.should_run_lane_a }}" == "true" || "${{ needs.check-trigger.outputs.should_run_lane_b }}" == "true" ]]; then
+            cat >> crossval-summary.md << 'EOF'
+
           - 🎯 **Accuracy**: Rust implementation within tolerance threshold
           - 🚀 **Performance**: Competitive with C++ reference
+          EOF
+          else
+            cat >> crossval-summary.md << 'EOF'
+
+          - ℹ️ **Accuracy & Performance**: Not evaluated in this run (both cross-validation lanes were skipped)
+          EOF
+          fi
+
+          cat >> crossval-summary.md << 'EOF'
+
           - 🛡️ **Memory Safety**: Zero undefined behavior (Rust guarantees)
           - 🔄 **Compatibility**: API parity maintained
 


### PR DESCRIPTION
### Motivation
- The summary generator in `Cross-Validation Summary` always printed accuracy and performance bullets even when both Lane A and Lane B were skipped, producing misleading PR comments. 
- The change ensures the PR summary reflects whether any cross-validation lane actually ran before claiming accuracy/performance results.

### Description
- Updated `.github/workflows/crossval.yml` to conditionally emit the accuracy and performance bullets only if `should_run_lane_a` or `should_run_lane_b` is `true`.
- When both lanes are skipped the workflow now appends a neutral line: `Accuracy & Performance: Not evaluated in this run (both cross-validation lanes were skipped)` and preserves the memory-safety and compatibility bullets.

### Testing
- Verified the patch with `git diff -- .github/workflows/crossval.yml` which showed the conditional logic inserted and succeeded. 
- Inspected the modified section with `nl -ba .github/workflows/crossval.yml | sed -n '548,605p'` to confirm the new branching and confirmed the commit via `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4daa12370833381b89f1ffed99861)