### PR TITLE
fix(docker): include full workspace in test-matrix base image

### DIFF
--- a/docker/Dockerfile.test-matrix
+++ b/docker/Dockerfile.test-matrix
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
-COPY crates/ ./crates/
+COPY . ./
 
 # ── CPU feature build + test ─────────────────────────────────────
 FROM base AS test-cpu


### PR DESCRIPTION
### Motivation
- The test-matrix base stage only copied `Cargo.toml`, `Cargo.lock`, and `crates/`, causing `cargo check --workspace` to fail with `can't find library bitnet` because the root `src/lib.rs` and other workspace members were missing.

### Description
- Update `docker/Dockerfile.test-matrix` to `COPY . ./` so the full repository (including `src/` and all workspace members) is present for workspace-wide `cargo` commands.

### Testing
- Reproduced the original failure by creating a temp directory with only `Cargo.toml`, `Cargo.lock`, and `crates/` and running `cargo check --workspace ...`, which failed with the manifest/library error as expected.
- Ran `cargo metadata --locked --no-deps` to confirm workspace metadata resolves, which succeeded locally.
- Could not run `docker build -f docker/Dockerfile.test-matrix --target test-cpu .` in this environment because `docker` is not installed, so CI should validate the final image build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4db3aa658833384de6c368fb13ce8)