### PR TITLE
Extract feature taxonomy into new `bitnet-feature-set-core` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
 name = "bitnet-bdd-grid-core"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-feature-set-core",
  "insta",
  "proptest",
  "serde",
@@ -689,6 +690,10 @@ dependencies = [
  "insta",
  "proptest",
 ]
+
+[[package]]
+name = "bitnet-feature-set-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-ffi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/bitnet-runtime-context-core",
   "crates/bitnet-bdd-grid",
   "crates/bitnet-bdd-grid-core",
+  "crates/bitnet-feature-set-core", # SRP: feature taxonomy and feature-set operations
   "crates/bitnet-compat",
   "crates/bitnet-ggml-ffi",     # GGML FFI for IQ2_S support
   "crates/bitnet-runtime-feature-flags",
@@ -153,6 +154,7 @@ default-members = [
   # Testing infrastructure crates (always built/tested by default)
   "crates/bitnet-bdd-grid",
   "crates/bitnet-bdd-grid-core",
+  "crates/bitnet-feature-set-core", # SRP: feature taxonomy and feature-set operations
   "crates/bitnet-feature-contract",
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server-health-types-core",

--- a/crates/bitnet-bdd-grid-core/Cargo.toml
+++ b/crates/bitnet-bdd-grid-core/Cargo.toml
@@ -13,6 +13,7 @@ description = "Core BDD scenario, feature, and grid primitives for BitNet"
 include = ["src/**", "Cargo.toml"]
 
 [dependencies]
+bitnet-feature-set-core = { path = "../bitnet-feature-set-core", version = "0.2.1-dev" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -3,9 +3,10 @@
 //! This crate intentionally stays free from curated policy content and instead
 //! provides stable, low-level types plus reusable grid helpers.
 
-use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
+
+pub use bitnet_feature_set_core::{BitnetFeature, FeatureSet, feature_set_from_names};
 
 /// Logical test scenario axis for BDD planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -92,183 +93,6 @@ impl FromStr for ExecutionEnvironment {
     }
 }
 
-/// Canonical feature axes for feature-flag contracts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum BitnetFeature {
-    Cpu,
-    Gpu,
-    Cuda,
-    Metal,
-    Vulkan,
-    Oneapi,
-    Inference,
-    Kernels,
-    Tokenizers,
-    Quantization,
-    Cli,
-    Server,
-    Ffi,
-    Python,
-    Wasm,
-    CrossValidation,
-    Trace,
-    Iq2sFfi,
-    CppFfi,
-    Fixtures,
-    Reporting,
-    Trend,
-    IntegrationTests,
-}
-
-impl fmt::Display for BitnetFeature {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Cpu => write!(f, "cpu"),
-            Self::Gpu => write!(f, "gpu"),
-            Self::Cuda => write!(f, "cuda"),
-            Self::Metal => write!(f, "metal"),
-            Self::Vulkan => write!(f, "vulkan"),
-            Self::Oneapi => write!(f, "oneapi"),
-            Self::Inference => write!(f, "inference"),
-            Self::Kernels => write!(f, "kernels"),
-            Self::Tokenizers => write!(f, "tokenizers"),
-            Self::Quantization => write!(f, "quantization"),
-            Self::Cli => write!(f, "cli"),
-            Self::Server => write!(f, "server"),
-            Self::Ffi => write!(f, "ffi"),
-            Self::Python => write!(f, "python"),
-            Self::Wasm => write!(f, "wasm"),
-            Self::CrossValidation => write!(f, "crossval"),
-            Self::Trace => write!(f, "trace"),
-            Self::Iq2sFfi => write!(f, "iq2s-ffi"),
-            Self::CppFfi => write!(f, "cpp-ffi"),
-            Self::Fixtures => write!(f, "fixtures"),
-            Self::Reporting => write!(f, "reporting"),
-            Self::Trend => write!(f, "trend"),
-            Self::IntegrationTests => write!(f, "integration-tests"),
-        }
-    }
-}
-
-impl FromStr for BitnetFeature {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
-            "cpu" => Ok(Self::Cpu),
-            "gpu" => Ok(Self::Gpu),
-            "cuda" => Ok(Self::Cuda),
-            "metal" => Ok(Self::Metal),
-            "vulkan" => Ok(Self::Vulkan),
-            "oneapi" => Ok(Self::Oneapi),
-            "inference" => Ok(Self::Inference),
-            "kernels" => Ok(Self::Kernels),
-            "tokenizers" => Ok(Self::Tokenizers),
-            "quantization" => Ok(Self::Quantization),
-            "cli" => Ok(Self::Cli),
-            "server" => Ok(Self::Server),
-            "ffi" => Ok(Self::Ffi),
-            "python" => Ok(Self::Python),
-            "wasm" => Ok(Self::Wasm),
-            "crossval" | "cross-validation" => Ok(Self::CrossValidation),
-            "trace" => Ok(Self::Trace),
-            "iq2s-ffi" => Ok(Self::Iq2sFfi),
-            "cpp-ffi" => Ok(Self::CppFfi),
-            "fixtures" => Ok(Self::Fixtures),
-            "reporting" => Ok(Self::Reporting),
-            "trend" => Ok(Self::Trend),
-            "integration-tests" => Ok(Self::IntegrationTests),
-            _ => Err("unknown feature"),
-        }
-    }
-}
-
-/// Ordered set of supported features.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct FeatureSet(BTreeSet<BitnetFeature>);
-
-impl FeatureSet {
-    /// Construct an empty set.
-    pub fn new() -> Self {
-        Self(BTreeSet::new())
-    }
-
-    /// Insert a feature.
-    pub fn insert(&mut self, feature: BitnetFeature) -> bool {
-        self.0.insert(feature)
-    }
-
-    /// Test whether a feature is enabled.
-    pub fn contains(&self, feature: BitnetFeature) -> bool {
-        self.0.contains(&feature)
-    }
-
-    /// Add all features from the provided slice.
-    pub fn extend<I>(&mut self, features: I)
-    where
-        I: IntoIterator<Item = BitnetFeature>,
-    {
-        self.0.extend(features);
-    }
-
-    /// Create a set from a string list (e.g. CLI/env var values).
-    pub fn from_names<I, S>(features: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<str>,
-    {
-        let mut set = Self::new();
-        for feature in features {
-            if let Ok(feature) = feature.as_ref().parse() {
-                set.insert(feature);
-            }
-        }
-        set
-    }
-
-    /// Human-readable representation for logs and diagnostics.
-    pub fn labels(&self) -> Vec<String> {
-        self.0.iter().map(ToString::to_string).collect()
-    }
-
-    /// Compute feature mismatches against requirements.
-    pub fn missing_required(&self, required: &Self) -> Self {
-        Self(required.0.difference(&self.0).copied().collect())
-    }
-
-    /// Compute forbidden feature overlap (features that should not be active).
-    pub fn forbidden_overlap(&self, forbidden: &Self) -> Self {
-        Self(self.0.intersection(&forbidden.0).copied().collect())
-    }
-
-    /// Check if this set satisfies required / forbidden constraints.
-    pub fn satisfies(&self, required: &Self, forbidden: &Self) -> bool {
-        self.missing_required(required).is_empty() && self.forbidden_overlap(forbidden).is_empty()
-    }
-
-    /// Expose iteration for callers that need compatibility logic.
-    pub fn iter(&self) -> impl Iterator<Item = &BitnetFeature> {
-        self.0.iter()
-    }
-
-    /// Whether set is empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl From<&[BitnetFeature]> for FeatureSet {
-    fn from(value: &[BitnetFeature]) -> Self {
-        Self(value.iter().copied().collect())
-    }
-}
-
-impl From<&[&str]> for FeatureSet {
-    fn from(value: &[&str]) -> Self {
-        Self::from_names(value.iter().copied())
-    }
-}
-
 /// Cell in the BDD grid.
 #[derive(Debug, Clone)]
 pub struct BddCell {
@@ -341,17 +165,6 @@ impl BddGrid {
     ) -> Option<(FeatureSet, FeatureSet)> {
         self.find(scenario, environment).map(|cell| cell.violations(features))
     }
-}
-
-/// Canonical, reusable helper for mapping runtime feature selections to `FeatureSet`.
-pub fn feature_set_from_names(features: &[&str]) -> FeatureSet {
-    let mut set = FeatureSet::new();
-    for feature in features {
-        if let Ok(feature) = feature.parse() {
-            set.insert(feature);
-        }
-    }
-    set
 }
 
 #[cfg(test)]

--- a/crates/bitnet-feature-set-core/Cargo.toml
+++ b/crates/bitnet-feature-set-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitnet-feature-set-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Core BitNet feature taxonomy and feature-set primitives"
+include = ["src/**", "Cargo.toml"]
+
+[dependencies]

--- a/crates/bitnet-feature-set-core/src/lib.rs
+++ b/crates/bitnet-feature-set-core/src/lib.rs
@@ -1,0 +1,189 @@
+//! Core BitNet feature taxonomy + feature-set operations.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::str::FromStr;
+
+/// Canonical feature axes for feature-flag contracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum BitnetFeature {
+    Cpu,
+    Gpu,
+    Cuda,
+    Metal,
+    Vulkan,
+    Oneapi,
+    Inference,
+    Kernels,
+    Tokenizers,
+    Quantization,
+    Cli,
+    Server,
+    Ffi,
+    Python,
+    Wasm,
+    CrossValidation,
+    Trace,
+    Iq2sFfi,
+    CppFfi,
+    Fixtures,
+    Reporting,
+    Trend,
+    IntegrationTests,
+}
+
+impl fmt::Display for BitnetFeature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cpu => write!(f, "cpu"),
+            Self::Gpu => write!(f, "gpu"),
+            Self::Cuda => write!(f, "cuda"),
+            Self::Metal => write!(f, "metal"),
+            Self::Vulkan => write!(f, "vulkan"),
+            Self::Oneapi => write!(f, "oneapi"),
+            Self::Inference => write!(f, "inference"),
+            Self::Kernels => write!(f, "kernels"),
+            Self::Tokenizers => write!(f, "tokenizers"),
+            Self::Quantization => write!(f, "quantization"),
+            Self::Cli => write!(f, "cli"),
+            Self::Server => write!(f, "server"),
+            Self::Ffi => write!(f, "ffi"),
+            Self::Python => write!(f, "python"),
+            Self::Wasm => write!(f, "wasm"),
+            Self::CrossValidation => write!(f, "crossval"),
+            Self::Trace => write!(f, "trace"),
+            Self::Iq2sFfi => write!(f, "iq2s-ffi"),
+            Self::CppFfi => write!(f, "cpp-ffi"),
+            Self::Fixtures => write!(f, "fixtures"),
+            Self::Reporting => write!(f, "reporting"),
+            Self::Trend => write!(f, "trend"),
+            Self::IntegrationTests => write!(f, "integration-tests"),
+        }
+    }
+}
+
+impl FromStr for BitnetFeature {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "cpu" => Ok(Self::Cpu),
+            "gpu" => Ok(Self::Gpu),
+            "cuda" => Ok(Self::Cuda),
+            "metal" => Ok(Self::Metal),
+            "vulkan" => Ok(Self::Vulkan),
+            "oneapi" => Ok(Self::Oneapi),
+            "inference" => Ok(Self::Inference),
+            "kernels" => Ok(Self::Kernels),
+            "tokenizers" => Ok(Self::Tokenizers),
+            "quantization" => Ok(Self::Quantization),
+            "cli" => Ok(Self::Cli),
+            "server" => Ok(Self::Server),
+            "ffi" => Ok(Self::Ffi),
+            "python" => Ok(Self::Python),
+            "wasm" => Ok(Self::Wasm),
+            "crossval" | "cross-validation" => Ok(Self::CrossValidation),
+            "trace" => Ok(Self::Trace),
+            "iq2s-ffi" => Ok(Self::Iq2sFfi),
+            "cpp-ffi" => Ok(Self::CppFfi),
+            "fixtures" => Ok(Self::Fixtures),
+            "reporting" => Ok(Self::Reporting),
+            "trend" => Ok(Self::Trend),
+            "integration-tests" => Ok(Self::IntegrationTests),
+            _ => Err("unknown feature"),
+        }
+    }
+}
+
+/// Ordered set of supported features.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FeatureSet(BTreeSet<BitnetFeature>);
+
+impl FeatureSet {
+    pub fn new() -> Self {
+        Self(BTreeSet::new())
+    }
+
+    pub fn insert(&mut self, feature: BitnetFeature) -> bool {
+        self.0.insert(feature)
+    }
+
+    pub fn contains(&self, feature: BitnetFeature) -> bool {
+        self.0.contains(&feature)
+    }
+
+    pub fn extend<I>(&mut self, features: I)
+    where
+        I: IntoIterator<Item = BitnetFeature>,
+    {
+        self.0.extend(features);
+    }
+
+    pub fn from_names<I, S>(features: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut set = Self::new();
+        for feature in features {
+            if let Ok(feature) = feature.as_ref().parse() {
+                set.insert(feature);
+            }
+        }
+        set
+    }
+
+    pub fn labels(&self) -> Vec<String> {
+        self.0.iter().map(ToString::to_string).collect()
+    }
+
+    pub fn missing_required(&self, required: &Self) -> Self {
+        Self(required.0.difference(&self.0).copied().collect())
+    }
+
+    pub fn forbidden_overlap(&self, forbidden: &Self) -> Self {
+        Self(self.0.intersection(&forbidden.0).copied().collect())
+    }
+
+    pub fn satisfies(&self, required: &Self, forbidden: &Self) -> bool {
+        self.missing_required(required).is_empty() && self.forbidden_overlap(forbidden).is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &BitnetFeature> {
+        self.0.iter()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<&[BitnetFeature]> for FeatureSet {
+    fn from(value: &[BitnetFeature]) -> Self {
+        Self(value.iter().copied().collect())
+    }
+}
+
+impl From<&[&str]> for FeatureSet {
+    fn from(value: &[&str]) -> Self {
+        Self::from_names(value.iter().copied())
+    }
+}
+
+/// Canonical helper for mapping runtime feature selections to `FeatureSet`.
+pub fn feature_set_from_names(features: &[&str]) -> FeatureSet {
+    FeatureSet::from_names(features.iter().copied())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_parser_ignores_unknown_features() {
+        let set = feature_set_from_names(&["inference", "unknown-feature", "kernels"]);
+        assert!(set.contains(BitnetFeature::Inference));
+        assert!(set.contains(BitnetFeature::Kernels));
+        assert!(!set.contains(BitnetFeature::Gpu));
+    }
+}


### PR DESCRIPTION
### Motivation
- `bitnet-bdd-grid-core` mixed feature taxonomy and grid semantics, creating unnecessary coupling between feature parsing/set algebra and BDD grid logic.
- Isolate the `BitnetFeature`/`FeatureSet` primitives so other crates can depend on feature-set operations without pulling grid types or implementations.

### Description
- Added a new microcrate `crates/bitnet-feature-set-core` that implements `BitnetFeature`, `FeatureSet`, and `feature_set_from_names` as the canonical feature taxonomy and set algebra.
- Refactored `crates/bitnet-bdd-grid-core` to depend on and re-export `bitnet-feature-set-core` via `pub use bitnet_feature_set_core::{BitnetFeature, FeatureSet, feature_set_from_names};` so its public API remains stable.
- Wired the new crate into the workspace members and `default-members` in `Cargo.toml` and added the dependency entry in `crates/bitnet-bdd-grid-core/Cargo.toml`.
- Created the new crate manifest `crates/bitnet-feature-set-core/Cargo.toml` and source `src/lib.rs` with accompanying unit tests mirroring the original behavior.

### Testing
- Ran `cargo test -p bitnet-feature-set-core -p bitnet-bdd-grid-core -p bitnet-bdd-grid` to validate the extraction and integration.
- All affected test suites (unit, property, snapshot, and grid tests) passed successfully with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e792a1d4833380bd79890e4be661)