### PR TITLE
fix(ci): format 10 workspace files for cargo fmt check

### DIFF
--- a/crates/bitnet-models/src/config_detection.rs
+++ b/crates/bitnet-models/src/config_detection.rs
@@ -57,8 +57,8 @@ type Result<T> = std::result::Result<T, ConfigDetectionError>;
 /// `{arch}.embedding_length`, etc.) and falls back to architecture defaults
 /// from the registry when a key is absent.
 pub fn detect_from_gguf(metadata: &HashMap<String, GgufValue>) -> Result<ModelConfig> {
-    let arch_str = gguf_string(metadata, "general.architecture")
-        .unwrap_or_else(|| "llama".to_string());
+    let arch_str =
+        gguf_string(metadata, "general.architecture").unwrap_or_else(|| "llama".to_string());
     let arch = detect_architecture(&arch_str);
     let defaults = get_defaults(&arch);
 
@@ -67,35 +67,31 @@ pub fn detect_from_gguf(metadata: &HashMap<String, GgufValue>) -> Result<ModelCo
     // Architecture-prefixed key helper
     let ak = |field: &str| -> String { format!("{arch_str}.{field}") };
 
-    cfg.hidden_size = gguf_usize(metadata, &ak("embedding_length"))
-        .unwrap_or(defaults.typical_hidden_size);
+    cfg.hidden_size =
+        gguf_usize(metadata, &ak("embedding_length")).unwrap_or(defaults.typical_hidden_size);
 
-    cfg.num_layers = gguf_usize(metadata, &ak("block_count"))
-        .unwrap_or(32);
+    cfg.num_layers = gguf_usize(metadata, &ak("block_count")).unwrap_or(32);
 
-    cfg.num_heads = gguf_usize(metadata, &ak("attention.head_count"))
-        .unwrap_or(32);
+    cfg.num_heads = gguf_usize(metadata, &ak("attention.head_count")).unwrap_or(32);
 
-    cfg.num_key_value_heads = gguf_usize(metadata, &ak("attention.head_count_kv"))
-        .unwrap_or(cfg.num_heads);
+    cfg.num_key_value_heads =
+        gguf_usize(metadata, &ak("attention.head_count_kv")).unwrap_or(cfg.num_heads);
 
-    cfg.intermediate_size = gguf_usize(metadata, &ak("feed_forward_length"))
-        .unwrap_or(cfg.hidden_size * 4);
+    cfg.intermediate_size =
+        gguf_usize(metadata, &ak("feed_forward_length")).unwrap_or(cfg.hidden_size * 4);
 
     cfg.vocab_size = gguf_usize(metadata, &ak("vocab_size"))
         .or_else(|| gguf_usize(metadata, "tokenizer.ggml.vocab_size"))
         .unwrap_or(defaults.vocab_size);
 
-    cfg.max_position_embeddings = gguf_usize(metadata, &ak("context_length"))
-        .unwrap_or(defaults.max_context);
+    cfg.max_position_embeddings =
+        gguf_usize(metadata, &ak("context_length")).unwrap_or(defaults.max_context);
 
-    cfg.rope_theta = gguf_f32(metadata, &ak("rope.freq_base"))
-        .or(Some(defaults.rope_base));
+    cfg.rope_theta = gguf_f32(metadata, &ak("rope.freq_base")).or(Some(defaults.rope_base));
 
     // Rope scaling (optional)
     if let Some(st) = gguf_string(metadata, &ak("rope.scaling.type")) {
-        let factor = gguf_f32(metadata, &ak("rope.scaling.factor"))
-            .unwrap_or(1.0);
+        let factor = gguf_f32(metadata, &ak("rope.scaling.factor")).unwrap_or(1.0);
         if st != "none" {
             cfg.rope_scaling = Some(RopeScaling { scaling_type: st, factor });
         }
@@ -125,38 +121,28 @@ pub fn detect_from_hf_config(config_json: &str) -> Result<ModelConfig> {
     let raw: serde_json::Value = serde_json::from_str(config_json)
         .map_err(|e| ConfigDetectionError::InvalidJson(e.to_string()))?;
 
-    let model_type = raw
-        .get("model_type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unknown");
+    let model_type = raw.get("model_type").and_then(|v| v.as_str()).unwrap_or("unknown");
     let arch = detect_architecture(model_type);
     let defaults = get_defaults(&arch);
 
     let mut cfg = ModelConfig { format: ModelFormat::SafeTensors, ..Default::default() };
 
-    cfg.hidden_size = json_usize(&raw, "hidden_size")
-        .unwrap_or(defaults.typical_hidden_size);
+    cfg.hidden_size = json_usize(&raw, "hidden_size").unwrap_or(defaults.typical_hidden_size);
 
-    cfg.num_layers = json_usize(&raw, "num_hidden_layers")
-        .unwrap_or(32);
+    cfg.num_layers = json_usize(&raw, "num_hidden_layers").unwrap_or(32);
 
-    cfg.num_heads = json_usize(&raw, "num_attention_heads")
-        .unwrap_or(32);
+    cfg.num_heads = json_usize(&raw, "num_attention_heads").unwrap_or(32);
 
-    cfg.num_key_value_heads = json_usize(&raw, "num_key_value_heads")
-        .unwrap_or(cfg.num_heads);
+    cfg.num_key_value_heads = json_usize(&raw, "num_key_value_heads").unwrap_or(cfg.num_heads);
 
-    cfg.intermediate_size = json_usize(&raw, "intermediate_size")
-        .unwrap_or(cfg.hidden_size * 4);
+    cfg.intermediate_size = json_usize(&raw, "intermediate_size").unwrap_or(cfg.hidden_size * 4);
 
-    cfg.vocab_size = json_usize(&raw, "vocab_size")
-        .unwrap_or(defaults.vocab_size);
+    cfg.vocab_size = json_usize(&raw, "vocab_size").unwrap_or(defaults.vocab_size);
 
-    cfg.max_position_embeddings = json_usize(&raw, "max_position_embeddings")
-        .unwrap_or(defaults.max_context);
+    cfg.max_position_embeddings =
+        json_usize(&raw, "max_position_embeddings").unwrap_or(defaults.max_context);
 
-    cfg.rope_theta = json_f32(&raw, "rope_theta")
-        .or(Some(defaults.rope_base));
+    cfg.rope_theta = json_f32(&raw, "rope_theta").or(Some(defaults.rope_base));
 
     // Rope scaling (optional JSON object)
     if let Some(rs) = raw.get("rope_scaling").and_then(|v| v.as_object()) {
@@ -166,10 +152,7 @@ pub fn detect_from_hf_config(config_json: &str) -> Result<ModelConfig> {
             .and_then(|v| v.as_str())
             .unwrap_or("none")
             .to_string();
-        let factor = rs
-            .get("factor")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(1.0) as f32;
+        let factor = rs.get("factor").and_then(|v| v.as_f64()).unwrap_or(1.0) as f32;
         if st != "none" {
             cfg.rope_scaling = Some(RopeScaling { scaling_type: st, factor });
         }
@@ -186,9 +169,7 @@ pub fn detect_from_hf_config(config_json: &str) -> Result<ModelConfig> {
     if let Some(act) = raw.get("hidden_act").and_then(|v| v.as_str()) {
         cfg.activation_type = match act.to_lowercase().as_str() {
             "silu" | "swish" => ActivationType::Silu,
-            "gelu" | "gelu_new" | "gelu_fast" | "gelu_pytorch_tanh" => {
-                ActivationType::Gelu
-            }
+            "gelu" | "gelu_new" | "gelu_fast" | "gelu_pytorch_tanh" => ActivationType::Gelu,
             "relu2" | "squared_relu" => ActivationType::Relu2,
             _ => defaults.activation,
         };
@@ -212,11 +193,7 @@ pub fn detect_from_hf_config(config_json: &str) -> Result<ModelConfig> {
 ///
 /// Architecture-specific defaults are applied automatically.
 pub fn auto_detect_config(model_path: &Path) -> Result<ModelConfig> {
-    let ext = model_path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_lowercase();
+    let ext = model_path.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
 
     match ext.as_str() {
         "gguf" => {
@@ -240,9 +217,7 @@ pub fn auto_detect_config(model_path: &Path) -> Result<ModelConfig> {
             let json = std::fs::read_to_string(model_path)?;
             detect_from_hf_config(&json)
         }
-        other => Err(ConfigDetectionError::UnrecognisedExtension(
-            other.to_string(),
-        )),
+        other => Err(ConfigDetectionError::UnrecognisedExtension(other.to_string())),
     }
 }
 
@@ -264,11 +239,8 @@ fn read_gguf_metadata(
 
     let file = File::open(path)?;
     let mmap = unsafe { Mmap::map(&file) }?;
-    let reader = GgufReader::new(&mmap).map_err(|e| {
-        ConfigDetectionError::Io(std::io::Error::other(
-            e.to_string(),
-        ))
-    })?;
+    let reader = GgufReader::new(&mmap)
+        .map_err(|e| ConfigDetectionError::Io(std::io::Error::other(e.to_string())))?;
 
     // Build a HashMap from the reader's metadata keys and typed getters.
     let mut map = HashMap::new();
@@ -628,14 +600,8 @@ mod tests {
     #[test]
     fn gguf_rope_scaling() {
         let mut metadata = llama_gguf_metadata();
-        metadata.insert(
-            "llama.rope.scaling.type".into(),
-            GgufValue::String("yarn".into()),
-        );
-        metadata.insert(
-            "llama.rope.scaling.factor".into(),
-            GgufValue::F32(4.0),
-        );
+        metadata.insert("llama.rope.scaling.type".into(), GgufValue::String("yarn".into()));
+        metadata.insert("llama.rope.scaling.factor".into(), GgufValue::F32(4.0));
         let cfg = detect_from_gguf(&metadata).unwrap();
         let rs = cfg.rope_scaling.as_ref().unwrap();
         assert_eq!(rs.scaling_type, "yarn");
@@ -649,9 +615,8 @@ mod tests {
     #[test]
     fn gguf_missing_fields_uses_defaults() {
         // Only architecture set — everything else falls back to defaults
-        let metadata = HashMap::from([
-            ("general.architecture".into(), GgufValue::String("llama".into())),
-        ]);
+        let metadata =
+            HashMap::from([("general.architecture".into(), GgufValue::String("llama".into()))]);
         let cfg = detect_from_gguf(&metadata).unwrap();
         // Should get llama defaults from the architecture registry
         assert_eq!(cfg.hidden_size, 4096); // llama typical_hidden_size
@@ -783,10 +748,7 @@ mod tests {
     fn auto_detect_unknown_extension() {
         let result = auto_detect_config(Path::new("model.bin"));
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            ConfigDetectionError::UnrecognisedExtension(_)
-        ));
+        assert!(matches!(result.unwrap_err(), ConfigDetectionError::UnrecognisedExtension(_)));
     }
 
     // ===================================================================

--- a/crates/bitnet-models/src/lib.rs
+++ b/crates/bitnet-models/src/lib.rs
@@ -40,8 +40,8 @@ pub use production_loader::*;
 pub use formats::gguf::GgufReader;
 
 // Export weight mapper utilities for crossval tests
-pub use weight_mapper::dry_run_remap_names;
 pub use weight_mapper::WeightMapper;
+pub use weight_mapper::dry_run_remap_names;
 
 // AC2: Re-export QK256 tolerance constants from bitnet-quantization (Issue #469)
 pub use bitnet_quantization::{QK256_SIZE_TOLERANCE_PERCENT, qk256_tolerance_bytes};

--- a/crates/bitnet-models/src/weight_mapper.rs
+++ b/crates/bitnet-models/src/weight_mapper.rs
@@ -1100,10 +1100,7 @@ fn llama_family_rules() -> Vec<MappingRule> {
         rule("model.layers.{n}.mlp.up_proj.weight", "blk.{n}.ffn_up.weight"),
         rule("model.layers.{n}.mlp.down_proj.weight", "blk.{n}.ffn_down.weight"),
         rule("model.layers.{n}.input_layernorm.weight", "blk.{n}.attn_norm.weight"),
-        rule(
-            "model.layers.{n}.post_attention_layernorm.weight",
-            "blk.{n}.ffn_norm.weight",
-        ),
+        rule("model.layers.{n}.post_attention_layernorm.weight", "blk.{n}.ffn_norm.weight"),
         rule("model.norm.weight", "output_norm.weight"),
         rule("lm_head.weight", "output.weight"),
     ]
@@ -1113,14 +1110,8 @@ fn llama_family_rules() -> Vec<MappingRule> {
 fn gemma_rules() -> Vec<MappingRule> {
     let mut rules = llama_family_rules();
     rules.extend([
-        rule(
-            "model.layers.{n}.pre_feedforward_layernorm.weight",
-            "blk.{n}.ffn_pre_norm.weight",
-        ),
-        rule(
-            "model.layers.{n}.post_feedforward_layernorm.weight",
-            "blk.{n}.ffn_post_norm.weight",
-        ),
+        rule("model.layers.{n}.pre_feedforward_layernorm.weight", "blk.{n}.ffn_pre_norm.weight"),
+        rule("model.layers.{n}.post_feedforward_layernorm.weight", "blk.{n}.ffn_post_norm.weight"),
     ]);
     rules
 }
@@ -1565,10 +1556,7 @@ mod tests {
     #[test]
     fn reverse_mapping_works() {
         let m = WeightMapper::for_architecture(ModelArchitecture::Phi);
-        assert_eq!(
-            m.reverse_map("token_embd.weight"),
-            Some("model.embed_tokens.weight".into()),
-        );
+        assert_eq!(m.reverse_map("token_embd.weight"), Some("model.embed_tokens.weight".into()),);
         assert_eq!(
             m.reverse_map("blk.7.attn_q.weight"),
             Some("model.layers.7.self_attn.q_proj.weight".into()),
@@ -1577,14 +1565,8 @@ mod tests {
             m.reverse_map("blk.0.ffn_gate.weight"),
             Some("model.layers.0.mlp.gate_proj.weight".into()),
         );
-        assert_eq!(
-            m.reverse_map("output_norm.weight"),
-            Some("model.norm.weight".into()),
-        );
-        assert_eq!(
-            m.reverse_map("output.weight"),
-            Some("lm_head.weight".into()),
-        );
+        assert_eq!(m.reverse_map("output_norm.weight"), Some("model.norm.weight".into()),);
+        assert_eq!(m.reverse_map("output.weight"), Some("lm_head.weight".into()),);
     }
 
     #[test]
@@ -1597,17 +1579,14 @@ mod tests {
     #[test]
     fn layer_number_extraction() {
         assert_eq!(
-            extract_layer_number("model.layers.42.self_attn.q_proj.weight", "model.layers.{n}.self_attn.q_proj.weight"),
+            extract_layer_number(
+                "model.layers.42.self_attn.q_proj.weight",
+                "model.layers.{n}.self_attn.q_proj.weight"
+            ),
             Some(42),
         );
-        assert_eq!(
-            extract_layer_number("blk.0.attn_q.weight", "blk.{n}.attn_q.weight"),
-            Some(0),
-        );
-        assert_eq!(
-            extract_layer_number("no_match", "blk.{n}.attn_q.weight"),
-            None,
-        );
+        assert_eq!(extract_layer_number("blk.0.attn_q.weight", "blk.{n}.attn_q.weight"), Some(0),);
+        assert_eq!(extract_layer_number("no_match", "blk.{n}.attn_q.weight"), None,);
     }
 
     #[test]
@@ -1630,7 +1609,11 @@ mod tests {
             assert!(m.map_name(hf).is_some(), "HF name '{}' should map", hf);
         }
         for internal in &internal_names {
-            assert!(m.reverse_map(internal).is_some(), "internal '{}' should reverse-map", internal);
+            assert!(
+                m.reverse_map(internal).is_some(),
+                "internal '{}' should reverse-map",
+                internal
+            );
         }
     }
 
@@ -1644,9 +1627,6 @@ mod tests {
     fn gemma_has_more_rules_than_llama() {
         let llama = WeightMapper::for_architecture(ModelArchitecture::Llama);
         let gemma = WeightMapper::for_architecture(ModelArchitecture::Gemma);
-        assert!(
-            gemma.rule_count() > llama.rule_count(),
-            "Gemma should have extra norm rules",
-        );
+        assert!(gemma.rule_count() > llama.rule_count(), "Gemma should have extra norm rules",);
     }
 }

--- a/crates/bitnet-tokenizers/src/discovery.rs
+++ b/crates/bitnet-tokenizers/src/discovery.rs
@@ -1526,12 +1526,8 @@ mod tests {
     #[cfg(feature = "cpu")]
     fn test_tokenizer_strategy_properties() {
         // Test strategy network requirements
-        let download_info = TokenizerDownloadInfo::basic(
-            "test/repo",
-            vec!["tokenizer.json"],
-            "test",
-            Some(1000),
-        );
+        let download_info =
+            TokenizerDownloadInfo::basic("test/repo", vec!["tokenizer.json"], "test", Some(1000));
 
         let strategies = [
             (TokenizerStrategy::Exact(PathBuf::from("test.json")), false, false),
@@ -2315,13 +2311,8 @@ mod tests {
         let m = ModelCompatibilityMatrix::default();
 
         // TikToken BPE models
-        let tiktoken_entries = [
-            &m.phi4_100k,
-            &m.phi4_mini_100k,
-            &m.qwen25_152k,
-            &m.llama31_128k,
-            &m.llama32_128k,
-        ];
+        let tiktoken_entries =
+            [&m.phi4_100k, &m.phi4_mini_100k, &m.qwen25_152k, &m.llama31_128k, &m.llama32_128k];
         for entry in tiktoken_entries {
             assert_eq!(
                 entry.tokenizer_type,
@@ -2332,13 +2323,8 @@ mod tests {
         }
 
         // SentencePiece models
-        let sp_entries = [
-            &m.gemma_256k,
-            &m.gemma2_256k,
-            &m.mistral_32k,
-            &m.mistral_v03_32k,
-            &m.mixtral_32k,
-        ];
+        let sp_entries =
+            [&m.gemma_256k, &m.gemma2_256k, &m.mistral_32k, &m.mistral_v03_32k, &m.mixtral_32k];
         for entry in sp_entries {
             assert_eq!(
                 entry.tokenizer_type,
@@ -2351,12 +2337,7 @@ mod tests {
         // Standard BPE models
         let bpe_entries = [&m.smollm_49k, &m.smollm2_49k];
         for entry in bpe_entries {
-            assert_eq!(
-                entry.tokenizer_type,
-                TokenizerType::Bpe,
-                "{} should be BPE",
-                entry.repo
-            );
+            assert_eq!(entry.tokenizer_type, TokenizerType::Bpe, "{} should be BPE", entry.repo);
         }
     }
 

--- a/crates/bitnet-tokenizers/src/download.rs
+++ b/crates/bitnet-tokenizers/src/download.rs
@@ -414,8 +414,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama2-32k".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -467,8 +467,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama3-128k".to_string(),
             expected_vocab: Some(128256),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -554,8 +554,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "llama2-32k".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -592,8 +592,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "invalid".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -627,8 +627,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string(), "tokenizer.model".to_string()],
             cache_key: "bitnet-custom".to_string(),
             expected_vocab: None,
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let downloader_result = SmartTokenizerDownload::new();
@@ -691,8 +691,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "test-tokenizer".to_string(),
             expected_vocab: Some(50257),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         }
     }
 
@@ -716,8 +716,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "timeout-test".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Test that timeout scenarios are handled gracefully
@@ -780,8 +780,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "large-download".to_string(),
             expected_vocab: Some(128256),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // In production, this would test actual disk space limits
@@ -812,8 +812,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "concurrent-test".to_string(),
             expected_vocab: Some(50257),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         });
 
         // Spawn multiple concurrent download tasks
@@ -962,8 +962,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "malformed-test".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Simulate malformed downloaded content
@@ -1177,8 +1177,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "offline-test".to_string(),
             expected_vocab: Some(32000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         // Test 1: Verify offline mode is set

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -48,8 +48,7 @@ pub use gguf_loader::{GgufTokKind, RustTokenizer};
 // New tokenizer discovery and strategy exports
 pub use bitnet_tokenizer_model_core::ModelTypeDetector;
 pub use discovery::{
-    SpecialTokenConfig, TokenizerDiscovery, TokenizerDownloadInfo, TokenizerStrategy,
-    TokenizerType,
+    SpecialTokenConfig, TokenizerDiscovery, TokenizerDownloadInfo, TokenizerStrategy, TokenizerType,
 };
 pub use download::{DownloadProgress, SmartTokenizerDownload};
 pub use error_handling::{CacheManager, TokenizerErrorHandler};

--- a/crates/bitnet-tokenizers/src/strategy.rs
+++ b/crates/bitnet-tokenizers/src/strategy.rs
@@ -991,8 +991,8 @@ mod tests {
             files: vec!["tokenizer.json".to_string()],
             cache_key: "invalid".to_string(),
             expected_vocab: Some(1000),
-                tokenizer_type: crate::discovery::TokenizerType::Unknown,
-                special_tokens: crate::discovery::SpecialTokenConfig::default(),
+            tokenizer_type: crate::discovery::TokenizerType::Unknown,
+            special_tokens: crate::discovery::SpecialTokenConfig::default(),
         };
 
         let download_strategy = TokenizerStrategy::NeedsDownload(download_info);

--- a/crates/bitnet-tokenizers/tests/discovery_matrix_tests.rs
+++ b/crates/bitnet-tokenizers/tests/discovery_matrix_tests.rs
@@ -130,8 +130,8 @@ fn download_info_construction() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "phi4".to_string(),
         expected_vocab: Some(100352),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     assert_eq!(info.repo, "microsoft/phi-4");
     assert_eq!(info.files.len(), 1);
@@ -145,8 +145,8 @@ fn download_info_no_expected_vocab() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "custom".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     assert!(info.expected_vocab.is_none());
 }
@@ -158,8 +158,8 @@ fn download_info_clone() {
         files: vec!["a.json".to_string(), "b.json".to_string()],
         cache_key: "test".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
     let cloned = info.clone();
     assert_eq!(info.repo, cloned.repo);

--- a/crates/bitnet-tokenizers/tests/integration_tests.rs
+++ b/crates/bitnet-tokenizers/tests/integration_tests.rs
@@ -84,8 +84,8 @@ async fn test_complete_pipeline_failure_recovery() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "integration-test".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::with_cache_dir(temp_dir.path().to_path_buf())
@@ -743,8 +743,8 @@ async fn test_error_recovery_graceful_degradation() {
                         files: vec!["tokenizer.json".to_string()],
                         cache_key: "test".to_string(),
                         expected_vocab: Some(1000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+                        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+                        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
                     };
 
                     let validation =

--- a/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
+++ b/crates/bitnet-tokenizers/tests/test_ac4_smart_download_integration.rs
@@ -30,8 +30,8 @@ async fn ac4_download_tokenizer_from_huggingface() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-llama2".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -66,8 +66,8 @@ async fn ac4_tokenizer_download_caching() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-gpt2".to_string(),
         expected_vocab: Some(50257),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -107,8 +107,8 @@ async fn ac4_download_verification() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-verification".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader = SmartTokenizerDownload::new().expect("Should initialize downloader");
@@ -137,8 +137,8 @@ async fn ac4_network_failure_handling() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-failure".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader_result = SmartTokenizerDownload::new();
@@ -173,8 +173,8 @@ async fn ac4_download_retry_logic() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-retry".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     let downloader_result = SmartTokenizerDownload::new();
@@ -238,8 +238,8 @@ async fn ac4_download_multiple_tokenizer_files() {
         files: vec!["tokenizer.json".to_string(), "tokenizer.model".to_string()],
         cache_key: "test-bitnet-multi".to_string(),
         expected_vocab: None,
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new()
@@ -273,8 +273,8 @@ async fn ac4_download_progress_monitoring() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-progress".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new() {
@@ -312,8 +312,8 @@ async fn ac4_offline_mode_handling() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-offline".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new() {
@@ -393,8 +393,8 @@ async fn ac4_download_with_vocab_validation() {
         files: vec!["tokenizer.json".to_string()],
         cache_key: "test-vocab-validation".to_string(),
         expected_vocab: Some(32000),
-                tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
-                special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
+        tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+        special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     };
 
     if let Ok(downloader) = SmartTokenizerDownload::new()


### PR DESCRIPTION
Format files from recent merges (#2389, #2384, #2351) that introduced unformatted code.

This unblocks all 25+ open Apple Silicon PRs and other team PRs.