### PR TITLE
fix(ci): fix BDD grid unit/local cell compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,6 +1849,7 @@ name = "bitnet-wgpu"
 version = "0.1.0"
 dependencies = [
  "bitnet-dispatch-core",
+ "bitnet-nvidia",
  "bytemuck",
  "pollster",
  "proptest",

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-dispatch-core = { path = "../bitnet-dispatch-core" }
+bitnet-nvidia = { path = "../bitnet-nvidia" }
 wgpu = { version = "24", features = ["vulkan-portability"] }
 bytemuck = { version = "1", features = ["derive"] }
 pollster = "0.4"

--- a/xtask/src/grid_check.rs
+++ b/xtask/src/grid_check.rs
@@ -66,7 +66,9 @@ pub fn run(cpu_only: bool, verbose: bool, dry_run: bool) -> Result<()> {
         cargo_features.sort();
         cargo_features.dedup();
 
-        let has_gpu = cargo_features.iter().any(|f| f == "gpu" || f == "cuda");
+        let has_gpu = cargo_features
+            .iter()
+            .any(|f| matches!(f.as_str(), "gpu" | "cuda" | "metal" | "vulkan" | "oneapi"));
         if cpu_only && has_gpu {
             results.push(CellResult {
                 label,


### PR DESCRIPTION
## Summary

Fixes all 5 BDD Grid Check failures:

### Root Cause 1: Missing dependency (fixes `unit/local [cpu]` and `e2e/pre-prod [cpu,full-cli]`)
`bitnet-wgpu` imports `bitnet_nvidia::is_nvidia_vendor` but was missing the `bitnet-nvidia` dependency in its `Cargo.toml`. This caused `cargo check --workspace` to fail for **every** feature combination.

### Root Cause 2: Incomplete GPU skip list (fixes `e2e/local [metal]`, `minimal/pre-prod [vulkan]`, `development/pre-prod [oneapi]`)
The `--cpu-only` flag in the grid checker only skipped `gpu` and `cuda` features, but `metal`, `vulkan`, and `oneapi` also require specific GPU hardware. Extended the skip predicate to include all GPU-like features.

### Changes
- `crates/bitnet-wgpu/Cargo.toml`: Add missing `bitnet-nvidia` path dependency
- `xtask/src/grid_check.rs`: Extend CPU-only GPU skip list to include `metal`, `vulkan`, `oneapi`
- `Cargo.lock`: Updated automatically

### Verification
```
BDD Grid Check Results:
unit/local               [cpu]                  ✓ PASS
e2e/pre-prod             [cpu,full-cli]         ✓ PASS
e2e/local                [metal]                - SKIP (GPU)
minimal/pre-prod         [vulkan]               - SKIP (GPU)
development/pre-prod     [oneapi]               - SKIP (GPU)
Grid check: 22 passed, 0 failed, 3 skipped
```