### PR TITLE
Extract atomic file write logic into bitnet-atomic-file-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bitnet-atomic-file-core",
  "bitnet-common",
  "bitnet-cpu-activations",
  "bitnet-device-probe",
@@ -425,6 +426,13 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vergen",
+]
+
+[[package]]
+name = "bitnet-atomic-file-core"
+version = "0.2.1-dev"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]
@@ -659,6 +667,7 @@ version = "0.1.0"
 name = "bitnet-download"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-atomic-file-core",
  "bitnet-download-core",
  "bitnet-http-retry",
  "httpdate",
@@ -1170,6 +1179,7 @@ name = "bitnet-receipts-core"
 version = "0.2.1-dev"
 dependencies = [
  "anyhow",
+ "bitnet-atomic-file-core",
  "bitnet-common",
  "bitnet-honest-compute",
  "bitnet-kernels",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
   "crates/bitnet-test-env",
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
+  "crates/bitnet-atomic-file-core", # SRP: shared atomic file write primitive
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
@@ -223,6 +224,7 @@ version = "0.2.1-dev"
 bitnet-common = { path = "crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { path = "crates/bitnet-atomic-file-core", version = "0.2.1-dev" }
 bitnet-models = { path = "crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-quantization = { path = "crates/bitnet-quantization", version = "0.2.1-dev", default-features = false }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
@@ -401,6 +403,7 @@ harness = false
 bitnet-math = { path = "crates/bitnet-math", version = "0.2.1-dev" }
 bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version = "0.2.1-dev" }
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { path = "crates/bitnet-atomic-file-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-atomic-file-core/Cargo.toml
+++ b/crates/bitnet-atomic-file-core/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bitnet-atomic-file-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+description = "SRP atomic file write helper with durable rename semantics"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/bitnet-atomic-file-core/src/lib.rs
+++ b/crates/bitnet-atomic-file-core/src/lib.rs
@@ -1,0 +1,47 @@
+use std::{fs, path::Path};
+
+/// Atomically writes bytes to `path` by writing to a temporary sibling file then renaming.
+///
+/// On Unix platforms this best-effort syncs both the temp file and parent directory to improve
+/// durability across sudden power loss.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::atomic_write;
+
+    #[test]
+    fn writes_and_replaces() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("data.json");
+
+        atomic_write(&path, b"v1").expect("first write");
+        assert_eq!(std::fs::read(&path).expect("read v1"), b"v1");
+
+        atomic_write(&path, b"v2").expect("second write");
+        assert_eq!(std::fs::read(&path).expect("read v2"), b"v2");
+    }
+}

--- a/crates/bitnet-download/Cargo.toml
+++ b/crates/bitnet-download/Cargo.toml
@@ -10,6 +10,7 @@ documentation.workspace = true
 description = "SRP download mechanics helpers for retry, offline mode, metadata, and validation"
 
 [dependencies]
+bitnet-atomic-file-core = { workspace = true }
 bitnet-download-core = { path = "../bitnet-download-core", version = "0.2.1-dev" }
 bitnet-http-retry = { path = "../bitnet-http-retry", version = "0.2.1-dev" }
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,6 +1,5 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
-    validate_downloaded_len,
+    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
@@ -18,6 +17,8 @@ pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
 }
+
+pub use bitnet_atomic_file_core::atomic_write;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-honest-compute = { path = "../bitnet-honest-compute", version = "0.2.1-dev" }
+bitnet-atomic-file-core = { workspace = true }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
 rustc_version_runtime = "0.3.0"
 

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `performance_baseline`: Performance metrics
 
 use anyhow::{Result, anyhow};
+use bitnet_atomic_file_core::atomic_write;
 use bitnet_common::CorrectionRecord;
 use bitnet_honest_compute::{
     classify_compute_path, validate_compute_path as validate_honest_compute_path,
@@ -381,9 +382,7 @@ impl InferenceReceipt {
         let json = serde_json::to_string_pretty(self)?;
 
         // Atomic write: write to temp file, then rename
-        let temp_path = path.with_extension("tmp");
-        std::fs::write(&temp_path, json)?;
-        std::fs::rename(&temp_path, path)?;
+        atomic_write(path, json.as_bytes())?;
 
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- Reduce duplication and follow SRP by isolating the atomic temp-file+rename write semantics into a small, reusable microcrate for other crates to consume.
- Provide a clearly named, tested primitive with explicit Unix durability hints so callers can rely on consistent behavior.

### Description
- Added a new crate `crates/bitnet-atomic-file-core` exposing `atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()>` and a unit test covering write-and-replace behavior.
- Rewired `crates/bitnet-download` to depend on and re-export `bitnet_atomic_file_core::atomic_write` and removed the local implementation.
- Updated `crates/bitnet-receipts-core` to call `atomic_write` when saving receipts (replacing temp-file + `rename` logic).
- Wired the new microcrate into the workspace `Cargo.toml` and updated lockfile entries so workspace and dependent crates build consistently.

### Testing
- Ran code formatting with `cargo fmt` which completed successfully.
- Ran `cargo test -p bitnet-atomic-file-core -p bitnet-download -p bitnet-receipts-core` and all unit tests and doctests for those crates passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a51001446c8333885e797255c31bb8)