### PR TITLE
refactor(download): extract atomic write helper into bitnet-download-core

### DIFF
--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,3 +1,4 @@
+use std::{fs, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -31,9 +32,36 @@ pub fn validate_downloaded_len(
     Ok(())
 }
 
+/// Atomically write bytes to `path` via a temporary sibling file.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn parses_content_range_total() {
@@ -49,5 +77,21 @@ mod tests {
             validate_downloaded_len(1, Some(2)),
             Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
         ));
+    }
+
+    #[test]
+    fn atomic_write_persists_contents() {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("bitnet_download_core_atomic_write_{suffix}.txt"));
+
+        atomic_write(&path, b"hello").expect("atomic write should succeed");
+        let contents = fs::read(&path).expect("file should be readable");
+        assert_eq!(contents, b"hello");
+
+        let _ = fs::remove_file(path);
     }
 }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Group download-related helpers into the SRP core crate so file-write persistence and download validation logic live together. 
- Remove duplication and make the atomic write primitive reusable by other crates without copying code. 
- Improve test coverage around the atomic write behavior to guard against regressions.

### Description
- Added `atomic_write(path: &Path, bytes: &[u8])` to `crates/bitnet-download-core/src/lib.rs` and implemented safe atomic write + optional fs sync on Unix. 
- Re-exported `atomic_write` from `crates/bitnet-download/src/lib.rs` and removed the duplicate implementation from `bitnet-download`. 
- Added a focused unit test `atomic_write_persists_contents` in `bitnet-download-core` and adjusted imports accordingly; files changed: `crates/bitnet-download-core/src/lib.rs` and `crates/bitnet-download/src/lib.rs`.

### Testing
- Ran `cargo fmt --all` which completed successfully. 
- Ran `cargo test -p bitnet-download-core -p bitnet-download` which passed; `bitnet-download` test suite ran 4 tests (all passed) and `bitnet-download-core` ran 3 tests including the new `atomic_write` test (all passed). 
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e773c6fc8333a584a1e79e19ffa1)