### PR TITLE
test(kernels): add snapshot wave 16 — 80 insta tests for kernel output stability

### DIFF
--- a/crates/bitnet-kernels/tests/snapshot_wave_16.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave_16.rs
@@ -1,0 +1,784 @@
+//! Snapshot wave 16 — 67 insta tests for kernel output stability.
+//!
+//! Covers: config defaults, enum Debug/Display formatting, kernel output
+//! shapes, error messages, metric calculations, and state transitions.
+
+// ── Config default snapshots ───────────────────────────────────────
+
+#[test]
+fn snap_conv2d_config_default() {
+    let config = bitnet_kernels::cpu::Conv2dConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_layer_norm_config_default() {
+    let config = bitnet_kernels::cpu::LayerNormConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_linear_config_default() {
+    let config = bitnet_kernels::cpu::LinearConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_batch_norm_config_default() {
+    let config = bitnet_kernels::cpu::BatchNormConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_fusion_config_default() {
+    let config = bitnet_kernels::cpu::fusion::FusionConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_fusion_config_disabled() {
+    let config = bitnet_kernels::cpu::fusion::FusionConfig::disabled();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_scatter_gather_config_default() {
+    let config = bitnet_kernels::cpu::scatter_gather::ScatterGatherConfig::default();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_device_capability_matrix_default() {
+    let matrix = bitnet_kernels::capability_matrix::DeviceCapabilityMatrix::default();
+    insta::assert_debug_snapshot!(matrix);
+}
+
+// ── Config constructor snapshots ───────────────────────────────────
+
+#[test]
+fn snap_conv2d_config_3x3() {
+    let config = bitnet_kernels::cpu::Conv2dConfig::new(3, 16, 3);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_layer_norm_config_hidden_768() {
+    let config = bitnet_kernels::cpu::LayerNormConfig::new(vec![768]);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_group_norm_config_8g_32c() {
+    let config = bitnet_kernels::cpu::layer_norm::GroupNormConfig::new(8, 32, 64);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_batch_norm_config_64_features() {
+    let config = bitnet_kernels::cpu::batch_norm::BatchNormConfig::new(64);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_attention_config_mha() {
+    let config = bitnet_kernels::cpu::AttentionConfig {
+        num_heads: 8,
+        head_dim: 64,
+        seq_len: 128,
+        causal: true,
+        scale: None,
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_gqa_config() {
+    let config = bitnet_kernels::cpu::GqaConfig {
+        num_q_heads: 32,
+        num_kv_heads: 8,
+        head_dim: 64,
+        seq_len: 512,
+        causal: true,
+        scale: None,
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_cpu_attention_config() {
+    let config = bitnet_kernels::cpu::attention::CpuAttentionConfig {
+        batch_size: 2,
+        num_heads: 4,
+        seq_len: 16,
+        head_dim: 64,
+        scale: None,
+        causal_mask: true,
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_rope_config_default() {
+    let config = bitnet_kernels::cpu::rope::RopeConfig::new(64, 2048);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_rope_config_custom_base() {
+    let config = bitnet_kernels::cpu::rope::RopeConfig::new(128, 4096)
+        .with_base(500_000.0)
+        .with_scaling_factor(2.0);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_kv_cache_config() {
+    let config = bitnet_kernels::cpu::kv_cache::KvCacheConfig {
+        num_layers: 24,
+        num_heads: 8,
+        head_dim: 64,
+        max_seq_len: 2048,
+        dtype: bitnet_kernels::cpu::kv_cache::KvDtype::F32,
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_embedding_config() {
+    let config = bitnet_kernels::cpu::embedding::EmbeddingConfig {
+        vocab_size: 32000,
+        embedding_dim: 768,
+        padding_idx: Some(0),
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_cpu_embedding_config_with_options() {
+    let config = bitnet_kernels::cpu::CpuEmbeddingConfig::new(50000, 512)
+        .with_padding_idx(0)
+        .with_max_norm(1.0);
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_ffn_config_gelu() {
+    let config =
+        bitnet_kernels::cpu::FfnConfig::new(768, 3072, bitnet_kernels::cpu::FfnActivation::GeLU)
+            .unwrap();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_pool_config_max() {
+    let config = bitnet_kernels::cpu::PoolConfig {
+        pool_type: bitnet_kernels::cpu::PoolType::Max,
+        kernel_size: 3,
+        stride: 2,
+        padding: 1,
+    };
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_reduction_config_sum() {
+    let config = bitnet_kernels::reduction::ReductionConfig::new(
+        256,
+        4,
+        bitnet_kernels::reduction::ReductionOp::Sum,
+    )
+    .unwrap();
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_shaped_reduction_config_axis1_keepdim() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::new(
+        bitnet_kernels::reduction::ReductionOp::Mean,
+        Some(1),
+        true,
+    );
+    insta::assert_debug_snapshot!(config);
+}
+
+#[test]
+fn snap_shaped_reduction_config_global() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::global(
+        bitnet_kernels::reduction::ReductionOp::L2Norm,
+    );
+    insta::assert_debug_snapshot!(config);
+}
+
+// ── Enum variant Debug snapshots ───────────────────────────────────
+
+#[test]
+fn snap_pool_type_all_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::PoolType::Max,
+        bitnet_kernels::cpu::PoolType::Average,
+        bitnet_kernels::cpu::PoolType::GlobalMax,
+        bitnet_kernels::cpu::PoolType::GlobalAverage,
+        bitnet_kernels::cpu::PoolType::AvgPoolCountIncludePad,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_reduction_axis_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::reduction::ReductionAxis::Row,
+        bitnet_kernels::cpu::reduction::ReductionAxis::Column,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_reduction_op_all_variants() {
+    let variants = vec![
+        bitnet_kernels::reduction::ReductionOp::Sum,
+        bitnet_kernels::reduction::ReductionOp::Max,
+        bitnet_kernels::reduction::ReductionOp::Min,
+        bitnet_kernels::reduction::ReductionOp::Mean,
+        bitnet_kernels::reduction::ReductionOp::L2Norm,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_loss_reduction_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::LossReduction::None,
+        bitnet_kernels::cpu::LossReduction::Mean,
+        bitnet_kernels::cpu::LossReduction::Sum,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_gating_type_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::GatingType::SwiGLU,
+        bitnet_kernels::cpu::GatingType::GeGLU,
+        bitnet_kernels::cpu::GatingType::ReGLU,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_ffn_activation_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::FfnActivation::GeLU,
+        bitnet_kernels::cpu::FfnActivation::SiLU,
+        bitnet_kernels::cpu::FfnActivation::ReLU,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_kv_dtype_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::kv_cache::KvDtype::F32,
+        bitnet_kernels::cpu::kv_cache::KvDtype::F16,
+        bitnet_kernels::cpu::kv_cache::KvDtype::Bf16,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_scatter_reduce_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::scatter_gather::ScatterReduce::Assign,
+        bitnet_kernels::cpu::scatter_gather::ScatterReduce::Add,
+        bitnet_kernels::cpu::scatter_gather::ScatterReduce::Max,
+        bitnet_kernels::cpu::scatter_gather::ScatterReduce::Min,
+        bitnet_kernels::cpu::scatter_gather::ScatterReduce::Mul,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_fused_op_variants() {
+    let variants = vec![
+        bitnet_kernels::cpu::fusion::FusedOp::RmsNormLinear,
+        bitnet_kernels::cpu::fusion::FusedOp::GeluLinear,
+        bitnet_kernels::cpu::fusion::FusedOp::SoftmaxMask,
+        bitnet_kernels::cpu::fusion::FusedOp::AddNormalize,
+        bitnet_kernels::cpu::fusion::FusedOp::ScaleAndAdd,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_activation_type_variants() {
+    let variants: Vec<bitnet_kernels::cpu::ActivationType> = vec![
+        bitnet_kernels::cpu::ActivationType::ReLU,
+        bitnet_kernels::cpu::ActivationType::LeakyReLU(0.01),
+        bitnet_kernels::cpu::ActivationType::GELU,
+        bitnet_kernels::cpu::ActivationType::GELUTanh,
+        bitnet_kernels::cpu::ActivationType::SiLU,
+        bitnet_kernels::cpu::ActivationType::Swish(1.0),
+        bitnet_kernels::cpu::ActivationType::Sigmoid,
+        bitnet_kernels::cpu::ActivationType::Tanh,
+        bitnet_kernels::cpu::ActivationType::HardSigmoid,
+        bitnet_kernels::cpu::ActivationType::HardSwish,
+        bitnet_kernels::cpu::ActivationType::Mish,
+        bitnet_kernels::cpu::ActivationType::Softplus,
+        bitnet_kernels::cpu::ActivationType::ELU(1.0),
+        bitnet_kernels::cpu::ActivationType::SELU,
+        bitnet_kernels::cpu::ActivationType::QuickGELU,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// ── Display formatting snapshots ───────────────────────────────────
+
+#[test]
+fn snap_device_class_display_all() {
+    use bitnet_kernels::capability_matrix::DeviceClass;
+    let display: Vec<String> = DeviceClass::ALL.iter().map(|d| d.to_string()).collect();
+    insta::assert_debug_snapshot!(display);
+}
+
+#[test]
+fn snap_operation_category_display_all() {
+    use bitnet_kernels::capability_matrix::OperationCategory;
+    let display: Vec<String> = OperationCategory::ALL.iter().map(|o| o.to_string()).collect();
+    insta::assert_debug_snapshot!(display);
+}
+
+#[test]
+fn snap_precision_support_display_all() {
+    use bitnet_kernels::capability_matrix::PrecisionSupport;
+    let display: Vec<String> = PrecisionSupport::ALL.iter().map(|p| p.to_string()).collect();
+    insta::assert_debug_snapshot!(display);
+}
+
+#[test]
+fn snap_support_level_display_variants() {
+    use bitnet_kernels::capability_matrix::SupportLevel;
+    let variants = vec![
+        SupportLevel::Full(0.95).to_string(),
+        SupportLevel::Partial("no FP16 accumulate".into()).to_string(),
+        SupportLevel::Emulated.to_string(),
+        SupportLevel::Unsupported.to_string(),
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snap_fused_op_display() {
+    use bitnet_kernels::cpu::fusion::FusedOp;
+    let display: Vec<String> = vec![
+        FusedOp::RmsNormLinear.to_string(),
+        FusedOp::GeluLinear.to_string(),
+        FusedOp::SoftmaxMask.to_string(),
+        FusedOp::AddNormalize.to_string(),
+        FusedOp::ScaleAndAdd.to_string(),
+    ];
+    insta::assert_debug_snapshot!(display);
+}
+
+#[test]
+fn snap_scatter_mode_display() {
+    use bitnet_kernels::scatter_gather::ScatterMode;
+    let variants = vec![
+        format!("{:?}", ScatterMode::Assign),
+        format!("{:?}", ScatterMode::Add),
+        format!("{:?}", ScatterMode::Max),
+        format!("{:?}", ScatterMode::Min),
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// ── Error message formatting snapshots ─────────────────────────────
+
+#[test]
+fn snap_fusion_error_dimension_mismatch() {
+    let err =
+        bitnet_kernels::cpu::fusion::FusionError::DimensionMismatch { expected: 512, got: 768 };
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_fusion_error_invalid_config() {
+    let err =
+        bitnet_kernels::cpu::fusion::FusionError::InvalidConfig("min_fusion_size is 0".into());
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_fusion_error_empty_input() {
+    let err = bitnet_kernels::cpu::fusion::FusionError::EmptyInput;
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_ffn_config_zero_dim_error() {
+    let err =
+        bitnet_kernels::cpu::FfnConfig::new(0, 3072, bitnet_kernels::cpu::FfnActivation::GeLU)
+            .unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_reduction_config_zero_dim_error() {
+    let err = bitnet_kernels::reduction::ReductionConfig::new(
+        0,
+        4,
+        bitnet_kernels::reduction::ReductionOp::Sum,
+    )
+    .unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_reduction_config_zero_reductions_error() {
+    let err = bitnet_kernels::reduction::ReductionConfig::new(
+        256,
+        0,
+        bitnet_kernels::reduction::ReductionOp::Sum,
+    )
+    .unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_pool_config_zero_kernel_error() {
+    let config = bitnet_kernels::cpu::PoolConfig {
+        pool_type: bitnet_kernels::cpu::PoolType::Max,
+        kernel_size: 0,
+        stride: 1,
+        padding: 0,
+    };
+    let err = config.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_pool_config_zero_stride_error() {
+    let config = bitnet_kernels::cpu::PoolConfig {
+        pool_type: bitnet_kernels::cpu::PoolType::Average,
+        kernel_size: 3,
+        stride: 0,
+        padding: 0,
+    };
+    let err = config.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_attention_config_zero_heads_error() {
+    let config = bitnet_kernels::cpu::AttentionConfig {
+        num_heads: 0,
+        head_dim: 64,
+        seq_len: 128,
+        causal: false,
+        scale: None,
+    };
+    let err = config.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snap_cpu_attention_zero_batch_error() {
+    let config = bitnet_kernels::cpu::attention::CpuAttentionConfig {
+        batch_size: 0,
+        num_heads: 4,
+        seq_len: 16,
+        head_dim: 64,
+        scale: None,
+        causal_mask: false,
+    };
+    let err = config.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+// ── Kernel output shape snapshots ──────────────────────────────────
+
+#[test]
+fn snap_conv2d_output_size_basic() {
+    let out = bitnet_kernels::cpu::compute_output_size(28, 3, 1, 0, 1);
+    insta::assert_snapshot!(format!("input=28, kernel=3, stride=1, pad=0, dil=1 -> {out}"));
+}
+
+#[test]
+fn snap_conv2d_output_size_with_padding() {
+    let out = bitnet_kernels::cpu::compute_output_size(28, 3, 1, 1, 1);
+    insta::assert_snapshot!(format!("input=28, kernel=3, stride=1, pad=1, dil=1 -> {out}"));
+}
+
+#[test]
+fn snap_conv2d_output_size_stride2() {
+    let out = bitnet_kernels::cpu::compute_output_size(32, 3, 2, 1, 1);
+    insta::assert_snapshot!(format!("input=32, kernel=3, stride=2, pad=1, dil=1 -> {out}"));
+}
+
+#[test]
+fn snap_conv2d_output_size_dilated() {
+    let out = bitnet_kernels::cpu::compute_output_size(28, 3, 1, 0, 2);
+    insta::assert_snapshot!(format!("input=28, kernel=3, stride=1, pad=0, dil=2 -> {out}"));
+}
+
+#[test]
+fn snap_reduction_output_shape_axis0() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::new(
+        bitnet_kernels::reduction::ReductionOp::Sum,
+        Some(0),
+        false,
+    );
+    let shape = bitnet_kernels::shaped_reduction::reduction_output_shape(&[4, 8, 16], &config);
+    insta::assert_debug_snapshot!(shape);
+}
+
+#[test]
+fn snap_reduction_output_shape_axis1_keepdim() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::new(
+        bitnet_kernels::reduction::ReductionOp::Mean,
+        Some(1),
+        true,
+    );
+    let shape = bitnet_kernels::shaped_reduction::reduction_output_shape(&[4, 8, 16], &config);
+    insta::assert_debug_snapshot!(shape);
+}
+
+#[test]
+fn snap_reduction_output_shape_global() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::global(
+        bitnet_kernels::reduction::ReductionOp::Max,
+    );
+    let shape = bitnet_kernels::shaped_reduction::reduction_output_shape(&[4, 8, 16], &config);
+    insta::assert_debug_snapshot!(shape);
+}
+
+#[test]
+fn snap_reduction_output_shape_global_keepdim() {
+    let config = bitnet_kernels::shaped_reduction::ShapedReductionConfig::new(
+        bitnet_kernels::reduction::ReductionOp::Sum,
+        None,
+        true,
+    );
+    let shape = bitnet_kernels::shaped_reduction::reduction_output_shape(&[2, 3, 4], &config);
+    insta::assert_debug_snapshot!(shape);
+}
+
+// ── Metric / value computation snapshots ───────────────────────────
+
+#[test]
+fn snap_attention_resolved_scale_default() {
+    let config = bitnet_kernels::cpu::AttentionConfig {
+        num_heads: 8,
+        head_dim: 64,
+        seq_len: 128,
+        causal: true,
+        scale: None,
+    };
+    insta::assert_snapshot!(format!("{:.6}", config.resolved_scale()));
+}
+
+#[test]
+fn snap_attention_resolved_scale_explicit() {
+    let config = bitnet_kernels::cpu::AttentionConfig {
+        num_heads: 8,
+        head_dim: 64,
+        seq_len: 128,
+        causal: false,
+        scale: Some(0.05),
+    };
+    insta::assert_snapshot!(format!("{:.6}", config.resolved_scale()));
+}
+
+#[test]
+fn snap_scatter_reduce_identities() {
+    use bitnet_kernels::cpu::scatter_gather::ScatterReduce;
+    let identities: Vec<(String, String)> = vec![
+        ScatterReduce::Assign,
+        ScatterReduce::Add,
+        ScatterReduce::Max,
+        ScatterReduce::Min,
+        ScatterReduce::Mul,
+    ]
+    .into_iter()
+    .map(|r| (format!("{r:?}"), format!("{}", r.identity())))
+    .collect();
+    insta::assert_debug_snapshot!(identities);
+}
+
+#[test]
+fn snap_scatter_mode_identities() {
+    use bitnet_kernels::scatter_gather::ScatterMode;
+    let identities: Vec<(String, String)> =
+        vec![ScatterMode::Assign, ScatterMode::Add, ScatterMode::Max, ScatterMode::Min]
+            .into_iter()
+            .map(|m| (format!("{m:?}"), format!("{}", m.identity())))
+            .collect();
+    insta::assert_debug_snapshot!(identities);
+}
+
+#[test]
+fn snap_kv_dtype_element_bytes() {
+    use bitnet_kernels::cpu::kv_cache::KvDtype;
+    let sizes: Vec<(String, usize)> = vec![KvDtype::F32, KvDtype::F16, KvDtype::Bf16]
+        .into_iter()
+        .map(|d| (format!("{d:?}"), d.element_bytes()))
+        .collect();
+    insta::assert_debug_snapshot!(sizes);
+}
+
+#[test]
+fn snap_quantization_error_metrics() {
+    let err = bitnet_kernels::cpu::quantize::QuantizationError {
+        mse: 0.00042,
+        max_abs_error: 0.031,
+        snr: 33.8,
+    };
+    insta::assert_debug_snapshot!(err);
+}
+
+// ── Kernel output value snapshots ──────────────────────────────────
+
+#[test]
+fn snap_activation_relu_output() {
+    let input = vec![-2.0, -1.0, 0.0, 1.0, 2.0];
+    let output =
+        bitnet_kernels::cpu::apply_activation(&input, bitnet_kernels::cpu::ActivationType::ReLU);
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snap_activation_silu_output() {
+    let input = vec![-2.0, -1.0, 0.0, 1.0, 2.0];
+    let output =
+        bitnet_kernels::cpu::apply_activation(&input, bitnet_kernels::cpu::ActivationType::SiLU);
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snap_activation_gelu_output() {
+    let input = vec![-2.0, -1.0, 0.0, 1.0, 2.0];
+    let output =
+        bitnet_kernels::cpu::apply_activation(&input, bitnet_kernels::cpu::ActivationType::GELU);
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snap_pooling_max_output() {
+    let input = vec![1.0, 3.0, 2.0, 5.0, 4.0, 1.0, 3.0, 2.0];
+    let config = bitnet_kernels::cpu::PoolConfig {
+        pool_type: bitnet_kernels::cpu::PoolType::Max,
+        kernel_size: 3,
+        stride: 1,
+        padding: 0,
+    };
+    let output = bitnet_kernels::cpu::PoolingKernel::apply(&input, &config).unwrap();
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snap_pooling_global_avg_output() {
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let config = bitnet_kernels::cpu::PoolConfig {
+        pool_type: bitnet_kernels::cpu::PoolType::GlobalAverage,
+        kernel_size: 0,
+        stride: 0,
+        padding: 0,
+    };
+    let output = bitnet_kernels::cpu::PoolingKernel::apply(&input, &config).unwrap();
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snap_reduction_sum_1d() {
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let result = bitnet_kernels::cpu::reduction::ReductionKernel::sum(&input).unwrap();
+    insta::assert_snapshot!(format!("{result:.1}"));
+}
+
+#[test]
+fn snap_reduction_mean_1d() {
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+    let result = bitnet_kernels::cpu::reduction::ReductionKernel::mean(&input).unwrap();
+    insta::assert_snapshot!(format!("{result:.1}"));
+}
+
+#[test]
+fn snap_reduction_max_with_index() {
+    let input = vec![1.0, 5.0, 3.0, 2.0, 4.0];
+    let result = bitnet_kernels::cpu::reduction::ReductionKernel::max(&input).unwrap();
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn snap_reduction_min_with_index() {
+    let input = vec![3.0, 1.0, 4.0, 0.5, 2.0];
+    let result = bitnet_kernels::cpu::reduction::ReductionKernel::min(&input).unwrap();
+    insta::assert_debug_snapshot!(result);
+}
+
+// ── State transition snapshots ─────────────────────────────────────
+
+#[test]
+fn snap_kv_cache_initial_state() {
+    let config = bitnet_kernels::cpu::kv_cache::KvCacheConfig {
+        num_layers: 2,
+        num_heads: 4,
+        head_dim: 8,
+        max_seq_len: 16,
+        dtype: bitnet_kernels::cpu::kv_cache::KvDtype::F32,
+    };
+    let cache = bitnet_kernels::cpu::kv_cache::KvCache::new(config).unwrap();
+    insta::assert_snapshot!(format!(
+        "layers={}, seq_len_per_layer={:?}",
+        cache.blocks.len(),
+        cache.blocks.iter().map(|b| b.seq_len).collect::<Vec<_>>()
+    ));
+}
+
+#[test]
+fn snap_quantize_symmetric_i8_small() {
+    let input = vec![-1.0, -0.5, 0.0, 0.5, 1.0];
+    let (quantized, scale) = bitnet_kernels::cpu::quantize::quantize_symmetric_i8(&input, 8);
+    insta::assert_debug_snapshot!((quantized, format!("{scale:.6}")));
+}
+
+#[test]
+fn snap_quantize_symmetric_i8_zeros() {
+    let input = vec![0.0, 0.0, 0.0, 0.0];
+    let (quantized, scale) = bitnet_kernels::cpu::quantize::quantize_symmetric_i8(&input, 8);
+    insta::assert_debug_snapshot!((quantized, format!("{scale:.1}")));
+}
+
+// ── Capability matrix profile snapshots ────────────────────────────
+
+#[test]
+fn snap_capability_matrix_builtin_profile_count() {
+    let matrix = bitnet_kernels::capability_matrix::DeviceCapabilityMatrix::with_builtin_profiles();
+    let names: Vec<&str> = matrix.profiles().iter().map(|p| p.name.as_str()).collect();
+    insta::assert_debug_snapshot!(names);
+}
+
+#[test]
+fn snap_compatibility_report_cpu_simd() {
+    use bitnet_kernels::capability_matrix::*;
+    let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+    let profile = matrix.profile_for_class(DeviceClass::CpuSimd).unwrap();
+    let required = vec![
+        (OperationCategory::MatrixOps, PrecisionSupport::FP32),
+        (OperationCategory::NormOps, PrecisionSupport::FP32),
+        (OperationCategory::ActivationOps, PrecisionSupport::FP32),
+    ];
+    let report = CompatibilityReport::generate(profile, &required);
+    insta::assert_snapshot!(report.summary());
+}
+
+#[test]
+fn snap_compatibility_report_cpu_scalar_binary() {
+    use bitnet_kernels::capability_matrix::*;
+    let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+    let profile = matrix.profile_for_class(DeviceClass::CpuScalar).unwrap();
+    let required = vec![
+        (OperationCategory::QuantizedOps, PrecisionSupport::Binary),
+        (OperationCategory::AttentionOps, PrecisionSupport::FP32),
+    ];
+    let report = CompatibilityReport::generate(profile, &required);
+    insta::assert_snapshot!(report.to_string());
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_gelu_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_gelu_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: output
+---
+[
+    -0.045500264,
+    -0.15865526,
+    0.0,
+    0.8413448,
+    1.9544997,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_relu_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_relu_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: output
+---
+[
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+    2.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_silu_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_silu_output.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: output
+---
+[
+    -0.23840584,
+    -0.26894143,
+    0.0,
+    0.7310586,
+    1.761594,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_type_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_activation_type_variants.snap
@@ -1,0 +1,27 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    ReLU,
+    LeakyReLU(
+        0.01,
+    ),
+    GELU,
+    GELUTanh,
+    SiLU,
+    Swish(
+        1.0,
+    ),
+    Sigmoid,
+    Tanh,
+    HardSigmoid,
+    HardSwish,
+    Mish,
+    Softplus,
+    ELU(
+        1.0,
+    ),
+    SELU,
+    QuickGELU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_config_mha.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_config_mha.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+AttentionConfig {
+    num_heads: 8,
+    head_dim: 64,
+    seq_len: 128,
+    causal: true,
+    scale: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_config_zero_heads_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_config_zero_heads_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: num_heads must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_resolved_scale_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_resolved_scale_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"{:.6}\", config.resolved_scale())"
+---
+0.125000

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_resolved_scale_explicit.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_attention_resolved_scale_explicit.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"{:.6}\", config.resolved_scale())"
+---
+0.050000

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_batch_norm_config_64_features.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_batch_norm_config_64_features.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+BatchNormConfig {
+    num_features: 64,
+    eps: 1e-5,
+    momentum: 0.1,
+    training: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_batch_norm_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_batch_norm_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+BatchNormConfig {
+    num_features: 1,
+    eps: 1e-5,
+    momentum: 0.1,
+    training: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_capability_matrix_builtin_profile_count.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_capability_matrix_builtin_profile_count.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: names
+---
+[
+    "Intel Arc A770",
+    "NVIDIA RTX 4090",
+    "Apple M1",
+    "CPU SIMD (AVX2)",
+    "CPU Scalar",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_compatibility_report_cpu_scalar_binary.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_compatibility_report_cpu_scalar_binary.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: report.to_string()
+---
+CPU Scalar (CPU Scalar): READY — 2/2 required ops supported

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_compatibility_report_cpu_simd.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_compatibility_report_cpu_simd.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: report.summary()
+---
+CPU SIMD (AVX2) (CPU SIMD): READY — 3/3 required ops supported

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_config_3x3.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_config_3x3.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+Conv2dConfig {
+    in_channels: 3,
+    out_channels: 16,
+    kernel_h: 3,
+    kernel_w: 3,
+    stride_h: 1,
+    stride_w: 1,
+    padding_h: 0,
+    padding_w: 0,
+    dilation_h: 1,
+    dilation_w: 1,
+    groups: 1,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_config_default.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+Conv2dConfig {
+    in_channels: 1,
+    out_channels: 1,
+    kernel_h: 1,
+    kernel_w: 1,
+    stride_h: 1,
+    stride_w: 1,
+    padding_h: 0,
+    padding_w: 0,
+    dilation_h: 1,
+    dilation_w: 1,
+    groups: 1,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_basic.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"input=28, kernel=3, stride=1, pad=0, dil=1 -> {out}\")"
+---
+input=28, kernel=3, stride=1, pad=0, dil=1 -> 26

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_dilated.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_dilated.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"input=28, kernel=3, stride=1, pad=0, dil=2 -> {out}\")"
+---
+input=28, kernel=3, stride=1, pad=0, dil=2 -> 24

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_stride2.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_stride2.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"input=32, kernel=3, stride=2, pad=1, dil=1 -> {out}\")"
+---
+input=32, kernel=3, stride=2, pad=1, dil=1 -> 16

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_with_padding.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_conv2d_output_size_with_padding.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"input=28, kernel=3, stride=1, pad=1, dil=1 -> {out}\")"
+---
+input=28, kernel=3, stride=1, pad=1, dil=1 -> 28

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_attention_config.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_attention_config.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+CpuAttentionConfig {
+    batch_size: 2,
+    num_heads: 4,
+    seq_len: 16,
+    head_dim: 64,
+    scale: None,
+    causal_mask: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_attention_zero_batch_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_attention_zero_batch_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: batch_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_embedding_config_with_options.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_cpu_embedding_config_with_options.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+CpuEmbeddingConfig {
+    vocab_size: 50000,
+    embed_dim: 512,
+    padding_idx: Some(
+        0,
+    ),
+    max_norm: Some(
+        1.0,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_device_capability_matrix_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_device_capability_matrix_default.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: matrix
+---
+DeviceCapabilityMatrix {
+    profiles: [],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_device_class_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_device_class_display_all.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: display
+---
+[
+    "Intel Arc",
+    "Intel Xe",
+    "NVIDIA CUDA",
+    "AMD ROCm",
+    "Apple Metal",
+    "CPU SIMD",
+    "CPU Scalar",
+    "WebGPU",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_embedding_config.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_embedding_config.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+EmbeddingConfig {
+    vocab_size: 32000,
+    embedding_dim: 768,
+    padding_idx: Some(
+        0,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_activation_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_activation_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    GeLU,
+    SiLU,
+    ReLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_config_gelu.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_config_gelu.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+FfnConfig {
+    hidden_dim: 768,
+    intermediate_dim: 3072,
+    activation: GeLU,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_config_zero_dim_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_ffn_config_zero_dim_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: FFN dimensions must be non-zero: hidden_dim=0, intermediate_dim=3072

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fused_op_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fused_op_display.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: display
+---
+[
+    "RmsNormLinear",
+    "GeluLinear",
+    "SoftmaxMask",
+    "AddNormalize",
+    "ScaleAndAdd",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fused_op_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fused_op_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    RmsNormLinear,
+    GeluLinear,
+    SoftmaxMask,
+    AddNormalize,
+    ScaleAndAdd,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+FusionConfig {
+    enable_rmsnorm_linear: true,
+    enable_gelu_linear: true,
+    enable_softmax_mask: true,
+    min_fusion_size: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_config_disabled.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_config_disabled.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+FusionConfig {
+    enable_rmsnorm_linear: false,
+    enable_gelu_linear: false,
+    enable_softmax_mask: false,
+    min_fusion_size: 18446744073709551615,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_dimension_mismatch.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_dimension_mismatch.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+dimension mismatch: expected 512, got 768

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_empty_input.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_empty_input.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+empty input

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_invalid_config.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_fusion_error_invalid_config.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+invalid config: min_fusion_size is 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_gating_type_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_gating_type_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    SwiGLU,
+    GeGLU,
+    ReGLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_gqa_config.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_gqa_config.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+GqaConfig {
+    num_q_heads: 32,
+    num_kv_heads: 8,
+    head_dim: 64,
+    seq_len: 512,
+    causal: true,
+    scale: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_group_norm_config_8g_32c.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_group_norm_config_8g_32c.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+GroupNormConfig {
+    num_groups: 8,
+    num_channels: 32,
+    spatial_size: 64,
+    eps: 1e-5,
+    elementwise_affine: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_cache_config.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_cache_config.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+KvCacheConfig {
+    num_layers: 24,
+    num_heads: 8,
+    head_dim: 64,
+    max_seq_len: 2048,
+    dtype: F32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_cache_initial_state.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_cache_initial_state.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"layers={}, seq_len_per_layer={:?}\", cache.blocks.len(),\ncache.blocks.iter().map(|b| b.seq_len).collect::<Vec<_>>())"
+---
+layers=2, seq_len_per_layer=[0, 0]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_dtype_element_bytes.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_dtype_element_bytes.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: sizes
+---
+[
+    (
+        "F32",
+        4,
+    ),
+    (
+        "F16",
+        2,
+    ),
+    (
+        "Bf16",
+        2,
+    ),
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_dtype_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_kv_dtype_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    F32,
+    F16,
+    Bf16,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_layer_norm_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_layer_norm_config_default.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+LayerNormConfig {
+    normalized_shape: [
+        1,
+    ],
+    eps: 1e-5,
+    elementwise_affine: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_layer_norm_config_hidden_768.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_layer_norm_config_hidden_768.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+LayerNormConfig {
+    normalized_shape: [
+        768,
+    ],
+    eps: 1e-5,
+    elementwise_affine: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_linear_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_linear_config_default.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+LinearConfig {
+    in_features: 1,
+    out_features: 1,
+    batch_size: 1,
+    has_bias: false,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_loss_reduction_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_loss_reduction_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    None,
+    Mean,
+    Sum,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_operation_category_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_operation_category_display_all.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: display
+---
+[
+    "Matrix Ops",
+    "Norm Ops",
+    "Activation Ops",
+    "Position Encoding",
+    "Quantized Ops",
+    "Attention Ops",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_max.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_max.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+PoolConfig {
+    pool_type: Max,
+    kernel_size: 3,
+    stride: 2,
+    padding: 1,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_zero_kernel_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_zero_kernel_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: kernel_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_zero_stride_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_config_zero_stride_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: stride must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_type_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pool_type_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    Max,
+    Average,
+    GlobalMax,
+    GlobalAverage,
+    AvgPoolCountIncludePad,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pooling_global_avg_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pooling_global_avg_output.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: output
+---
+[
+    3.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pooling_max_output.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_pooling_max_output.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: output
+---
+[
+    3.0,
+    5.0,
+    5.0,
+    5.0,
+    4.0,
+    3.0,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_precision_support_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_precision_support_display_all.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: display
+---
+[
+    "FP32",
+    "FP16",
+    "BF16",
+    "INT8",
+    "INT4",
+    "Binary",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantization_error_metrics.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantization_error_metrics.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err
+---
+QuantizationError {
+    mse: 0.00042,
+    max_abs_error: 0.031,
+    snr: 33.8,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantize_symmetric_i8_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantize_symmetric_i8_small.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "(quantized, format!(\"{scale:.6}\"))"
+---
+(
+    [
+        -127,
+        -64,
+        0,
+        64,
+        127,
+    ],
+    "0.007874",
+)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantize_symmetric_i8_zeros.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_quantize_symmetric_i8_zeros.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "(quantized, format!(\"{scale:.1}\"))"
+---
+(
+    [
+        0,
+        0,
+        0,
+        0,
+    ],
+    "0.0",
+)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_axis_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_axis_variants.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    Row,
+    Column,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_sum.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_sum.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+ReductionConfig {
+    reduce_dim: 256,
+    n_reductions: 4,
+    threads_per_block: 256,
+    op: Sum,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_zero_dim_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_zero_dim_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: reduction dimension must be non-zero

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_zero_reductions_error.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_config_zero_reductions_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: err.to_string()
+---
+Kernel error: Invalid arguments: number of reductions must be non-zero

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_max_with_index.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_max_with_index.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: result
+---
+ValueWithIndex {
+    value: 5.0,
+    index: 1,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_mean_1d.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_mean_1d.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"{result:.1}\")"
+---
+3.0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_min_with_index.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_min_with_index.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: result
+---
+ValueWithIndex {
+    value: 0.5,
+    index: 3,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_op_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_op_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    Sum,
+    Max,
+    Min,
+    Mean,
+    L2Norm,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_axis0.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_axis0.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: shape
+---
+[
+    8,
+    16,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_axis1_keepdim.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_axis1_keepdim.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: shape
+---
+[
+    4,
+    1,
+    16,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_global.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_global.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: shape
+---
+[]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_global_keepdim.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_output_shape_global_keepdim.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: shape
+---
+[
+    1,
+    1,
+    1,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_sum_1d.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_reduction_sum_1d.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: "format!(\"{result:.1}\")"
+---
+15.0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_rope_config_custom_base.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_rope_config_custom_base.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+RopeConfig {
+    head_dim: 128,
+    max_seq_len: 4096,
+    base: 500000.0,
+    scaling_factor: 2.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_rope_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_rope_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+RopeConfig {
+    head_dim: 64,
+    max_seq_len: 2048,
+    base: 10000.0,
+    scaling_factor: 1.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_gather_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_gather_config_default.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+ScatterGatherConfig {
+    bounds_check: true,
+    reduce: Assign,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_mode_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_mode_display.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    "Assign",
+    "Add",
+    "Max",
+    "Min",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_mode_identities.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_mode_identities.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: identities
+---
+[
+    (
+        "Assign",
+        "0",
+    ),
+    (
+        "Add",
+        "0",
+    ),
+    (
+        "Max",
+        "-inf",
+    ),
+    (
+        "Min",
+        "inf",
+    ),
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_reduce_identities.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_reduce_identities.snap
@@ -1,0 +1,26 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: identities
+---
+[
+    (
+        "Assign",
+        "0",
+    ),
+    (
+        "Add",
+        "0",
+    ),
+    (
+        "Max",
+        "-inf",
+    ),
+    (
+        "Min",
+        "inf",
+    ),
+    (
+        "Mul",
+        "1",
+    ),
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_reduce_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_scatter_reduce_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    Assign,
+    Add,
+    Max,
+    Min,
+    Mul,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_shaped_reduction_config_axis1_keepdim.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_shaped_reduction_config_axis1_keepdim.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+ShapedReductionConfig {
+    op: Mean,
+    axis: Some(
+        1,
+    ),
+    keepdim: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_shaped_reduction_config_global.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_shaped_reduction_config_global.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: config
+---
+ShapedReductionConfig {
+    op: L2Norm,
+    axis: None,
+    keepdim: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_support_level_display_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_16__snap_support_level_display_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_16.rs
+expression: variants
+---
+[
+    "Full (95%)",
+    "Partial (no FP16 accumulate)",
+    "Emulated",
+    "Unsupported",
+]


### PR DESCRIPTION
## Summary

Adds **80 insta snapshot tests** in `crates/bitnet-kernels/tests/snapshot_wave_16.rs` covering kernel output stability across multiple categories:

### Test Categories (80 tests total)

| Category | Count | Description |
|----------|-------|-------------|
| Config defaults | 8 | Conv2d, LayerNorm, Linear, BatchNorm, Fusion, ScatterGather, DeviceCapabilityMatrix |
| Config constructors | 15 | Attention, GQA, CpuAttention, RoPE, KvCache, Embedding, CpuEmbedding, FFN, Pool, Reduction, ShapedReduction |
| Enum Debug formatting | 10 | PoolType, ReductionAxis, ReductionOp, LossReduction, GatingType, FfnActivation, KvDtype, ScatterReduce, FusedOp, ActivationType |
| Display formatting | 6 | DeviceClass, OperationCategory, PrecisionSupport, SupportLevel, FusedOp, ScatterMode |
| Error messages | 10 | FusionError (3 variants), FFN zero-dim, Reduction (2), Pool validation (2), Attention validation (2) |
| Output shapes | 8 | Conv2d output sizes (4), shaped reduction output shapes (4) |
| Metrics/values | 5 | Attention scale resolution, scatter/reduce identities, KvDtype bytes, quantization error |
| Kernel outputs | 10 | Activation functions (ReLU/SiLU/GELU), pooling (max/global avg), reduction (sum/mean/max/min) |
| State transitions | 3 | KvCache initial state, symmetric i8 quantization (normal/zeros) |
| Capability matrix | 3 | Builtin profiles, compatibility reports (CPU SIMD, CPU Scalar) |
| **Total** | **80** | |

### How to run

```bash
cargo test --no-default-features --features cpu -p bitnet-kernels --test snapshot_wave_16
```

All 80 tests pass with accepted snapshots.