### PR TITLE
refactor(download): move atomic_write into bitnet-download-core

### DIFF
--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,3 +1,4 @@
+use std::{fs, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -31,9 +32,39 @@ pub fn validate_downloaded_len(
     Ok(())
 }
 
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     #[test]
     fn parses_content_range_total() {
@@ -49,5 +80,26 @@ mod tests {
             validate_downloaded_len(1, Some(2)),
             Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
         ));
+    }
+
+    #[test]
+    fn atomic_write_replaces_file_contents() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("bitnet-download-core-{unique}"));
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let file = dir.join("etag.txt");
+
+        atomic_write(&file, b"v1").expect("initial write succeeds");
+        atomic_write(&file, b"v2").expect("replacement write succeeds");
+
+        let read_back = fs::read(&file).expect("read back written file");
+        assert_eq!(read_back, b"v2");
+
+        let _ = fs::remove_file(file.with_extension("tmp"));
+        let _ = fs::remove_file(&file);
+        let _ = fs::remove_dir(&dir);
     }
 }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Consolidate low-level download/file helpers into the SRP core crate so metadata write primitives live alongside other download primitives and can be reused across callers.

### Description

- Add `atomic_write(path: &Path, bytes: &[u8])` to `crates/bitnet-download-core` and expose it alongside existing helpers (`offline_enabled`, `parse_content_range_total`, `validate_downloaded_len`).
- Remove the duplicate `atomic_write` implementation from `crates/bitnet-download` and re-export `atomic_write` from the core crate to preserve the public façade.
- Add a unit test `atomic_write_replaces_file_contents` in `bitnet-download-core` that verifies repeated atomic writes replace file contents and performs cleanup.
- Tidy imports and run formatting to keep the workspace consistent.

### Testing

- Ran `cargo fmt --all` which completed successfully.
- Ran `cargo test -p bitnet-download-core -p bitnet-download` and all unit tests passed (core test for `atomic_write` passed and `bitnet-download` tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e7706cd08333890ed526a7095a1a)