### PR TITLE
test(kernels): add snapshot wave 22 — kernel configuration regression tests

### DIFF
--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -140,6 +140,10 @@ name = "bdd_wave_7"
 path = "tests/bdd_wave_7.rs"
 required-features = ["cpu"]
 
+[[test]]
+name = "snapshot_wave22"
+path = "tests/snapshot_wave22.rs"
+
 [[example]]
 name = "gpu_validation"
 path = "examples/gpu_validation.rs"

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -141,3 +141,5 @@ pub mod gather;
 pub use gather::{gather_rows, index_select_dim, scatter_add_rows};
 pub mod pipeline_parallel;
 pub use pipeline_parallel::*;
+pub mod cache_matmul;
+pub mod tensor_parallel;

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -34,24 +34,33 @@ pub mod activations;
 pub mod attention;
 pub mod batch_norm;
 pub mod conv1d;
+pub mod cooperative_groups;
+pub mod dequant;
 pub mod elementwise;
 pub mod embedding;
 pub mod ffn;
+pub mod fused_attention;
 pub mod fusion;
 pub mod gating;
+pub mod graph_exec;
 pub mod kv_cache;
 pub mod layernorm;
 pub mod linear;
+pub mod loss;
 pub mod matmul;
 pub mod memory_pool;
 pub mod pooling;
+pub mod profiling;
 pub mod qk256_gemv;
 pub mod quantize;
 pub mod quantized_matmul;
 pub mod rmsnorm;
 pub mod rope;
 pub mod softmax;
+pub mod sparse;
+pub mod stream_mgmt;
 pub mod transpose;
+pub mod warp_ops;
 
 pub use activations::{
     ActivationConfig, ActivationType, SiluGateConfig, activation_cpu, launch_activation,

--- a/crates/bitnet-kernels/tests/snapshot_wave22.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave22.rs
@@ -1,0 +1,781 @@
+//! Wave 22 snapshot tests — kernel configuration regression tests.
+//!
+//! Pins the Debug representations of CUDA stream management, sparse matrix,
+//! graph execution, fused attention, profiling, dequantization, cooperative
+//! groups, CPU pipeline/tensor parallelism, capability matrix, and OpenCL
+//! autotuner / telemetry / registry / cache structs so that unintentional
+//! changes are caught at review time.
+
+// =========================================================================
+// Section 1 — CUDA stream management configs
+// =========================================================================
+
+use bitnet_kernels::cuda::stream_mgmt::{
+    DefaultStreamBehavior, PipelineStageKind, ScheduleStrategy, StreamConfig, StreamOp,
+    StreamPriority, StreamScheduler,
+};
+
+#[test]
+fn stream_config_default() {
+    let cfg = StreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn stream_config_high_priority_profiling() {
+    let cfg = StreamConfig {
+        num_streams: 8,
+        priority: StreamPriority::High,
+        default_stream_behavior: DefaultStreamBehavior::Legacy,
+        enable_profiling: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn stream_priority_all_variants() {
+    let variants: Vec<StreamPriority> =
+        vec![StreamPriority::Low, StreamPriority::Normal, StreamPriority::High];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn default_stream_behavior_all_variants() {
+    let variants: Vec<DefaultStreamBehavior> =
+        vec![DefaultStreamBehavior::Legacy, DefaultStreamBehavior::PerThread];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn pipeline_stage_kind_all_variants() {
+    let variants: Vec<PipelineStageKind> = vec![
+        PipelineStageKind::HostToDevice,
+        PipelineStageKind::Compute,
+        PipelineStageKind::DeviceToHost,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn stream_op_basic() {
+    let op = StreamOp::new("matmul_kernel", 1000);
+    insta::assert_debug_snapshot!(op);
+}
+
+#[test]
+fn stream_op_with_dependency() {
+    let op = StreamOp::new("softmax_kernel", 500).with_dependency(42);
+    insta::assert_debug_snapshot!(op);
+}
+
+#[test]
+fn schedule_strategy_all_variants() {
+    let variants: Vec<ScheduleStrategy> = vec![
+        ScheduleStrategy::RoundRobin,
+        ScheduleStrategy::LeastLoaded,
+        ScheduleStrategy::PriorityBased,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn stream_scheduler_round_robin() {
+    let scheduler = StreamScheduler::new(ScheduleStrategy::RoundRobin);
+    insta::assert_debug_snapshot!(scheduler);
+}
+
+// =========================================================================
+// Section 2 — CUDA sparse matrix configs
+// =========================================================================
+
+use bitnet_kernels::cuda::sparse::{ElementwiseSpOp, SparseConfig, SparseFormat};
+
+#[test]
+fn sparse_format_all_variants() {
+    let formats: Vec<SparseFormat> = vec![
+        SparseFormat::CSR,
+        SparseFormat::CSC,
+        SparseFormat::COO,
+        SparseFormat::BSR,
+        SparseFormat::Block,
+    ];
+    insta::assert_debug_snapshot!(formats);
+}
+
+#[test]
+fn sparse_config_csr_basic() {
+    let cfg = SparseConfig::new(SparseFormat::CSR, 1024, 512).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn sparse_config_bsr_with_block_size() {
+    let cfg = SparseConfig::new(SparseFormat::BSR, 2048, 2048)
+        .unwrap()
+        .with_block_size(64)
+        .unwrap()
+        .with_threshold(0.01);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn elementwise_sp_op_all_variants() {
+    let ops: Vec<ElementwiseSpOp> =
+        vec![ElementwiseSpOp::Add, ElementwiseSpOp::Sub, ElementwiseSpOp::Mul];
+    insta::assert_debug_snapshot!(ops);
+}
+
+// =========================================================================
+// Section 3 — CUDA graph execution configs
+// =========================================================================
+
+use bitnet_kernels::cuda::graph_exec::{
+    CaptureState, GraphNode, LayerGraphConfig, MultiStreamConfig, NodeKind, OptimizeStats,
+};
+
+#[test]
+fn node_kind_kernel() {
+    let kind = NodeKind::Kernel { name: "gemm_i2s".into(), grid: [128, 1, 1], block: [256, 1, 1] };
+    insta::assert_debug_snapshot!(kind);
+}
+
+#[test]
+fn node_kind_all_simple_variants() {
+    let kinds: Vec<NodeKind> = vec![
+        NodeKind::MemCopy { bytes: 4096 },
+        NodeKind::MemSet { bytes: 1024 },
+        NodeKind::HostCallback { label: "sync_point".into() },
+        NodeKind::Barrier,
+        NodeKind::Empty,
+    ];
+    insta::assert_debug_snapshot!(kinds);
+}
+
+#[test]
+fn graph_node_kernel_with_params() {
+    let node = GraphNode::kernel("rmsnorm_fwd", [64, 1, 1], [256, 1, 1])
+        .with_param("eps", 1e-6)
+        .on_stream(0);
+    insta::assert_debug_snapshot!(node);
+}
+
+#[test]
+fn graph_node_memcopy() {
+    let node = GraphNode::memcopy(65536).on_stream(1);
+    insta::assert_debug_snapshot!(node);
+}
+
+#[test]
+fn capture_state_all_variants() {
+    let states: Vec<CaptureState> =
+        vec![CaptureState::Idle, CaptureState::Capturing, CaptureState::Complete];
+    insta::assert_debug_snapshot!(states);
+}
+
+#[test]
+fn layer_graph_config_default() {
+    let cfg = LayerGraphConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn multi_stream_config_default() {
+    let cfg = MultiStreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn optimize_stats_default() {
+    let stats = OptimizeStats::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 4 — CUDA fused attention configs
+// =========================================================================
+
+use bitnet_kernels::cuda::fused_attention::{
+    AttentionMetrics, AttentionPattern, FusedAttentionConfig, FusedAttentionError,
+};
+
+#[test]
+fn fused_attention_config_basic() {
+    let cfg = FusedAttentionConfig::new(64, 8, 8, 2048).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn fused_attention_config_gqa_flash() {
+    let cfg = FusedAttentionConfig::new(128, 32, 8, 4096)
+        .unwrap()
+        .with_causal(true)
+        .with_flash_attention(true);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn attention_pattern_all_variants() {
+    let patterns: Vec<AttentionPattern> = vec![
+        AttentionPattern::Causal,
+        AttentionPattern::Full,
+        AttentionPattern::SlidingWindow { window_size: 256 },
+        AttentionPattern::Sparse { block_size: 64 },
+    ];
+    insta::assert_debug_snapshot!(patterns);
+}
+
+#[test]
+fn fused_attention_error_display() {
+    let errors: Vec<String> = vec![
+        format!("{:?}", FusedAttentionError::InvalidConfig("head_dim must be > 0".into())),
+        format!(
+            "{:?}",
+            FusedAttentionError::ShapeMismatch {
+                expected: "[1,8,64,64]".into(),
+                actual: "[1,8,64,32]".into(),
+            }
+        ),
+        format!("{:?}", FusedAttentionError::SequenceTooLong { seq_len: 8192, max_seq_len: 4096 }),
+        format!("{:?}", FusedAttentionError::InvalidGqaRatio { num_heads: 8, num_kv_heads: 3 }),
+    ];
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn attention_metrics_compute() {
+    let m = AttentionMetrics::compute(8, 128, 128, 64);
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn attention_metrics_compute_gqa() {
+    let m = AttentionMetrics::compute_gqa(32, 8, 256, 256, 128);
+    insta::assert_debug_snapshot!(m);
+}
+
+// =========================================================================
+// Section 5 — CUDA dequantization configs
+// =========================================================================
+
+use bitnet_kernels::cuda::dequant::{DequantConfig, DequantPrecision, QuantBitWidth, ScaleMode};
+
+#[test]
+fn dequant_config_default() {
+    let cfg = DequantConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn dequant_precision_all_variants() {
+    let variants: Vec<DequantPrecision> = vec![DequantPrecision::F32, DequantPrecision::F16];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn quant_bit_width_all_variants() {
+    let variants: Vec<QuantBitWidth> =
+        vec![QuantBitWidth::Int2, QuantBitWidth::Int4, QuantBitWidth::Int8];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn scale_mode_all_variants() {
+    let variants: Vec<ScaleMode> =
+        vec![ScaleMode::Uniform, ScaleMode::PerBlock, ScaleMode::PerChannel];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// =========================================================================
+// Section 6 — CUDA loss configs
+// =========================================================================
+
+use bitnet_kernels::cuda::loss::{LossConfig, LossReduction as CudaLossReduction};
+
+#[test]
+fn cuda_loss_config_basic() {
+    let cfg = LossConfig::new(64, 32000).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cuda_loss_reduction_all_variants() {
+    let variants: Vec<CudaLossReduction> =
+        vec![CudaLossReduction::Mean, CudaLossReduction::Sum, CudaLossReduction::None];
+    insta::assert_debug_snapshot!(variants);
+}
+
+// =========================================================================
+// Section 7 — CUDA cooperative groups configs
+// =========================================================================
+
+use bitnet_kernels::cuda::cooperative_groups::{
+    CoalescedGroup, CooperativeGroupConfig, CooperativeReduceOp, GridGroup, ThreadBlockGroup,
+};
+
+#[test]
+fn cooperative_group_config_default() {
+    let cfg = CooperativeGroupConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cooperative_reduce_op_all_variants() {
+    let ops: Vec<CooperativeReduceOp> = vec![
+        CooperativeReduceOp::Sum,
+        CooperativeReduceOp::Max,
+        CooperativeReduceOp::Min,
+        CooperativeReduceOp::Product,
+    ];
+    insta::assert_debug_snapshot!(ops);
+}
+
+#[test]
+fn thread_block_group_debug() {
+    let g = ThreadBlockGroup::new(256, 0).unwrap();
+    insta::assert_debug_snapshot!(g);
+}
+
+#[test]
+fn grid_group_debug() {
+    let g = GridGroup::new(256, 128).unwrap();
+    insta::assert_debug_snapshot!(g);
+}
+
+#[test]
+fn coalesced_group_debug() {
+    let g = CoalescedGroup::new(0xFFFF_FFFF).unwrap();
+    insta::assert_debug_snapshot!(g);
+}
+
+// =========================================================================
+// Section 8 — CUDA warp ops config
+// =========================================================================
+
+use bitnet_kernels::cuda::warp_ops::WarpConfig;
+
+#[test]
+fn warp_config_default() {
+    let cfg = WarpConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 9 — CUDA profiling configs
+// =========================================================================
+
+use bitnet_kernels::cuda::profiling::{
+    Bottleneck, BottleneckAnalyzer, OccupancyCalculator, OccupancyLimiter,
+};
+
+#[test]
+fn occupancy_calculator_sm80() {
+    let calc = OccupancyCalculator::new(2048, 32, 163_840, 65536);
+    insta::assert_debug_snapshot!(calc);
+}
+
+#[test]
+fn occupancy_limiter_all_variants() {
+    let limiters: Vec<OccupancyLimiter> = vec![
+        OccupancyLimiter::Threads,
+        OccupancyLimiter::Blocks,
+        OccupancyLimiter::SharedMemory,
+        OccupancyLimiter::Registers,
+    ];
+    insta::assert_debug_snapshot!(limiters);
+}
+
+#[test]
+fn bottleneck_all_variants() {
+    let variants: Vec<Bottleneck> = vec![
+        Bottleneck::MemoryBound,
+        Bottleneck::ComputeBound,
+        Bottleneck::LatencyBound,
+        Bottleneck::Unknown,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn bottleneck_analyzer_default() {
+    let analyzer = BottleneckAnalyzer::new();
+    insta::assert_debug_snapshot!(analyzer);
+}
+
+// =========================================================================
+// Section 10 — CPU pipeline parallel configs
+// =========================================================================
+
+use bitnet_kernels::cpu::pipeline_parallel::{PipelineConfig, PipelineSchedule, PipelineStage};
+
+#[test]
+fn pipeline_schedule_all_variants() {
+    let variants: Vec<PipelineSchedule> = vec![
+        PipelineSchedule::Sequential,
+        PipelineSchedule::GPipe,
+        PipelineSchedule::PipeDream,
+        PipelineSchedule::Interleaved,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn pipeline_stage_with_affinity() {
+    let stage = PipelineStage::new(0, 8).with_affinity(2);
+    insta::assert_debug_snapshot!(stage);
+}
+
+#[test]
+fn pipeline_config_two_stage_gpipe() {
+    let cfg = PipelineConfig::new(
+        vec![PipelineStage::new(0, 16), PipelineStage::new(16, 32)],
+        4,
+        PipelineSchedule::GPipe,
+    );
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 11 — CPU tensor parallel configs
+// =========================================================================
+
+use bitnet_kernels::cpu::tensor_parallel::{
+    CommBackend, ShardingStrategy, TensorParallelConfig, TensorParallelError, TensorParallelMetrics,
+};
+
+#[test]
+fn comm_backend_all_variants() {
+    let variants: Vec<CommBackend> = vec![CommBackend::InProcess, CommBackend::SharedMemory];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn tensor_parallel_config_debug() {
+    let cfg = TensorParallelConfig {
+        num_ranks: 4,
+        rank_id: 0,
+        comm_backend: CommBackend::InProcess,
+        overlap_compute_comm: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn sharding_strategy_all_variants() {
+    let variants: Vec<ShardingStrategy> = vec![
+        ShardingStrategy::ColumnParallel,
+        ShardingStrategy::RowParallel,
+        ShardingStrategy::Custom { splits: vec![128, 256, 128] },
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn tensor_parallel_error_variants() {
+    let errors: Vec<TensorParallelError> = vec![
+        TensorParallelError::InvalidConfig("num_ranks must be > 0".into()),
+        TensorParallelError::UnevenSharding { tensor_len: 100, num_shards: 3 },
+        TensorParallelError::ShardIndexOutOfBounds { index: 5, total: 4 },
+    ];
+    insta::assert_debug_snapshot!(errors);
+}
+
+#[test]
+fn tensor_parallel_metrics_default() {
+    let m = TensorParallelMetrics::default();
+    insta::assert_debug_snapshot!(m);
+}
+
+// =========================================================================
+// Section 12 — CPU cache-aware matmul configs
+// =========================================================================
+
+use bitnet_kernels::cpu::cache_matmul::{CacheConfig, TilingStrategy};
+
+#[test]
+fn cache_config_conservative() {
+    let cfg = CacheConfig::conservative();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn cache_config_custom_sizes() {
+    let cfg = CacheConfig::with_sizes(32768, 262144, 8388608, 64);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn tiling_strategy_debug() {
+    let ts = TilingStrategy { block_m: 64, block_n: 128, block_k: 32 };
+    insta::assert_debug_snapshot!(ts);
+}
+
+// =========================================================================
+// Section 13 — CPU pooling configs
+// =========================================================================
+
+use bitnet_kernels::cpu::pooling::{PoolConfig, PoolType};
+
+#[test]
+fn pool_type_all_variants() {
+    let types: Vec<PoolType> = vec![
+        PoolType::Max,
+        PoolType::Average,
+        PoolType::GlobalMax,
+        PoolType::GlobalAverage,
+        PoolType::AvgPoolCountIncludePad,
+        PoolType::Lp(2.0),
+        PoolType::Adaptive,
+    ];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn pool_config_default() {
+    let cfg = PoolConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn pool_config_max_pool_3x3() {
+    let cfg = PoolConfig::new(PoolType::Max, 3, 2, 1);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 14 — CPU linear config
+// =========================================================================
+
+use bitnet_kernels::cpu::linear::LinearConfig;
+
+#[test]
+fn linear_config_basic() {
+    let cfg = LinearConfig::new(1, 768, 3072).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn linear_config_with_bias() {
+    let cfg = LinearConfig::new(4, 2048, 5504).unwrap().with_bias(true);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 15 — Capability matrix configs
+// =========================================================================
+
+use bitnet_kernels::capability_matrix::{
+    CapabilityEntry, DeviceClass, OperationCategory, PrecisionSupport, SupportLevel,
+};
+
+#[test]
+fn device_class_all_variants() {
+    let classes: Vec<DeviceClass> = vec![
+        DeviceClass::IntelArc,
+        DeviceClass::IntelXe,
+        DeviceClass::NvidiaCuda,
+        DeviceClass::AmdRocm,
+        DeviceClass::AppleMetal,
+        DeviceClass::CpuSimd,
+        DeviceClass::CpuScalar,
+        DeviceClass::WebGpu,
+    ];
+    insta::assert_debug_snapshot!(classes);
+}
+
+#[test]
+fn support_level_all_variants() {
+    let levels: Vec<SupportLevel> = vec![
+        SupportLevel::Full(0.95),
+        SupportLevel::Partial("requires fallback for large matrices".into()),
+        SupportLevel::Emulated,
+        SupportLevel::Unsupported,
+    ];
+    insta::assert_debug_snapshot!(levels);
+}
+
+#[test]
+fn capability_entry_full_support() {
+    let entry = CapabilityEntry::new(
+        OperationCategory::MatrixOps,
+        PrecisionSupport::FP32,
+        SupportLevel::Full(1.0),
+    );
+    insta::assert_debug_snapshot!(entry);
+}
+
+// =========================================================================
+// Section 16 — OpenCL autotuner configs
+// =========================================================================
+
+use bitnet_kernels::opencl_autotuner::{
+    BenchmarkResult as TuningBenchmarkResult, ParamSet, SearchStrategy, TuningCacheKey, TuningParam,
+};
+
+#[test]
+fn tuning_param_debug() {
+    let p = TuningParam::new("workgroup_size", 32, 512, 32, 256);
+    insta::assert_debug_snapshot!(p);
+}
+
+#[test]
+fn search_strategy_all_variants() {
+    let variants: Vec<SearchStrategy> = vec![
+        SearchStrategy::Exhaustive,
+        SearchStrategy::RandomSample(100),
+        SearchStrategy::SimulatedAnnealing {
+            initial_temp: 1.0,
+            cooling_rate: 0.95,
+            iterations: 500,
+        },
+        SearchStrategy::BayesianOpt { evaluations: 50 },
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn tuning_benchmark_result_debug() {
+    let r = TuningBenchmarkResult::new(
+        ParamSet(vec![("wg_size".into(), 256), ("tile_m".into(), 16)]),
+        42.5,
+        120.0,
+        800.0,
+    );
+    insta::assert_debug_snapshot!(r);
+}
+
+#[test]
+fn tuning_cache_key_debug() {
+    let key = TuningCacheKey::new("gemm_f32", "Intel Arc A770", vec![1024, 1024, 1024]);
+    insta::assert_debug_snapshot!(key);
+}
+
+// =========================================================================
+// Section 17 — OpenCL telemetry configs
+// =========================================================================
+
+use bitnet_kernels::opencl_telemetry::{KernelMetrics, Metric, MetricKind, TelemetryConfig};
+
+#[test]
+fn metric_kind_all_variants() {
+    let kinds: Vec<MetricKind> =
+        vec![MetricKind::Counter, MetricKind::Gauge, MetricKind::Histogram, MetricKind::Timer];
+    insta::assert_debug_snapshot!(kinds);
+}
+
+#[test]
+fn metric_counter_debug() {
+    let m = Metric::new("kernel_dispatches", MetricKind::Counter, 42.0);
+    // Filter the timestamp which varies per run (spans multiple lines in Debug)
+    insta::with_settings!({filters => vec![
+        (r"tv_sec: \d+", "tv_sec: [FILTERED]"),
+        (r"tv_nsec: \d+", "tv_nsec: [FILTERED]"),
+    ]}, {
+        insta::assert_debug_snapshot!(m);
+    });
+}
+
+#[test]
+fn kernel_metrics_fresh() {
+    let m = KernelMetrics::new("gemm_i2s");
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn telemetry_config_default() {
+    let cfg = TelemetryConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 18 — OpenCL kernel registry configs
+// =========================================================================
+
+use bitnet_kernels::opencl_registry::{DeviceConstraints, KernelOp, KernelVariant};
+
+#[test]
+fn kernel_op_all_variants() {
+    let ops: Vec<KernelOp> = vec![
+        KernelOp::MatMul,
+        KernelOp::MatVec,
+        KernelOp::Softmax,
+        KernelOp::RmsNorm,
+        KernelOp::LayerNorm,
+        KernelOp::RoPE,
+        KernelOp::Attention,
+        KernelOp::SiLU,
+        KernelOp::GELU,
+        KernelOp::ReLU,
+        KernelOp::ElementwiseAdd,
+        KernelOp::ElementwiseMul,
+        KernelOp::Scale,
+        KernelOp::Embedding,
+        KernelOp::Dequantize,
+        KernelOp::KvCacheAppend,
+    ];
+    insta::assert_debug_snapshot!(ops);
+}
+
+#[test]
+fn kernel_variant_all_variants() {
+    let variants: Vec<KernelVariant> = vec![
+        KernelVariant::OpenClScalar,
+        KernelVariant::OpenClTiled,
+        KernelVariant::OpenClVectorized,
+        KernelVariant::CpuSimd,
+        KernelVariant::CpuScalar,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn device_constraints_a770() {
+    let dc = DeviceConstraints::a770_defaults();
+    insta::assert_debug_snapshot!(dc);
+}
+
+// =========================================================================
+// Section 19 — OpenCL cache configs
+// =========================================================================
+
+use bitnet_kernels::opencl_cache::{
+    CacheConfig as OclCacheConfig, CacheEvictionStrategy, CachePolicy, CacheStats as OclCacheStats,
+};
+
+#[test]
+fn cache_policy_all_variants() {
+    let policies: Vec<CachePolicy> = vec![
+        CachePolicy::NoCache,
+        CachePolicy::MemoryOnly,
+        CachePolicy::DiskOnly,
+        CachePolicy::MemoryAndDisk,
+    ];
+    insta::assert_debug_snapshot!(policies);
+}
+
+#[test]
+fn cache_eviction_strategy_all_variants() {
+    let strategies: Vec<CacheEvictionStrategy> = vec![
+        CacheEvictionStrategy::Lru,
+        CacheEvictionStrategy::Lfu,
+        CacheEvictionStrategy::Fifo,
+        CacheEvictionStrategy::SizeWeighted,
+    ];
+    insta::assert_debug_snapshot!(strategies);
+}
+
+#[test]
+fn ocl_cache_config_default() {
+    let cfg = OclCacheConfig::default();
+    // Filter the cache directory path which varies per system
+    insta::with_settings!({filters => vec![
+        (r#"cache_dir: ".*""#, r#"cache_dir: "[CACHE_DIR]""#),
+    ]}, {
+        insta::assert_debug_snapshot!(cfg);
+    });
+}
+
+#[test]
+fn ocl_cache_stats_default() {
+    let stats = OclCacheStats::default();
+    insta::assert_debug_snapshot!(stats);
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_metrics_compute.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_metrics_compute.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 249
+expression: m
+---
+AttentionMetrics {
+    flops: 33554432,
+    memory_bytes: 1048576,
+    arithmetic_intensity: 32.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_metrics_compute_gqa.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_metrics_compute_gqa.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 255
+expression: m
+---
+AttentionMetrics {
+    flops: 1073741824,
+    memory_bytes: 10485760,
+    arithmetic_intensity: 102.4,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_pattern_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__attention_pattern_all_variants.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 226
+expression: patterns
+---
+[
+    Causal,
+    Full,
+    SlidingWindow {
+        window_size: 256,
+    },
+    Sparse {
+        block_size: 64,
+    },
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__bottleneck_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__bottleneck_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 397
+expression: variants
+---
+[
+    MemoryBound,
+    ComputeBound,
+    LatencyBound,
+    Unknown,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__bottleneck_analyzer_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__bottleneck_analyzer_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 403
+expression: analyzer
+---
+BottleneckAnalyzer {
+    latency_threshold_us: 5.0,
+    memory_util_threshold: 0.6,
+    compute_util_threshold: 0.6,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_config_conservative.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_config_conservative.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 499
+expression: cfg
+---
+CacheConfig {
+    l1_size: 32768,
+    l2_size: 262144,
+    l3_size: 8388608,
+    cache_line_size: 64,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_config_custom_sizes.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_config_custom_sizes.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 505
+expression: cfg
+---
+CacheConfig {
+    l1_size: 32768,
+    l2_size: 262144,
+    l3_size: 8388608,
+    cache_line_size: 64,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_eviction_strategy_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_eviction_strategy_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 764
+expression: strategies
+---
+[
+    Lru,
+    Lfu,
+    Fifo,
+    SizeWeighted,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_policy_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cache_policy_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 753
+expression: policies
+---
+[
+    NoCache,
+    MemoryOnly,
+    DiskOnly,
+    MemoryAndDisk,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__capability_entry_full_support.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__capability_entry_full_support.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 605
+expression: entry
+---
+CapabilityEntry {
+    operation: MatrixOps,
+    precision: FP32,
+    support: Full(
+        1.0,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__capture_state_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__capture_state_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 174
+expression: states
+---
+[
+    Idle,
+    Capturing,
+    Complete,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__coalesced_group_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__coalesced_group_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 349
+expression: g
+---
+CoalescedGroup {
+    active_mask: 4294967295,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__comm_backend_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__comm_backend_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 450
+expression: variants
+---
+[
+    InProcess,
+    SharedMemory,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cooperative_group_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cooperative_group_config_default.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 320
+expression: cfg
+---
+CooperativeGroupConfig {
+    group_size: 256,
+    grid_sync: false,
+    thread_block_cluster: false,
+    cluster_size: 1,
+    shared_mem_bytes: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cooperative_reduce_op_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cooperative_reduce_op_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 331
+expression: ops
+---
+[
+    Sum,
+    Max,
+    Min,
+    Product,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cuda_loss_config_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cuda_loss_config_basic.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 299
+expression: cfg
+---
+LossConfig {
+    n: 64,
+    n_classes: 32000,
+    threads_per_block: 256,
+    reduction: Mean,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cuda_loss_reduction_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__cuda_loss_reduction_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 306
+expression: variants
+---
+[
+    Mean,
+    Sum,
+    None,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__default_stream_behavior_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__default_stream_behavior_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 48
+expression: variants
+---
+[
+    Legacy,
+    PerThread,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__dequant_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__dequant_config_default.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 267
+expression: cfg
+---
+DequantConfig {
+    bit_width: Int2,
+    precision: F32,
+    block_size: 256,
+    scale_mode: PerBlock,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__dequant_precision_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__dequant_precision_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 273
+expression: variants
+---
+[
+    F32,
+    F16,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__device_class_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__device_class_all_variants.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 584
+expression: classes
+---
+[
+    IntelArc,
+    IntelXe,
+    NvidiaCuda,
+    AmdRocm,
+    AppleMetal,
+    CpuSimd,
+    CpuScalar,
+    WebGpu,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__device_constraints_a770.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__device_constraints_a770.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 734
+expression: dc
+---
+DeviceConstraints {
+    max_workgroup_size: 1024,
+    max_local_memory: 65536,
+    subgroup_sizes: [
+        8,
+        16,
+        32,
+    ],
+    has_fp16: true,
+    has_int8_dot: true,
+    compute_units: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__elementwise_sp_op_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__elementwise_sp_op_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 127
+expression: ops
+---
+[
+    Add,
+    Sub,
+    Mul,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_config_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_config_basic.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 206
+expression: cfg
+---
+FusedAttentionConfig {
+    head_dim: 64,
+    num_heads: 8,
+    num_kv_heads: 8,
+    max_seq_len: 2048,
+    causal: false,
+    flash_attention: false,
+    use_alibi: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_config_gqa_flash.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_config_gqa_flash.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 215
+expression: cfg
+---
+FusedAttentionConfig {
+    head_dim: 128,
+    num_heads: 32,
+    num_kv_heads: 8,
+    max_seq_len: 4096,
+    causal: true,
+    flash_attention: true,
+    use_alibi: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_error_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__fused_attention_error_display.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 243
+expression: errors
+---
+[
+    "InvalidConfig(\"head_dim must be > 0\")",
+    "ShapeMismatch { expected: \"[1,8,64,64]\", actual: \"[1,8,64,32]\" }",
+    "SequenceTooLong { seq_len: 8192, max_seq_len: 4096 }",
+    "InvalidGqaRatio { num_heads: 8, num_kv_heads: 3 }",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__graph_node_kernel_with_params.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__graph_node_kernel_with_params.snap
@@ -1,0 +1,28 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 161
+expression: node
+---
+GraphNode {
+    id: NodeId(
+        1,
+    ),
+    kind: Kernel {
+        name: "rmsnorm_fwd",
+        grid: [
+            64,
+            1,
+            1,
+        ],
+        block: [
+            256,
+            1,
+            1,
+        ],
+    },
+    params: {
+        "eps": 1e-6,
+    },
+    stream: 0,
+    enabled: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__graph_node_memcopy.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__graph_node_memcopy.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 167
+expression: node
+---
+GraphNode {
+    id: NodeId(
+        2,
+    ),
+    kind: MemCopy {
+        bytes: 65536,
+    },
+    params: {},
+    stream: 1,
+    enabled: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__grid_group_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__grid_group_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 343
+expression: g
+---
+GridGroup {
+    block_size: 256,
+    num_blocks: 128,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_metrics_fresh.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_metrics_fresh.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 681
+expression: m
+---
+KernelMetrics {
+    kernel_name: "gemm_i2s",
+    dispatch_count: 0,
+    total_time: 0ns,
+    min_time: 18446744073709551615.999999999s,
+    max_time: 0ns,
+    total_flops: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_op_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_op_all_variants.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 716
+expression: ops
+---
+[
+    MatMul,
+    MatVec,
+    Softmax,
+    RmsNorm,
+    LayerNorm,
+    RoPE,
+    Attention,
+    SiLU,
+    GELU,
+    ReLU,
+    ElementwiseAdd,
+    ElementwiseMul,
+    Scale,
+    Embedding,
+    Dequantize,
+    KvCacheAppend,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_variant_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__kernel_variant_all_variants.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 728
+expression: variants
+---
+[
+    OpenClScalar,
+    OpenClTiled,
+    OpenClVectorized,
+    CpuSimd,
+    CpuScalar,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__layer_graph_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__layer_graph_config_default.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 180
+expression: cfg
+---
+LayerGraphConfig {
+    hidden_dim: 2048,
+    num_heads: 16,
+    seq_len: 128,
+    include_mlp: true,
+    include_attention: true,
+    attention_stream: 0,
+    mlp_stream: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__linear_config_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__linear_config_basic.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 555
+expression: cfg
+---
+LinearConfig {
+    in_features: 768,
+    out_features: 3072,
+    batch_size: 1,
+    has_bias: false,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__linear_config_with_bias.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__linear_config_with_bias.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 561
+expression: cfg
+---
+LinearConfig {
+    in_features: 2048,
+    out_features: 5504,
+    batch_size: 4,
+    has_bias: true,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__metric_counter_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__metric_counter_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 675
+expression: m
+---
+Metric {
+    name: "kernel_dispatches",
+    kind: Counter,
+    value: 42.0,
+    labels: {},
+    timestamp: SystemTime {
+        tv_sec: [FILTERED],
+        tv_nsec: [FILTERED],
+    },
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__metric_kind_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__metric_kind_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 664
+expression: kinds
+---
+[
+    Counter,
+    Gauge,
+    Histogram,
+    Timer,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__multi_stream_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__multi_stream_config_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 186
+expression: cfg
+---
+MultiStreamConfig {
+    num_streams: 2,
+    sync_barriers: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__node_kind_all_simple_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__node_kind_all_simple_variants.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 153
+expression: kinds
+---
+[
+    MemCopy {
+        bytes: 4096,
+    },
+    MemSet {
+        bytes: 1024,
+    },
+    HostCallback {
+        label: "sync_point",
+    },
+    Barrier,
+    Empty,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__node_kind_kernel.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__node_kind_kernel.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 141
+expression: kind
+---
+Kernel {
+    name: "gemm_i2s",
+    grid: [
+        128,
+        1,
+        1,
+    ],
+    block: [
+        256,
+        1,
+        1,
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__occupancy_calculator_sm80.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__occupancy_calculator_sm80.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 375
+expression: calc
+---
+OccupancyCalculator {
+    max_threads_per_sm: 2048,
+    max_blocks_per_sm: 32,
+    max_shared_mem_per_sm: 163840,
+    max_registers_per_sm: 65536,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__occupancy_limiter_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__occupancy_limiter_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 386
+expression: limiters
+---
+[
+    Threads,
+    Blocks,
+    SharedMemory,
+    Registers,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__ocl_cache_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__ocl_cache_config_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 774
+expression: cfg
+---
+CacheConfig {
+    max_entries: 256,
+    max_total_size: 268435456,
+    cache_dir: "[CACHE_DIR]",
+    ttl: None,
+    policy: MemoryOnly,
+    eviction_strategy: Lru,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__ocl_cache_stats_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__ocl_cache_stats_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 781
+expression: stats
+---
+CacheStats {
+    hits: 0,
+    misses: 0,
+    evictions: 0,
+    stores: 0,
+    total_binary_size: 0,
+    entry_count: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__optimize_stats_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__optimize_stats_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 192
+expression: stats
+---
+OptimizeStats {
+    nodes_removed: 0,
+    edges_removed: 0,
+    nodes_merged: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_config_two_stage_gpipe.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_config_two_stage_gpipe.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 436
+expression: cfg
+---
+PipelineConfig {
+    stages: [
+        PipelineStage {
+            start_layer: 0,
+            end_layer: 16,
+            thread_affinity: None,
+        },
+        PipelineStage {
+            start_layer: 16,
+            end_layer: 32,
+            thread_affinity: None,
+        },
+    ],
+    micro_batch_size: 4,
+    schedule: GPipe,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_schedule_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_schedule_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 420
+expression: variants
+---
+[
+    Sequential,
+    GPipe,
+    PipeDream,
+    Interleaved,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_stage_kind_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_stage_kind_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 58
+expression: variants
+---
+[
+    HostToDevice,
+    Compute,
+    DeviceToHost,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_stage_with_affinity.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pipeline_stage_with_affinity.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 426
+expression: stage
+---
+PipelineStage {
+    start_layer: 0,
+    end_layer: 8,
+    thread_affinity: Some(
+        2,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_config_default.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 537
+expression: cfg
+---
+PoolConfig {
+    pool_type: Max,
+    kernel_size: 1,
+    stride: 1,
+    padding: 0,
+    dilation: 1,
+    ceil_mode: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_config_max_pool_3x3.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_config_max_pool_3x3.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 543
+expression: cfg
+---
+PoolConfig {
+    pool_type: Max,
+    kernel_size: 3,
+    stride: 2,
+    padding: 1,
+    dilation: 1,
+    ceil_mode: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_type_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__pool_type_all_variants.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 531
+expression: types
+---
+[
+    Max,
+    Average,
+    GlobalMax,
+    GlobalAverage,
+    AvgPoolCountIncludePad,
+    Lp(
+        2.0,
+    ),
+    Adaptive,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__quant_bit_width_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__quant_bit_width_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 280
+expression: variants
+---
+[
+    Int2,
+    Int4,
+    Int8,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__scale_mode_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__scale_mode_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 287
+expression: variants
+---
+[
+    Uniform,
+    PerBlock,
+    PerChannel,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__schedule_strategy_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__schedule_strategy_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 80
+expression: variants
+---
+[
+    RoundRobin,
+    LeastLoaded,
+    PriorityBased,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__search_strategy_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__search_strategy_all_variants.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 634
+expression: variants
+---
+[
+    Exhaustive,
+    RandomSample(
+        100,
+    ),
+    SimulatedAnnealing {
+        initial_temp: 1.0,
+        cooling_rate: 0.95,
+        iterations: 500,
+    },
+    BayesianOpt {
+        evaluations: 50,
+    },
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sharding_strategy_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sharding_strategy_all_variants.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 471
+expression: variants
+---
+[
+    ColumnParallel,
+    RowParallel,
+    Custom {
+        splits: [
+            128,
+            256,
+            128,
+        ],
+    },
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_config_bsr_with_block_size.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_config_bsr_with_block_size.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 120
+expression: cfg
+---
+SparseConfig {
+    format: BSR,
+    block_size: 64,
+    threshold: 0.01,
+    rows: 2048,
+    cols: 2048,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_config_csr_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_config_csr_basic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 110
+expression: cfg
+---
+SparseConfig {
+    format: CSR,
+    block_size: 32,
+    threshold: 0.0,
+    rows: 1024,
+    cols: 512,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_format_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__sparse_format_all_variants.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 104
+expression: formats
+---
+[
+    CSR,
+    CSC,
+    COO,
+    BSR,
+    Block,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_config_default.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 23
+expression: cfg
+---
+StreamConfig {
+    num_streams: 4,
+    priority: Normal,
+    default_stream_behavior: PerThread,
+    enable_profiling: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_config_high_priority_profiling.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_config_high_priority_profiling.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 34
+expression: cfg
+---
+StreamConfig {
+    num_streams: 8,
+    priority: High,
+    default_stream_behavior: Legacy,
+    enable_profiling: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_op_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_op_basic.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 64
+expression: op
+---
+StreamOp {
+    label: "matmul_kernel",
+    cost: 1000,
+    depends_on: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_op_with_dependency.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_op_with_dependency.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 70
+expression: op
+---
+StreamOp {
+    label: "softmax_kernel",
+    cost: 500,
+    depends_on: Some(
+        42,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_priority_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_priority_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 41
+expression: variants
+---
+[
+    Low,
+    Normal,
+    High,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_scheduler_round_robin.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__stream_scheduler_round_robin.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 86
+expression: scheduler
+---
+StreamScheduler {
+    strategy: RoundRobin,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__support_level_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__support_level_all_variants.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 595
+expression: levels
+---
+[
+    Full(
+        0.95,
+    ),
+    Partial(
+        "requires fallback for large matrices",
+    ),
+    Emulated,
+    Unsupported,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__telemetry_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__telemetry_config_default.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 687
+expression: cfg
+---
+TelemetryConfig {
+    export_interval: 15s,
+    retention: 3600s,
+    enabled_kinds: [
+        Counter,
+        Gauge,
+        Histogram,
+        Timer,
+    ],
+    max_metrics: 10000,
+    prometheus_enabled: true,
+    metric_prefix: "bitnet_opencl",
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_config_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 461
+expression: cfg
+---
+TensorParallelConfig {
+    num_ranks: 4,
+    rank_id: 0,
+    comm_backend: InProcess,
+    overlap_compute_comm: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_error_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_error_variants.snap
@@ -1,0 +1,18 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 481
+expression: errors
+---
+[
+    InvalidConfig(
+        "num_ranks must be > 0",
+    ),
+    UnevenSharding {
+        tensor_len: 100,
+        num_shards: 3,
+    },
+    ShardIndexOutOfBounds {
+        index: 5,
+        total: 4,
+    },
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_metrics_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tensor_parallel_metrics_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 487
+expression: m
+---
+TensorParallelMetrics {
+    comm_time_ms: 0.0,
+    compute_time_ms: 0.0,
+    overlap_efficiency: 0.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__thread_block_group_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__thread_block_group_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 337
+expression: g
+---
+ThreadBlockGroup {
+    num_threads: 256,
+    block_idx: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tiling_strategy_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tiling_strategy_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 511
+expression: ts
+---
+TilingStrategy {
+    block_m: 64,
+    block_n: 128,
+    block_k: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_benchmark_result_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_benchmark_result_debug.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 645
+expression: r
+---
+BenchmarkResult {
+    params: ParamSet(
+        [
+            (
+                "wg_size",
+                256,
+            ),
+            (
+                "tile_m",
+                16,
+            ),
+        ],
+    ),
+    elapsed_us: 42.5,
+    gflops: 120.0,
+    bandwidth_gb_s: 800.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_cache_key_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_cache_key_debug.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 651
+expression: key
+---
+TuningCacheKey {
+    kernel_name: "gemm_f32",
+    device_name: "Intel Arc A770",
+    shape: [
+        1024,
+        1024,
+        1024,
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_param_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__tuning_param_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 619
+expression: p
+---
+TuningParam {
+    name: "workgroup_size",
+    min: 32,
+    max: 512,
+    step: 32,
+    current: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__warp_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave22__warp_config_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave22.rs
+assertion_line: 361
+expression: cfg
+---
+WarpConfig {
+    warp_size: 32,
+    active_mask: 4294967295,
+}


### PR DESCRIPTION
## Summary

Add **77 snapshot tests** across 19 sections covering previously untested kernel configuration structs for regression detection.

### What's covered

**CUDA modules** (9 newly exported from `cuda/mod.rs`):
- `stream_mgmt`: StreamConfig, StreamPriority, StreamOp, ScheduleStrategy, StreamScheduler
- `sparse`: SparseFormat, SparseConfig, ElementwiseSpOp
- `graph_exec`: NodeKind, GraphNode, LayerGraphConfig, CaptureState, MultiStreamConfig, OptimizeStats
- `fused_attention`: FusedAttentionConfig, AttentionPattern, FusedAttentionError, AttentionMetrics
- `dequant`: DequantConfig, DequantPrecision, QuantBitWidth, ScaleMode
- `loss`: LossConfig, LossReduction
- `cooperative_groups`: CooperativeGroupConfig, ThreadBlockGroup, GridGroup, CoalescedGroup
- `warp_ops`: WarpConfig
- `profiling`: OccupancyCalculator, OccupancyLimiter, Bottleneck, BottleneckAnalyzer

**CPU modules** (2 newly exported from `cpu/mod.rs`):
- `tensor_parallel`: TensorParallelConfig, CommBackend, ShardingStrategy, TensorParallelError, TensorParallelMetrics
- `cache_matmul`: CacheConfig, TilingStrategy

**Cross-cutting modules**:
- `capability_matrix`: DeviceClass, SupportLevel, CapabilityEntry
- `opencl_autotuner`: TuningParam, SearchStrategy, ParamSet, BenchmarkResult, TuningCacheKey
- `opencl_telemetry`: MetricKind, Metric, KernelMetrics, TelemetryConfig
- `opencl_registry`: KernelOp, KernelVariant, DeviceConstraints
- `opencl_cache`: CachePolicy, CacheEvictionStrategy, CacheConfig, CacheStats
- CPU pooling: PoolType, PoolConfig
- CPU linear: LinearConfig

### Changes
- `crates/bitnet-kernels/tests/snapshot_wave22.rs` — 77 snapshot tests
- `crates/bitnet-kernels/tests/snapshots/snapshot_wave22__*.snap` — 77 accepted snapshot files
- `crates/bitnet-kernels/src/cuda/mod.rs` — Export 9 previously-private CUDA modules
- `crates/bitnet-kernels/src/cpu/mod.rs` — Export `cache_matmul` and `tensor_parallel` modules
- `crates/bitnet-kernels/Cargo.toml` — Register `snapshot_wave22` test target

### Verification
```
cargo test -p bitnet-kernels --test snapshot_wave22 --no-default-features --features cpu
# test result: ok. 77 passed; 0 failed; 0 ignored
```
