### PR TITLE
Extract device-probe env override parsing into new SRP core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,6 +620,7 @@ version = "0.2.1-dev"
 dependencies = [
  "ash",
  "bitnet-common",
+ "bitnet-device-probe-env-core",
  "bitnet-intel-gpu-id",
  "insta",
  "libloading 0.8.9",
@@ -631,6 +632,10 @@ dependencies = [
  "temp-env",
  "wgpu",
 ]
+
+[[package]]
+name = "bitnet-device-probe-env-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-dispatch-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
   "crates/bitnet-sampling",
       "crates/bitnet-transformer",  # Extracted from bitnet-models; depends on bitnet-quantization
   "crates/bitnet-device-probe",  # SRP: device detection / capability probing
+  "crates/bitnet-device-probe-env-core", # SRP: env parsing core for device-probe overrides
   "crates/bitnet-device-config-core", # SRP: shared device config parsing + resolution core
   "crates/bitnet-intel-gpu-id",  # SRP: Intel GPU/Arc identification heuristics
   "crates/bitnet-logits",        # SRP: pure logits transform functions
@@ -161,6 +162,7 @@ default-members = [
   "crates/bitnet-runtime-profile-core",
   # SRP microcrate extractions (phase-6)
   "crates/bitnet-device-probe",
+  "crates/bitnet-device-probe-env-core",
   "crates/bitnet-logits",
   "crates/bitnet-probability",
   "crates/bitnet-logits-filters",

--- a/crates/bitnet-device-probe-env-core/Cargo.toml
+++ b/crates/bitnet-device-probe-env-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-device-probe-env-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core helpers for BitNet device-probe environment overrides"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-device-probe-env-core/src/lib.rs
+++ b/crates/bitnet-device-probe-env-core/src/lib.rs
@@ -1,0 +1,76 @@
+use std::collections::HashSet;
+
+/// Returns true when strict-mode is enabled and fake runtime overrides should be ignored.
+#[must_use]
+pub fn strict_mode_enabled() -> bool {
+    strict_mode_enabled_from_value(std::env::var("BITNET_STRICT_MODE").ok().as_deref())
+}
+
+/// Parse strict-mode from an optional env value.
+#[must_use]
+pub fn strict_mode_enabled_from_value(value: Option<&str>) -> bool {
+    value
+        .map(|v| {
+            let normalized = v.trim().to_ascii_lowercase();
+            normalized == "1" || normalized == "true"
+        })
+        .unwrap_or(false)
+}
+
+/// Parse a fake GPU backend set from BITNET_GPU_FAKE.
+///
+/// Returns an empty set for `none` and supports delimiters: `, ; | <space>`.
+#[must_use]
+pub fn parse_fake_gpu_backends(value: &str) -> HashSet<String> {
+    let normalized = value.trim().to_ascii_lowercase();
+    if normalized == "none" {
+        return HashSet::new();
+    }
+
+    normalized
+        .split([',', ';', '|', ' '])
+        .filter(|part| !part.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// Resolve fake GPU backend overrides from environment unless strict-mode is enabled.
+#[must_use]
+pub fn fake_gpu_backends() -> Option<HashSet<String>> {
+    if strict_mode_enabled() {
+        return None;
+    }
+
+    let fake = std::env::var("BITNET_GPU_FAKE").ok()?;
+    Some(parse_fake_gpu_backends(&fake))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strict_mode_parsing_works() {
+        assert!(strict_mode_enabled_from_value(Some("1")));
+        assert!(strict_mode_enabled_from_value(Some("true")));
+        assert!(strict_mode_enabled_from_value(Some("TRUE")));
+        assert!(!strict_mode_enabled_from_value(Some("0")));
+        assert!(!strict_mode_enabled_from_value(Some("false")));
+        assert!(!strict_mode_enabled_from_value(None));
+    }
+
+    #[test]
+    fn fake_backend_parsing_supports_multiple_delimiters() {
+        let parsed = parse_fake_gpu_backends("cuda, rocm;oneapi|gpu");
+        assert!(parsed.contains("cuda"));
+        assert!(parsed.contains("rocm"));
+        assert!(parsed.contains("oneapi"));
+        assert!(parsed.contains("gpu"));
+    }
+
+    #[test]
+    fn fake_backend_none_means_empty_override_set() {
+        let parsed = parse_fake_gpu_backends("none");
+        assert!(parsed.is_empty());
+    }
+}

--- a/crates/bitnet-device-probe/Cargo.toml
+++ b/crates/bitnet-device-probe/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-intel-gpu-id = { path = "../bitnet-intel-gpu-id", version = "0.2.1-dev" }
+bitnet-device-probe-env-core = { path = "../bitnet-device-probe-env-core", version = "0.2.1-dev" }
 log.workspace = true
 ash = { version = "0.38.0", optional = true }
 opencl3 = { version = "0.9", optional = true }

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -4,6 +4,8 @@
 //! extracted from `bitnet-kernels` for use by the broader workspace.
 
 pub use bitnet_common::kernel_registry::SimdLevel;
+#[cfg(any(feature = "gpu", feature = "cuda", feature = "rocm", feature = "oneapi"))]
+use bitnet_device_probe_env_core::fake_gpu_backends;
 
 pub mod intel_arc;
 pub use intel_arc::{
@@ -178,35 +180,6 @@ pub fn gpu_available_runtime() -> bool {
 #[inline]
 pub const fn gpu_available_runtime() -> bool {
     false
-}
-
-#[cfg(any(feature = "gpu", feature = "cuda", feature = "rocm", feature = "oneapi"))]
-fn strict_mode_enabled() -> bool {
-    std::env::var("BITNET_STRICT_MODE")
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false)
-}
-
-#[cfg(any(feature = "gpu", feature = "cuda", feature = "rocm", feature = "oneapi"))]
-fn fake_gpu_backends() -> Option<std::collections::HashSet<String>> {
-    if strict_mode_enabled() {
-        return None;
-    }
-
-    let fake = std::env::var("BITNET_GPU_FAKE").ok()?;
-    let normalized = fake.trim().to_ascii_lowercase();
-
-    if normalized == "none" {
-        return Some(std::collections::HashSet::new());
-    }
-
-    let set = normalized
-        .split([',', ';', '|', ' '])
-        .filter(|part| !part.is_empty())
-        .map(ToOwned::to_owned)
-        .collect();
-
-    Some(set)
 }
 
 #[cfg(any(feature = "gpu", feature = "cuda", feature = "rocm", feature = "oneapi"))]


### PR DESCRIPTION
### Motivation
- `bitnet-device-probe` contained both hardware probing and environment-override parsing responsibilities which are reusable and suitable to isolate into a small SRP core crate.
- Centralizing `BITNET_STRICT_MODE` and `BITNET_GPU_FAKE` parsing reduces duplication and makes env-parsing policy easier to test and reuse.

### Description
- Add a new microcrate `bitnet-device-probe-env-core` that implements `strict_mode_enabled`, `strict_mode_enabled_from_value`, `parse_fake_gpu_backends`, and `fake_gpu_backends` along with focused unit tests for parsing behavior.
- Wire the new crate into the workspace `Cargo.toml` and add it as a dependency in `crates/bitnet-device-probe/Cargo.toml`.
- Remove the duplicated env-parsing implementation from `crates/bitnet-device-probe/src/lib.rs` and consume `fake_gpu_backends()` from the new core crate.
- Apply `cargo fmt` to ensure consistent formatting.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test -p bitnet-device-probe-env-core --lib` and all tests passed (3 passed, 0 failed).
- Ran `cargo check -p bitnet-device-probe-env-core && cargo check -p bitnet-device-probe --no-default-features` and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e77533748333a4bf7975e43332c2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new internal library module for environment-driven configuration helpers, improving code organization and reusability across the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->