### PR TITLE
feat(kernels): add OpenCL continuous batching module

### DIFF
--- a/crates/bitnet-kernels/src/opencl_continuous_batch.rs
+++ b/crates/bitnet-kernels/src/opencl_continuous_batch.rs
@@ -1,135 +1,114 @@
-//! Continuous batching engine for OpenCL multi-request serving.
+//! OpenCL continuous (iteration-level) batching for serving multiple requests
+//! with different generation lengths.
 //!
-//! Implements dynamic sequence scheduling inspired by vLLM/Orca,
-//! enabling concurrent prefill and decode phases within a single batch.
-//! Designed for Intel Arc A770 GPUs via OpenCL, with CPU reference
-//! implementations for correctness testing.
+//! Each forward-pass iteration processes one token per active slot.  Finished
+//! requests free their slots immediately and new requests fill the gaps
+//! without stalling the batch.
 
 use std::fmt;
 
 // ---------------------------------------------------------------------------
-// Types
+// Configuration
 // ---------------------------------------------------------------------------
 
 /// Configuration for the continuous batching engine.
 #[derive(Debug, Clone)]
-pub struct BatchConfig {
-    /// Maximum number of concurrent sequences.
+pub struct ContinuousBatchConfig {
+    /// Maximum number of concurrent generation slots.
     pub max_batch_size: usize,
     /// Maximum sequence length (prompt + generated tokens).
     pub max_seq_len: usize,
-    /// Number of tokens consumed per prefill iteration.
-    pub prefill_chunk_size: usize,
-    /// Whether priority-based preemption is enabled.
-    pub enable_preemption: bool,
+    /// Timeout in milliseconds for a single iteration.
+    pub iteration_timeout_ms: u64,
 }
 
-/// State of a sequence within the batch.
-#[derive(Debug, Clone, PartialEq)]
-pub enum SequenceState {
-    /// Processing prompt tokens.
-    Prefilling,
-    /// Auto-regressive token generation.
-    Decoding,
-    /// Temporarily paused (e.g. preempted).
-    Paused,
-    /// Generation finished normally.
-    Completed,
-    /// Generation failed with reason.
-    Failed(String),
-}
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
 
-/// Metadata and state for a single in-flight sequence.
+/// A request submitted for generation.
 #[derive(Debug, Clone)]
-pub struct SequenceInfo {
-    /// Unique identifier.
-    pub id: u64,
-    /// Original prompt token IDs.
+pub struct GenerationRequest {
+    /// Unique request identifier (assigned by [`SlotManager`]).
+    pub request_id: u64,
+    /// Input token IDs (the prompt).
     pub prompt_tokens: Vec<u32>,
-    /// Tokens produced so far.
-    pub generated_tokens: Vec<u32>,
-    /// Current lifecycle state.
-    pub state: SequenceState,
+    /// Maximum number of *new* tokens to generate.
+    pub max_tokens: usize,
     /// Scheduling priority (higher = more important).
     pub priority: u32,
-    /// Arrival timestamp in nanoseconds.
-    pub arrival_time_ns: u64,
 }
 
-/// A slot that may hold a sequence.
+/// A slot in the batch that may hold an active generation.
 #[derive(Debug, Clone)]
-pub struct BatchSlot {
-    /// Index within the batch.
+pub struct GenerationSlot {
+    /// Index within the batch (0-based, reassigned on compact).
     pub slot_id: usize,
-    /// Currently assigned sequence, if any.
-    pub sequence: Option<SequenceInfo>,
-    /// Whether KV-cache memory has been reserved.
-    pub kv_allocated: bool,
+    /// The request occupying this slot, if any.
+    pub request: Option<GenerationRequest>,
+    /// Number of tokens generated so far.
+    pub current_position: usize,
+    /// Maximum tokens this slot will generate (copied from request).
+    pub max_tokens: usize,
+    /// Whether this slot is actively generating.
+    pub is_active: bool,
+    /// Tokens generated in this slot (output buffer).
+    generated_tokens: Vec<u32>,
 }
 
-/// The continuous batching engine.
-#[derive(Debug)]
-pub struct ContinuousBatch {
-    /// Fixed-size slot array.
-    pub slots: Vec<BatchSlot>,
-    /// Engine configuration.
-    pub config: BatchConfig,
-    /// Monotonic iteration counter.
-    pub iteration_count: u64,
-    /// Cumulative statistics.
-    pub stats: BatchStats,
-    /// Counter for generating unique sequence IDs.
-    next_seq_id: u64,
+impl GenerationSlot {
+    fn empty(slot_id: usize) -> Self {
+        Self {
+            slot_id,
+            request: None,
+            current_position: 0,
+            max_tokens: 0,
+            is_active: false,
+            generated_tokens: Vec::new(),
+        }
+    }
+
+    /// Whether the slot has reached its generation limit.
+    pub fn is_finished(&self) -> bool {
+        self.is_active && self.current_position >= self.max_tokens
+    }
+
+    /// Read-only access to generated tokens.
+    pub fn generated_tokens(&self) -> &[u32] {
+        &self.generated_tokens
+    }
 }
 
-/// Aggregate statistics for the batch engine.
-#[derive(Debug, Clone, Default)]
-pub struct BatchStats {
-    pub total_sequences_served: u64,
-    pub total_tokens_generated: u64,
-    pub avg_prefill_latency_ms: f64,
-    pub avg_decode_latency_ms: f64,
-    pub preemptions: u64,
-    pub utilization_pct: f64,
-}
-
-/// An action the scheduler may emit.
-#[derive(Debug, Clone, PartialEq)]
-pub enum ScheduleAction {
-    /// Begin or continue prefilling the given sequence.
-    AddToPrefill(u64),
-    /// Continue decoding the given sequence.
-    ContinueDecode(u64),
-    /// Preempt (pause) the given sequence.
-    Preempt(u64),
-    /// Evict the given sequence from the batch.
-    Evict(u64),
-    /// Nothing to do.
-    NoOp,
-}
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
 
 /// Errors produced by the batching engine.
 #[derive(Debug, Clone, PartialEq)]
 pub enum BatchError {
     /// All batch slots are occupied.
     BatchFull,
-    /// No sequence with the given ID was found.
-    SequenceNotFound(u64),
-    /// The operation is not valid for the current sequence state.
-    InvalidState,
-    /// Preemption could not be carried out.
+    /// The specified slot was not found or is not active.
+    SlotNotFound(usize),
+    /// The request ID was not found.
+    RequestNotFound(u64),
+    /// Preemption is disabled or no suitable candidate exists.
     PreemptionFailed,
-    /// Configuration or parameter error.
+    /// Configuration / parameter error.
     ConfigError(String),
 }
 
 impl fmt::Display for BatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::BatchFull => write!(f, "batch is full"),
-            Self::SequenceNotFound(id) => write!(f, "sequence {id} not found"),
-            Self::InvalidState => write!(f, "invalid sequence state for operation"),
-            Self::PreemptionFailed => write!(f, "preemption failed"),
+            Self::BatchFull => write!(f, "all batch slots are occupied"),
+            Self::SlotNotFound(id) => {
+                write!(f, "slot {id} not found or inactive")
+            }
+            Self::RequestNotFound(id) => write!(f, "request {id} not found"),
+            Self::PreemptionFailed => {
+                write!(f, "preemption failed or disabled")
+            }
             Self::ConfigError(msg) => write!(f, "config error: {msg}"),
         }
     }
@@ -138,316 +117,413 @@ impl fmt::Display for BatchError {
 impl std::error::Error for BatchError {}
 
 // ---------------------------------------------------------------------------
+// SlotManager
+// ---------------------------------------------------------------------------
+
+/// Manages active and free generation slots.
+#[derive(Debug)]
+pub struct SlotManager {
+    slots: Vec<GenerationSlot>,
+    config: ContinuousBatchConfig,
+    next_request_id: u64,
+    stats: ContinuousBatchStats,
+}
+
+impl SlotManager {
+    /// Create a new slot manager.
+    pub fn new(config: ContinuousBatchConfig) -> Self {
+        let slots = (0..config.max_batch_size).map(GenerationSlot::empty).collect();
+        Self { slots, config, next_request_id: 1, stats: ContinuousBatchStats::default() }
+    }
+
+    /// Insert a new request into the first available slot.
+    ///
+    /// Returns `(slot_id, request_id)`.
+    pub fn insert(
+        &mut self,
+        prompt_tokens: Vec<u32>,
+        max_tokens: usize,
+        priority: u32,
+    ) -> Result<(usize, u64), BatchError> {
+        if prompt_tokens.is_empty() {
+            return Err(BatchError::ConfigError("prompt must not be empty".into()));
+        }
+        if max_tokens == 0 {
+            return Err(BatchError::ConfigError("max_tokens must be > 0".into()));
+        }
+
+        let slot = self.slots.iter_mut().find(|s| !s.is_active).ok_or(BatchError::BatchFull)?;
+
+        let request_id = self.next_request_id;
+        self.next_request_id += 1;
+
+        slot.request = Some(GenerationRequest { request_id, prompt_tokens, max_tokens, priority });
+        slot.current_position = 0;
+        slot.max_tokens = max_tokens;
+        slot.is_active = true;
+        slot.generated_tokens.clear();
+
+        let slot_id = slot.slot_id;
+        Ok((slot_id, request_id))
+    }
+
+    /// Remove a request by slot index, freeing the slot.
+    pub fn remove(&mut self, slot_id: usize) -> Result<GenerationRequest, BatchError> {
+        let slot = self
+            .slots
+            .iter_mut()
+            .find(|s| s.slot_id == slot_id && s.is_active)
+            .ok_or(BatchError::SlotNotFound(slot_id))?;
+
+        let request = slot.request.take().ok_or(BatchError::SlotNotFound(slot_id))?;
+        let gen_len = slot.generated_tokens.len() as u64;
+
+        slot.is_active = false;
+        slot.current_position = 0;
+        slot.max_tokens = 0;
+        slot.generated_tokens.clear();
+
+        self.stats.total_completed += 1;
+        self.stats.total_tokens_generated += gen_len;
+        let n = self.stats.total_completed as f64;
+        self.stats.avg_generation_length =
+            self.stats.avg_generation_length * ((n - 1.0) / n) + gen_len as f64 / n;
+
+        Ok(request)
+    }
+
+    /// Remove a request by its request ID.
+    pub fn remove_by_request_id(
+        &mut self,
+        request_id: u64,
+    ) -> Result<GenerationRequest, BatchError> {
+        let slot_id = self
+            .slots
+            .iter()
+            .find(|s| s.is_active && s.request.as_ref().is_some_and(|r| r.request_id == request_id))
+            .map(|s| s.slot_id)
+            .ok_or(BatchError::RequestNotFound(request_id))?;
+        self.remove(slot_id)
+    }
+
+    /// Compact: move all active slots to the front, reassign IDs.
+    pub fn compact(&mut self) {
+        self.slots.sort_by(|a, b| b.is_active.cmp(&a.is_active));
+        for (i, slot) in self.slots.iter_mut().enumerate() {
+            slot.slot_id = i;
+        }
+    }
+
+    /// Number of active slots.
+    pub fn active_count(&self) -> usize {
+        self.slots.iter().filter(|s| s.is_active).count()
+    }
+
+    /// Whether all slots are occupied.
+    pub fn is_full(&self) -> bool {
+        self.active_count() == self.config.max_batch_size
+    }
+
+    /// Get a reference to a slot by its current slot_id.
+    pub fn get_slot(&self, slot_id: usize) -> Option<&GenerationSlot> {
+        self.slots.iter().find(|s| s.slot_id == slot_id)
+    }
+
+    /// Get a mutable reference to a slot by its current slot_id.
+    pub fn get_slot_mut(&mut self, slot_id: usize) -> Option<&mut GenerationSlot> {
+        self.slots.iter_mut().find(|s| s.slot_id == slot_id)
+    }
+
+    /// All slots (active and inactive).
+    pub fn slots(&self) -> &[GenerationSlot] {
+        &self.slots
+    }
+
+    /// Engine configuration.
+    pub fn config(&self) -> &ContinuousBatchConfig {
+        &self.config
+    }
+
+    /// Accumulated stats (call [`compute_stats`] for a utilisation snapshot).
+    pub fn stats(&self) -> &ContinuousBatchStats {
+        &self.stats
+    }
+
+    /// Snapshot of stats with live utilisation.
+    pub fn compute_stats(&self) -> ContinuousBatchStats {
+        let utilization = if self.config.max_batch_size > 0 {
+            self.active_count() as f64 / self.config.max_batch_size as f64
+        } else {
+            0.0
+        };
+        ContinuousBatchStats {
+            slot_utilization: utilization,
+            preemption_count: self.stats.preemption_count,
+            avg_generation_length: self.stats.avg_generation_length,
+            total_completed: self.stats.total_completed,
+            total_tokens_generated: self.stats.total_tokens_generated,
+        }
+    }
+
+    fn record_preemption(&mut self) {
+        self.stats.preemption_count += 1;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IterationBatch
+// ---------------------------------------------------------------------------
+
+/// Tokens for the current iteration across all active slots.
+#[derive(Debug, Clone, Default)]
+pub struct IterationBatch {
+    /// Slot indices included in this iteration.
+    pub slot_indices: Vec<usize>,
+    /// Token ID for each included slot.
+    pub tokens: Vec<u32>,
+    /// Sequence position for each slot.
+    pub positions: Vec<usize>,
+}
+
+impl IterationBatch {
+    /// Number of slots in this iteration.
+    pub fn len(&self) -> usize {
+        self.slot_indices.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.slot_indices.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SlotScheduler
+// ---------------------------------------------------------------------------
+
+/// Decides which slots to include in each iteration.
+pub struct SlotScheduler;
+
+impl SlotScheduler {
+    /// Build an [`IterationBatch`] from the current slot manager state.
+    ///
+    /// Includes every active, non-finished slot.  Each slot contributes its
+    /// most recent generated token, or the first prompt token if none have
+    /// been generated yet.
+    pub fn build_iteration(manager: &SlotManager) -> IterationBatch {
+        let mut batch = IterationBatch::default();
+        for slot in manager.slots() {
+            if !slot.is_active || slot.is_finished() {
+                continue;
+            }
+            let token = if let Some(&last) = slot.generated_tokens.last() {
+                last
+            } else if let Some(req) = &slot.request {
+                req.prompt_tokens.first().copied().unwrap_or(0)
+            } else {
+                0
+            };
+            batch.slot_indices.push(slot.slot_id);
+            batch.tokens.push(token);
+            batch.positions.push(slot.current_position);
+        }
+        batch
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PreemptionPolicy
+// ---------------------------------------------------------------------------
+
+/// Policy for preempting low-priority slots when memory is scarce.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PreemptionPolicy {
+    /// Never preempt.
+    Disabled,
+    /// Preempt the lowest-priority active slot.
+    LowestPriority,
+    /// Preempt the slot with the shortest generation so far.
+    ShortestGeneration,
+}
+
+impl PreemptionPolicy {
+    /// Find a slot to preempt whose priority is strictly below
+    /// `new_priority`.  Returns the victim's `slot_id`.
+    pub fn select_victim(&self, manager: &SlotManager, new_priority: u32) -> Option<usize> {
+        match self {
+            Self::Disabled => None,
+            Self::LowestPriority => manager
+                .slots()
+                .iter()
+                .filter(|s| {
+                    s.is_active && s.request.as_ref().is_some_and(|r| r.priority < new_priority)
+                })
+                .min_by_key(|s| s.request.as_ref().map(|r| r.priority).unwrap_or(u32::MAX))
+                .map(|s| s.slot_id),
+            Self::ShortestGeneration => manager
+                .slots()
+                .iter()
+                .filter(|s| {
+                    s.is_active && s.request.as_ref().is_some_and(|r| r.priority < new_priority)
+                })
+                .min_by_key(|s| s.current_position)
+                .map(|s| s.slot_id),
+        }
+    }
+
+    /// Preempt a victim and insert a new request in its place.
+    ///
+    /// Returns `(new_slot_id, new_request_id, evicted_request)`.
+    pub fn preempt_and_insert(
+        &self,
+        manager: &mut SlotManager,
+        prompt_tokens: Vec<u32>,
+        max_tokens: usize,
+        priority: u32,
+    ) -> Result<(usize, u64, GenerationRequest), BatchError> {
+        let victim = self.select_victim(manager, priority).ok_or(BatchError::PreemptionFailed)?;
+        let evicted = manager.remove(victim)?;
+        manager.record_preemption();
+        let (slot_id, req_id) = manager.insert(prompt_tokens, max_tokens, priority)?;
+        Ok((slot_id, req_id, evicted))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CompactBatcher
+// ---------------------------------------------------------------------------
+
+/// Removes gaps from finished slots and maintains contiguous batch layout.
+pub struct CompactBatcher;
+
+impl CompactBatcher {
+    /// Remove all finished slots and compact the batch.
+    ///
+    /// Returns the completed requests.
+    pub fn compact_finished(manager: &mut SlotManager) -> Vec<GenerationRequest> {
+        let finished: Vec<usize> =
+            manager.slots().iter().filter(|s| s.is_finished()).map(|s| s.slot_id).collect();
+
+        let mut completed = Vec::new();
+        for id in finished {
+            if let Ok(req) = manager.remove(id) {
+                completed.push(req);
+            }
+        }
+        manager.compact();
+        completed
+    }
+
+    /// Compact without removing finished slots.
+    pub fn compact_gaps(manager: &mut SlotManager) {
+        manager.compact();
+    }
+
+    /// Check whether active slots are contiguous (no gaps).
+    pub fn is_contiguous(manager: &SlotManager) -> bool {
+        let active = manager.active_count();
+        if active == 0 {
+            return true;
+        }
+        manager.slots().iter().take(active).all(|s| s.is_active)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ContinuousBatchStats
+// ---------------------------------------------------------------------------
+
+/// Aggregate statistics for the continuous batching engine.
+#[derive(Debug, Clone, Default)]
+pub struct ContinuousBatchStats {
+    /// Current slot utilisation (0.0–1.0).
+    pub slot_utilization: f64,
+    /// Number of preemptions performed.
+    pub preemption_count: u64,
+    /// Average generation length across completed requests.
+    pub avg_generation_length: f64,
+    /// Total requests completed.
+    pub total_completed: u64,
+    /// Total tokens generated across all completed requests.
+    pub total_tokens_generated: u64,
+}
+
+// ---------------------------------------------------------------------------
 // CPU reference implementations
 // ---------------------------------------------------------------------------
 
-/// Create a new continuous batch from the given configuration.
-pub fn create_continuous_batch(config: BatchConfig) -> ContinuousBatch {
-    let slots = (0..config.max_batch_size)
-        .map(|i| BatchSlot { slot_id: i, sequence: None, kv_allocated: false })
-        .collect();
-    ContinuousBatch {
-        slots,
-        config,
-        iteration_count: 0,
-        stats: BatchStats::default(),
-        next_seq_id: 1,
-    }
-}
-
-/// Add a new sequence to the batch, returning its unique ID.
-pub fn cpu_add_sequence(
-    batch: &mut ContinuousBatch,
-    prompt: Vec<u32>,
-    priority: u32,
-) -> Result<u64, BatchError> {
-    if prompt.is_empty() {
-        return Err(BatchError::ConfigError("prompt must not be empty".into()));
-    }
-    let slot =
-        batch.slots.iter_mut().find(|s| s.sequence.is_none()).ok_or(BatchError::BatchFull)?;
-
-    let id = batch.next_seq_id;
-    batch.next_seq_id += 1;
-
-    let now_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as u64;
-
-    slot.sequence = Some(SequenceInfo {
-        id,
-        prompt_tokens: prompt,
-        generated_tokens: Vec::new(),
-        state: SequenceState::Prefilling,
-        priority,
-        arrival_time_ns: now_ns,
-    });
-    slot.kv_allocated = true;
-    Ok(id)
-}
-
-/// Remove a sequence from the batch, returning its info.
-pub fn cpu_remove_sequence(
-    batch: &mut ContinuousBatch,
-    seq_id: u64,
-) -> Result<SequenceInfo, BatchError> {
-    let slot = batch
-        .slots
-        .iter_mut()
-        .find(|s| s.sequence.as_ref().is_some_and(|seq| seq.id == seq_id))
-        .ok_or(BatchError::SequenceNotFound(seq_id))?;
-
-    let info = slot.sequence.take().unwrap();
-    slot.kv_allocated = false;
-    batch.stats.total_sequences_served += 1;
-    Ok(info)
-}
-
-/// Produce a list of scheduling actions for the current iteration.
-///
-/// Policy: prefilling sequences are scheduled first (lower latency-to-first-token),
-/// followed by decoding sequences ordered by priority (descending).
-pub fn cpu_schedule_iteration(batch: &mut ContinuousBatch) -> Vec<ScheduleAction> {
-    batch.iteration_count += 1;
-
-    let mut actions = Vec::new();
-
-    // Collect prefilling sequences sorted by priority (descending).
-    let mut prefilling: Vec<(u64, u32)> = batch
-        .slots
-        .iter()
-        .filter_map(|s| {
-            s.sequence
-                .as_ref()
-                .filter(|seq| seq.state == SequenceState::Prefilling)
-                .map(|seq| (seq.id, seq.priority))
-        })
-        .collect();
-    prefilling.sort_by(|a, b| b.1.cmp(&a.1));
-
-    for (id, _) in &prefilling {
-        actions.push(ScheduleAction::AddToPrefill(*id));
-    }
-
-    // Collect decoding sequences (sorted by priority desc).
-    let mut decoding: Vec<(u64, u32)> = batch
-        .slots
-        .iter()
-        .filter_map(|s| {
-            s.sequence
-                .as_ref()
-                .filter(|seq| seq.state == SequenceState::Decoding)
-                .map(|seq| (seq.id, seq.priority))
-        })
-        .collect();
-    decoding.sort_by(|a, b| b.1.cmp(&a.1));
-
-    for (id, _) in &decoding {
-        actions.push(ScheduleAction::ContinueDecode(*id));
-    }
-
-    if actions.is_empty() {
-        actions.push(ScheduleAction::NoOp);
-    }
-
-    actions
-}
-
-/// Execute a prefill step for the given sequence.
-///
-/// Consumes up to `prefill_chunk_size` prompt tokens. When the prompt is
-/// exhausted the sequence transitions to `Decoding`. The returned token is
-/// selected via argmax over `logits`.
-pub fn cpu_execute_prefill_step(
-    batch: &mut ContinuousBatch,
-    seq_id: u64,
+/// CPU reference: advance one generation step for the given slot.
+pub fn cpu_step_slot(
+    manager: &mut SlotManager,
+    slot_id: usize,
     logits: &[f32],
 ) -> Result<u32, BatchError> {
-    let chunk_size = batch.config.prefill_chunk_size;
-    let max_seq_len = batch.config.max_seq_len;
-    let seq = batch
-        .slots
-        .iter_mut()
-        .find_map(|s| {
-            s.sequence
-                .as_mut()
-                .filter(|seq| seq.id == seq_id && seq.state == SequenceState::Prefilling)
-        })
-        .ok_or(BatchError::SequenceNotFound(seq_id))?;
+    let max_seq_len = manager.config().max_seq_len;
+    let slot = manager
+        .get_slot_mut(slot_id)
+        .filter(|s| s.is_active && !s.is_finished())
+        .ok_or(BatchError::SlotNotFound(slot_id))?;
 
-    // Determine how many prompt tokens have been "processed".
-    let processed = seq.generated_tokens.len() + chunk_size;
-    let prompt_len = seq.prompt_tokens.len();
+    let token = cpu_argmax(logits);
 
-    let token = argmax(logits);
-
-    // Check max sequence length.
-    if seq.prompt_tokens.len() + seq.generated_tokens.len() + 1 > max_seq_len {
-        seq.state = SequenceState::Completed;
+    let prompt_len = slot.request.as_ref().map(|r| r.prompt_tokens.len()).unwrap_or(0);
+    if prompt_len + slot.current_position + 1 > max_seq_len {
+        slot.current_position = slot.max_tokens; // mark finished
         return Ok(token);
     }
 
-    seq.generated_tokens.push(token);
-    batch.stats.total_tokens_generated += 1;
-
-    if processed >= prompt_len {
-        seq.state = SequenceState::Decoding;
-    }
-
+    slot.generated_tokens.push(token);
+    slot.current_position += 1;
     Ok(token)
 }
 
-/// Execute a single decode step for the given sequence.
-///
-/// The token is selected via argmax over `logits`.
-pub fn cpu_execute_decode_step(
-    batch: &mut ContinuousBatch,
-    seq_id: u64,
-    logits: &[f32],
-) -> Result<u32, BatchError> {
-    let max_seq_len = batch.config.max_seq_len;
-    let seq = batch
-        .slots
-        .iter_mut()
-        .find_map(|s| {
-            s.sequence
-                .as_mut()
-                .filter(|seq| seq.id == seq_id && seq.state == SequenceState::Decoding)
-        })
-        .ok_or(BatchError::SequenceNotFound(seq_id))?;
-
-    let token = argmax(logits);
-
-    if seq.prompt_tokens.len() + seq.generated_tokens.len() + 1 > max_seq_len {
-        seq.state = SequenceState::Completed;
-        return Ok(token);
-    }
-
-    seq.generated_tokens.push(token);
-    batch.stats.total_tokens_generated += 1;
-
-    Ok(token)
-}
-
-/// Preempt (pause) a running sequence to free resources for higher-priority work.
-pub fn cpu_preempt_sequence(batch: &mut ContinuousBatch, seq_id: u64) -> Result<(), BatchError> {
-    if !batch.config.enable_preemption {
-        return Err(BatchError::PreemptionFailed);
-    }
-    let seq = batch
-        .slots
-        .iter_mut()
-        .find_map(|s| {
-            s.sequence.as_mut().filter(|seq| {
-                seq.id == seq_id
-                    && (seq.state == SequenceState::Prefilling
-                        || seq.state == SequenceState::Decoding)
-            })
-        })
-        .ok_or(BatchError::SequenceNotFound(seq_id))?;
-
-    seq.state = SequenceState::Paused;
-    batch.stats.preemptions += 1;
-    Ok(())
-}
-
-/// Resume a previously paused sequence.
-pub fn cpu_resume_sequence(batch: &mut ContinuousBatch, seq_id: u64) -> Result<(), BatchError> {
-    let seq = batch
-        .slots
-        .iter_mut()
-        .find_map(|s| {
-            s.sequence.as_mut().filter(|seq| seq.id == seq_id && seq.state == SequenceState::Paused)
-        })
-        .ok_or(BatchError::SequenceNotFound(seq_id))?;
-
-    // If the prompt hasn't been fully consumed, resume in prefill mode.
-    let prompt_len = seq.prompt_tokens.len();
-    let chunk = batch.config.prefill_chunk_size;
-    let processed = seq.generated_tokens.len() + chunk;
-    if processed < prompt_len {
-        seq.state = SequenceState::Prefilling;
-    } else {
-        seq.state = SequenceState::Decoding;
-    }
-    Ok(())
-}
-
-/// Return references to all active (non-empty) sequences.
-pub fn cpu_get_active_sequences(batch: &ContinuousBatch) -> Vec<&SequenceInfo> {
-    batch.slots.iter().filter_map(|s| s.sequence.as_ref()).collect()
-}
-
-/// Compute aggregate statistics for the batch.
-pub fn cpu_compute_batch_stats(batch: &ContinuousBatch) -> BatchStats {
-    let occupied = batch.slots.iter().filter(|s| s.sequence.is_some()).count();
-    let utilization = if batch.config.max_batch_size > 0 {
-        (occupied as f64 / batch.config.max_batch_size as f64) * 100.0
-    } else {
-        0.0
-    };
-    BatchStats {
-        total_sequences_served: batch.stats.total_sequences_served,
-        total_tokens_generated: batch.stats.total_tokens_generated,
-        avg_prefill_latency_ms: batch.stats.avg_prefill_latency_ms,
-        avg_decode_latency_ms: batch.stats.avg_decode_latency_ms,
-        preemptions: batch.stats.preemptions,
-        utilization_pct: utilization,
-    }
-}
-
-/// Identify the lowest-priority active sequence whose priority is strictly
-/// below `new_priority`, returning its ID as a preemption candidate.
-pub fn cpu_should_preempt(batch: &ContinuousBatch, new_priority: u32) -> Option<u64> {
-    if !batch.config.enable_preemption {
-        return None;
-    }
-    batch
-        .slots
+/// CPU reference: advance one iteration for every active, non-finished slot.
+pub fn cpu_step_iteration(
+    manager: &mut SlotManager,
+    logits_per_slot: &[Vec<f32>],
+) -> Result<Vec<(usize, u32)>, BatchError> {
+    let active_ids: Vec<usize> = manager
+        .slots()
         .iter()
-        .filter_map(|s| {
-            s.sequence.as_ref().filter(|seq| {
-                (seq.state == SequenceState::Prefilling || seq.state == SequenceState::Decoding)
-                    && seq.priority < new_priority
-            })
-        })
-        .min_by_key(|seq| seq.priority)
-        .map(|seq| seq.id)
+        .filter(|s| s.is_active && !s.is_finished())
+        .map(|s| s.slot_id)
+        .collect();
+
+    if active_ids.len() > logits_per_slot.len() {
+        return Err(BatchError::ConfigError("not enough logits for active slots".into()));
+    }
+
+    let mut results = Vec::new();
+    for (i, &sid) in active_ids.iter().enumerate() {
+        let tok = cpu_step_slot(manager, sid, &logits_per_slot[i])?;
+        results.push((sid, tok));
+    }
+    Ok(results)
 }
 
-/// Format a human-readable status string for the batch.
-pub fn format_batch_status(batch: &ContinuousBatch) -> String {
-    let active = cpu_get_active_sequences(batch);
-    let prefilling = active.iter().filter(|s| s.state == SequenceState::Prefilling).count();
-    let decoding = active.iter().filter(|s| s.state == SequenceState::Decoding).count();
-    let paused = active.iter().filter(|s| s.state == SequenceState::Paused).count();
-    let completed = active.iter().filter(|s| s.state == SequenceState::Completed).count();
-    format!(
-        "Batch(iter={}, slots={}/{}, prefill={}, decode={}, paused={}, completed={}, tokens={})",
-        batch.iteration_count,
-        active.len(),
-        batch.config.max_batch_size,
-        prefilling,
-        decoding,
-        paused,
-        completed,
-        batch.stats.total_tokens_generated,
-    )
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/// Argmax over a logit slice. Returns 0 for empty slices.
-fn argmax(logits: &[f32]) -> u32 {
+/// CPU reference: argmax over a logit slice.  Returns 0 for empty slices.
+pub fn cpu_argmax(logits: &[f32]) -> u32 {
     logits
         .iter()
         .enumerate()
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
         .map(|(i, _)| i as u32)
         .unwrap_or(0)
+}
+
+/// Format a human-readable status line.
+pub fn format_status(manager: &SlotManager) -> String {
+    let stats = manager.compute_stats();
+    format!(
+        "ContinuousBatch(active={}/{}, util={:.1}%, \
+         completed={}, tokens={}, preemptions={})",
+        manager.active_count(),
+        manager.config().max_batch_size,
+        stats.slot_utilization * 100.0,
+        stats.total_completed,
+        stats.total_tokens_generated,
+        stats.preemption_count,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -458,16 +534,11 @@ fn argmax(logits: &[f32]) -> u32 {
 mod tests {
     use super::*;
 
-    fn default_config() -> BatchConfig {
-        BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 8,
-            enable_preemption: true,
-        }
+    fn cfg4() -> ContinuousBatchConfig {
+        ContinuousBatchConfig { max_batch_size: 4, max_seq_len: 128, iteration_timeout_ms: 100 }
     }
 
-    fn simple_logits(best: usize, len: usize) -> Vec<f32> {
+    fn logits(best: usize, len: usize) -> Vec<f32> {
         let mut v = vec![0.0f32; len];
         if best < len {
             v[best] = 1.0;
@@ -475,703 +546,707 @@ mod tests {
         v
     }
 
-    // ---- Creation ----------------------------------------------------------
+    // == SlotManager creation ===============================================
 
     #[test]
-    fn test_create_batch() {
-        let batch = create_continuous_batch(default_config());
-        assert_eq!(batch.slots.len(), 4);
-        assert_eq!(batch.iteration_count, 0);
-        assert!(batch.slots.iter().all(|s| s.sequence.is_none()));
+    fn test_create_manager_empty_slots() {
+        let mgr = SlotManager::new(cfg4());
+        assert_eq!(mgr.slots().len(), 4);
+        assert_eq!(mgr.active_count(), 0);
+        assert!(mgr.slots().iter().all(|s| !s.is_active));
     }
 
     #[test]
-    fn test_create_batch_slot_ids() {
-        let batch = create_continuous_batch(default_config());
-        for (i, slot) in batch.slots.iter().enumerate() {
-            assert_eq!(slot.slot_id, i);
-            assert!(!slot.kv_allocated);
+    fn test_create_manager_slot_ids() {
+        let mgr = SlotManager::new(cfg4());
+        for (i, s) in mgr.slots().iter().enumerate() {
+            assert_eq!(s.slot_id, i);
         }
     }
 
-    // ---- Adding sequences --------------------------------------------------
+    // == Insert =============================================================
 
     #[test]
-    fn test_add_sequence() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1, 2, 3], 10).unwrap();
-        assert_eq!(id, 1);
-        let active = cpu_get_active_sequences(&batch);
-        assert_eq!(active.len(), 1);
-        assert_eq!(active[0].prompt_tokens, vec![1, 2, 3]);
+    fn test_insert_returns_slot_and_id() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (slot, rid) = mgr.insert(vec![1, 2, 3], 10, 5).unwrap();
+        assert_eq!(slot, 0);
+        assert_eq!(rid, 1);
     }
 
     #[test]
-    fn test_add_sequence_state_is_prefilling() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![10], 5).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Prefilling);
+    fn test_insert_fills_first_free_slot() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        let (slot, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        assert_eq!(slot, 1);
     }
 
     #[test]
-    fn test_add_sequence_kv_allocated() {
-        let mut batch = create_continuous_batch(default_config());
-        cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        assert!(batch.slots[0].kv_allocated);
+    fn test_insert_multiple_requests() {
+        let mut mgr = SlotManager::new(cfg4());
+        for _ in 0..4 {
+            mgr.insert(vec![1], 5, 0).unwrap();
+        }
+        assert_eq!(mgr.active_count(), 4);
     }
 
     #[test]
-    fn test_add_multiple_sequences() {
-        let mut batch = create_continuous_batch(default_config());
-        let id1 = cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        let id2 = cpu_add_sequence(&mut batch, vec![2], 2).unwrap();
-        let id3 = cpu_add_sequence(&mut batch, vec![3], 3).unwrap();
-        assert_ne!(id1, id2);
-        assert_ne!(id2, id3);
-        assert_eq!(cpu_get_active_sequences(&batch).len(), 3);
-    }
-
-    #[test]
-    fn test_add_sequence_unique_ids() {
-        let mut batch = create_continuous_batch(default_config());
-        let ids: Vec<u64> =
-            (0..4).map(|_| cpu_add_sequence(&mut batch, vec![1], 0).unwrap()).collect();
-        let set: std::collections::HashSet<u64> = ids.iter().copied().collect();
+    fn test_insert_returns_unique_ids() {
+        let mut mgr = SlotManager::new(cfg4());
+        let ids: Vec<u64> = (0..4).map(|_| mgr.insert(vec![1], 5, 0).unwrap().1).collect();
+        let set: std::collections::HashSet<u64> = ids.into_iter().collect();
         assert_eq!(set.len(), 4);
     }
 
     #[test]
-    fn test_add_sequence_empty_prompt_error() {
-        let mut batch = create_continuous_batch(default_config());
-        let err = cpu_add_sequence(&mut batch, vec![], 1).unwrap_err();
+    fn test_insert_empty_prompt_error() {
+        let mut mgr = SlotManager::new(cfg4());
+        let err = mgr.insert(vec![], 5, 0).unwrap_err();
         assert!(matches!(err, BatchError::ConfigError(_)));
     }
 
-    // ---- Batch full --------------------------------------------------------
+    #[test]
+    fn test_insert_zero_max_tokens_error() {
+        let mut mgr = SlotManager::new(cfg4());
+        let err = mgr.insert(vec![1], 0, 0).unwrap_err();
+        assert!(matches!(err, BatchError::ConfigError(_)));
+    }
 
     #[test]
-    fn test_batch_full_error() {
-        let mut batch = create_continuous_batch(default_config());
+    fn test_insert_batch_full() {
+        let mut mgr = SlotManager::new(cfg4());
         for _ in 0..4 {
-            cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
+            mgr.insert(vec![1], 5, 0).unwrap();
         }
-        let err = cpu_add_sequence(&mut batch, vec![1], 0).unwrap_err();
-        assert_eq!(err, BatchError::BatchFull);
-    }
-
-    // ---- Removing sequences ------------------------------------------------
-
-    #[test]
-    fn test_remove_sequence() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1, 2], 5).unwrap();
-        let info = cpu_remove_sequence(&mut batch, id).unwrap();
-        assert_eq!(info.id, id);
-        assert_eq!(cpu_get_active_sequences(&batch).len(), 0);
+        assert_eq!(mgr.insert(vec![1], 5, 0).unwrap_err(), BatchError::BatchFull);
     }
 
     #[test]
-    fn test_remove_frees_slot() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_remove_sequence(&mut batch, id).unwrap();
-        assert!(!batch.slots[0].kv_allocated);
-        // Should be able to add again
-        cpu_add_sequence(&mut batch, vec![2], 0).unwrap();
+    fn test_is_full() {
+        let mut mgr = SlotManager::new(cfg4());
+        assert!(!mgr.is_full());
+        for _ in 0..4 {
+            mgr.insert(vec![1], 5, 0).unwrap();
+        }
+        assert!(mgr.is_full());
+    }
+
+    // == Remove =============================================================
+
+    #[test]
+    fn test_remove_by_slot_id() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1, 2], 5, 0).unwrap();
+        let req = mgr.remove(sid).unwrap();
+        assert_eq!(req.prompt_tokens, vec![1, 2]);
+        assert_eq!(mgr.active_count(), 0);
     }
 
     #[test]
-    fn test_remove_nonexistent_sequence() {
-        let mut batch = create_continuous_batch(default_config());
-        let err = cpu_remove_sequence(&mut batch, 999).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(999));
+    fn test_remove_frees_slot_for_reuse() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.remove(sid).unwrap();
+        let (sid2, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        assert_eq!(sid2, sid);
     }
 
     #[test]
-    fn test_remove_increments_served_count() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_remove_sequence(&mut batch, id).unwrap();
-        assert_eq!(batch.stats.total_sequences_served, 1);
-    }
-
-    // ---- Scheduling --------------------------------------------------------
-
-    #[test]
-    fn test_schedule_empty_batch() {
-        let mut batch = create_continuous_batch(default_config());
-        let actions = cpu_schedule_iteration(&mut batch);
-        assert_eq!(actions, vec![ScheduleAction::NoOp]);
+    fn test_remove_nonexistent_slot() {
+        let mut mgr = SlotManager::new(cfg4());
+        assert_eq!(mgr.remove(99).unwrap_err(), BatchError::SlotNotFound(99));
     }
 
     #[test]
-    fn test_schedule_prefill_first() {
-        let mut batch = create_continuous_batch(default_config());
-        // Prompt of length 7 < chunk_size(8), so one prefill step transitions to Decoding
-        let id1 = cpu_add_sequence(&mut batch, vec![1, 2, 3, 4, 5, 6, 7], 1).unwrap();
-
-        // Transition id1: execute one prefill to move to Decoding
-        cpu_execute_prefill_step(&mut batch, id1, &simple_logits(5, 10)).unwrap();
-        // processed = 0 + 8 = 8 >= 7 -> Decoding
-
-        let id2 =
-            cpu_add_sequence(&mut batch, vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19], 2).unwrap();
-
-        let actions = cpu_schedule_iteration(&mut batch);
-        // Prefill should come before decode
-        assert!(matches!(actions[0], ScheduleAction::AddToPrefill(_)));
-        assert_eq!(actions[0], ScheduleAction::AddToPrefill(id2));
-        assert!(actions.iter().any(|a| *a == ScheduleAction::ContinueDecode(id1)));
+    fn test_remove_inactive_slot() {
+        let mut mgr = SlotManager::new(cfg4());
+        assert_eq!(mgr.remove(0).unwrap_err(), BatchError::SlotNotFound(0));
     }
 
     #[test]
-    fn test_schedule_increments_iteration() {
-        let mut batch = create_continuous_batch(default_config());
-        cpu_schedule_iteration(&mut batch);
-        cpu_schedule_iteration(&mut batch);
-        assert_eq!(batch.iteration_count, 2);
+    fn test_remove_by_request_id() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (_, rid) = mgr.insert(vec![10, 20], 5, 3).unwrap();
+        let req = mgr.remove_by_request_id(rid).unwrap();
+        assert_eq!(req.request_id, rid);
+        assert_eq!(req.priority, 3);
     }
 
     #[test]
-    fn test_schedule_priority_ordering_decode() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
+    fn test_remove_by_request_id_not_found() {
+        let mut mgr = SlotManager::new(cfg4());
+        assert_eq!(mgr.remove_by_request_id(42).unwrap_err(), BatchError::RequestNotFound(42));
+    }
+
+    // == Insert into freed slot (gap filling) ===============================
+
+    #[test]
+    fn test_new_request_fills_gap() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        let (_s1, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        mgr.remove(s0).unwrap();
+        let (s_new, _) = mgr.insert(vec![3], 5, 0).unwrap();
+        assert_eq!(s_new, s0); // reuses freed slot
+    }
+
+    #[test]
+    fn test_insert_after_removal_reuses_slot() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 1,
+            max_seq_len: 64,
+            iteration_timeout_ms: 50,
+        });
+        let (sid, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.remove(sid).unwrap();
+        let (sid2, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        assert_eq!(sid2, sid);
+    }
+
+    // == Finished detection =================================================
+
+    #[test]
+    fn test_finished_slot_detection() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 2, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(3, 8)).unwrap();
+        assert!(!mgr.get_slot(sid).unwrap().is_finished());
+        cpu_step_slot(&mut mgr, sid, &logits(4, 8)).unwrap();
+        assert!(mgr.get_slot(sid).unwrap().is_finished());
+    }
+
+    #[test]
+    fn test_compact_finished_removes_done() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 1, 0).unwrap();
+        cpu_step_slot(&mut mgr, s0, &logits(0, 8)).unwrap();
+        assert!(mgr.get_slot(s0).unwrap().is_finished());
+
+        let completed = CompactBatcher::compact_finished(&mut mgr);
+        assert_eq!(completed.len(), 1);
+        assert_eq!(mgr.active_count(), 0);
+    }
+
+    // == Multiple requests at different positions ===========================
+
+    #[test]
+    fn test_multiple_requests_different_positions() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 10, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 10, 0).unwrap();
+        // Advance s0 by 3 steps, s1 by 1 step
+        for _ in 0..3 {
+            cpu_step_slot(&mut mgr, s0, &logits(1, 8)).unwrap();
+        }
+        cpu_step_slot(&mut mgr, s1, &logits(2, 8)).unwrap();
+        assert_eq!(mgr.get_slot(s0).unwrap().current_position, 3);
+        assert_eq!(mgr.get_slot(s1).unwrap().current_position, 1);
+    }
+
+    #[test]
+    fn test_step_advances_position() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 10, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(5, 8)).unwrap();
+        assert_eq!(mgr.get_slot(sid).unwrap().current_position, 1);
+        assert_eq!(mgr.get_slot(sid).unwrap().generated_tokens(), &[5]);
+    }
+
+    #[test]
+    fn test_step_multiple_slots() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 10, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 10, 0).unwrap();
+        let t0 = cpu_step_slot(&mut mgr, s0, &logits(3, 8)).unwrap();
+        let t1 = cpu_step_slot(&mut mgr, s1, &logits(7, 8)).unwrap();
+        assert_eq!(t0, 3);
+        assert_eq!(t1, 7);
+    }
+
+    // == Preemption =========================================================
+
+    #[test]
+    fn test_preemption_disabled() {
+        let mgr = SlotManager::new(cfg4());
+        assert_eq!(PreemptionPolicy::Disabled.select_victim(&mgr, 100), None);
+    }
+
+    #[test]
+    fn test_preemption_lowest_priority() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s_low, _) = mgr.insert(vec![1], 5, 1).unwrap();
+        mgr.insert(vec![2], 5, 5).unwrap();
+        mgr.insert(vec![3], 5, 10).unwrap();
+        let victim = PreemptionPolicy::LowestPriority.select_victim(&mgr, 8);
+        assert_eq!(victim, Some(s_low));
+    }
+
+    #[test]
+    fn test_preemption_shortest_generation() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 10, 1).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 10, 2).unwrap();
+        // Advance s0 by 5 steps so s1 is shorter
+        for _ in 0..5 {
+            cpu_step_slot(&mut mgr, s0, &logits(0, 8)).unwrap();
+        }
+        cpu_step_slot(&mut mgr, s1, &logits(0, 8)).unwrap();
+        let victim = PreemptionPolicy::ShortestGeneration.select_victim(&mgr, 100);
+        assert_eq!(victim, Some(s1));
+    }
+
+    #[test]
+    fn test_preemption_no_victim_all_higher() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 10).unwrap();
+        assert_eq!(PreemptionPolicy::LowestPriority.select_victim(&mgr, 5), None);
+    }
+
+    #[test]
+    fn test_preempt_and_insert() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 1,
             max_seq_len: 128,
-            prefill_chunk_size: 1, // prompt consumed in one step
-            enable_preemption: false,
+            iteration_timeout_ms: 100,
         });
-        let id_lo = cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        let id_hi = cpu_add_sequence(&mut batch, vec![2], 10).unwrap();
+        mgr.insert(vec![1], 5, 1).unwrap();
+        assert!(mgr.is_full());
 
-        // Move both to Decoding
-        cpu_execute_prefill_step(&mut batch, id_lo, &simple_logits(0, 8)).unwrap();
-        cpu_execute_prefill_step(&mut batch, id_hi, &simple_logits(0, 8)).unwrap();
-
-        let actions = cpu_schedule_iteration(&mut batch);
-        let decode_ids: Vec<u64> = actions
-            .iter()
-            .filter_map(|a| match a {
-                ScheduleAction::ContinueDecode(id) => Some(*id),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(decode_ids, vec![id_hi, id_lo]);
-    }
-
-    // ---- Prefill step ------------------------------------------------------
-
-    #[test]
-    fn test_prefill_generates_token() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1, 2], 0).unwrap();
-        let tok = cpu_execute_prefill_step(&mut batch, id, &simple_logits(7, 10)).unwrap();
-        assert_eq!(tok, 7);
+        let (sid, rid, evicted) =
+            PreemptionPolicy::LowestPriority.preempt_and_insert(&mut mgr, vec![2], 5, 10).unwrap();
+        assert_eq!(sid, 0);
+        assert!(rid > 0);
+        assert_eq!(evicted.priority, 1);
+        assert_eq!(mgr.active_count(), 1);
     }
 
     #[test]
-    fn test_prefill_transition_to_decoding() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
+    fn test_preemption_count_tracked() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 1,
             max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
+            iteration_timeout_ms: 100,
         });
-        let id = cpu_add_sequence(&mut batch, vec![1, 2, 3], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Decoding);
+        mgr.insert(vec![1], 5, 1).unwrap();
+        PreemptionPolicy::LowestPriority.preempt_and_insert(&mut mgr, vec![2], 5, 10).unwrap();
+        assert_eq!(mgr.stats().preemption_count, 1);
     }
 
     #[test]
-    fn test_prefill_stays_prefilling_long_prompt() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 256,
-            prefill_chunk_size: 2,
-            enable_preemption: false,
-        });
-        let prompt: Vec<u32> = (0..20).collect();
-        let id = cpu_add_sequence(&mut batch, prompt, 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Prefilling);
-    }
-
-    #[test]
-    fn test_prefill_wrong_sequence_error() {
-        let mut batch = create_continuous_batch(default_config());
-        let err = cpu_execute_prefill_step(&mut batch, 999, &simple_logits(0, 8)).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(999));
-    }
-
-    #[test]
-    fn test_prefill_updates_token_count() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(3, 8)).unwrap();
-        assert_eq!(batch.stats.total_tokens_generated, 1);
-    }
-
-    // ---- Decode step -------------------------------------------------------
-
-    #[test]
-    fn test_decode_generates_token() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
-        });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        let tok = cpu_execute_decode_step(&mut batch, id, &simple_logits(5, 8)).unwrap();
-        assert_eq!(tok, 5);
-    }
-
-    #[test]
-    fn test_decode_wrong_state_error() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0).unwrap();
-        // Still prefilling – decode should fail to find it.
-        let err = cpu_execute_decode_step(&mut batch, id, &simple_logits(0, 8)).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(id));
-    }
-
-    #[test]
-    fn test_decode_increments_generated_tokens() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
-        });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        cpu_execute_decode_step(&mut batch, id, &simple_logits(1, 8)).unwrap();
-        cpu_execute_decode_step(&mut batch, id, &simple_logits(2, 8)).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.generated_tokens.len(), 3); // 1 from prefill + 2 from decode
-    }
-
-    #[test]
-    fn test_decode_respects_max_seq_len() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 3, // prompt(1) + generated can be at most 3
-            prefill_chunk_size: 4,
-            enable_preemption: false,
-        });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap(); // gen=1, total=2
-        cpu_execute_decode_step(&mut batch, id, &simple_logits(0, 8)).unwrap(); // gen=2, total=3
-        // Next would exceed max_seq_len
-        let tok = cpu_execute_decode_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Completed);
-        assert_eq!(tok, 0);
-    }
-
-    // ---- Preemption --------------------------------------------------------
-
-    #[test]
-    fn test_preempt_sequence() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Paused);
-    }
-
-    #[test]
-    fn test_preempt_increments_stat() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        assert_eq!(batch.stats.preemptions, 1);
-    }
-
-    #[test]
-    fn test_preempt_disabled() {
-        let mut batch =
-            create_continuous_batch(BatchConfig { enable_preemption: false, ..default_config() });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        let err = cpu_preempt_sequence(&mut batch, id).unwrap_err();
+    fn test_preempt_and_insert_fails_disabled() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 1).unwrap();
+        let err =
+            PreemptionPolicy::Disabled.preempt_and_insert(&mut mgr, vec![2], 5, 10).unwrap_err();
         assert_eq!(err, BatchError::PreemptionFailed);
     }
 
+    // == Compaction ==========================================================
+
     #[test]
-    fn test_preempt_nonexistent() {
-        let mut batch = create_continuous_batch(default_config());
-        let err = cpu_preempt_sequence(&mut batch, 42).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(42));
+    fn test_compact_no_gaps() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        CompactBatcher::compact_gaps(&mut mgr);
+        assert!(CompactBatcher::is_contiguous(&mgr));
     }
 
     #[test]
-    fn test_preempt_already_paused() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        let err = cpu_preempt_sequence(&mut batch, id).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(id));
+    fn test_compact_fills_gap() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        mgr.insert(vec![3], 5, 0).unwrap();
+        mgr.remove(s1).unwrap(); // gap at index 1
+        assert!(!CompactBatcher::is_contiguous(&mgr));
+        CompactBatcher::compact_gaps(&mut mgr);
+        assert!(CompactBatcher::is_contiguous(&mgr));
+        assert_eq!(mgr.active_count(), 2);
     }
 
-    // ---- Resume ------------------------------------------------------------
+    #[test]
+    fn test_compact_multiple_gaps() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        let (s2, _) = mgr.insert(vec![3], 5, 0).unwrap();
+        mgr.insert(vec![4], 5, 0).unwrap();
+        mgr.remove(s0).unwrap();
+        mgr.remove(s2).unwrap();
+        CompactBatcher::compact_gaps(&mut mgr);
+        assert!(CompactBatcher::is_contiguous(&mgr));
+        assert_eq!(mgr.active_count(), 2);
+    }
 
     #[test]
-    fn test_resume_sequence() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
+    fn test_compact_preserves_active_data() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![10], 5, 0).unwrap();
+        mgr.insert(vec![20], 5, 0).unwrap();
+        cpu_step_slot(&mut mgr, s0, &logits(7, 8)).unwrap();
+        mgr.remove(s0).unwrap();
+        CompactBatcher::compact_gaps(&mut mgr);
+        // The remaining slot should still have its prompt
+        let active: Vec<&GenerationSlot> = mgr.slots().iter().filter(|s| s.is_active).collect();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].request.as_ref().unwrap().prompt_tokens, vec![20]);
+    }
+
+    // == Contiguous layout ==================================================
+
+    #[test]
+    fn test_contiguous_after_compact() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        mgr.insert(vec![3], 5, 0).unwrap();
+        mgr.remove(s1).unwrap();
+        CompactBatcher::compact_gaps(&mut mgr);
+        assert!(CompactBatcher::is_contiguous(&mgr));
+    }
+
+    #[test]
+    fn test_not_contiguous_with_gap() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        mgr.insert(vec![3], 5, 0).unwrap();
+        mgr.remove(s1).unwrap();
+        assert!(!CompactBatcher::is_contiguous(&mgr));
+    }
+
+    #[test]
+    fn test_contiguous_empty_batch() {
+        let mgr = SlotManager::new(cfg4());
+        assert!(CompactBatcher::is_contiguous(&mgr));
+    }
+
+    // == Stats ==============================================================
+
+    #[test]
+    fn test_stats_initial_zeros() {
+        let mgr = SlotManager::new(cfg4());
+        let s = mgr.compute_stats();
+        assert_eq!(s.total_completed, 0);
+        assert_eq!(s.total_tokens_generated, 0);
+        assert_eq!(s.preemption_count, 0);
+        assert!((s.slot_utilization).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_stats_after_completion() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 2, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap();
+        CompactBatcher::compact_finished(&mut mgr);
+        assert_eq!(mgr.stats().total_completed, 1);
+        assert_eq!(mgr.stats().total_tokens_generated, 2);
+    }
+
+    #[test]
+    fn test_stats_utilization() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        let s = mgr.compute_stats();
+        assert!((s.slot_utilization - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_stats_avg_generation_length() {
+        let mut mgr = SlotManager::new(cfg4());
+        // Request 1: generate 2 tokens
+        let (s0, _) = mgr.insert(vec![1], 2, 0).unwrap();
+        cpu_step_slot(&mut mgr, s0, &logits(0, 8)).unwrap();
+        cpu_step_slot(&mut mgr, s0, &logits(0, 8)).unwrap();
+        CompactBatcher::compact_finished(&mut mgr);
+        assert!((mgr.stats().avg_generation_length - 2.0).abs() < f64::EPSILON);
+
+        // Request 2: generate 4 tokens
+        let (s1, _) = mgr.insert(vec![2], 4, 0).unwrap();
+        for _ in 0..4 {
+            cpu_step_slot(&mut mgr, s1, &logits(0, 8)).unwrap();
+        }
+        CompactBatcher::compact_finished(&mut mgr);
+        // avg = (2 + 4) / 2 = 3
+        assert!((mgr.stats().avg_generation_length - 3.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_stats_multiple_completions() {
+        let mut mgr = SlotManager::new(cfg4());
+        for _ in 0..3 {
+            let (sid, _) = mgr.insert(vec![1], 1, 0).unwrap();
+            cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap();
+            CompactBatcher::compact_finished(&mut mgr);
+        }
+        assert_eq!(mgr.stats().total_completed, 3);
+        assert_eq!(mgr.stats().total_tokens_generated, 3);
+    }
+
+    #[test]
+    fn test_stats_preemption_count() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 1,
             max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: true,
+            iteration_timeout_ms: 100,
         });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        cpu_resume_sequence(&mut batch, id).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Decoding);
+        mgr.insert(vec![1], 5, 1).unwrap();
+        PreemptionPolicy::LowestPriority.preempt_and_insert(&mut mgr, vec![2], 5, 10).unwrap();
+        PreemptionPolicy::LowestPriority.preempt_and_insert(&mut mgr, vec![3], 5, 20).unwrap();
+        assert_eq!(mgr.stats().preemption_count, 2);
     }
 
-    #[test]
-    fn test_resume_back_to_prefilling() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 256,
-            prefill_chunk_size: 2,
-            enable_preemption: true,
-        });
-        let prompt: Vec<u32> = (0..20).collect();
-        let id = cpu_add_sequence(&mut batch, prompt, 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        cpu_resume_sequence(&mut batch, id).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Prefilling);
-    }
-
-    #[test]
-    fn test_resume_not_paused_error() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        let err = cpu_resume_sequence(&mut batch, id).unwrap_err();
-        assert_eq!(err, BatchError::SequenceNotFound(id));
-    }
-
-    // ---- Should preempt ----------------------------------------------------
-
-    #[test]
-    fn test_should_preempt_finds_lowest() {
-        let mut batch = create_continuous_batch(default_config());
-        let id_low = cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        let _id_med = cpu_add_sequence(&mut batch, vec![2], 5).unwrap();
-        let _id_hi = cpu_add_sequence(&mut batch, vec![3], 10).unwrap();
-        let victim = cpu_should_preempt(&batch, 8);
-        assert_eq!(victim, Some(id_low));
-    }
-
-    #[test]
-    fn test_should_preempt_none_when_all_higher() {
-        let mut batch = create_continuous_batch(default_config());
-        cpu_add_sequence(&mut batch, vec![1], 10).unwrap();
-        assert_eq!(cpu_should_preempt(&batch, 5), None);
-    }
-
-    #[test]
-    fn test_should_preempt_disabled() {
-        let mut batch =
-            create_continuous_batch(BatchConfig { enable_preemption: false, ..default_config() });
-        cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        assert_eq!(cpu_should_preempt(&batch, 100), None);
-    }
-
-    #[test]
-    fn test_should_preempt_ignores_paused() {
-        let mut batch = create_continuous_batch(default_config());
-        let id = cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        assert_eq!(cpu_should_preempt(&batch, 100), None);
-    }
-
-    // ---- Concurrent prefill + decode ---------------------------------------
-
-    #[test]
-    fn test_concurrent_prefill_and_decode() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 2,
-            enable_preemption: false,
-        });
-        // Seq A: short prompt, will move to decode quickly
-        let id_a = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id_a, &simple_logits(0, 8)).unwrap();
-        // id_a should be Decoding now (prompt=1 < chunk=2 processed=1+2=3>=1)
-
-        // Seq B: long prompt, still prefilling
-        let _id_b =
-            cpu_add_sequence(&mut batch, vec![10, 11, 12, 13, 14, 15, 16, 17, 18, 19], 0).unwrap();
-
-        let actions = cpu_schedule_iteration(&mut batch);
-        let has_prefill = actions.iter().any(|a| matches!(a, ScheduleAction::AddToPrefill(_)));
-        let has_decode = actions.iter().any(|a| matches!(a, ScheduleAction::ContinueDecode(_)));
-        assert!(has_prefill);
-        assert!(has_decode);
-    }
-
-    // ---- Stats tracking ----------------------------------------------------
-
-    #[test]
-    fn test_stats_tokens_generated() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
-        });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        cpu_execute_decode_step(&mut batch, id, &simple_logits(1, 8)).unwrap();
-        cpu_execute_decode_step(&mut batch, id, &simple_logits(2, 8)).unwrap();
-        assert_eq!(batch.stats.total_tokens_generated, 3);
-    }
-
-    #[test]
-    fn test_compute_batch_stats_utilization() {
-        let mut batch = create_continuous_batch(default_config());
-        cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_add_sequence(&mut batch, vec![2], 0).unwrap();
-        let stats = cpu_compute_batch_stats(&batch);
-        assert!((stats.utilization_pct - 50.0).abs() < f64::EPSILON);
-    }
-
-    #[test]
-    fn test_compute_batch_stats_empty() {
-        let batch = create_continuous_batch(default_config());
-        let stats = cpu_compute_batch_stats(&batch);
-        assert!((stats.utilization_pct).abs() < f64::EPSILON);
-        assert_eq!(stats.total_tokens_generated, 0);
-    }
-
-    // ---- Format status -----------------------------------------------------
-
-    #[test]
-    fn test_format_batch_status() {
-        let mut batch = create_continuous_batch(default_config());
-        cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        let status = format_batch_status(&batch);
-        assert!(status.contains("slots=1/4"));
-        assert!(status.contains("prefill=1"));
-    }
-
-    #[test]
-    fn test_format_batch_status_empty() {
-        let batch = create_continuous_batch(default_config());
-        let status = format_batch_status(&batch);
-        assert!(status.contains("slots=0/4"));
-    }
-
-    // ---- Edge: max_batch_size=1 --------------------------------------------
+    // == Edge cases ==========================================================
 
     #[test]
     fn test_single_slot_batch() {
-        let mut batch = create_continuous_batch(BatchConfig {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
             max_batch_size: 1,
             max_seq_len: 64,
-            prefill_chunk_size: 4,
-            enable_preemption: true,
+            iteration_timeout_ms: 50,
         });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        assert_eq!(cpu_add_sequence(&mut batch, vec![2], 0).unwrap_err(), BatchError::BatchFull);
-        cpu_remove_sequence(&mut batch, id).unwrap();
-        cpu_add_sequence(&mut batch, vec![3], 0).unwrap();
+        let (sid, _) = mgr.insert(vec![1], 3, 0).unwrap();
+        assert!(mgr.is_full());
+        mgr.remove(sid).unwrap();
+        assert!(!mgr.is_full());
+        mgr.insert(vec![2], 3, 0).unwrap();
     }
 
-    // ---- Edge: all sequences completed -------------------------------------
-
     #[test]
-    fn test_all_completed_schedule() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 2,
-            max_seq_len: 2,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
+    fn test_single_slot_full_then_free() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 1,
+            max_seq_len: 64,
+            iteration_timeout_ms: 50,
         });
-        let id1 = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        let id2 = cpu_add_sequence(&mut batch, vec![2], 0).unwrap();
-
-        // Force completion via max_seq_len
-        cpu_execute_prefill_step(&mut batch, id1, &simple_logits(0, 8)).unwrap();
-        cpu_execute_prefill_step(&mut batch, id2, &simple_logits(0, 8)).unwrap();
-        // Now prompt(1)+generated(1)=2=max_seq_len; next decode triggers Completed
-        cpu_execute_decode_step(&mut batch, id1, &simple_logits(0, 8)).unwrap();
-        cpu_execute_decode_step(&mut batch, id2, &simple_logits(0, 8)).unwrap();
-
-        let actions = cpu_schedule_iteration(&mut batch);
-        assert_eq!(actions, vec![ScheduleAction::NoOp]);
+        let (sid, _) = mgr.insert(vec![1], 1, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap();
+        CompactBatcher::compact_finished(&mut mgr);
+        assert!(!mgr.is_full());
+        mgr.insert(vec![2], 1, 0).unwrap();
     }
 
-    // ---- Property: batch never exceeds max ---------------------------------
-
     #[test]
-    fn test_property_batch_size_bounded() {
-        let cfg = BatchConfig {
-            max_batch_size: 3,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
-        };
-        let mut batch = create_continuous_batch(cfg);
-        for _ in 0..3 {
-            cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
+    fn test_all_slots_full() {
+        let mut mgr = SlotManager::new(cfg4());
+        for i in 0..4 {
+            mgr.insert(vec![i as u32 + 1], 5, 0).unwrap();
         }
-        assert!(cpu_add_sequence(&mut batch, vec![1], 0).is_err());
-        assert!(cpu_get_active_sequences(&batch).len() <= 3);
+        assert!(mgr.is_full());
+        assert_eq!(mgr.insert(vec![99], 5, 0).unwrap_err(), BatchError::BatchFull);
     }
 
-    // ---- Property: generated tokens monotonically increase -----------------
+    #[test]
+    fn test_all_finish_simultaneously() {
+        let mut mgr = SlotManager::new(cfg4());
+        let mut sids = Vec::new();
+        for _ in 0..4 {
+            let (sid, _) = mgr.insert(vec![1], 1, 0).unwrap();
+            sids.push(sid);
+        }
+        for sid in &sids {
+            cpu_step_slot(&mut mgr, *sid, &logits(0, 8)).unwrap();
+        }
+        let completed = CompactBatcher::compact_finished(&mut mgr);
+        assert_eq!(completed.len(), 4);
+        assert_eq!(mgr.active_count(), 0);
+    }
 
     #[test]
-    fn test_property_generated_tokens_monotonic() {
-        let mut batch = create_continuous_batch(BatchConfig {
+    fn test_max_seq_len_boundary() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
             max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: false,
+            max_seq_len: 3, // prompt(1) + 2 generated = 3
+            iteration_timeout_ms: 100,
         });
-        let id = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
+        let (sid, _) = mgr.insert(vec![1], 10, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap(); // total=2
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap(); // total=3
+        // Next step exceeds max_seq_len
+        cpu_step_slot(&mut mgr, sid, &logits(0, 8)).unwrap();
+        assert!(mgr.get_slot(sid).unwrap().is_finished());
+    }
 
-        let mut prev_len = 1usize; // from prefill
+    #[test]
+    fn test_large_batch_size() {
+        let mut mgr = SlotManager::new(ContinuousBatchConfig {
+            max_batch_size: 64,
+            max_seq_len: 1024,
+            iteration_timeout_ms: 200,
+        });
+        for _ in 0..64 {
+            mgr.insert(vec![1], 5, 0).unwrap();
+        }
+        assert!(mgr.is_full());
+        assert_eq!(mgr.active_count(), 64);
+    }
+
+    // == Property tests =====================================================
+
+    #[test]
+    fn test_property_active_count_bounded() {
+        let mut mgr = SlotManager::new(cfg4());
+        for _ in 0..4 {
+            mgr.insert(vec![1], 5, 0).unwrap();
+        }
+        assert!(mgr.active_count() <= 4);
+        assert!(mgr.insert(vec![1], 5, 0).is_err());
+    }
+
+    #[test]
+    fn test_property_insert_remove_balanced() {
+        let mut mgr = SlotManager::new(cfg4());
+        let mut ids = Vec::new();
+        for _ in 0..4 {
+            ids.push(mgr.insert(vec![1], 5, 0).unwrap().0);
+        }
+        for sid in ids {
+            mgr.remove(sid).unwrap();
+        }
+        assert_eq!(mgr.active_count(), 0);
+    }
+
+    #[test]
+    fn test_property_tokens_monotonic() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 20, 0).unwrap();
+        let mut prev = 0;
         for i in 0..10 {
-            cpu_execute_decode_step(&mut batch, id, &simple_logits(i % 8, 8)).unwrap();
-            let seq = batch
-                .slots
-                .iter()
-                .find_map(|s| s.sequence.as_ref().filter(|s| s.id == id))
-                .unwrap();
-            assert!(seq.generated_tokens.len() > prev_len);
-            prev_len = seq.generated_tokens.len();
+            cpu_step_slot(&mut mgr, sid, &logits(i % 8, 8)).unwrap();
+            let pos = mgr.get_slot(sid).unwrap().current_position;
+            assert!(pos > prev);
+            prev = pos;
         }
     }
 
-    // ---- Argmax helper -----------------------------------------------------
+    // == SlotScheduler ======================================================
+
+    #[test]
+    fn test_scheduler_builds_iteration_batch() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        let batch = SlotScheduler::build_iteration(&mgr);
+        assert_eq!(batch.len(), 2);
+        assert!(!batch.is_empty());
+    }
+
+    #[test]
+    fn test_scheduler_excludes_finished_slots() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 1, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        cpu_step_slot(&mut mgr, s0, &logits(0, 8)).unwrap();
+        assert!(mgr.get_slot(s0).unwrap().is_finished());
+        let batch = SlotScheduler::build_iteration(&mgr);
+        assert_eq!(batch.len(), 1);
+        assert!(!batch.slot_indices.contains(&s0));
+    }
+
+    #[test]
+    fn test_scheduler_empty_batch() {
+        let mgr = SlotManager::new(cfg4());
+        let batch = SlotScheduler::build_iteration(&mgr);
+        assert!(batch.is_empty());
+        assert_eq!(batch.len(), 0);
+    }
+
+    #[test]
+    fn test_scheduler_tokens_from_prompt() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![42], 5, 0).unwrap();
+        let batch = SlotScheduler::build_iteration(&mgr);
+        assert_eq!(batch.tokens[0], 42);
+    }
+
+    #[test]
+    fn test_scheduler_tokens_from_generated() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (sid, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        cpu_step_slot(&mut mgr, sid, &logits(7, 8)).unwrap();
+        let batch = SlotScheduler::build_iteration(&mgr);
+        assert_eq!(batch.tokens[0], 7);
+    }
+
+    // == CPU reference ======================================================
+
+    #[test]
+    fn test_cpu_step_iteration() {
+        let mut mgr = SlotManager::new(cfg4());
+        let (s0, _) = mgr.insert(vec![1], 5, 0).unwrap();
+        let (s1, _) = mgr.insert(vec![2], 5, 0).unwrap();
+        let logits_list = vec![logits(3, 8), logits(6, 8)];
+        let results = cpu_step_iteration(&mut mgr, &logits_list).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], (s0, 3));
+        assert_eq!(results[1], (s1, 6));
+    }
+
+    #[test]
+    fn test_cpu_step_iteration_not_enough_logits() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        mgr.insert(vec![2], 5, 0).unwrap();
+        let err = cpu_step_iteration(&mut mgr, &[logits(0, 8)]).unwrap_err();
+        assert!(matches!(err, BatchError::ConfigError(_)));
+    }
+
+    // == Argmax =============================================================
 
     #[test]
     fn test_argmax_basic() {
-        assert_eq!(argmax(&[0.1, 0.9, 0.2]), 1);
+        assert_eq!(cpu_argmax(&[0.1, 0.9, 0.2]), 1);
     }
 
     #[test]
     fn test_argmax_empty() {
-        assert_eq!(argmax(&[]), 0);
+        assert_eq!(cpu_argmax(&[]), 0);
     }
 
     #[test]
     fn test_argmax_negative() {
-        assert_eq!(argmax(&[-1.0, -0.5, -2.0]), 1);
+        assert_eq!(cpu_argmax(&[-1.0, -0.5, -2.0]), 1);
     }
 
-    // ---- BatchError display ------------------------------------------------
+    // == BatchError display =================================================
 
     #[test]
     fn test_batch_error_display() {
-        assert_eq!(format!("{}", BatchError::BatchFull), "batch is full");
-        assert!(format!("{}", BatchError::SequenceNotFound(7)).contains("7"));
-        assert_eq!(format!("{}", BatchError::InvalidState), "invalid sequence state for operation");
+        assert_eq!(format!("{}", BatchError::BatchFull), "all batch slots are occupied");
+        assert!(format!("{}", BatchError::SlotNotFound(7)).contains("7"));
+        assert!(format!("{}", BatchError::RequestNotFound(42)).contains("42"));
+        assert_eq!(format!("{}", BatchError::PreemptionFailed), "preemption failed or disabled");
+        assert!(format!("{}", BatchError::ConfigError("bad".into())).contains("bad"));
     }
 
-    // ---- Preempt then add higher priority ----------------------------------
+    // == Format status ======================================================
 
     #[test]
-    fn test_preempt_and_add_higher_priority() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 1,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: true,
-        });
-        let id_low = cpu_add_sequence(&mut batch, vec![1], 1).unwrap();
-        assert_eq!(cpu_add_sequence(&mut batch, vec![2], 10).unwrap_err(), BatchError::BatchFull);
-
-        // Preempt the low-priority sequence
-        cpu_preempt_sequence(&mut batch, id_low).unwrap();
-        // Slot is still occupied (paused), so still full
-        assert_eq!(cpu_add_sequence(&mut batch, vec![2], 10).unwrap_err(), BatchError::BatchFull);
-
-        // Remove the preempted sequence to truly free the slot
-        cpu_remove_sequence(&mut batch, id_low).unwrap();
-        let id_hi = cpu_add_sequence(&mut batch, vec![2], 10).unwrap();
-        assert_ne!(id_hi, id_low);
+    fn test_format_status() {
+        let mut mgr = SlotManager::new(cfg4());
+        mgr.insert(vec![1], 5, 0).unwrap();
+        let s = format_status(&mgr);
+        assert!(s.contains("active=1/4"));
+        assert!(s.contains("util=25.0%"));
     }
 
-    // ---- Sequence state transitions ----------------------------------------
-
     #[test]
-    fn test_full_lifecycle() {
-        let mut batch = create_continuous_batch(BatchConfig {
-            max_batch_size: 4,
-            max_seq_len: 128,
-            prefill_chunk_size: 4,
-            enable_preemption: true,
-        });
-        let id = cpu_add_sequence(&mut batch, vec![1, 2], 5).unwrap();
-        // Prefilling
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Prefilling);
-
-        // Prefill -> Decoding
-        cpu_execute_prefill_step(&mut batch, id, &simple_logits(0, 8)).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Decoding);
-
-        // Decoding -> Paused
-        cpu_preempt_sequence(&mut batch, id).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Paused);
-
-        // Paused -> Decoding (resume)
-        cpu_resume_sequence(&mut batch, id).unwrap();
-        let seq =
-            batch.slots.iter().find_map(|s| s.sequence.as_ref().filter(|s| s.id == id)).unwrap();
-        assert_eq!(seq.state, SequenceState::Decoding);
-
-        // Remove
-        let info = cpu_remove_sequence(&mut batch, id).unwrap();
-        assert_eq!(info.generated_tokens.len(), 1);
+    fn test_format_status_empty() {
+        let mgr = SlotManager::new(cfg4());
+        let s = format_status(&mgr);
+        assert!(s.contains("active=0/4"));
     }
 
-    // ---- Multiple preemptions stats ----------------------------------------
+    // == IterationBatch helpers =============================================
 
     #[test]
-    fn test_multiple_preemptions_tracked() {
-        let mut batch = create_continuous_batch(default_config());
-        let id1 = cpu_add_sequence(&mut batch, vec![1], 0).unwrap();
-        let id2 = cpu_add_sequence(&mut batch, vec![2], 0).unwrap();
-        cpu_preempt_sequence(&mut batch, id1).unwrap();
-        cpu_preempt_sequence(&mut batch, id2).unwrap();
-        assert_eq!(batch.stats.preemptions, 2);
-    }
-
-    // ---- SequenceState clone/eq --------------------------------------------
-
-    #[test]
-    fn test_sequence_state_eq() {
-        assert_eq!(SequenceState::Prefilling, SequenceState::Prefilling);
-        assert_ne!(SequenceState::Prefilling, SequenceState::Decoding);
-        assert_eq!(SequenceState::Failed("x".into()), SequenceState::Failed("x".into()));
-        assert_ne!(SequenceState::Failed("x".into()), SequenceState::Failed("y".into()));
+    fn test_iteration_batch_len_empty() {
+        let b = IterationBatch::default();
+        assert_eq!(b.len(), 0);
+        assert!(b.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
Adds opencl_continuous_batch.rs — continuous (iteration-level) batching for serving multiple requests with different generation lengths on OpenCL.

## Components
- **ContinuousBatchConfig** — max_batch_size, max_seq_len, iteration_timeout_ms
- **GenerationSlot** — slot_id, request, current_position, max_tokens, is_active
- **SlotManager** — manages active/free slots with insert/remove/compact
- **IterationBatch** — tokens for this iteration across all active slots
- **SlotScheduler** — decides which slots to include in each iteration
- **PreemptionPolicy** — preempt low-priority slots when memory is scarce (Disabled/LowestPriority/ShortestGeneration)
- **CompactBatcher** — removes gaps from finished slots, maintains contiguous batch
- **ContinuousBatchStats** — slot utilization, preemption count, avg generation length
- CPU reference implementations (cpu_step_slot, cpu_step_iteration, cpu_argmax)

## Tests
66 tests covering slot allocation/deallocation, gap filling, preemption policies, compaction, contiguous layout, stats tracking, edge cases, and property tests.

## Verification
- `cargo test -p bitnet-kernels --lib --no-default-features --features cpu -- opencl_continuous_batch` — 66 passed
- `cargo clippy -p bitnet-kernels --no-default-features --features cpu -- -D warnings` — clean
- `cargo fmt -p bitnet-kernels -- --check` — clean (for our file)