### PR TITLE
Extract shutdown signaling into a dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,7 @@ dependencies = [
  "bitnet-models",
  "bitnet-runtime-bootstrap",
  "bitnet-server-health-types-core",
+ "bitnet-shutdown-core",
  "bitnet-startup-contract-guard",
  "bitnet-tokenizers",
  "chrono",
@@ -1362,6 +1363,13 @@ version = "0.2.1-dev"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitnet-shutdown-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server-health-types-core", # SRP: reusable server health endpoint contract types
+  "crates/bitnet-shutdown-core", # SRP: shared shutdown signaling primitive
   "crates/bitnet-server",
   "crates/bitnet-cli-sampling-core", # SRP: reusable CLI sampling primitives
   "crates/bitnet-scoring-core", # SRP: reusable NLL/logit scoring primitives
@@ -156,6 +157,7 @@ default-members = [
   "crates/bitnet-feature-contract",
   "crates/bitnet-feature-matrix",
   "crates/bitnet-server-health-types-core",
+  "crates/bitnet-shutdown-core",
   "crates/bitnet-testing-policy-core",
   "crates/bitnet-testing-scenarios-core",
   "crates/bitnet-runtime-profile-core",

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -30,6 +30,7 @@ bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 bitnet-server-health-types-core = { path = "../bitnet-server-health-types-core", version = "0.2.1-dev" }
+bitnet-shutdown-core = { path = "../bitnet-shutdown-core", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true
 clap.workspace = true

--- a/crates/bitnet-server/src/shutdown.rs
+++ b/crates/bitnet-server/src/shutdown.rs
@@ -10,35 +10,35 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use bitnet_shutdown_core::ShutdownSignal;
 use tracing::{debug, info, warn};
 
 use crate::concurrency::ConcurrencyManager;
 
 /// Shutdown coordinator for graceful server termination
 pub struct ShutdownCoordinator {
-    shutdown_flag: Arc<AtomicBool>,
+    signal: ShutdownSignal,
 }
 
 impl ShutdownCoordinator {
     /// Create a new shutdown coordinator
     pub fn new() -> Self {
-        Self { shutdown_flag: Arc::new(AtomicBool::new(false)) }
+        Self { signal: ShutdownSignal::new() }
     }
 
     /// Get the shutdown flag for middleware
     pub fn flag(&self) -> Arc<AtomicBool> {
-        Arc::clone(&self.shutdown_flag)
+        self.signal.flag()
     }
 
     /// Check if shutdown has been initiated
     pub fn is_shutting_down(&self) -> bool {
-        self.shutdown_flag.load(AtomicOrdering::SeqCst)
+        self.signal.is_shutting_down()
     }
 
     /// Initiate graceful shutdown
     pub fn initiate_shutdown(&self) {
-        self.shutdown_flag.store(true, AtomicOrdering::SeqCst);
-        info!("Shutdown flag set - new requests will be rejected");
+        self.signal.initiate_shutdown();
     }
 
     /// Wait for active requests to drain

--- a/crates/bitnet-shutdown-core/Cargo.toml
+++ b/crates/bitnet-shutdown-core/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors.workspace = true
+categories.workspace = true
+description = "SRP core primitive for process shutdown signaling"
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+name = "bitnet-shutdown-core"
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+tracing.workspace = true

--- a/crates/bitnet-shutdown-core/src/lib.rs
+++ b/crates/bitnet-shutdown-core/src/lib.rs
@@ -1,0 +1,72 @@
+//! Shared shutdown signaling primitives.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tracing::info;
+
+/// Process-wide shutdown signal that can be shared across tasks.
+#[derive(Clone, Debug)]
+pub struct ShutdownSignal {
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl ShutdownSignal {
+    /// Create a new shutdown signal in the "not shutting down" state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { shutdown_flag: Arc::new(AtomicBool::new(false)) }
+    }
+
+    /// Returns an [`Arc`] to the underlying atomic flag.
+    #[must_use]
+    pub fn flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shutdown_flag)
+    }
+
+    /// Returns true if shutdown has been initiated.
+    #[must_use]
+    pub fn is_shutting_down(&self) -> bool {
+        self.shutdown_flag.load(Ordering::SeqCst)
+    }
+
+    /// Marks shutdown as initiated.
+    pub fn initiate_shutdown(&self) {
+        self.shutdown_flag.store(true, Ordering::SeqCst);
+        info!("Shutdown flag set - new requests will be rejected");
+    }
+}
+
+impl Default for ShutdownSignal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShutdownSignal;
+
+    #[test]
+    fn defaults_to_not_shutting_down() {
+        let signal = ShutdownSignal::default();
+        assert!(!signal.is_shutting_down());
+    }
+
+    #[test]
+    fn initiate_shutdown_sets_flag() {
+        let signal = ShutdownSignal::new();
+        signal.initiate_shutdown();
+        assert!(signal.is_shutting_down());
+    }
+
+    #[test]
+    fn cloned_signal_shares_state() {
+        let signal = ShutdownSignal::new();
+        let clone = signal.clone();
+
+        clone.initiate_shutdown();
+
+        assert!(signal.is_shutting_down());
+    }
+}


### PR DESCRIPTION
### Motivation

- Extract a small, reusable shutdown signaling primitive from the server to follow SRP and make coordinated shutdown state available to other runtime components.
- Reduce server implementation surface by delegating atomic flag lifecycle and logging to a framework-agnostic microcrate.

### Description

- Add new workspace microcrate `crates/bitnet-shutdown-core` implementing `ShutdownSignal` (new/`flag`/`is_shutting_down`/`initiate_shutdown`) and unit tests. 
- Wire `bitnet-shutdown-core` into the workspace `Cargo.toml` and `default-members` so it builds with standard workspace flows. 
- Update `crates/bitnet-server/Cargo.toml` to depend on `bitnet-shutdown-core` and refactor `ShutdownCoordinator` in `crates/bitnet-server/src/shutdown.rs` to delegate to `ShutdownSignal` while leaving request-drain logic and middleware in-place. 
- Update `Cargo.lock` to include the new package entry for `bitnet-shutdown-core`.

### Testing

- Ran `cargo fmt` successfully. 
- Ran `cargo test -p bitnet-shutdown-core` and all unit tests passed (`3` tests). 
- Ran `cargo check -p bitnet-server --lib` to validate the dependency wiring and compilation path (build started and progressed through the dependency graph; compilation was observed but terminated in this environment due to long compile-time constraints after confirming the new crate is discoverable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e776adc483338690e4f49345fec9)