### PR TITLE
Extract CPU reference matmul into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-logits",
  "bitnet-math",
+ "bitnet-matmul-ref-core",
  "bitnet-models",
  "bitnet-quantization",
  "bitnet-quantization-bits",
@@ -960,6 +961,10 @@ version = "0.2.1-dev"
 dependencies = [
  "proptest",
 ]
+
+[[package]]
+name = "bitnet-matmul-ref-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-metal"
@@ -1874,6 +1879,7 @@ dependencies = [
 name = "bitnet-wgpu-runner"
 version = "0.1.0"
 dependencies = [
+ "bitnet-matmul-ref-core",
  "bytemuck",
  "pollster",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
   "crates/bitnet-server",
   "crates/bitnet-cli-sampling-core", # SRP: reusable CLI sampling primitives
   "crates/bitnet-scoring-core", # SRP: reusable NLL/logit scoring primitives
+  "crates/bitnet-matmul-ref-core", # SRP: deterministic CPU reference matmul helpers
   "crates/bitnet-cli",
   "crates/bitnet-st2gguf",      # SafeTensors to GGUF converter
   "crates/bitnet-safetensors-ln", # SRP: shared SafeTensors LayerNorm utilities
@@ -241,6 +242,7 @@ async-trait = "0.1.89"
 bitnet-logits = { path = "crates/bitnet-logits", version = "0.2.1-dev" }
 bitnet-rope = { path = "crates/bitnet-rope", version = "0.2.1-dev" }
 bitnet-transformer = { path = "crates/bitnet-transformer", version = "0.2.1-dev" }
+bitnet-matmul-ref-core = { path = "crates/bitnet-matmul-ref-core", version = "0.2.1-dev" }
 bitnet-tests = { path = "tests", version = "0.2.1-dev", package = "bitnet-tests", default-features = false }
 candle-core = { version = "0.9.1", default-features = false }
 candle-nn = { version = "0.9.1", default-features = false }

--- a/crates/bitnet-matmul-ref-core/Cargo.toml
+++ b/crates/bitnet-matmul-ref-core/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bitnet-matmul-ref-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for deterministic CPU reference matmul helpers"
+rust-version.workspace = true
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-matmul-ref-core/src/lib.rs
+++ b/crates/bitnet-matmul-ref-core/src/lib.rs
@@ -1,0 +1,106 @@
+//! Deterministic CPU reference matrix multiplication helpers.
+//!
+//! This crate isolates small, backend-agnostic matmul helpers that are used by
+//! GPU validation tests and runtime sanity checks.
+
+/// Error returned when matrix dimensions and flat buffer lengths do not match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MatmulDimensionError {
+    /// Human-friendly matrix name (`"matrix A"` or `"matrix B"`).
+    pub name: &'static str,
+    /// Expected flat element count.
+    pub expected: usize,
+    /// Actual flat element count.
+    pub actual: usize,
+}
+
+impl std::fmt::Display for MatmulDimensionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "invalid dimensions for {}: expected {}, got {}",
+            self.name, self.expected, self.actual
+        )
+    }
+}
+
+impl std::error::Error for MatmulDimensionError {}
+
+/// Validate flattened matrix buffer sizes for `M×K` and `K×N` inputs.
+pub fn validate_flat_matmul_inputs(
+    a_len: usize,
+    b_len: usize,
+    m: u32,
+    n: u32,
+    k: u32,
+) -> Result<(), MatmulDimensionError> {
+    let expected_a = (m * k) as usize;
+    if a_len != expected_a {
+        return Err(MatmulDimensionError { name: "matrix A", expected: expected_a, actual: a_len });
+    }
+
+    let expected_b = (k * n) as usize;
+    if b_len != expected_b {
+        return Err(MatmulDimensionError { name: "matrix B", expected: expected_b, actual: b_len });
+    }
+
+    Ok(())
+}
+
+/// Compute `C = A × B` for row-major flattened matrices.
+pub fn cpu_matmul(a: &[f32], b: &[f32], m: u32, n: u32, k: u32) -> Vec<f32> {
+    validate_flat_matmul_inputs(a.len(), b.len(), m, n, k).unwrap_or_else(|e| panic!("{e}"));
+
+    let (m, n, k) = (m as usize, n as usize, k as usize);
+    let mut c = vec![0.0f32; m * n];
+    for row in 0..m {
+        for col in 0..n {
+            let mut sum = 0.0f32;
+            for i in 0..k {
+                sum += a[row * k + i] * b[i * n + col];
+            }
+            c[row * n + col] = sum;
+        }
+    }
+    c
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_matrix_a_size() {
+        let err = validate_flat_matmul_inputs(3, 4, 2, 2, 2).expect_err("expected size mismatch");
+        assert_eq!(err.name, "matrix A");
+        assert_eq!(err.expected, 4);
+        assert_eq!(err.actual, 3);
+    }
+
+    #[test]
+    fn validates_matrix_b_size() {
+        let err = validate_flat_matmul_inputs(4, 3, 2, 2, 2).expect_err("expected size mismatch");
+        assert_eq!(err.name, "matrix B");
+        assert_eq!(err.expected, 4);
+        assert_eq!(err.actual, 3);
+    }
+
+    #[test]
+    fn multiplies_non_square() {
+        #[rustfmt::skip]
+        let a = vec![1.0, 2.0, 3.0,
+                     4.0, 5.0, 6.0];
+        #[rustfmt::skip]
+        let b = vec![7.0,  8.0,
+                     9.0,  10.0,
+                     11.0, 12.0];
+        let c = cpu_matmul(&a, &b, 2, 2, 3);
+        assert_eq!(c, vec![58.0, 64.0, 139.0, 154.0]);
+    }
+
+    #[test]
+    #[should_panic(expected = "invalid dimensions for matrix A: expected 4, got 2")]
+    fn cpu_matmul_panics_on_invalid_a() {
+        cpu_matmul(&[1.0, 2.0], &[1.0; 4], 2, 2, 2);
+    }
+}

--- a/crates/bitnet-wgpu-runner/Cargo.toml
+++ b/crates/bitnet-wgpu-runner/Cargo.toml
@@ -7,6 +7,7 @@ description = "Kernel execution runner for wgpu compute pipelines"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+bitnet-matmul-ref-core = { path = "../bitnet-matmul-ref-core", version = "0.2.1-dev" }
 wgpu = { version = "24", features = ["vulkan-portability"] }
 bytemuck = { version = "1", features = ["derive"] }
 thiserror = "2"

--- a/crates/bitnet-wgpu-runner/src/lib.rs
+++ b/crates/bitnet-wgpu-runner/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod matmul;
 pub mod runner;
 
+pub use bitnet_matmul_ref_core::cpu_matmul;
 pub use error::RunnerError;
-pub use matmul::{MatmulRunner, cpu_matmul};
+pub use matmul::MatmulRunner;
 pub use runner::{CompiledKernel, KernelRunner};

--- a/crates/bitnet-wgpu-runner/src/matmul.rs
+++ b/crates/bitnet-wgpu-runner/src/matmul.rs
@@ -1,5 +1,8 @@
 use crate::error::RunnerError;
 use crate::runner::{KernelRunner, matmul_workgroups};
+use bitnet_matmul_ref_core::validate_flat_matmul_inputs;
+#[cfg(test)]
+use bitnet_matmul_ref_core::cpu_matmul;
 
 /// WGSL shader for naive matrix multiplication.
 ///
@@ -70,20 +73,11 @@ impl MatmulRunner {
         n: u32,
         k: u32,
     ) -> Result<Vec<f32>, RunnerError> {
-        let expected_a = (m * k) as usize;
-        if a.len() != expected_a {
+        if let Err(err) = validate_flat_matmul_inputs(a.len(), b.len(), m, n, k) {
             return Err(RunnerError::InvalidDimensions {
-                expected: expected_a,
-                actual: a.len(),
-                name: "matrix A",
-            });
-        }
-        let expected_b = (k * n) as usize;
-        if b.len() != expected_b {
-            return Err(RunnerError::InvalidDimensions {
-                expected: expected_b,
-                actual: b.len(),
-                name: "matrix B",
+                expected: err.expected,
+                actual: err.actual,
+                name: err.name,
             });
         }
 
@@ -113,29 +107,6 @@ impl MatmulRunner {
 
         self.runner.read_buffer_f32(&buf_c, (m * n) as usize).await
     }
-}
-
-/// CPU reference implementation of matrix multiplication for validation.
-///
-/// - `a`: M×K matrix in row-major order
-/// - `b`: K×N matrix in row-major order
-/// - Returns: M×N result matrix in row-major order
-pub fn cpu_matmul(a: &[f32], b: &[f32], m: u32, n: u32, k: u32) -> Vec<f32> {
-    let (m, n, k) = (m as usize, n as usize, k as usize);
-    assert_eq!(a.len(), m * k, "matrix A size mismatch");
-    assert_eq!(b.len(), k * n, "matrix B size mismatch");
-
-    let mut c = vec![0.0f32; m * n];
-    for row in 0..m {
-        for col in 0..n {
-            let mut sum = 0.0f32;
-            for i in 0..k {
-                sum += a[row * k + i] * b[i * n + col];
-            }
-            c[row * n + col] = sum;
-        }
-    }
-    c
 }
 
 #[cfg(test)]
@@ -246,13 +217,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "matrix A size mismatch")]
+    #[should_panic(expected = "invalid dimensions for matrix A: expected 4, got 2")]
     fn cpu_matmul_wrong_a_size() {
         cpu_matmul(&[1.0, 2.0], &[1.0; 4], 2, 2, 2);
     }
 
     #[test]
-    #[should_panic(expected = "matrix B size mismatch")]
+    #[should_panic(expected = "invalid dimensions for matrix B: expected 4, got 2")]
     fn cpu_matmul_wrong_b_size() {
         cpu_matmul(&[1.0; 4], &[1.0, 2.0], 2, 2, 2);
     }

--- a/tests/gpu_property_tests.rs
+++ b/tests/gpu_property_tests.rs
@@ -4,6 +4,7 @@
 //! Tolerance-based comparison accounts for floating-point differences between
 //! CPU and GPU execution paths.
 
+use bitnet_matmul_ref_core::cpu_matmul;
 use proptest::prelude::*;
 
 // ---------------------------------------------------------------------------
@@ -32,20 +33,6 @@ fn approx_eq(a: &[f32], b: &[f32], abs_tol: f32, rel_tol: f32) -> Result<(), Str
 // ---------------------------------------------------------------------------
 // CPU reference implementations
 // ---------------------------------------------------------------------------
-
-fn cpu_matmul(a: &[f32], b: &[f32], m: usize, n: usize, k: usize) -> Vec<f32> {
-    let mut c = vec![0.0f32; m * n];
-    for i in 0..m {
-        for j in 0..n {
-            let mut sum = 0.0f32;
-            for l in 0..k {
-                sum += a[i * k + l] * b[l * n + j];
-            }
-            c[i * n + j] = sum;
-        }
-    }
-    c
-}
 
 fn cpu_softmax(input: &[f32], rows: usize, cols: usize) -> Vec<f32> {
     let mut output = vec![0.0f32; rows * cols];
@@ -229,7 +216,7 @@ proptest! {
         for i in 0..k {
             eye[i * k + i] = 1.0;
         }
-        let result = cpu_matmul(&a, &eye, m, k, k);
+        let result = cpu_matmul(&a, &eye, m as u32, k as u32, k as u32);
         approx_eq(&a, &result, ABS_TOL, REL_TOL)?;
     }
 
@@ -237,7 +224,7 @@ proptest! {
     fn prop_matmul_zero(m in small_dim(), n in small_dim(), k in small_dim()) {
         let a = vec![0.0f32; m * k];
         let b: Vec<f32> = (0..k * n).map(|i| i as f32).collect();
-        let result = cpu_matmul(&a, &b, m, n, k);
+        let result = cpu_matmul(&a, &b, m as u32, n as u32, k as u32);
         approx_eq(&result, &vec![0.0f32; m * n], ABS_TOL, REL_TOL)?;
     }
 
@@ -245,7 +232,7 @@ proptest! {
     fn prop_matmul_finite(m in 1..=16usize, n in 1..=16usize, k in 1..=16usize) {
         let a: Vec<f32> = (0..m * k).map(|i| ((i % 7) as f32 - 3.0) * 0.5).collect();
         let b: Vec<f32> = (0..k * n).map(|i| ((i % 5) as f32 - 2.0) * 0.5).collect();
-        let result = cpu_matmul(&a, &b, m, n, k);
+        let result = cpu_matmul(&a, &b, m as u32, n as u32, k as u32);
         prop_assert_eq!(result.len(), m * n);
         for v in &result {
             prop_assert!(v.is_finite());


### PR DESCRIPTION
### Motivation

- Isolate deterministic CPU matrix-multiplication reference logic into a single SRP microcrate so multiple consumers (GPU runners, test harnesses) can share one authoritative implementation and validation.
- Remove duplicated CPU matmul code across the tree and centralize flat-buffer dimension validation to reduce divergence and make tests more maintainable.

### Description

- Added a new workspace microcrate `crates/bitnet-matmul-ref-core` providing `cpu_matmul`, `validate_flat_matmul_inputs`, and `MatmulDimensionError` with unit tests.
- Registered the new crate in the workspace `Cargo.toml` members and added it to root `dev-dependencies` so tests can consume it via `bitnet-matmul-ref-core`.
- Wired `crates/bitnet-wgpu-runner` to depend on the new microcrate, re-export `cpu_matmul` from the runner crate root, and replaced local matmul input checks in `MatmulRunner::multiply` with `validate_flat_matmul_inputs`.
- Updated `tests/gpu_property_tests.rs` to use the shared `cpu_matmul` (adjusting `usize -> u32` call sites) and removed the duplicate local `cpu_matmul` implementation; ran `cargo fmt` to update formatting.

### Testing

- Ran `cargo fmt` to format changes (completed successfully).
- Ran `cargo test -p bitnet-matmul-ref-core` (unit tests): all tests passed (`4 passed`).
- Ran `cargo test -p bitnet-wgpu-runner --lib`: library tests passed (24 passed; 4 tests ignored because they require a GPU runtime).
- Attempted `cargo test --test gpu_property_tests --no-run` to validate higher-level test target registration and observed that this particular test file is not exposed as a direct default-package test target in the workspace layout (command failed with "no test target named `gpu_property_tests`").

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e776adc483338690e4f49345fec9)