### PR TITLE
test(metal): Metal shader validation tests for Apple Silicon

### DIFF
--- a/crates/bitnet-kernels/tests/metal_shader_validation.rs
+++ b/crates/bitnet-kernels/tests/metal_shader_validation.rs
@@ -1,0 +1,535 @@
+//! Metal shader validation tests for Apple Silicon.
+//!
+//! These tests validate Metal shader source structure, configuration,
+//! and correctness properties without requiring GPU hardware.
+
+#![cfg(feature = "cpu")]
+
+/// Metal shader entry point marker
+const METAL_KERNEL_MARKER: &str = "kernel void";
+
+/// Maximum threads per threadgroup on Apple Silicon and Metal in general
+const METAL_MAX_THREADS_PER_THREADGROUP: u32 = 1024;
+
+/// Metal buffer alignment requirement (256 bytes)
+const METAL_BUFFER_ALIGNMENT: usize = 256;
+
+/// Apple Silicon SIMD group size
+const APPLE_SILICON_SIMD_GROUP_SIZE: u32 = 32;
+
+/// Maximum threadgroup memory on Apple Silicon (32KB)
+const METAL_MAX_THREADGROUP_MEMORY: u32 = 32768;
+
+/// Maximum texture dimension
+const METAL_MAX_TEXTURE_DIMENSION: u32 = 16384;
+
+/// Metal kernel configuration
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MetalKernelConfig {
+    workgroup_size: [u32; 3],
+    entry_point: String,
+    threadgroup_memory: u32,
+}
+
+/// Metal buffer configuration
+#[derive(Debug, Clone)]
+struct MetalBufferConfig {
+    size: usize,
+    alignment: usize,
+}
+
+/// Supported Metal pixel formats
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MetalPixelFormat {
+    RGBA8Unorm,
+    RGBA16Float,
+    RGBA32Float,
+    R32Float,
+    R16Float,
+    BGRA8Unorm,
+}
+
+impl MetalPixelFormat {
+    fn bytes_per_pixel(&self) -> u32 {
+        match self {
+            MetalPixelFormat::RGBA8Unorm => 4,
+            MetalPixelFormat::RGBA16Float => 8,
+            MetalPixelFormat::RGBA32Float => 16,
+            MetalPixelFormat::R32Float => 4,
+            MetalPixelFormat::R16Float => 2,
+            MetalPixelFormat::BGRA8Unorm => 4,
+        }
+    }
+}
+
+/// GPU performance state hints
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GPUPerformanceStateHint {
+    Normal,
+    LowPower,
+    HighPerformance,
+}
+
+/// Test: Validate Metal shader source syntax
+///
+/// Checks for common syntax errors in Metal shader strings:
+/// - Unmatched braces
+/// - Missing semicolons in function signatures
+/// - Invalid kernel void declarations
+#[test]
+fn test_metal_kernel_source_syntax() {
+    let valid_shader = r#"
+        kernel void compute_kernel(
+            device float *data [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            data[id] = data[id] * 2.0f;
+        }
+    "#;
+
+    let invalid_shader_unmatched_open = r#"
+        kernel void compute_kernel(
+            device float *data [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            data[id] = data[id] * 2.0f;
+    "#;
+
+    let invalid_shader_unmatched_close = r#"
+        kernel void compute_kernel(
+            device float *data [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            data[id] = data[id] * 2.0f;
+        }}
+    "#;
+
+    // Check valid shader
+    assert!(validate_shader_syntax(valid_shader).is_ok());
+
+    // Check invalid shaders
+    assert!(validate_shader_syntax(invalid_shader_unmatched_open).is_err());
+    assert!(validate_shader_syntax(invalid_shader_unmatched_close).is_err());
+}
+
+/// Test: Verify workgroup sizes are powers of 2 and within Metal limits
+#[test]
+fn test_metal_workgroup_sizes_valid() {
+    // Valid: power of 2, within limits
+    let valid_configs = vec![
+        MetalKernelConfig {
+            workgroup_size: [1, 1, 1],
+            entry_point: "kernel1".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [64, 8, 1],
+            entry_point: "kernel2".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [8, 8, 4],
+            entry_point: "kernel3".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [32, 32, 1],
+            entry_point: "kernel4".to_string(),
+            threadgroup_memory: 0,
+        },
+    ];
+
+    for config in valid_configs {
+        assert!(validate_workgroup_size(&config).is_ok());
+    }
+
+    // Invalid: not powers of 2 or exceed limits
+    let invalid_configs = vec![
+        MetalKernelConfig {
+            workgroup_size: [3, 1, 1],
+            entry_point: "kernel1".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [64, 7, 1],
+            entry_point: "kernel2".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [64, 64, 1], // 4096 total, exceeds 1024 limit
+            entry_point: "kernel3".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [256, 4, 2], // 2048 > 1024, invalid
+            entry_point: "kernel4".to_string(),
+            threadgroup_memory: 0,
+        },
+    ];
+
+    assert!(validate_workgroup_size(&invalid_configs[0]).is_err()); // 3 not power of 2
+    assert!(validate_workgroup_size(&invalid_configs[1]).is_err()); // 7 not power of 2
+    assert!(validate_workgroup_size(&invalid_configs[2]).is_err()); // 4096 exceeds limit
+    assert!(validate_workgroup_size(&invalid_configs[3]).is_err()); // 2048 exceeds limit
+}
+
+/// Test: Verify buffer sizes are multiples of 256 (Metal alignment requirement)
+#[test]
+fn test_metal_buffer_alignment() {
+    // Valid alignments
+    let valid_buffers = vec![
+        MetalBufferConfig { size: 256, alignment: 256 },
+        MetalBufferConfig { size: 512, alignment: 256 },
+        MetalBufferConfig { size: 1024, alignment: 256 },
+        MetalBufferConfig { size: 65536, alignment: 256 },
+    ];
+
+    for buffer in valid_buffers {
+        assert!(validate_buffer_alignment(&buffer).is_ok());
+    }
+
+    // Invalid alignments
+    let invalid_buffers = vec![
+        MetalBufferConfig { size: 255, alignment: 256 },
+        MetalBufferConfig { size: 257, alignment: 256 },
+        MetalBufferConfig { size: 512, alignment: 128 },
+    ];
+
+    for buffer in invalid_buffers {
+        assert!(validate_buffer_alignment(&buffer).is_err());
+    }
+}
+
+/// Test: Verify each shader source contains at least one kernel void entry point
+#[test]
+fn test_metal_shader_entry_points() {
+    let shader_with_entry = r#"
+        kernel void compute_add(
+            device float *result [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            result[id] = 1.0f + 2.0f;
+        }
+    "#;
+
+    let shader_with_multiple_entries = r#"
+        kernel void compute_add(
+            device float *result [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            result[id] = 1.0f + 2.0f;
+        }
+
+        kernel void compute_mul(
+            device float *result [[ buffer(0) ]],
+            uint id [[ thread_position_in_grid ]]
+        ) {
+            result[id] *= 2.0f;
+        }
+    "#;
+
+    let shader_without_entry = r#"
+        float helper_function(float x) {
+            return x * 2.0f;
+        }
+    "#;
+
+    assert!(validate_shader_entry_points(shader_with_entry).is_ok());
+    assert_eq!(count_entry_points(shader_with_entry), 1);
+
+    assert!(validate_shader_entry_points(shader_with_multiple_entries).is_ok());
+    assert_eq!(count_entry_points(shader_with_multiple_entries), 2);
+
+    assert!(validate_shader_entry_points(shader_without_entry).is_err());
+    assert_eq!(count_entry_points(shader_without_entry), 0);
+}
+
+/// Test: Verify threadgroup memory allocations don't exceed Apple Silicon limits (32KB)
+#[test]
+fn test_metal_threadgroup_memory_bounds() {
+    // Valid threadgroup memory allocations
+    let valid_configs = vec![
+        MetalKernelConfig {
+            workgroup_size: [64, 1, 1],
+            entry_point: "kernel1".to_string(),
+            threadgroup_memory: 0,
+        },
+        MetalKernelConfig {
+            workgroup_size: [256, 1, 1],
+            entry_point: "kernel2".to_string(),
+            threadgroup_memory: 8192,
+        },
+        MetalKernelConfig {
+            workgroup_size: [512, 1, 1],
+            entry_point: "kernel3".to_string(),
+            threadgroup_memory: 16384,
+        },
+        MetalKernelConfig {
+            workgroup_size: [1024, 1, 1],
+            entry_point: "kernel4".to_string(),
+            threadgroup_memory: 32768,
+        },
+    ];
+
+    for config in valid_configs {
+        assert!(validate_threadgroup_memory(&config).is_ok());
+    }
+
+    // Invalid: exceeds 32KB limit
+    let invalid_config = MetalKernelConfig {
+        workgroup_size: [1024, 1, 1],
+        entry_point: "kernel5".to_string(),
+        threadgroup_memory: 32769,
+    };
+
+    assert!(validate_threadgroup_memory(&invalid_config).is_err());
+
+    // Invalid: way over the limit
+    let over_limit = MetalKernelConfig {
+        workgroup_size: [512, 1, 1],
+        entry_point: "kernel6".to_string(),
+        threadgroup_memory: 65536,
+    };
+
+    assert!(validate_threadgroup_memory(&over_limit).is_err());
+}
+
+/// Test: Verify SIMD group size is 32 for Apple Silicon
+#[test]
+fn test_metal_simd_group_size() {
+    // Apple Silicon always uses SIMD width of 32
+    assert_eq!(APPLE_SILICON_SIMD_GROUP_SIZE, 32);
+
+    // Workgroup sizes should ideally be multiples of SIMD group size for efficiency
+    let simd_aligned = vec![32, 64, 128, 256, 512, 1024];
+    for size in simd_aligned {
+        assert_eq!(size % APPLE_SILICON_SIMD_GROUP_SIZE, 0);
+    }
+
+    // This configuration is inefficient but valid
+    let inefficient_size = 48u32;
+    assert_ne!(inefficient_size % APPLE_SILICON_SIMD_GROUP_SIZE, 0);
+
+    // Verify SIMD group size bounds
+    assert!(APPLE_SILICON_SIMD_GROUP_SIZE <= METAL_MAX_THREADS_PER_THREADGROUP);
+}
+
+/// Test: Test format enum coverage for common Metal pixel formats
+#[test]
+fn test_metal_texture_format_support() {
+    // Verify all formats are supported
+    let formats = vec![
+        MetalPixelFormat::RGBA8Unorm,
+        MetalPixelFormat::RGBA16Float,
+        MetalPixelFormat::RGBA32Float,
+        MetalPixelFormat::R32Float,
+        MetalPixelFormat::R16Float,
+        MetalPixelFormat::BGRA8Unorm,
+    ];
+
+    for format in &formats {
+        assert!(format.bytes_per_pixel() > 0);
+    }
+
+    // Verify bytes_per_pixel calculations
+    assert_eq!(MetalPixelFormat::RGBA8Unorm.bytes_per_pixel(), 4);
+    assert_eq!(MetalPixelFormat::RGBA16Float.bytes_per_pixel(), 8);
+    assert_eq!(MetalPixelFormat::RGBA32Float.bytes_per_pixel(), 16);
+    assert_eq!(MetalPixelFormat::R32Float.bytes_per_pixel(), 4);
+    assert_eq!(MetalPixelFormat::R16Float.bytes_per_pixel(), 2);
+    assert_eq!(MetalPixelFormat::BGRA8Unorm.bytes_per_pixel(), 4);
+
+    // Verify texture dimension limits
+    let valid_dimensions = vec![(256, 256), (1024, 1024), (4096, 4096), (16384, 16384)];
+    for (width, height) in valid_dimensions {
+        assert!(width <= METAL_MAX_TEXTURE_DIMENSION);
+        assert!(height <= METAL_MAX_TEXTURE_DIMENSION);
+    }
+
+    let invalid_dimension = 16385u32;
+    assert!(invalid_dimension > METAL_MAX_TEXTURE_DIMENSION);
+}
+
+/// Test: Verify dispatch grid dimensions are within u32::MAX
+#[test]
+fn test_metal_dispatch_dimensions() {
+    // Valid dispatch dimensions
+    let valid_dispatches = vec![(1, 1, 1), (256, 256, 1), (1024, 1024, 64), (65536, 65536, 256)];
+
+    for (width, height, depth) in valid_dispatches {
+        assert!(validate_dispatch_dimensions(width, height, depth).is_ok());
+    }
+
+    // Ensure overflow detection doesn't occur for valid u32 values
+    let max_u32 = u32::MAX;
+    assert!(validate_dispatch_dimensions(max_u32, 1, 1).is_ok());
+    assert!(validate_dispatch_dimensions(1, max_u32, 1).is_ok());
+    assert!(validate_dispatch_dimensions(1, 1, max_u32).is_ok());
+}
+
+/// Test: Test argument buffer struct layout and alignment
+#[test]
+fn test_metal_argument_buffer_layout() {
+    // Simulate argument buffer packing
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct ArgumentBuffer {
+        buffer_ptr: usize,   // 8 bytes on 64-bit
+        texture_handle: u32, // 4 bytes
+        sampler_handle: u32, // 4 bytes
+        padding: u32,        // 4 bytes for alignment
+    }
+
+    let arg_buffer =
+        ArgumentBuffer { buffer_ptr: 0x1000, texture_handle: 1, sampler_handle: 2, padding: 0 };
+
+    // Size should be 20 bytes (8 + 4 + 4 + 4), typically aligned to 16 or 32
+    let size = std::mem::size_of::<ArgumentBuffer>();
+    assert!(size >= 20);
+    assert!(size % 4 == 0);
+
+    // Verify buffer pointer alignment
+    assert_eq!(arg_buffer.buffer_ptr % 8, 0);
+
+    // Metal requires proper alignment for argument buffers
+    assert!(std::mem::align_of::<ArgumentBuffer>() >= 4);
+}
+
+/// Test: Test GPU performance state hint validity
+#[test]
+fn test_metal_performance_state_hints() {
+    // All hint values should be valid
+    let hints = vec![
+        GPUPerformanceStateHint::Normal,
+        GPUPerformanceStateHint::LowPower,
+        GPUPerformanceStateHint::HighPerformance,
+    ];
+
+    for hint in hints {
+        assert!(validate_performance_state_hint(hint).is_ok());
+    }
+
+    // Normal is the default
+    let default_hint = GPUPerformanceStateHint::Normal;
+    assert!(validate_performance_state_hint(default_hint).is_ok());
+
+    // All hints should be distinct
+    assert_ne!(GPUPerformanceStateHint::Normal, GPUPerformanceStateHint::LowPower);
+    assert_ne!(GPUPerformanceStateHint::Normal, GPUPerformanceStateHint::HighPerformance);
+    assert_ne!(GPUPerformanceStateHint::LowPower, GPUPerformanceStateHint::HighPerformance);
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/// Validate Metal shader syntax
+fn validate_shader_syntax(shader: &str) -> Result<(), String> {
+    let open_braces = shader.matches('{').count();
+    let close_braces = shader.matches('}').count();
+
+    if open_braces != close_braces {
+        return Err(format!("Unmatched braces: {} open, {} close", open_braces, close_braces));
+    }
+
+    // Check for kernel void declaration without parentheses before opening brace
+    if let Some(pos) = shader.find("kernel void") {
+        let after_kernel = &shader[pos..];
+        if !after_kernel.contains('(') {
+            return Err("kernel void declaration missing function signature".to_string());
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate workgroup size configuration
+fn validate_workgroup_size(config: &MetalKernelConfig) -> Result<(), String> {
+    let [x, y, z] = config.workgroup_size;
+
+    // Check if each dimension is a power of 2
+    if !is_power_of_two(x) {
+        return Err(format!("X dimension {} is not a power of 2", x));
+    }
+    if !is_power_of_two(y) {
+        return Err(format!("Y dimension {} is not a power of 2", y));
+    }
+    if !is_power_of_two(z) {
+        return Err(format!("Z dimension {} is not a power of 2", z));
+    }
+
+    // Check total thread count doesn't exceed limit
+    let total_threads = x as u64 * y as u64 * z as u64;
+    if total_threads > METAL_MAX_THREADS_PER_THREADGROUP as u64 {
+        return Err(format!(
+            "Total threads {} exceeds limit {}",
+            total_threads, METAL_MAX_THREADS_PER_THREADGROUP
+        ));
+    }
+
+    Ok(())
+}
+
+/// Check if a number is a power of 2
+fn is_power_of_two(n: u32) -> bool {
+    n > 0 && (n & (n - 1)) == 0
+}
+
+/// Validate buffer alignment configuration
+fn validate_buffer_alignment(buffer: &MetalBufferConfig) -> Result<(), String> {
+    if buffer.size % METAL_BUFFER_ALIGNMENT != 0 {
+        return Err(format!(
+            "Buffer size {} is not a multiple of {}",
+            buffer.size, METAL_BUFFER_ALIGNMENT
+        ));
+    }
+
+    if buffer.alignment < METAL_BUFFER_ALIGNMENT {
+        return Err(format!(
+            "Buffer alignment {} is less than required {}",
+            buffer.alignment, METAL_BUFFER_ALIGNMENT
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate shader has entry points
+fn validate_shader_entry_points(shader: &str) -> Result<(), String> {
+    if !shader.contains(METAL_KERNEL_MARKER) {
+        return Err("No kernel void entry point found in shader".to_string());
+    }
+    Ok(())
+}
+
+/// Count kernel void entry points in shader
+fn count_entry_points(shader: &str) -> usize {
+    shader.matches(METAL_KERNEL_MARKER).count()
+}
+
+/// Validate threadgroup memory bounds
+fn validate_threadgroup_memory(config: &MetalKernelConfig) -> Result<(), String> {
+    if config.threadgroup_memory > METAL_MAX_THREADGROUP_MEMORY {
+        return Err(format!(
+            "Threadgroup memory {} exceeds limit {}",
+            config.threadgroup_memory, METAL_MAX_THREADGROUP_MEMORY
+        ));
+    }
+    Ok(())
+}
+
+/// Validate dispatch dimensions
+fn validate_dispatch_dimensions(width: u32, height: u32, depth: u32) -> Result<(), String> {
+    if width == 0 || height == 0 || depth == 0 {
+        return Err("Dispatch dimensions must be non-zero".to_string());
+    }
+    // u32::MAX is valid for each dimension independently
+    Ok(())
+}
+
+/// Validate performance state hint
+fn validate_performance_state_hint(_hint: GPUPerformanceStateHint) -> Result<(), String> {
+    // All defined hints are valid
+    Ok(())
+}


### PR DESCRIPTION
Add 10 Metal shader validation tests that verify configuration correctness without requiring GPU hardware:

### Test Coverage
- **Workgroup size bounds**: Validate workgroup sizes are powers of 2 and total threads ≤ 1024
- **Buffer alignment**: Verify buffers are multiples of 256 bytes (Metal requirement)
- **Shader syntax**: Validate Metal shader source strings for matched braces
- **Entry points**: Verify each shader has at least one `kernel void` entry point
- **Threadgroup memory**: Validate allocations don't exceed 32KB Apple Silicon limit
- **SIMD group size**: Verify Apple Silicon SIMD width is 32
- **Texture formats**: Test format enum coverage for Metal pixel formats
- **Dispatch dimensions**: Verify grid dimensions are within u32::MAX
- **Argument buffers**: Test struct layout and alignment requirements
- **Performance hints**: Validate GPU performance state hint validity

### CI Status
All tests run on Linux CI without requiring GPU hardware since they only validate configuration values and source strings.