### PR TITLE
Extract client IP header parsing into reusable SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-client-ip-core"
+version = "0.2.1-dev"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "bitnet-common"
 version = "0.2.1-dev"
 dependencies = [
@@ -1307,6 +1314,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bitnet-client-ip-core",
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ members = [
   "crates/bitnet-opencl",       # OpenCL GPU backend with KV cache & paged attention
   "crates/bitnet-wgpu-shaders-i2s", # WGSL compute shaders for I2_S 2-bit inference
   "crates/bitnet-qk256-dispatch",
+  "crates/bitnet-client-ip-core", # SRP: reusable client IP extraction from proxy headers
 ]
 resolver = "2"
 # Build & test these by default. Others (root `bitnet`, `tests`, `xtask`,

--- a/crates/bitnet-client-ip-core/Cargo.toml
+++ b/crates/bitnet-client-ip-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-client-ip-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Reusable client IP extraction helpers from HTTP headers"
+rust-version.workspace = true
+
+[dependencies]
+http = "1.3.1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-client-ip-core/src/lib.rs
+++ b/crates/bitnet-client-ip-core/src/lib.rs
@@ -1,0 +1,67 @@
+use http::HeaderMap;
+use std::net::IpAddr;
+
+/// Extract the client IP from common proxy headers.
+///
+/// Resolution order:
+/// 1. `x-forwarded-for` (first comma-separated IP)
+/// 2. `x-real-ip`
+#[must_use]
+pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
+    // Try X-Forwarded-For header first (for reverse proxies)
+    if let Some(forwarded) = headers.get("x-forwarded-for")
+        && let Ok(forwarded_str) = forwarded.to_str()
+        && let Some(first_ip) = forwarded_str.split(',').next()
+        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    // Try X-Real-IP header
+    if let Some(real_ip) = headers.get("x-real-ip")
+        && let Ok(ip_str) = real_ip.to_str()
+        && let Ok(ip) = ip_str.parse::<IpAddr>()
+    {
+        return Some(ip);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_first_forwarded_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "203.0.113.2, 198.51.100.10".parse().expect("valid header value"),
+        );
+
+        let extracted = extract_client_ip_from_headers(&headers);
+        assert_eq!(extracted, Some("203.0.113.2".parse().expect("valid IP")));
+    }
+
+    #[test]
+    fn falls_back_to_x_real_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-real-ip", "198.51.100.7".parse().expect("valid header value"));
+
+        let extracted = extract_client_ip_from_headers(&headers);
+        assert_eq!(extracted, Some("198.51.100.7".parse().expect("valid IP")));
+    }
+
+    #[test]
+    fn returns_none_for_invalid_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            "not-an-ip, still-not-an-ip".parse().expect("valid header value"),
+        );
+
+        let extracted = extract_client_ip_from_headers(&headers);
+        assert_eq!(extracted, None);
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -22,6 +22,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.89"
 axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-client-ip-core = { path = "../bitnet-client-ip-core", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -30,6 +30,7 @@ use axum::{
     response::{Json, Response},
     routing::{get, post},
 };
+use bitnet_client_ip_core::extract_client_ip_from_headers;
 use bitnet_common::Device;
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
@@ -759,14 +760,10 @@ fn parse_device(device: &str) -> Result<Device> {
     }
 }
 
-/// Extract client IP from headers using security module's implementation
-fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    security::extract_client_ip_from_headers(headers)
-}
-
 #[cfg(test)]
 mod tests {
     use super::parse_device;
+    use bitnet_client_ip_core::extract_client_ip_from_headers;
     use bitnet_common::Device;
 
     #[test]

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -7,6 +7,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use bitnet_client_ip_core::extract_client_ip_from_headers;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::net::IpAddr;
@@ -348,29 +349,6 @@ pub async fn ip_blocking_middleware(
 /// Extract client IP from request
 fn extract_client_ip(request: &Request) -> Option<IpAddr> {
     extract_client_ip_from_headers(request.headers())
-}
-
-/// Extract client IP from headers (shared utility)
-pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    // Try X-Forwarded-For header first (for reverse proxies)
-    if let Some(forwarded) = headers.get("x-forwarded-for")
-        && let Ok(forwarded_str) = forwarded.to_str()
-        && let Some(first_ip) = forwarded_str.split(',').next()
-        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Try X-Real-IP header
-    if let Some(real_ip) = headers.get("x-real-ip")
-        && let Ok(ip_str) = real_ip.to_str()
-        && let Ok(ip) = ip_str.parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Fall back to connection info (would need to be passed from the server)
-    None
 }
 
 /// CORS middleware configuration


### PR DESCRIPTION
### Motivation
- Client-IP extraction from proxy headers is a small, pure HTTP utility that violates SRP when embedded in the server security module and is useful to other crates. 
- Spliting it into a focused microcrate makes the logic reusable and easier to test in isolation.

### Description
- Added a new microcrate `crates/bitnet-client-ip-core` that exposes `extract_client_ip_from_headers` and depends on `http` (new files: `crates/bitnet-client-ip-core/Cargo.toml`, `crates/bitnet-client-ip-core/src/lib.rs`).
- Registered the new crate in the workspace `Cargo.toml` and added a dependency in `crates/bitnet-server/Cargo.toml` so other workspace crates can reuse the helper.
- Removed the duplicated in-module implementation from `crates/bitnet-server/src/security.rs` and updated `crates/bitnet-server/src/lib.rs` and `security.rs` to call `bitnet_client_ip_core::extract_client_ip_from_headers` instead.
- Added focused unit tests in the new crate to verify forwarded-header precedence, `x-real-ip` fallback, and invalid header handling.

### Testing
- Ran `cargo fmt` to normalize formatting (succeeded).
- Ran `cargo test -p bitnet-client-ip-core` which executed the unit tests in the new microcrate (3 tests) and passed.
- Attempted `cargo test` / `cargo check` for `bitnet-server` (e.g. `cargo test -p bitnet-server security::tests::test_prompt_validation --lib` and `cargo check -p bitnet-server --lib --no-default-features`), but those builds were interrupted in this environment due to long compile durations and therefore did not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e776adc483338690e4f49345fec9)