### PR TITLE
Extract SafeTensors discovery into reusable core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-safetensors-discovery-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
 name = "bitnet-safetensors-ln"
 version = "0.2.1-dev"
 dependencies = [
@@ -1381,6 +1390,7 @@ name = "bitnet-st-tools"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-safetensors-discovery-core",
  "bitnet-safetensors-ln",
  "bytemuck",
  "clap",
@@ -1389,7 +1399,6 @@ dependencies = [
  "safetensors 0.6.2",
  "serde_json",
  "tempfile",
- "walkdir",
 ]
 
 [[package]]
@@ -1399,6 +1408,7 @@ dependencies = [
  "anyhow",
  "bitnet-common",
  "bitnet-models",
+ "bitnet-safetensors-discovery-core",
  "bytemuck",
  "clap",
  "console 0.16.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
   "crates/bitnet-cli",
   "crates/bitnet-st2gguf",      # SafeTensors to GGUF converter
   "crates/bitnet-safetensors-ln", # SRP: shared SafeTensors LayerNorm utilities
+  "crates/bitnet-safetensors-discovery-core", # SRP: shared SafeTensors file discovery helpers
   "crates/bitnet-st-tools",     # SafeTensors inspection & merge utilities
   "crates/bitnet-trace",        # Tensor activation tracing for cross-validation
   "crates/bitnet-ffi",
@@ -387,6 +388,7 @@ required-features = ["cpu"]
 [workspace.dependencies]
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
+bitnet-safetensors-discovery-core = { path = "crates/bitnet-safetensors-discovery-core", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"

--- a/crates/bitnet-safetensors-discovery-core/Cargo.toml
+++ b/crates/bitnet-safetensors-discovery-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-safetensors-discovery-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "SRP core helpers for discovering SafeTensors files from file or directory inputs"
+
+[dependencies]
+thiserror.workspace = true
+walkdir = "2.5.0"
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/bitnet-safetensors-discovery-core/src/lib.rs
+++ b/crates/bitnet-safetensors-discovery-core/src/lib.rs
@@ -1,0 +1,117 @@
+//! Pure discovery helpers for resolving SafeTensors inputs.
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use walkdir::WalkDir;
+
+#[derive(Debug, Error)]
+pub enum SafetensorsDiscoveryError {
+    #[error("input path does not exist: {0}")]
+    InputDoesNotExist(PathBuf),
+    #[error("input file is not .safetensors: {0}")]
+    InputIsNotSafetensors(PathBuf),
+    #[error("no .safetensors files found in {0}")]
+    NoSafetensorsFiles(PathBuf),
+    #[error(transparent)]
+    Walkdir(#[from] walkdir::Error),
+}
+
+/// Collect all `.safetensors` files from a single file input or a directory.
+///
+/// For directory input, only depth-1 files are considered and output paths are sorted.
+pub fn collect_safetensors_files(input: &Path) -> Result<Vec<PathBuf>, SafetensorsDiscoveryError> {
+    if !input.exists() {
+        return Err(SafetensorsDiscoveryError::InputDoesNotExist(input.to_path_buf()));
+    }
+
+    let mut out = vec![];
+    if input.is_file() {
+        if is_safetensors(input) {
+            out.push(input.to_path_buf());
+        } else {
+            return Err(SafetensorsDiscoveryError::InputIsNotSafetensors(input.to_path_buf()));
+        }
+    } else {
+        for entry in WalkDir::new(input).min_depth(1).max_depth(1) {
+            let entry = entry?;
+            if entry.file_type().is_file() {
+                let path = entry.path();
+                if is_safetensors(path) {
+                    out.push(path.to_path_buf());
+                }
+            }
+        }
+    }
+
+    if out.is_empty() {
+        return Err(SafetensorsDiscoveryError::NoSafetensorsFiles(input.to_path_buf()));
+    }
+
+    out.sort();
+    Ok(out)
+}
+
+/// Resolve the first `.safetensors` file for an input file or directory.
+pub fn resolve_first_safetensors_file(input: &Path) -> Result<PathBuf, SafetensorsDiscoveryError> {
+    let mut files = collect_safetensors_files(input)?;
+    Ok(files.remove(0))
+}
+
+fn is_safetensors(path: &Path) -> bool {
+    path.extension().and_then(|s| s.to_str()) == Some("safetensors")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn collects_from_single_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("model.safetensors");
+        fs::write(&file, b"x").unwrap();
+
+        let files = collect_safetensors_files(&file).unwrap();
+        assert_eq!(files, vec![file]);
+    }
+
+    #[test]
+    fn rejects_non_safetensors_single_file() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("model.bin");
+        fs::write(&file, b"x").unwrap();
+
+        let err = collect_safetensors_files(&file).unwrap_err();
+        assert!(matches!(err, SafetensorsDiscoveryError::InputIsNotSafetensors(_)));
+    }
+
+    #[test]
+    fn collects_depth_one_files_sorted() {
+        let dir = tempdir().unwrap();
+        let b = dir.path().join("b.safetensors");
+        let a = dir.path().join("a.safetensors");
+        let subdir = dir.path().join("nested");
+        fs::create_dir_all(&subdir).unwrap();
+        let nested = subdir.join("nested.safetensors");
+        fs::write(&a, b"a").unwrap();
+        fs::write(&b, b"b").unwrap();
+        fs::write(&nested, b"n").unwrap();
+
+        let files = collect_safetensors_files(dir.path()).unwrap();
+        assert_eq!(files, vec![a, b]);
+    }
+
+    #[test]
+    fn resolve_first_returns_sorted_first() {
+        let dir = tempdir().unwrap();
+        let b = dir.path().join("b.safetensors");
+        let a = dir.path().join("a.safetensors");
+        fs::write(&a, b"a").unwrap();
+        fs::write(&b, b"b").unwrap();
+
+        let first = resolve_first_safetensors_file(dir.path()).unwrap();
+        assert_eq!(first, a);
+    }
+}

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -12,7 +12,7 @@ description = "SafeTensors utilities for BitNet: LN inspection and LN-preserving
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }
 bitnet-safetensors-ln = { path = "../bitnet-safetensors-ln", version = "0.2.1-dev" }
-walkdir = "2.5.0"
+bitnet-safetensors-discovery-core = { path = "../bitnet-safetensors-discovery-core", version = "0.2.1-dev" }
 safetensors = "0.6.2"
 half = "2.7.1"
 bytemuck = { version = "1.24.0", features = ["extern_crate_alloc"] }

--- a/crates/bitnet-st-tools/src/bin/st-merge-ln-f16.rs
+++ b/crates/bitnet-st-tools/src/bin/st-merge-ln-f16.rs
@@ -7,10 +7,10 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use walkdir::WalkDir;
 
 #[path = "../common.rs"]
 mod common;
+use bitnet_safetensors_discovery_core::collect_safetensors_files;
 use common::{cast_ln_to_f16, is_ln_gamma, read_safetensors_bytes};
 
 #[derive(Parser, Debug)]
@@ -30,29 +30,7 @@ struct Cli {
 }
 
 fn collect_files(input: &Path) -> Result<Vec<PathBuf>> {
-    let mut out = vec![];
-    if input.is_file() {
-        if input.extension().and_then(|s| s.to_str()) == Some("safetensors") {
-            out.push(input.to_path_buf());
-        } else {
-            return Err(anyhow!("input file is not .safetensors"));
-        }
-    } else {
-        for e in WalkDir::new(input).min_depth(1).max_depth(1) {
-            let e = e?;
-            if e.file_type().is_file() {
-                let p = e.path();
-                if p.extension().and_then(|s| s.to_str()) == Some("safetensors") {
-                    out.push(p.to_path_buf());
-                }
-            }
-        }
-    }
-    if out.is_empty() {
-        return Err(anyhow!("no .safetensors files found in {}", input.display()));
-    }
-    out.sort();
-    Ok(out)
+    Ok(collect_safetensors_files(input)?)
 }
 
 fn main() -> Result<()> {

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 # BitNet-rs internal crates
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
+bitnet-safetensors-discovery-core = { path = "../bitnet-safetensors-discovery-core", version = "0.2.1-dev" }
 
 # Core dependencies
 anyhow.workspace = true

--- a/crates/bitnet-st2gguf/src/main.rs
+++ b/crates/bitnet-st2gguf/src/main.rs
@@ -41,6 +41,7 @@ mod layernorm;
 mod writer;
 
 use anyhow::{Context, Result, bail, ensure};
+use bitnet_safetensors_discovery_core::resolve_first_safetensors_file;
 use clap::Parser;
 use half::f16;
 use safetensors::SafeTensors;
@@ -183,21 +184,7 @@ fn resolve_input(input: &Path) -> Result<(PathBuf, Option<PathBuf>)> {
 
 /// Find the first *.safetensors file in a directory
 fn find_safetensors(dir: &Path) -> Result<PathBuf> {
-    let entries = fs::read_dir(dir)
-        .with_context(|| format!("Failed to read directory: {}", dir.display()))?;
-
-    for entry in entries {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file()
-            && let Some(ext) = path.extension()
-            && ext == "safetensors"
-        {
-            return Ok(path);
-        }
-    }
-
-    bail!("No *.safetensors file found in directory: {}", dir.display())
+    resolve_first_safetensors_file(dir).map_err(Into::into)
 }
 
 /// Load config.json if it exists


### PR DESCRIPTION
### Motivation
- Multiple SafeTensors tools duplicated file-or-directory discovery logic, so extract that responsibility into a single SRP microcrate to make discovery deterministic and reusable.
- Centralizing discovery reduces code duplication and keeps CLI/tool logic focused on conversion and LayerNorm handling.

### Description
- Added a new microcrate `crates/bitnet-safetensors-discovery-core` that provides `collect_safetensors_files` and `resolve_first_safetensors_file` along with typed errors (`SafetensorsDiscoveryError`) and unit tests (new files: `crates/bitnet-safetensors-discovery-core/Cargo.toml`, `crates/bitnet-safetensors-discovery-core/src/lib.rs`).
- Updated workspace manifests and dependencies to include the new crate in `Cargo.toml` and `workspace.dependencies` so other crates can reuse it.
- Replaced duplicated discovery code in `crates/bitnet-st-tools/src/bin/st-merge-ln-f16.rs` and `crates/bitnet-st2gguf/src/main.rs` to call the shared helpers instead of local implementations, and adjusted those crates' `Cargo.toml` to depend on the new microcrate.
- Minor cleanup: removed `walkdir` usage from the two tools and imported the shared API; ensured imports (e.g. `anyhow::anyhow`) compile cleanly.

### Testing
- Ran unit tests for the new microcrate with `cargo test -p bitnet-safetensors-discovery-core` and they passed (`4 passed; 0 failed`).
- Ran integration/unit tests for the converter with `cargo test -p bitnet-st2gguf --tests` and they passed (all tests passed in that crate).
- Built and ran the test binary for the merge tool with `cargo test -p bitnet-st-tools --bin st-merge-ln-f16 --no-run` (compilation succeeded) and validated the test suite for `st-merge-ln-f16` during workspace test runs (all relevant tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e77533748333a4bf7975e43332c2)