### PR TITLE
refactor(download): extract atomic metadata writes into bitnet-download-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
 name = "bitnet-download-core"
 version = "0.2.1-dev"
 dependencies = [
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -7,10 +7,13 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 documentation.workspace = true
-description = "SRP core download helpers for offline mode and content-length validation"
+description = "SRP core download helpers for offline mode, content-length validation, and atomic metadata writes"
 
 [dependencies]
 thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,5 +1,7 @@
 use thiserror::Error;
 
+use std::{fs, path::Path};
+
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum DownloadValidationError {
     #[error("download truncated: got {downloaded} bytes, expected {expected} bytes")]
@@ -31,6 +33,32 @@ pub fn validate_downloaded_len(
     Ok(())
 }
 
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(file) = fs::File::open(&tmp) {
+            file.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -49,5 +77,16 @@ mod tests {
             validate_downloaded_len(1, Some(2)),
             Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
         ));
+    }
+
+    #[test]
+    fn atomic_write_persists_bytes() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("etag.txt");
+
+        atomic_write(&path, b"etag-v1").expect("write metadata atomically");
+
+        let bytes = fs::read(path).expect("read metadata");
+        assert_eq!(bytes, b"etag-v1");
     }
 }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Centralize low-level download metadata persistence (atomic writes) into the SRP core crate so pure, platform-agnostic helpers live alongside other download validation utilities.
- Keep the higher-level `bitnet-download` crate focused on HTTP retry/headers and preserve the existing public API surface for callers.

### Description
- Moved `atomic_write` implementation from `crates/bitnet-download/src/lib.rs` into `crates/bitnet-download-core/src/lib.rs` and added appropriate `use` imports for `std::fs` and `std::path::Path`.
- Re-exported `atomic_write` from `crates/bitnet-download/src/lib.rs` to preserve the external API.
- Added a core-level unit test `atomic_write_persists_bytes` in `bitnet-download-core` that uses `tempfile` to verify atomic persistence behavior.
- Updated `crates/bitnet-download-core/Cargo.toml` description and added `tempfile` as a `dev-dependency` for the new test.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test -p bitnet-download-core -p bitnet-download` and observed all unit tests passing: core tests (including `atomic_write_persists_bytes`) and download tests ran successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e771dd408333b90194843ffc886b)