### PR TITLE
Extract CLI exit codes into shared `bitnet-exit-codes-core` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "bitnet-cli-sampling-core",
  "bitnet-common",
  "bitnet-eval-core",
+ "bitnet-exit-codes-core",
  "bitnet-ggml-ffi",
  "bitnet-inference",
  "bitnet-kernels",
@@ -669,6 +670,10 @@ dependencies = [
 
 [[package]]
 name = "bitnet-eval-core"
+version = "0.2.1-dev"
+
+[[package]]
+name = "bitnet-exit-codes-core"
 version = "0.2.1-dev"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
   "crates/bitnet-server-health-types-core", # SRP: reusable server health endpoint contract types
   "crates/bitnet-server",
   "crates/bitnet-cli-sampling-core", # SRP: reusable CLI sampling primitives
+  "crates/bitnet-exit-codes-core", # SRP: shared process exit code contract for CLI/validation tooling
   "crates/bitnet-scoring-core", # SRP: reusable NLL/logit scoring primitives
   "crates/bitnet-cli",
   "crates/bitnet-st2gguf",      # SafeTensors to GGUF converter

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -38,6 +38,7 @@ bitnet-validation = { path = "../bitnet-validation", version = "0.2.1-dev" }
 bitnet-sampling = { path = "../bitnet-sampling", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-cli-sampling-core = { path = "../bitnet-cli-sampling-core", version = "0.2.1-dev" }
+bitnet-exit-codes-core = { path = "../bitnet-exit-codes-core", version = "0.2.1-dev" }
 bitnet-scoring-core = { path = "../bitnet-scoring-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 candle-core.workspace = true

--- a/crates/bitnet-cli/src/exit.rs
+++ b/crates/bitnet-cli/src/exit.rs
@@ -1,22 +1,7 @@
-// Exit codes for precise CI triage
-#[allow(dead_code)]
-pub const EXIT_SUCCESS: i32 = 0;
-#[allow(dead_code)]
-pub const EXIT_GENERIC_FAIL: i32 = 1;
-#[allow(dead_code)]
-pub const EXIT_STRICT_MAPPING: i32 = 3;
-pub const EXIT_STRICT_TOKENIZER: i32 = 4;
-// Validation gate exit codes
-#[allow(dead_code)]
-pub const EXIT_NLL_TOO_HIGH: i32 = 5;
-#[allow(dead_code)]
-pub const EXIT_TAU_TOO_LOW: i32 = 6;
-#[allow(dead_code)]
-pub const EXIT_ARGMAX_MISMATCH: i32 = 7;
-// LayerNorm validation exit code
-#[allow(dead_code)]
-pub const EXIT_LN_SUSPICIOUS: i32 = 8;
-#[allow(dead_code)]
-pub const EXIT_PERF_FAIL: i32 = 9;
-#[allow(dead_code)]
-pub const EXIT_RSS_FAIL: i32 = 10;
+// Exit codes for precise CI triage.
+#[allow(unused_imports)]
+pub use bitnet_exit_codes_core::{
+    EXIT_ARGMAX_MISMATCH, EXIT_GENERIC_FAIL, EXIT_LN_SUSPICIOUS, EXIT_NLL_TOO_HIGH,
+    EXIT_PERF_FAIL, EXIT_RSS_FAIL, EXIT_STRICT_MAPPING, EXIT_STRICT_TOKENIZER, EXIT_SUCCESS,
+    EXIT_TAU_TOO_LOW,
+};

--- a/crates/bitnet-exit-codes-core/Cargo.toml
+++ b/crates/bitnet-exit-codes-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitnet-exit-codes-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core crate for BitNet CLI/validation exit codes"
+
+[lib]
+name = "bitnet_exit_codes_core"
+path = "src/lib.rs"

--- a/crates/bitnet-exit-codes-core/src/lib.rs
+++ b/crates/bitnet-exit-codes-core/src/lib.rs
@@ -1,0 +1,44 @@
+//! Shared process exit code contract for CLI and validation tooling.
+//!
+//! Keeping these constants in a dedicated microcrate makes the numeric
+//! contract reusable and auditable across binaries.
+
+/// Command completed successfully.
+pub const EXIT_SUCCESS: i32 = 0;
+/// Generic non-specific failure.
+pub const EXIT_GENERIC_FAIL: i32 = 1;
+/// Strict mapping gate failure.
+pub const EXIT_STRICT_MAPPING: i32 = 3;
+/// Strict tokenizer gate failure.
+pub const EXIT_STRICT_TOKENIZER: i32 = 4;
+/// NLL quality gate failure.
+pub const EXIT_NLL_TOO_HIGH: i32 = 5;
+/// Tau quality gate failure.
+pub const EXIT_TAU_TOO_LOW: i32 = 6;
+/// Argmax parity gate failure.
+pub const EXIT_ARGMAX_MISMATCH: i32 = 7;
+/// LayerNorm/projection strict validation failure.
+pub const EXIT_LN_SUSPICIOUS: i32 = 8;
+/// Performance benchmark gate failure.
+pub const EXIT_PERF_FAIL: i32 = 9;
+/// RSS memory ceiling gate failure.
+pub const EXIT_RSS_FAIL: i32 = 10;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_codes_remain_stable() {
+        assert_eq!(EXIT_SUCCESS, 0);
+        assert_eq!(EXIT_GENERIC_FAIL, 1);
+        assert_eq!(EXIT_STRICT_MAPPING, 3);
+        assert_eq!(EXIT_STRICT_TOKENIZER, 4);
+        assert_eq!(EXIT_NLL_TOO_HIGH, 5);
+        assert_eq!(EXIT_TAU_TOO_LOW, 6);
+        assert_eq!(EXIT_ARGMAX_MISMATCH, 7);
+        assert_eq!(EXIT_LN_SUSPICIOUS, 8);
+        assert_eq!(EXIT_PERF_FAIL, 9);
+        assert_eq!(EXIT_RSS_FAIL, 10);
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize the numeric process exit-code contract used by CLI and validation tooling to follow SRP and make the contract auditable and reusable.
- Avoid duplication of numeric constants across binaries so other crates can depend on a single authoritative source.

### Description

- Add a new microcrate `crates/bitnet-exit-codes-core` with `Cargo.toml` and `src/lib.rs` exposing stable exit-code constants and a small unit test to lock the numeric contract.
- Register the new crate as a workspace member (`Cargo.toml`) and add it as a dependency of `crates/bitnet-cli` (`crates/bitnet-cli/Cargo.toml`).
- Replace the inline constants in `crates/bitnet-cli/src/exit.rs` with a re-export shim (`pub use bitnet_exit_codes_core::...`) and add `#[allow(unused_imports)]` to silence compile-time warnings.
- Updated the lockfile to include the new package and dependency edge so the workspace builds cleanly.

### Testing

- Ran `cargo test -p bitnet-exit-codes-core` and the crate unit test `exit_codes_remain_stable` passed.
- Ran `cargo test -p bitnet-cli --test snapshot_wave10` and all snapshot tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e7706cd08333890ed526a7095a1a)