### PR TITLE
Extract atomic metadata writes into bitnet-atomic-file-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-atomic-file-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "bitnet-bdd-grid"
 version = "0.2.1-dev"
 dependencies = [
@@ -640,6 +647,7 @@ version = "0.1.0"
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-atomic-file-core",
  "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
+  "crates/bitnet-atomic-file-core", # SRP: atomic file persistence helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
@@ -174,6 +175,7 @@ default-members = [
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
+  "crates/bitnet-atomic-file-core", # SRP: atomic file persistence helpers
 ]
 
 [package]

--- a/crates/bitnet-atomic-file-core/Cargo.toml
+++ b/crates/bitnet-atomic-file-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-atomic-file-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP atomic file write helpers for durable small metadata persistence"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/bitnet-atomic-file-core/src/lib.rs
+++ b/crates/bitnet-atomic-file-core/src/lib.rs
@@ -1,0 +1,61 @@
+use std::{fs, path::Path};
+
+/// Atomically writes bytes to `path` via a sibling temporary file.
+///
+/// On Unix, this also fsyncs the temporary file and its parent directory to
+/// improve durability guarantees for metadata updates.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write;
+    use std::fs;
+
+    #[test]
+    fn writes_file_contents() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("meta.txt");
+
+        atomic_write(&path, b"etag-value").expect("write succeeds");
+
+        let got = fs::read(&path).expect("read written file");
+        assert_eq!(got, b"etag-value");
+    }
+
+    #[test]
+    fn overwrite_is_atomic_and_removes_tmp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("meta.txt");
+        let tmp = dir.path().join("meta.tmp");
+
+        atomic_write(&path, b"old").expect("initial write");
+        atomic_write(&path, b"new").expect("overwrite write");
+
+        let got = fs::read(&path).expect("read overwritten file");
+        assert_eq!(got, b"new");
+        assert!(!tmp.exists(), "temporary file should not remain after rename");
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-atomic-file-core = { path = "../bitnet-atomic-file-core", version = "0.2.1-dev" }
 bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -4,7 +4,7 @@ pub use bitnet_download_core::{
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -18,31 +18,7 @@ pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     parse_retry_after_secs_at(retry_after, now)
 }
 
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
-}
+pub use bitnet_atomic_file_core::atomic_write;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
### Motivation

- `atomic_write` is a generic, durable metadata persistence concern that is orthogonal to HTTP/download logic and should be reusable across crates.
- Splitting the helper into a focused SRP microcrate reduces responsibilities of `bitnet-download` and centralizes filesystem durability semantics for auditability and reuse.

### Description

- Add a new microcrate `crates/bitnet-atomic-file-core` implementing `atomic_write(path: &Path, bytes: &[u8])` with Unix `fsync` semantics and unit tests in `src/lib.rs`.
- Wire the new crate into the workspace members and `default-members` so it is built and tested as part of the workspace.
- Update `crates/bitnet-download` to depend on `bitnet-atomic-file-core` and re-export `atomic_write` to preserve existing call sites while removing the inlined implementation.
- Add a dev-dependency (`tempfile`) for the new crate tests and run `cargo fmt` to normalize formatting.

### Testing

- Ran `cargo test -p bitnet-atomic-file-core -p bitnet-download` and all unit tests passed for both crates (4 tests in `bitnet-download`, 2 tests in `bitnet-atomic-file-core`).
- Ran `cargo fmt` to format changes successfully.
- Started `cargo check -p xtask` to validate workspace integration; the check progressed but was left running/terminated due to long-running transitive native builds in this environment, so full `xtask` verification is inconclusive here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e771dd408333b90194843ffc886b)