### PR TITLE
fix(docker): include full workspace in test-matrix build context

### DIFF
--- a/docker/Dockerfile.test-matrix
+++ b/docker/Dockerfile.test-matrix
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY crates/ ./crates/
+COPY . ./
 
 # ── CPU feature build + test ─────────────────────────────────────
 FROM base AS test-cpu


### PR DESCRIPTION
### Motivation
- The test matrix Dockerfile only copied `Cargo.toml`, `Cargo.lock`, and `crates/` which omitted the root crate sources (e.g. `src/lib.rs`), causing `cargo check --workspace` in CI to fail with `can't find library bitnet`.
- The intent is to ensure the container has the full workspace so workspace-wide checks and tests can parse and build the root crate.

### Description
- Updated `docker/Dockerfile.test-matrix` to copy the entire repository into the build context by replacing the selective copies with `COPY . ./` in the `base` stage.
- This ensures root-level sources and any other files referenced by the workspace are present when running `cargo check`/`cargo test` in subsequent stages.

### Testing
- Attempted to run `docker build -f docker/Dockerfile.test-matrix --target test-cpu -t bitnet-rs:test-cpu .`, but the runner environment does not have the `docker` CLI installed so a container build could not be executed.
- Ran `cargo check --workspace --locked --no-default-features --features cpu` locally in the repository which completed successfully, validating that the workspace manifest and root crate are resolvable when workspace files are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4db3aa658833384de6c368fb13ce8)