### PR TITLE
fix(docker): include root crate sources in Docker build contexts

### DIFF
--- a/docker/Dockerfile.intel-gpu
+++ b/docker/Dockerfile.intel-gpu
@@ -27,7 +27,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # Copy workspace
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
 
 # Compile check with oneapi feature (validates Intel backend wiring)

--- a/docker/Dockerfile.nvidia-gpu
+++ b/docker/Dockerfile.nvidia-gpu
@@ -22,7 +22,8 @@ ENV PATH=/root/.cargo/bin:$PATH
 WORKDIR /app
 
 # Copy workspace
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
 
 # Build with GPU feature

--- a/docker/Dockerfile.test-matrix
+++ b/docker/Dockerfile.test-matrix
@@ -15,7 +15,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
 
 # ── CPU feature build + test ─────────────────────────────────────

--- a/infra/docker/Dockerfile.cpu
+++ b/infra/docker/Dockerfile.cpu
@@ -13,7 +13,8 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy workspace files
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
 
 # Build release binary with CPU optimizations

--- a/infra/docker/Dockerfile.gpu
+++ b/infra/docker/Dockerfile.gpu
@@ -17,7 +17,8 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /app
 
 # Copy workspace files
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
+COPY src/ ./src/
 COPY crates/ ./crates/
 
 # Build release binary with GPU support


### PR DESCRIPTION
### Motivation
- CI Docker builds running `cargo check`/`cargo build` fail to parse the workspace manifest with `can't find library bitnet` because the root crate sources were not copied into the image build context before Cargo ran.

### Description
- Copy `build.rs` and the root `src/` tree into the image before workspace `crates/` is used so Cargo can find the `bitnet` library in the build context.
- Apply this change consistently across the test matrix and CI/deployment Dockerfiles: `docker/Dockerfile.test-matrix`, `docker/Dockerfile.intel-gpu`, `docker/Dockerfile.nvidia-gpu`, `infra/docker/Dockerfile.cpu`, and `infra/docker/Dockerfile.gpu`.
- Keep existing workspace `crates/` copying behavior; only add the root crate sources required for the root library crate.

### Testing
- Ran `cargo metadata --format-version 1 --no-deps --locked` which completed successfully. 
- Ran a local workspace `cargo check --workspace --locked --no-default-features --features cpu` which progressed through compilation of the workspace crates. 
- Attempted to run `docker build -f docker/Dockerfile.test-matrix --target test-cpu -t bitnet-rs:test-cpu .` but the environment does not have `docker` installed so the image build could not be executed in this runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4db3aa658833384de6c368fb13ce8)