### PR TITLE
test(snapshots): add wave 18 inference and model snapshot tests

### DIFF
--- a/crates/bitnet-inference/tests/snapshot_wave18.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave18.rs
@@ -1,0 +1,420 @@
+//! Wave 18 snapshot tests for inference engine and model structures.
+//!
+//! Covers: GenerationConfig presets, SamplingConfig/SamplingStrategy,
+//! InferenceConfig variants, CacheConfig, KVCache stats, InferenceMetrics,
+//! ThroughputMetrics, TimingMetrics, InferenceResult, PerformanceMetrics,
+//! ModelConfig defaults, BatchConfig, StreamingConfig, MetricsReport,
+//! LatencyHistogram, and MemoryProfiler.
+
+use std::time::Duration;
+
+use bitnet_common::ModelConfig;
+use bitnet_inference::cache::{CacheConfig, KVCache};
+use bitnet_inference::config::{GenerationConfig, InferenceConfig};
+use bitnet_inference::engine::{InferenceResult, PerformanceMetrics};
+use bitnet_inference::generation::{
+    GenConfig, SampleConfig, SamplingStrategy as GenSamplingStrategy,
+};
+use bitnet_inference::metrics::{
+    InferenceMetrics, LatencyHistogram, MemoryProfiler, MetricsCollector, MetricsReport,
+    ThroughputTracker,
+};
+use bitnet_inference::streaming::StreamingConfig;
+use bitnet_inference::{BatchConfig, ThroughputMetrics, TimingMetrics};
+
+// ============================================================================
+// GenerationConfig presets
+// ============================================================================
+
+#[test]
+fn w18_generation_config_default_debug() {
+    let cfg = GenerationConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_generation_config_greedy_debug() {
+    let cfg = GenerationConfig::greedy();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_generation_config_creative_debug() {
+    let cfg = GenerationConfig::creative();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_generation_config_balanced_debug() {
+    let cfg = GenerationConfig::balanced();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_generation_config_with_stops() {
+    let cfg = GenerationConfig::greedy()
+        .with_max_tokens(16)
+        .with_stop_sequences(vec!["</s>".into(), "\n\n".into()])
+        .with_stop_token_ids(vec![128009, 128001])
+        .with_eos_token_id(Some(2))
+        .with_seed(42);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_generation_config_logits_tap() {
+    let cfg = GenerationConfig::default().with_logits_tap_steps(5).with_logits_topk(20);
+    insta::assert_snapshot!(format!(
+        "logits_tap_steps={} logits_topk={}",
+        cfg.logits_tap_steps, cfg.logits_topk
+    ));
+}
+
+// ============================================================================
+// Generation-module SamplingConfig / SamplingStrategy
+// ============================================================================
+
+#[test]
+fn w18_gen_sample_config_default_debug() {
+    let cfg = SampleConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_gen_sampling_strategy_default_debug() {
+    let cfg = SampleConfig::default();
+    let strategy = GenSamplingStrategy::new(cfg);
+    insta::assert_debug_snapshot!(strategy);
+}
+
+#[test]
+fn w18_gen_sampling_strategy_greedy_debug() {
+    let cfg = SampleConfig {
+        temperature: 0.0,
+        top_k: None,
+        top_p: None,
+        repetition_penalty: 1.0,
+        do_sample: false,
+    };
+    let strategy = GenSamplingStrategy::new(cfg);
+    insta::assert_debug_snapshot!(strategy);
+}
+
+// ============================================================================
+// Generation-module GenConfig (autoregressive)
+// ============================================================================
+
+#[test]
+fn w18_gen_config_default_debug() {
+    let cfg = GenConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// InferenceConfig
+// ============================================================================
+
+#[test]
+fn w18_inference_config_cpu_optimized() {
+    // Pin thread count for reproducible snapshots
+    let mut cfg = InferenceConfig::cpu_optimized();
+    cfg.num_threads = 4;
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_inference_config_gpu_optimized() {
+    let mut cfg = InferenceConfig::gpu_optimized();
+    cfg.num_threads = 4;
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_inference_config_memory_efficient() {
+    let mut cfg = InferenceConfig::memory_efficient();
+    cfg.num_threads = 4;
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// CacheConfig
+// ============================================================================
+
+#[test]
+fn w18_cache_config_default_debug() {
+    let cfg = CacheConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// KVCache stats after operations
+// ============================================================================
+
+#[test]
+fn w18_kv_cache_empty_stats() {
+    let cfg = CacheConfig::default();
+    let cache = KVCache::new(cfg).unwrap();
+    insta::assert_debug_snapshot!(cache.stats());
+}
+
+#[test]
+fn w18_kv_cache_after_store() {
+    let cfg = CacheConfig::default();
+    let mut cache = KVCache::new(cfg).unwrap();
+    cache.store(0, 0, vec![1.0, 2.0, 3.0, 4.0], vec![5.0, 6.0, 7.0, 8.0]).unwrap();
+    cache.store(0, 1, vec![9.0, 10.0, 11.0, 12.0], vec![13.0, 14.0, 15.0, 16.0]).unwrap();
+    cache.store(1, 0, vec![0.5; 4], vec![0.25; 4]).unwrap();
+    insta::assert_debug_snapshot!(cache.stats());
+}
+
+#[test]
+fn w18_kv_cache_after_hits_and_misses() {
+    let cfg = CacheConfig::default();
+    let mut cache = KVCache::new(cfg).unwrap();
+    cache.store(0, 0, vec![1.0; 4], vec![2.0; 4]).unwrap();
+    // 2 hits, 1 miss
+    let _ = cache.get(0, 0);
+    let _ = cache.get(0, 0);
+    let _ = cache.get(0, 99);
+    insta::assert_debug_snapshot!(cache.stats());
+}
+
+#[test]
+fn w18_kv_cache_prefill_tracking() {
+    let cfg = CacheConfig::default();
+    let mut cache = KVCache::new(cfg).unwrap();
+    cache.record_prefill(64);
+    cache.record_incremental(1);
+    cache.record_incremental(1);
+    insta::assert_snapshot!(format!(
+        "prefilled={} total={}",
+        cache.num_tokens_prefilled(),
+        cache.num_tokens_total()
+    ));
+}
+
+// ============================================================================
+// InferenceMetrics
+// ============================================================================
+
+#[test]
+fn w18_inference_metrics_sample() {
+    let m = InferenceMetrics::new(128, 64, 25.0, 3200.0, 1_048_576, 0.85);
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_inference_metrics_zero_time() {
+    let m = InferenceMetrics::new(0, 0, 0.0, 0.0, 0, 0.0);
+    insta::assert_debug_snapshot!(m);
+}
+
+// ============================================================================
+// MetricsCollector → snapshot
+// ============================================================================
+
+#[test]
+fn w18_metrics_collector_after_requests() {
+    let c = MetricsCollector::new();
+    c.record_request(32, 16, 2_000_000_000, 50_000_000);
+    c.record_request(64, 32, 4_000_000_000, 80_000_000);
+    c.record_cache_hit();
+    c.record_cache_hit();
+    c.record_cache_miss();
+    c.update_peak_memory(2_097_152);
+    insta::assert_debug_snapshot!(c.snapshot());
+}
+
+// ============================================================================
+// ThroughputMetrics & TimingMetrics
+// ============================================================================
+
+#[test]
+fn w18_throughput_metrics_default_debug() {
+    let m = ThroughputMetrics::default();
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_throughput_metrics_sample() {
+    let m = ThroughputMetrics {
+        prefill_tokens_per_sec: Some(1200.0),
+        decode_tokens_per_sec: Some(45.5),
+        end_to_end_tokens_per_sec: 42.0,
+        total_tokens: 128,
+    };
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_timing_metrics_default_debug() {
+    let m = TimingMetrics::default();
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_timing_metrics_sample() {
+    let m = TimingMetrics {
+        prefill_ms: Some(120),
+        decode_ms: Some(3000),
+        tokenization_encode_ms: Some(5),
+        tokenization_decode_ms: Some(3),
+        total_ms: 3128,
+    };
+    insta::assert_debug_snapshot!(m);
+}
+
+// ============================================================================
+// PerformanceMetrics & InferenceResult
+// ============================================================================
+
+#[test]
+fn w18_performance_metrics_default_debug() {
+    let m = PerformanceMetrics::default();
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_performance_metrics_sample() {
+    let m = PerformanceMetrics {
+        total_latency_ms: 5000,
+        tokens_generated: 128,
+        tokens_per_second: 25.6,
+        first_token_latency_ms: Some(45),
+        average_token_latency_ms: Some(39.0),
+        memory_usage_bytes: Some(536_870_912),
+        cache_hit_rate: Some(0.92),
+        backend_type: "cpu-avx2".to_string(),
+        model_load_time_ms: Some(1200),
+        tokenizer_encode_time_ms: Some(5),
+        tokenizer_decode_time_ms: Some(3),
+        forward_pass_time_ms: Some(4500),
+        sampling_time_ms: Some(200),
+    };
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w18_inference_result_sample() {
+    let perf = PerformanceMetrics {
+        total_latency_ms: 2000,
+        tokens_generated: 32,
+        tokens_per_second: 16.0,
+        first_token_latency_ms: Some(50),
+        average_token_latency_ms: Some(62.5),
+        memory_usage_bytes: None,
+        cache_hit_rate: None,
+        backend_type: "cpu".to_string(),
+        model_load_time_ms: None,
+        tokenizer_encode_time_ms: None,
+        tokenizer_decode_time_ms: None,
+        forward_pass_time_ms: None,
+        sampling_time_ms: None,
+    };
+    let result =
+        InferenceResult::new("The capital of France is Paris.".to_string(), 32, 2000, 16.0, perf);
+    insta::assert_debug_snapshot!(result);
+}
+
+// ============================================================================
+// ModelConfig (bitnet-common)
+// ============================================================================
+
+#[test]
+fn w18_model_config_default_debug() {
+    let cfg = ModelConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// BatchConfig
+// ============================================================================
+
+#[test]
+fn w18_batch_config_default_debug() {
+    let cfg = BatchConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w18_batch_config_custom() {
+    let cfg = BatchConfig::new(16, Duration::from_millis(500)).with_max_total_tokens(16384);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// StreamingConfig
+// ============================================================================
+
+#[test]
+fn w18_streaming_config_default_debug() {
+    let cfg = StreamingConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ============================================================================
+// LatencyHistogram
+// ============================================================================
+
+#[test]
+fn w18_latency_histogram_with_samples() {
+    let mut h = LatencyHistogram::new();
+    for i in 1..=20 {
+        h.record(i as f64 * 5.0);
+    }
+    insta::assert_snapshot!(format!(
+        "count={} mean={:.1} min={:.1} max={:.1} p50={:.1} p95={:.1} p99={:.1}",
+        h.count(),
+        h.mean().unwrap(),
+        h.min().unwrap(),
+        h.max().unwrap(),
+        h.p50().unwrap(),
+        h.p95().unwrap(),
+        h.p99().unwrap(),
+    ));
+}
+
+// ============================================================================
+// MemoryProfiler
+// ============================================================================
+
+#[test]
+fn w18_memory_profiler_after_ops() {
+    let mp = MemoryProfiler::new();
+    mp.record_allocation(4096);
+    mp.record_allocation(8192);
+    mp.record_deallocation(2048);
+    insta::assert_snapshot!(format!(
+        "current={} peak={} allocs={} deallocs={}",
+        mp.current_bytes(),
+        mp.peak_bytes(),
+        mp.allocation_count(),
+        mp.deallocation_count(),
+    ));
+}
+
+// ============================================================================
+// MetricsReport
+// ============================================================================
+
+#[test]
+fn w18_metrics_report_build() {
+    let c = MetricsCollector::new();
+    c.record_request(32, 48, 3_000_000_000, 60_000_000);
+    c.record_cache_hit();
+    c.record_cache_hit();
+    c.record_cache_miss();
+    c.update_peak_memory(4_194_304);
+
+    let mut h = LatencyHistogram::new();
+    h.record(30.0);
+    h.record(45.0);
+    h.record(60.0);
+
+    let t = ThroughputTracker::new(Duration::from_secs(60));
+    let mp = MemoryProfiler::new();
+    mp.record_allocation(4_194_304);
+
+    let report = MetricsReport::build(&c, &mut h, &t, &mp);
+    insta::assert_debug_snapshot!(report);
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_batch_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_batch_config_custom.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+BatchConfig {
+    max_batch_size: 16,
+    timeout: 500ms,
+    max_total_tokens: 16384,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_batch_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_batch_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+BatchConfig {
+    max_batch_size: 8,
+    timeout: 30s,
+    max_total_tokens: 8192,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_cache_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_cache_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+CacheConfig {
+    max_size_bytes: 1073741824,
+    max_sequence_length: 2048,
+    enable_compression: false,
+    eviction_policy: LRU,
+    block_size: 64,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_config_default_debug.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 512,
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+    seed: None,
+    eos_token_id: 2,
+    pad_token_id: 0,
+    min_length: 1,
+    max_length: 2048,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sample_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sample_config_default_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sampling_strategy_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sampling_strategy_default_debug.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: strategy
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 1.0,
+        top_k: Some(
+            50,
+        ),
+        top_p: Some(
+            0.9,
+        ),
+        repetition_penalty: 1.1,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sampling_strategy_greedy_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_gen_sampling_strategy_greedy_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: strategy
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 0.0,
+        top_k: None,
+        top_p: None,
+        repetition_penalty: 1.0,
+        do_sample: false,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_balanced_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_balanced_debug.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 100,
+    temperature: 0.7,
+    top_k: 50,
+    top_p: 0.9,
+    repetition_penalty: 1.05,
+    stop_sequences: [],
+    stop_token_ids: [],
+    stop_string_window: 64,
+    seed: None,
+    skip_special_tokens: true,
+    eos_token_id: None,
+    logits_tap_steps: 0,
+    logits_topk: 10,
+    logits_cb: false,
+    add_bos: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_creative_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_creative_debug.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 100,
+    temperature: 0.9,
+    top_k: 100,
+    top_p: 0.95,
+    repetition_penalty: 1.1,
+    stop_sequences: [],
+    stop_token_ids: [],
+    stop_string_window: 64,
+    seed: None,
+    skip_special_tokens: true,
+    eos_token_id: None,
+    logits_tap_steps: 0,
+    logits_topk: 10,
+    logits_cb: false,
+    add_bos: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_default_debug.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 100,
+    temperature: 0.7,
+    top_k: 50,
+    top_p: 0.9,
+    repetition_penalty: 1.0,
+    stop_sequences: [],
+    stop_token_ids: [],
+    stop_string_window: 64,
+    seed: None,
+    skip_special_tokens: true,
+    eos_token_id: None,
+    logits_tap_steps: 0,
+    logits_topk: 10,
+    logits_cb: false,
+    add_bos: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_greedy_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_greedy_debug.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 100,
+    temperature: 0.0,
+    top_k: 1,
+    top_p: 1.0,
+    repetition_penalty: 1.0,
+    stop_sequences: [],
+    stop_token_ids: [],
+    stop_string_window: 64,
+    seed: None,
+    skip_special_tokens: true,
+    eos_token_id: None,
+    logits_tap_steps: 0,
+    logits_topk: 10,
+    logits_cb: false,
+    add_bos: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_logits_tap.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_logits_tap.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: "format!(\"logits_tap_steps={} logits_topk={}\", cfg.logits_tap_steps,\ncfg.logits_topk)"
+---
+logits_tap_steps=5 logits_topk=20

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_with_stops.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_generation_config_with_stops.snap
@@ -1,0 +1,31 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 16,
+    temperature: 0.0,
+    top_k: 1,
+    top_p: 1.0,
+    repetition_penalty: 1.0,
+    stop_sequences: [
+        "</s>",
+        "\n\n",
+    ],
+    stop_token_ids: [
+        128009,
+        128001,
+    ],
+    stop_string_window: 64,
+    seed: Some(
+        42,
+    ),
+    skip_special_tokens: true,
+    eos_token_id: Some(
+        2,
+    ),
+    logits_tap_steps: 0,
+    logits_topk: 10,
+    logits_cb: false,
+    add_bos: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_cpu_optimized.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_cpu_optimized.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+InferenceConfig {
+    max_context_length: 2048,
+    num_threads: 4,
+    batch_size: 1,
+    mixed_precision: false,
+    memory_pool_size: 536870912,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_gpu_optimized.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_gpu_optimized.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+InferenceConfig {
+    max_context_length: 2048,
+    num_threads: 4,
+    batch_size: 4,
+    mixed_precision: true,
+    memory_pool_size: 1073741824,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_memory_efficient.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_config_memory_efficient.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+InferenceConfig {
+    max_context_length: 1024,
+    num_threads: 4,
+    batch_size: 1,
+    mixed_precision: false,
+    memory_pool_size: 268435456,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_metrics_sample.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_metrics_sample.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+InferenceMetrics {
+    prompt_tokens: 128,
+    generated_tokens: 64,
+    time_to_first_token_ms: 25.0,
+    total_generation_time_ms: 3200.0,
+    tokens_per_second: 20.0,
+    peak_memory_bytes: 1048576,
+    cache_hit_rate: 0.85,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_metrics_zero_time.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_metrics_zero_time.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+InferenceMetrics {
+    prompt_tokens: 0,
+    generated_tokens: 0,
+    time_to_first_token_ms: 0.0,
+    total_generation_time_ms: 0.0,
+    tokens_per_second: 0.0,
+    peak_memory_bytes: 0,
+    cache_hit_rate: 0.0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_result_sample.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_inference_result_sample.snap
@@ -1,0 +1,29 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: result
+---
+InferenceResult {
+    generated_text: "The capital of France is Paris.",
+    tokens_generated: 32,
+    latency_ms: 2000,
+    tokens_per_second: 16.0,
+    performance_metrics: PerformanceMetrics {
+        total_latency_ms: 2000,
+        tokens_generated: 32,
+        tokens_per_second: 16.0,
+        first_token_latency_ms: Some(
+            50,
+        ),
+        average_token_latency_ms: Some(
+            62.5,
+        ),
+        memory_usage_bytes: None,
+        cache_hit_rate: None,
+        backend_type: "cpu",
+        model_load_time_ms: None,
+        tokenizer_encode_time_ms: None,
+        tokenizer_decode_time_ms: None,
+        forward_pass_time_ms: None,
+        sampling_time_ms: None,
+    },
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_after_hits_and_misses.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_after_hits_and_misses.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cache.stats()
+---
+CacheStats {
+    total_entries: 1,
+    compressed_entries: 0,
+    current_size_bytes: 32,
+    max_size_bytes: 1073741824,
+    hit_rate: 0.6666666666666666,
+    memory_efficiency: 2.9802322387695313e-8,
+    cache_size: 32,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_after_store.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_after_store.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cache.stats()
+---
+CacheStats {
+    total_entries: 3,
+    compressed_entries: 0,
+    current_size_bytes: 96,
+    max_size_bytes: 1073741824,
+    hit_rate: 0.0,
+    memory_efficiency: 8.940696716308594e-8,
+    cache_size: 96,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_empty_stats.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_empty_stats.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cache.stats()
+---
+CacheStats {
+    total_entries: 0,
+    compressed_entries: 0,
+    current_size_bytes: 0,
+    max_size_bytes: 1073741824,
+    hit_rate: 0.0,
+    memory_efficiency: 0.0,
+    cache_size: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_prefill_tracking.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_kv_cache_prefill_tracking.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: "format!(\"prefilled={} total={}\", cache.num_tokens_prefilled(),\ncache.num_tokens_total())"
+---
+prefilled=64 total=66

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_latency_histogram_with_samples.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_latency_histogram_with_samples.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: "format!(\"count={} mean={:.1} min={:.1} max={:.1} p50={:.1} p95={:.1} p99={:.1}\",\nh.count(), h.mean().unwrap(), h.min().unwrap(), h.max().unwrap(),\nh.p50().unwrap(), h.p95().unwrap(), h.p99().unwrap(),)"
+---
+count=20 mean=52.5 min=5.0 max=100.0 p50=55.0 p95=95.0 p99=100.0

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_memory_profiler_after_ops.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_memory_profiler_after_ops.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: "format!(\"current={} peak={} allocs={} deallocs={}\", mp.current_bytes(),\nmp.peak_bytes(), mp.allocation_count(), mp.deallocation_count(),)"
+---
+current=10240 peak=12288 allocs=2 deallocs=1

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_metrics_collector_after_requests.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_metrics_collector_after_requests.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: c.snapshot()
+---
+InferenceMetrics {
+    prompt_tokens: 96,
+    generated_tokens: 48,
+    time_to_first_token_ms: 80.0,
+    total_generation_time_ms: 6000.0,
+    tokens_per_second: 8.0,
+    peak_memory_bytes: 2097152,
+    cache_hit_rate: 0.6666666666666666,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_metrics_report_build.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_metrics_report_build.snap
@@ -1,0 +1,42 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: report
+---
+MetricsReport {
+    inference: InferenceMetrics {
+        prompt_tokens: 32,
+        generated_tokens: 48,
+        time_to_first_token_ms: 60.0,
+        total_generation_time_ms: 3000.0,
+        tokens_per_second: 16.0,
+        peak_memory_bytes: 4194304,
+        cache_hit_rate: 0.6666666666666666,
+    },
+    latency_p50_ms: Some(
+        45.0,
+    ),
+    latency_p90_ms: Some(
+        60.0,
+    ),
+    latency_p95_ms: Some(
+        60.0,
+    ),
+    latency_p99_ms: Some(
+        60.0,
+    ),
+    latency_mean_ms: Some(
+        45.0,
+    ),
+    latency_min_ms: Some(
+        30.0,
+    ),
+    latency_max_ms: Some(
+        60.0,
+    ),
+    latency_samples: 3,
+    throughput_tps: 0.0,
+    memory_current_bytes: 4194304,
+    memory_peak_bytes: 4194304,
+    memory_allocation_count: 1,
+    memory_deallocation_count: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_model_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_model_config_default_debug.snap
@@ -1,0 +1,26 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+ModelConfig {
+    path: None,
+    format: Gguf,
+    vocab_size: 32000,
+    hidden_size: 4096,
+    num_layers: 32,
+    num_heads: 32,
+    num_key_value_heads: 0,
+    intermediate_size: 11008,
+    max_position_embeddings: 2048,
+    rope_theta: None,
+    rope_scaling: None,
+    rms_norm_eps: None,
+    norm_type: LayerNorm,
+    activation_type: Silu,
+    tokenizer: TokenizerConfig {
+        bos_id: None,
+        eos_id: None,
+        unk_id: None,
+        pad_id: None,
+    },
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_performance_metrics_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_performance_metrics_default_debug.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+PerformanceMetrics {
+    total_latency_ms: 0,
+    tokens_generated: 0,
+    tokens_per_second: 0.0,
+    first_token_latency_ms: None,
+    average_token_latency_ms: None,
+    memory_usage_bytes: None,
+    cache_hit_rate: None,
+    backend_type: "unknown",
+    model_load_time_ms: None,
+    tokenizer_encode_time_ms: None,
+    tokenizer_decode_time_ms: None,
+    forward_pass_time_ms: None,
+    sampling_time_ms: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_performance_metrics_sample.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_performance_metrics_sample.snap
@@ -1,0 +1,37 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+PerformanceMetrics {
+    total_latency_ms: 5000,
+    tokens_generated: 128,
+    tokens_per_second: 25.6,
+    first_token_latency_ms: Some(
+        45,
+    ),
+    average_token_latency_ms: Some(
+        39.0,
+    ),
+    memory_usage_bytes: Some(
+        536870912,
+    ),
+    cache_hit_rate: Some(
+        0.92,
+    ),
+    backend_type: "cpu-avx2",
+    model_load_time_ms: Some(
+        1200,
+    ),
+    tokenizer_encode_time_ms: Some(
+        5,
+    ),
+    tokenizer_decode_time_ms: Some(
+        3,
+    ),
+    forward_pass_time_ms: Some(
+        4500,
+    ),
+    sampling_time_ms: Some(
+        200,
+    ),
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_streaming_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_streaming_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: cfg
+---
+StreamingConfig {
+    buffer_size: 10,
+    flush_interval_ms: 50,
+    max_retries: 3,
+    token_timeout_ms: 5000,
+    cancellable: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_throughput_metrics_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_throughput_metrics_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+ThroughputMetrics {
+    prefill_tokens_per_sec: None,
+    decode_tokens_per_sec: None,
+    end_to_end_tokens_per_sec: 0.0,
+    total_tokens: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_throughput_metrics_sample.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_throughput_metrics_sample.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+ThroughputMetrics {
+    prefill_tokens_per_sec: Some(
+        1200.0,
+    ),
+    decode_tokens_per_sec: Some(
+        45.5,
+    ),
+    end_to_end_tokens_per_sec: 42.0,
+    total_tokens: 128,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_timing_metrics_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_timing_metrics_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+TimingMetrics {
+    prefill_ms: None,
+    decode_ms: None,
+    tokenization_encode_ms: None,
+    tokenization_decode_ms: None,
+    total_ms: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_timing_metrics_sample.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave18__w18_timing_metrics_sample.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave18.rs
+expression: m
+---
+TimingMetrics {
+    prefill_ms: Some(
+        120,
+    ),
+    decode_ms: Some(
+        3000,
+    ),
+    tokenization_encode_ms: Some(
+        5,
+    ),
+    tokenization_decode_ms: Some(
+        3,
+    ),
+    total_ms: 3128,
+}


### PR DESCRIPTION
Add 35 snapshot assertions (wave 18) covering inference engine and model structures.