### PR TITLE
fix(ci): restore bitnet-nvidia dep in bitnet-wgpu, expand cpu_only grid skip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ name = "bitnet-wgpu"
 version = "0.1.0"
 dependencies = [
  "bitnet-dispatch-core",
+ "bitnet-nvidia",
  "bytemuck",
  "pollster",
  "proptest",

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-dispatch-core = { path = "../bitnet-dispatch-core" }
+bitnet-nvidia = { path = "../bitnet-nvidia" }
 wgpu = { version = "24", features = ["vulkan-portability"] }
 bytemuck = { version = "1", features = ["derive"] }
 pollster = "0.4"

--- a/xtask/src/grid_check.rs
+++ b/xtask/src/grid_check.rs
@@ -66,7 +66,9 @@ pub fn run(cpu_only: bool, verbose: bool, dry_run: bool) -> Result<()> {
         cargo_features.sort();
         cargo_features.dedup();
 
-        let has_gpu = cargo_features.iter().any(|f| f == "gpu" || f == "cuda");
+        let has_gpu = cargo_features
+            .iter()
+            .any(|f| matches!(f.as_str(), "gpu" | "cuda" | "metal" | "vulkan" | "oneapi"));
         if cpu_only && has_gpu {
             results.push(CellResult {
                 label,


### PR DESCRIPTION
## P0: Fix CI Core Success on main

Two fixes that unblock Documentation and BDD Grid Check jobs:

### 1. Restore bitnet-nvidia dependency in bitnet-wgpu
`device.rs` imports `bitnet_nvidia::is_nvidia_vendor` but the dependency was
dropped when `bitnet-dispatch-core` was added. This breaks:
- **Documentation** job (`cargo doc --workspace`)
- **BDD Grid Check** e2e/pre-prod cell (`cargo check --features cpu,full-cli`)

### 2. Expand cpu_only skip in grid_check
The `--cpu-only` flag only skipped `gpu`/`cuda` features but not `metal`/`vulkan`/`oneapi`,
causing 3 grid cells to fail on ubuntu CI runners that lack these backends.

### Impact
Fixes CI Core Success for **ALL open PRs** (this was blocking ~185 PRs).
