### PR TITLE
test(fuzz): add wave 26 fuzz targets for batch norm, thread pool, pipeline

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -575,3 +575,39 @@ name = "fuzz_cuda_quantize_roundtrip"
 path = "fuzz_targets/fuzz_cuda_quantize_roundtrip.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_batch_norm_numerical"
+path = "fuzz_targets/fuzz_batch_norm_numerical.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_profiling_timing"
+path = "fuzz_targets/fuzz_profiling_timing.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_thread_pool_scheduling"
+path = "fuzz_targets/fuzz_thread_pool_scheduling.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_element_wise_chains"
+path = "fuzz_targets/fuzz_element_wise_chains.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_softmax_large_values"
+path = "fuzz_targets/fuzz_softmax_large_values.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_pipeline_parallel_stages"
+path = "fuzz_targets/fuzz_pipeline_parallel_stages.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_batch_norm_numerical.rs
+++ b/fuzz/fuzz_targets/fuzz_batch_norm_numerical.rs
@@ -1,0 +1,168 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::batch_norm::{BatchNormConfig, batch_norm_forward, batch_norm_inference};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct BatchNormNumericalInput {
+    channels: u8,
+    batch_size: u8,
+    data: Vec<u8>,
+    gamma_data: Vec<u8>,
+    beta_data: Vec<u8>,
+    mean_data: Vec<u8>,
+    var_data: Vec<u8>,
+    eps_byte: u8,
+    momentum_byte: u8,
+    inject_extreme: bool,
+    extreme_positions: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: BatchNormNumericalInput| {
+    let channels = (input.channels as usize % 32) + 1;
+    let batch_size = (input.batch_size as usize % 8) + 1;
+    let total = batch_size * channels;
+    let eps = 1e-7 + (input.eps_byte as f32 / 255.0) * 1e-3;
+    let momentum = (input.momentum_byte as f32 / 255.0).clamp(0.01, 0.99);
+
+    let mut data = bytes_to_f32(&input.data, total);
+    let gamma = bytes_to_f32(&input.gamma_data, channels);
+    let beta = bytes_to_f32(&input.beta_data, channels);
+    let mean_raw = bytes_to_f32(&input.mean_data, channels);
+    let var_raw = bytes_to_f32(&input.var_data, channels);
+
+    if data.len() < total
+        || gamma.len() < channels
+        || beta.len() < channels
+        || mean_raw.len() < channels
+        || var_raw.len() < channels
+    {
+        return;
+    }
+
+    // Inject extreme but finite values to stress numerical stability.
+    if input.inject_extreme {
+        for (i, &pos) in input.extreme_positions.iter().take(8).enumerate() {
+            let idx = pos as usize % total;
+            match i % 6 {
+                0 => data[idx] = 1e30,
+                1 => data[idx] = -1e30,
+                2 => data[idx] = 1e-30,
+                3 => data[idx] = -1e-30,
+                4 => data[idx] = f32::MIN_POSITIVE,
+                5 => data[idx] = -f32::MIN_POSITIVE,
+                _ => {}
+            }
+        }
+    }
+
+    // Filter out non-finite inputs.
+    if data[..total]
+        .iter()
+        .chain(gamma[..channels].iter())
+        .chain(beta[..channels].iter())
+        .chain(mean_raw[..channels].iter())
+        .chain(var_raw[..channels].iter())
+        .any(|x| !x.is_finite())
+    {
+        return;
+    }
+
+    let running_var: Vec<f32> = var_raw[..channels].iter().map(|&v| v.abs()).collect();
+
+    let config = BatchNormConfig { num_features: channels, eps, momentum, training: true };
+
+    // Test forward (training) path.
+    if let Ok((output, updated_mean, updated_var)) = batch_norm_forward(
+        &data[..total],
+        &gamma[..channels],
+        &beta[..channels],
+        &mean_raw[..channels],
+        &running_var,
+        &config,
+    ) {
+        assert_eq!(output.len(), total);
+        for (i, &val) in output.iter().enumerate() {
+            assert!(!val.is_nan(), "forward NaN at {i}");
+            assert!(!val.is_infinite(), "forward Inf at {i}");
+        }
+        for (i, &val) in updated_mean.iter().enumerate() {
+            assert!(!val.is_nan(), "updated_mean NaN at {i}");
+            assert!(!val.is_infinite(), "updated_mean Inf at {i}");
+        }
+        for (i, &val) in updated_var.iter().enumerate() {
+            assert!(!val.is_nan(), "updated_var NaN at {i}");
+            assert!(val >= 0.0 || !val.is_finite(), "updated_var negative at {i}: {val}");
+        }
+    }
+
+    // Test inference path.
+    let infer_config = BatchNormConfig { num_features: channels, eps, momentum, training: false };
+    if let Ok(output) = batch_norm_inference(
+        &data[..total],
+        &gamma[..channels],
+        &beta[..channels],
+        &mean_raw[..channels],
+        &running_var,
+        eps,
+    ) {
+        assert_eq!(output.len(), total);
+        for (i, &val) in output.iter().enumerate() {
+            assert!(!val.is_nan(), "inference NaN at {i}");
+            assert!(!val.is_infinite(), "inference Inf at {i}");
+        }
+    }
+
+    // Invariant: zero variance with non-zero eps should not produce NaN.
+    let zero_var = vec![0.0f32; channels];
+    if let Ok(output) = batch_norm_inference(
+        &data[..total],
+        &gamma[..channels],
+        &beta[..channels],
+        &mean_raw[..channels],
+        &zero_var,
+        eps,
+    ) {
+        for (i, &val) in output.iter().enumerate() {
+            assert!(!val.is_nan(), "zero-var inference NaN at {i}");
+        }
+    }
+
+    // Invariant: identical inputs across batch should produce identical outputs.
+    let single_sample: Vec<f32> = data[..channels].to_vec();
+    let repeated: Vec<f32> = single_sample.iter().copied().cycle().take(total).collect();
+    if let Ok(output) = batch_norm_inference(
+        &repeated,
+        &gamma[..channels],
+        &beta[..channels],
+        &mean_raw[..channels],
+        &running_var,
+        eps,
+    ) {
+        for bi in 1..batch_size {
+            for c in 0..channels {
+                let first = output[c];
+                let other = output[bi * channels + c];
+                if first.is_finite() && other.is_finite() {
+                    assert!(
+                        (first - other).abs() < 1e-5,
+                        "batch consistency violation ch={c} b0={first} b{bi}={other}"
+                    );
+                }
+            }
+        }
+    }
+
+    // Suppress unused variable warning.
+    let _ = infer_config;
+});

--- a/fuzz/fuzz_targets/fuzz_element_wise_chains.rs
+++ b/fuzz/fuzz_targets/fuzz_element_wise_chains.rs
@@ -1,0 +1,135 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::activations::{ActivationType, activate, activate_inplace};
+use bitnet_kernels::cpu::fusion::{fused_add_normalize, fused_scale_add};
+use bitnet_kernels::cpu::residual::{add_residual, add_residual_scaled};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ElementWiseChainInput {
+    data_a: Vec<u8>,
+    data_b: Vec<u8>,
+    dim: u8,
+    chain_ops: Vec<u8>,
+    scale_byte: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fn select_activation(sel: u8) -> ActivationType {
+    match sel % 10 {
+        0 => ActivationType::ReLU,
+        1 => ActivationType::GELU,
+        2 => ActivationType::SiLU,
+        3 => ActivationType::Sigmoid,
+        4 => ActivationType::Tanh,
+        5 => ActivationType::HardSigmoid,
+        6 => ActivationType::HardSwish,
+        7 => ActivationType::Mish,
+        8 => ActivationType::Softplus,
+        9 => ActivationType::SELU,
+        _ => unreachable!(),
+    }
+}
+
+fuzz_target!(|input: ElementWiseChainInput| {
+    let dim = (input.dim as usize % 64) + 2;
+
+    let a_raw = bytes_to_f32(&input.data_a, dim);
+    let b_raw = bytes_to_f32(&input.data_b, dim);
+    if a_raw.len() < dim || b_raw.len() < dim {
+        return;
+    }
+    let a = &a_raw[..dim];
+    let b = &b_raw[..dim];
+
+    // Skip non-finite inputs.
+    if a.iter().chain(b.iter()).any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let scale = (input.scale_byte as f32 / 255.0) * 4.0 - 2.0;
+
+    let ops = if input.chain_ops.is_empty() { &[0u8][..] } else { &input.chain_ops[..] };
+
+    let mut current = a.to_vec();
+
+    for &op_sel in ops.iter().take(8) {
+        match op_sel % 5 {
+            0 => {
+                // Activation function (element-wise).
+                let act = select_activation(op_sel / 5);
+                current = activate(&current, act);
+                for (i, &v) in current.iter().enumerate() {
+                    assert!(!v.is_nan(), "activation {act:?} NaN at {i}");
+                }
+            }
+            1 => {
+                // Residual add.
+                let mut buf = current.clone();
+                if buf.len() == b.len() {
+                    if add_residual(&mut buf, b).is_ok() {
+                        current = buf;
+                    }
+                }
+            }
+            2 => {
+                // Scaled residual add.
+                let mut buf = current.clone();
+                if buf.len() == b.len() && scale.is_finite() {
+                    if add_residual_scaled(&mut buf, b, scale).is_ok() {
+                        current = buf;
+                    }
+                }
+            }
+            3 => {
+                // Fused scale+add.
+                if current.len() == b.len() && scale.is_finite() {
+                    if let Ok(out) = fused_scale_add(&current, b, scale) {
+                        current = out;
+                    }
+                }
+            }
+            4 => {
+                // Fused add+normalize.
+                if current.len() == b.len() && current.len() >= 2 {
+                    let gamma = vec![1.0f32; current.len()];
+                    if let Ok(out) = fused_add_normalize(&current, b, &gamma, 1e-5) {
+                        current = out;
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+
+        // Bail out early if values become non-finite to avoid cascading issues.
+        if current.iter().any(|x| !x.is_finite()) {
+            return;
+        }
+    }
+
+    // Invariant: output length must match input length.
+    assert_eq!(current.len(), dim, "chain changed output length");
+
+    // Invariant: activate and activate_inplace must agree.
+    let act = select_activation(ops[0]);
+    let alloc_out = activate(a, act);
+    let mut inplace_out = a.to_vec();
+    activate_inplace(&mut inplace_out, act);
+    for (i, (&al, &ip)) in alloc_out.iter().zip(inplace_out.iter()).enumerate() {
+        assert!(
+            (al - ip).abs() < 1e-6
+                || (al.is_nan() && ip.is_nan())
+                || (al.is_infinite() && ip.is_infinite() && al.signum() == ip.signum()),
+            "activate vs inplace mismatch at {i}: {al} vs {ip}"
+        );
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_pipeline_parallel_stages.rs
+++ b/fuzz/fuzz_targets/fuzz_pipeline_parallel_stages.rs
@@ -1,0 +1,140 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::opencl_pipeline::{InferencePipeline, PipelineConfig, PipelineStage};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct PipelineInput {
+    num_layers: u8,
+    hidden_dim_factor: u8,
+    num_heads: u8,
+    intermediate_factor: u8,
+    vocab_size_factor: u8,
+    max_seq_len: u8,
+    use_gpu: bool,
+    fallback_to_cpu: bool,
+    input_ids: Vec<u8>,
+    position_byte: u8,
+    num_executions: u8,
+}
+
+fuzz_target!(|input: PipelineInput| {
+    let num_layers = (input.num_layers as usize % 8) + 1;
+    let num_heads = (input.num_heads as usize % 8) + 1;
+    // head_dim must be > 0; we pick small values to keep it fast.
+    let head_dim = (input.hidden_dim_factor as usize % 8) + 4;
+    let hidden_dim = num_heads * head_dim;
+    let intermediate_dim = ((input.intermediate_factor as usize % 8) + 1) * hidden_dim;
+    let vocab_size = ((input.vocab_size_factor as usize % 16) + 1) * 64;
+    let max_seq_len = (input.max_seq_len as usize % 128) + 1;
+
+    let config = PipelineConfig {
+        num_layers,
+        hidden_dim,
+        num_heads,
+        head_dim,
+        intermediate_dim,
+        vocab_size,
+        max_seq_len,
+        use_gpu: input.use_gpu,
+        fallback_to_cpu: input.fallback_to_cpu,
+    };
+
+    // Validation must not panic.
+    if config.validate().is_err() {
+        return;
+    }
+
+    let mut pipeline = match InferencePipeline::new(config.clone()) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Verify stage_order and stages_per_token are consistent.
+    let expected_stages = 1 + num_layers * 4 + 2;
+    assert_eq!(pipeline.stages_per_token(), expected_stages, "stages_per_token mismatch");
+    assert_eq!(pipeline.stage_order().len(), expected_stages, "stage_order length mismatch");
+
+    // Verify stage order structure: Embedding, then per-layer (RmsNorm, Attention,
+    // RmsNorm, FeedForward), then FinalNorm, LogitProjection.
+    let order = pipeline.stage_order();
+    assert_eq!(order[0], PipelineStage::Embedding);
+    for layer in 0..num_layers {
+        let base = 1 + layer * 4;
+        assert_eq!(order[base], PipelineStage::RmsNorm);
+        assert_eq!(order[base + 1], PipelineStage::Attention);
+        assert_eq!(order[base + 2], PipelineStage::RmsNorm);
+        assert_eq!(order[base + 3], PipelineStage::FeedForward);
+    }
+    assert_eq!(order[order.len() - 2], PipelineStage::FinalNorm);
+    assert_eq!(order[order.len() - 1], PipelineStage::LogitProjection);
+
+    // Build input_ids from fuzz data.
+    let ids: Vec<u32> =
+        input.input_ids.iter().take(8).map(|&b| b as u32 % vocab_size as u32).collect();
+
+    if ids.is_empty() {
+        // Empty input_ids should produce an error, not a panic.
+        let result = pipeline.execute_single_token_cpu(&[], 0);
+        assert!(result.is_err());
+        return;
+    }
+
+    let position = input.position_byte as usize % max_seq_len;
+
+    // Execute must not panic.
+    match pipeline.execute_single_token_cpu(&ids, position) {
+        Ok(execution) => {
+            // Verify execution results are internally consistent.
+            assert_eq!(execution.stages.len(), expected_stages);
+            assert_eq!(execution.tokens_generated, 1);
+
+            // Total time must be non-negative.
+            assert!(execution.total_time_ns > 0 || execution.stages.is_empty());
+
+            // GPU utilization must be in [0.0, 1.0].
+            let util = execution.gpu_utilization();
+            assert!((0.0..=1.0).contains(&util), "gpu_utilization out of range: {util}");
+
+            // Slowest stage must not panic.
+            if let Some(slowest) = execution.slowest_stage() {
+                assert!(slowest.execution_time_ns <= execution.total_time_ns);
+            }
+
+            // Summary string must not panic.
+            let _ = execution.summary();
+
+            // Total fallbacks must not exceed total stages.
+            assert!(execution.total_fallbacks() <= execution.stages.len());
+
+            // Verify output shapes are plausible.
+            for stage in &execution.stages {
+                assert!(!stage.output_shape.is_empty(), "empty output_shape");
+                for &s in &stage.output_shape {
+                    assert!(s > 0, "zero dimension in output_shape");
+                }
+            }
+        }
+        Err(_) => {
+            // Errors are acceptable; the important thing is no panic.
+        }
+    }
+
+    // Execute multiple times to verify execution_count tracking.
+    let num_extra = (input.num_executions as usize % 4).min(3);
+    let initial_count = pipeline.execution_count();
+    for _ in 0..num_extra {
+        let _ = pipeline.execute_single_token_cpu(&ids, position);
+    }
+    assert!(pipeline.execution_count() >= initial_count, "execution_count did not increase");
+
+    // Config accessor must not panic.
+    let cfg = pipeline.config();
+    assert_eq!(cfg.num_layers, num_layers);
+    assert_eq!(cfg.hidden_dim, hidden_dim);
+
+    // Position >= max_seq_len should produce error, not panic.
+    let result = pipeline.execute_single_token_cpu(&ids, max_seq_len);
+    assert!(result.is_err());
+});

--- a/fuzz/fuzz_targets/fuzz_profiling_timing.rs
+++ b/fuzz/fuzz_targets/fuzz_profiling_timing.rs
@@ -1,0 +1,137 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::opencl_profiling::{KernelProfile, ProfilingSession};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ProfilingInput {
+    /// Raw bytes to derive kernel names and timing values.
+    entries: Vec<ProfileEntry>,
+}
+
+#[derive(Arbitrary, Debug)]
+struct ProfileEntry {
+    name_bytes: Vec<u8>,
+    global_dims: Vec<u8>,
+    local_dims: Vec<u8>,
+    queued_ns: u64,
+    submit_ns: u64,
+    start_ns: u64,
+    end_ns: u64,
+    bytes_transferred: u16,
+    flop_count: u32,
+}
+
+fuzz_target!(|input: ProfilingInput| {
+    if input.entries.is_empty() || input.entries.len() > 128 {
+        return;
+    }
+
+    let mut session = ProfilingSession::new();
+
+    for entry in &input.entries {
+        // Derive a kernel name from arbitrary bytes (valid UTF-8 subset).
+        let name: String = entry
+            .name_bytes
+            .iter()
+            .take(64)
+            .map(|&b| {
+                let c = b % 62;
+                match c {
+                    0..=9 => (b'0' + c) as char,
+                    10..=35 => (b'a' + c - 10) as char,
+                    36..=61 => (b'A' + c - 36) as char,
+                    _ => '_',
+                }
+            })
+            .collect();
+
+        if name.is_empty() {
+            continue;
+        }
+
+        let global_work_size: Vec<usize> =
+            entry.global_dims.iter().take(3).map(|&b| (b as usize % 256) + 1).collect();
+        let local_work_size: Vec<usize> =
+            entry.local_dims.iter().take(3).map(|&b| (b as usize % 64) + 1).collect();
+
+        let profile = KernelProfile {
+            kernel_name: name.clone(),
+            global_work_size,
+            local_work_size,
+            queued_ns: entry.queued_ns,
+            submit_ns: entry.submit_ns,
+            start_ns: entry.start_ns,
+            end_ns: entry.end_ns,
+        };
+
+        // Derived timing metrics must not panic.
+        let queue_lat = profile.queue_latency_us();
+        let exec_time = profile.execution_time_us();
+        let total_time = profile.total_time_us();
+        let bw = profile.bandwidth_gb_s(entry.bytes_transferred as usize);
+        let gf = profile.gflops(entry.flop_count as u64);
+
+        // Invariant: all timing values are non-negative (saturating_sub).
+        assert!(queue_lat >= 0.0, "queue_latency_us negative: {queue_lat}");
+        assert!(exec_time >= 0.0, "execution_time_us negative: {exec_time}");
+        assert!(total_time >= 0.0, "total_time_us negative: {total_time}");
+        assert!(bw >= 0.0, "bandwidth negative: {bw}");
+        assert!(gf >= 0.0, "gflops negative: {gf}");
+
+        // Invariant: no NaN in derived metrics.
+        assert!(!queue_lat.is_nan(), "queue_latency_us NaN");
+        assert!(!exec_time.is_nan(), "execution_time_us NaN");
+        assert!(!total_time.is_nan(), "total_time_us NaN");
+        assert!(!bw.is_nan(), "bandwidth NaN");
+        assert!(!gf.is_nan(), "gflops NaN");
+
+        session.record(profile);
+    }
+
+    // Session operations must not panic.
+    let _elapsed = session.elapsed();
+    let _len = session.len();
+    let _empty = session.is_empty();
+
+    assert_eq!(session.is_empty(), session.len() == 0);
+
+    // Query by kernel name must not panic.
+    let _ = session.by_kernel("nonexistent_kernel_xyz");
+    if let Some(entry) = input.entries.first() {
+        let name: String = entry
+            .name_bytes
+            .iter()
+            .take(64)
+            .map(|&b| {
+                let c = b % 62;
+                match c {
+                    0..=9 => (b'0' + c) as char,
+                    10..=35 => (b'a' + c - 10) as char,
+                    36..=61 => (b'A' + c - 36) as char,
+                    _ => '_',
+                }
+            })
+            .collect();
+        let _ = session.by_kernel(&name);
+    }
+
+    // Slowest-N query must not panic.
+    let _ = session.slowest(0);
+    let _ = session.slowest(1);
+    let _ = session.slowest(input.entries.len());
+    let _ = session.slowest(input.entries.len() + 100);
+
+    // GPU time must be non-negative.
+    let gpu_time = session.total_gpu_time_ms();
+    assert!(gpu_time >= 0.0, "total_gpu_time_ms negative: {gpu_time}");
+
+    // Summary must not panic and must be internally consistent.
+    if !session.is_empty() {
+        let summary = session.summary();
+        assert_eq!(summary.total_kernels, session.len());
+        assert!(summary.total_gpu_time_ms >= 0.0);
+        assert!(summary.avg_kernel_time_us >= 0.0);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_softmax_large_values.rs
+++ b/fuzz/fuzz_targets/fuzz_softmax_large_values.rs
@@ -1,0 +1,115 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::batch::batched_softmax;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct SoftmaxLargeInput {
+    dim: u8,
+    batch: u8,
+    data: Vec<u8>,
+    extreme_mode: u8,
+    extreme_positions: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: SoftmaxLargeInput| {
+    let dim = (input.dim as usize % 128) + 2;
+    let batch = (input.batch as usize % 8) + 1;
+    let total = batch * dim;
+
+    let mut data = bytes_to_f32(&input.data, total);
+    if data.len() < total {
+        return;
+    }
+
+    // Inject extreme values based on fuzz-selected mode.
+    for &pos in input.extreme_positions.iter().take(16) {
+        let idx = pos as usize % total;
+        match input.extreme_mode % 8 {
+            0 => data[idx] = f32::MAX,
+            1 => data[idx] = f32::MIN,
+            2 => data[idx] = 1e38,
+            3 => data[idx] = -1e38,
+            4 => data[idx] = f32::MAX / 2.0,
+            5 => data[idx] = f32::MIN / 2.0,
+            6 => data[idx] = f32::MIN_POSITIVE,
+            7 => data[idx] = -f32::MIN_POSITIVE,
+            _ => {}
+        }
+    }
+
+    // Filter to finite-only for the main test.
+    let mut finite_data = data[..total].to_vec();
+    for v in &mut finite_data {
+        if !v.is_finite() {
+            *v = 0.0;
+        }
+    }
+
+    // batched_softmax with extreme but finite values must not produce NaN.
+    if let Ok(out) = batched_softmax(&finite_data, batch, dim) {
+        assert_eq!(out.len(), total);
+        for (i, &v) in out.iter().enumerate() {
+            assert!(!v.is_nan(), "softmax NaN at {i}");
+            assert!(!v.is_infinite(), "softmax Inf at {i}");
+            assert!(v >= 0.0, "softmax negative at {i}: {v}");
+            assert!(v <= 1.0 + 1e-6, "softmax >1 at {i}: {v}");
+        }
+
+        // Each row must sum to approximately 1.0.
+        for bi in 0..batch {
+            let row = &out[bi * dim..(bi + 1) * dim];
+            let sum: f32 = row.iter().sum();
+            assert!((sum - 1.0).abs() < 1e-3, "softmax row {bi} sum={sum} (expected ~1.0)");
+        }
+    }
+
+    // Also exercise bitnet_logits softmax for cross-check.
+    let mut logits_copy = finite_data[..dim].to_vec();
+    bitnet_logits::softmax_in_place(&mut logits_copy);
+    for (i, &v) in logits_copy.iter().enumerate() {
+        assert!(!v.is_nan(), "bitnet_logits softmax NaN at {i}");
+        assert!(v >= 0.0, "bitnet_logits softmax negative at {i}: {v}");
+    }
+    let sum: f32 = logits_copy.iter().sum();
+    if sum.is_finite() {
+        assert!((sum - 1.0).abs() < 1e-3, "bitnet_logits softmax sum={sum} (expected ~1.0)");
+    }
+
+    // Invariant: softmax(x + c) == softmax(x) for any constant c (shift invariance).
+    let shift = 1000.0f32;
+    let shifted: Vec<f32> = finite_data[..dim].iter().map(|&v| v + shift).collect();
+    // Build full batch input by repeating the first row.
+    let single_batch_orig = finite_data[..dim].to_vec();
+    if let (Ok(out_orig), Ok(out_shifted)) =
+        (batched_softmax(&single_batch_orig, 1, dim), batched_softmax(&shifted, 1, dim))
+    {
+        for (i, (&a, &b)) in out_orig.iter().zip(out_shifted.iter()).enumerate() {
+            if a.is_finite() && b.is_finite() {
+                assert!((a - b).abs() < 1e-4, "shift invariance violated at {i}: {a} vs {b}");
+            }
+        }
+    }
+
+    // Invariant: uniform input → uniform output.
+    let uniform = vec![42.0f32; dim];
+    if let Ok(out) = batched_softmax(&uniform, 1, dim) {
+        let expected = 1.0 / dim as f32;
+        for (i, &v) in out.iter().enumerate() {
+            assert!(
+                (v - expected).abs() < 1e-5,
+                "uniform softmax at {i}: expected {expected}, got {v}"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_thread_pool_scheduling.rs
+++ b/fuzz/fuzz_targets/fuzz_thread_pool_scheduling.rs
@@ -1,0 +1,132 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::batch::{
+    batched_add, batched_layer_norm, batched_matmul, batched_softmax,
+};
+use libfuzzer_sys::fuzz_target;
+
+/// Fuzz work scheduling by exercising batched operations with varying task
+/// counts, simulating the work-distribution patterns of a thread pool.
+#[derive(Arbitrary, Debug)]
+struct ThreadPoolInput {
+    batch_size: u8,
+    dim: u8,
+    inner_dim: u8,
+    data: Vec<u8>,
+    weights: Vec<u8>,
+    gamma_data: Vec<u8>,
+    beta_data: Vec<u8>,
+    op_sequence: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: ThreadPoolInput| {
+    let batch = (input.batch_size as usize % 8) + 1;
+    let dim = (input.dim as usize % 32) + 2;
+    let inner = (input.inner_dim as usize % 16) + 2;
+    let total = batch * dim;
+
+    let data = bytes_to_f32(&input.data, total);
+    if data.len() < total {
+        return;
+    }
+    let data = &data[..total];
+
+    // Skip non-finite inputs.
+    if data.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    // Execute a fuzz-selected sequence of batched operations.
+    let ops = if input.op_sequence.is_empty() { &[0u8][..] } else { &input.op_sequence[..] };
+
+    for &op_sel in ops.iter().take(8) {
+        match op_sel % 4 {
+            0 => {
+                // Batched softmax: must not panic, output must be valid probabilities.
+                if let Ok(out) = batched_softmax(data, batch, dim) {
+                    assert_eq!(out.len(), total);
+                    for (i, &v) in out.iter().enumerate() {
+                        assert!(!v.is_nan(), "batched_softmax NaN at {i}");
+                        assert!(v >= 0.0, "batched_softmax negative at {i}: {v}");
+                    }
+                    // Each batch row should sum to ~1.0.
+                    for bi in 0..batch {
+                        let row_sum: f32 = out[bi * dim..(bi + 1) * dim].iter().sum();
+                        if row_sum.is_finite() {
+                            assert!((row_sum - 1.0).abs() < 1e-3, "softmax row {bi} sum={row_sum}");
+                        }
+                    }
+                }
+            }
+            1 => {
+                // Batched matmul: a=[batch, 1, dim], b=[batch, dim, inner] → [batch, 1, inner].
+                let weight_count = batch * dim * inner;
+                let weights = bytes_to_f32(&input.weights, weight_count);
+                if weights.len() >= weight_count
+                    && weights[..weight_count].iter().all(|x| x.is_finite())
+                {
+                    // a is [batch * 1 * dim], b is [batch * dim * inner]
+                    if let Ok(out) =
+                        batched_matmul(data, &weights[..weight_count], batch, 1, dim, inner)
+                    {
+                        assert_eq!(out.len(), batch * inner);
+                    }
+                }
+            }
+            2 => {
+                // Batched layer norm: must not panic.
+                let gamma = bytes_to_f32(&input.gamma_data, dim);
+                let beta = bytes_to_f32(&input.beta_data, dim);
+                if gamma.len() >= dim
+                    && beta.len() >= dim
+                    && gamma[..dim].iter().all(|x| x.is_finite())
+                    && beta[..dim].iter().all(|x| x.is_finite())
+                {
+                    if let Ok(out) =
+                        batched_layer_norm(data, &gamma[..dim], &beta[..dim], batch, dim, 1e-5)
+                    {
+                        assert_eq!(out.len(), total);
+                        for (i, &v) in out.iter().enumerate() {
+                            assert!(!v.is_nan(), "batched_layer_norm NaN at {i}");
+                        }
+                    }
+                }
+            }
+            3 => {
+                // Batched add: must not panic.
+                let b_data = bytes_to_f32(&input.weights, total);
+                if b_data.len() >= total && b_data[..total].iter().all(|x| x.is_finite()) {
+                    if let Ok(out) = batched_add(data, &b_data[..total], batch, dim) {
+                        assert_eq!(out.len(), total);
+                        for (i, &v) in out.iter().enumerate() {
+                            assert!(v.is_finite(), "batched_add non-finite at {i}");
+                        }
+                    }
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    // Invariant: running the same operation twice yields identical results.
+    if let Ok(out1) = batched_softmax(data, batch, dim) {
+        if let Ok(out2) = batched_softmax(data, batch, dim) {
+            for (i, (&a, &b)) in out1.iter().zip(out2.iter()).enumerate() {
+                assert!(
+                    (a - b).abs() < 1e-7 || (a.is_nan() && b.is_nan()),
+                    "determinism violated at {i}: {a} vs {b}"
+                );
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Wave 26 Fuzz Targets

Add 6 new fuzz targets exercising newer kernel modules:

| Target | Module Under Test | Key Invariants |
|--------|-------------------|----------------|
| `fuzz_batch_norm_numerical` | `cpu::batch_norm` | No NaN/Inf output, zero-variance safety, batch consistency |
| `fuzz_profiling_timing` | `opencl_profiling` | Non-negative timing metrics, session summary consistency |
| `fuzz_thread_pool_scheduling` | `cpu::batch` | Correct output shapes, probability sums, determinism |
| `fuzz_element_wise_chains` | `cpu::activations`, `cpu::fusion`, `cpu::residual` | No NaN propagation, allocate-vs-inplace parity |
| `fuzz_softmax_large_values` | `cpu::batch::batched_softmax`, `bitnet_logits` | Numerical stability with extreme values, shift invariance |
| `fuzz_pipeline_parallel_stages` | `opencl_pipeline` | Stage ordering, execution counting, config validation |

### Testing
- `cargo build --manifest-path fuzz/Cargo.toml` ✅
- `cargo clippy --manifest-path fuzz/Cargo.toml` ✅ (no new warnings)
- All 6 targets compile and register correctly as `[[bin]]` entries

### Total fuzz target count: 92 (was 86)