### PR TITLE
test(fuzz): add wave 25 fuzz targets (quantize round-trip, embedding bounds)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -539,3 +539,15 @@ name = "fuzz_activation_elementwise"
 path = "fuzz_targets/fuzz_activation_elementwise.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_quantize_round_trip"
+path = "fuzz_targets/fuzz_quantize_round_trip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_embedding_bounds"
+path = "fuzz_targets/fuzz_embedding_bounds.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_embedding_bounds.rs
+++ b/fuzz/fuzz_targets/fuzz_embedding_bounds.rs
@@ -1,0 +1,144 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::embedding::{EmbeddingConfig, embedding_lookup, embedding_lookup_simd};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct EmbeddingBoundsInput {
+    vocab_size: u8,
+    embed_dim: u8,
+    table_data: Vec<u8>,
+    indices: Vec<u16>,
+    padding_idx: Option<u8>,
+    test_boundary: bool,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .map(|v| if v.is_finite() { v } else { 0.0 })
+        .collect()
+}
+
+fuzz_target!(|input: EmbeddingBoundsInput| {
+    let vocab_size = (input.vocab_size as usize % 64) + 1;
+    let embed_dim = (input.embed_dim as usize % 32) + 1;
+    let table_len = vocab_size * embed_dim;
+
+    let mut table = bytes_to_f32(&input.table_data, table_len);
+    table.resize(table_len, 0.0);
+
+    // Build index list from fuzzed bytes, including boundary values.
+    let mut indices: Vec<u32> = input.indices.iter().take(128).map(|&i| i as u32).collect();
+
+    if input.test_boundary {
+        // Inject boundary indices: 0, vocab_size-1, vocab_size, u32::MAX.
+        indices.push(0);
+        if vocab_size > 0 {
+            indices.push((vocab_size - 1) as u32);
+        }
+        indices.push(vocab_size as u32);
+        indices.push(u32::MAX);
+    }
+
+    if indices.is_empty() {
+        return;
+    }
+
+    // --- scalar embedding_lookup ---
+    // Only valid indices should succeed; any OOB should return Err, never panic.
+    let all_valid = indices.iter().all(|&idx| (idx as usize) < vocab_size);
+
+    match embedding_lookup(&table, &indices, embed_dim) {
+        Ok(result) => {
+            // Invariant 1: All indices must have been in-bounds.
+            assert!(all_valid, "embedding_lookup succeeded with OOB indices");
+
+            // Invariant 2: Output length = indices.len() * embed_dim.
+            assert_eq!(
+                result.len(),
+                indices.len() * embed_dim,
+                "output length mismatch: expected {}, got {}",
+                indices.len() * embed_dim,
+                result.len()
+            );
+
+            // Invariant 3: All output values are finite.
+            for (i, &v) in result.iter().enumerate() {
+                assert!(v.is_finite(), "non-finite output at index {i}: {v}");
+            }
+
+            // Invariant 4: Lookup result matches table slice for each index.
+            for (i, &idx) in indices.iter().enumerate() {
+                let start = (idx as usize) * embed_dim;
+                let expected = &table[start..start + embed_dim];
+                let actual = &result[i * embed_dim..(i + 1) * embed_dim];
+                assert_eq!(expected, actual, "lookup mismatch at token {idx}");
+            }
+        }
+        Err(_) => {
+            // OOB index detected — this is expected, not a panic.
+        }
+    }
+
+    // --- SIMD embedding_lookup_simd ---
+    let padding_idx = input.padding_idx.map(|p| p as u32);
+    let config = EmbeddingConfig { vocab_size, embedding_dim: embed_dim, padding_idx };
+
+    // Filter to valid-only indices for SIMD path comparison.
+    let valid_indices: Vec<u32> = indices
+        .iter()
+        .copied()
+        .filter(|&idx| (idx as usize) < vocab_size)
+        .filter(|&idx| Some(idx) != padding_idx)
+        .collect();
+
+    if !valid_indices.is_empty() {
+        match embedding_lookup_simd(&table, &valid_indices, &config) {
+            Ok(simd_result) => {
+                // Invariant 5: SIMD result length matches.
+                assert_eq!(
+                    simd_result.len(),
+                    valid_indices.len() * embed_dim,
+                    "SIMD output length mismatch"
+                );
+
+                // Invariant 6: SIMD matches scalar for same valid inputs.
+                if let Ok(scalar_result) = embedding_lookup(&table, &valid_indices, embed_dim) {
+                    assert_eq!(
+                        scalar_result.len(),
+                        simd_result.len(),
+                        "scalar vs SIMD length mismatch"
+                    );
+                    for (i, (&s, &d)) in scalar_result.iter().zip(simd_result.iter()).enumerate() {
+                        assert_eq!(s, d, "scalar vs SIMD mismatch at index {i}: {s} vs {d}");
+                    }
+                }
+            }
+            Err(_) => {
+                // Acceptable — SIMD path may also reject.
+            }
+        }
+    }
+
+    // --- Padding index path ---
+    if let Some(pad) = padding_idx {
+        if (pad as usize) < vocab_size {
+            let pad_indices = vec![pad];
+            match embedding_lookup_simd(&table, &pad_indices, &config) {
+                Ok(result) => {
+                    // Invariant 7: Padding index produces all zeros.
+                    assert_eq!(result.len(), embed_dim);
+                    for (i, &v) in result.iter().enumerate() {
+                        assert_eq!(v, 0.0, "padding index output non-zero at {i}: {v}");
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_quantize_round_trip.rs
+++ b/fuzz/fuzz_targets/fuzz_quantize_round_trip.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::{BitNetTensor, Device, QuantizationType, Tensor};
+use bitnet_quantization::Quantize;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct QuantRoundTripInput {
+    qtype_selector: u8,
+    data: Vec<u8>,
+    extra_len: u8,
+}
+
+fn bytes_to_f32_finite(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .map(|v| if v.is_finite() { v } else { 0.0 })
+        .collect()
+}
+
+fuzz_target!(|input: QuantRoundTripInput| {
+    // Select quantization type from fuzzer byte.
+    let qtype = match input.qtype_selector % 3 {
+        0 => QuantizationType::I2S,
+        1 => QuantizationType::TL1,
+        _ => QuantizationType::TL2,
+    };
+
+    // Build a float vector with length in [4, 512].
+    let target_len = ((input.extra_len as usize % 128) + 1) * 4;
+    let floats = bytes_to_f32_finite(&input.data, target_len);
+
+    if floats.len() < 4 || floats.len() > 64 * 1024 {
+        return;
+    }
+
+    let shape = [floats.len()];
+
+    let tensor = match BitNetTensor::from_slice(&floats, &shape, &Device::Cpu) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    // Quantize — must not panic on any finite input.
+    let quantized = match tensor.quantize(qtype) {
+        Ok(q) => q,
+        Err(_) => return,
+    };
+
+    // Invariant 1: Quantized type matches request.
+    assert_eq!(
+        quantized.qtype, qtype,
+        "quantized type mismatch: expected {qtype:?}, got {:?}",
+        quantized.qtype
+    );
+
+    // Dequantize — must not panic.
+    let deq = match quantized.dequantize() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+
+    // Invariant 2: All dequantized values are finite.
+    if let Ok(slice) = deq.as_slice::<f32>() {
+        for (i, &v) in slice.iter().enumerate() {
+            assert!(
+                v.is_finite(),
+                "dequantized value non-finite at index {i}: {v} (qtype={qtype:?})"
+            );
+        }
+
+        // Invariant 3: Output length matches input length.
+        assert_eq!(
+            slice.len(),
+            floats.len(),
+            "round-trip length mismatch: input {} vs output {} (qtype={qtype:?})",
+            floats.len(),
+            slice.len()
+        );
+    }
+
+    // Invariant 4: Double round-trip produces identical quantized output.
+    if let Ok(re_tensor) = BitNetTensor::from_slice(
+        &{
+            match deq.as_slice::<f32>() {
+                Ok(s) => s.to_vec(),
+                Err(_) => return,
+            }
+        },
+        &shape,
+        &Device::Cpu,
+    ) {
+        if let Ok(re_quantized) = re_tensor.quantize(qtype) {
+            if let Ok(re_deq) = re_quantized.dequantize() {
+                if let (Ok(first), Ok(second)) = (deq.as_slice::<f32>(), re_deq.as_slice::<f32>()) {
+                    assert_eq!(first.len(), second.len(), "double round-trip length mismatch");
+                    for (i, (&a, &b)) in first.iter().zip(second.iter()).enumerate() {
+                        assert_eq!(
+                            a, b,
+                            "double round-trip diverged at index {i}: {a} vs {b} (qtype={qtype:?})"
+                        );
+                    }
+                }
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Wave 25 Fuzz Targets

Adds 2 new fuzz targets for kernel and inference operations, bringing the total to 55 targets.

### New targets

| Target | Subsystem | What it fuzzes |
|--------|-----------|----------------|
| `fuzz_quantize_round_trip` | quantization | Quantize→dequantize round trip across I2S/TL1/TL2 with double round-trip idempotency |
| `fuzz_embedding_bounds` | kernels | Embedding lookup with boundary indices (0, max, OOB, u32::MAX), scalar vs SIMD parity, padding |

### Existing targets (already in main)

The following wave 25 targets were already merged:
- `fuzz_matmul_shapes` — Matrix multiply with random shapes
- `fuzz_attention_scores` — Attention score computation with random Q/K/V
- `fuzz_layernorm_stability` — Layer normalization with extreme values
- `fuzz_kv_cache_ops` — KV cache append/retrieve operations

### Properties verified

**fuzz_quantize_round_trip:**
- Quantized type matches request
- All dequantized values are finite
- Output length matches input length
- Double round-trip produces identical output (idempotency)

**fuzz_embedding_bounds:**
- Valid lookups return correct dimension
- OOB indices return error (never panic)
- Output length = indices.len() × embed_dim
- Scalar vs SIMD results are bitwise identical
- Padding index produces all-zero output

### Verification
- `cargo check -p bitnet-fuzz --all-targets` ✅
- `cargo fmt --all` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced fuzz testing infrastructure with new test targets for embedding operations and quantization workflows to improve code robustness and reliability.
  * Added comprehensive coverage for boundary conditions, error handling, and algorithm consistency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->