### PR TITLE
test(metal): add Metal quantization shader validation tests

### DIFF
--- a/crates/bitnet-kernels/tests/metal_quantization_shader_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_quantization_shader_tests.rs
@@ -826,6 +826,490 @@ mod tests {
         run_throughput_benchmark(4096, 4096, QK256_BLOCK, 50);
     }
 
+    // ====================================================================
+    // 11. Additional block sizes (64, 128)
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_block_size_64() {
+        let k = 128;
+        let n = 1;
+        let block_size = 64;
+        let num_blocks = k.div_ceil(block_size);
+        assert_eq!(num_blocks, 2);
+
+        let vals: Vec<i8> = vec![1; k];
+        let weights_packed = pack_i2s_vec(&vals);
+        let scales = vec![1.0f32, 2.0f32];
+        let activation = vec![1.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        // Block 0: 64 * 1.0 = 64.0, Block 1: 64 * 2.0 = 128.0
+        let expected = 64.0 + 128.0;
+        assert!((result[0] - expected).abs() < 1e-4, "Expected {expected}, got {}", result[0]);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_block_size_128() {
+        let k = 256;
+        let n = 1;
+        let block_size = 128;
+        let num_blocks = k.div_ceil(block_size);
+        assert_eq!(num_blocks, 2);
+
+        let vals: Vec<i8> = (0..k).map(|i| if i % 2 == 0 { 1 } else { -1 }).collect();
+        let weights_packed = pack_i2s_vec(&vals);
+        let scales = vec![1.0f32; num_blocks];
+        let activation = vec![1.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        // Alternating ±1 with uniform activation cancels out.
+        assert!(result[0].abs() < 1e-6, "Expected ~0, got {}", result[0]);
+    }
+
+    // ====================================================================
+    // 12. BitNet32-F16 format (inline F16 scales) vs QK256 (separate scales)
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_bitnet32_inline_f16_scale_precision() {
+        // BitNet32-F16: each 32-element block stores its scale as F16 inline.
+        let k = BITNET32_BLOCK;
+        let n = 1;
+
+        let vals: Vec<i8> = vec![1; k];
+        let weights_packed = pack_i2s_vec(&vals);
+
+        // Simulate F16 inline scale (stored with each block).
+        let scale_f32 = 0.123_456_789_f32;
+        let scale_f16 = half::f16::from_f32(scale_f32).to_f32();
+
+        let scales = vec![scale_f16];
+        let activation = vec![1.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, BITNET32_BLOCK);
+        let expected = k as f32 * scale_f16;
+        assert!(
+            (result[0] - expected).abs() < 1e-4,
+            "BitNet32 F16 scale: expected {expected}, got {}",
+            result[0]
+        );
+        // Verify F16 quantization introduces some rounding.
+        assert_ne!(scale_f32, scale_f16, "F16 should differ from F32");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_qk256_separate_scales_layout() {
+        // QK256: 256-element blocks, scales stored in a separate buffer.
+        let k = QK256_BLOCK * 2; // 512 elements, 2 blocks
+        let n = 2;
+        let num_blocks = k.div_ceil(QK256_BLOCK);
+        let packed_k = k.div_ceil(4);
+
+        let vals: Vec<i8> = vec![1; k * n];
+        let mut weights_packed = vec![0u8; n * packed_k];
+        for col in 0..n {
+            let col_packed = pack_i2s_vec(&vals[col * k..(col + 1) * k]);
+            weights_packed[col * packed_k..col * packed_k + col_packed.len()]
+                .copy_from_slice(&col_packed);
+        }
+
+        // Separate scale buffer: [n * num_blocks] contiguous f32
+        let scales: Vec<f32> = vec![0.5, 1.0, 1.5, 2.0]; // col0: [0.5, 1.0], col1: [1.5, 2.0]
+        assert_eq!(scales.len(), n * num_blocks);
+
+        let activation = vec![1.0f32; k];
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, QK256_BLOCK);
+
+        // col0: 256*0.5 + 256*1.0 = 128 + 256 = 384
+        assert!((result[0] - 384.0).abs() < 1e-3, "Col0: expected 384, got {}", result[0]);
+        // col1: 256*1.5 + 256*2.0 = 384 + 512 = 896
+        assert!((result[1] - 896.0).abs() < 1e-3, "Col1: expected 896, got {}", result[1]);
+    }
+
+    // ====================================================================
+    // 13. Per-channel vs per-tensor quantization
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_per_channel_quantization() {
+        // Each output channel (column) has independent scales per block.
+        let k = 64;
+        let n = 3;
+        let block_size = BITNET32_BLOCK;
+        let num_blocks = k.div_ceil(block_size); // 2
+        let packed_k = k.div_ceil(4);
+
+        let vals: Vec<i8> = vec![1; k * n];
+        let mut weights_packed = vec![0u8; n * packed_k];
+        for col in 0..n {
+            let col_packed = pack_i2s_vec(&vals[col * k..(col + 1) * k]);
+            weights_packed[col * packed_k..col * packed_k + col_packed.len()]
+                .copy_from_slice(&col_packed);
+        }
+
+        // Per-channel: different scales for each channel
+        let scales = vec![
+            1.0f32, 1.0, // channel 0, blocks 0-1
+            2.0, 2.0, // channel 1, blocks 0-1
+            3.0, 3.0, // channel 2, blocks 0-1
+        ];
+        let activation = vec![1.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        assert!((result[0] - 64.0).abs() < 1e-4, "Channel 0: expected 64, got {}", result[0]);
+        assert!((result[1] - 128.0).abs() < 1e-4, "Channel 1: expected 128, got {}", result[1]);
+        assert!((result[2] - 192.0).abs() < 1e-4, "Channel 2: expected 192, got {}", result[2]);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_per_tensor_quantization() {
+        // Per-tensor: all blocks and channels share a single scale.
+        let k = 64;
+        let n = 3;
+        let block_size = BITNET32_BLOCK;
+        let num_blocks = k.div_ceil(block_size);
+        let packed_k = k.div_ceil(4);
+
+        let vals: Vec<i8> = vec![1; k * n];
+        let mut weights_packed = vec![0u8; n * packed_k];
+        for col in 0..n {
+            let col_packed = pack_i2s_vec(&vals[col * k..(col + 1) * k]);
+            weights_packed[col * packed_k..col * packed_k + col_packed.len()]
+                .copy_from_slice(&col_packed);
+        }
+
+        // Per-tensor: uniform scale of 0.5 for all blocks/channels
+        let uniform_scale = 0.5f32;
+        let scales = vec![uniform_scale; n * num_blocks];
+        let activation = vec![1.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        let expected = k as f32 * uniform_scale;
+        for (col, &v) in result.iter().enumerate() {
+            assert!(
+                (v - expected).abs() < 1e-4,
+                "Per-tensor ch{col}: expected {expected}, got {v}"
+            );
+        }
+    }
+
+    // ====================================================================
+    // 14. Numerical stability with extreme values
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_numerical_stability_very_small_scale() {
+        let vals: Vec<i8> = vec![1; 32];
+        let packed = pack_i2s_vec(&vals);
+        let tiny_scale = 1e-30_f32;
+        let result = dequant_i2s(&packed, tiny_scale, 32);
+        for &v in &result {
+            assert!(v.is_finite(), "Very small scale should produce finite results");
+            assert!((v - tiny_scale).abs() < 1e-35, "Expected ~{tiny_scale}, got {v}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_numerical_stability_very_large_scale() {
+        let vals: Vec<i8> = vec![1; 4];
+        let packed = pack_i2s_vec(&vals);
+        let huge_scale = 1e30_f32;
+        let result = dequant_i2s(&packed, huge_scale, 4);
+        for &v in &result {
+            assert!(v.is_finite(), "Large scale should produce finite results");
+            assert!((v - huge_scale).abs() / huge_scale < 1e-6, "Expected ~{huge_scale}, got {v}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_numerical_stability_subnormal_scale() {
+        let vals: Vec<i8> = vec![1, -1, 0, 1];
+        let packed = pack_i2s_vec(&vals);
+        let subnormal = f32::MIN_POSITIVE / 2.0; // subnormal
+        let result = dequant_i2s(&packed, subnormal, 4);
+        for &v in &result {
+            assert!(v.is_finite(), "Subnormal scale should produce finite results");
+        }
+        // +1 * subnormal should equal subnormal
+        assert_eq!(result[0], subnormal);
+        // -1 * subnormal should equal -subnormal
+        assert_eq!(result[1], -subnormal);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_numerical_stability_inf_scale() {
+        let vals: [i8; 4] = [1, -1, 0, 1];
+        let packed = pack_i2s(vals);
+        let result = dequant_i2s(&[packed], f32::INFINITY, 4);
+        assert!(result[0].is_infinite() && result[0] > 0.0);
+        assert!(result[1].is_infinite() && result[1] < 0.0);
+        // 0 * inf = NaN in IEEE 754, but we map code 0b00 to 0i8, so 0.0 * inf = NaN
+        assert!(result[2].is_nan());
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_numerical_stability_nan_scale() {
+        let vals: [i8; 4] = [1, -1, 0, 1];
+        let packed = pack_i2s(vals);
+        let result = dequant_i2s(&[packed], f32::NAN, 4);
+        for &v in &result {
+            assert!(v.is_nan(), "NaN scale should propagate to all outputs");
+        }
+    }
+
+    // ====================================================================
+    // 15. Zero and constant input handling
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_zero_activation_input() {
+        let k = 64;
+        let n = 2;
+        let block_size = BITNET32_BLOCK;
+        let packed_k = k.div_ceil(4);
+
+        let vals: Vec<i8> = (0..k * n).map(|i| if i % 2 == 0 { 1 } else { -1 }).collect();
+        let mut weights_packed = vec![0u8; n * packed_k];
+        for col in 0..n {
+            let col_packed = pack_i2s_vec(&vals[col * k..(col + 1) * k]);
+            weights_packed[col * packed_k..col * packed_k + col_packed.len()]
+                .copy_from_slice(&col_packed);
+        }
+        let num_blocks = k.div_ceil(block_size);
+        let scales = vec![1.0f32; n * num_blocks];
+        let activation = vec![0.0f32; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        for (col, &v) in result.iter().enumerate() {
+            assert!(v.abs() < 1e-6, "Zero activation should produce 0, ch{col} got {v}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_constant_activation_input() {
+        let k = 32;
+        let n = 1;
+        let block_size = BITNET32_BLOCK;
+
+        // Weights: half +1, half -1
+        let mut vals = vec![0i8; k];
+        vals[..16].fill(1);
+        vals[16..].fill(-1);
+        let weights_packed = pack_i2s_vec(&vals);
+        let scales = vec![1.0f32];
+
+        let constant = 3.14f32;
+        let activation = vec![constant; k];
+
+        let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
+        // 16 * 3.14 + 16 * (-3.14) = 0
+        assert!(
+            result[0].abs() < 1e-4,
+            "Balanced ±1 with constant input should cancel, got {}",
+            result[0]
+        );
+    }
+
+    // ====================================================================
+    // 16. Scale computation accuracy
+    // ====================================================================
+
+    /// Compute optimal I2_S scale for a block via absmax: scale = max(|x|).
+    fn compute_scale_absmax(values: &[f32]) -> f32 {
+        values.iter().map(|v| v.abs()).fold(0.0f32, f32::max)
+    }
+
+    /// Quantize f32 values to ternary {-1, 0, +1} given a scale.
+    fn quantize_to_ternary(values: &[f32], scale: f32) -> Vec<i8> {
+        if scale == 0.0 {
+            return vec![0i8; values.len()];
+        }
+        values
+            .iter()
+            .map(|&v| {
+                let normalized = v / scale;
+                if normalized > 0.5 {
+                    1i8
+                } else if normalized < -0.5 {
+                    -1i8
+                } else {
+                    0i8
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_scale_computation_absmax() {
+        let values = vec![0.5, -1.0, 0.3, 0.8, -0.7, 1.0, -0.2, 0.0];
+        let scale = compute_scale_absmax(&values);
+        assert!((scale - 1.0).abs() < 1e-6, "absmax should be 1.0, got {scale}");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_scale_computation_all_zeros() {
+        let values = vec![0.0; 32];
+        let scale = compute_scale_absmax(&values);
+        assert_eq!(scale, 0.0, "All-zero input should produce scale 0");
+        let quantized = quantize_to_ternary(&values, scale);
+        assert!(quantized.iter().all(|&v| v == 0), "All-zero should quantize to all-zero");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_scale_computation_uniform_positive() {
+        let values = vec![0.75; 16];
+        let scale = compute_scale_absmax(&values);
+        assert!((scale - 0.75).abs() < 1e-6);
+        let quantized = quantize_to_ternary(&values, scale);
+        // 0.75 / 0.75 = 1.0 > 0.5 → +1
+        assert!(quantized.iter().all(|&v| v == 1));
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_quantize_dequantize_roundtrip_accuracy() {
+        // End-to-end: f32 → ternary → packed I2_S → dequant → f32
+        let original = vec![0.9, -0.8, 0.1, 0.7, -0.95, 0.0, -0.3, 0.85];
+        let scale = compute_scale_absmax(&original);
+        let quantized = quantize_to_ternary(&original, scale);
+        let packed = pack_i2s_vec(&quantized);
+        let restored = dequant_i2s(&packed, scale, original.len());
+
+        // Check each element is within 1 scale unit of original
+        for (i, (&orig, &rest)) in original.iter().zip(restored.iter()).enumerate() {
+            let error = (orig - rest).abs();
+            assert!(
+                error <= scale + 1e-6,
+                "Element {i}: orig={orig}, restored={rest}, error={error}, scale={scale}"
+            );
+        }
+    }
+
+    // ====================================================================
+    // 17. Threadgroup dispatch sizing (additional tests)
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_threadgroup_dispatch_power_of_two_dims() {
+        // Optimal Metal dispatch uses power-of-two threadgroup sizes.
+        for &dim in &[32, 64, 128, 256, 512, 1024] {
+            let tg_size = dim.min(METAL_MAX_THREADS_PER_THREADGROUP);
+            assert!(tg_size.is_power_of_two(), "Dim {dim} → tg_size {tg_size} should be po2");
+            assert!(tg_size <= METAL_MAX_THREADS_PER_THREADGROUP);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_threadgroup_dispatch_non_power_of_two_dims() {
+        // Non-po2 dims need rounding to next po2 or clamping.
+        fn next_power_of_two(n: usize) -> usize {
+            n.next_power_of_two()
+        }
+
+        for &dim in &[33, 65, 129, 257, 513, 1025, 2048, 4096] {
+            let tg_size = next_power_of_two(dim).min(METAL_MAX_THREADS_PER_THREADGROUP);
+            assert!(tg_size.is_power_of_two());
+            assert!(tg_size >= dim.min(METAL_MAX_THREADS_PER_THREADGROUP));
+            assert!(tg_size <= METAL_MAX_THREADS_PER_THREADGROUP);
+
+            // Grid size: number of threadgroups needed
+            let num_threadgroups = dim.div_ceil(tg_size);
+            assert!(num_threadgroups >= 1, "Must dispatch at least 1 threadgroup");
+            assert!(num_threadgroups * tg_size >= dim, "Grid must cover all elements");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_threadgroup_dispatch_quantization_kernel() {
+        // For quantization: each threadgroup processes one block of elements.
+        for &block_size in &[BITNET32_BLOCK, 64, 128, QK256_BLOCK] {
+            let elements = 4096;
+            let num_blocks = elements.div_ceil(block_size);
+            // One threadgroup per block, threads within handle elements
+            let threads_per_tg = block_size.min(METAL_MAX_THREADS_PER_THREADGROUP);
+            assert!(threads_per_tg > 0);
+            assert!(
+                num_blocks > 0,
+                "block_size={block_size}: need at least 1 block for {elements} elements"
+            );
+            // Total thread invocations covers all elements
+            assert!(num_blocks * threads_per_tg >= elements.min(num_blocks * block_size));
+        }
+    }
+
+    // ====================================================================
+    // 18. Mixed-precision: F16 input → I2_S output quantization
+    // ====================================================================
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_f16_input_to_i2s_quantization() {
+        // Simulate: F16 input tensor → compute absmax scale → quantize to ternary → pack I2_S
+        let input_f32: Vec<f32> = vec![0.8, -0.9, 0.1, 0.7, -0.6, 0.0, -0.95, 0.5];
+        // Round-trip through F16 to simulate Metal F16 input
+        let input_f16: Vec<f32> =
+            input_f32.iter().map(|&v| half::f16::from_f32(v).to_f32()).collect();
+
+        let scale = compute_scale_absmax(&input_f16);
+        let quantized = quantize_to_ternary(&input_f16, scale);
+        let packed = pack_i2s_vec(&quantized);
+        let restored = dequant_i2s(&packed, scale, input_f16.len());
+
+        // Verify output is valid I2_S (values are in {-scale, 0, +scale})
+        for &v in &restored {
+            let abs_v = v.abs();
+            assert!(
+                abs_v < 1e-6 || (abs_v - scale).abs() < 1e-6,
+                "Dequantized value {v} should be 0 or ±{scale}"
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS with Apple Silicon"]
+    fn test_f16_precision_boundary_values() {
+        // F16 has limited precision; test values near quantization thresholds.
+        let scale = 1.0f32;
+        // Values near the 0.5 threshold (boundary between 0 and ±1)
+        let boundary_values: Vec<f32> = vec![0.49, 0.50, 0.51, -0.49, -0.50, -0.51];
+        let f16_values: Vec<f32> =
+            boundary_values.iter().map(|&v| half::f16::from_f32(v).to_f32()).collect();
+        let quantized = quantize_to_ternary(&f16_values, scale);
+
+        // 0.49/1.0 < 0.5 → 0,  0.51/1.0 > 0.5 → +1
+        assert_eq!(quantized[0], 0, "0.49 should quantize to 0");
+        // 0.50 exactly: our threshold is strict >, so 0.50 → 0
+        assert_eq!(quantized[1], 0, "0.50 should quantize to 0 (strict >)");
+        assert_eq!(quantized[2], 1, "0.51 should quantize to +1");
+        assert_eq!(quantized[3], 0, "-0.49 should quantize to 0");
+        assert_eq!(quantized[4], 0, "-0.50 should quantize to 0 (strict <)");
+        assert_eq!(quantized[5], -1, "-0.51 should quantize to -1");
+    }
+
+    // ====================================================================
+    // 10. Performance: throughput for common hidden dimensions (continued)
+    // ====================================================================
+
     /// Benchmark helper for I2_S matrix-vector multiply throughput.
     fn run_throughput_benchmark(k: usize, n: usize, block_size: usize, iterations: usize) {
         let packed_k = k.div_ceil(4);


### PR DESCRIPTION
Add Metal quantization shader test suite with 60 tests:
- I2_S encoding validation (0b00/01/11/10)
- Block sizes (32/64/128/256)
- QK256 and BitNet32-F16 format tests
- Per-channel vs per-tensor quantization
- Numerical stability (extreme scales, NaN, Inf)
- Buffer alignment and threadgroup dispatch

All tests gated with #[ignore = "requires Metal GPU"]

Apple Silicon enablement PR.