### PR TITLE
test(snapshots): add wave 17 kernel configuration snapshot tests

### DIFF
--- a/crates/bitnet-kernels/tests/snapshot_wave17.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave17.rs
@@ -1,0 +1,488 @@
+#![allow(non_snake_case)]
+//! Wave 17 snapshot tests for `bitnet-kernels` — kernel configs,
+//! capability matrix types, SIMD detection, quantization formats,
+//! RoPE/attention/pooling/reduction configs, and activation types.
+//!
+//! Pins Debug representations of key configuration structs so that
+//! unintentional changes to public-facing types are caught at review time.
+
+// =========================================================================
+// Section 1 — Quantization format descriptions
+// =========================================================================
+
+use bitnet_common::types::QuantizationType;
+
+#[test]
+fn snapshot_wave17__quantization_type_i2s_display() {
+    insta::assert_snapshot!(format!("{}", QuantizationType::I2S));
+}
+
+#[test]
+fn snapshot_wave17__quantization_type_tl1_display() {
+    insta::assert_snapshot!(format!("{}", QuantizationType::TL1));
+}
+
+#[test]
+fn snapshot_wave17__quantization_type_tl2_display() {
+    insta::assert_snapshot!(format!("{}", QuantizationType::TL2));
+}
+
+#[test]
+fn snapshot_wave17__quantization_type_i2s_debug() {
+    insta::assert_debug_snapshot!(QuantizationType::I2S);
+}
+
+#[test]
+fn snapshot_wave17__quantization_type_tl1_debug() {
+    insta::assert_debug_snapshot!(QuantizationType::TL1);
+}
+
+#[test]
+fn snapshot_wave17__quantization_type_tl2_debug() {
+    insta::assert_debug_snapshot!(QuantizationType::TL2);
+}
+
+// =========================================================================
+// Section 2 — SIMD capability detection
+// =========================================================================
+
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+
+#[test]
+fn snapshot_wave17__simd_level_all_variants_display() {
+    let levels =
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512];
+    let output: Vec<String> = levels.iter().map(|l| format!("{l}")).collect();
+    insta::assert_snapshot!(output.join("\n"));
+}
+
+#[test]
+fn snapshot_wave17__simd_level_all_variants_debug() {
+    let levels =
+        [SimdLevel::Scalar, SimdLevel::Neon, SimdLevel::Sse42, SimdLevel::Avx2, SimdLevel::Avx512];
+    insta::assert_debug_snapshot!(levels);
+}
+
+#[test]
+fn snapshot_wave17__kernel_backend_all_variants_debug() {
+    let backends = [
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::OpenCL,
+    ];
+    insta::assert_debug_snapshot!(backends);
+}
+
+#[test]
+fn snapshot_wave17__kernel_capabilities_cpu_only() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: false,
+        cuda_runtime: false,
+        hip_compiled: false,
+        hip_runtime: false,
+        oneapi_compiled: false,
+        oneapi_runtime: false,
+        opencl_compiled: false,
+        opencl_runtime: false,
+        cpp_ffi: false,
+        simd_level: SimdLevel::Avx2,
+    };
+    insta::assert_debug_snapshot!(caps);
+}
+
+#[test]
+fn snapshot_wave17__kernel_capabilities_full_gpu() {
+    let caps = KernelCapabilities {
+        cpu_rust: true,
+        cuda_compiled: true,
+        cuda_runtime: true,
+        hip_compiled: false,
+        hip_runtime: false,
+        oneapi_compiled: false,
+        oneapi_runtime: false,
+        opencl_compiled: true,
+        opencl_runtime: true,
+        cpp_ffi: true,
+        simd_level: SimdLevel::Avx512,
+    };
+    insta::assert_debug_snapshot!(caps);
+}
+
+// =========================================================================
+// Section 3 — Activation function types
+// =========================================================================
+
+use bitnet_common::config::ActivationType;
+use bitnet_kernels::cpu::ffn::FfnActivation;
+
+#[test]
+fn snapshot_wave17__activation_type_all_variants_debug() {
+    let activations = [ActivationType::Silu, ActivationType::Relu2, ActivationType::Gelu];
+    insta::assert_debug_snapshot!(activations);
+}
+
+#[test]
+fn snapshot_wave17__ffn_activation_all_variants_debug() {
+    let activations = [FfnActivation::GeLU, FfnActivation::SiLU, FfnActivation::ReLU];
+    insta::assert_debug_snapshot!(activations);
+}
+
+// =========================================================================
+// Section 4 — RoPE configuration for different model sizes
+// =========================================================================
+
+use bitnet_kernels::cpu::rope::RopeConfig;
+
+#[test]
+fn snapshot_wave17__rope_config_small_model() {
+    let cfg = RopeConfig::new(64, 2048);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__rope_config_medium_model() {
+    let cfg = RopeConfig::new(128, 4096);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__rope_config_large_model() {
+    let cfg = RopeConfig::new(128, 8192).with_base(500_000.0);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__rope_config_with_scaling() {
+    let cfg = RopeConfig::new(128, 32768).with_base(10_000.0).with_scaling_factor(4.0);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 5 — Attention configuration
+// =========================================================================
+
+use bitnet_kernels::cpu::attention::{AttentionConfig, CpuAttentionConfig, GqaConfig};
+
+#[test]
+fn snapshot_wave17__attention_config_standard_mha() {
+    let cfg =
+        AttentionConfig { num_heads: 32, head_dim: 128, seq_len: 512, causal: true, scale: None };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__attention_config_small() {
+    let cfg = AttentionConfig {
+        num_heads: 8,
+        head_dim: 64,
+        seq_len: 256,
+        causal: false,
+        scale: Some(0.1),
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__gqa_config_4_to_1_ratio() {
+    let cfg = GqaConfig {
+        num_q_heads: 32,
+        num_kv_heads: 8,
+        head_dim: 128,
+        seq_len: 1024,
+        causal: true,
+        scale: None,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__gqa_config_mqa() {
+    let cfg = GqaConfig {
+        num_q_heads: 32,
+        num_kv_heads: 1,
+        head_dim: 128,
+        seq_len: 2048,
+        causal: true,
+        scale: None,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__cpu_attention_config_batched() {
+    let cfg = CpuAttentionConfig {
+        batch_size: 4,
+        num_heads: 16,
+        seq_len: 512,
+        head_dim: 64,
+        scale: None,
+        causal_mask: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__cpu_attention_config_single() {
+    let cfg = CpuAttentionConfig {
+        batch_size: 1,
+        num_heads: 32,
+        seq_len: 128,
+        head_dim: 128,
+        scale: Some(0.088),
+        causal_mask: false,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 6 — Pooling operation parameters
+// =========================================================================
+
+use bitnet_kernels::cpu::pooling::{PoolConfig, PoolType};
+
+#[test]
+fn snapshot_wave17__pool_type_all_variants_debug() {
+    let types = [
+        PoolType::Max,
+        PoolType::Average,
+        PoolType::GlobalMax,
+        PoolType::GlobalAverage,
+        PoolType::AvgPoolCountIncludePad,
+    ];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn snapshot_wave17__pool_config_max_pool_3() {
+    let cfg = PoolConfig { pool_type: PoolType::Max, kernel_size: 3, stride: 1, padding: 1 };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__pool_config_avg_pool_2() {
+    let cfg = PoolConfig { pool_type: PoolType::Average, kernel_size: 2, stride: 2, padding: 0 };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__pool_config_global_max() {
+    let cfg = PoolConfig { pool_type: PoolType::GlobalMax, kernel_size: 0, stride: 0, padding: 0 };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__pool_config_global_average() {
+    let cfg =
+        PoolConfig { pool_type: PoolType::GlobalAverage, kernel_size: 0, stride: 0, padding: 0 };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 7 — Reduction operation parameters
+// =========================================================================
+
+use bitnet_kernels::reduction::{ReductionConfig, ReductionOp};
+
+#[test]
+fn snapshot_wave17__reduction_op_all_variants_debug() {
+    let ops = [
+        ReductionOp::Sum,
+        ReductionOp::Max,
+        ReductionOp::Min,
+        ReductionOp::Mean,
+        ReductionOp::L2Norm,
+    ];
+    insta::assert_debug_snapshot!(ops);
+}
+
+#[test]
+fn snapshot_wave17__reduction_config_sum_256() {
+    let cfg = ReductionConfig::new(256, 64, ReductionOp::Sum).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__reduction_config_mean_1024() {
+    let cfg = ReductionConfig::new(1024, 32, ReductionOp::Mean).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__reduction_config_l2norm_512() {
+    let cfg = ReductionConfig::new(512, 16, ReductionOp::L2Norm).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 8 — Shaped reduction configs
+// =========================================================================
+
+use bitnet_kernels::shaped_reduction::ShapedReductionConfig;
+
+#[test]
+fn snapshot_wave17__shaped_reduction_global_sum() {
+    let cfg = ShapedReductionConfig::global(ReductionOp::Sum);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__shaped_reduction_axis_mean_keepdim() {
+    let cfg = ShapedReductionConfig::new(ReductionOp::Mean, Some(1), true);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__shaped_reduction_axis_max_no_keepdim() {
+    let cfg = ShapedReductionConfig::new(ReductionOp::Max, Some(0), false);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 9 — Scatter/gather configs
+// =========================================================================
+
+use bitnet_kernels::scatter_gather::{GatherConfig, ScatterMode};
+
+#[test]
+fn snapshot_wave17__scatter_mode_all_variants_debug() {
+    let modes = [ScatterMode::Assign, ScatterMode::Add, ScatterMode::Max, ScatterMode::Min];
+    insta::assert_debug_snapshot!(modes);
+}
+
+#[test]
+fn snapshot_wave17__gather_config_axis0() {
+    let cfg = GatherConfig::new(0, (4, 8), true).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__gather_config_axis1_no_bounds_check() {
+    let cfg = GatherConfig::new(1, (16, 32), false).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 10 — Device capability matrix types
+// =========================================================================
+
+use bitnet_kernels::capability_matrix::{
+    CapabilityEntry, DeviceClass, DeviceProfile, OperationCategory, PrecisionSupport, SupportLevel,
+};
+
+#[test]
+fn snapshot_wave17__capability_entry_full_support() {
+    let entry = CapabilityEntry::new(
+        OperationCategory::MatrixOps,
+        PrecisionSupport::FP16,
+        SupportLevel::Full(0.95),
+    );
+    insta::assert_debug_snapshot!(entry);
+}
+
+#[test]
+fn snapshot_wave17__capability_entry_partial_support() {
+    let entry = CapabilityEntry::new(
+        OperationCategory::QuantizedOps,
+        PrecisionSupport::INT8,
+        SupportLevel::Partial("no native i2s".to_string()),
+    );
+    insta::assert_debug_snapshot!(entry);
+}
+
+#[test]
+fn snapshot_wave17__device_profile_cpu_simd() {
+    let profile = DeviceProfile {
+        device_class: DeviceClass::CpuSimd,
+        name: "x86_64 AVX2".to_string(),
+        compute_units: 8,
+        memory_gb: 32,
+        capabilities: vec![
+            CapabilityEntry::new(
+                OperationCategory::MatrixOps,
+                PrecisionSupport::FP32,
+                SupportLevel::Full(0.90),
+            ),
+            CapabilityEntry::new(
+                OperationCategory::NormOps,
+                PrecisionSupport::FP32,
+                SupportLevel::Full(0.95),
+            ),
+            CapabilityEntry::new(
+                OperationCategory::ActivationOps,
+                PrecisionSupport::FP32,
+                SupportLevel::Full(0.92),
+            ),
+        ],
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+#[test]
+fn snapshot_wave17__device_profile_nvidia_gpu() {
+    let profile = DeviceProfile {
+        device_class: DeviceClass::NvidiaCuda,
+        name: "NVIDIA RTX 4090".to_string(),
+        compute_units: 128,
+        memory_gb: 24,
+        capabilities: vec![
+            CapabilityEntry::new(
+                OperationCategory::MatrixOps,
+                PrecisionSupport::FP16,
+                SupportLevel::Full(0.98),
+            ),
+            CapabilityEntry::new(
+                OperationCategory::AttentionOps,
+                PrecisionSupport::FP16,
+                SupportLevel::Full(0.96),
+            ),
+        ],
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+// =========================================================================
+// Section 11 — Common config types
+// =========================================================================
+
+use bitnet_common::config::{InferenceConfig, ModelFormat, NormType, RopeScaling};
+use bitnet_common::types::Device;
+
+#[test]
+fn snapshot_wave17__inference_config_default() {
+    let cfg = InferenceConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_wave17__device_all_variants_debug() {
+    let devices = [
+        Device::Cpu,
+        Device::Cuda(0),
+        Device::Hip(0),
+        Device::Npu,
+        Device::Metal,
+        Device::OpenCL(0),
+    ];
+    insta::assert_debug_snapshot!(devices);
+}
+
+#[test]
+fn snapshot_wave17__norm_type_all_variants_debug() {
+    let norms = [NormType::LayerNorm, NormType::RmsNorm];
+    insta::assert_debug_snapshot!(norms);
+}
+
+#[test]
+fn snapshot_wave17__model_format_all_variants_debug() {
+    let formats = [ModelFormat::Gguf, ModelFormat::SafeTensors, ModelFormat::HuggingFace];
+    insta::assert_debug_snapshot!(formats);
+}
+
+#[test]
+fn snapshot_wave17__rope_scaling_config_debug() {
+    let scaling = RopeScaling { scaling_type: "linear".to_string(), factor: 4.0 };
+    insta::assert_debug_snapshot!(scaling);
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__activation_type_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__activation_type_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: activations
+---
+[
+    Silu,
+    Relu2,
+    Gelu,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__attention_config_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__attention_config_small.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+AttentionConfig {
+    num_heads: 8,
+    head_dim: 64,
+    seq_len: 256,
+    causal: false,
+    scale: Some(
+        0.1,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__attention_config_standard_mha.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__attention_config_standard_mha.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+AttentionConfig {
+    num_heads: 32,
+    head_dim: 128,
+    seq_len: 512,
+    causal: true,
+    scale: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__capability_entry_full_support.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__capability_entry_full_support.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: entry
+---
+CapabilityEntry {
+    operation: MatrixOps,
+    precision: FP16,
+    support: Full(
+        0.95,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__capability_entry_partial_support.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__capability_entry_partial_support.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: entry
+---
+CapabilityEntry {
+    operation: QuantizedOps,
+    precision: INT8,
+    support: Partial(
+        "no native i2s",
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__cpu_attention_config_batched.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__cpu_attention_config_batched.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+CpuAttentionConfig {
+    batch_size: 4,
+    num_heads: 16,
+    seq_len: 512,
+    head_dim: 64,
+    scale: None,
+    causal_mask: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__cpu_attention_config_single.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__cpu_attention_config_single.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+CpuAttentionConfig {
+    batch_size: 1,
+    num_heads: 32,
+    seq_len: 128,
+    head_dim: 128,
+    scale: Some(
+        0.088,
+    ),
+    causal_mask: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_all_variants_debug.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: devices
+---
+[
+    Cpu,
+    Cuda(
+        0,
+    ),
+    Hip(
+        0,
+    ),
+    Npu,
+    Metal,
+    OpenCL(
+        0,
+    ),
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_profile_cpu_simd.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_profile_cpu_simd.snap
@@ -1,0 +1,33 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: profile
+---
+DeviceProfile {
+    device_class: CpuSimd,
+    name: "x86_64 AVX2",
+    compute_units: 8,
+    memory_gb: 32,
+    capabilities: [
+        CapabilityEntry {
+            operation: MatrixOps,
+            precision: FP32,
+            support: Full(
+                0.9,
+            ),
+        },
+        CapabilityEntry {
+            operation: NormOps,
+            precision: FP32,
+            support: Full(
+                0.95,
+            ),
+        },
+        CapabilityEntry {
+            operation: ActivationOps,
+            precision: FP32,
+            support: Full(
+                0.92,
+            ),
+        },
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_profile_nvidia_gpu.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__device_profile_nvidia_gpu.snap
@@ -1,0 +1,26 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: profile
+---
+DeviceProfile {
+    device_class: NvidiaCuda,
+    name: "NVIDIA RTX 4090",
+    compute_units: 128,
+    memory_gb: 24,
+    capabilities: [
+        CapabilityEntry {
+            operation: MatrixOps,
+            precision: FP16,
+            support: Full(
+                0.98,
+            ),
+        },
+        CapabilityEntry {
+            operation: AttentionOps,
+            precision: FP16,
+            support: Full(
+                0.96,
+            ),
+        },
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__ffn_activation_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__ffn_activation_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: activations
+---
+[
+    GeLU,
+    SiLU,
+    ReLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gather_config_axis0.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gather_config_axis0.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+GatherConfig {
+    axis: 0,
+    indices_shape: (
+        4,
+        8,
+    ),
+    bounds_check: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gather_config_axis1_no_bounds_check.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gather_config_axis1_no_bounds_check.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+GatherConfig {
+    axis: 1,
+    indices_shape: (
+        16,
+        32,
+    ),
+    bounds_check: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gqa_config_4_to_1_ratio.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gqa_config_4_to_1_ratio.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+GqaConfig {
+    num_q_heads: 32,
+    num_kv_heads: 8,
+    head_dim: 128,
+    seq_len: 1024,
+    causal: true,
+    scale: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gqa_config_mqa.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__gqa_config_mqa.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+GqaConfig {
+    num_q_heads: 32,
+    num_kv_heads: 1,
+    head_dim: 128,
+    seq_len: 2048,
+    causal: true,
+    scale: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__inference_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__inference_config_default.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+InferenceConfig {
+    max_length: 2048,
+    max_new_tokens: 512,
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    seed: None,
+    add_bos: true,
+    append_eos: false,
+    mask_pad: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_backend_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_backend_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: backends
+---
+[
+    CpuRust,
+    Cuda,
+    Hip,
+    OneApi,
+    OpenCL,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_capabilities_cpu_only.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_capabilities_cpu_only.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: caps
+---
+KernelCapabilities {
+    cpu_rust: true,
+    cuda_compiled: false,
+    cuda_runtime: false,
+    hip_compiled: false,
+    hip_runtime: false,
+    oneapi_compiled: false,
+    oneapi_runtime: false,
+    opencl_compiled: false,
+    opencl_runtime: false,
+    cpp_ffi: false,
+    simd_level: Avx2,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_capabilities_full_gpu.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__kernel_capabilities_full_gpu.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: caps
+---
+KernelCapabilities {
+    cpu_rust: true,
+    cuda_compiled: true,
+    cuda_runtime: true,
+    hip_compiled: false,
+    hip_runtime: false,
+    oneapi_compiled: false,
+    oneapi_runtime: false,
+    opencl_compiled: true,
+    opencl_runtime: true,
+    cpp_ffi: true,
+    simd_level: Avx512,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__model_format_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__model_format_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: formats
+---
+[
+    Gguf,
+    SafeTensors,
+    HuggingFace,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__norm_type_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__norm_type_all_variants_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: norms
+---
+[
+    LayerNorm,
+    RmsNorm,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_avg_pool_2.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_avg_pool_2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+PoolConfig {
+    pool_type: Average,
+    kernel_size: 2,
+    stride: 2,
+    padding: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_global_average.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_global_average.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+PoolConfig {
+    pool_type: GlobalAverage,
+    kernel_size: 0,
+    stride: 0,
+    padding: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_global_max.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_global_max.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+PoolConfig {
+    pool_type: GlobalMax,
+    kernel_size: 0,
+    stride: 0,
+    padding: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_max_pool_3.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_config_max_pool_3.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+PoolConfig {
+    pool_type: Max,
+    kernel_size: 3,
+    stride: 1,
+    padding: 1,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_type_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__pool_type_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: types
+---
+[
+    Max,
+    Average,
+    GlobalMax,
+    GlobalAverage,
+    AvgPoolCountIncludePad,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_i2s_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_i2s_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "QuantizationType::I2S"
+---
+I2S

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_i2s_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_i2s_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "format!(\"{}\", QuantizationType::I2S)"
+---
+I2_S

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl1_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl1_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "QuantizationType::TL1"
+---
+TL1

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl1_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl1_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "format!(\"{}\", QuantizationType::TL1)"
+---
+TL1

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl2_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl2_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "QuantizationType::TL2"
+---
+TL2

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl2_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__quantization_type_tl2_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "format!(\"{}\", QuantizationType::TL2)"
+---
+TL2

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_l2norm_512.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_l2norm_512.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ReductionConfig {
+    reduce_dim: 512,
+    n_reductions: 16,
+    threads_per_block: 512,
+    op: L2Norm,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_mean_1024.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_mean_1024.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ReductionConfig {
+    reduce_dim: 1024,
+    n_reductions: 32,
+    threads_per_block: 1024,
+    op: Mean,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_sum_256.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_config_sum_256.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ReductionConfig {
+    reduce_dim: 256,
+    n_reductions: 64,
+    threads_per_block: 256,
+    op: Sum,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_op_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__reduction_op_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: ops
+---
+[
+    Sum,
+    Max,
+    Min,
+    Mean,
+    L2Norm,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_large_model.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_large_model.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+RopeConfig {
+    head_dim: 128,
+    max_seq_len: 8192,
+    base: 500000.0,
+    scaling_factor: 1.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_medium_model.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_medium_model.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+RopeConfig {
+    head_dim: 128,
+    max_seq_len: 4096,
+    base: 10000.0,
+    scaling_factor: 1.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_small_model.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_small_model.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+RopeConfig {
+    head_dim: 64,
+    max_seq_len: 2048,
+    base: 10000.0,
+    scaling_factor: 1.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_with_scaling.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_config_with_scaling.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+RopeConfig {
+    head_dim: 128,
+    max_seq_len: 32768,
+    base: 10000.0,
+    scaling_factor: 4.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_scaling_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__rope_scaling_config_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: scaling
+---
+RopeScaling {
+    scaling_type: "linear",
+    factor: 4.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__scatter_mode_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__scatter_mode_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: modes
+---
+[
+    Assign,
+    Add,
+    Max,
+    Min,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_axis_max_no_keepdim.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_axis_max_no_keepdim.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ShapedReductionConfig {
+    op: Max,
+    axis: Some(
+        0,
+    ),
+    keepdim: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_axis_mean_keepdim.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_axis_mean_keepdim.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ShapedReductionConfig {
+    op: Mean,
+    axis: Some(
+        1,
+    ),
+    keepdim: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_global_sum.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__shaped_reduction_global_sum.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: cfg
+---
+ShapedReductionConfig {
+    op: Sum,
+    axis: None,
+    keepdim: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__simd_level_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__simd_level_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: levels
+---
+[
+    Scalar,
+    Neon,
+    Sse42,
+    Avx2,
+    Avx512,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__simd_level_all_variants_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave17__snapshot_wave17__simd_level_all_variants_display.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave17.rs
+expression: "output.join(\"\\n\")"
+---
+scalar
+neon
+sse4.2
+avx2
+avx512


### PR DESCRIPTION
## Summary

Add **47 snapshot assertions** (wave 17) for key kernel configuration structures in `bitnet-kernels`, ensuring output stability across:

### Snapshot Coverage
1. **Quantization formats** — I2_S, TL1, TL2 Display and Debug output (6 snapshots)
2. **SIMD capability detection** — SimdLevel, KernelBackend, KernelCapabilities (5 snapshots)
3. **Activation functions** — ActivationType, FfnActivation variants (2 snapshots)
4. **RoPE configuration** — small/medium/large models, custom base and scaling (4 snapshots)
5. **Attention configuration** — MHA, GQA (4:1 ratio), MQA, CpuAttentionConfig (6 snapshots)
6. **Pooling operations** — PoolType variants, max/avg/global pool configs (5 snapshots)
7. **Reduction operations** — ReductionOp variants, sum/mean/L2norm configs (4 snapshots)
8. **Shaped reductions** — global, axis-specific with keepdim (3 snapshots)
9. **Scatter/gather** — ScatterMode variants, GatherConfig axis configs (3 snapshots)
10. **Device capability matrix** — CapabilityEntry, DeviceProfile for CPU and GPU (4 snapshots)
11. **Common config types** — InferenceConfig defaults, Device/NormType/ModelFormat/RopeScaling (5 snapshots)

### Verification
- `cargo test --test snapshot_wave17 -p bitnet-kernels --no-default-features --features cpu` — **47 passed**
- `cargo clippy --test snapshot_wave17 -p bitnet-kernels --no-default-features --features cpu -- -D warnings` — clean
- `cargo fmt --all` — formatted

### Files
- `crates/bitnet-kernels/tests/snapshot_wave17.rs` — test file
- `crates/bitnet-kernels/tests/snapshots/snapshot_wave17__*.snap` — 47 snapshot files