### PR TITLE
test(fuzz): add wave 28 — 6 fuzz targets for CUDA/CPU kernel operations

### DIFF
--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -51,6 +51,7 @@ pub mod quantized_matmul;
 pub mod rmsnorm;
 pub mod rope;
 pub mod softmax;
+pub mod stream_mgmt;
 pub mod transpose;
 
 pub use activations::{

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -611,3 +611,33 @@ name = "fuzz_pipeline_parallel_stages"
 path = "fuzz_targets/fuzz_pipeline_parallel_stages.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_cuda_memory_pool"
+path = "fuzz_targets/fuzz_cuda_memory_pool.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cuda_stream_schedule"
+path = "fuzz_targets/fuzz_cuda_stream_schedule.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_attention_mask"
+path = "fuzz_targets/fuzz_cpu_attention_mask.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_cpu_layer_norm"
+path = "fuzz_targets/fuzz_cpu_layer_norm.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_quantize_roundtrip"
+path = "fuzz_targets/fuzz_quantize_roundtrip.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_cpu_attention_mask.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_attention_mask.rs
@@ -1,0 +1,92 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::attention_mask::{
+    apply_mask, combine_masks, create_causal_mask, create_padding_mask, create_sliding_window_mask,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct AttentionMaskInput {
+    seq_len: u16,
+    window: u16,
+    padding_lengths: Vec<u16>,
+    scores_data: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: AttentionMaskInput| {
+    let seq_len = (input.seq_len as usize % 128) + 1;
+    let window = (input.window as usize % 128) + 1;
+
+    // --- Causal mask ---
+    let causal = create_causal_mask(seq_len);
+    assert_eq!(causal.len(), seq_len * seq_len, "causal mask size mismatch");
+    // Upper triangle must be -inf (blocked), diagonal and below must be 0.0 (attend).
+    for row in 0..seq_len {
+        for col in 0..seq_len {
+            let val = causal[row * seq_len + col];
+            if col <= row {
+                assert_eq!(val, 0.0, "causal mask should attend at ({row},{col})");
+            } else {
+                assert!(
+                    val.is_infinite() && val < 0.0,
+                    "causal mask should block at ({row},{col})"
+                );
+            }
+        }
+    }
+
+    // --- Sliding window mask ---
+    let sliding = create_sliding_window_mask(seq_len, window);
+    assert_eq!(sliding.len(), seq_len * seq_len, "sliding window mask size mismatch");
+    for &val in &sliding {
+        assert!(val == 0.0 || (val.is_infinite() && val < 0.0), "unexpected mask value: {val}");
+    }
+
+    // --- Padding mask ---
+    if !input.padding_lengths.is_empty() {
+        let batch = input.padding_lengths.len().min(16);
+        let max_len = seq_len;
+        let lengths: Vec<usize> =
+            input.padding_lengths[..batch].iter().map(|&l| (l as usize) % (max_len + 1)).collect();
+        let padding = create_padding_mask(&lengths, max_len);
+        assert_eq!(padding.len(), batch * max_len, "padding mask size mismatch");
+    }
+
+    // --- combine_masks ---
+    let combined = combine_masks(&causal, &sliding, seq_len);
+    assert_eq!(combined.len(), seq_len * seq_len, "combined mask size mismatch");
+
+    // --- apply_mask ---
+    let total = seq_len * seq_len;
+    let mut scores = bytes_to_f32(&input.scores_data, total);
+    if scores.len() < total {
+        scores.resize(total, 0.0);
+    }
+    // Filter non-finite scores to avoid spurious failures.
+    for s in scores.iter_mut() {
+        if !s.is_finite() {
+            *s = 0.0;
+        }
+    }
+    apply_mask(&mut scores, &causal, seq_len);
+    // After applying causal mask, upper-triangle scores must be -inf.
+    for row in 0..seq_len {
+        for col in (row + 1)..seq_len {
+            let val = scores[row * seq_len + col];
+            assert!(
+                val.is_infinite() && val < 0.0,
+                "score at ({row},{col}) should be -inf after causal mask, got {val}"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cpu_layer_norm.rs
+++ b/fuzz/fuzz_targets/fuzz_cpu_layer_norm.rs
@@ -1,0 +1,105 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::layer_norm::{LayerNormConfig, layer_norm, rms_norm};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct LayerNormInput {
+    batch_size: u8,
+    hidden_dim: u16,
+    eps_byte: u8,
+    use_beta: bool,
+    use_rms: bool,
+    input_data: Vec<u8>,
+    gamma_data: Vec<u8>,
+    beta_data: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: LayerNormInput| {
+    let batch_size = (input.batch_size as usize % 8) + 1;
+    let hidden_dim = (input.hidden_dim as usize % 512) + 1;
+    let total = batch_size * hidden_dim;
+
+    // Map eps to a small positive value in [1e-12, 1e-1].
+    let eps = 10.0f32.powf(-12.0 + (input.eps_byte as f32 / 255.0) * 11.0);
+
+    let config =
+        LayerNormConfig { normalized_shape: vec![hidden_dim], eps, elementwise_affine: true };
+
+    let raw_input = bytes_to_f32(&input.input_data, total);
+    if raw_input.len() < total {
+        return;
+    }
+    let input_data: Vec<f32> = raw_input[..total]
+        .iter()
+        .map(|&v| if v.is_finite() { v.clamp(-1e6, 1e6) } else { 0.0 })
+        .collect();
+
+    let raw_gamma = bytes_to_f32(&input.gamma_data, hidden_dim);
+    if raw_gamma.len() < hidden_dim {
+        return;
+    }
+    let gamma: Vec<f32> = raw_gamma[..hidden_dim]
+        .iter()
+        .map(|&v| if v.is_finite() { v.clamp(-1e3, 1e3) } else { 1.0 })
+        .collect();
+
+    if input.use_rms {
+        // --- RMS norm ---
+        if let Ok(out) = rms_norm(&input_data, &gamma, &config) {
+            assert_eq!(out.len(), total, "rms_norm output length mismatch");
+            for (i, &val) in out.iter().enumerate() {
+                assert!(val.is_finite(), "rms_norm output non-finite at {i}: {val}");
+            }
+        }
+    } else {
+        // --- Layer norm ---
+        let beta_opt = if input.use_beta {
+            let raw_beta = bytes_to_f32(&input.beta_data, hidden_dim);
+            if raw_beta.len() < hidden_dim {
+                return;
+            }
+            let beta: Vec<f32> = raw_beta[..hidden_dim]
+                .iter()
+                .map(|&v| if v.is_finite() { v.clamp(-1e3, 1e3) } else { 0.0 })
+                .collect();
+            Some(beta)
+        } else {
+            None
+        };
+
+        if let Ok(out) = layer_norm(&input_data, &gamma, beta_opt.as_deref(), &config) {
+            assert_eq!(out.len(), total, "layer_norm output length mismatch");
+            for (i, &val) in out.iter().enumerate() {
+                assert!(val.is_finite(), "layer_norm output non-finite at {i}: {val}");
+            }
+
+            // Invariant: if gamma is all-ones and beta is all-zeros, output should
+            // be approximately zero-mean per sample (within floating-point tolerance).
+            let all_ones = gamma.iter().all(|&g| (g - 1.0).abs() < 1e-6);
+            let all_zero_beta =
+                beta_opt.as_ref().map(|b| b.iter().all(|&v| v.abs() < 1e-6)).unwrap_or(true);
+            if all_ones && all_zero_beta && !input.use_beta {
+                for b in 0..batch_size {
+                    let start = b * hidden_dim;
+                    let end = start + hidden_dim;
+                    let mean: f32 = out[start..end].iter().sum::<f32>() / hidden_dim as f32;
+                    assert!(
+                        mean.abs() < 0.1,
+                        "layer_norm output mean {mean} for batch {b} (expected ~0)"
+                    );
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_cuda_memory_pool.rs
+++ b/fuzz/fuzz_targets/fuzz_cuda_memory_pool.rs
@@ -1,0 +1,89 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cuda::memory_pool::{MemoryPool, MemoryPoolConfig};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct MemoryPoolInput {
+    /// Encoded allocator choice: 0=BestFit, 1=Buddy, 2=Slab.
+    allocator_byte: u8,
+    /// Fuzzed initial pool size (mapped to realistic range).
+    initial_size_byte: u8,
+    /// Sequence of operations: (op_type, size_byte).
+    ops: Vec<(u8, u8)>,
+}
+
+fuzz_target!(|input: MemoryPoolInput| {
+    // Realistic pool sizes: 1 KiB – 4 MiB.
+    let initial_size = ((input.initial_size_byte as usize) % 4096 + 1) * 1024;
+    let config = MemoryPoolConfig {
+        initial_size,
+        max_size: initial_size * 4,
+        block_size: 256,
+        alignment: 256,
+    };
+
+    let mut pool = match input.allocator_byte % 3 {
+        0 => MemoryPool::with_best_fit(config),
+        1 => MemoryPool::with_buddy(config),
+        _ => MemoryPool::with_slab(config, 4096),
+    };
+    let mut pool = match pool {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let mut live_ids = Vec::new();
+
+    for &(op, size_byte) in input.ops.iter().take(128) {
+        match op % 5 {
+            // Allocate
+            0 | 1 => {
+                let size = (size_byte as usize % 4096) + 1;
+                if let Ok(block) = pool.allocate(size) {
+                    live_ids.push(block.id);
+                }
+            }
+            // Deallocate
+            2 => {
+                if let Some(id) = live_ids.pop() {
+                    let _ = pool.deallocate(id);
+                }
+            }
+            // Touch (LRU update)
+            3 => {
+                if let Some(&id) = live_ids.last() {
+                    let _ = pool.touch(id);
+                }
+            }
+            // Evict LRU
+            _ => {
+                if let Ok((evicted_id, _size)) = pool.evict_least_recently_used() {
+                    live_ids.retain(|id| *id != evicted_id);
+                }
+            }
+        }
+    }
+
+    // Invariant: pressure is in [0, 1].
+    let pressure = pool.memory_pressure();
+    assert!((0.0..=1.0).contains(&pressure), "memory_pressure out of range: {pressure}");
+
+    // Invariant: peak_usage >= current usage.
+    let stats = pool.memory_usage();
+    assert!(
+        pool.peak_usage() >= stats.used,
+        "peak_usage {} < current used {}",
+        pool.peak_usage(),
+        stats.used,
+    );
+
+    // Defragment must not panic.
+    pool.defragment();
+
+    // Reset must not panic.
+    pool.reset();
+    let stats_after = pool.memory_usage();
+    assert_eq!(stats_after.used, 0, "used should be 0 after reset");
+});

--- a/fuzz/fuzz_targets/fuzz_cuda_stream_schedule.rs
+++ b/fuzz/fuzz_targets/fuzz_cuda_stream_schedule.rs
@@ -1,0 +1,95 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cuda::stream_mgmt::{
+    DefaultStreamBehavior, StreamConfig, StreamPool, StreamPriority,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct StreamInput {
+    num_streams: u8,
+    priority_byte: u8,
+    ops: Vec<(u8, u8)>,
+}
+
+fuzz_target!(|input: StreamInput| {
+    let num_streams = (input.num_streams as usize % 8) + 1;
+    let priority = match input.priority_byte % 3 {
+        0 => StreamPriority::Low,
+        1 => StreamPriority::Normal,
+        _ => StreamPriority::High,
+    };
+    let config = StreamConfig {
+        num_streams,
+        priority,
+        default_stream_behavior: DefaultStreamBehavior::PerThread,
+        enable_profiling: false,
+    };
+
+    let mut pool = match StreamPool::new(config) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Invariant: pool has the requested number of streams.
+    assert_eq!(pool.num_streams(), num_streams);
+
+    let mut next_event_id: u64 = 1;
+    let mut created_events = Vec::new();
+
+    for &(op, param) in input.ops.iter().take(128) {
+        let stream_idx = param as usize % num_streams;
+        match op % 7 {
+            // acquire_next
+            0 => {
+                let idx = pool.acquire_next();
+                assert!(idx < num_streams, "acquire_next returned out-of-bounds index");
+            }
+            // acquire_least_loaded
+            1 => {
+                let idx = pool.acquire_least_loaded();
+                assert!(idx < num_streams, "acquire_least_loaded returned out-of-bounds index");
+            }
+            // create_event + record
+            2 => {
+                let event = pool.create_event();
+                let eid = event.id;
+                created_events.push(eid);
+                let _ = pool.record_event(eid, stream_idx);
+                next_event_id = next_event_id.wrapping_add(1);
+            }
+            // wait on existing event
+            3 => {
+                if let Some(&eid) = created_events.last() {
+                    let _ = pool.wait_event(eid, stream_idx);
+                }
+            }
+            // sync single stream
+            4 => {
+                let _ = pool.sync_stream(stream_idx);
+            }
+            // sync all
+            5 => {
+                let _ = pool.sync_all();
+            }
+            // destroy event
+            _ => {
+                if let Some(eid) = created_events.pop() {
+                    let _ = pool.destroy_event(eid);
+                }
+            }
+        }
+    }
+
+    // Invariant: stream access with valid index must not panic.
+    for i in 0..num_streams {
+        assert!(pool.stream(i).is_ok());
+    }
+
+    // Invariant: out-of-bounds access returns Err.
+    assert!(pool.stream(num_streams).is_err());
+
+    // Final sync must not panic.
+    let _ = pool.sync_all();
+});

--- a/fuzz/fuzz_targets/fuzz_kv_cache_ops.rs
+++ b/fuzz/fuzz_targets/fuzz_kv_cache_ops.rs
@@ -1,93 +1,19 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::kv_cache::{
+    KvCache, KvCacheConfig, KvDtype, kv_cache_append, kv_cache_clear, kv_cache_memory_usage,
+    kv_cache_slice,
+};
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Arbitrary, Debug)]
 struct KvCacheInput {
-    n_layers: u8,
-    n_heads: u8,
+    num_layers: u8,
+    num_heads: u8,
     head_dim: u8,
-    ops: Vec<CacheOp>,
-}
-
-#[derive(Arbitrary, Debug)]
-enum CacheOp {
-    Append { layer: u8, data: Vec<u8> },
-    ReadLayer { layer: u8 },
-    ReadAll,
-    Reset,
-    TrimTo { max_seq: u8 },
-}
-
-struct KvCache {
-    n_layers: usize,
-    n_heads: usize,
-    head_dim: usize,
-    keys: Vec<Vec<f32>>,
-    values: Vec<Vec<f32>>,
-    seq_lens: Vec<usize>,
-}
-
-impl KvCache {
-    fn new(n_layers: usize, n_heads: usize, head_dim: usize) -> Self {
-        Self {
-            n_layers,
-            n_heads,
-            head_dim,
-            keys: vec![Vec::new(); n_layers],
-            values: vec![Vec::new(); n_layers],
-            seq_lens: vec![0; n_layers],
-        }
-    }
-
-    fn append(&mut self, layer: usize, k: &[f32], v: &[f32]) -> bool {
-        if layer >= self.n_layers {
-            return false;
-        }
-        let step_size = self.n_heads * self.head_dim;
-        if k.len() != step_size || v.len() != step_size {
-            return false;
-        }
-        self.keys[layer].extend_from_slice(k);
-        self.values[layer].extend_from_slice(v);
-        self.seq_lens[layer] += 1;
-        true
-    }
-
-    fn read_layer(&self, layer: usize) -> Option<(&[f32], &[f32], usize)> {
-        if layer >= self.n_layers {
-            return None;
-        }
-        Some((&self.keys[layer], &self.values[layer], self.seq_lens[layer]))
-    }
-
-    fn seq_len(&self, layer: usize) -> usize {
-        if layer >= self.n_layers {
-            return 0;
-        }
-        self.seq_lens[layer]
-    }
-
-    fn reset(&mut self) {
-        for layer in 0..self.n_layers {
-            self.keys[layer].clear();
-            self.values[layer].clear();
-            self.seq_lens[layer] = 0;
-        }
-    }
-
-    fn trim_to(&mut self, max_seq: usize) {
-        let step_size = self.n_heads * self.head_dim;
-        for layer in 0..self.n_layers {
-            if self.seq_lens[layer] > max_seq {
-                let keep = max_seq * step_size;
-                self.keys[layer].truncate(keep);
-                self.values[layer].truncate(keep);
-                self.seq_lens[layer] = max_seq;
-            }
-        }
-    }
+    max_seq_len: u8,
+    ops: Vec<(u8, u8, Vec<u8>)>,
 }
 
 fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
@@ -100,94 +26,89 @@ fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
 }
 
 fuzz_target!(|input: KvCacheInput| {
-    let n_layers = (input.n_layers as usize % 4) + 1;
-    let n_heads = (input.n_heads as usize % 4) + 1;
-    let head_dim = (input.head_dim as usize % 16) + 1;
-    let step_size = n_heads * head_dim;
+    let num_layers = (input.num_layers as usize % 4) + 1;
+    let num_heads = (input.num_heads as usize % 4) + 1;
+    let head_dim = (input.head_dim as usize % 32) + 1;
+    let max_seq_len = (input.max_seq_len as usize % 64) + 1;
+    let token_elems = num_heads * head_dim;
 
-    let mut cache = KvCache::new(n_layers, n_heads, head_dim);
+    let config =
+        KvCacheConfig { num_layers, num_heads, head_dim, max_seq_len, dtype: KvDtype::F32 };
 
-    // Invariant 1: Fresh cache has zero seq_len for all layers
-    for l in 0..n_layers {
-        assert_eq!(cache.seq_len(l), 0, "fresh cache layer {l} should have seq_len=0");
+    let mut cache = match KvCache::new(config) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Invariant: freshly created cache has zero sequence length.
+    for layer in 0..num_layers {
+        assert_eq!(cache.seq_len(layer).unwrap(), 0);
     }
 
-    for op in input.ops.into_iter().take(256) {
-        match op {
-            CacheOp::Append { layer, data } => {
-                let layer_idx = layer as usize % n_layers;
-                let kv_data = bytes_to_f32(&data, step_size * 2);
-                if kv_data.len() >= step_size * 2 {
-                    let k = &kv_data[..step_size];
-                    let v = &kv_data[step_size..step_size * 2];
-                    let prev_len = cache.seq_len(layer_idx);
-                    let ok = cache.append(layer_idx, k, v);
-                    if ok {
-                        // Invariant 2: seq_len increments by 1 on successful append
-                        assert_eq!(
-                            cache.seq_len(layer_idx),
-                            prev_len + 1,
-                            "seq_len should increment by 1"
-                        );
+    for (op, param, raw_data) in input.ops.iter().take(64) {
+        let layer = *param as usize % num_layers;
+        match op % 4 {
+            // Append single token
+            0 => {
+                let keys = bytes_to_f32(raw_data, token_elems);
+                let values =
+                    bytes_to_f32(raw_data.get(token_elems * 4..).unwrap_or(&[]), token_elems);
+                if keys.len() < token_elems || values.len() < token_elems {
+                    continue;
+                }
+                // Filter non-finite values.
+                let keys: Vec<f32> = keys[..token_elems]
+                    .iter()
+                    .map(|&v| if v.is_finite() { v } else { 0.0 })
+                    .collect();
+                let values: Vec<f32> = values[..token_elems]
+                    .iter()
+                    .map(|&v| if v.is_finite() { v } else { 0.0 })
+                    .collect();
 
-                        // Invariant 3: Key/value buffer size matches seq_len * step_size
-                        let (keys, values, seq) = cache.read_layer(layer_idx).unwrap();
-                        assert_eq!(keys.len(), seq * step_size, "key buffer size mismatch");
-                        assert_eq!(values.len(), seq * step_size, "value buffer size mismatch");
+                let prev_len = cache.seq_len(layer).unwrap_or(0);
+                if kv_cache_append(&mut cache, layer, &keys, &values).is_ok() {
+                    let new_len = cache.seq_len(layer).unwrap();
+                    assert!(
+                        new_len > prev_len,
+                        "seq_len should increase after append: {prev_len} -> {new_len}"
+                    );
+                }
+            }
+            // Slice
+            1 => {
+                let seq = cache.seq_len(layer).unwrap_or(0);
+                if seq > 0 {
+                    let start = *param as usize % seq;
+                    let end = start + 1;
+                    if let Ok((k_slice, v_slice)) = kv_cache_slice(&cache, layer, start, end) {
+                        assert_eq!(k_slice.len(), token_elems);
+                        assert_eq!(v_slice.len(), token_elems);
                     }
                 }
             }
-            CacheOp::ReadLayer { layer } => {
-                let layer_idx = layer as usize % n_layers;
-                let result = cache.read_layer(layer_idx);
-                // Invariant 4: Valid layer read always succeeds
-                assert!(result.is_some(), "valid layer {layer_idx} read should succeed");
-                let (keys, values, seq) = result.unwrap();
-                assert_eq!(keys.len(), values.len(), "k/v lengths should match");
-                assert_eq!(keys.len(), seq * step_size, "buffer size vs seq_len mismatch");
-            }
-            CacheOp::ReadAll => {
-                for l in 0..n_layers {
-                    let (keys, values, seq) = cache.read_layer(l).unwrap();
-                    assert_eq!(keys.len(), seq * step_size);
-                    assert_eq!(values.len(), seq * step_size);
+            // Clear
+            2 => {
+                kv_cache_clear(&mut cache);
+                for l in 0..num_layers {
+                    assert_eq!(cache.seq_len(l).unwrap(), 0, "seq_len should be 0 after clear");
                 }
             }
-            CacheOp::Reset => {
-                cache.reset();
-                // Invariant 5: After reset, all layers have seq_len=0
-                for l in 0..n_layers {
-                    assert_eq!(cache.seq_len(l), 0, "after reset, layer {l} should have seq_len=0");
-                    let (keys, values, _) = cache.read_layer(l).unwrap();
-                    assert!(keys.is_empty(), "keys should be empty after reset");
-                    assert!(values.is_empty(), "values should be empty after reset");
-                }
-            }
-            CacheOp::TrimTo { max_seq } => {
-                let max = (max_seq as usize % 32) + 1;
-                cache.trim_to(max);
-                // Invariant 6: After trim, all seq_lens <= max
-                for l in 0..n_layers {
-                    assert!(
-                        cache.seq_len(l) <= max,
-                        "after trim to {max}, layer {l} has seq_len={}",
-                        cache.seq_len(l)
-                    );
-                }
+            // Memory usage
+            _ => {
+                let usage = kv_cache_memory_usage(&cache);
+                assert!(usage > 0, "memory usage should be positive");
             }
         }
     }
 
-    // Invariant 7: Out-of-bounds layer reads return None
-    assert!(cache.read_layer(n_layers).is_none(), "OOB layer read should return None");
-    assert_eq!(cache.seq_len(n_layers), 0, "OOB layer seq_len should be 0");
-
-    // Invariant 8: Layers are independent — appending to one doesn't affect others
-    cache.reset();
-    let dummy_k = vec![1.0f32; step_size];
-    let dummy_v = vec![2.0f32; step_size];
-    cache.append(0, &dummy_k, &dummy_v);
-    for l in 1..n_layers {
-        assert_eq!(cache.seq_len(l), 0, "layer {l} should be unaffected by append to layer 0");
+    // Invariant: layer independence — appending to one layer doesn't affect others.
+    kv_cache_clear(&mut cache);
+    let token_keys = vec![1.0f32; token_elems];
+    let token_values = vec![2.0f32; token_elems];
+    if num_layers >= 2 {
+        let _ = kv_cache_append(&mut cache, 0, &token_keys, &token_values);
+        assert_eq!(cache.seq_len(0).unwrap(), 1);
+        assert_eq!(cache.seq_len(1).unwrap(), 0, "layers should be independent");
     }
 });

--- a/fuzz/fuzz_targets/fuzz_quantize_roundtrip.rs
+++ b/fuzz/fuzz_targets/fuzz_quantize_roundtrip.rs
@@ -1,0 +1,98 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_quantization::int8_quant::{
+    CalibrationMethod, Int8QuantConfig, dequantize_tensor_int8, quantize_tensor_int8,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct QuantizeRoundtripInput {
+    /// Fuzz data length (mapped to realistic tensor size).
+    len_byte: u8,
+    /// Per-channel vs per-tensor.
+    per_channel: bool,
+    /// Symmetric vs asymmetric.
+    symmetric: bool,
+    /// Calibration method selector.
+    calibration_byte: u8,
+    /// Raw float data.
+    data: Vec<u8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: QuantizeRoundtripInput| {
+    let target_len = (input.len_byte as usize % 256) + 1;
+
+    let raw = bytes_to_f32(&input.data, target_len);
+    if raw.len() < target_len {
+        return;
+    }
+
+    // Clamp to realistic float range and filter non-finite.
+    let data: Vec<f32> = raw[..target_len]
+        .iter()
+        .map(|&v| if v.is_finite() { v.clamp(-1e4, 1e4) } else { 0.0 })
+        .collect();
+
+    let calibration_method = match input.calibration_byte % 3 {
+        0 => CalibrationMethod::MinMax,
+        1 => CalibrationMethod::Percentile(99.9),
+        _ => CalibrationMethod::MSE,
+    };
+
+    let config = Int8QuantConfig {
+        per_channel: input.per_channel,
+        symmetric: input.symmetric,
+        calibration_method,
+    };
+
+    // --- Int8 quantize → dequantize roundtrip ---
+    let (quantized, params) = quantize_tensor_int8(&data, &config);
+    assert_eq!(quantized.len(), data.len(), "quantized length mismatch");
+
+    // Scales must be non-negative and finite.
+    for (i, &s) in params.scales.iter().enumerate() {
+        assert!(s.is_finite(), "scale non-finite at {i}: {s}");
+        assert!(s >= 0.0, "scale negative at {i}: {s}");
+    }
+
+    let dequantized = dequantize_tensor_int8(&quantized, &params);
+    assert_eq!(dequantized.len(), data.len(), "dequantized length mismatch");
+
+    // Invariant: all dequantized values are finite.
+    for (i, &val) in dequantized.iter().enumerate() {
+        assert!(val.is_finite(), "dequantized value non-finite at {i}: {val}");
+    }
+
+    // Invariant: roundtrip error is bounded for int8 quantization.
+    // Max absolute error should be proportional to scale (1 LSB = scale).
+    let max_scale = params.scales.iter().copied().fold(0.0f32, f32::max);
+    if max_scale > 0.0 {
+        for (i, (&orig, &deq)) in data.iter().zip(dequantized.iter()).enumerate() {
+            let err = (orig - deq).abs();
+            // Int8 quantization error should be within 1 scale step.
+            assert!(
+                err <= max_scale + 1e-5,
+                "roundtrip error {err} exceeds max_scale {max_scale} at index {i} \
+                 (orig={orig}, deq={deq})"
+            );
+        }
+    }
+
+    // Invariant: zero input quantizes to zero (within tolerance).
+    let zeros = vec![0.0f32; target_len];
+    let (q_zero, p_zero) = quantize_tensor_int8(&zeros, &config);
+    let d_zero = dequantize_tensor_int8(&q_zero, &p_zero);
+    for (i, &val) in d_zero.iter().enumerate() {
+        assert!(val.abs() < 1e-6, "zero input dequantized to {val} at index {i}");
+    }
+});


### PR DESCRIPTION
## Wave 28 Fuzz Targets

Adds 6 new fuzz targets exercising core kernel and quantization APIs:

| Target | Area | APIs Tested |
|--------|------|-------------|
| `fuzz_cuda_memory_pool` | CUDA | `MemoryPool::allocate/deallocate/evict/defragment/reset` |
| `fuzz_cuda_stream_schedule` | CUDA | `StreamPool::acquire_next/record_event/wait_event/sync` |
| `fuzz_cpu_attention_mask` | CPU | `create_causal_mask/create_sliding_window_mask/apply_mask/combine_masks` |
| `fuzz_cpu_layer_norm` | CPU | `layer_norm/rms_norm` with arbitrary dims and eps |
| `fuzz_quantize_roundtrip` | Quantization | `quantize_tensor_int8/dequantize_tensor_int8` roundtrip |
| `fuzz_kv_cache_ops` | CPU | `kv_cache_append/kv_cache_slice/kv_cache_clear/kv_cache_memory_usage` |

### Changes
- 5 new fuzz target files
- Rewrote existing `fuzz_kv_cache_ops` to use real `bitnet_kernels::cpu::kv_cache` API
- Exported `cuda::stream_mgmt` module for fuzz target access
- Registered all new targets as `[[bin]]` entries in `fuzz/Cargo.toml`

### Verification
- `cargo fmt --all` ✅
- `cargo check` (fuzz crate) ✅