### PR TITLE
fix(docker): include root crate and workspace dirs in test-matrix build context

### DIFF
--- a/docker/Dockerfile.test-matrix
+++ b/docker/Dockerfile.test-matrix
@@ -16,7 +16,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
+COPY src/ ./src/
 COPY crates/ ./crates/
+COPY crossval/ ./crossval/
+COPY tests/ ./tests/
+COPY tests-new/ ./tests-new/
+COPY xtask/ ./xtask/
+COPY xtask-build-helper/ ./xtask-build-helper/
+COPY fuzz/ ./fuzz/
+COPY tools/ ./tools/
 
 # ── CPU feature build + test ─────────────────────────────────────
 FROM base AS test-cpu


### PR DESCRIPTION
### Motivation
- The `test-cpu` stage in `docker/Dockerfile.test-matrix` failed because the container image build context did not include the root crate source (`src/`) or several workspace member directories, preventing `cargo` from locating the `bitnet` library and resolving workspace members.

### Description
- Add `COPY src/ ./src/` to the `base` stage so the root library (`src/lib.rs`) is present for `cargo check` inside the image.
- Add `COPY` entries for workspace folders (`crossval`, `tests`, `tests-new`, `xtask`, `xtask-build-helper`, `fuzz`, `tools`) to ensure workspace member resolution succeeds during in-container builds.

### Testing
- Ran a manifest-resolution simulation by copying `Cargo.toml`, `Cargo.lock` and the added directories into a temporary directory and executing `cargo metadata --locked --format-version 1 --no-deps`, which returned `OK`.
- Attempted to run `docker build -f docker/Dockerfile.test-matrix --target test-cpu`, but `docker` is not installed in this environment so the container build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4db3aa658833384de6c368fb13ce8)