### PR TITLE
refactor(server): extract shared health status/component types

### DIFF
--- a/crates/bitnet-server-health-types-core/src/lib.rs
+++ b/crates/bitnet-server-health-types-core/src/lib.rs
@@ -3,6 +3,24 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Generic health status used by server health endpoints.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+/// Individual component health state and diagnostics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ComponentHealth {
+    pub status: HealthStatus,
+    pub message: String,
+    pub last_check: String,
+    pub response_time_ms: Option<u64>,
+}
+
 /// Liveness probe response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LivenessResponse {
@@ -53,7 +71,7 @@ pub struct ReadinessResponse {
 pub struct Ac05HealthResponse {
     pub status: String,
     pub timestamp: String,
-    pub components: HashMap<String, String>,
+    pub components: HashMap<String, ComponentHealth>,
     pub system_metrics: SystemMetrics,
     pub performance_indicators: PerformanceIndicators,
 }
@@ -69,11 +87,24 @@ mod tests {
             status: "healthy".to_string(),
             timestamp: "2023-12-01T10:30:00Z".to_string(),
             components: [
-                ("model_manager".to_string(), "healthy".to_string()),
-                ("execution_router".to_string(), "healthy".to_string()),
-                ("batch_engine".to_string(), "healthy".to_string()),
-                ("device_monitor".to_string(), "healthy".to_string()),
-                ("quantization_engine".to_string(), "healthy".to_string()),
+                (
+                    "model_manager".to_string(),
+                    ComponentHealth {
+                        status: HealthStatus::Healthy,
+                        message: "ok".to_string(),
+                        last_check: "2023-12-01T10:30:00Z".to_string(),
+                        response_time_ms: Some(4),
+                    },
+                ),
+                (
+                    "execution_router".to_string(),
+                    ComponentHealth {
+                        status: HealthStatus::Healthy,
+                        message: "ok".to_string(),
+                        last_check: "2023-12-01T10:30:00Z".to_string(),
+                        response_time_ms: Some(3),
+                    },
+                ),
             ]
             .into_iter()
             .collect(),
@@ -97,9 +128,14 @@ mod tests {
 
         assert_eq!(serialized["status"], "healthy");
         assert_eq!(serialized["timestamp"], "2023-12-01T10:30:00Z");
-        assert_eq!(serialized["components"]["model_manager"], "healthy");
+        assert_eq!(serialized["components"]["model_manager"]["status"], "healthy");
         assert_eq!(serialized["system_metrics"]["cpu_utilization"], 0.65);
         assert_eq!(serialized["performance_indicators"]["sla_compliance"], 0.995);
+    }
+
+    #[test]
+    fn health_status_serializes_as_lowercase() {
+        assert_eq!(serde_json::to_string(&HealthStatus::Degraded).unwrap(), "\"degraded\"");
     }
 
     #[test]

--- a/crates/bitnet-server/src/monitoring/ac05_types.rs
+++ b/crates/bitnet-server/src/monitoring/ac05_types.rs
@@ -4,6 +4,6 @@
 //! `bitnet-server-health-types-core` to keep existing import paths stable.
 
 pub use bitnet_server_health_types_core::{
-    Ac05HealthResponse, LivenessResponse, PerformanceIndicators, ReadinessChecks,
-    ReadinessResponse, SystemMetrics,
+    Ac05HealthResponse, ComponentHealth, HealthStatus, LivenessResponse, PerformanceIndicators,
+    ReadinessChecks, ReadinessResponse, SystemMetrics,
 };

--- a/crates/bitnet-server/src/monitoring/health.rs
+++ b/crates/bitnet-server/src/monitoring/health.rs
@@ -17,24 +17,7 @@ use tokio::sync::RwLock;
 use super::ac05_types::LivenessResponse;
 use super::metrics::MetricsCollector;
 use crate::health::PerformanceMetrics;
-
-/// Health check status
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum HealthStatus {
-    Healthy,
-    Degraded,
-    Unhealthy,
-}
-
-/// Individual component health
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ComponentHealth {
-    pub status: HealthStatus,
-    pub message: String,
-    pub last_check: String,
-    pub response_time_ms: Option<u64>,
-}
+use bitnet_server_health_types_core::{ComponentHealth, HealthStatus};
 
 /// Build metadata included in health response
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
### Motivation
- Consolidate duplicated health endpoint DTOs into a small SRP microcrate so the server and other consumers can share stable health contracts instead of maintaining local, stringly-typed copies.
- Make AC05 health responses more structured by using typed component health values to improve diagnostics and reduce downstream parsing work.

### Description
- Move `HealthStatus` and `ComponentHealth` into `crates/bitnet-server-health-types-core/src/lib.rs` and make them `Serialize`/`Deserialize` DTOs with lowercase serde names (`HealthStatus`).
- Change `Ac05HealthResponse.components` to `HashMap<String, ComponentHealth>` and update unit tests in the health-types crate to validate the new structured shape and serialization casing.
- Re-export the new types from `crates/bitnet-server/src/monitoring/ac05_types.rs` to preserve existing import paths and update `crates/bitnet-server/src/monitoring/health.rs` to consume `bitnet_server_health_types_core::{ComponentHealth, HealthStatus}` and remove the duplicated local definitions.

### Testing
- Ran `cargo test -p bitnet-server-health-types-core` and all tests passed (`6 passed; 0 failed`).
- Ran `cargo fmt --all` to ensure formatting, which completed successfully.
- Attempted targeted `bitnet-server` builds/tests (`cargo test` / `cargo check -p bitnet-server --lib --no-default-features`) but they were started and then interrupted in this environment due to long compile times and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e773c6fc8333a584a1e79e19ffa1)