### PR TITLE
docs: record container benchmark attempt and benchmarking caveats

### DIFF
--- a/docs/benchmarking-setup.md
+++ b/docs/benchmarking-setup.md
@@ -107,6 +107,39 @@ Creates `benchmark-results/benchmark-config.json` with:
 
 ## Running Benchmarks
 
+## Latest Container Benchmark Attempt (2026-03-02)
+
+We attempted to run the benchmark flow in the project container to validate that the
+documented commands still execute end-to-end.
+
+### What worked
+
+- `xtask bench-compare` runs successfully when invoked with explicit thresholds:
+
+```bash
+cargo run -p xtask --no-default-features -- bench-compare \
+  --baseline baselines/cpu-main.json \
+  --current baselines/cpu-main.json \
+  --thresholds benchmarks/thresholds/default.toml
+```
+
+This produced a pass report (`No performance regressions`) and confirms the comparison
+pipeline is functional in this environment.
+
+### What failed in this container (and why)
+
+1. **`xtask benchmark` with default feature resolution** failed at link time due missing CUDA
+   shared libraries (`-lcuda`, `-lnvrtc`, `-lcurand`, `-lcublas`, `-lcublasLt`).
+2. **`xtask benchmark` with `--no-default-features`** launched but failed at runtime on
+   `tests/models/mini.gguf` with an out-of-memory allocation request.
+
+### Practical guidance
+
+- Use `--no-default-features` for `xtask` benchmarking in CPU-only environments.
+- Prefer a real benchmark model fixture (not `tests/models/mini.gguf`) for throughput runs.
+- Keep using `bench-compare` in CI for regression checks when full decode benchmarking is not
+  available.
+
 After setup, you'll have several benchmark options:
 
 ### 1. Python Comparison Benchmark (Recommended)


### PR DESCRIPTION
### Motivation
- Record the results of an end-to-end benchmarking attempt inside the project container so contributors know which benchmark flows work in constrained environments and why some runs fail (missing GPU libs, OOM). 

### Description
- Added a `Latest Container Benchmark Attempt (2026-03-02)` section to `docs/benchmarking-setup.md` that documents a successful `bench-compare` path, the linker failure when running `xtask benchmark` with default features (missing CUDA libraries), the out-of-memory failure when running `xtask benchmark` with `--no-default-features` against `tests/models/mini.gguf`, and practical guidance for CPU-only CI/container usage. 

### Testing
- Ran `cargo run -p xtask --no-default-features -- bench-compare --baseline baselines/cpu-main.json --current baselines/cpu-main.json --thresholds benchmarks/thresholds/default.toml` which passed; attempted `cargo run -p xtask -- benchmark --model tests/models/mini.gguf --tokens 32 --allow-mock --json benchmarks/results/mini-cpu-benchmark.json` which failed at link time due to missing CUDA libraries; and attempted `cargo run -p xtask --no-default-features -- benchmark --model tests/models/mini.gguf --tokens 32 --allow-mock --json benchmarks/results/mini-cpu-benchmark.json` which failed at runtime with an OOM allocation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d8c48c588333bb067a4e644457ba)