### PR TITLE
refactor(download): extract atomic metadata writes into bitnet-download-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
 name = "bitnet-download-core"
 version = "0.2.1-dev"
 dependencies = [
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -14,3 +14,6 @@ thiserror.workspace = true
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,4 +1,5 @@
 use thiserror::Error;
+use std::{fs, path::Path};
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum DownloadValidationError {
@@ -31,9 +32,36 @@ pub fn validate_downloaded_len(
     Ok(())
 }
 
+/// Atomic write helper for small metadata files (etag/last-modified).
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    fs::write(&tmp, bytes)?;
+
+    #[cfg(unix)]
+    {
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            f.sync_all()?;
+        }
+    }
+
+    fs::rename(&tmp, path)?;
+
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent()
+            && let Ok(dir) = std::fs::File::open(parent)
+        {
+            let _ = dir.sync_all();
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::tempdir;
 
     #[test]
     fn parses_content_range_total() {
@@ -49,5 +77,22 @@ mod tests {
             validate_downloaded_len(1, Some(2)),
             Err(DownloadValidationError::Truncated { downloaded: 1, expected: 2 })
         ));
+    }
+
+    #[test]
+    fn atomic_write_creates_file() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("etag.txt");
+        atomic_write(&path, b"abc").expect("atomic write should succeed");
+        assert_eq!(std::fs::read(&path).expect("file should exist"), b"abc");
+    }
+
+    #[test]
+    fn atomic_write_overwrites_file() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("etag.txt");
+        atomic_write(&path, b"first").expect("first write should succeed");
+        atomic_write(&path, b"second").expect("second write should succeed");
+        assert_eq!(std::fs::read(&path).expect("file should exist"), b"second");
     }
 }

--- a/crates/bitnet-download/src/lib.rs
+++ b/crates/bitnet-download/src/lib.rs
@@ -1,10 +1,11 @@
 pub use bitnet_download_core::{
-    DownloadValidationError, offline_enabled, parse_content_range_total, validate_downloaded_len,
+    DownloadValidationError, atomic_write, offline_enabled, parse_content_range_total,
+    validate_downloaded_len,
 };
 pub use bitnet_http_retry::exp_backoff_ms;
 use bitnet_http_retry::retry_after_secs_at as parse_retry_after_secs_at;
 use reqwest::header::{HeaderMap, RETRY_AFTER};
-use std::{fs, path::Path, time::SystemTime};
+use std::time::SystemTime;
 /// Parse Retry-After header (supports both seconds and HTTP-date), capping to 1 hour.
 #[must_use]
 pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
@@ -16,32 +17,6 @@ pub fn retry_after_secs(headers: &HeaderMap) -> u64 {
 pub fn retry_after_secs_at(headers: &HeaderMap, now: SystemTime) -> u64 {
     let retry_after = headers.get(RETRY_AFTER).and_then(|v| v.to_str().ok());
     parse_retry_after_secs_at(retry_after, now)
-}
-
-/// Atomic write helper for small metadata files (etag/last-modified).
-pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
-
-    #[cfg(unix)]
-    {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
-    }
-
-    fs::rename(&tmp, path)?;
-
-    #[cfg(unix)]
-    {
-        if let Some(parent) = path.parent()
-            && let Ok(dir) = std::fs::File::open(parent)
-        {
-            let _ = dir.sync_all();
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation

- Centralize low-level download helpers so filesystem atomic-write semantics live in the SRP microcrate alongside other pure download validation utilities.

### Description

- Moved `atomic_write` from `crates/bitnet-download/src/lib.rs` into `crates/bitnet-download-core/src/lib.rs` and implemented robust atomic write semantics with optional `sync_all` on Unix.
- Re-exported `atomic_write` from `crates/bitnet-download/src/lib.rs` to preserve the public API surface.
- Added unit tests `atomic_write_creates_file` and `atomic_write_overwrites_file` to `crates/bitnet-download-core/src/lib.rs` and added `tempfile` as a dev-dependency in `crates/bitnet-download-core/Cargo.toml` for deterministic temp dirs.
- Updated `Cargo.lock` to reflect the new dev-dependency and code movement.

### Testing

- Ran `cargo test -p bitnet-download-core -p bitnet-download`, and all unit tests completed successfully for both crates (tests for `bitnet-download-core` and `bitnet-download` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a510044fec8333adbb5b1b66e7d1bc)