### PR TITLE
Extract server circuit breaker into reusable SRP core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-circuit-breaker-core"
+version = "0.2.1-dev"
+dependencies = [
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bitnet-cli"
 version = "0.2.1-dev"
 dependencies = [
@@ -1307,6 +1316,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bitnet-circuit-breaker-core",
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-circuit-breaker-core", # SRP: reusable async circuit-breaker primitives
   "crates/bitnet-device-config-core", # SRP: shared device config parsing + resolution core
   "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
   "crates/bitnet-logits",        # SRP: pure logits transform functions

--- a/crates/bitnet-circuit-breaker-core/Cargo.toml
+++ b/crates/bitnet-circuit-breaker-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bitnet-circuit-breaker-core"
+version = "0.2.1-dev"
+edition = "2024"
+license = "MIT"
+description = "SRP core async circuit breaker primitives"
+repository = "https://github.com/microsoft/BitNet"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["sync", "time", "macros", "rt"] }
+tracing = { workspace = true }

--- a/crates/bitnet-circuit-breaker-core/src/lib.rs
+++ b/crates/bitnet-circuit-breaker-core/src/lib.rs
@@ -1,0 +1,159 @@
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CircuitBreakerState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CircuitBreakerConfig {
+    pub failure_threshold: u64,
+    pub timeout: Duration,
+    pub half_open_max_requests: u64,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self { failure_threshold: 10, timeout: Duration::from_secs(30), half_open_max_requests: 3 }
+    }
+}
+
+#[derive(Debug)]
+pub struct CircuitBreaker {
+    state: RwLock<CircuitBreakerState>,
+    failure_count: AtomicU64,
+    success_count: AtomicU64,
+    last_failure_time: RwLock<Option<Instant>>,
+    config: CircuitBreakerConfig,
+}
+
+impl CircuitBreaker {
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            state: RwLock::new(CircuitBreakerState::Closed),
+            failure_count: AtomicU64::new(0),
+            success_count: AtomicU64::new(0),
+            last_failure_time: RwLock::new(None),
+            config,
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self::new(CircuitBreakerConfig {
+            failure_threshold: u64::MAX,
+            timeout: Duration::ZERO,
+            half_open_max_requests: 1,
+        })
+    }
+
+    pub async fn can_execute(&self) -> bool {
+        let state = self.state.read().await;
+        match *state {
+            CircuitBreakerState::Closed => true,
+            CircuitBreakerState::Open => {
+                drop(state);
+                self.check_timeout().await
+            }
+            CircuitBreakerState::HalfOpen => {
+                self.success_count.load(Ordering::Relaxed) < self.config.half_open_max_requests
+            }
+        }
+    }
+
+    pub async fn record_success(&self) {
+        self.success_count.fetch_add(1, Ordering::Relaxed);
+
+        let state = self.state.read().await;
+        if matches!(*state, CircuitBreakerState::HalfOpen)
+            && self.success_count.load(Ordering::Relaxed) >= self.config.half_open_max_requests
+        {
+            drop(state);
+            let mut state = self.state.write().await;
+            *state = CircuitBreakerState::Closed;
+            self.failure_count.store(0, Ordering::Relaxed);
+            self.success_count.store(0, Ordering::Relaxed);
+            info!("Circuit breaker closed - service recovered");
+        }
+    }
+
+    pub async fn record_failure(&self) {
+        let failures = self.failure_count.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if failures >= self.config.failure_threshold {
+            let mut state = self.state.write().await;
+            if !matches!(*state, CircuitBreakerState::Open) {
+                *state = CircuitBreakerState::Open;
+                let mut last_failure = self.last_failure_time.write().await;
+                *last_failure = Some(Instant::now());
+                warn!(failures, "Circuit breaker opened - too many failures");
+            }
+        }
+    }
+
+    pub async fn state(&self) -> CircuitBreakerState {
+        self.state.read().await.clone()
+    }
+
+    async fn check_timeout(&self) -> bool {
+        let last_failure = self.last_failure_time.read().await;
+        if let Some(last_failure_time) = *last_failure {
+            if last_failure_time.elapsed() >= self.config.timeout {
+                drop(last_failure);
+                let mut state = self.state.write().await;
+                *state = CircuitBreakerState::HalfOpen;
+                self.success_count.store(0, Ordering::Relaxed);
+                info!("Circuit breaker half-open - testing service recovery");
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn opens_after_failure_threshold() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 2,
+            timeout: Duration::from_millis(20),
+            half_open_max_requests: 1,
+        });
+
+        breaker.record_failure().await;
+        assert_eq!(breaker.state().await, CircuitBreakerState::Closed);
+
+        breaker.record_failure().await;
+        assert_eq!(breaker.state().await, CircuitBreakerState::Open);
+        assert!(!breaker.can_execute().await);
+    }
+
+    #[tokio::test]
+    async fn transitions_to_half_open_after_timeout() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            timeout: Duration::from_millis(5),
+            half_open_max_requests: 1,
+        });
+
+        breaker.record_failure().await;
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(breaker.can_execute().await);
+        assert_eq!(breaker.state().await, CircuitBreakerState::HalfOpen);
+
+        breaker.record_success().await;
+        assert_eq!(breaker.state().await, CircuitBreakerState::Closed);
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-circuit-breaker-core = { path = "../bitnet-circuit-breaker-core", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/concurrency.rs
+++ b/crates/bitnet-server/src/concurrency.rs
@@ -1,6 +1,7 @@
 //! Concurrency management with backpressure and rate limiting
 
 use anyhow::Result;
+use bitnet_circuit_breaker_core::{CircuitBreaker, CircuitBreakerConfig, CircuitBreakerState};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -8,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, RwLock, Semaphore};
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Concurrency management configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,108 +90,6 @@ impl RateLimitBucket {
     }
 }
 
-/// Circuit breaker states
-#[derive(Debug, Clone, PartialEq, Serialize)]
-pub enum CircuitBreakerState {
-    Closed,   // Normal operation
-    Open,     // Blocking requests
-    HalfOpen, // Testing if service recovered
-}
-
-/// Circuit breaker for fault tolerance
-#[derive(Debug)]
-pub struct CircuitBreaker {
-    state: RwLock<CircuitBreakerState>,
-    failure_count: AtomicU64,
-    success_count: AtomicU64,
-    last_failure_time: RwLock<Option<Instant>>,
-    failure_threshold: u64,
-    timeout: Duration,
-    half_open_max_requests: u64,
-}
-
-impl CircuitBreaker {
-    fn new(failure_threshold: u64, timeout: Duration) -> Self {
-        Self {
-            state: RwLock::new(CircuitBreakerState::Closed),
-            failure_count: AtomicU64::new(0),
-            success_count: AtomicU64::new(0),
-            last_failure_time: RwLock::new(None),
-            failure_threshold,
-            timeout,
-            half_open_max_requests: 3,
-        }
-    }
-
-    async fn can_execute(&self) -> bool {
-        let state = self.state.read().await;
-
-        match *state {
-            CircuitBreakerState::Closed => true,
-            CircuitBreakerState::Open => {
-                drop(state);
-                self.check_timeout().await
-            }
-            CircuitBreakerState::HalfOpen => {
-                // Allow limited requests in half-open state
-                self.success_count.load(Ordering::Relaxed) < self.half_open_max_requests
-            }
-        }
-    }
-
-    async fn record_success(&self) {
-        self.success_count.fetch_add(1, Ordering::Relaxed);
-
-        let state = self.state.read().await;
-        if matches!(*state, CircuitBreakerState::HalfOpen)
-            && self.success_count.load(Ordering::Relaxed) >= self.half_open_max_requests
-        {
-            drop(state);
-            let mut state = self.state.write().await;
-            *state = CircuitBreakerState::Closed;
-            self.failure_count.store(0, Ordering::Relaxed);
-            self.success_count.store(0, Ordering::Relaxed);
-            info!("Circuit breaker closed - service recovered");
-        }
-    }
-
-    async fn record_failure(&self) {
-        let failures = self.failure_count.fetch_add(1, Ordering::Relaxed) + 1;
-
-        if failures >= self.failure_threshold {
-            let mut state = self.state.write().await;
-            if !matches!(*state, CircuitBreakerState::Open) {
-                *state = CircuitBreakerState::Open;
-                let mut last_failure = self.last_failure_time.write().await;
-                *last_failure = Some(Instant::now());
-                warn!(failures = failures, "Circuit breaker opened - too many failures");
-            }
-        }
-    }
-
-    async fn check_timeout(&self) -> bool {
-        let last_failure = self.last_failure_time.read().await;
-        if let Some(last_failure_time) = *last_failure {
-            if last_failure_time.elapsed() >= self.timeout {
-                drop(last_failure);
-                let mut state = self.state.write().await;
-                *state = CircuitBreakerState::HalfOpen;
-                self.success_count.store(0, Ordering::Relaxed);
-                info!("Circuit breaker half-open - testing service recovery");
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        }
-    }
-
-    async fn get_state(&self) -> CircuitBreakerState {
-        self.state.read().await.clone()
-    }
-}
-
 /// Request metadata for tracking
 #[derive(Debug, Clone)]
 pub struct RequestMetadata {
@@ -223,12 +122,13 @@ impl ConcurrencyManager {
         ));
 
         let circuit_breaker = if config.circuit_breaker_enabled {
-            Arc::new(CircuitBreaker::new(
-                config.circuit_breaker_failure_threshold,
-                config.circuit_breaker_timeout,
-            ))
+            Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
+                failure_threshold: config.circuit_breaker_failure_threshold,
+                timeout: config.circuit_breaker_timeout,
+                half_open_max_requests: 3,
+            }))
         } else {
-            Arc::new(CircuitBreaker::new(u64::MAX, Duration::from_secs(0)))
+            Arc::new(CircuitBreaker::disabled())
         };
 
         Self {
@@ -399,7 +299,7 @@ impl ConcurrencyManager {
         };
 
         let current_load = self.get_current_load().await;
-        let circuit_breaker_state = self.circuit_breaker.get_state().await;
+        let circuit_breaker_state = self.circuit_breaker.state().await;
 
         ConcurrencyStats {
             active_requests,
@@ -417,7 +317,7 @@ impl ConcurrencyManager {
     /// Get health status
     pub async fn get_health(&self) -> ConcurrencyHealth {
         let stats = self.get_stats().await;
-        let circuit_breaker_state = self.circuit_breaker.get_state().await;
+        let circuit_breaker_state = self.circuit_breaker.state().await;
 
         let healthy =
             stats.current_load < 0.9 && circuit_breaker_state != CircuitBreakerState::Open;


### PR DESCRIPTION
### Motivation
- Reduce responsibility in the server concurrency module by extracting the circuit-breaker state machine into a small SRP microcrate so the server focuses on admission/backpressure only.
- Make the circuit-breaker logic reusable across other components and easier to test in isolation.

### Description
- Added a new microcrate `crates/bitnet-circuit-breaker-core` that implements `CircuitBreaker`, `CircuitBreakerConfig`, and `CircuitBreakerState` with async transition logic and logging hooks.
- Removed the in-file circuit-breaker implementation from `crates/bitnet-server/src/concurrency.rs` and updated the file to import and use `bitnet-circuit-breaker-core::{CircuitBreaker, CircuitBreakerConfig, CircuitBreakerState}` instead.
- Wired the new crate into the workspace `Cargo.toml` and into `crates/bitnet-server/Cargo.toml`, and updated the lockfile entries accordingly.
- Kept the server-side integration points intact by replacing direct state methods with calls to the new crate (`can_execute`, `record_success`, `record_failure`, `state`), and updated a few call sites to use the new API.

### Testing
- Ran `cargo fmt --all` to ensure formatting, which completed successfully.
- Ran `cargo test -p bitnet-circuit-breaker-core`, and the unit tests passed (`2 passed; 0 failed`).
- Attempted `cargo check -p bitnet-server --lib --no-default-features` to validate integration, but the compile was interrupted by environment time constraints (long workspace build); local `cargo check` is recommended in CI to fully validate the server build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e7706cd08333890ed526a7095a1a)