### PR TITLE
fix(format): cargo fmt on 13 files with formatting drift v3

### DIFF
--- a/crates/bitnet-inference/tests/context_length_tests.rs
+++ b/crates/bitnet-inference/tests/context_length_tests.rs
@@ -48,8 +48,7 @@ mod rope_scaling {
         // Position 0 is always cos=1,sin=0 for both bases
         // Position 1+ should differ
         let pos1_offset = 128; // head_dim elements per position
-        let any_diff =
-            (0..128).any(|i| (f1[pos1_offset + i] - f2[pos1_offset + i]).abs() > 1e-7);
+        let any_diff = (0..128).any(|i| (f1[pos1_offset + i] - f2[pos1_offset + i]).abs() > 1e-7);
         assert!(any_diff, "base=10000 vs base=500000 must produce different frequencies");
     }
 
@@ -66,11 +65,8 @@ mod rope_scaling {
 
     #[test]
     fn rope_table_memory_reasonable() {
-        let sizes = [
-            (4096, 128, "4K default"),
-            (16384, 128, "16K Phi-4"),
-            (131072, 128, "128K Qwen2.5"),
-        ];
+        let sizes =
+            [(4096, 128, "4K default"), (16384, 128, "16K Phi-4"), (131072, 128, "128K Qwen2.5")];
         for (seq_len, head_dim, label) in sizes {
             let cfg = RopeConfig::new(head_dim, seq_len);
             let freqs = rope::compute_frequencies(&cfg);
@@ -126,12 +122,7 @@ mod kv_cache_sizing {
     use bitnet_inference::layers::attention::KVCache;
 
     /// Helper: compute expected KV cache memory for given parameters.
-    fn expected_kv_bytes(
-        seq_len: usize,
-        layers: usize,
-        kv_heads: usize,
-        head_dim: usize,
-    ) -> usize {
+    fn expected_kv_bytes(seq_len: usize, layers: usize, kv_heads: usize, head_dim: usize) -> usize {
         // Each layer has K + V tensors, each of shape [seq_len, kv_heads, head_dim]
         seq_len * kv_heads * head_dim * std::mem::size_of::<f32>() * 2 * layers
     }
@@ -225,10 +216,7 @@ mod kv_cache_sizing {
             "GQA ({gqa_mem} bytes) must use less memory than MHA ({mha_mem} bytes)"
         );
         let ratio = mha_mem as f64 / gqa_mem as f64;
-        assert!(
-            (ratio - 4.0).abs() < 0.1,
-            "GQA should be ~4× smaller: ratio={ratio:.2}"
-        );
+        assert!((ratio - 4.0).abs() < 0.1, "GQA should be ~4× smaller: ratio={ratio:.2}");
 
         // Also verify the formula scales to Phi-4 sizes
         let mha_16k = expected_kv_bytes(16384, 40, 32, 128);
@@ -298,10 +286,7 @@ mod context_boundaries {
         });
         assert!(result.is_err(), "seq_len > max_context should error");
         let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("exceeds"),
-            "error should mention exceeding: {err}"
-        );
+        assert!(err.contains("exceeds"), "error should mention exceeding: {err}");
     }
 
     #[test]
@@ -310,8 +295,7 @@ mod context_boundaries {
 
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         let result = rt.block_on(async {
-            let tensor =
-                BitNetTensor::zeros(&[1, 1, 4, 64], DType::F32, &Device::Cpu).unwrap();
+            let tensor = BitNetTensor::zeros(&[1, 1, 4, 64], DType::F32, &Device::Cpu).unwrap();
             rope.apply(&tensor, 1).await
         });
         assert!(result.is_ok(), "single token should work: {:?}", result.err());
@@ -323,8 +307,7 @@ mod context_boundaries {
 
         let rt = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
         let result = rt.block_on(async {
-            let tensor =
-                BitNetTensor::zeros(&[1, 0, 4, 64], DType::F32, &Device::Cpu).unwrap();
+            let tensor = BitNetTensor::zeros(&[1, 0, 4, 64], DType::F32, &Device::Cpu).unwrap();
             rope.apply(&tensor, 0).await
         });
         // seq_len=0 returns Ok(clone) per the implementation

--- a/crates/bitnet-inference/tests/dense_inference_path_tests.rs
+++ b/crates/bitnet-inference/tests/dense_inference_path_tests.rs
@@ -18,10 +18,7 @@ use bitnet_inference::simple_forward::{Weights, logits_for_token};
 fn assert_close(actual: &[f32], expected: &[f32], tol: f32, label: &str) {
     assert_eq!(actual.len(), expected.len(), "{label}: length mismatch");
     for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
-        assert!(
-            (a - e).abs() < tol,
-            "{label}[{i}]: expected {e:.6}, got {a:.6} (tol={tol})",
-        );
+        assert!((a - e).abs() < tol, "{label}[{i}]: expected {e:.6}, got {a:.6} (tol={tol})",);
     }
 }
 
@@ -190,10 +187,7 @@ fn rmsnorm_normalises_dense_weights() {
 
     // Output RMS should be approximately 1.0 when weights are all-ones.
     let out_rms: f32 = (output.iter().map(|x| x * x).sum::<f32>() / dim as f32).sqrt();
-    assert!(
-        (out_rms - 1.0).abs() < 0.01,
-        "rmsnorm output RMS should be ~1.0, got {out_rms}"
-    );
+    assert!((out_rms - 1.0).abs() < 0.01, "rmsnorm output RMS should be ~1.0, got {out_rms}");
 }
 
 #[test]
@@ -331,9 +325,7 @@ fn forward_pass_seq512_works() {
     let w1 = synthetic_weights(dim, inter);
     let w2 = synthetic_weights(inter, dim);
     let norm_w = vec![1.0f32; dim];
-    let input: Vec<f32> = (0..seq_len * dim)
-        .map(|i| ((i as f32) * 0.001).sin())
-        .collect();
+    let input: Vec<f32> = (0..seq_len * dim).map(|i| ((i as f32) * 0.001).sin()).collect();
 
     let output =
         dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
@@ -378,10 +370,8 @@ fn f32_forward_pass_is_deterministic() {
     let norm_w = vec![1.0f32; dim];
     let input: Vec<f32> = (0..dim).map(|i| (i as f32 + 1.0) * 0.1).collect();
 
-    let out1 =
-        dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
-    let out2 =
-        dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
+    let out1 = dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
+    let out2 = dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
 
     // Bit-exact: same input, same weights → identical output
     assert_eq!(out1, out2, "f32 forward pass must be deterministic");
@@ -405,10 +395,24 @@ fn f16_forward_pass_matches_f32_within_tolerance() {
     let w1_f16: Vec<f32> = w1_f32.iter().map(|&v| to_f16(v)).collect();
     let w2_f16: Vec<f32> = w2_f32.iter().map(|&v| to_f16(v)).collect();
 
-    let out_f32 =
-        dense_transformer_block(&input, &w1_f32, &w2_f32, &norm_w, dim, inter, ActivationType::Silu);
-    let out_f16 =
-        dense_transformer_block(&input, &w1_f16, &w2_f16, &norm_w, dim, inter, ActivationType::Silu);
+    let out_f32 = dense_transformer_block(
+        &input,
+        &w1_f32,
+        &w2_f32,
+        &norm_w,
+        dim,
+        inter,
+        ActivationType::Silu,
+    );
+    let out_f16 = dense_transformer_block(
+        &input,
+        &w1_f16,
+        &w2_f16,
+        &norm_w,
+        dim,
+        inter,
+        ActivationType::Silu,
+    );
 
     assert_close(&out_f16, &out_f32, 1e-3, "f16 vs f32");
 }
@@ -431,10 +435,23 @@ fn bf16_loaded_weights_match_f32_within_tolerance() {
     let w1_bf16: Vec<f32> = w1_f32.iter().map(|&v| to_bf16(v)).collect();
     let w2_bf16: Vec<f32> = w2_f32.iter().map(|&v| to_bf16(v)).collect();
 
-    let out_f32 =
-        dense_transformer_block(&input, &w1_f32, &w2_f32, &norm_w, dim, inter, ActivationType::Silu);
+    let out_f32 = dense_transformer_block(
+        &input,
+        &w1_f32,
+        &w2_f32,
+        &norm_w,
+        dim,
+        inter,
+        ActivationType::Silu,
+    );
     let out_bf16 = dense_transformer_block(
-        &input, &w1_bf16, &w2_bf16, &norm_w, dim, inter, ActivationType::Silu,
+        &input,
+        &w1_bf16,
+        &w2_bf16,
+        &norm_w,
+        dim,
+        inter,
+        ActivationType::Silu,
     );
 
     // BF16 has lower precision than F16, so use a wider tolerance.
@@ -474,13 +491,7 @@ fn numerical_stability_large_activations() {
         dense_transformer_block(&input, &w1, &w2, &norm_w, dim, inter, ActivationType::Silu);
 
     // RMSNorm should tame the large values; output must remain finite
-    assert!(
-        output.iter().all(|v| v.is_finite()),
-        "large-activation output must be finite"
-    );
+    assert!(output.iter().all(|v| v.is_finite()), "large-activation output must be finite");
     // No NaN/Inf propagation
-    assert!(
-        !output.iter().any(|v| v.is_nan()),
-        "no NaN in large-activation forward pass"
-    );
+    assert!(!output.iter().any(|v| v.is_nan()), "no NaN in large-activation forward pass");
 }

--- a/crates/bitnet-inference/tests/gqa_config_tests.rs
+++ b/crates/bitnet-inference/tests/gqa_config_tests.rs
@@ -34,7 +34,8 @@ struct GqaGeometry {
 
 fn gqa_geometry(cfg: &ModelConfig) -> GqaGeometry {
     let head_dim = cfg.hidden_size / cfg.num_heads;
-    let effective_kv = if cfg.num_key_value_heads == 0 { cfg.num_heads } else { cfg.num_key_value_heads };
+    let effective_kv =
+        if cfg.num_key_value_heads == 0 { cfg.num_heads } else { cfg.num_key_value_heads };
     let group_size = cfg.num_heads / effective_kv;
     GqaGeometry {
         head_dim,
@@ -151,7 +152,8 @@ fn head_dim_calculation_various_sizes() {
 /// Compute per-layer KV cache size in bytes (f32) for a given config.
 fn kv_cache_bytes_per_layer(cfg: &ModelConfig, max_seq_len: usize) -> usize {
     let g = gqa_geometry(cfg);
-    let effective_kv = if cfg.num_key_value_heads == 0 { cfg.num_heads } else { cfg.num_key_value_heads };
+    let effective_kv =
+        if cfg.num_key_value_heads == 0 { cfg.num_heads } else { cfg.num_key_value_heads };
     // K + V, each: [kv_heads, max_seq_len, head_dim] × sizeof(f32)
     2 * effective_kv * max_seq_len * g.head_dim * std::mem::size_of::<f32>()
 }
@@ -261,11 +263,7 @@ fn kv_broadcast_shape_all_ratios() {
             "{name}: expanded KV must match Q head count"
         );
         // Verify the repeat factor
-        assert_eq!(
-            kv_shape[1] * group_size,
-            heads,
-            "{name}: kv_heads × group_size == num_heads"
-        );
+        assert_eq!(kv_shape[1] * group_size, heads, "{name}: kv_heads × group_size == num_heads");
     }
 }
 
@@ -425,16 +423,10 @@ fn parametric_sweep_real_architectures() {
     ];
 
     for &(name, hidden, heads, kv_heads, intermediate) in architectures {
-        assert_eq!(
-            hidden % heads, 0,
-            "{name}: hidden_size must be divisible by num_heads"
-        );
+        assert_eq!(hidden % heads, 0, "{name}: hidden_size must be divisible by num_heads");
         assert!(kv_heads > 0, "{name}: kv_heads must be > 0");
         assert!(kv_heads <= heads, "{name}: kv_heads <= heads");
-        assert_eq!(
-            heads % kv_heads, 0,
-            "{name}: heads must be divisible by kv_heads"
-        );
+        assert_eq!(heads % kv_heads, 0, "{name}: heads must be divisible by kv_heads");
 
         let cfg = model_config(hidden, heads, kv_heads, intermediate);
         let g = gqa_geometry(&cfg);
@@ -455,14 +447,14 @@ fn parametric_sweep_real_architectures() {
 fn transformer_mha_validation_logic() {
     let test_cases: &[(usize, usize, usize, bool)] = &[
         // (hidden, heads, kv_heads, should_pass)
-        (4096, 32, 32, true),   // MHA
-        (4096, 32, 8, true),    // GQA 4:1
-        (2560, 40, 10, true),   // GQA Phi-4
-        (4096, 32, 4, true),    // GQA 8:1
-        (4096, 32, 1, true),    // MQA
-        (4096, 32, 0, true),    // 0 → defaults to MHA
-        (4096, 32, 7, false),   // not divisible
-        (4097, 32, 8, false),   // hidden not divisible by heads
+        (4096, 32, 32, true), // MHA
+        (4096, 32, 8, true),  // GQA 4:1
+        (2560, 40, 10, true), // GQA Phi-4
+        (4096, 32, 4, true),  // GQA 8:1
+        (4096, 32, 1, true),  // MQA
+        (4096, 32, 0, true),  // 0 → defaults to MHA
+        (4096, 32, 7, false), // not divisible
+        (4097, 32, 8, false), // hidden not divisible by heads
     ];
 
     for &(hidden, heads, kv_heads, should_pass) in test_cases {

--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -126,8 +126,7 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("tinyllama") {
         return ModelArchitecture::TinyLlama;
     }
-    if lower.contains("codellama") || lower.contains("code-llama") || lower.contains("code_llama")
-    {
+    if lower.contains("codellama") || lower.contains("code-llama") || lower.contains("code_llama") {
         return ModelArchitecture::CodeLlama;
     }
     if lower.contains("starcoder") {
@@ -419,10 +418,7 @@ mod tests {
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
-        assert_eq!(
-            detect_architecture("microsoft/BitNet-b1.58-2B-4T"),
-            ModelArchitecture::BitNet,
-        );
+        assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
     }
 
     #[test]

--- a/crates/bitnet-prompt-templates-core/src/lib.rs
+++ b/crates/bitnet-prompt-templates-core/src/lib.rs
@@ -5770,10 +5770,7 @@ mod detect_logging_tests {
 
     #[test]
     fn test_detect_mistral_from_jinja() {
-        let t = TemplateType::detect(
-            None,
-            Some("[INST] {{ message }} [/INST]"),
-        );
+        let t = TemplateType::detect(None, Some("[INST] {{ message }} [/INST]"));
         assert_eq!(t, TemplateType::MistralChat);
     }
 
@@ -5835,10 +5832,7 @@ mod detect_logging_tests {
             TemplateType::detect(Some("qwen2.5-7b-instruct"), None),
             TemplateType::Qwen25Chat,
         );
-        assert_eq!(
-            TemplateType::detect(Some("Qwen-2.5-Coder"), None),
-            TemplateType::Qwen25Chat,
-        );
+        assert_eq!(TemplateType::detect(Some("Qwen-2.5-Coder"), None), TemplateType::Qwen25Chat,);
     }
 
     #[test]
@@ -5867,18 +5861,9 @@ mod detect_logging_tests {
 
     #[test]
     fn test_qwen25_fromstr_roundtrip() {
-        assert_eq!(
-            "qwen25-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Qwen25Chat,
-        );
-        assert_eq!(
-            "qwen2.5-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Qwen25Chat,
-        );
-        assert_eq!(
-            "qwen2.5".parse::<TemplateType>().unwrap(),
-            TemplateType::Qwen25Chat,
-        );
+        assert_eq!("qwen25-chat".parse::<TemplateType>().unwrap(), TemplateType::Qwen25Chat,);
+        assert_eq!("qwen2.5-chat".parse::<TemplateType>().unwrap(), TemplateType::Qwen25Chat,);
+        assert_eq!("qwen2.5".parse::<TemplateType>().unwrap(), TemplateType::Qwen25Chat,);
         assert_eq!(TemplateType::Qwen25Chat.to_string(), "qwen25-chat");
     }
 
@@ -5903,14 +5888,8 @@ mod detect_logging_tests {
 
     #[test]
     fn test_detect_gemma2_from_name() {
-        assert_eq!(
-            TemplateType::detect(Some("gemma-2-9b-it"), None),
-            TemplateType::Gemma2Chat,
-        );
-        assert_eq!(
-            TemplateType::detect(Some("gemma2-2b"), None),
-            TemplateType::Gemma2Chat,
-        );
+        assert_eq!(TemplateType::detect(Some("gemma-2-9b-it"), None), TemplateType::Gemma2Chat,);
+        assert_eq!(TemplateType::detect(Some("gemma2-2b"), None), TemplateType::Gemma2Chat,);
     }
 
     #[test]
@@ -5934,18 +5913,9 @@ mod detect_logging_tests {
 
     #[test]
     fn test_gemma2_fromstr_roundtrip() {
-        assert_eq!(
-            "gemma2-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Gemma2Chat,
-        );
-        assert_eq!(
-            "gemma-2-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Gemma2Chat,
-        );
-        assert_eq!(
-            "gemma2".parse::<TemplateType>().unwrap(),
-            TemplateType::Gemma2Chat,
-        );
+        assert_eq!("gemma2-chat".parse::<TemplateType>().unwrap(), TemplateType::Gemma2Chat,);
+        assert_eq!("gemma-2-chat".parse::<TemplateType>().unwrap(), TemplateType::Gemma2Chat,);
+        assert_eq!("gemma2".parse::<TemplateType>().unwrap(), TemplateType::Gemma2Chat,);
         assert_eq!(TemplateType::Gemma2Chat.to_string(), "gemma2-chat");
     }
 
@@ -5992,30 +5962,17 @@ mod detect_logging_tests {
         ];
         let s = t.render_chat(&hist, Some("Be helpful.")).unwrap();
         assert!(s.contains("<|begin_of_text|>"));
-        assert!(
-            s.contains("<|start_header_id|>system<|end_header_id|>\n\nBe helpful.<|eot_id|>")
-        );
+        assert!(s.contains("<|start_header_id|>system<|end_header_id|>\n\nBe helpful.<|eot_id|>"));
         assert!(s.contains("<|start_header_id|>user<|end_header_id|>\n\nHello<|eot_id|>"));
-        assert!(
-            s.contains("<|start_header_id|>assistant<|end_header_id|>\n\nHi!<|eot_id|>")
-        );
+        assert!(s.contains("<|start_header_id|>assistant<|end_header_id|>\n\nHi!<|eot_id|>"));
         assert!(s.ends_with("<|start_header_id|>assistant<|end_header_id|>\n\n"));
     }
 
     #[test]
     fn test_llama31_fromstr_roundtrip() {
-        assert_eq!(
-            "llama31-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Llama31Chat,
-        );
-        assert_eq!(
-            "llama-3.1-chat".parse::<TemplateType>().unwrap(),
-            TemplateType::Llama31Chat,
-        );
-        assert_eq!(
-            "llama3.1".parse::<TemplateType>().unwrap(),
-            TemplateType::Llama31Chat,
-        );
+        assert_eq!("llama31-chat".parse::<TemplateType>().unwrap(), TemplateType::Llama31Chat,);
+        assert_eq!("llama-3.1-chat".parse::<TemplateType>().unwrap(), TemplateType::Llama31Chat,);
+        assert_eq!("llama3.1".parse::<TemplateType>().unwrap(), TemplateType::Llama31Chat,);
         assert_eq!(TemplateType::Llama31Chat.to_string(), "llama31-chat");
     }
 
@@ -6066,17 +6023,8 @@ mod detect_logging_tests {
             "mistral-nemo-chat".parse::<TemplateType>().unwrap(),
             TemplateType::MistralNemoChat,
         );
-        assert_eq!(
-            "mistral-nemo".parse::<TemplateType>().unwrap(),
-            TemplateType::MistralNemoChat,
-        );
-        assert_eq!(
-            "nemo".parse::<TemplateType>().unwrap(),
-            TemplateType::MistralNemoChat,
-        );
-        assert_eq!(
-            TemplateType::MistralNemoChat.to_string(),
-            "mistral-nemo-chat",
-        );
+        assert_eq!("mistral-nemo".parse::<TemplateType>().unwrap(), TemplateType::MistralNemoChat,);
+        assert_eq!("nemo".parse::<TemplateType>().unwrap(), TemplateType::MistralNemoChat,);
+        assert_eq!(TemplateType::MistralNemoChat.to_string(), "mistral-nemo-chat",);
     }
 }

--- a/crates/bitnet-quantization/tests/bf16_conversion_tests.rs
+++ b/crates/bitnet-quantization/tests/bf16_conversion_tests.rs
@@ -41,7 +41,15 @@ fn bf16_neg_one_representation() {
 fn bf16_f32_roundtrip_preserves_representable_values() {
     // Values exactly representable in BF16 must survive the round-trip
     let representable: &[f32] = &[
-        0.0, 1.0, -1.0, 2.0, 0.5, 0.25, 128.0, -256.0, 0.00390625, // 2^-8
+        0.0,
+        1.0,
+        -1.0,
+        2.0,
+        0.5,
+        0.25,
+        128.0,
+        -256.0,
+        0.00390625,         // 2^-8
         bf16::MAX.to_f32(), // exact BF16 max
     ];
     for &v in representable {
@@ -134,10 +142,7 @@ fn bf16_bit_pattern_is_f32_upper_16() {
             // Only check for values that don't require rounding
             let reconstructed = f32::from_bits((bf.to_bits() as u32) << 16);
             let direct = bf.to_f32();
-            assert_eq!(
-                reconstructed, direct,
-                "BF16→F32 should zero-extend lower 16 bits for {v}"
-            );
+            assert_eq!(reconstructed, direct, "BF16→F32 should zero-extend lower 16 bits for {v}");
         }
         // Always verify that BF16 bits are related to F32 upper bits
         let diff = (bf.to_bits() as i32 - f32_upper as i32).unsigned_abs();
@@ -216,11 +221,7 @@ fn bf16_to_f16_subnormal_conversion() {
     let f32_val = bf16_subnormal.to_f32();
     let f16_val = f16::from_f32(f32_val);
     // BF16 subnormals are much smaller than F16 can represent, expect zero
-    assert_eq!(
-        f16_val.to_f32(),
-        0.0,
-        "BF16 subnormal ({f32_val:e}) should flush to zero in F16"
-    );
+    assert_eq!(f16_val.to_f32(), 0.0, "BF16 subnormal ({f32_val:e}) should flush to zero in F16");
 }
 
 #[test]
@@ -254,7 +255,8 @@ fn bf16_f16_f32_roundtrip_error_bound() {
 
 #[test]
 fn batch_bf16_to_f32_conversion() {
-    let bf16_weights: Vec<bf16> = (0..1024).map(|i| bf16::from_f32(i as f32 * 0.01 - 5.0)).collect();
+    let bf16_weights: Vec<bf16> =
+        (0..1024).map(|i| bf16::from_f32(i as f32 * 0.01 - 5.0)).collect();
     let f32_weights: Vec<f32> = bf16_weights.iter().map(|b| b.to_f32()).collect();
 
     assert_eq!(f32_weights.len(), 1024);
@@ -273,10 +275,7 @@ fn batch_conversion_10m_elements_perf() {
     let elapsed = start.elapsed();
 
     assert_eq!(f32_data.len(), n);
-    assert!(
-        elapsed.as_secs_f64() < 1.0,
-        "10M BF16→F32 conversions took {elapsed:?}, expected <1s"
-    );
+    assert!(elapsed.as_secs_f64() < 1.0, "10M BF16→F32 conversions took {elapsed:?}, expected <1s");
 }
 
 #[test]
@@ -318,35 +317,25 @@ fn batch_conversion_single_element() {
 #[test]
 fn model_layernorm_weight_range() {
     // LayerNorm weights are typically ~0.9–1.1
-    let weights: Vec<f32> = (0..1000)
-        .map(|i| 0.9 + (i as f32 / 1000.0) * 0.2)
-        .collect();
+    let weights: Vec<f32> = (0..1000).map(|i| 0.9 + (i as f32 / 1000.0) * 0.2).collect();
 
     for &w in &weights {
         let rt = bf16::from_f32(w).to_f32();
         let err = (rt - w).abs();
-        assert!(
-            err < 1e-2,
-            "LayerNorm weight {w} has BF16 error {err} >= 1e-2"
-        );
+        assert!(err < 1e-2, "LayerNorm weight {w} has BF16 error {err} >= 1e-2");
     }
 }
 
 #[test]
 fn model_attention_weight_range() {
     // Attention weights are typically small: ~-0.01 to 0.01
-    let weights: Vec<f32> = (0..1000)
-        .map(|i| -0.01 + (i as f32 / 1000.0) * 0.02)
-        .collect();
+    let weights: Vec<f32> = (0..1000).map(|i| -0.01 + (i as f32 / 1000.0) * 0.02).collect();
 
     for &w in &weights {
         let rt = bf16::from_f32(w).to_f32();
         let err = (rt - w).abs();
         // Near zero, absolute error for BF16 is very small
-        assert!(
-            err < 1e-4,
-            "attention weight {w} has BF16 error {err} >= 1e-4"
-        );
+        assert!(err < 1e-4, "attention weight {w} has BF16 error {err} >= 1e-4");
     }
 }
 
@@ -381,9 +370,8 @@ fn model_large_embedding_matrix_conversion() {
 
 #[test]
 fn model_mixed_sign_preserves_sign() {
-    let values: &[f32] = &[
-        1.0, -1.0, 0.5, -0.5, 100.0, -100.0, 0.001, -0.001, 1e-10, -1e-10, 1e30, -1e30,
-    ];
+    let values: &[f32] =
+        &[1.0, -1.0, 0.5, -0.5, 100.0, -100.0, 0.001, -0.001, 1e-10, -1e-10, 1e30, -1e30];
 
     for &v in values {
         let bf = bf16::from_f32(v);
@@ -391,11 +379,7 @@ fn model_mixed_sign_preserves_sign() {
         if v == 0.0 {
             continue;
         }
-        assert_eq!(
-            v.is_sign_positive(),
-            rt.is_sign_positive(),
-            "sign flipped for {v} → {rt}"
-        );
+        assert_eq!(v.is_sign_positive(), rt.is_sign_positive(), "sign flipped for {v} → {rt}");
     }
 }
 
@@ -419,22 +403,10 @@ fn model_conversion_error_histogram() {
     let p100 = errors[n - 1];
 
     // BF16 ULP for values in [-1,1]: ~2^-8 = 0.00390625
-    assert!(
-        p50 < 0.004,
-        "p50 error {p50} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p90 < 0.004,
-        "p90 error {p90} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p99 < 0.004,
-        "p99 error {p99} too large (expected <0.004 for BF16)"
-    );
-    assert!(
-        p100 < 0.005,
-        "max error {p100} too large (expected <0.005 for BF16)"
-    );
+    assert!(p50 < 0.004, "p50 error {p50} too large (expected <0.004 for BF16)");
+    assert!(p90 < 0.004, "p90 error {p90} too large (expected <0.004 for BF16)");
+    assert!(p99 < 0.004, "p99 error {p99} too large (expected <0.004 for BF16)");
+    assert!(p100 < 0.005, "max error {p100} too large (expected <0.005 for BF16)");
 
     // Print percentiles for visibility in test output
     eprintln!("BF16 conversion error percentiles (n={n}):");

--- a/crates/bitnet-tokenizers/src/discovery.rs
+++ b/crates/bitnet-tokenizers/src/discovery.rs
@@ -1526,12 +1526,8 @@ mod tests {
     #[cfg(feature = "cpu")]
     fn test_tokenizer_strategy_properties() {
         // Test strategy network requirements
-        let download_info = TokenizerDownloadInfo::basic(
-            "test/repo",
-            vec!["tokenizer.json"],
-            "test",
-            Some(1000),
-        );
+        let download_info =
+            TokenizerDownloadInfo::basic("test/repo", vec!["tokenizer.json"], "test", Some(1000));
 
         let strategies = [
             (TokenizerStrategy::Exact(PathBuf::from("test.json")), false, false),
@@ -2315,13 +2311,8 @@ mod tests {
         let m = ModelCompatibilityMatrix::default();
 
         // TikToken BPE models
-        let tiktoken_entries = [
-            &m.phi4_100k,
-            &m.phi4_mini_100k,
-            &m.qwen25_152k,
-            &m.llama31_128k,
-            &m.llama32_128k,
-        ];
+        let tiktoken_entries =
+            [&m.phi4_100k, &m.phi4_mini_100k, &m.qwen25_152k, &m.llama31_128k, &m.llama32_128k];
         for entry in tiktoken_entries {
             assert_eq!(
                 entry.tokenizer_type,
@@ -2332,13 +2323,8 @@ mod tests {
         }
 
         // SentencePiece models
-        let sp_entries = [
-            &m.gemma_256k,
-            &m.gemma2_256k,
-            &m.mistral_32k,
-            &m.mistral_v03_32k,
-            &m.mixtral_32k,
-        ];
+        let sp_entries =
+            [&m.gemma_256k, &m.gemma2_256k, &m.mistral_32k, &m.mistral_v03_32k, &m.mixtral_32k];
         for entry in sp_entries {
             assert_eq!(
                 entry.tokenizer_type,
@@ -2351,12 +2337,7 @@ mod tests {
         // Standard BPE models
         let bpe_entries = [&m.smollm_49k, &m.smollm2_49k];
         for entry in bpe_entries {
-            assert_eq!(
-                entry.tokenizer_type,
-                TokenizerType::Bpe,
-                "{} should be BPE",
-                entry.repo
-            );
+            assert_eq!(entry.tokenizer_type, TokenizerType::Bpe, "{} should be BPE", entry.repo);
         }
     }
 

--- a/crates/bitnet-tokenizers/src/download.rs
+++ b/crates/bitnet-tokenizers/src/download.rs
@@ -414,8 +414,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama2-32k".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -467,8 +467,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama3-128k".to_string(),
             expected_vocab: Some(128256),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -554,8 +554,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama2-32k".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -592,8 +592,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "invalid".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -627,8 +627,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string(), "tokenizer.model".to_string()],
             cache_key: "bitnet-custom".to_string(),
             expected_vocab: None,
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -691,8 +691,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "test-tokenizer".to_string(),
             expected_vocab: Some(50257),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         }
     }
 
@@ -716,8 +716,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "timeout-test".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Test that timeout scenarios are handled gracefully
@@ -780,8 +780,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "large-download".to_string(),
             expected_vocab: Some(128256),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // In production, this would test actual disk space limits
@@ -812,8 +812,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "concurrent-test".to_string(),
             expected_vocab: Some(50257),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         });
 
         // Spawn multiple concurrent download tasks
@@ -962,8 +962,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "malformed-test".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Simulate malformed downloaded content
@@ -1177,8 +1177,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "offline-test".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Test 1: Verify offline mode is set

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -48,8 +48,7 @@ pub use gguf_loader::{GgufTokKind, RustTokenizer};
 // New tokenizer discovery and strategy exports
 pub use bitnet_tokenizer_model_core::ModelTypeDetector;
 pub use discovery::{
-    SpecialTokenConfig, TokenizerDiscovery, TokenizerDownloadInfo, TokenizerStrategy,
-    TokenizerType,
+    SpecialTokenConfig, TokenizerDiscovery, TokenizerDownloadInfo, TokenizerStrategy, TokenizerType,
 };
 pub use download::{DownloadProgress, SmartTokenizerDownload};
 pub use error_handling::{CacheManager, TokenizerErrorHandler};

--- a/crates/bitnet-tokenizers/src/strategy.rs
+++ b/crates/bitnet-tokenizers/src/strategy.rs
@@ -991,8 +991,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "invalid".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let download_strategy = TokenizerStrategy::NeedsDownload(download_info);

--- a/crates/bitnet-tokenizers/tests/discovery_matrix_tests.rs
+++ b/crates/bitnet-tokenizers/tests/discovery_matrix_tests.rs
@@ -130,8 +130,8 @@ fn download_info_construction() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "phi4".to_string(),
         expected_vocab: Some(100352),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     assert_eq!(info.repo, "microsoft/phi-4");
     assert_eq!(info.files.len(), 1);
@@ -145,8 +145,8 @@ fn download_info_no_expected_vocab() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "custom".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     assert!(info.expected_vocab.is_none());
 }
@@ -158,8 +158,8 @@ fn download_info_clone() {
         files: vec!["a.json".to_string(), "b.json".to_string()],
         cache_key: "test".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     let cloned = info.clone();
     assert_eq!(info.repo, cloned.repo);

--- a/crates/bitnet-tokenizers/tests/integration_tests.rs
+++ b/crates/bitnet-tokenizers/tests/integration_tests.rs
@@ -84,8 +84,8 @@ async fn test_complete_pipeline_failure_recovery() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "integration-test".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::with_cache_dir(temp_dir.path().to_path_buf())
@@ -743,8 +743,8 @@ async fn test_error_recovery_graceful_degradation() {
                         files: vec!["tokenizer.json".to_string()],
                         cache_key: "test".to_string(),
                         expected_vocab: Some(1000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+                        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+                        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
                     };
 
                     let validation =

--- a/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
+++ b/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
@@ -30,8 +30,8 @@ async fn ac4_download_tokenizer_from_huggingface() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-llama2".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -66,8 +66,8 @@ async fn ac4_tokenizer_download_caching() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-gpt2".to_string(),
         expected_vocab: Some(50257),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -107,8 +107,8 @@ async fn ac4_download_verification() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-verification".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -137,8 +137,8 @@ async fn ac4_network_failure_handling() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-failure".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader_result = SmartTokenizerDownload::new();
@@ -173,8 +173,8 @@ async fn ac4_download_retry_logic() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-retry".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader_result = SmartTokenizerDownload::new();
@@ -238,8 +238,8 @@ async fn ac4_download_multiple_tokenizer_files() {
         files: vec!["tokenizer.json".to_string(), "tokenizer.model".to_string()],
         cache_key: "test-bitnet-multi".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new()
@@ -273,8 +273,8 @@ async fn ac4_download_progress_monitoring() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-progress".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new() {
@@ -312,8 +312,8 @@ async fn ac4_offline_mode_handling() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-offline".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new() {
@@ -393,8 +393,8 @@ async fn ac4_download_with_vocab_validation() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-vocab-validation".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new()


### PR DESCRIPTION
## P0: Format Fix

Formatting drift on main introduced by recently merged PRs #2333, #2339, #2340.

### Files affected (13)
- `context_length_tests.rs` - test formatting
- `dense_inference_path_tests.rs` - test formatting  
- `gqa_config_tests.rs` - test formatting
- `architecture.rs` - source formatting
- `prompt-templates-core/lib.rs` - source formatting
- `bf16_conversion_tests.rs` - test formatting
- 7 tokenizer files (discovery, download, lib, strategy, tests)

### Impact
All open PRs are blocked until this merges - formatting check is the first CI step.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>