### PR TITLE
fix(format): cargo fmt on files with formatting drift v2

### DIFF
--- a/crates/bitnet-inference/src/cpu_opt.rs
+++ b/crates/bitnet-inference/src/cpu_opt.rs
@@ -732,16 +732,8 @@ mod tests {
     #[test]
     fn test_silu_numerical_stability_extremes() {
         let out = silu(&[100.0, -100.0]);
-        assert!(
-            (out[0] - 100.0).abs() < 1e-3,
-            "silu(100) should ≈ 100, got {}",
-            out[0]
-        );
-        assert!(
-            out[1].abs() < 1e-10,
-            "silu(-100) should ≈ 0, got {}",
-            out[1]
-        );
+        assert!((out[0] - 100.0).abs() < 1e-3, "silu(100) should ≈ 100, got {}", out[0]);
+        assert!(out[1].abs() < 1e-10, "silu(-100) should ≈ 0, got {}", out[1]);
         // No NaN or Inf
         for &v in &out {
             assert!(v.is_finite(), "silu output must be finite, got {v}");
@@ -768,11 +760,11 @@ mod tests {
     fn test_silu_known_reference_values() {
         let inputs = [0.0f32, 1.0, -1.0, 2.0, -2.0];
         let expected = [
-            0.0,      // silu(0) = 0
-            0.7311,   // silu(1) ≈ 0.7311
-            -0.2689,  // silu(-1) ≈ -0.2689
-            1.7616,   // silu(2) ≈ 1.7616
-            -0.2384,  // silu(-2) ≈ -0.2384
+            0.0,     // silu(0) = 0
+            0.7311,  // silu(1) ≈ 0.7311
+            -0.2689, // silu(-1) ≈ -0.2689
+            1.7616,  // silu(2) ≈ 1.7616
+            -0.2384, // silu(-2) ≈ -0.2384
         ];
         let out = silu(&inputs);
         for (i, (&got, &want)) in out.iter().zip(expected.iter()).enumerate() {
@@ -816,10 +808,7 @@ mod tests {
         rmsnorm(&input, &weight, &mut output, 1, dim, 1e-5).unwrap();
         // rms(1,1,1,1) = sqrt(1 + eps) ≈ 1.0, so output ≈ weight
         for (i, &v) in output.iter().enumerate() {
-            assert!(
-                (v - 1.0).abs() < 0.01,
-                "all-ones: output[{i}] = {v}, expected ≈ 1.0"
-            );
+            assert!((v - 1.0).abs() < 0.01, "all-ones: output[{i}] = {v}, expected ≈ 1.0");
         }
     }
 

--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -126,8 +126,7 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("tinyllama") {
         return ModelArchitecture::TinyLlama;
     }
-    if lower.contains("codellama") || lower.contains("code-llama") || lower.contains("code_llama")
-    {
+    if lower.contains("codellama") || lower.contains("code-llama") || lower.contains("code_llama") {
         return ModelArchitecture::CodeLlama;
     }
     if lower.contains("starcoder") {
@@ -419,10 +418,7 @@ mod tests {
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
-        assert_eq!(
-            detect_architecture("microsoft/BitNet-b1.58-2B-4T"),
-            ModelArchitecture::BitNet,
-        );
+        assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
     }
 
     #[test]

--- a/crates/bitnet-models/src/safetensors_reader.rs
+++ b/crates/bitnet-models/src/safetensors_reader.rs
@@ -97,21 +97,15 @@ impl SafeTensorsReader {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file) }?;
 
-        let shard_name = path
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("model.safetensors")
-            .to_string();
+        let shard_name =
+            path.file_name().and_then(|n| n.to_str()).unwrap_or("model.safetensors").to_string();
 
         let tensor_metadata = Self::extract_metadata_from_bytes(&mmap, &shard_name)?;
 
         let mut shards = HashMap::new();
         shards.insert(shard_name, mmap);
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// Open a sharded SafeTensors model from its index file.
@@ -174,10 +168,7 @@ impl SafeTensorsReader {
             );
         }
 
-        Ok(Self {
-            tensor_metadata,
-            shards,
-        })
+        Ok(Self { tensor_metadata, shards })
     }
 
     /// List all tensor names in the model, sorted alphabetically.
@@ -218,9 +209,7 @@ impl SafeTensorsReader {
         let st = SafeTensors::deserialize(mmap)
             .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
-        let view = st
-            .tensor(name)
-            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let data = view.data();
 
@@ -253,14 +242,12 @@ impl SafeTensorsReader {
         data: &[u8],
         shard_name: &str,
     ) -> Result<HashMap<String, TensorMeta>> {
-        let st =
-            SafeTensors::deserialize(data).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+        let st = SafeTensors::deserialize(data)
+            .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
 
         let mut metadata = HashMap::new();
         for name in st.names() {
-            let view = st
-                .tensor(name)
-                .map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
+            let view = st.tensor(name).map_err(|e| SafeTensorsReaderError::Parse(e.to_string()))?;
             metadata.insert(
                 name.to_string(),
                 TensorMeta {
@@ -286,9 +273,7 @@ fn read_f32_le(data: &[u8]) -> Vec<f32> {
 /// Read little-endian u16 values from a byte slice, handling potential
 /// alignment issues with memory-mapped data.
 fn read_u16_le(data: &[u8]) -> Vec<u16> {
-    data.chunks_exact(2)
-        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
-        .collect()
+    data.chunks_exact(2).map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]])).collect()
 }
 
 /// Deserialized shard index (`model.safetensors.index.json`).
@@ -305,9 +290,7 @@ mod tests {
     use tempfile::{NamedTempFile, TempDir};
 
     /// Helper: serialize tensors to a safetensors byte vector.
-    fn make_safetensors(
-        tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>,
-    ) -> Vec<u8> {
+    fn make_safetensors(tensors: Vec<(&str, SafeDtype, Vec<usize>, &[u8])>) -> Vec<u8> {
         let views: Vec<(String, TensorView)> = tensors
             .into_iter()
             .map(|(name, dtype, shape, data)| {
@@ -345,13 +328,10 @@ mod tests {
     #[test]
     fn bf16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![1.0, -2.5, 0.0, 42.0];
-        let bf16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::bf16::from_f32(f).to_le_bytes())
-            .collect();
+        let bf16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::bf16::from_f32(f).to_le_bytes()).collect();
 
-        let data =
-            make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
+        let data = make_safetensors(vec![("bias", SafeDtype::BF16, vec![4], &bf16_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -372,10 +352,8 @@ mod tests {
     #[test]
     fn f16_to_f32_conversion() {
         let f32_values: Vec<f32> = vec![0.5, -1.0, 3.14, 0.0];
-        let f16_bytes: Vec<u8> = f32_values
-            .iter()
-            .flat_map(|&f| half::f16::from_f32(f).to_le_bytes())
-            .collect();
+        let f16_bytes: Vec<u8> =
+            f32_values.iter().flat_map(|&f| half::f16::from_f32(f).to_le_bytes()).collect();
 
         let data = make_safetensors(vec![("proj", SafeDtype::F16, vec![2, 2], &f16_bytes)]);
 
@@ -401,14 +379,12 @@ mod tests {
         // Shard 1: embedding
         let embed_vals: Vec<f32> = vec![0.1, 0.2, 0.3, 0.4];
         let embed_bytes: Vec<u8> = embed_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard1 =
-            make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
+        let shard1 = make_safetensors(vec![("embed", SafeDtype::F32, vec![2, 2], &embed_bytes)]);
 
         // Shard 2: projection
         let proj_vals: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let proj_bytes: Vec<u8> = proj_vals.iter().flat_map(|f| f.to_le_bytes()).collect();
-        let shard2 =
-            make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
+        let shard2 = make_safetensors(vec![("proj", SafeDtype::F32, vec![3, 2], &proj_bytes)]);
 
         std::fs::write(dir.path().join("shard-00001.safetensors"), &shard1).unwrap();
         std::fs::write(dir.path().join("shard-00002.safetensors"), &shard2).unwrap();
@@ -439,12 +415,8 @@ mod tests {
 
     #[test]
     fn error_missing_tensor() {
-        let data = make_safetensors(vec![(
-            "existing",
-            SafeDtype::F32,
-            vec![1],
-            &1.0f32.to_le_bytes(),
-        )]);
+        let data =
+            make_safetensors(vec![("existing", SafeDtype::F32, vec![1], &1.0f32.to_le_bytes())]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -465,12 +437,8 @@ mod tests {
     #[test]
     fn error_unsupported_dtype() {
         // I64 is not supported for F32 conversion
-        let i64_bytes: Vec<u8> = vec![1i64, 2i64]
-            .iter()
-            .flat_map(|i| i.to_le_bytes())
-            .collect();
-        let data =
-            make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
+        let i64_bytes: Vec<u8> = vec![1i64, 2i64].iter().flat_map(|i| i.to_le_bytes()).collect();
+        let data = make_safetensors(vec![("ids", SafeDtype::I64, vec![2], &i64_bytes)]);
 
         let mut file = NamedTempFile::new().unwrap();
         file.write_all(&data).unwrap();
@@ -512,10 +480,7 @@ mod tests {
     #[test]
     fn multiple_tensors_single_file() {
         let w1: Vec<u8> = vec![1.0f32, 2.0].iter().flat_map(|f| f.to_le_bytes()).collect();
-        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0]
-            .iter()
-            .flat_map(|f| f.to_le_bytes())
-            .collect();
+        let w2: Vec<u8> = vec![3.0f32, 4.0, 5.0].iter().flat_map(|f| f.to_le_bytes()).collect();
 
         let data = make_safetensors(vec![
             ("layer.0.weight", SafeDtype::F32, vec![2], &w1),
@@ -529,9 +494,6 @@ mod tests {
         let reader = SafeTensorsReader::from_file(file.path()).unwrap();
         assert_eq!(reader.tensor_count(), 2);
         assert_eq!(reader.load_tensor("layer.0.weight").unwrap(), vec![1.0, 2.0]);
-        assert_eq!(
-            reader.load_tensor("layer.1.weight").unwrap(),
-            vec![3.0, 4.0, 5.0]
-        );
+        assert_eq!(reader.load_tensor("layer.1.weight").unwrap(), vec![3.0, 4.0, 5.0]);
     }
 }

--- a/crates/bitnet-quantization/tests/bf16_conversion_tests.rs
+++ b/crates/bitnet-quantization/tests/bf16_conversion_tests.rs
@@ -41,7 +41,15 @@ fn bf16_neg_one_representation() {
 fn bf16_f32_roundtrip_preserves_representable_values() {
     // Values exactly representable in BF16 must survive the round-trip
     let representable: &[f32] = &[
-        0.0, 1.0, -1.0, 2.0, 0.5, 0.25, 128.0, -256.0, 0.00390625, // 2^-8
+        0.0,
+        1.0,
+        -1.0,
+        2.0,
+        0.5,
+        0.25,
+        128.0,
+        -256.0,
+        0.00390625,         // 2^-8
         bf16::MAX.to_f32(), // exact BF16 max
     ];
     for &v in representable {
@@ -134,10 +142,7 @@ fn bf16_bit_pattern_is_f32_upper_16() {
             // Only check for values that don't require rounding
             let reconstructed = f32::from_bits((bf.to_bits() as u32) << 16);
             let direct = bf.to_f32();
-            assert_eq!(
-                reconstructed, direct,
-                "BF16→F32 should zero-extend lower 16 bits for {v}"
-            );
+            assert_eq!(reconstructed, direct, "BF16→F32 should zero-extend lower 16 bits for {v}");
         }
         // Always verify that BF16 bits are related to F32 upper bits
         let diff = (bf.to_bits() as i32 - f32_upper as i32).unsigned_abs();
@@ -216,11 +221,7 @@ fn bf16_to_f16_subnormal_conversion() {
     let f32_val = bf16_subnormal.to_f32();
     let f16_val = f16::from_f32(f32_val);
     // BF16 subnormals are much smaller than F16 can represent, expect zero
-    assert_eq!(
-        f16_val.to_f32(),
-        0.0,
-        "BF16 subnormal ({f32_val:e}) should flush to zero in F16"
-    );
+    assert_eq!(f16_val.to_f32(), 0.0, "BF16 subnormal ({f32_val:e}) should flush to zero in F16");
 }
 
 #[test]
@@ -254,7 +255,8 @@ fn bf16_f16_f32_roundtrip_error_bound() {
 
 #[test]
 fn batch_bf16_to_f32_conversion() {
-    let bf16_weights: Vec<bf16> = (0..1024).map(|i| bf16::from_f32(i as f32 * 0.01 - 5.0)).collect();
+    let bf16_weights: Vec<bf16> =
+        (0..1024).map(|i| bf16::from_f32(i as f32 * 0.01 - 5.0)).collect();
     let f32_weights: Vec<f32> = bf16_weights.iter().map(|b| b.to_f32()).collect();
 
     assert_eq!(f32_weights.len(), 1024);
@@ -273,10 +275,7 @@ fn batch_conversion_10m_elements_perf() {
     let elapsed = start.elapsed();
 
     assert_eq!(f32_data.len(), n);
-    assert!(
-        elapsed.as_secs_f64() < 1.0,
-        "10M BF16→F32 conversions took {elapsed:?}, expected <1s"
-    );
+    assert!(elapsed.as_secs_f64() < 1.0, "10M BF16→F32 conversions took {elapsed:?}, expected <1s");
 }
 
 #[test]
@@ -318,35 +317,25 @@ fn batch_conversion_single_element() {
 #[test]
 fn model_layernorm_weight_range() {
     // LayerNorm weights are typically ~0.9–1.1
-    let weights: Vec<f32> = (0..1000)
-        .map(|i| 0.9 + (i as f32 / 1000.0) * 0.2)
-        .collect();
+    let weights: Vec<f32> = (0..1000).map(|i| 0.9 + (i as f32 / 1000.0) * 0.2).collect();
 
     for &w in &weights {
         let rt = bf16::from_f32(w).to_f32();
         let err = (rt - w).abs();
-        assert!(
-            err < 1e-2,
-            "LayerNorm weight {w} has BF16 error {err} >= 1e-2"
-        );
+        assert!(err < 1e-2, "LayerNorm weight {w} has BF16 error {err} >= 1e-2");
     }
 }
 
 #[test]
 fn model_attention_weight_range() {
     // Attention weights are typically small: ~-0.01 to 0.01
-    let weights: Vec<f32> = (0..1000)
-        .map(|i| -0.01 + (i as f32 / 1000.0) * 0.02)
-        .collect();
+    let weights: Vec<f32> = (0..1000).map(|i| -0.01 + (i as f32 / 1000.0) * 0.02).collect();
 
     for &w in &weights {
         let rt = bf16::from_f32(w).to_f32();
         let err = (rt - w).abs();
         // Near zero, absolute error for BF16 is very small
-        assert!(
-            err < 1e-4,
-            "attention weight {w} has BF16 error {err} >= 1e-4"
-        );
+        assert!(err < 1e-4, "attention weight {w} has BF16 error {err} >= 1e-4");
     }
 }
 
@@ -381,9 +370,8 @@ fn model_large_embedding_matrix_conversion() {
 
 #[test]
 fn model_mixed_sign_preserves_sign() {
-    let values: &[f32] = &[
-        1.0, -1.0, 0.5, -0.5, 100.0, -100.0, 0.001, -0.001, 1e-10, -1e-10, 1e30, -1e30,
-    ];
+    let values: &[f32] =
+        &[1.0, -1.0, 0.5, -0.5, 100.0, -100.0, 0.001, -0.001, 1e-10, -1e-10, 1e30, -1e30];
 
     for &v in values {
         let bf = bf16::from_f32(v);
@@ -391,11 +379,7 @@ fn model_mixed_sign_preserves_sign() {
         if v == 0.0 {
             continue;
         }
-        assert_eq!(
-            v.is_sign_positive(),
-            rt.is_sign_positive(),
-            "sign flipped for {v} → {rt}"
-        );
+        assert_eq!(v.is_sign_positive(), rt.is_sign_positive(), "sign flipped for {v} → {rt}");
     }
 }
 
@@ -419,22 +403,10 @@ fn model_conversion_error_histogram() {
     let p100 = errors[n - 1];
 
     // BF16 ULP for values in [-1,1]: ~2^-8 = 0.00390625
-    assert!(
-        p50 < 0.004,
-        "p50 error {p50} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p90 < 0.004,
-        "p90 error {p90} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p99 < 0.004,
-        "p99 error {p99} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p100 < 0.005,
-        "max error {p100} too large (expected <0.005 for BF16)"
-    );
+    assert!(p50 < 0.004, "p50 error {p50} too large (expected <0.004 for BF16)");
+    assert!(p90 < 0.004, "p90 error {p90} too large (expected <0.004 for BF16)");
+    assert!(p99 < 0.004, "p99 error {p99} too large (expected <0.004 for BF16)");
+    assert!(p100 < 0.005, "max error {p100} too large (expected <0.005 for BF16)");
 
     // Print percentiles for visibility in test output
     eprintln!("BF16 conversion error percentiles (n={n}):");


### PR DESCRIPTION
Recent merges from other teams introduced formatting that doesn't match rustfmt rules. This runs cargo fmt --all to fix.

Files fixed:
- cpu_opt.rs
- architecture.rs
- safetensors_reader.rs
- bf16_conversion_tests.rs

P0: This blocks CI for all open PRs.