### PR TITLE
Extract shared build metadata into `bitnet-build-info-core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitnet-build-info-core",
  "bitnet-common",
  "bitnet-device-probe",
  "bitnet-ggml-ffi",
@@ -455,6 +456,10 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "bitnet-build-info-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-cli"
@@ -1307,6 +1312,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bitnet-build-info-core",
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/bitnet-math",
   "crates/bitnet-simd",
   "crates/bitnet-warn-once",
+  "crates/bitnet-build-info-core", # SRP: reusable build metadata constants
   "crates/bitnet-runtime-context",
   "crates/bitnet-runtime-context-core",
   "crates/bitnet-bdd-grid",
@@ -220,6 +221,7 @@ version = "0.2.1-dev"
 bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-build-info-core = { path = "crates/bitnet-build-info-core", version = "0.2.1-dev" }
 bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
@@ -388,6 +390,7 @@ required-features = ["cpu"]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-build-info-core = { path = "crates/bitnet-build-info-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-build-info-core/Cargo.toml
+++ b/crates/bitnet-build-info-core/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bitnet-build-info-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP: reusable build metadata constants from vergen env vars"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]

--- a/crates/bitnet-build-info-core/src/lib.rs
+++ b/crates/bitnet-build-info-core/src/lib.rs
@@ -1,0 +1,56 @@
+//! Reusable build metadata constants sourced from `vergen` environment variables.
+
+/// Git commit hash at build time.
+pub const GIT_SHA: &str = match option_env!("VERGEN_GIT_SHA") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+/// Git branch name at build time.
+pub const GIT_BRANCH: &str = match option_env!("VERGEN_GIT_BRANCH") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+/// Build timestamp at build time.
+pub const BUILD_TIMESTAMP: &str = match option_env!("VERGEN_BUILD_TIMESTAMP") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+/// Rust version used for build.
+pub const RUSTC_VERSION: &str = match option_env!("VERGEN_RUSTC_SEMVER") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+/// Cargo target triple used for build.
+pub const CARGO_TARGET_TRIPLE: &str = match option_env!("VERGEN_CARGO_TARGET_TRIPLE") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+/// Cargo optimization level used for build.
+pub const CARGO_OPT_LEVEL: &str = match option_env!("VERGEN_CARGO_OPT_LEVEL") {
+    Some(value) => value,
+    None => "unknown",
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constants_are_non_empty() {
+        for value in [
+            GIT_SHA,
+            GIT_BRANCH,
+            BUILD_TIMESTAMP,
+            RUSTC_VERSION,
+            CARGO_TARGET_TRIPLE,
+            CARGO_OPT_LEVEL,
+        ] {
+            assert!(!value.is_empty());
+        }
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-build-info-core = { path = "../bitnet-build-info-core", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/monitoring/health.rs
+++ b/crates/bitnet-server/src/monitoring/health.rs
@@ -153,18 +153,12 @@ impl HealthChecker {
             version: env!("CARGO_PKG_VERSION").to_string(),
             build: BuildInfo {
                 version: env!("CARGO_PKG_VERSION").to_string(),
-                git_sha: option_env!("VERGEN_GIT_SHA").unwrap_or("unknown").to_string(),
-                git_branch: option_env!("VERGEN_GIT_BRANCH").unwrap_or("unknown").to_string(),
-                build_timestamp: option_env!("VERGEN_BUILD_TIMESTAMP")
-                    .unwrap_or("unknown")
-                    .to_string(),
-                rustc_version: option_env!("VERGEN_RUSTC_SEMVER").unwrap_or("unknown").to_string(),
-                cargo_target: option_env!("VERGEN_CARGO_TARGET_TRIPLE")
-                    .unwrap_or("unknown")
-                    .to_string(),
-                cargo_profile: option_env!("VERGEN_CARGO_OPT_LEVEL")
-                    .unwrap_or("unknown")
-                    .to_string(),
+                git_sha: bitnet_build_info_core::GIT_SHA.to_string(),
+                git_branch: bitnet_build_info_core::GIT_BRANCH.to_string(),
+                build_timestamp: bitnet_build_info_core::BUILD_TIMESTAMP.to_string(),
+                rustc_version: bitnet_build_info_core::RUSTC_VERSION.to_string(),
+                cargo_target: bitnet_build_info_core::CARGO_TARGET_TRIPLE.to_string(),
+                cargo_profile: bitnet_build_info_core::CARGO_OPT_LEVEL.to_string(),
                 #[cfg(any(feature = "gpu", feature = "cuda"))]
                 cuda_version: Some(self.get_cuda_version()),
                 #[cfg(not(any(feature = "gpu", feature = "cuda")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,28 +119,16 @@ pub const MSRV: &str = "1.90.0";
 /// Build information
 pub mod build_info {
     /// Git commit hash at build time
-    pub const GIT_HASH: &str = match option_env!("VERGEN_GIT_SHA") {
-        Some(hash) => hash,
-        None => "unknown",
-    };
+    pub const GIT_HASH: &str = bitnet_build_info_core::GIT_SHA;
 
     /// Build timestamp
-    pub const BUILD_TIMESTAMP: &str = match option_env!("VERGEN_BUILD_TIMESTAMP") {
-        Some(timestamp) => timestamp,
-        None => "unknown",
-    };
+    pub const BUILD_TIMESTAMP: &str = bitnet_build_info_core::BUILD_TIMESTAMP;
 
     /// Target triple
-    pub const TARGET: &str = match option_env!("VERGEN_CARGO_TARGET_TRIPLE") {
-        Some(target) => target,
-        None => "unknown",
-    };
+    pub const TARGET: &str = bitnet_build_info_core::CARGO_TARGET_TRIPLE;
 
     /// Rust version used for build
-    pub const RUSTC_VERSION: &str = match option_env!("VERGEN_RUSTC_SEMVER") {
-        Some(version) => version,
-        None => "unknown",
-    };
+    pub const RUSTC_VERSION: &str = bitnet_build_info_core::RUSTC_VERSION;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Remove duplicated `vergen` environment lookups spread across crates by centralizing build metadata access into a single SRP microcrate. 
- Make build-time metadata (git sha, branch, timestamp, rustc, target, opt-level) reusable across workspace crates to reduce boilerplate and keep behavior consistent. 

### Description

- Added a new microcrate `crates/bitnet-build-info-core` exposing constants `GIT_SHA`, `GIT_BRANCH`, `BUILD_TIMESTAMP`, `RUSTC_VERSION`, `CARGO_TARGET_TRIPLE`, and `CARGO_OPT_LEVEL` derived from `option_env!(...)`. 
- Registered the new microcrate in the workspace `Cargo.toml` and added it as a dependency in the root crate and `bitnet-server`. 
- Updated the root `bitnet` crate `build_info` module (`src/lib.rs`) to re-export values from `bitnet-build-info-core` instead of repeating `option_env!` logic. 
- Updated `crates/bitnet-server/src/monitoring/health.rs` to use the shared constants when constructing `BuildInfo` for health responses. 
- Added a small unit test in `bitnet-build-info-core` that asserts the constants are non-empty. 

### Testing

- Ran `cargo fmt` successfully. 
- Ran `cargo test -p bitnet-build-info-core` and all tests passed. 
- Ran `cargo test -p bitnet-server --lib` and the server tests completed successfully (all tests passed). 
- Ran `cargo test -p bitnet --lib` which failed due to a pre-existing version assertion in the root crate test expecting `"0.1.2"` while the package `version` is `"0.2.1-dev"`, unrelated to the build-info extraction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e771dd408333b90194843ffc886b)