### PR TITLE
docs: CHANGELOG entries for waves 127–128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ## [Unreleased]
 
+### Added — OpenCL Compute Operations (Waves 127–128)
+
+- **OpenCL continuous batching**: Iteration-level continuous batching for OpenCL inference pipeline, 66 tests (#2450)
+- **OpenCL weight dequantization kernels**: 7 quantization format dequantization kernels for OpenCL, 82 tests (#2447)
+- **OpenCL numerical stability suite**: Numerical stability validation and tolerance testing for OpenCL kernels, 69 tests (#2443)
+- **OpenCL GPU memory allocator**: Buddy-system GPU memory allocator for OpenCL device memory management, 66 tests (#2441)
+- **OpenCL cross-backend verification**: Cross-backend numerical verification framework for OpenCL vs CPU results, 77 tests (#2457)
+- **OpenCL SwiGLU FFN with MoE router**: SwiGLU feed-forward network with mixture-of-experts routing for OpenCL, 79 tests (#2459)
+- **OpenCL layer normalization variants**: LayerNorm, RMSNorm, and GroupNorm implementations for OpenCL, 70 tests (#2460)
+- **OpenCL tensor reshape operations**: Transpose, permute, concat, and split tensor operations for OpenCL, 86 tests (#2456)
+- **OpenCL reduction operations**: 9 reduction operations with tree-reduction strategy for OpenCL, 106 tests (#2461)
+- **CHANGELOG waves 125–126**: Documentation of waves 125–126 OpenCL PRs (#2444)
+
 ### Added — A770 OpenCL Runtime & Diagnostics (Waves 112–113)
 
 - **CHANGELOG Waves 110–111**: Documentation of waves 110–111 OpenCL engine and optimization PRs (#2138)


### PR DESCRIPTION
Add CHANGELOG entries for waves 127–128 OpenCL PRs.

### Wave 127
- PR #2450: OpenCL continuous batching (iteration-level) (66 tests)
- PR #2447: OpenCL weight dequantization kernels — 7 formats (82 tests)
- PR #2443: OpenCL numerical stability suite (69 tests)
- PR #2441: OpenCL GPU memory allocator with buddy system (66 tests)
- PR #2457: OpenCL cross-backend verification framework (77 tests)

### Wave 128
- PR #2459: OpenCL SwiGLU FFN with MoE router (79 tests)
- PR #2460: OpenCL layer normalization variants — LayerNorm/RMSNorm/GroupNorm (70 tests)
- PR #2456: OpenCL tensor reshape operations — transpose/permute/concat/split (86 tests)
- PR #2461: OpenCL reduction operations — 9 ops with tree reduction (106 tests)
- PR #2444: CHANGELOG entries for waves 125-126