### PR TITLE
test(fuzz): add wave 22 fuzz targets (6 new, 90 total)

### DIFF
--- a/crates/bitnet-inference/src/cpu_opt.rs
+++ b/crates/bitnet-inference/src/cpu_opt.rs
@@ -732,16 +732,8 @@ mod tests {
     #[test]
     fn test_silu_numerical_stability_extremes() {
         let out = silu(&[100.0, -100.0]);
-        assert!(
-            (out[0] - 100.0).abs() < 1e-3,
-            "silu(100) should ≈ 100, got {}",
-            out[0]
-        );
-        assert!(
-            out[1].abs() < 1e-10,
-            "silu(-100) should ≈ 0, got {}",
-            out[1]
-        );
+        assert!((out[0] - 100.0).abs() < 1e-3, "silu(100) should ≈ 100, got {}", out[0]);
+        assert!(out[1].abs() < 1e-10, "silu(-100) should ≈ 0, got {}", out[1]);
         // No NaN or Inf
         for &v in &out {
             assert!(v.is_finite(), "silu output must be finite, got {v}");
@@ -768,11 +760,11 @@ mod tests {
     fn test_silu_known_reference_values() {
         let inputs = [0.0f32, 1.0, -1.0, 2.0, -2.0];
         let expected = [
-            0.0,      // silu(0) = 0
-            0.7311,   // silu(1) ≈ 0.7311
-            -0.2689,  // silu(-1) ≈ -0.2689
-            1.7616,   // silu(2) ≈ 1.7616
-            -0.2384,  // silu(-2) ≈ -0.2384
+            0.0,     // silu(0) = 0
+            0.7311,  // silu(1) ≈ 0.7311
+            -0.2689, // silu(-1) ≈ -0.2689
+            1.7616,  // silu(2) ≈ 1.7616
+            -0.2384, // silu(-2) ≈ -0.2384
         ];
         let out = silu(&inputs);
         for (i, (&got, &want)) in out.iter().zip(expected.iter()).enumerate() {
@@ -816,10 +808,7 @@ mod tests {
         rmsnorm(&input, &weight, &mut output, 1, dim, 1e-5).unwrap();
         // rms(1,1,1,1) = sqrt(1 + eps) ≈ 1.0, so output ≈ weight
         for (i, &v) in output.iter().enumerate() {
-            assert!(
-                (v - 1.0).abs() < 0.01,
-                "all-ones: output[{i}] = {v}, expected ≈ 1.0"
-            );
+            assert!((v - 1.0).abs() < 0.01, "all-ones: output[{i}] = {v}, expected ≈ 1.0");
         }
     }
 

--- a/crates/bitnet-models/src/safetensors_reader.rs
+++ b/crates/bitnet-models/src/safetensors_reader.rs
@@ -97,21 +97,15 @@ impl SafeTensorsReader {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file) }?;
 
-        let shard_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("model.safetensors")
-            .to_string();
+        let shard_name =
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("model.safetensors").to_string();
 
         let tensor_metadata = Self::extract_metadata_from_bytes(&mmap, &shard_name)?;
 
         let mut shards = HashMap::new();
         shards.insert(shard_name, mmap);
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// Open a sharded SafeTensors model from its index file.
@@ -174,10 +168,7 @@ impl SafeTensorsReader {
             );
         }
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// List all tensor names in the model, sorted alphabetically.
@@ -218,9 +209,7 @@ impl SafeTensorsReader {
         let st = SafeTensors::deserialize(mmap)
             .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
-        let view = st
-            .tensor(name)
-            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let data = view.data();
 
@@ -253,14 +242,12 @@ impl SafeTensorsReader {
         data: &[u8],
         shard_name: &str,
     ) -> Result<HashMap<String, TensorMeta>> {
-        let st =
-            SafeTensors::deserialize(data).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let st = SafeTensors::deserialize(data)
+            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let mut metadata = HashMap::new();
         for name in st.names() {
-            let view = st
-                .tensor(name)
-                .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+            let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
             metadata.insert(
                 name.to_string(),
                 TensorMeta {
@@ -286,9 +273,7 @@ fn read_f32_le(data: &[u8]) -> Vec<f32> {
 /// Read little-endian u16 values from a byte slice, handling potential
 /// alignment issues with memory-mapped data.
 fn read_u16_le(data: &[u8]) -> Vec<u16> {
-    data.chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect()
+    data.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
 }
 
 /// Deserialized shard index (`model.safetensors.index.json`).
@@ -305,9 +290,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     /// Helper: serialize tensors to a safetensors byte vector.
-    fn make_safetensors(
-        tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>,
-    ) -> Vec<u8> {
+    fn make_safetensors(tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>) -> Vec<u8> {
         let views: Vec<(String, TensorView)> = tensors
             .into_iter()
             .map(|(name, dtype, shape, data)| {
@@ -345,13 +328,10 @@ mod tests {
     #[test]
     fn bf16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![1.0, -2.5, 0.0, 42.0];
-        let bf16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::bf16::from_f32(f).to_le_bytes())
-            .collect();
+        let bf16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::bf16::from_f32(f).to_le_bytes()).collect();
 
-        let data =
-            make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
+        let data = make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -372,10 +352,8 @@ mod tests {
     #[test]
     fn f16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![0.5, -1.0, 3.14, 0.0];
-        let f16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::f16::from_f32(f).to_le_bytes())
-            .collect();
+        let f16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::f16::from_f32(f).to_le_bytes()).collect();
 
         let data = make_safetensors(vec![("proj", SafeDtype::F16, vec![2, 2], &f16_bytes)]);
 
@@ -401,14 +379,12 @@ mod tests {
         // Shard 1: embedding
         let embed_vals: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
         let embed_bytes: Vec<u8> = embed_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard1 =
-            make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
+        let shard1 = make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
 
         // Shard 2: projection
         let proj_vals: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let proj_bytes: Vec<u8> = proj_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard2 =
-            make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
+        let shard2 = make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
 
         std::fs::write(dir.path().join("shard-00001.safetensors"), &shard1).unwrap();
         std::fs::write(dir.path().join("shard-00002.safetensors"), &shard2).unwrap();
@@ -439,12 +415,8 @@ mod tests {
 
     #[test]
     fn error_missing_tensor() {
-        let data = make_safetensors(vec![(
-            "existing",
-            SafeDtype::F32,
-            vec![1],
-            &1.0f32.to_le_bytes(),
-        )]);
+        let data =
+            make_safetensors(vec![("existing", SafeDtype::F32, vec![1], &1.0f32.to_le_bytes())]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -465,12 +437,8 @@ mod tests {
     #[test]
     fn error_unsupported_dtype() {
         // I64 is not supported for F32 conversion
-        let i64_bytes: Vec<u8> = vec![1i64, 2i64]
-            .iter()
-            .flat_map(|i| i.to_le_bytes())
-            .collect();
-        let data =
-            make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
+        let i64_bytes: Vec<u8> = vec![1i64, 2i64].iter().flat_map(|i| i.to_le_bytes()).collect();
+        let data = make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -512,10 +480,7 @@ mod tests {
     #[test]
     fn multiple_tensors_single_file() {
         let w1: Vec<u8> = vec![1.0f32, 2.0].iter().flat_map(|f| f.to_le_bytes()).collect();
-        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0]
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let data = make_safetensors(vec![
             ("layer.0.weight", SafeDtype::F32, vec![2], &w1),
@@ -529,9 +494,6 @@ mod tests {
         let reader = SafeTensorsReader::from_file(file.path()).unwrap();
         assert_eq!(reader.tensor_count(), 2);
         assert_eq!(reader.load_tensor("layer.0.weight").unwrap(), vec![1.0, 2.0]);
-        assert_eq!(
-            reader.load_tensor("layer.1.weight").unwrap(),
-            vec![3.0, 4.0, 5.0]
-        );
+        assert_eq!(reader.load_tensor("layer.1.weight").unwrap(), vec![3.0, 4.0, 5.0]);
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -539,3 +539,39 @@ name = "fuzz_activation_elementwise"
 path = "fuzz_targets/fuzz_activation_elementwise.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_kv_cache_append_slice"
+path = "fuzz_targets/fuzz_kv_cache_append_slice.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_gradient_ops"
+path = "fuzz_targets/fuzz_gradient_ops.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_positional_encoding"
+path = "fuzz_targets/fuzz_positional_encoding.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_loss_computation"
+path = "fuzz_targets/fuzz_loss_computation.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_tensor_reshape"
+path = "fuzz_targets/fuzz_tensor_reshape.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_quantize_roundtrip"
+path = "fuzz_targets/fuzz_quantize_roundtrip.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_gradient_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_gradient_ops.rs
@@ -1,0 +1,155 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::gather::{gather_rows, scatter_add_rows};
+use bitnet_kernels::cpu::gating::{geglu, reglu, swiglu};
+use bitnet_kernels::cpu::residual::{add_residual, add_residual_scaled};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz gating activations (SwiGLU, GeGLU, ReGLU) and gradient-scatter
+/// operations (scatter_add_rows) with random inputs.
+#[derive(Arbitrary, Debug)]
+struct GradientInput {
+    data: Vec<u8>,
+    op: u8,
+    rows: u8,
+    row_len: u8,
+    indices: Vec<u8>,
+    scale: f32,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: GradientInput| {
+    let values = bytes_to_f32(&input.data, 512);
+    if values.is_empty() {
+        return;
+    }
+
+    match input.op % 5 {
+        0 => {
+            // SwiGLU gating
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let gate = &values[..half];
+            let up = &values[half..half * 2];
+            let mut output = vec![0.0f32; half];
+            if swiglu(gate, up, &mut output).is_ok() {
+                for (i, &v) in output.iter().enumerate() {
+                    assert!(v.is_finite(), "SwiGLU non-finite at {i}: {v}");
+                }
+            }
+        }
+        1 => {
+            // GeGLU gating
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let gate = &values[..half];
+            let up = &values[half..half * 2];
+            let mut output = vec![0.0f32; half];
+            if geglu(gate, up, &mut output).is_ok() {
+                for (i, &v) in output.iter().enumerate() {
+                    assert!(v.is_finite(), "GeGLU non-finite at {i}: {v}");
+                }
+            }
+        }
+        2 => {
+            // ReGLU gating
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let gate = &values[..half];
+            let up = &values[half..half * 2];
+            let mut output = vec![0.0f32; half];
+            if reglu(gate, up, &mut output).is_ok() {
+                for (i, &v) in output.iter().enumerate() {
+                    assert!(v.is_finite(), "ReGLU non-finite at {i}: {v}");
+                }
+            }
+        }
+        3 => {
+            // scatter_add_rows — gradient accumulation
+            let num_rows = (input.rows as usize % 8) + 1;
+            let row_len = (input.row_len as usize % 8) + 1;
+            let table_size = num_rows * row_len;
+            if values.len() < table_size {
+                return;
+            }
+            let mut table: Vec<f32> =
+                values[..table_size].iter().map(|&v| if v.is_finite() { v } else { 0.0 }).collect();
+            let table_before = table.clone();
+
+            let indices: Vec<usize> =
+                input.indices.iter().take(8).map(|&i| i as usize % num_rows).collect();
+            if indices.is_empty() {
+                return;
+            }
+            let grad_size = indices.len() * row_len;
+            let grads: Vec<f32> = values
+                .iter()
+                .cycle()
+                .take(grad_size)
+                .map(|&v| if v.is_finite() { v } else { 0.0 })
+                .collect();
+
+            if scatter_add_rows(&mut table, num_rows, row_len, &indices, &grads).is_ok() {
+                // Verify all outputs are finite
+                for (i, &v) in table.iter().enumerate() {
+                    assert!(v.is_finite(), "scatter_add non-finite at {i}: {v}");
+                }
+                // Verify gather→scatter round-trip consistency:
+                // gathered rows should exist in the table
+                if let Ok(gathered) = gather_rows(&table, num_rows, row_len, &indices) {
+                    assert_eq!(gathered.len(), indices.len() * row_len);
+                }
+            } else {
+                // On error, table should be unchanged or partially updated
+                let _ = table_before;
+            }
+        }
+        _ => {
+            // Residual add with scaling — gradient passthrough
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let residual: Vec<f32> =
+                values[..half].iter().map(|&v| if v.is_finite() { v } else { 0.0 }).collect();
+            let mut output: Vec<f32> = values[half..half * 2]
+                .iter()
+                .map(|&v| if v.is_finite() { v } else { 0.0 })
+                .collect();
+            let expected: Vec<f32> =
+                output.iter().zip(residual.iter()).map(|(o, r)| o + r).collect();
+
+            if add_residual(&mut output, &residual).is_ok() {
+                for (i, (&got, &want)) in output.iter().zip(expected.iter()).enumerate() {
+                    assert!(
+                        (got - want).abs() < 1e-5,
+                        "residual mismatch at {i}: got={got} want={want}"
+                    );
+                }
+            }
+
+            // Scaled variant
+            let scale = if input.scale.is_finite() { input.scale.clamp(-10.0, 10.0) } else { 1.0 };
+            let mut output2: Vec<f32> = values[half..half * 2]
+                .iter()
+                .map(|&v| if v.is_finite() { v } else { 0.0 })
+                .collect();
+            let _ = add_residual_scaled(&mut output2, &residual, scale);
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_kv_cache_append_slice.rs
+++ b/fuzz/fuzz_targets/fuzz_kv_cache_append_slice.rs
@@ -1,0 +1,100 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::kv_cache::{
+    KvCache, KvCacheConfig, KvDtype, kv_cache_append, kv_cache_clear, kv_cache_memory_usage,
+    kv_cache_slice, paged_kv_cache_alloc,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    num_layers: u8,
+    num_heads: u8,
+    head_dim: u8,
+    max_seq_len: u8,
+    ops: Vec<CacheOp>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum CacheOp {
+    Append { layer: u8, data: Vec<u8> },
+    Slice { layer: u8, start: u8, end: u8 },
+    Clear,
+    MemUsage,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: Input| {
+    let num_layers = (input.num_layers as usize % 4) + 1;
+    let num_heads = (input.num_heads as usize % 4) + 1;
+    let head_dim = (input.head_dim as usize % 8) + 1;
+    let max_seq_len = (input.max_seq_len as usize % 16) + 1;
+    let token_elems = num_heads * head_dim;
+
+    let config =
+        KvCacheConfig { num_layers, num_heads, head_dim, max_seq_len, dtype: KvDtype::F32 };
+
+    let mut cache = match KvCache::new(config) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Invariant: fresh cache has num_layers blocks and zero seq_len
+    assert_eq!(cache.num_layers(), num_layers);
+    for l in 0..num_layers {
+        assert_eq!(cache.seq_len(l).unwrap(), 0);
+    }
+
+    for op in input.ops.into_iter().take(128) {
+        match op {
+            CacheOp::Append { layer, data } => {
+                let l = layer as usize % num_layers;
+                let vals = bytes_to_f32(&data, token_elems * 2);
+                if vals.len() >= token_elems {
+                    let k = &vals[..token_elems];
+                    let v = if vals.len() >= token_elems * 2 {
+                        &vals[token_elems..token_elems * 2]
+                    } else {
+                        k
+                    };
+                    let prev = cache.seq_len(l).unwrap();
+                    if kv_cache_append(&mut cache, l, k, v).is_ok() {
+                        assert_eq!(cache.seq_len(l).unwrap(), prev + 1);
+                    }
+                }
+            }
+            CacheOp::Slice { layer, start, end } => {
+                let l = layer as usize % num_layers;
+                let s = start as usize;
+                let e = end as usize;
+                if let Ok((keys, values)) = kv_cache_slice(&cache, l, s, e) {
+                    let expected = (e - s) * token_elems;
+                    assert_eq!(keys.len(), expected);
+                    assert_eq!(values.len(), expected);
+                }
+            }
+            CacheOp::Clear => {
+                kv_cache_clear(&mut cache);
+                for l in 0..num_layers {
+                    assert_eq!(cache.seq_len(l).unwrap(), 0);
+                }
+            }
+            CacheOp::MemUsage => {
+                let usage = kv_cache_memory_usage(&cache);
+                assert!(usage > 0);
+            }
+        }
+    }
+
+    // Also exercise paged allocation path
+    let _ = paged_kv_cache_alloc((num_layers % 4) + 1, (max_seq_len % 8) + 1, num_heads, head_dim);
+});

--- a/fuzz/fuzz_targets/fuzz_loss_computation.rs
+++ b/fuzz/fuzz_targets/fuzz_loss_computation.rs
@@ -1,0 +1,184 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::loss::{
+    LossReduction, cross_entropy_loss, kl_divergence, mse_loss, smooth_l1_loss,
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz cross-entropy, MSE, huber (smooth-L1) loss, and KL divergence
+/// with focus on reduction-mode cross-validation and edge-case inputs.
+#[derive(Arbitrary, Debug)]
+struct LossInput {
+    data: Vec<u8>,
+    op: u8,
+    num_classes: u8,
+    beta_byte: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn finite_vec(raw: &[f32], n: usize) -> Vec<f32> {
+    raw.iter().take(n).map(|&v| if v.is_finite() { v.clamp(-100.0, 100.0) } else { 0.0 }).collect()
+}
+
+fuzz_target!(|input: LossInput| {
+    let values = bytes_to_f32(&input.data, 256);
+    if values.len() < 4 {
+        return;
+    }
+
+    match input.op % 4 {
+        0 => {
+            // Cross-entropy: compare reduction modes
+            let num_classes = (input.num_classes as usize % 8) + 2;
+            let batch_size = values.len() / (num_classes + 1);
+            if batch_size == 0 {
+                return;
+            }
+            let logits = finite_vec(&values, batch_size * num_classes);
+            let targets: Vec<usize> = values
+                .iter()
+                .skip(batch_size * num_classes)
+                .take(batch_size)
+                .map(|v| (v.abs() as usize) % num_classes)
+                .collect();
+            if targets.len() != batch_size {
+                return;
+            }
+
+            // All three reductions must not panic
+            let r_none = cross_entropy_loss(&logits, &targets, num_classes, LossReduction::None);
+            let r_mean = cross_entropy_loss(&logits, &targets, num_classes, LossReduction::Mean);
+            let r_sum = cross_entropy_loss(&logits, &targets, num_classes, LossReduction::Sum);
+
+            // Cross-validate: sum of per-sample == Sum reduction
+            if let (Ok((_, per_sample)), Ok((sum_scalar, _))) = (&r_none, &r_sum) {
+                let manual_sum: f32 = per_sample.iter().sum();
+                if manual_sum.is_finite() && sum_scalar.is_finite() {
+                    assert!(
+                        (manual_sum - sum_scalar).abs() < 1e-3,
+                        "CE sum mismatch: manual={manual_sum} vs sum={sum_scalar}"
+                    );
+                }
+            }
+
+            // Cross-validate: mean == sum / batch_size
+            if let (Ok((mean_scalar, _)), Ok((sum_scalar, _))) = (&r_mean, &r_sum) {
+                if mean_scalar.is_finite() && sum_scalar.is_finite() && batch_size > 0 {
+                    let expected_mean = sum_scalar / batch_size as f32;
+                    assert!(
+                        (mean_scalar - expected_mean).abs() < 1e-3,
+                        "CE mean mismatch: {mean_scalar} vs {expected_mean}"
+                    );
+                }
+            }
+        }
+        1 => {
+            // MSE: symmetry and non-negativity
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let a = finite_vec(&values, half);
+            let b = finite_vec(&values[half..], half);
+            let n = a.len().min(b.len());
+            if n == 0 {
+                return;
+            }
+
+            if let Ok(mse_ab) = mse_loss(&a[..n], &b[..n], LossReduction::Mean) {
+                assert!(mse_ab >= 0.0, "MSE negative: {mse_ab}");
+                assert!(mse_ab.is_finite(), "MSE non-finite: {mse_ab}");
+
+                // MSE(a,b) == MSE(b,a)
+                if let Ok(mse_ba) = mse_loss(&b[..n], &a[..n], LossReduction::Mean) {
+                    assert!(
+                        (mse_ab - mse_ba).abs() < 1e-5,
+                        "MSE not symmetric: {mse_ab} vs {mse_ba}"
+                    );
+                }
+
+                // MSE(a,a) == 0
+                if let Ok(mse_aa) = mse_loss(&a[..n], &a[..n], LossReduction::Mean) {
+                    assert!(mse_aa.abs() < 1e-6, "MSE(a,a) != 0: {mse_aa}");
+                }
+            }
+        }
+        2 => {
+            // Huber (smooth-L1): compare with MSE for small errors
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let a = finite_vec(&values, half);
+            let b = finite_vec(&values[half..], half);
+            let n = a.len().min(b.len());
+            if n == 0 {
+                return;
+            }
+
+            let beta = match input.beta_byte % 4 {
+                0 => 0.1,
+                1 => 0.5,
+                2 => 1.0,
+                _ => 5.0,
+            };
+
+            if let Ok(huber) = smooth_l1_loss(&a[..n], &b[..n], beta, LossReduction::Mean) {
+                assert!(huber >= 0.0, "Huber negative: {huber}");
+                assert!(huber.is_finite(), "Huber non-finite: {huber}");
+            }
+
+            // Non-negative for all reduction modes
+            for red in [LossReduction::None, LossReduction::Sum, LossReduction::Mean] {
+                if let Ok(h) = smooth_l1_loss(&a[..n], &b[..n], beta, red) {
+                    assert!(h >= -1e-6, "Huber negative with {:?}: {h}", red);
+                }
+            }
+        }
+        _ => {
+            // KL divergence: KL(p || p) ≈ 0
+            let half = values.len() / 2;
+            if half == 0 {
+                return;
+            }
+            let log_p = finite_vec(&values, half);
+            let q = finite_vec(&values[half..], half);
+            let n = log_p.len().min(q.len());
+            if n == 0 {
+                return;
+            }
+
+            // Just verify no panics for arbitrary inputs
+            let _ = kl_divergence(&log_p[..n], &q[..n], LossReduction::Mean);
+            let _ = kl_divergence(&log_p[..n], &q[..n], LossReduction::Sum);
+            let _ = kl_divergence(&log_p[..n], &q[..n], LossReduction::None);
+
+            // Self-divergence should be near zero for valid probability-like inputs
+            let p_norm: Vec<f32> = {
+                let sum: f32 = log_p[..n].iter().map(|x| x.exp()).sum();
+                if sum.is_finite() && sum > 0.0 {
+                    log_p[..n].iter().map(|x| x.exp() / sum).collect()
+                } else {
+                    return;
+                }
+            };
+            let log_p_norm: Vec<f32> = p_norm.iter().map(|x| x.ln()).collect();
+            if log_p_norm.iter().all(|x| x.is_finite()) {
+                if let Ok(self_kl) = kl_divergence(&log_p_norm, &p_norm, LossReduction::Sum) {
+                    if self_kl.is_finite() {
+                        assert!(self_kl.abs() < 1e-3, "KL self-divergence should be ~0: {self_kl}");
+                    }
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_positional_encoding.rs
+++ b/fuzz/fuzz_targets/fuzz_positional_encoding.rs
@@ -1,0 +1,152 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::embedding::{
+    CpuEmbeddingConfig, embedding_with_position, positional_embedding,
+};
+use bitnet_kernels::cpu::rope::{RopeConfig, apply_rope, apply_rope_batch, compute_frequencies};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz sinusoidal positional embeddings, RoPE frequency tables,
+/// and RoPE application to random vectors.
+#[derive(Arbitrary, Debug)]
+struct PosEncInput {
+    op: u8,
+    seq_len: u8,
+    embed_dim: u8,
+    position: u8,
+    base: f32,
+    #[allow(dead_code)]
+    scaling_factor: f32,
+    data: Vec<u8>,
+    indices: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: PosEncInput| {
+    match input.op % 4 {
+        0 => {
+            // Sinusoidal positional embedding
+            let seq_len = (input.seq_len as usize % 32) + 1;
+            let dim = ((input.embed_dim as usize % 16) + 1) * 2; // must be even
+            let pe = positional_embedding(seq_len, dim);
+            assert_eq!(pe.len(), seq_len * dim, "PE shape mismatch");
+            for (i, &v) in pe.iter().enumerate() {
+                assert!(v.is_finite(), "PE non-finite at {i}: {v}");
+                assert!(v.abs() <= 1.0 + 1e-6, "PE out of [-1,1] at {i}: {v}");
+            }
+        }
+        1 => {
+            // RoPE compute_frequencies + apply_rope
+            let head_dim = ((input.embed_dim as usize % 16) + 1) * 2;
+            let max_seq = (input.seq_len as usize % 32) + 1;
+            let base = input.base.abs();
+            if !base.is_finite() || base <= 0.0 {
+                return;
+            }
+
+            let config = RopeConfig::new(head_dim, max_seq).with_base(base);
+            let freqs = compute_frequencies(&config);
+            assert_eq!(freqs.len(), head_dim / 2, "freq table size mismatch");
+            for (i, &f) in freqs.iter().enumerate() {
+                assert!(f.is_finite(), "freq non-finite at {i}: {f}");
+            }
+
+            // Apply to a single position
+            let mut vec = bytes_to_f32(&input.data, head_dim);
+            if vec.len() < head_dim {
+                vec.resize(head_dim, 0.0);
+            }
+            for v in &mut vec {
+                if !v.is_finite() {
+                    *v = 0.0;
+                }
+            }
+            let norm_before: f32 = vec.iter().map(|x| x * x).sum();
+
+            let pos = input.position as usize % max_seq;
+            apply_rope(&mut vec, pos, head_dim, &freqs);
+
+            for (i, &v) in vec.iter().enumerate() {
+                assert!(v.is_finite(), "RoPE output non-finite at {i}: {v}");
+            }
+            // Norm preservation: RoPE is a rotation
+            if norm_before > 1e-12 {
+                let norm_after: f32 = vec.iter().map(|x| x * x).sum();
+                let ratio = norm_after / norm_before;
+                assert!((ratio - 1.0).abs() < 1e-4, "RoPE norm not preserved: ratio={ratio}");
+            }
+        }
+        2 => {
+            // RoPE batch application
+            let head_dim = ((input.embed_dim as usize % 8) + 1) * 2;
+            let num_heads = (input.indices.first().copied().unwrap_or(1) as usize % 4) + 1;
+            let seq_len = (input.seq_len as usize % 8) + 1;
+            let total = seq_len * num_heads * head_dim;
+            let max_seq = seq_len + (input.position as usize % 8);
+
+            let base = input.base.abs();
+            if !base.is_finite() || base <= 0.0 {
+                return;
+            }
+            let config = RopeConfig::new(head_dim, max_seq).with_base(base);
+            let freqs = compute_frequencies(&config);
+
+            let mut data = bytes_to_f32(&input.data, total);
+            if data.len() < total {
+                data.resize(total, 0.0);
+            }
+            for v in &mut data {
+                if !v.is_finite() {
+                    *v = 0.0;
+                }
+            }
+
+            let start_pos = input.position as usize % max_seq.saturating_sub(seq_len).max(1);
+            apply_rope_batch(&mut data, start_pos, seq_len, num_heads, head_dim, &freqs);
+
+            for (i, &v) in data.iter().enumerate() {
+                assert!(v.is_finite(), "RoPE batch non-finite at {i}: {v}");
+            }
+        }
+        _ => {
+            // embedding_with_position: sinusoidal PE added to embeddings
+            let vocab_size = (input.indices.first().copied().unwrap_or(4) as usize % 16) + 4;
+            let dim = ((input.embed_dim as usize % 8) + 1) * 2;
+            let table_size = vocab_size * dim;
+
+            let mut table = bytes_to_f32(&input.data, table_size);
+            if table.len() < table_size {
+                table.resize(table_size, 0.0);
+            }
+            for v in &mut table {
+                if !v.is_finite() {
+                    *v = 0.0;
+                }
+            }
+
+            let indices: Vec<u32> =
+                input.indices.iter().take(8).map(|&i| (i as u32) % (vocab_size as u32)).collect();
+            if indices.is_empty() {
+                return;
+            }
+
+            let config = CpuEmbeddingConfig::new(vocab_size, dim);
+            let pos_offset = input.position as usize;
+            if let Ok(result) = embedding_with_position(&table, &indices, &config, pos_offset) {
+                assert_eq!(result.len(), indices.len() * dim);
+                for (i, &v) in result.iter().enumerate() {
+                    assert!(v.is_finite(), "embed+PE non-finite at {i}: {v}");
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_quantize_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_quantize_roundtrip.rs
@@ -1,0 +1,133 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_quantization::device_aware_quantizer::{
+    AccuracyValidator, CPUQuantizer, ToleranceConfig,
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz quantize→dequantize round-trip accuracy using the
+/// CPUQuantizer and AccuracyValidator, exercising I2S, TL1, TL2
+/// with random data and tolerance configurations.
+#[derive(Arbitrary, Debug)]
+struct RoundtripInput {
+    data: Vec<u8>,
+    qtype: u8,
+    block_size_sel: u8,
+    strict: bool,
+    i2s_tol: u8,
+    tl_tol: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: RoundtripInput| {
+    let block_size = match input.block_size_sel % 4 {
+        0 => 4,
+        1 => 8,
+        2 => 16,
+        _ => 32,
+    };
+
+    let mut values = bytes_to_f32(&input.data, 128);
+    if values.len() < block_size {
+        if values.is_empty() {
+            return;
+        }
+        values.resize(block_size, 0.0);
+    }
+    let n = (values.len() / block_size) * block_size;
+    if n == 0 {
+        return;
+    }
+    values.truncate(n);
+
+    for v in &mut values {
+        if !v.is_finite() {
+            *v = 0.0;
+        } else if v.abs() > 1000.0 {
+            *v = v.signum() * 1000.0;
+        }
+    }
+
+    let tol_config = ToleranceConfig {
+        i2s_tolerance: (input.i2s_tol as f64 / 255.0) * 0.1 + 1e-4,
+        tl_tolerance: (input.tl_tol as f64 / 255.0) * 0.1 + 1e-3,
+        strict_validation: input.strict,
+        ..ToleranceConfig::default()
+    };
+
+    let quantizer = CPUQuantizer::new(tol_config.clone());
+    let validator = AccuracyValidator::new(tol_config);
+
+    match input.qtype % 3 {
+        0 => {
+            // I2S round-trip via CPUQuantizer
+            if let Ok(quantized) = quantizer.quantize_i2s(&values) {
+                if let Ok(dequantized) = quantizer.dequantize_i2s(&quantized) {
+                    assert_eq!(dequantized.len(), n, "I2S dequant length mismatch");
+                    for (i, &v) in dequantized.iter().enumerate() {
+                        assert!(v.is_finite(), "I2S dequant non-finite at {i}: {v}");
+                    }
+
+                    if let Ok(report) = validator.validate_i2s_accuracy(&values, &quantized) {
+                        assert!(
+                            report.max_absolute_error.is_finite(),
+                            "I2S accuracy: max_err non-finite"
+                        );
+                    }
+                }
+
+                // Double roundtrip: idempotency check
+                if let Ok(deq1) = quantizer.dequantize_i2s(&quantized) {
+                    if let Ok(q2) = quantizer.quantize_i2s(&deq1) {
+                        if let Ok(deq2) = quantizer.dequantize_i2s(&q2) {
+                            assert_eq!(deq1.len(), deq2.len());
+                            for (i, (&a, &b)) in deq1.iter().zip(deq2.iter()).enumerate() {
+                                assert!(
+                                    (a - b).abs() < 1e-5,
+                                    "I2S double roundtrip diverged at {i}: {a} vs {b}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        1 => {
+            // TL1 round-trip
+            if let Ok(quantized) = quantizer.quantize_tl1(&values) {
+                if let Ok(dequantized) = quantizer.dequantize_tl1(&quantized) {
+                    assert_eq!(dequantized.len(), n, "TL1 dequant length mismatch");
+                    for (i, &v) in dequantized.iter().enumerate() {
+                        assert!(v.is_finite(), "TL1 dequant non-finite at {i}: {v}");
+                    }
+                    if let Ok(report) = validator.validate_tl_accuracy(&values, &quantized) {
+                        assert!(report.max_absolute_error.is_finite());
+                    }
+                }
+            }
+        }
+        _ => {
+            // TL2 round-trip
+            if let Ok(quantized) = quantizer.quantize_tl2(&values) {
+                if let Ok(dequantized) = quantizer.dequantize_tl2(&quantized) {
+                    assert_eq!(dequantized.len(), n, "TL2 dequant length mismatch");
+                    for (i, &v) in dequantized.iter().enumerate() {
+                        assert!(v.is_finite(), "TL2 dequant non-finite at {i}: {v}");
+                    }
+                    if let Ok(report) = validator.validate_tl_accuracy(&values, &quantized) {
+                        assert!(report.max_absolute_error.is_finite());
+                    }
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_tensor_reshape.rs
+++ b/fuzz/fuzz_targets/fuzz_tensor_reshape.rs
@@ -1,0 +1,176 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::concat::ConcatKernel;
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz ConcatKernel operations: concat, split, stack, and shape
+/// computation with random shapes and data.
+#[derive(Arbitrary, Debug)]
+struct ReshapeInput {
+    data: Vec<u8>,
+    op: u8,
+    dim_a: u8,
+    dim_b: u8,
+    dim_c: u8,
+    axis: u8,
+    n_splits: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: ReshapeInput| {
+    let values = bytes_to_f32(&input.data, 512);
+    if values.is_empty() {
+        return;
+    }
+
+    match input.op % 4 {
+        0 => {
+            // Concat two tensors along a fuzzed axis
+            let rows = (input.dim_a as usize % 4) + 1;
+            let cols = (input.dim_b as usize % 4) + 1;
+            let extra_cols = (input.dim_c as usize % 4) + 1;
+            let shape_a = [rows, cols];
+            let shape_b = [rows, extra_cols];
+            let total_a = rows * cols;
+            let total_b = rows * extra_cols;
+            if values.len() < total_a + total_b {
+                return;
+            }
+            let a = &values[..total_a];
+            let b = &values[total_a..total_a + total_b];
+            let axis = input.axis as usize % 2;
+
+            let inputs: &[&[f32]] = &[a, b];
+            let sa: &[usize] = &shape_a;
+            let sb: &[usize] = &shape_b;
+            let shapes: &[&[usize]] = &[sa, sb];
+
+            // Concat along valid axis
+            if axis == 1 {
+                // Axis 1: rows must match
+                if let Ok(result) = ConcatKernel::concat(inputs, shapes, 1) {
+                    assert_eq!(result.len(), rows * (cols + extra_cols));
+                }
+            } else {
+                // Axis 0: cols must match — only try if equal
+                if cols == extra_cols {
+                    if let Ok(result) = ConcatKernel::concat(inputs, shapes, 0) {
+                        assert_eq!(result.len(), (rows * 2) * cols);
+                    }
+                }
+            }
+
+            // Verify concat_output_shape
+            if axis == 1 {
+                if let Ok(out_shape) = ConcatKernel::concat_output_shape(shapes, 1) {
+                    assert_eq!(out_shape, vec![rows, cols + extra_cols]);
+                }
+            }
+        }
+        1 => {
+            // Split then re-concat should be identity
+            let rows = (input.dim_a as usize % 4) + 1;
+            let cols = (input.dim_b as usize % 8) + 2;
+            let total = rows * cols;
+            if values.len() < total {
+                return;
+            }
+            let data = &values[..total];
+            let shape = [rows, cols];
+            let n_splits = (input.n_splits as usize % cols).max(1);
+            if cols % n_splits != 0 {
+                return;
+            }
+
+            if let Ok(parts) = ConcatKernel::split(data, &shape, 1, n_splits) {
+                assert_eq!(parts.len(), n_splits);
+                let chunk_cols = cols / n_splits;
+                for p in &parts {
+                    assert_eq!(p.len(), rows * chunk_cols);
+                }
+
+                // Re-concat should recover original
+                let refs: Vec<&[f32]> = parts.iter().map(|p| p.as_slice()).collect();
+                let chunk_shape = [rows, chunk_cols];
+                let shapes: Vec<&[usize]> = (0..n_splits).map(|_| chunk_shape.as_slice()).collect();
+                if let Ok(recovered) = ConcatKernel::concat(&refs, &shapes, 1) {
+                    assert_eq!(recovered.len(), total);
+                    for (i, (&orig, &rec)) in data.iter().zip(recovered.iter()).enumerate() {
+                        if orig.is_finite() && rec.is_finite() {
+                            assert!(
+                                (orig - rec).abs() < 1e-6,
+                                "split→concat not identity at {i}: {orig} vs {rec}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        2 => {
+            // Stack multiple 1-D vectors
+            let dim = (input.dim_a as usize % 8) + 1;
+            let n = (input.dim_b as usize % 4) + 2;
+            let total = n * dim;
+            if values.len() < total {
+                return;
+            }
+
+            let vecs: Vec<&[f32]> = (0..n).map(|i| &values[i * dim..(i + 1) * dim]).collect();
+            let shape = [dim];
+            let axis = input.axis as usize % 2;
+
+            if let Ok(stacked) = ConcatKernel::stack(&vecs, &shape, axis) {
+                if let Ok(expected_shape) = ConcatKernel::stack_output_shape(&shape, axis, n) {
+                    let expected_numel: usize = expected_shape.iter().product();
+                    assert_eq!(stacked.len(), expected_numel);
+                }
+            }
+        }
+        _ => {
+            // Split with custom sizes
+            let rows = (input.dim_a as usize % 4) + 1;
+            let cols = (input.dim_b as usize % 8) + 2;
+            let total = rows * cols;
+            if values.len() < total {
+                return;
+            }
+            let data = &values[..total];
+            let shape = [rows, cols];
+
+            // Generate sizes that sum to cols
+            let s1 = (input.dim_c as usize % cols).max(1);
+            let s2 = cols - s1;
+            if s2 == 0 {
+                return;
+            }
+            let sizes = [s1, s2];
+
+            if let Ok(parts) = ConcatKernel::split_sizes(data, &shape, 1, &sizes) {
+                assert_eq!(parts.len(), 2);
+                assert_eq!(parts[0].len(), rows * s1);
+                assert_eq!(parts[1].len(), rows * s2);
+            }
+
+            // Verify split_output_shapes with equal splits
+            let n_equal = if cols >= 2 { 2 } else { 1 };
+            if cols % n_equal == 0 {
+                if let Ok(out_shapes) = ConcatKernel::split_output_shapes(&shape, 1, n_equal) {
+                    assert_eq!(out_shapes.len(), n_equal);
+                    for s in &out_shapes {
+                        assert_eq!(s[0], rows);
+                        assert_eq!(s[1], cols / n_equal);
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Fuzz Wave 22

Add 6 new fuzz targets, bringing total from 84 to 90.

### New Targets

| Target | What it fuzzes | Key invariants |
|--------|---------------|----------------|
| `fuzz_kv_cache_append_slice` | Real `KvCache` kernel API (append/slice/clear/paged alloc) | seq_len increment, buffer sizes, post-clear zero |
| `fuzz_gradient_ops` | SwiGLU/GeGLU/ReGLU gating + `scatter_add_rows` gradient accumulation | Finite outputs, residual add correctness |
| `fuzz_positional_encoding` | Sinusoidal PE, RoPE frequencies, `apply_rope`/`apply_rope_batch` | PE in [-1,1], norm preservation, finite outputs |
| `fuzz_loss_computation` | Cross-entropy/MSE/huber/KL with reduction-mode cross-validation | Reduction consistency (sum = Σ per-sample), MSE symmetry, KL self-divergence ≈ 0 |
| `fuzz_tensor_reshape` | `ConcatKernel` concat/split/stack/split_sizes | Split→concat identity, shape computation |
| `fuzz_quantize_roundtrip` | `CPUQuantizer` + `AccuracyValidator` I2S/TL1/TL2 round-trip | Finite dequant, double-roundtrip idempotency, accuracy report validity |

### Verification

- `cargo check` passes in `fuzz/` directory (all 90 targets compile)
- `cargo fmt --all` applied
