### PR TITLE
Extract test-gating helpers into a dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,10 +1481,19 @@ name = "bitnet-test-fixtures-core"
 version = "0.2.1-dev"
 
 [[package]]
+name = "bitnet-test-gating-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-test-env",
+ "serial_test",
+]
+
+[[package]]
 name = "bitnet-test-support"
 version = "0.2.1-dev"
 dependencies = [
  "bitnet-test-env",
+ "bitnet-test-gating-core",
  "insta",
  "proptest",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ members = [
   "crates/bitnet-startup-contract-guard",
   "crates/bitnet-test-support",
   "crates/bitnet-test-env",
+  "crates/bitnet-test-gating-core",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
@@ -131,6 +132,7 @@ default-members = [
   "crates/bitnet-transformer",
   "crates/bitnet-test-support",
   "crates/bitnet-test-env",
+  "crates/bitnet-test-gating-core",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
@@ -467,6 +469,7 @@ tracing-test = "0.2.6"
 rand = "0.9.2"
 bitnet-test-support = { path = "crates/bitnet-test-support", version = "0.2.1-dev" }
 bitnet-test-env = { path = "crates/bitnet-test-env", version = "0.2.1-dev" }
+bitnet-test-gating-core = { path = "crates/bitnet-test-gating-core", version = "0.2.1-dev" }
 
 # HTTP client for examples
 reqwest = { version = "0.12.24", features = ["json"] }

--- a/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
+++ b/crates/bitnet-inference/tests/ac3_autoregressive_generation.rs
@@ -12,6 +12,7 @@ use bitnet_common::Device;
 use bitnet_inference::GenerationConfig;
 use bitnet_inference::InferenceEngine;
 use bitnet_models::{BitNetModel, Model};
+use bitnet_test_support::run_slow_tests;
 use bitnet_tokenizers::Tokenizer;
 use bitnet_tokenizers::UniversalTokenizer;
 use candle_core::Tensor as CandleTensor;
@@ -167,7 +168,7 @@ async fn test_ac3_basic_autoregressive_generation() -> Result<()> {
 #[cfg(feature = "cpu")]
 #[tokio::test]
 async fn test_ac3_temperature_sampling_validation() -> Result<()> {
-    if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
+    if !run_slow_tests() {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
         return Ok(());
     }
@@ -237,7 +238,7 @@ async fn test_ac3_temperature_sampling_validation() -> Result<()> {
 #[cfg(feature = "cpu")]
 #[tokio::test]
 async fn test_ac3_top_k_sampling_validation() -> Result<()> {
-    if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
+    if !run_slow_tests() {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
         return Ok(());
     }
@@ -304,7 +305,7 @@ async fn test_ac3_top_k_sampling_validation() -> Result<()> {
 #[cfg(feature = "cpu")]
 #[tokio::test]
 async fn test_ac3_nucleus_sampling_validation() -> Result<()> {
-    if std::env::var("BITNET_RUN_SLOW_TESTS").ok().as_deref() != Some("1") {
+    if !run_slow_tests() {
         eprintln!("⏭️  Skipping slow mock-generation test; set BITNET_RUN_SLOW_TESTS=1 to enable");
         return Ok(());
     }

--- a/crates/bitnet-test-gating-core/Cargo.toml
+++ b/crates/bitnet-test-gating-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-test-gating-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Test gating primitives for model-path and opt-in slow/e2e checks"
+publish = true
+
+[dependencies]
+
+[dev-dependencies]
+bitnet-test-env.workspace = true
+serial_test.workspace = true

--- a/crates/bitnet-test-gating-core/src/lib.rs
+++ b/crates/bitnet-test-gating-core/src/lib.rs
@@ -1,0 +1,33 @@
+//! # bitnet-test-gating-core
+//!
+//! Pure test-gating helpers for opt-in slow/E2E tests and model path discovery.
+
+#![deny(unused_must_use)]
+
+use std::path::PathBuf;
+
+/// Returns the model path from `BITNET_MODEL_PATH` env var, or `None` if not set.
+#[must_use]
+pub fn model_path() -> Option<PathBuf> {
+    std::env::var("BITNET_MODEL_PATH").ok().map(Into::into)
+}
+
+/// Returns true if an env var is exactly set to `"1"`.
+#[must_use]
+pub fn env_flag_enabled(key: &str) -> bool {
+    std::env::var(key).map(|v| v == "1").unwrap_or(false)
+}
+
+/// Returns `true` if slow / integration tests should run.
+/// Controlled by `BITNET_RUN_SLOW_TESTS=1`.
+#[must_use]
+pub fn run_slow_tests() -> bool {
+    env_flag_enabled("BITNET_RUN_SLOW_TESTS")
+}
+
+/// Returns `true` if end-to-end tests should run.
+/// Controlled by `BITNET_RUN_E2E=1`.
+#[must_use]
+pub fn run_e2e() -> bool {
+    env_flag_enabled("BITNET_RUN_E2E")
+}

--- a/crates/bitnet-test-gating-core/tests/gating_tests.rs
+++ b/crates/bitnet-test-gating-core/tests/gating_tests.rs
@@ -1,0 +1,48 @@
+use bitnet_test_env::{EnvGuard, EnvScope};
+use bitnet_test_gating_core::{env_flag_enabled, model_path, run_e2e, run_slow_tests};
+use serial_test::serial;
+
+#[test]
+#[serial(bitnet_env)]
+fn model_path_none_when_absent() {
+    let guard = EnvGuard::new("BITNET_MODEL_PATH");
+    guard.remove();
+    assert!(model_path().is_none());
+}
+
+#[test]
+#[serial(bitnet_env)]
+fn model_path_present_when_set() {
+    let guard = EnvGuard::new("BITNET_MODEL_PATH");
+    guard.set("/tmp/model.gguf");
+    assert_eq!(
+        model_path().and_then(|p| p.into_os_string().into_string().ok()),
+        Some(String::from("/tmp/model.gguf"))
+    );
+}
+
+#[test]
+#[serial(bitnet_env)]
+fn env_flag_enabled_only_for_one() {
+    let guard = EnvGuard::new("BITNET_FLAG_TEST");
+
+    guard.remove();
+    assert!(!env_flag_enabled("BITNET_FLAG_TEST"));
+
+    guard.set("0");
+    assert!(!env_flag_enabled("BITNET_FLAG_TEST"));
+
+    guard.set("1");
+    assert!(env_flag_enabled("BITNET_FLAG_TEST"));
+}
+
+#[test]
+#[serial(bitnet_env)]
+fn run_slow_and_e2e_delegate_to_flag_helper() {
+    let mut scope = EnvScope::new();
+    scope.set("BITNET_RUN_SLOW_TESTS", "1");
+    scope.set("BITNET_RUN_E2E", "0");
+
+    assert!(run_slow_tests());
+    assert!(!run_e2e());
+}

--- a/crates/bitnet-test-support/Cargo.toml
+++ b/crates/bitnet-test-support/Cargo.toml
@@ -11,6 +11,7 @@ publish = true
 
 [dependencies]
 bitnet-test-env.workspace = true
+bitnet-test-gating-core.workspace = true
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/bitnet-test-support/src/lib.rs
+++ b/crates/bitnet-test-support/src/lib.rs
@@ -12,34 +12,5 @@
 
 pub mod env_guard;
 
+pub use bitnet_test_gating_core::{env_flag_enabled, model_path, run_e2e, run_slow_tests};
 pub use env_guard::{EnvGuard, EnvScope};
-
-/// Returns the model path from `BITNET_MODEL_PATH` env var, or `None` if not set.
-/// Use this to gate tests that require a real GGUF model.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// #[test]
-/// fn test_real_model() {
-///     let Some(path) = bitnet_test_support::model_path() else {
-///         return; // skip if no model
-///     };
-///     // ...use path...
-/// }
-/// ```
-pub fn model_path() -> Option<std::path::PathBuf> {
-    std::env::var("BITNET_MODEL_PATH").ok().map(Into::into)
-}
-
-/// Returns `true` if slow / integration tests should run.
-/// Controlled by `BITNET_RUN_SLOW_TESTS=1`.
-pub fn run_slow_tests() -> bool {
-    std::env::var("BITNET_RUN_SLOW_TESTS").map(|v| v == "1").unwrap_or(false)
-}
-
-/// Returns `true` if end-to-end tests should run.
-/// Controlled by `BITNET_RUN_E2E=1`.
-pub fn run_e2e() -> bool {
-    std::env::var("BITNET_RUN_E2E").map(|v| v == "1").unwrap_or(false)
-}


### PR DESCRIPTION
### Motivation

- Separate pure test-gating policy (model-path discovery and opt-in slow/E2E flags) from environment-isolation primitives so each crate has a single Responsibility (SRP) and can be reused without cycles.

### Description

- Add a new microcrate `crates/bitnet-test-gating-core` providing `model_path()`, `env_flag_enabled()`, `run_slow_tests()`, and `run_e2e()` as pure, dependency-free helpers (`src/lib.rs`).
- Add focused unit tests for the new crate (`tests/gating_tests.rs`) verifying model-path behavior and strict `"1"` semantics for flags.
- Update `crates/bitnet-test-support` to re-export the gating helpers from `bitnet-test-gating-core` and keep the existing `EnvGuard`/`EnvScope` env-lock primitives (`src/lib.rs`, `Cargo.toml`).
- Wire the new crate into the workspace and dependency graph by updating `Cargo.toml` (members, default-members, and workspace dependencies) and `Cargo.lock`.
- Integrate the helper into an existing consumer by replacing direct `BITNET_RUN_SLOW_TESTS` env checks in `crates/bitnet-inference/tests/ac3_autoregressive_generation.rs` with `run_slow_tests()`.

### Testing

- Ran `cargo test -p bitnet-test-gating-core` and the gating tests passed (4 passed, 0 failed).
- Ran `cargo test -p bitnet-test-support` and the test-support suite passed (multiple unit and snapshot tests; all passed).
- Ran the combined run that included the AC3 generation test file using `run_slow_tests()` and it executed successfully (the slow integration tests are gate-guarded and did not run by default, reporting 0 tests executed for that invocation).
- Ran `cargo fmt` to ensure formatting; it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e77533748333a4bf7975e43332c2)