### PR TITLE
test(kernels): add snapshot wave 21 — 48 insta tests for kernel configs

### DIFF
--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -155,6 +155,10 @@ path = "tests/metal_layernorm_shader_tests.rs"
 name = "metal_reduction_shader_tests"
 path = "tests/metal_reduction_shader_tests.rs"
 
+[[test]]
+name = "snapshot_wave_21"
+path = "tests/snapshot_wave_21.rs"
+
 [[example]]
 name = "gpu_validation"
 path = "examples/gpu_validation.rs"

--- a/crates/bitnet-kernels/tests/snapshot_wave_21.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave_21.rs
@@ -1,0 +1,401 @@
+//! Wave 21 snapshot tests for CUDA and CPU kernel configurations in
+//! `bitnet-kernels`.
+//!
+//! Pins the Debug representations of profiling, stream management,
+//! graph execution, cooperative groups, warp primitives, scatter/gather,
+//! batch normalization, loss functions, and tensor parallel configs.
+
+use std::time::Duration;
+
+// =========================================================================
+// Section 1 — CUDA profiling configs
+// =========================================================================
+
+use bitnet_kernels::cuda::profiling::{
+    BandwidthMetrics, Bottleneck, BottleneckAnalyzer, ComputeMetrics, KernelProfile,
+    MemoryEventKind, OccupancyCalculator, OccupancyLimiter, ProfileAccumulator,
+};
+
+#[test]
+fn occupancy_calculator_default_debug() {
+    let calc = OccupancyCalculator::default();
+    insta::assert_debug_snapshot!(calc);
+}
+
+#[test]
+fn occupancy_result_thread_limited() {
+    let calc = OccupancyCalculator::default();
+    let result = calc.calculate(256, 0, 32);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn occupancy_result_shared_mem_limited() {
+    let calc = OccupancyCalculator::new(2048, 32, 49152, 65536);
+    let result = calc.calculate(128, 32768, 16);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn bandwidth_metrics_debug() {
+    let bw = BandwidthMetrics::new(1024 * 1024, 512 * 1024, Duration::from_micros(100), 900e9);
+    insta::assert_debug_snapshot!(bw);
+}
+
+#[test]
+fn compute_metrics_debug() {
+    let cm = ComputeMetrics::new(1_000_000_000, Duration::from_millis(1), 312e12);
+    insta::assert_debug_snapshot!(cm);
+}
+
+#[test]
+fn kernel_profile_minimal_debug() {
+    let p = KernelProfile::new("matmul_f32", Duration::from_micros(42));
+    insta::assert_debug_snapshot!(p);
+}
+
+#[test]
+fn kernel_profile_with_grid_block_debug() {
+    let p = KernelProfile::new("rmsnorm", Duration::from_micros(8))
+        .with_grid_dim(128, 1, 1)
+        .with_block_dim(256, 1, 1);
+    insta::assert_debug_snapshot!(p);
+}
+
+#[test]
+fn bottleneck_analyzer_default_debug() {
+    let ba = BottleneckAnalyzer::default();
+    insta::assert_debug_snapshot!(ba);
+}
+
+#[test]
+fn bottleneck_all_variants_debug() {
+    let variants = vec![
+        Bottleneck::MemoryBound,
+        Bottleneck::ComputeBound,
+        Bottleneck::LatencyBound,
+        Bottleneck::Unknown,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn occupancy_limiter_all_variants_debug() {
+    let variants = vec![
+        OccupancyLimiter::Threads,
+        OccupancyLimiter::Blocks,
+        OccupancyLimiter::SharedMemory,
+        OccupancyLimiter::Registers,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn memory_event_kind_variants_debug() {
+    let variants = vec![MemoryEventKind::Allocate, MemoryEventKind::Deallocate];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn profile_accumulator_empty_debug() {
+    let acc = ProfileAccumulator::new();
+    insta::assert_debug_snapshot!(acc);
+}
+
+// =========================================================================
+// Section 2 — CUDA stream management configs
+// =========================================================================
+
+use bitnet_kernels::cuda::stream_mgmt::{
+    DefaultStreamBehavior, PipelineStage, PipelineStageKind, StreamConfig, StreamPriority,
+};
+
+#[test]
+fn stream_config_default_debug() {
+    let cfg = StreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn stream_priority_all_variants_debug() {
+    let variants = vec![StreamPriority::Low, StreamPriority::Normal, StreamPriority::High];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn default_stream_behavior_variants_debug() {
+    let variants = vec![DefaultStreamBehavior::Legacy, DefaultStreamBehavior::PerThread];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn pipeline_stage_h2d_debug() {
+    let stage = PipelineStage::new(PipelineStageKind::HostToDevice, "weights_upload", 4096);
+    insta::assert_debug_snapshot!(stage);
+}
+
+#[test]
+fn pipeline_stage_compute_debug() {
+    let stage = PipelineStage::new(PipelineStageKind::Compute, "matmul_kernel", 65536);
+    insta::assert_debug_snapshot!(stage);
+}
+
+#[test]
+fn pipeline_stage_kind_all_variants_debug() {
+    let variants = vec![
+        PipelineStageKind::HostToDevice,
+        PipelineStageKind::Compute,
+        PipelineStageKind::DeviceToHost,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// =========================================================================
+// Section 3 — CUDA graph execution configs
+// =========================================================================
+
+use bitnet_kernels::cuda::graph_exec::{LayerGraphConfig, MultiStreamConfig, OptimizeStats};
+
+#[test]
+fn layer_graph_config_default_debug() {
+    let cfg = LayerGraphConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn multi_stream_config_default_debug() {
+    let cfg = MultiStreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn optimize_stats_default_debug() {
+    let stats = OptimizeStats::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 4 — CUDA cooperative groups configs
+// =========================================================================
+
+use bitnet_kernels::cuda::cooperative_groups::{
+    CoalescedGroup, CooperativeGroupConfig, CooperativeReduceOp, GridGroup, ThreadBlockGroup,
+};
+
+#[test]
+fn cooperative_group_config_default_debug() {
+    let cfg = CooperativeGroupConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cooperative_group_config_with_grid_sync_debug() {
+    let cfg = CooperativeGroupConfig::new(512).unwrap().with_grid_sync();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cooperative_group_config_with_cluster_debug() {
+    let cfg = CooperativeGroupConfig::new(256).unwrap().with_cluster(4).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cooperative_reduce_op_all_variants_debug() {
+    let variants = vec![
+        CooperativeReduceOp::Sum,
+        CooperativeReduceOp::Max,
+        CooperativeReduceOp::Min,
+        CooperativeReduceOp::Product,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn thread_block_group_debug() {
+    let tbg = ThreadBlockGroup::new(256, 0).unwrap();
+    insta::assert_debug_snapshot!(tbg);
+}
+
+#[test]
+fn grid_group_debug() {
+    let gg = GridGroup::new(256, 128).unwrap();
+    insta::assert_debug_snapshot!(gg);
+}
+
+#[test]
+fn coalesced_group_full_mask_debug() {
+    let cg = CoalescedGroup::new(0xFFFF_FFFF).unwrap();
+    insta::assert_debug_snapshot!(cg);
+}
+
+#[test]
+fn coalesced_group_partial_mask_debug() {
+    let cg = CoalescedGroup::new(0x0000_00FF).unwrap();
+    insta::assert_debug_snapshot!(cg);
+}
+
+// =========================================================================
+// Section 5 — CUDA warp operations configs
+// =========================================================================
+
+use bitnet_kernels::cuda::warp_ops::WarpConfig;
+
+#[test]
+fn warp_config_default_debug() {
+    let cfg = WarpConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 6 — CPU scatter/gather configs
+// =========================================================================
+
+use bitnet_kernels::cpu::scatter_gather::{ScatterGatherConfig, ScatterReduce};
+
+#[test]
+fn scatter_gather_config_default_debug() {
+    let cfg = ScatterGatherConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn scatter_gather_config_with_add_debug() {
+    let cfg = ScatterGatherConfig::with_reduce(ScatterReduce::Add);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn scatter_reduce_all_variants_debug() {
+    let variants = vec![
+        ScatterReduce::Assign,
+        ScatterReduce::Add,
+        ScatterReduce::Max,
+        ScatterReduce::Min,
+        ScatterReduce::Mul,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// =========================================================================
+// Section 7 — CPU batch norm configs
+// =========================================================================
+
+use bitnet_kernels::cpu::batch_norm::BatchNormConfig;
+use bitnet_kernels::cpu::batch_normalization::{SimdBatchNormConfig, SimdBatchNormState};
+
+#[test]
+fn batch_norm_config_default_debug() {
+    let cfg = BatchNormConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn batch_norm_config_training_debug() {
+    let cfg = BatchNormConfig { num_features: 256, eps: 1e-5, momentum: 0.1, training: true };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn simd_batch_norm_config_default_debug() {
+    let cfg = SimdBatchNormConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn simd_batch_norm_state_initial_debug() {
+    let state = SimdBatchNormState::new(4);
+    insta::assert_debug_snapshot!(state);
+}
+
+// =========================================================================
+// Section 8 — CPU loss function types
+// =========================================================================
+
+use bitnet_kernels::cpu::loss::LossReduction;
+
+#[test]
+fn loss_reduction_all_variants_debug() {
+    let variants = vec![LossReduction::None, LossReduction::Mean, LossReduction::Sum];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// =========================================================================
+// Section 9 — CPU tensor parallel configs
+// =========================================================================
+
+use bitnet_kernels::cpu::tensor_parallel::{
+    CommBackend, ShardingStrategy, TensorParallelConfig, TensorParallelError,
+    TensorParallelMetrics, TensorShard,
+};
+
+#[test]
+fn tensor_parallel_config_2rank_debug() {
+    let cfg = TensorParallelConfig {
+        num_ranks: 2,
+        rank_id: 0,
+        comm_backend: CommBackend::InProcess,
+        overlap_compute_comm: false,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn tensor_parallel_config_4rank_overlap_debug() {
+    let cfg = TensorParallelConfig {
+        num_ranks: 4,
+        rank_id: 1,
+        comm_backend: CommBackend::SharedMemory,
+        overlap_compute_comm: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn comm_backend_all_variants_debug() {
+    let variants = vec![CommBackend::InProcess, CommBackend::SharedMemory];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn sharding_strategy_column_debug() {
+    let s = ShardingStrategy::ColumnParallel;
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn sharding_strategy_row_debug() {
+    let s = ShardingStrategy::RowParallel;
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn sharding_strategy_custom_debug() {
+    let s = ShardingStrategy::Custom { splits: vec![128, 256, 128] };
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn tensor_shard_debug() {
+    let shard =
+        TensorShard { data: vec![1.0, 2.0, 3.0, 4.0], rank_id: 0, shard_index: 0, total_shards: 2 };
+    insta::assert_debug_snapshot!(shard);
+}
+
+#[test]
+fn tensor_parallel_metrics_default_debug() {
+    let m = TensorParallelMetrics::default();
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn tensor_parallel_error_uneven_debug() {
+    let e = TensorParallelError::UnevenSharding { tensor_len: 100, num_shards: 3 };
+    insta::assert_debug_snapshot!(e);
+}
+
+#[test]
+fn tensor_parallel_error_oob_debug() {
+    let e = TensorParallelError::ShardIndexOutOfBounds { index: 5, total: 4 };
+    insta::assert_debug_snapshot!(e);
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bandwidth_metrics_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bandwidth_metrics_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 42
+expression: bw
+---
+BandwidthMetrics {
+    bytes_read: 1048576,
+    bytes_written: 524288,
+    duration: 100µs,
+    peak_bandwidth_bytes_per_sec: 900000000000.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__batch_norm_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__batch_norm_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 292
+expression: cfg
+---
+BatchNormConfig {
+    num_features: 1,
+    eps: 1e-5,
+    momentum: 0.1,
+    training: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__batch_norm_config_training_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__batch_norm_config_training_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 298
+expression: cfg
+---
+BatchNormConfig {
+    num_features: 256,
+    eps: 1e-5,
+    momentum: 0.1,
+    training: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bottleneck_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bottleneck_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 79
+expression: variants
+---
+[
+    MemoryBound,
+    ComputeBound,
+    LatencyBound,
+    Unknown,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bottleneck_analyzer_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__bottleneck_analyzer_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 68
+expression: ba
+---
+BottleneckAnalyzer {
+    latency_threshold_us: 5.0,
+    memory_util_threshold: 0.6,
+    compute_util_threshold: 0.6,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__coalesced_group_full_mask_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__coalesced_group_full_mask_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 231
+expression: cg
+---
+CoalescedGroup {
+    active_mask: 4294967295,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__coalesced_group_partial_mask_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__coalesced_group_partial_mask_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 237
+expression: cg
+---
+CoalescedGroup {
+    active_mask: 255,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__comm_backend_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__comm_backend_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 359
+expression: variants
+---
+[
+    InProcess,
+    SharedMemory,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__compute_metrics_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__compute_metrics_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 48
+expression: cm
+---
+ComputeMetrics {
+    flops: 1000000000,
+    duration: 1ms,
+    peak_flops: 312000000000000.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_default_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 190
+expression: cfg
+---
+CooperativeGroupConfig {
+    group_size: 256,
+    grid_sync: false,
+    thread_block_cluster: false,
+    cluster_size: 1,
+    shared_mem_bytes: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_with_cluster_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_with_cluster_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 202
+expression: cfg
+---
+CooperativeGroupConfig {
+    group_size: 256,
+    grid_sync: false,
+    thread_block_cluster: true,
+    cluster_size: 4,
+    shared_mem_bytes: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_with_grid_sync_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_group_config_with_grid_sync_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 196
+expression: cfg
+---
+CooperativeGroupConfig {
+    group_size: 512,
+    grid_sync: true,
+    thread_block_cluster: false,
+    cluster_size: 1,
+    shared_mem_bytes: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_reduce_op_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__cooperative_reduce_op_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 213
+expression: variants
+---
+[
+    Sum,
+    Max,
+    Min,
+    Product,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__default_stream_behavior_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__default_stream_behavior_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 128
+expression: variants
+---
+[
+    Legacy,
+    PerThread,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__grid_group_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__grid_group_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 225
+expression: gg
+---
+GridGroup {
+    block_size: 256,
+    num_blocks: 128,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__kernel_profile_minimal_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__kernel_profile_minimal_debug.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 54
+expression: p
+---
+KernelProfile {
+    name: "matmul_f32",
+    duration: 42µs,
+    bandwidth: None,
+    compute: None,
+    occupancy: None,
+    grid_dim: [
+        1,
+        1,
+        1,
+    ],
+    block_dim: [
+        1,
+        1,
+        1,
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__kernel_profile_with_grid_block_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__kernel_profile_with_grid_block_debug.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 62
+expression: p
+---
+KernelProfile {
+    name: "rmsnorm",
+    duration: 8µs,
+    bandwidth: None,
+    compute: None,
+    occupancy: None,
+    grid_dim: [
+        128,
+        1,
+        1,
+    ],
+    block_dim: [
+        256,
+        1,
+        1,
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__layer_graph_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__layer_graph_config_default_debug.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 164
+expression: cfg
+---
+LayerGraphConfig {
+    hidden_dim: 2048,
+    num_heads: 16,
+    seq_len: 128,
+    include_mlp: true,
+    include_attention: true,
+    attention_stream: 0,
+    mlp_stream: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__loss_reduction_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__loss_reduction_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 322
+expression: variants
+---
+[
+    None,
+    Mean,
+    Sum,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__memory_event_kind_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__memory_event_kind_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 96
+expression: variants
+---
+[
+    Allocate,
+    Deallocate,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__multi_stream_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__multi_stream_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 170
+expression: cfg
+---
+MultiStreamConfig {
+    num_streams: 2,
+    sync_barriers: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_calculator_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_calculator_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 22
+expression: calc
+---
+OccupancyCalculator {
+    max_threads_per_sm: 2048,
+    max_blocks_per_sm: 32,
+    max_shared_mem_per_sm: 163840,
+    max_registers_per_sm: 65536,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_limiter_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_limiter_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 90
+expression: variants
+---
+[
+    Threads,
+    Blocks,
+    SharedMemory,
+    Registers,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_result_shared_mem_limited.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_result_shared_mem_limited.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 36
+expression: result
+---
+OccupancyResult {
+    theoretical: 0.0625,
+    active_warps: 4,
+    max_warps: 64,
+    limiter: SharedMemory,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_result_thread_limited.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__occupancy_result_thread_limited.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 29
+expression: result
+---
+OccupancyResult {
+    theoretical: 1.0,
+    active_warps: 64,
+    max_warps: 64,
+    limiter: Threads,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__optimize_stats_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__optimize_stats_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 176
+expression: stats
+---
+OptimizeStats {
+    nodes_removed: 0,
+    edges_removed: 0,
+    nodes_merged: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_compute_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_compute_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 140
+expression: stage
+---
+PipelineStage {
+    kind: Compute,
+    label: "matmul_kernel",
+    cost: 65536,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_h2d_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_h2d_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 134
+expression: stage
+---
+PipelineStage {
+    kind: HostToDevice,
+    label: "weights_upload",
+    cost: 4096,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_kind_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__pipeline_stage_kind_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 150
+expression: variants
+---
+[
+    HostToDevice,
+    Compute,
+    DeviceToHost,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__profile_accumulator_empty_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__profile_accumulator_empty_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 102
+expression: acc
+---
+ProfileAccumulator {
+    entries: {},
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_gather_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_gather_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 261
+expression: cfg
+---
+ScatterGatherConfig {
+    bounds_check: true,
+    reduce: Assign,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_gather_config_with_add_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_gather_config_with_add_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 267
+expression: cfg
+---
+ScatterGatherConfig {
+    bounds_check: true,
+    reduce: Add,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_reduce_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__scatter_reduce_all_variants_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 279
+expression: variants
+---
+[
+    Assign,
+    Add,
+    Max,
+    Min,
+    Mul,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_column_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_column_debug.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 365
+expression: s
+---
+ColumnParallel

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_custom_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_custom_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 377
+expression: s
+---
+Custom {
+    splits: [
+        128,
+        256,
+        128,
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_row_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__sharding_strategy_row_debug.snap
@@ -1,0 +1,6 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 371
+expression: s
+---
+RowParallel

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__simd_batch_norm_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__simd_batch_norm_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 304
+expression: cfg
+---
+SimdBatchNormConfig {
+    epsilon: 1e-5,
+    momentum: 0.1,
+    affine: true,
+    track_running_stats: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__simd_batch_norm_state_initial_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__simd_batch_norm_state_initial_debug.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 310
+expression: state
+---
+SimdBatchNormState {
+    running_mean: [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ],
+    running_var: [
+        1.0,
+        1.0,
+        1.0,
+        1.0,
+    ],
+    num_batches_tracked: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__stream_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__stream_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 116
+expression: cfg
+---
+StreamConfig {
+    num_streams: 4,
+    priority: Normal,
+    default_stream_behavior: PerThread,
+    enable_profiling: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__stream_priority_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__stream_priority_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 122
+expression: variants
+---
+[
+    Low,
+    Normal,
+    High,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_config_2rank_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_config_2rank_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 342
+expression: cfg
+---
+TensorParallelConfig {
+    num_ranks: 2,
+    rank_id: 0,
+    comm_backend: InProcess,
+    overlap_compute_comm: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_config_4rank_overlap_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_config_4rank_overlap_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 353
+expression: cfg
+---
+TensorParallelConfig {
+    num_ranks: 4,
+    rank_id: 1,
+    comm_backend: SharedMemory,
+    overlap_compute_comm: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_error_oob_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_error_oob_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 406
+expression: e
+---
+ShardIndexOutOfBounds {
+    index: 5,
+    total: 4,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_error_uneven_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_error_uneven_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 400
+expression: e
+---
+UnevenSharding {
+    tensor_len: 100,
+    num_shards: 3,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_metrics_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_parallel_metrics_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 394
+expression: m
+---
+TensorParallelMetrics {
+    comm_time_ms: 0.0,
+    compute_time_ms: 0.0,
+    overlap_efficiency: 0.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_shard_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__tensor_shard_debug.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 388
+expression: shard
+---
+TensorShard {
+    data: [
+        1.0,
+        2.0,
+        3.0,
+        4.0,
+    ],
+    rank_id: 0,
+    shard_index: 0,
+    total_shards: 2,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__thread_block_group_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__thread_block_group_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 219
+expression: tbg
+---
+ThreadBlockGroup {
+    num_threads: 256,
+    block_idx: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__warp_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave_21__warp_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave_21.rs
+assertion_line: 249
+expression: cfg
+---
+WarpConfig {
+    warp_size: 32,
+    active_mask: 4294967295,
+}


### PR DESCRIPTION
## Summary

Add **snapshot wave 21** with 48 insta snapshot tests pinning Debug representations of recent kernel module types in `bitnet-kernels`.

### Coverage (9 sections, 48 tests)

| Section | Module | Tests |
|---------|--------|-------|
| 1 | CUDA profiling (occupancy, bandwidth, compute, bottleneck) | 13 |
| 2 | CUDA stream management (config, pipeline stages) | 6 |
| 3 | CUDA graph execution (layer graph, multi-stream, optimizer) | 3 |
| 4 | CUDA cooperative groups (config, thread block, grid, coalesced) | 8 |
| 5 | CUDA warp operations (config) | 1 |
| 6 | CPU scatter/gather (config, reduce variants) | 3 |
| 7 | CPU batch normalization (config, SIMD config, state) | 4 |
| 8 | CPU loss functions (reduction variants) | 1 |
| 9 | CPU tensor parallel (config, sharding, shard, metrics, errors) | 9 |

### Verification

```
cargo test -p bitnet-kernels --test snapshot_wave_21 --no-default-features --features cpu
test result: ok. 48 passed; 0 failed; 0 ignored
```