### PR TITLE
Fix misleading cross-validation summary when no lanes run

### DIFF
--- a/.github/workflows/crossval.yml
+++ b/.github/workflows/crossval.yml
@@ -571,14 +571,24 @@ jobs:
             echo "- ⏭️  **Lane A (BitNet.cpp)**: Skipped" >> crossval-summary.md
           fi
 
+          echo "" >> crossval-summary.md
+          echo "## Key Findings" >> crossval-summary.md
+          echo "" >> crossval-summary.md
+
+          LANE_A_RAN="${{ needs.check-trigger.outputs.should_run_lane_a }}"
+          LANE_B_RAN="${{ needs.check-trigger.outputs.should_run_lane_b }}"
+
+          if [[ "$LANE_A_RAN" == "true" || "$LANE_B_RAN" == "true" ]]; then
+            echo "- 🎯 **Accuracy**: Rust implementation within tolerance threshold" >> crossval-summary.md
+            echo "- 🚀 **Performance**: Competitive with C++ reference" >> crossval-summary.md
+          else
+            echo "- ℹ️ **Accuracy/Performance**: Not evaluated in this run (both cross-validation lanes were skipped)" >> crossval-summary.md
+          fi
+
+          echo "- 🛡️ **Memory Safety**: Zero undefined behavior (Rust guarantees)" >> crossval-summary.md
+          echo "- 🔄 **Compatibility**: API parity maintained" >> crossval-summary.md
+
           cat >> crossval-summary.md << 'EOF'
-
-          ## Key Findings
-
-          - 🎯 **Accuracy**: Rust implementation within tolerance threshold
-          - 🚀 **Performance**: Competitive with C++ reference
-          - 🛡️ **Memory Safety**: Zero undefined behavior (Rust guarantees)
-          - 🔄 **Compatibility**: API parity maintained
 
           ## Artifacts
 


### PR DESCRIPTION
### Motivation
- The cross-validation summary always printed fixed "Key Findings" statements (including performance claims) even when both Lane A and Lane B were skipped, which is misleading.
- The change aims to ensure accuracy/performance statements are only reported when at least one cross-validation lane actually ran.

### Description
- Update `.github/workflows/crossval.yml` summary generation to compute `LANE_A_RAN` and `LANE_B_RAN` and conditionally emit accuracy/performance lines only if either flag is `true`.
- When both lanes are skipped the summary now emits an explicit "Not evaluated in this run (both cross-validation lanes were skipped)" message instead of claiming results.
- The memory-safety and API-compatibility notes are preserved and the artifacts section remains unchanged.

### Testing
- Searched the repository for related workflow text with `rg` to find the summary generation and related logic, and the search succeeded.
- Inspected the relevant workflow sections with `nl`/`sed` to validate the inserted conditional block and its placement, and the file excerpts matched the intended changes.
- Applied the patch with the repository tooling which reported success and then verified the updated file diff and working tree status, showing the expected insertions and deletions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4daa12370833381b89f1ffed99861)