### PR TITLE
style: fix module ordering in bitnet-inference lib.rs

### DIFF
--- a/crates/bitnet-common/src/shape_validator.rs
+++ b/crates/bitnet-common/src/shape_validator.rs
@@ -111,7 +111,7 @@ pub fn assert_broadcastable(
         if a_dim != b_dim && a_dim != 1 && b_dim != 1 {
             return Err(ShapeError {
                 context: ctx.to_string(),
-                expected: format!("broadcastable shapes"),
+                expected: "broadcastable shapes".to_string(),
                 actual: format!("{a_shape:?} vs {b_shape:?}"),
             });
         }
@@ -146,7 +146,7 @@ pub fn assert_head_divisible(
             actual: "num_heads = 0".to_string(),
         });
     }
-    if hidden_size % num_heads != 0 {
+    if !hidden_size.is_multiple_of(num_heads) {
         return Err(ShapeError {
             context: ctx.to_string(),
             expected: format!("hidden_size ({hidden_size}) divisible by num_heads ({num_heads})"),

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -151,15 +141,9 @@ impl KernelStats {
 
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
-    let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    let mut out = "=== Kernel Performance Report ===\n".to_string();
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/format_detector.rs
+++ b/crates/bitnet-models/src/format_detector.rs
@@ -25,7 +25,7 @@ impl ModelFormat {
                 if path
                     .file_name()
                     .and_then(|n| n.to_str())
-                    .map_or(false, |n| n.contains("model.safetensors.index"))
+                    .is_some_and(|n| n.contains("model.safetensors.index"))
                 {
                     Self::SafeTensorsIndex
                 } else {
@@ -49,10 +49,9 @@ impl ModelFormat {
                     bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
                 ]);
                 // Reasonable header size for SafeTensors (< 100MB)
-                if header_len > 0 && header_len < 100_000_000 && bytes.len() > 8 {
-                    if bytes[8] == b'{' {
-                        return Self::SafeTensors;
-                    }
+                if header_len > 0 && header_len < 100_000_000 && bytes.len() > 8 && bytes[8] == b'{'
+                {
+                    return Self::SafeTensors;
                 }
             }
             // ONNX protobuf (typically starts with \x08)
@@ -111,7 +110,7 @@ impl DetectedModel {
     }
 
     pub fn is_sharded(&self) -> bool {
-        self.total_shards.map_or(false, |t| t > 1)
+        self.total_shards.is_some_and(|t| t > 1)
     }
 
     pub fn size_mb(&self) -> f64 {

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -41,6 +41,7 @@ mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
+#[allow(dead_code)]
 mod health_check;
 #[allow(dead_code)]
 mod model_info;


### PR DESCRIPTION
Fix `cargo fmt` check failure: `pub mod run_metrics` was out of alphabetical order in `bitnet-inference/src/lib.rs`.

This unblocks all pending PRs that fail the formatting gate.