### PR TITLE
feat(neon): add cache prefetch and staging for Apple Silicon inference

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
@@ -1,9 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::needless_range_loop)]
-#![allow(clippy::manual_div_ceil)]
-#![allow(clippy::manual_is_multiple_of)]
-#![allow(clippy::let_and_return)]
 //! ARM NEON optimized attention masking kernels for Apple Silicon.
 //!
 //! Provides SIMD-accelerated attention mask application using `float32x4`


### PR DESCRIPTION
Adds cache-aware prefetch operations for Apple Silicon M-series processors.

## Changes
- PrefetchConfig with Apple Silicon defaults (128-byte cache lines)
- StagingBuffer for data pre-loading
- Prefetched copy and accumulate operations
- Cache-line-aware tiled matmul

## Tests
46 tests covering all operations.