### PR TITLE
Only report accuracy/performance in crossval summary when lanes run

### DIFF
--- a/.github/workflows/crossval.yml
+++ b/.github/workflows/crossval.yml
@@ -571,14 +571,26 @@ jobs:
             echo "- ⏭️  **Lane A (BitNet.cpp)**: Skipped" >> crossval-summary.md
           fi
 
-          cat >> crossval-summary.md << 'EOF'
+          cat >> crossval-summary.md << EOF
 
           ## Key Findings
 
-          - 🎯 **Accuracy**: Rust implementation within tolerance threshold
-          - 🚀 **Performance**: Competitive with C++ reference
           - 🛡️ **Memory Safety**: Zero undefined behavior (Rust guarantees)
           - 🔄 **Compatibility**: API parity maintained
+          EOF
+
+          if [[ "${{ needs.check-trigger.outputs.should_run_lane_a }}" == "true" ]] || [[ "${{ needs.check-trigger.outputs.should_run_lane_b }}" == "true" ]]; then
+            cat >> crossval-summary.md << EOF
+          - 🎯 **Accuracy**: Rust implementation within tolerance threshold
+          - 🚀 **Performance**: Competitive with C++ reference
+            EOF
+          else
+            cat >> crossval-summary.md << EOF
+          - ℹ️ **Accuracy/Performance**: Not evaluated in this run because both cross-validation lanes were skipped
+            EOF
+          fi
+
+          cat >> crossval-summary.md << 'EOF'
 
           ## Artifacts
 


### PR DESCRIPTION
### Motivation
- The cross-validation summary could claim "Accuracy/Performance" even when both Lane A and Lane B were skipped, which is misleading for PR comments.
- The change ensures the summary only asserts accuracy/performance when at least one cross-validation lane actually executed.
- Memory-safety and API-compatibility statements remain unconditional because they are independent of lane execution in the summary context.

### Description
- Update `.github/workflows/crossval.yml` to write the Key Findings block in two parts so that memory-safety and compatibility are always present and accuracy/performance are conditional. 
- Add a runtime check that emits accuracy/performance lines only if `should_run_lane_a` or `should_run_lane_b` is `true`.
- When both lanes are skipped the workflow now emits an explicit informational line: `Accuracy/Performance: Not evaluated in this run because both cross-validation lanes were skipped`.
- Preserve existing artifact upload and PR comment behavior so the modified summary is uploaded and posted as before.

### Testing
- No automated tests were run for this change; the modification is to a CI workflow file and will be exercised when the cross-validation workflow runs on CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4daa12370833381b89f1ffed99861)