### PR TITLE
Extract atomic file operations into reusable SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-atomic-file-core"
+version = "0.2.1-dev"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bitnet-bdd-grid"
 version = "0.2.1-dev"
 dependencies = [
@@ -462,6 +472,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "bitnet-atomic-file-core",
  "bitnet-cli-sampling-core",
  "bitnet-common",
  "bitnet-eval-core",
@@ -640,6 +651,7 @@ version = "0.1.0"
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-atomic-file-core",
  "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
@@ -970,6 +982,7 @@ name = "bitnet-models"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-atomic-file-core",
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
@@ -1148,6 +1161,7 @@ name = "bitnet-receipts-core"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-atomic-file-core",
  "bitnet-common",
  "bitnet-honest-compute",
  "bitnet-kernels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
+  "crates/bitnet-atomic-file-core", # SRP: atomic file replacement helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-nvidia",        # SRP: NVIDIA-specific tuning heuristics
@@ -174,6 +175,7 @@ default-members = [
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
+  "crates/bitnet-atomic-file-core", # SRP: atomic file replacement helpers
 ]
 
 [package]
@@ -388,6 +390,7 @@ required-features = ["cpu"]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { path = "crates/bitnet-atomic-file-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-atomic-file-core/Cargo.toml
+++ b/crates/bitnet-atomic-file-core/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "bitnet-atomic-file-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP atomic file write primitives for durable replace-style writes"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/bitnet-atomic-file-core/src/lib.rs
+++ b/crates/bitnet-atomic-file-core/src/lib.rs
@@ -1,0 +1,125 @@
+use serde::Serialize;
+use std::{fs, path::Path};
+
+/// Atomically replace a file by writing bytes to a sibling temporary path and renaming.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(file) = std::fs::File::open(&tmp) {
+            file.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+/// Serialize a value to pretty JSON and atomically replace the target file.
+
+/// Atomically replace `destination` by renaming an existing temporary file.
+pub fn atomic_rename(temp_path: &Path, destination: &Path) -> std::io::Result<()> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        if let Ok(file) = std::fs::File::open(temp_path) {
+            file.sync_all()?;
+        }
+    }
+
+    fs::rename(temp_path, destination)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = destination.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+pub fn atomic_write_json_pretty<T: Serialize>(
+    path: &Path,
+    value: &T,
+) -> Result<(), AtomicJsonError> {
+    let json = serde_json::to_vec_pretty(value)?;
+    atomic_write(path, &json)?;
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AtomicJsonError {
+    #[error(transparent)]
+    Serialize(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn writes_bytes_atomically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("state.bin");
+
+        atomic_write(&path, b"first").expect("write first");
+        assert_eq!(fs::read_to_string(&path).expect("read first"), "first");
+
+        atomic_write(&path, b"second").expect("write second");
+        assert_eq!(fs::read_to_string(&path).expect("read second"), "second");
+    }
+
+    #[test]
+    fn renames_temp_file_atomically() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let temp = dir.path().join("out.tmp");
+        let final_path = dir.path().join("out.bin");
+
+        File::create(&temp).expect("create temp");
+        fs::write(&temp, b"payload").expect("write temp");
+        atomic_rename(&temp, &final_path).expect("rename");
+
+        assert!(!temp.exists());
+        assert_eq!(fs::read_to_string(&final_path).expect("read"), "payload");
+    }
+
+    #[test]
+    fn writes_pretty_json_atomically() {
+        #[derive(Serialize)]
+        struct Payload {
+            answer: u32,
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("payload.json");
+
+        atomic_write_json_pretty(&path, &Payload { answer: 42 }).expect("write json");
+        let written = fs::read_to_string(&path).expect("read json");
+        assert!(written.contains("\"answer\": 42"));
+    }
+}

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -23,6 +23,7 @@ name = "bitnet"
 path = "src/main.rs"
 
 [dependencies]
+bitnet-atomic-file-core = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }

--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -57,6 +57,7 @@ use std::{
 use tokio::fs;
 use tracing::{debug, error, info, warn};
 
+use bitnet_atomic_file_core::atomic_write_json_pretty;
 use bitnet_inference::{InferenceEngine, KernelRecorder, SamplingConfig, TemplateType};
 use bitnet_models::ModelLoader;
 use bitnet_tokenizers::Tokenizer;
@@ -1039,10 +1040,8 @@ impl InferenceCommand {
             fs::create_dir_all(parent)?;
         }
 
-        // Atomic write: tmp → rename to prevent partial copies during chat
-        let tmp_path = receipt_path.with_extension("json.tmp");
-        fs::write(&tmp_path, serde_json::to_vec_pretty(&receipt)?)?;
-        fs::rename(&tmp_path, receipt_path)?;
+        // Atomic write to prevent partial copies during chat.
+        atomic_write_json_pretty(receipt_path, &receipt)?;
 
         debug!("Receipt written to {} ({} tokens)", receipt_path.display(), tokens_generated);
         Ok(())

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-atomic-file-core = { workspace = true }
 bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,12 @@
+pub use bitnet_atomic_file_core::atomic_write;
 pub use bitnet_download_core::{
     DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
+
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +18,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -15,6 +15,7 @@ include = [
 ]
 
 [dependencies]
+bitnet-atomic-file-core = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }

--- a/crates/bitnet-models/src/security.rs
+++ b/crates/bitnet-models/src/security.rs
@@ -1,5 +1,6 @@
 // Security utilities for model loading and verification
 use anyhow::{Result, anyhow};
+use bitnet_atomic_file_core::atomic_rename;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -200,7 +201,7 @@ impl SecureModelDownloader {
         self.verifier.verify_model(&temp_path, expected_hash)?;
 
         // Move to final destination
-        std::fs::rename(&temp_path, destination)?;
+        atomic_rename(&temp_path, destination)?;
 
         tracing::info!("Successfully downloaded and verified model: {}", destination.display());
         Ok(())

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+bitnet-atomic-file-core = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `performance_baseline`: Performance metrics
 
 use anyhow::{Result, anyhow};
+use bitnet_atomic_file_core::atomic_write;
 use bitnet_common::CorrectionRecord;
 use bitnet_honest_compute::{
     classify_compute_path, validate_compute_path as validate_honest_compute_path,
@@ -381,9 +382,7 @@ impl InferenceReceipt {
         let json = serde_json::to_string_pretty(self)?;
 
         // Atomic write: write to temp file, then rename
-        let temp_path = path.with_extension("tmp");
-        std::fs::write(&temp_path, json)?;
-        std::fs::rename(&temp_path, path)?;
+        atomic_write(path, json.as_bytes())?;
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Several crates duplicated replace-style atomic write/rename semantics for durable metadata and receipts, which risks subtle divergence in durability guarantees. 
- Centralizing the logic as a small SRP microcrate clarifies ownership of durability behavior and enables reuse across download, model, and receipt codepaths. 

### Description
- Add new microcrate `crates/bitnet-atomic-file-core` exporting `atomic_write`, `atomic_rename`, and `atomic_write_json_pretty` with unit tests for each behavior. 
- Wire the new crate into the workspace and workspace dependencies so it is available to consumers. 
- Refactor `crates/bitnet-download` to re-export and use `atomic_write` instead of duplicating temp-write/rename logic. 
- Refactor `crates/bitnet-receipts-core::InferenceReceipt::save`, `crates/bitnet-models::SecureModelDownloader`, and the CLI receipt path in `crates/bitnet-cli` to use `atomic_write` / `atomic_rename` / `atomic_write_json_pretty` respectively. 

### Testing
- Ran `cargo fmt` successfully to ensure style consistency. 
- Ran targeted library tests: `cargo test -p bitnet-atomic-file-core --lib`, `cargo test -p bitnet-download --lib`, `cargo test -p bitnet-receipts-core --lib`, `cargo test -p bitnet-models --lib`, and `cargo test -p bitnet-cli --lib`, and all of those lib tests passed. 
- A broader full-package test run (multi-package workspace run) surfaced a pre-existing, unrelated `bitnet-cli` integration test failure (`template_detect::test_detect_instruct_from_tokenizer_name`) which is not caused by these changes; scoped validation for touched packages was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e77533748333a4bf7975e43332c2)