### PR TITLE
Extract tokenizer vocabulary logic into `bitnet-vocabulary-core` microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ dependencies = [
  "bitnet-test-support",
  "bitnet-tests",
  "bitnet-tokenizer-model-core",
+ "bitnet-vocabulary-core",
  "dirs",
  "futures-util",
  "insta",
@@ -1781,6 +1782,15 @@ dependencies = [
  "serde",
  "serde_yaml_ng",
  "tempfile",
+]
+
+[[package]]
+name = "bitnet-vocabulary-core"
+version = "0.2.1-dev"
+dependencies = [
+ "bitnet-common",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/bitnet-rope",
   "crates/bitnet-tokenizers",
   "crates/bitnet-tokenizer-model-core", # SRP: tokenizer model/vocabulary detection helpers
+  "crates/bitnet-vocabulary-core", # SRP: shared vocabulary and special-token primitives
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
@@ -135,6 +136,7 @@ default-members = [
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
   "crates/bitnet-tokenizer-model-core",
+  "crates/bitnet-vocabulary-core",
   "crates/bitnet-tokenizer-discovery-core",
   "crates/bitnet-cpu-activations", # SRP: CPU activation kernels shared microcrate
   "crates/bitnet-kernels",

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -21,6 +21,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizer-model-core = { path = "../bitnet-tokenizer-model-core", version = "0.2.1-dev" }
+bitnet-vocabulary-core = { path = "../bitnet-vocabulary-core", version = "0.2.1-dev" }
 anyhow.workspace = true
 tracing.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -26,7 +26,7 @@ pub mod error_handling;
 pub mod fallback;
 pub mod strategy;
 pub mod utils;
-pub mod vocabulary;
+pub use bitnet_vocabulary_core as vocabulary;
 
 use bitnet_common::{BitNetError, ModelError, Result};
 use std::path::Path;

--- a/crates/bitnet-vocabulary-core/Cargo.toml
+++ b/crates/bitnet-vocabulary-core/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bitnet-vocabulary-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP vocabulary and special-token primitives extracted from bitnet-tokenizers"
+
+[dependencies]
+bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-vocabulary-core/src/lib.rs
+++ b/crates/bitnet-vocabulary-core/src/lib.rs
@@ -1,0 +1,245 @@
+//! Shared vocabulary management primitives.
+//!
+//! Provides efficient token↔ID lookup, special token handling, and vocabulary
+//! operations such as merging multiple vocabularies for multi-model scenarios.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Deserialize;
+
+use bitnet_common::{BitNetError, Result};
+
+/// Configuration for special tokens in a vocabulary.
+#[derive(Debug, Clone, Default, serde::Serialize, Deserialize)]
+pub struct VocabConfig {
+    pub unk_token: Option<String>,
+    pub bos_token: Option<String>,
+    pub eos_token: Option<String>,
+    pub pad_token: Option<String>,
+    pub additional_special_tokens: Vec<String>,
+}
+
+/// Resolved special-token IDs for fast runtime checks.
+#[derive(Debug, Clone, Default)]
+pub struct SpecialTokens {
+    pub unk_id: Option<u32>,
+    pub bos_id: Option<u32>,
+    pub eos_id: Option<u32>,
+    pub pad_id: Option<u32>,
+    /// All special token IDs (including BOS/EOS/UNK/PAD and additional).
+    all_ids: HashSet<u32>,
+}
+
+impl SpecialTokens {
+    /// Returns `true` if `id` is any registered special token.
+    pub fn contains(&self, id: u32) -> bool {
+        self.all_ids.contains(&id)
+    }
+}
+
+/// Bidirectional vocabulary with O(1) lookups in both directions.
+#[derive(Debug, Clone)]
+pub struct Vocabulary {
+    token_to_id: HashMap<String, u32>,
+    id_to_token: HashMap<u32, String>,
+    config: VocabConfig,
+    special: SpecialTokens,
+}
+
+impl Vocabulary {
+    /// Build a vocabulary from an explicit token→ID map and config.
+    pub fn new(token_to_id: HashMap<String, u32>, config: VocabConfig) -> Self {
+        let id_to_token: HashMap<u32, String> =
+            token_to_id.iter().map(|(t, &id)| (id, t.clone())).collect();
+        let special = Self::resolve_special(&token_to_id, &config);
+        Self { token_to_id, id_to_token, config, special }
+    }
+
+    /// Load vocabulary from the "model" → "vocab" section of a
+    /// HuggingFace `tokenizer.json` file.
+    pub fn from_json(data: &str) -> Result<Self> {
+        #[derive(Deserialize)]
+        struct ModelSection {
+            vocab: HashMap<String, u32>,
+        }
+        #[derive(Deserialize)]
+        struct Root {
+            model: ModelSection,
+            #[serde(default)]
+            added_tokens: Vec<AddedToken>,
+        }
+        #[derive(Deserialize)]
+        struct AddedToken {
+            content: String,
+            id: u32,
+            special: bool,
+        }
+
+        let root: Root = serde_json::from_str(data)
+            .map_err(|e| BitNetError::Config(format!("failed to parse vocabulary JSON: {e}")))?;
+
+        let mut token_to_id = root.model.vocab;
+        let mut additional: Vec<String> = Vec::new();
+        for at in &root.added_tokens {
+            token_to_id.entry(at.content.clone()).or_insert(at.id);
+            if at.special {
+                additional.push(at.content.clone());
+            }
+        }
+
+        let config =
+            VocabConfig { additional_special_tokens: additional, ..VocabConfig::default() };
+
+        Ok(Self::new(token_to_id, config))
+    }
+
+    pub fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.token_to_id.get(token).copied()
+    }
+
+    pub fn id_to_token(&self, id: u32) -> Option<&str> {
+        self.id_to_token.get(&id).map(String::as_str)
+    }
+
+    pub fn contains(&self, token: &str) -> bool {
+        self.token_to_id.contains_key(token)
+    }
+
+    pub fn is_special_token(&self, id: u32) -> bool {
+        self.special.contains(id)
+    }
+
+    pub fn vocab_size(&self) -> usize {
+        self.token_to_id.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, u32)> {
+        self.token_to_id.iter().map(|(t, &id)| (t.as_str(), id))
+    }
+
+    pub fn config(&self) -> &VocabConfig {
+        &self.config
+    }
+
+    pub fn special_tokens(&self) -> &SpecialTokens {
+        &self.special
+    }
+
+    pub fn merge_vocabularies(vocabs: &[Vocabulary]) -> Vocabulary {
+        let mut merged: Vec<String> = Vec::new();
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut all_additional: Vec<String> = Vec::new();
+
+        for vocab in vocabs {
+            let mut pairs: Vec<(&str, u32)> = vocab.iter().collect();
+            pairs.sort_by_key(|&(_, id)| id);
+            for (tok, _) in pairs {
+                if seen.insert(tok.to_string()) {
+                    merged.push(tok.to_string());
+                }
+            }
+            for extra in &vocab.config.additional_special_tokens {
+                if !all_additional.contains(extra) {
+                    all_additional.push(extra.clone());
+                }
+            }
+        }
+
+        let token_to_id: HashMap<String, u32> =
+            merged.into_iter().enumerate().map(|(i, t)| (t, i as u32)).collect();
+
+        let config =
+            VocabConfig { additional_special_tokens: all_additional, ..VocabConfig::default() };
+
+        Vocabulary::new(token_to_id, config)
+    }
+
+    fn resolve_special(map: &HashMap<String, u32>, config: &VocabConfig) -> SpecialTokens {
+        let resolve = |opt: &Option<String>| -> Option<u32> {
+            opt.as_ref().and_then(|t| map.get(t.as_str()).copied())
+        };
+
+        let unk_id = resolve(&config.unk_token);
+        let bos_id = resolve(&config.bos_token);
+        let eos_id = resolve(&config.eos_token);
+        let pad_id = resolve(&config.pad_token);
+
+        let mut all_ids: HashSet<u32> = HashSet::new();
+        for id in [unk_id, bos_id, eos_id, pad_id].into_iter().flatten() {
+            all_ids.insert(id);
+        }
+        for tok in &config.additional_special_tokens {
+            if let Some(&id) = map.get(tok.as_str()) {
+                all_ids.insert(id);
+            }
+        }
+
+        SpecialTokens { unk_id, bos_id, eos_id, pad_id, all_ids }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_map() -> HashMap<String, u32> {
+        HashMap::from([
+            ("hello".into(), 0),
+            ("world".into(), 1),
+            ("<unk>".into(), 2),
+            ("<s>".into(), 3),
+            ("</s>".into(), 4),
+            ("<pad>".into(), 5),
+        ])
+    }
+
+    fn sample_config() -> VocabConfig {
+        VocabConfig {
+            unk_token: Some("<unk>".into()),
+            bos_token: Some("<s>".into()),
+            eos_token: Some("</s>".into()),
+            pad_token: Some("<pad>".into()),
+            additional_special_tokens: vec![],
+        }
+    }
+
+    fn sample_vocab() -> Vocabulary {
+        Vocabulary::new(sample_map(), sample_config())
+    }
+
+    #[test]
+    fn test_basic_construction_and_lookup() {
+        let v = sample_vocab();
+        assert_eq!(v.token_to_id("hello"), Some(0));
+        assert_eq!(v.token_to_id("world"), Some(1));
+        assert_eq!(v.id_to_token(0), Some("hello"));
+        assert_eq!(v.id_to_token(1), Some("world"));
+    }
+
+    #[test]
+    fn test_vocab_size() {
+        let v = sample_vocab();
+        assert_eq!(v.vocab_size(), 6);
+    }
+
+    #[test]
+    fn test_special_token_identification() {
+        let v = sample_vocab();
+        assert!(v.is_special_token(2));
+        assert!(v.is_special_token(3));
+        assert!(v.is_special_token(4));
+        assert!(v.is_special_token(5));
+        assert!(!v.is_special_token(0));
+        assert!(!v.is_special_token(1));
+    }
+
+    #[test]
+    fn test_special_tokens_struct_accessors() {
+        let v = sample_vocab();
+        let st = v.special_tokens();
+        assert_eq!(st.unk_id, Some(2));
+        assert_eq!(st.bos_id, Some(3));
+        assert_eq!(st.eos_id, Some(4));
+        assert_eq!(st.pad_id, Some(5));
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce coupling by extracting cohesive vocabulary and special-token logic into a small, dependency-light SRP microcrate for reuse across the workspace.
- Preserve existing public API for consumers of `bitnet-tokenizers` while enabling independent testing and maintenance of vocabulary primitives.

### Description
- Added a new crate `crates/bitnet-vocabulary-core` providing `VocabConfig`, `SpecialTokens`, `Vocabulary`, JSON loading, merging, and unit tests in `src/lib.rs` and a `Cargo.toml` manifest.
- Wired the new crate into the workspace `Cargo.toml` and `default-members` so it builds and tests as a first-class microcrate.
- Updated `crates/bitnet-tokenizers` to depend on and re-export the new crate via `pub use bitnet_vocabulary_core as vocabulary;` so existing consumers keep the `bitnet_tokenizers::vocabulary` path.
- Regenerated lockfile entries to include the new crate and added unit tests that mirror the original vocabulary behavior.

### Testing
- Ran `cargo test -p bitnet-vocabulary-core`, which completed successfully (4 passed, 0 failed).
- Ran `cargo test -p bitnet-tokenizers --lib vocabulary`, which built successfully (tests filtered/none run for that target) and did not fail.
- Ran `cargo fmt --all` to normalize formatting, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4e776adc483338690e4f49345fec9)