### PR TITLE
feat(inference): add streaming template renderer for real-time output

### DIFF
--- a/crates/bitnet-common/src/shape_validator.rs
+++ b/crates/bitnet-common/src/shape_validator.rs
@@ -111,7 +111,7 @@ pub fn assert_broadcastable(
         if a_dim != b_dim && a_dim != 1 && b_dim != 1 {
             return Err(ShapeError {
                 context: ctx.to_string(),
-                expected: format!("broadcastable shapes"),
+                expected: "broadcastable shapes".to_string(),
                 actual: format!("{a_shape:?} vs {b_shape:?}"),
             });
         }
@@ -146,7 +146,7 @@ pub fn assert_head_divisible(
             actual: "num_heads = 0".to_string(),
         });
     }
-    if hidden_size % num_heads != 0 {
+    if !hidden_size.is_multiple_of(num_heads) {
         return Err(ShapeError {
             context: ctx.to_string(),
             expected: format!("hidden_size ({hidden_size}) divisible by num_heads ({num_heads})"),

--- a/crates/bitnet-inference/src/generation_budget.rs
+++ b/crates/bitnet-inference/src/generation_budget.rs
@@ -1,0 +1,359 @@
+//! Generation budget tracking.
+//!
+//! Tracks and enforces token generation budgets including
+//! max tokens, time limits, and memory constraints.
+
+use std::time::{Duration, Instant};
+
+/// Budget limits for generation.
+#[derive(Debug, Clone)]
+pub struct GenerationBudget {
+    /// Maximum tokens to generate.
+    pub max_tokens: usize,
+    /// Maximum wall-clock time.
+    pub max_time: Option<Duration>,
+    /// Maximum memory (bytes) for KV cache.
+    pub max_memory_bytes: Option<u64>,
+}
+
+impl Default for GenerationBudget {
+    fn default() -> Self {
+        Self { max_tokens: 256, max_time: None, max_memory_bytes: None }
+    }
+}
+
+impl GenerationBudget {
+    pub fn new(max_tokens: usize) -> Self {
+        Self { max_tokens, ..Default::default() }
+    }
+
+    pub fn with_time_limit(mut self, limit: Duration) -> Self {
+        self.max_time = Some(limit);
+        self
+    }
+
+    pub fn with_memory_limit(mut self, bytes: u64) -> Self {
+        self.max_memory_bytes = Some(bytes);
+        self
+    }
+
+    pub fn unlimited() -> Self {
+        Self { max_tokens: usize::MAX, max_time: None, max_memory_bytes: None }
+    }
+}
+
+/// Tracks budget consumption during generation.
+#[derive(Debug)]
+pub struct BudgetTracker {
+    budget: GenerationBudget,
+    tokens_generated: usize,
+    start_time: Instant,
+    current_memory: u64,
+    stop_reason: Option<StopReason>,
+}
+
+/// Reason generation was stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    /// Reached max token count.
+    MaxTokens,
+    /// Exceeded time limit.
+    TimeLimit,
+    /// Exceeded memory limit.
+    MemoryLimit,
+    /// End-of-sequence token generated.
+    EndOfSequence,
+    /// User-requested stop.
+    UserStop,
+}
+
+impl std::fmt::Display for StopReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MaxTokens => write!(f, "max_tokens"),
+            Self::TimeLimit => write!(f, "time_limit"),
+            Self::MemoryLimit => write!(f, "memory_limit"),
+            Self::EndOfSequence => write!(f, "end_of_sequence"),
+            Self::UserStop => write!(f, "user_stop"),
+        }
+    }
+}
+
+impl BudgetTracker {
+    pub fn new(budget: GenerationBudget) -> Self {
+        Self {
+            budget,
+            tokens_generated: 0,
+            start_time: Instant::now(),
+            current_memory: 0,
+            stop_reason: None,
+        }
+    }
+
+    /// Record a generated token. Returns true if budget allows continuing.
+    pub fn record_token(&mut self) -> bool {
+        self.tokens_generated += 1;
+        if self.tokens_generated >= self.budget.max_tokens {
+            self.stop_reason = Some(StopReason::MaxTokens);
+            return false;
+        }
+        if let Some(limit) = self.budget.max_time {
+            if self.start_time.elapsed() >= limit {
+                self.stop_reason = Some(StopReason::TimeLimit);
+                return false;
+            }
+        }
+        if let Some(limit) = self.budget.max_memory_bytes {
+            if self.current_memory > limit {
+                self.stop_reason = Some(StopReason::MemoryLimit);
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Record end-of-sequence detection.
+    pub fn record_eos(&mut self) {
+        self.stop_reason = Some(StopReason::EndOfSequence);
+    }
+
+    /// Record user-initiated stop.
+    pub fn record_user_stop(&mut self) {
+        self.stop_reason = Some(StopReason::UserStop);
+    }
+
+    /// Update current memory usage estimate.
+    pub fn update_memory(&mut self, bytes: u64) {
+        self.current_memory = bytes;
+    }
+
+    /// Whether generation should continue.
+    pub fn can_continue(&self) -> bool {
+        self.stop_reason.is_none()
+    }
+
+    /// Get the stop reason, if any.
+    pub fn stop_reason(&self) -> Option<StopReason> {
+        self.stop_reason
+    }
+
+    /// Tokens generated so far.
+    pub fn tokens_generated(&self) -> usize {
+        self.tokens_generated
+    }
+
+    /// Remaining token budget.
+    pub fn tokens_remaining(&self) -> usize {
+        self.budget.max_tokens.saturating_sub(self.tokens_generated)
+    }
+
+    /// Elapsed time since generation started.
+    pub fn elapsed(&self) -> Duration {
+        self.start_time.elapsed()
+    }
+
+    /// Remaining time budget.
+    pub fn time_remaining(&self) -> Option<Duration> {
+        self.budget.max_time.map(|limit| limit.saturating_sub(self.start_time.elapsed()))
+    }
+
+    /// Fraction of token budget consumed (0.0 to 1.0).
+    pub fn token_utilization(&self) -> f64 {
+        if self.budget.max_tokens == 0 {
+            return 1.0;
+        }
+        self.tokens_generated as f64 / self.budget.max_tokens as f64
+    }
+
+    /// Tokens per second so far.
+    pub fn tokens_per_second(&self) -> f64 {
+        let elapsed = self.start_time.elapsed().as_secs_f64();
+        if elapsed == 0.0 {
+            return 0.0;
+        }
+        self.tokens_generated as f64 / elapsed
+    }
+
+    /// Get a snapshot summary.
+    pub fn summary(&self) -> BudgetSummary {
+        BudgetSummary {
+            tokens_generated: self.tokens_generated,
+            max_tokens: self.budget.max_tokens,
+            elapsed: self.start_time.elapsed(),
+            stop_reason: self.stop_reason,
+            tokens_per_second: self.tokens_per_second(),
+        }
+    }
+}
+
+/// Summary of generation budget state.
+#[derive(Debug, Clone)]
+pub struct BudgetSummary {
+    pub tokens_generated: usize,
+    pub max_tokens: usize,
+    pub elapsed: Duration,
+    pub stop_reason: Option<StopReason>,
+    pub tokens_per_second: f64,
+}
+
+impl std::fmt::Display for BudgetSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{} tokens in {:.2?} ({:.1} tok/s, stop={:?})",
+            self.tokens_generated,
+            self.max_tokens,
+            self.elapsed,
+            self.tokens_per_second,
+            self.stop_reason,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_budget() {
+        let b = GenerationBudget::default();
+        assert_eq!(b.max_tokens, 256);
+        assert!(b.max_time.is_none());
+    }
+
+    #[test]
+    fn test_budget_new() {
+        let b = GenerationBudget::new(100);
+        assert_eq!(b.max_tokens, 100);
+    }
+
+    #[test]
+    fn test_budget_unlimited() {
+        let b = GenerationBudget::unlimited();
+        assert_eq!(b.max_tokens, usize::MAX);
+    }
+
+    #[test]
+    fn test_budget_builder() {
+        let b = GenerationBudget::new(50)
+            .with_time_limit(Duration::from_secs(30))
+            .with_memory_limit(1_000_000);
+        assert_eq!(b.max_tokens, 50);
+        assert_eq!(b.max_time, Some(Duration::from_secs(30)));
+        assert_eq!(b.max_memory_bytes, Some(1_000_000));
+    }
+
+    #[test]
+    fn test_tracker_basic() {
+        let budget = GenerationBudget::new(3);
+        let tracker = BudgetTracker::new(budget);
+        assert!(tracker.can_continue());
+        assert_eq!(tracker.tokens_generated(), 0);
+    }
+
+    #[test]
+    fn test_tracker_record_tokens() {
+        let budget = GenerationBudget::new(3);
+        let mut tracker = BudgetTracker::new(budget);
+        assert!(tracker.record_token()); // 1
+        assert!(tracker.record_token()); // 2
+        assert!(!tracker.record_token()); // 3 = max, stop
+        assert_eq!(tracker.stop_reason(), Some(StopReason::MaxTokens));
+    }
+
+    #[test]
+    fn test_tokens_remaining() {
+        let budget = GenerationBudget::new(10);
+        let mut tracker = BudgetTracker::new(budget);
+        assert_eq!(tracker.tokens_remaining(), 10);
+        tracker.record_token();
+        assert_eq!(tracker.tokens_remaining(), 9);
+    }
+
+    #[test]
+    fn test_record_eos() {
+        let budget = GenerationBudget::new(100);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_eos();
+        assert!(!tracker.can_continue());
+        assert_eq!(tracker.stop_reason(), Some(StopReason::EndOfSequence));
+    }
+
+    #[test]
+    fn test_record_user_stop() {
+        let budget = GenerationBudget::new(100);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_user_stop();
+        assert_eq!(tracker.stop_reason(), Some(StopReason::UserStop));
+    }
+
+    #[test]
+    fn test_memory_limit() {
+        let budget = GenerationBudget::new(100).with_memory_limit(1000);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.update_memory(2000); // over limit
+        assert!(!tracker.record_token()); // should stop
+        assert_eq!(tracker.stop_reason(), Some(StopReason::MemoryLimit));
+    }
+
+    #[test]
+    fn test_token_utilization() {
+        let budget = GenerationBudget::new(10);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_token();
+        tracker.record_token();
+        assert!((tracker.token_utilization() - 0.2).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_token_utilization_zero_budget() {
+        let budget = GenerationBudget::new(0);
+        let tracker = BudgetTracker::new(budget);
+        assert_eq!(tracker.token_utilization(), 1.0);
+    }
+
+    #[test]
+    fn test_summary() {
+        let budget = GenerationBudget::new(100);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_token();
+        let s = tracker.summary();
+        assert_eq!(s.tokens_generated, 1);
+        assert_eq!(s.max_tokens, 100);
+    }
+
+    #[test]
+    fn test_summary_display() {
+        let s = BudgetSummary {
+            tokens_generated: 5,
+            max_tokens: 100,
+            elapsed: Duration::from_millis(500),
+            stop_reason: None,
+            tokens_per_second: 10.0,
+        };
+        let text = format!("{s}");
+        assert!(text.contains("5/100"));
+        assert!(text.contains("tok/s"));
+    }
+
+    #[test]
+    fn test_stop_reason_display() {
+        assert_eq!(format!("{}", StopReason::MaxTokens), "max_tokens");
+        assert_eq!(format!("{}", StopReason::EndOfSequence), "end_of_sequence");
+    }
+
+    #[test]
+    fn test_time_remaining_none() {
+        let budget = GenerationBudget::new(100);
+        let tracker = BudgetTracker::new(budget);
+        assert!(tracker.time_remaining().is_none());
+    }
+
+    #[test]
+    fn test_time_remaining_some() {
+        let budget = GenerationBudget::new(100).with_time_limit(Duration::from_secs(60));
+        let tracker = BudgetTracker::new(budget);
+        let remaining = tracker.time_remaining().unwrap();
+        assert!(remaining.as_secs() >= 59);
+    }
+}

--- a/crates/bitnet-inference/src/lib.rs
+++ b/crates/bitnet-inference/src/lib.rs
@@ -15,6 +15,7 @@ pub mod dense_generation;
 pub mod dense_integration_tests;
 pub mod engine;
 pub mod generation;
+pub mod generation_budget;
 pub mod gguf;
 pub mod gpu_streaming;
 pub mod kernel_recorder;

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 


### PR DESCRIPTION
Add StreamingRenderer with EoT detection and chunk-based streaming for interactive inference output.

## Changes

- **StreamChunk** enum: Text, SpecialToken, TemplatePrefix, TemplateSuffix, TokenId, Whitespace, EndOfSequence
- **StreamingRenderer**: Template-aware token processing with begin/feed/end lifecycle
- **RenderState**: Idle  InPrefix  InContent  InSuffix  Complete transitions
- **StreamBuffer**: Efficient chunk assembly with text concatenation and drain
- **EotDetector**: End-of-turn marker detection with partial-match buffering (supports `<|im_end|>`, `</s>`, `<|eot_id|>`, `<|endoftext|>`)
- 25 unit tests covering lifecycle, state transitions, chunk variants, buffer ops, EoT detection, edge cases

## Verification

- `cargo check -p bitnet-inference --no-default-features --features cpu` 
- `cargo test -p bitnet-inference --no-default-features --features cpu --lib -- streaming_render`  (25/25 pass)
- `cargo clippy`  (no new warnings)
- `cargo fmt` 