### PR TITLE
test(metal): add Metal FFN shader tests

### DIFF
--- a/crates/bitnet-kernels/tests/metal_ffn_shader_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_ffn_shader_tests.rs
@@ -848,4 +848,635 @@ mod tests {
         assert!(gelu(-3.0).abs() < 0.02);
         assert!(gelu(1.0) > gelu(-1.0));
     }
+
+    // ── 13. SwiGLU deep coverage ────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_zero_gate_produces_zero() {
+        // SwiGLU(x, 0) = silu(0) * x = 0 * x = 0
+        for &x in &[-5.0_f32, -1.0, 0.0, 1.0, 5.0, 100.0] {
+            let result = swiglu(x, 0.0);
+            assert!(result.abs() < 1e-7, "SwiGLU({x}, 0) should be 0, got {result}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_zero_input_produces_zero() {
+        // SwiGLU(0, gate) = silu(gate) * 0 = 0
+        for &g in &[-5.0_f32, -1.0, 0.0, 1.0, 5.0] {
+            let result = swiglu(0.0, g);
+            assert!(result.abs() < 1e-7, "SwiGLU(0, {g}) should be 0, got {result}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_large_positive_gate_approximates_identity() {
+        // For large gate, silu(gate) ≈ gate, so SwiGLU(x, gate) ≈ gate * x
+        let gate = 20.0_f32;
+        let x = 1.5;
+        let result = swiglu(x, gate);
+        let approx = gate * x;
+        assert!(
+            (result - approx).abs() / approx.abs() < 0.01,
+            "SwiGLU({x}, {gate}) = {result}, expected ≈ {approx}",
+        );
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_negative_gate_suppresses_output() {
+        // For large negative gate, silu(gate) ≈ 0
+        let gate = -20.0_f32;
+        let x = 100.0;
+        let result = swiglu(x, gate);
+        assert!(result.abs() < 0.01, "SwiGLU({x}, {gate}) should ≈ 0, got {result}");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_symmetry_properties() {
+        // SwiGLU is NOT symmetric: SwiGLU(x, g) ≠ SwiGLU(g, x) in general
+        let x = 2.0_f32;
+        let g = 3.0_f32;
+        let a = swiglu(x, g);
+        let b = swiglu(g, x);
+        assert!((a - b).abs() > 1e-6, "SwiGLU should not be symmetric in general");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_swiglu_vectorized_batch() {
+        // Simulate vectorized SwiGLU over a batch of 256 elements (Metal SIMD width multiple)
+        let n = 256;
+        let ups = make_vec(n, 200);
+        let gates = make_vec(n, 201);
+        let results: Vec<f32> = ups.iter().zip(gates.iter()).map(|(&u, &g)| swiglu(u, g)).collect();
+        assert_eq!(results.len(), n);
+        // All results must be finite
+        assert!(results.iter().all(|v| v.is_finite()));
+    }
+
+    // ── 14. Gate projection tests ───────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_gate_projection_identity_weights() {
+        // Identity-like gate weight: output should approximate input (for square dims)
+        let dim = 32;
+        let input = make_vec(dim, 300);
+        let mut w_gate = vec![0.0_f32; dim * dim];
+        for i in 0..dim {
+            w_gate[i * dim + i] = 1.0;
+        }
+        let gate_out = matmul(&input, &w_gate, 1, dim, dim);
+        for i in 0..dim {
+            assert!((gate_out[i] - input[i]).abs() < 1e-5, "identity gate mismatch at {i}",);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_gate_projection_output_range() {
+        let hidden = 64;
+        let inter = 256;
+        let input = make_vec(hidden, 301);
+        let w_gate = make_vec(inter * hidden, 302);
+        let gate_out = matmul(&input, &w_gate, 1, hidden, inter);
+        assert_eq!(gate_out.len(), inter);
+        assert!(gate_out.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_gate_projection_scaling_with_dimension() {
+        // Larger hidden dims produce larger dot-product magnitudes
+        let dims = [32, 64, 128, 256];
+        let mut max_magnitudes = Vec::new();
+        for &hidden in &dims {
+            let inter = hidden * 4;
+            let input = make_vec(hidden, 303);
+            let w_gate = make_vec(inter * hidden, 304);
+            let gate_out = matmul(&input, &w_gate, 1, hidden, inter);
+            let max_mag = gate_out.iter().map(|v| v.abs()).fold(0.0_f32, f32::max);
+            max_magnitudes.push(max_mag);
+        }
+        // Magnitude generally grows with dimension
+        assert!(max_magnitudes.last().unwrap() > max_magnitudes.first().unwrap());
+    }
+
+    // ── 15. Up projection tests ─────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_up_projection_zero_input_produces_zero() {
+        let hidden = 64;
+        let inter = 256;
+        let input = vec![0.0_f32; hidden];
+        let w_up = make_vec(inter * hidden, 400);
+        let up_out = matmul(&input, &w_up, 1, hidden, inter);
+        assert!(up_out.iter().all(|&v| v.abs() < 1e-7));
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_up_projection_nonstandard_ratios() {
+        // Test non-standard hidden:intermediate ratios (not 1:4)
+        let test_cases: &[(usize, usize)] = &[
+            (64, 171),   // ~2.67× (LLaMA-like 8/3×)
+            (128, 342),  // ~2.67×
+            (256, 683),  // ~2.67×
+            (512, 1365), // ~2.67×
+        ];
+        for &(hidden, inter) in test_cases {
+            let input = make_vec(hidden, 401);
+            let w_up = make_vec(inter * hidden, 402);
+            let up_out = matmul(&input, &w_up, 1, hidden, inter);
+            assert_eq!(up_out.len(), inter);
+            assert!(up_out.iter().all(|v| v.is_finite()));
+        }
+    }
+
+    // ── 16. Down projection extended ────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_down_projection_with_activated_input() {
+        let hidden = 64;
+        let inter = 256;
+        let raw = make_vec(inter, 500);
+        let activated: Vec<f32> = raw.iter().map(|&v| silu(v)).collect();
+        let w_down = make_vec(hidden * inter, 501);
+        let output = matmul(&activated, &w_down, 1, inter, hidden);
+        assert_eq!(output.len(), hidden);
+        assert!(output.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_down_projection_preserves_batch_dim() {
+        let batch = 8;
+        let hidden = 32;
+        let inter = 128;
+        let activated = make_vec(batch * inter, 502);
+        let w_down = make_vec(hidden * inter, 503);
+        let output = matmul(&activated, &w_down, batch, inter, hidden);
+        assert_eq!(output.len(), batch * hidden);
+    }
+
+    // ── 17. Hidden dimension scaling ────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_hidden_dim_power_of_two_alignment() {
+        let pow2_dims = [64, 128, 256, 512, 1024, 2048, 4096, 8192];
+        for &dim in &pow2_dims {
+            assert_eq!(dim % SIMD_GROUP_SIZE as usize, 0, "dim={dim} not SIMD-aligned");
+            let tg = optimal_threadgroup_1d(dim);
+            assert!(tg >= SIMD_GROUP_SIZE);
+            assert_eq!(tg % SIMD_GROUP_SIZE, 0);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_hidden_dim_non_power_of_two() {
+        // BitNet and LLaMA use non-power-of-2 intermediate dims
+        let non_pow2_dims = [768, 1536, 3072, 5632, 11008, 13824];
+        for &dim in &non_pow2_dims {
+            let bytes = aligned_matrix_bytes(1, dim);
+            assert_eq!(bytes % UNIFORM_BUFFER_ALIGNMENT, 0);
+            let tg = optimal_threadgroup_1d(dim);
+            let count = threadgroup_count(dim, tg);
+            assert!((count as usize) * (tg as usize) >= dim);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_hidden_dim_bitnet_2b_config() {
+        // BitNet 2B: hidden=2048, intermediate=5632
+        let cfg = FfnConfig {
+            hidden_dim: 2048,
+            intermediate_dim: 5632,
+            activation: FfnActivation::SwiGLU,
+            ..Default::default()
+        };
+        let weight_bytes = ffn_weight_bytes(&cfg);
+        let act_bytes = ffn_activation_buffer_bytes(&cfg);
+        assert!(weight_bytes > 0);
+        assert!(act_bytes > 0);
+        assert_eq!(weight_bytes % UNIFORM_BUFFER_ALIGNMENT, 0);
+        assert_eq!(act_bytes % UNIFORM_BUFFER_ALIGNMENT, 0);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_hidden_dim_scaling_intermediate_ratio() {
+        // Verify common hidden:intermediate ratios
+        let configs: &[(usize, usize, &str)] = &[
+            (768, 3072, "GPT-2 4×"),
+            (1024, 4096, "Generic 4×"),
+            (2048, 5632, "BitNet-2B ~2.75×"),
+            (4096, 11008, "LLaMA-7B ~2.69×"),
+        ];
+        for &(hidden, inter, label) in configs {
+            let ratio = inter as f64 / hidden as f64;
+            assert!(ratio > 2.0 && ratio <= 4.5, "{label}: unexpected ratio {ratio:.2}");
+            let cfg =
+                FfnConfig { hidden_dim: hidden, intermediate_dim: inter, ..Default::default() };
+            assert!(ffn_weight_bytes(&cfg) > 0);
+        }
+    }
+
+    // ── 18. Batch FFN extended ──────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_batch_ffn_single_vs_batch_equivalence_swiglu() {
+        let hidden = 16;
+        let inter = 64;
+        let w_gate = make_vec(inter * hidden, 600);
+        let w_up = make_vec(inter * hidden, 601);
+        let w_down = make_vec(hidden * inter, 602);
+
+        let run_single = |input: &[f32]| -> Vec<f32> {
+            let gate_proj = matmul(input, &w_gate, 1, hidden, inter);
+            let up_proj = matmul(input, &w_up, 1, hidden, inter);
+            let gated: Vec<f32> =
+                gate_proj.iter().zip(up_proj.iter()).map(|(&g, &u)| swiglu(u, g)).collect();
+            matmul(&gated, &w_down, 1, inter, hidden)
+        };
+
+        let batch = 4;
+        let mut batch_input = Vec::new();
+        let mut expected = Vec::new();
+        for b in 0..batch {
+            let tok = make_vec(hidden, 603 + b as u64);
+            expected.extend(run_single(&tok));
+            batch_input.extend(tok);
+        }
+
+        // Run as batch
+        let gate_batch = matmul(&batch_input, &w_gate, batch, hidden, inter);
+        let up_batch = matmul(&batch_input, &w_up, batch, hidden, inter);
+        let gated_batch: Vec<f32> =
+            gate_batch.iter().zip(up_batch.iter()).map(|(&g, &u)| swiglu(u, g)).collect();
+        let output_batch = matmul(&gated_batch, &w_down, batch, inter, hidden);
+
+        for i in 0..batch * hidden {
+            assert!((output_batch[i] - expected[i]).abs() < 1e-4, "batch SwiGLU mismatch at {i}",);
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_batch_ffn_large_batch_buffer_sizing() {
+        for &batch in &[64, 128, 256, 512] {
+            let cfg = FfnConfig {
+                hidden_dim: 2048,
+                intermediate_dim: 5632,
+                activation: FfnActivation::SwiGLU,
+                batch_size: batch,
+                ..Default::default()
+            };
+            let act = ffn_activation_buffer_bytes(&cfg);
+            let min_bytes = 2 * batch * 5632 * 4; // gate + up, f32
+            assert!(act >= min_bytes, "batch={batch}: act={act} < min={min_bytes}");
+        }
+    }
+
+    // ── 19. Numerical precision ─────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_silu_near_zero() {
+        // SiLU near zero: silu(x) ≈ x/2 for small x
+        let small_values = [1e-3_f32, 1e-5, 1e-7, -1e-3, -1e-5, -1e-7];
+        for &x in &small_values {
+            let result = silu(x);
+            let approx = x / 2.0;
+            assert!(
+                (result - approx).abs() < x.abs() * 0.1,
+                "silu({x}) = {result}, expected ≈ {approx}",
+            );
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_swiglu_subnormals() {
+        // Subnormal float inputs should not produce NaN
+        let subnormal = f32::MIN_POSITIVE / 2.0;
+        let result = swiglu(subnormal, subnormal);
+        assert!(result.is_finite(), "SwiGLU with subnormals produced non-finite: {result}");
+        assert!(!result.is_nan(), "SwiGLU with subnormals produced NaN");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_accumulation_order() {
+        // Kahan-style test: sum small + large values, check error
+        let hidden = 128;
+        let inter = 512;
+        // Use values that stress accumulation: alternating large/small
+        let input: Vec<f32> = (0..hidden).map(|i| if i % 2 == 0 { 1e4 } else { 1e-4 }).collect();
+        let w = make_vec(inter * hidden, 700);
+        let result = matmul(&input, &w, 1, hidden, inter);
+        assert!(result.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_relu_exact_zero_boundary() {
+        // ReLU at exact boundaries
+        assert_eq!(relu(0.0), 0.0);
+        assert_eq!(relu(-0.0), 0.0); // negative zero
+        assert_eq!(relu(f32::MIN_POSITIVE), f32::MIN_POSITIVE);
+        assert_eq!(relu(-f32::MIN_POSITIVE), 0.0);
+        assert_eq!(relu(f32::EPSILON), f32::EPSILON);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_gelu_tanh_approximation() {
+        // GELU tanh approximation should be close to exact erfc-based GELU
+        let test_points = [-3.0_f32, -1.0, -0.5, 0.0, 0.5, 1.0, 3.0];
+        for &x in &test_points {
+            let result = gelu(x);
+            assert!(result.is_finite(), "GELU({x}) is not finite");
+            // GELU(x) ≈ x * Φ(x), should be bounded by |x|
+            assert!(result.abs() <= x.abs() + 0.2, "GELU({x}) = {result} out of expected range");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_numerical_precision_large_intermediate_values() {
+        // Large values after up-projection should not overflow in activation
+        let large_vals = [100.0_f32, 500.0, 1000.0, -100.0, -500.0];
+        for &v in &large_vals {
+            assert!(silu(v).is_finite(), "silu({v}) overflow");
+            assert!(gelu(v).is_finite(), "gelu({v}) overflow");
+            assert!(relu(v).is_finite(), "relu({v}) overflow");
+        }
+    }
+
+    // ── 20. Edge cases ──────────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_zero_weight_matrix() {
+        let hidden = 32;
+        let inter = 128;
+        let input = make_vec(hidden, 800);
+        let w_zero = vec![0.0_f32; inter * hidden];
+        let output = matmul(&input, &w_zero, 1, hidden, inter);
+        assert!(output.iter().all(|&v| v.abs() < 1e-7), "zero weights should produce zero output");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_single_element_dimension() {
+        let hidden = 1;
+        let inter = 4;
+        let input = vec![2.0_f32];
+        let w_up = make_vec(inter * hidden, 801);
+        let w_down = make_vec(hidden * inter, 802);
+
+        let mut up = matmul(&input, &w_up, 1, hidden, inter);
+        apply_activation(&mut up, FfnActivation::ReLU);
+        let output = matmul(&up, &w_down, 1, inter, hidden);
+        assert_eq!(output.len(), 1);
+        assert!(output[0].is_finite());
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_all_negative_input_relu() {
+        let n = 256;
+        let input: Vec<f32> = (0..n).map(|i| -(i as f32 + 1.0)).collect();
+        let mut activated = input;
+        apply_activation(&mut activated, FfnActivation::ReLU);
+        assert!(activated.iter().all(|&v| v == 0.0), "all-negative input should produce all zeros");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_nan_propagation() {
+        // NaN in input should propagate (not silently become zero)
+        let result = silu(f32::NAN);
+        assert!(result.is_nan(), "silu(NaN) should be NaN");
+        let result = swiglu(1.0, f32::NAN);
+        assert!(result.is_nan(), "swiglu(1, NaN) should be NaN");
+        let result = swiglu(f32::NAN, 1.0);
+        assert!(result.is_nan(), "swiglu(NaN, 1) should be NaN");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_infinity_handling() {
+        assert_eq!(relu(f32::INFINITY), f32::INFINITY);
+        assert_eq!(relu(f32::NEG_INFINITY), 0.0);
+        // silu(inf) = inf (since sigmoid(inf) = 1)
+        assert!(silu(f32::INFINITY).is_infinite() && silu(f32::INFINITY) > 0.0);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_edge_case_minimum_ffn_config() {
+        let cfg = FfnConfig {
+            hidden_dim: 1,
+            intermediate_dim: 1,
+            activation: FfnActivation::ReLU,
+            batch_size: 1,
+            ..Default::default()
+        };
+        let bytes = ffn_weight_bytes(&cfg);
+        assert!(bytes > 0, "minimum config should still allocate buffers");
+        let act = ffn_activation_buffer_bytes(&cfg);
+        assert!(act > 0);
+    }
+
+    // ── 21. Fused operations ────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_fused_gate_up_swiglu_correctness() {
+        // Fused gate+up followed by SwiGLU should match separate path
+        let hidden = 32;
+        let inter = 128;
+        let input = make_vec(hidden, 900);
+
+        // Separate path
+        let w_gate = make_vec(inter * hidden, 901);
+        let w_up = make_vec(inter * hidden, 902);
+        let gate_sep = matmul(&input, &w_gate, 1, hidden, inter);
+        let up_sep = matmul(&input, &w_up, 1, hidden, inter);
+        let separate: Vec<f32> =
+            gate_sep.iter().zip(up_sep.iter()).map(|(&g, &u)| swiglu(u, g)).collect();
+
+        // Fused path: concat weights into [2*inter, hidden]
+        let mut w_fused = w_gate.clone();
+        w_fused.extend_from_slice(&w_up);
+        let fused_out = matmul(&input, &w_fused, 1, hidden, 2 * inter);
+        let fused: Vec<f32> = fused_out[..inter]
+            .iter()
+            .zip(fused_out[inter..].iter())
+            .map(|(&g, &u)| swiglu(u, g))
+            .collect();
+
+        for i in 0..inter {
+            assert!((fused[i] - separate[i]).abs() < 1e-4, "fused SwiGLU mismatch at {i}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_fused_residual_add() {
+        // Fused residual: output = input + FFN(input)
+        let hidden = 64;
+        let inter = 256;
+        let input = make_vec(hidden, 910);
+        let w_up = make_vec(inter * hidden, 911);
+        let w_down = make_vec(hidden * inter, 912);
+
+        let mut up = matmul(&input, &w_up, 1, hidden, inter);
+        apply_activation(&mut up, FfnActivation::SiLU);
+        let ffn_out = matmul(&up, &w_down, 1, inter, hidden);
+
+        let fused: Vec<f32> = input.iter().zip(ffn_out.iter()).map(|(a, b)| a + b).collect();
+        for i in 0..hidden {
+            let expected = input[i] + ffn_out[i];
+            assert!((fused[i] - expected).abs() < 1e-6, "fused residual mismatch at {i}");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_fused_norm_then_ffn_pipeline() {
+        // Pre-norm → gate-up → SwiGLU → down → residual
+        let hidden = 32;
+        let inter = 128;
+        let eps = 1e-5;
+        let input = make_vec(hidden, 920);
+        let gamma = vec![1.0_f32; hidden];
+        let w_gate = make_vec(inter * hidden, 921);
+        let w_up = make_vec(inter * hidden, 922);
+        let w_down = make_vec(hidden * inter, 923);
+
+        // Step 1: RMSNorm
+        let normed = rms_norm(&input, &gamma, eps);
+        // Step 2: Gate + Up projections
+        let gate_proj = matmul(&normed, &w_gate, 1, hidden, inter);
+        let up_proj = matmul(&normed, &w_up, 1, hidden, inter);
+        // Step 3: SwiGLU
+        let gated: Vec<f32> =
+            gate_proj.iter().zip(up_proj.iter()).map(|(&g, &u)| swiglu(u, g)).collect();
+        // Step 4: Down projection
+        let ffn_out = matmul(&gated, &w_down, 1, inter, hidden);
+        // Step 5: Residual
+        let output: Vec<f32> = input.iter().zip(ffn_out.iter()).map(|(a, b)| a + b).collect();
+
+        assert_eq!(output.len(), hidden);
+        assert!(output.iter().all(|v| v.is_finite()));
+    }
+
+    // ── 22. Memory access patterns ──────────────────────────────
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_memory_coalesced_access_pattern() {
+        // Metal threadgroups of 32 threads should access 32 consecutive f32s
+        // Verify buffer layout supports coalesced reads
+        let hidden = 256;
+        let inter = 1024;
+        let stride = hidden; // row-major stride
+        for row in 0..inter {
+            let base = row * stride;
+            // Each SIMD group reads 32 consecutive elements
+            for lane in 0..SIMD_GROUP_SIZE as usize {
+                let idx = base + lane;
+                assert!(idx < inter * hidden, "out of bounds access at row={row} lane={lane}");
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_memory_stride_alignment_for_projections() {
+        // Row strides must be aligned for efficient Metal buffer access
+        let configs: &[(usize, usize)] = &[(768, 3072), (1024, 4096), (2048, 5632), (4096, 11008)];
+        for &(hidden, inter) in configs {
+            // Row stride in bytes for weight matrices
+            let gate_stride = hidden * std::mem::size_of::<f32>();
+            let down_stride = inter * std::mem::size_of::<f32>();
+            // Strides should be at least 4-byte aligned (f32)
+            assert_eq!(gate_stride % 4, 0, "gate stride not f32-aligned");
+            assert_eq!(down_stride % 4, 0, "down stride not f32-aligned");
+            // Prefer 16-byte alignment for float4 vector loads
+            let gate_vec4_ok = (hidden % 4) == 0;
+            assert!(gate_vec4_ok, "hidden={hidden} not float4-aligned");
+        }
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_memory_threadgroup_tile_coverage() {
+        // Verify tiled dispatch covers full matrix without gaps
+        let hidden = 2048;
+        let inter = 5632;
+        let tile_m = 8_usize; // rows per threadgroup
+        let tile_n = 32_usize; // cols per threadgroup (SIMD width)
+
+        let tg_rows = (inter + tile_m - 1) / tile_m;
+        let tg_cols = (hidden + tile_n - 1) / tile_n;
+        let total_covered_rows = tg_rows * tile_m;
+        let total_covered_cols = tg_cols * tile_n;
+        assert!(total_covered_rows >= inter);
+        assert!(total_covered_cols >= hidden);
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_memory_activation_buffer_no_overlap() {
+        // Gate and up activation buffers must not overlap
+        let cfg = FfnConfig {
+            hidden_dim: 2048,
+            intermediate_dim: 5632,
+            activation: FfnActivation::SwiGLU,
+            batch_size: 4,
+            ..Default::default()
+        };
+        let elem = std::mem::size_of::<f32>();
+        let gate_size = cfg.batch_size * cfg.intermediate_dim * elem;
+        let up_size = cfg.batch_size * cfg.intermediate_dim * elem;
+        let total = ffn_activation_buffer_bytes(&cfg);
+        // Total must accommodate both gate and up without overlap
+        assert!(total >= gate_size + up_size, "activation buffer too small for gate+up");
+    }
+
+    #[test]
+    #[ignore = "requires Metal GPU - run on macOS Apple Silicon"]
+    fn test_memory_quantized_block_stride() {
+        // I2_S 256-element blocks: verify stride between consecutive blocks
+        let block_data_bytes = 64_usize; // 256 × 2 bits
+        let block_scale_bytes = 2_usize; // f16 scale
+        let block_total = block_data_bytes + block_scale_bytes; // 66 bytes
+        assert_eq!(block_total, 66);
+
+        // For a 2048×5632 weight matrix
+        let elements = 2048 * 5632;
+        let blocks = (elements + 255) / 256;
+        let raw_bytes = blocks * block_total;
+        let aligned = align_up(raw_bytes, UNIFORM_BUFFER_ALIGNMENT);
+        assert!(aligned >= raw_bytes);
+        // Each block is addressable at block_index * 66
+        for b in 0..blocks.min(100) {
+            let offset = b * block_total;
+            assert!(offset < raw_bytes);
+        }
+    }
 }


### PR DESCRIPTION
Add comprehensive Metal FFN shader test suite for Apple Silicon.

## Changes
- 72 tests for SwiGLU, gate/up/down projections, hidden dim scaling
- Numerical precision and edge case coverage (subnormals, NaN, infinity)
- Batch processing tests with single-vs-batch equivalence
- Fused operation tests (gate+up, residual, norm+FFN pipeline)
- Memory access pattern validation (coalescing, stride, tile coverage)
- All tests gated with `#[ignore = "requires Metal GPU ..."]`

Part of Apple Silicon enablement.