### PR TITLE
Extract atomic file persistence into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-atomic-file-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "bitnet-bdd-grid"
 version = "0.2.1-dev"
 dependencies = [
@@ -640,6 +647,7 @@ version = "0.1.0"
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-atomic-file-core",
  "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
@@ -1148,6 +1156,7 @@ name = "bitnet-receipts-core"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-atomic-file-core",
  "bitnet-common",
  "bitnet-honest-compute",
  "bitnet-kernels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,8 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
-  "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
+  "crates/bitnet-download-core", # SRP: core download validation helpers
+  "crates/bitnet-atomic-file-core", # SRP: atomic file-write persistence helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
@@ -388,6 +389,7 @@ required-features = ["cpu"]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { path = "crates/bitnet-atomic-file-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-atomic-file-core/Cargo.toml
+++ b/crates/bitnet-atomic-file-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-atomic-file-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP microcrate for atomic file persistence helpers"
+
+[dependencies]
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-atomic-file-core/src/lib.rs
+++ b/crates/bitnet-atomic-file-core/src/lib.rs
@@ -1,0 +1,61 @@
+//! Atomic file persistence helpers.
+//! This crate keeps small file-write durability mechanics isolated from higher-level
+//! domains like downloads and receipts.
+
+use std::path::Path;
+
+/// Atomically write bytes to `path` by writing a sibling temporary file then renaming.
+///
+/// On Unix, this fsyncs the temporary file and containing directory to reduce the risk
+/// of data loss on sudden power failure.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(file) = std::fs::File::open(&tmp) {
+            file.sync_all()?;
+        }
+    }
+
+    std::fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write;
+
+    #[test]
+    fn atomic_write_persists_bytes() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("value.json");
+
+        atomic_write(&path, br#"{"ok":true}"#).expect("write");
+        let actual = std::fs::read_to_string(&path).expect("read");
+
+        assert_eq!(actual, r#"{"ok":true}"#);
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing_file() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let path = tempdir.path().join("value.txt");
+        std::fs::write(&path, "old").expect("seed file");
+
+        atomic_write(&path, b"new").expect("write");
+
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), "new");
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-atomic-file-core = { path = "../bitnet-atomic-file-core", version = "0.2.1-dev" }
 bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
+pub use bitnet_atomic_file_core::atomic_write;
 pub use bitnet_download_core::{
     DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { path = "../bitnet-atomic-file-core", version = "0.2.1-dev" }
 bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
 rustc_version_runtime = "0.3.0"

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `performance_baseline`: Performance metrics
 
 use anyhow::{Result, anyhow};
+use bitnet_atomic_file_core::atomic_write;
 use bitnet_common::CorrectionRecord;
 use bitnet_honest_compute::{
     classify_compute_path, validate_compute_path as validate_honest_compute_path,
@@ -380,10 +381,8 @@ impl InferenceReceipt {
         // Serialize to pretty JSON
         let json = serde_json::to_string_pretty(self)?;
 
-        // Atomic write: write to temp file, then rename
-        let temp_path = path.with_extension("tmp");
-        std::fs::write(&temp_path, json)?;
-        std::fs::rename(&temp_path, path)?;
+        // Atomic write: write to temp file, fsync where available, then rename
+        atomic_write(path, json.as_bytes())?;
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Isolate cross-cutting atomic file persistence mechanics (temp-file + rename and Unix best-effort fsync) into a single SRP microcrate to remove duplicated logic and centralize durability behavior.
- Reduce coupling and make small file-write semantics reusable by multiple domains (downloads, receipts) without copying implementation.

### Description
- Added a new microcrate `crates/bitnet-atomic-file-core` that exposes `atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()>` and includes focused unit tests for write/overwrite behavior.
- Wired the crate into the workspace (`Cargo.toml` members and `[workspace.dependencies]`) and updated the lockfile entries to reflect the new dependency edges.
- Refactored `crates/bitnet-download` to depend on and re-export `atomic_write` and removed the duplicated inline atomic-write implementation from that crate.
- Refactored `crates/bitnet-receipts-core` to call `atomic_write` from the new microcrate in `InferenceReceipt::save` instead of performing its own temp-file + rename sequence.

### Testing
- Ran `cargo fmt` to apply formatting, which completed successfully.
- Ran `cargo test -p bitnet-atomic-file-core -p bitnet-download -p bitnet-receipts-core` and observed all unit tests and doctests pass (all tests green).
- Re-ran the same tests with `--quiet` to confirm stable output and all tests remained passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e771dd408333b90194843ffc886b)