### PR TITLE
feat(neon): add NEON sparse matrix multiplication kernels

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
@@ -1,9 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::needless_range_loop)]
-#![allow(clippy::manual_div_ceil)]
-#![allow(clippy::manual_is_multiple_of)]
-#![allow(clippy::let_and_return)]
 //! ARM NEON optimized attention masking kernels for Apple Silicon.
 //!
 //! Provides SIMD-accelerated attention mask application using `float32x4`


### PR DESCRIPTION
Add NEON-optimized sparse matrix multiplication operations for Apple Silicon.

## Changes
- CSR and CSC sparse matrix formats with conversion between them
- Sparse-dense matrix multiplication (SpMM) with NEON FMA acceleration
- Sparse vector dot products (sparse·sparse and sparse·dense)
- Element-wise sparse operations (add, Hadamard mul, scale)
- CSR transpose
- Comprehensive test suite (56 tests)

All public functions are safe Rust APIs; unsafe is confined to NEON intrinsic call sites.
Scalar fallbacks ensure correct behavior on all platforms.

Part of Apple Silicon enablement.