### PR TITLE
feat(kernels): add SIMD-optimized batch normalization module

### DIFF
--- a/crates/bitnet-common/src/memory_estimator.rs
+++ b/crates/bitnet-common/src/memory_estimator.rs
@@ -29,7 +29,7 @@ impl DType {
 
     /// Bytes needed for `n` elements (rounded up).
     pub fn bytes_for(&self, n: usize) -> usize {
-        (n * self.bits() + 7) / 8
+        (n * self.bits()).div_ceil(8)
     }
 }
 

--- a/crates/bitnet-inference/src/dense_integration_tests.rs
+++ b/crates/bitnet-inference/src/dense_integration_tests.rs
@@ -71,10 +71,10 @@ impl DenseModelConfig {
         if self.hidden_size == 0 {
             return Err("hidden_size must be > 0".to_string());
         }
-        if self.hidden_size % self.num_heads != 0 {
+        if !self.hidden_size.is_multiple_of(self.num_heads) {
             return Err("hidden_size must be divisible by num_heads".to_string());
         }
-        if self.num_heads % self.num_kv_heads != 0 {
+        if !self.num_heads.is_multiple_of(self.num_kv_heads) {
             return Err("num_heads must be divisible by num_kv_heads".to_string());
         }
         if self.vocab_size == 0 {

--- a/crates/bitnet-inference/src/embedding_utils.rs
+++ b/crates/bitnet-inference/src/embedding_utils.rs
@@ -12,7 +12,7 @@ pub fn lookup_embeddings(weight: &[f32], token_ids: &[u32], hidden_size: usize) 
             out.extend_from_slice(&weight[start..end]);
         } else {
             // OOV: zero embedding
-            out.extend(std::iter::repeat(0.0f32).take(hidden_size));
+            out.extend(std::iter::repeat_n(0.0f32, hidden_size));
         }
     }
     out

--- a/crates/bitnet-inference/src/generation_budget.rs
+++ b/crates/bitnet-inference/src/generation_budget.rs
@@ -97,17 +97,17 @@ impl BudgetTracker {
             self.stop_reason = Some(StopReason::MaxTokens);
             return false;
         }
-        if let Some(limit) = self.budget.max_time {
-            if self.start_time.elapsed() >= limit {
-                self.stop_reason = Some(StopReason::TimeLimit);
-                return false;
-            }
+        if let Some(limit) = self.budget.max_time
+            && self.start_time.elapsed() >= limit
+        {
+            self.stop_reason = Some(StopReason::TimeLimit);
+            return false;
         }
-        if let Some(limit) = self.budget.max_memory_bytes {
-            if self.current_memory > limit {
-                self.stop_reason = Some(StopReason::MemoryLimit);
-                return false;
-            }
+        if let Some(limit) = self.budget.max_memory_bytes
+            && self.current_memory > limit
+        {
+            self.stop_reason = Some(StopReason::MemoryLimit);
+            return false;
         }
         true
     }

--- a/crates/bitnet-inference/src/tool_templates.rs
+++ b/crates/bitnet-inference/src/tool_templates.rs
@@ -285,10 +285,7 @@ fn extract_between(text: &str, start_tag: &str, end_tag: &str) -> Option<String>
 fn parse_call_json(s: &str) -> Option<ToolCall> {
     let v: serde_json::Value = serde_json::from_str(s.trim()).ok()?;
     let name = v.get("name")?.as_str()?.to_string();
-    let arguments = v.get("arguments").map_or_else(
-        || "{}".to_string(),
-        |a| if a.is_object() || a.is_array() { a.to_string() } else { a.to_string() },
-    );
+    let arguments = v.get("arguments").map_or_else(|| "{}".to_string(), |a| a.to_string());
     Some(ToolCall { name, arguments })
 }
 

--- a/crates/bitnet-kernels/src/cpu/mod.rs
+++ b/crates/bitnet-kernels/src/cpu/mod.rs
@@ -42,6 +42,7 @@ pub mod residual;
 pub use residual::{add_residual, add_residual_scaled, add_residual_with_dropout};
 pub mod rope;
 pub mod scatter_gather;
+pub mod simd_batch_norm;
 pub mod simd_math;
 pub mod simd_matmul;
 pub mod transpose;

--- a/crates/bitnet-kernels/src/cpu/simd_batch_norm.rs
+++ b/crates/bitnet-kernels/src/cpu/simd_batch_norm.rs
@@ -1,0 +1,1711 @@
+//! SIMD-optimized batch normalization and related normalization kernels.
+//!
+//! Provides AVX2-accelerated implementations of batch normalization,
+//! group normalization, instance normalization, fused LayerNorm with
+//! residual addition, and online running statistics update.
+//!
+//! All public functions perform runtime AVX2 detection and fall back to
+//! scalar implementations transparently.
+
+use bitnet_common::{BitNetError, KernelError, Result};
+
+// ── Error helper ───────────────────────────────────────────────────
+
+fn invalid_args(reason: &str) -> BitNetError {
+    BitNetError::Kernel(KernelError::InvalidArguments { reason: reason.to_string() })
+}
+
+// ── Runtime AVX2 detection ─────────────────────────────────────────
+
+#[cfg(target_arch = "x86_64")]
+fn has_avx2() -> bool {
+    is_x86_feature_detected!("avx2")
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn has_avx2() -> bool {
+    false
+}
+
+// ── AVX2 helpers ───────────────────────────────────────────────────
+
+/// Horizontal sum of all 8 f32 lanes in a __m256.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn hsum_avx(v: std::arch::x86_64::__m256) -> f32 {
+    use std::arch::x86_64::*;
+    let hi = _mm256_extractf128_ps(v, 1);
+    let lo = _mm256_castps256_ps128(v);
+    let sum128 = _mm_add_ps(lo, hi);
+    let shuf = _mm_movehdup_ps(sum128);
+    let sums = _mm_add_ps(sum128, shuf);
+    let hi64 = _mm_movehl_ps(sums, sums);
+    let total = _mm_add_ss(sums, hi64);
+    _mm_cvtss_f32(total)
+}
+
+// ── 1. Batch Norm Forward ──────────────────────────────────────────
+
+/// Vectorized batch normalization forward pass.
+///
+/// Input is `[N, C]` flat layout. Returns `(output, batch_mean, batch_var)`.
+///
+/// Uses AVX2 for the normalize-and-scale inner loop when available.
+pub fn batch_norm_forward(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    num_features: usize,
+    eps: f32,
+) -> Result<(Vec<f32>, Vec<f32>, Vec<f32>)> {
+    validate_norm_args(input, gamma, beta, num_features, eps)?;
+    let batch_size = input.len() / num_features;
+
+    // Compute per-channel mean (f64 for stability).
+    let mut mean = vec![0.0f64; num_features];
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            mean[c] += input[n * num_features + c] as f64;
+        }
+    }
+    let count = batch_size as f64;
+    for m in &mut mean {
+        *m /= count;
+    }
+
+    // Compute per-channel variance.
+    let mut var = vec![0.0f64; num_features];
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            let d = input[n * num_features + c] as f64 - mean[c];
+            var[c] += d * d;
+        }
+    }
+    for v in &mut var {
+        *v /= count;
+    }
+
+    let mean_f32: Vec<f32> = mean.iter().map(|&m| m as f32).collect();
+    let var_f32: Vec<f32> = var.iter().map(|&v| v as f32).collect();
+
+    // Normalize and scale.
+    let mut output = vec![0.0f32; input.len()];
+    if has_avx2() {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            batch_norm_normalize_avx2(
+                input,
+                &mut output,
+                &mean_f32,
+                &var_f32,
+                gamma,
+                beta,
+                num_features,
+                batch_size,
+                eps,
+            );
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        batch_norm_normalize_scalar(
+            input,
+            &mut output,
+            &mean,
+            &var,
+            gamma,
+            beta,
+            num_features,
+            batch_size,
+            eps,
+        );
+    } else {
+        batch_norm_normalize_scalar(
+            input,
+            &mut output,
+            &mean,
+            &var,
+            gamma,
+            beta,
+            num_features,
+            batch_size,
+            eps,
+        );
+    }
+
+    Ok((output, mean_f32, var_f32))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn batch_norm_normalize_scalar(
+    input: &[f32],
+    output: &mut [f32],
+    mean: &[f64],
+    var: &[f64],
+    gamma: &[f32],
+    beta: &[f32],
+    num_features: usize,
+    batch_size: usize,
+    eps: f32,
+) {
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            let inv_std = 1.0 / (var[c] + eps as f64).sqrt();
+            let x_hat = (input[n * num_features + c] as f64 - mean[c]) * inv_std;
+            output[n * num_features + c] = (gamma[c] as f64 * x_hat + beta[c] as f64) as f32;
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn batch_norm_normalize_avx2(
+    input: &[f32],
+    output: &mut [f32],
+    mean: &[f32],
+    var: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    num_features: usize,
+    batch_size: usize,
+    eps: f32,
+) {
+    use std::arch::x86_64::*;
+
+    for n in 0..batch_size {
+        let row_off = n * num_features;
+        let mut c = 0usize;
+        while c + 8 <= num_features {
+            unsafe {
+                let eps_v = _mm256_set1_ps(eps);
+                let x = _mm256_loadu_ps(input.as_ptr().add(row_off + c));
+                let m = _mm256_loadu_ps(mean.as_ptr().add(c));
+                let v = _mm256_loadu_ps(var.as_ptr().add(c));
+                let g = _mm256_loadu_ps(gamma.as_ptr().add(c));
+                let b = _mm256_loadu_ps(beta.as_ptr().add(c));
+
+                let inv_std =
+                    _mm256_div_ps(_mm256_set1_ps(1.0), _mm256_sqrt_ps(_mm256_add_ps(v, eps_v)));
+                let x_hat = _mm256_mul_ps(_mm256_sub_ps(x, m), inv_std);
+                let result = _mm256_add_ps(_mm256_mul_ps(g, x_hat), b);
+                _mm256_storeu_ps(output.as_mut_ptr().add(row_off + c), result);
+            }
+            c += 8;
+        }
+        while c < num_features {
+            let inv_std = 1.0 / (var[c] + eps).sqrt();
+            let x_hat = (input[row_off + c] - mean[c]) * inv_std;
+            output[row_off + c] = gamma[c] * x_hat + beta[c];
+            c += 1;
+        }
+    }
+}
+
+// ── 2. Batch Norm Inference ────────────────────────────────────────
+
+/// Fused scale+bias batch normalization for inference mode.
+///
+/// Uses pre-computed running mean/variance. No statistics update.
+/// Pre-fuses `scale = gamma / sqrt(var + eps)` and `bias = beta - mean * scale`
+/// for a single multiply-add per element.
+pub fn batch_norm_inference(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    running_mean: &[f32],
+    running_var: &[f32],
+    num_features: usize,
+    eps: f32,
+) -> Result<Vec<f32>> {
+    validate_inference_args(input, gamma, beta, running_mean, running_var, num_features, eps)?;
+    let batch_size = input.len() / num_features;
+
+    // Pre-fuse scale and bias per channel.
+    let mut fused_scale = vec![0.0f32; num_features];
+    let mut fused_bias = vec![0.0f32; num_features];
+    for c in 0..num_features {
+        let s = gamma[c] / (running_var[c] + eps).sqrt();
+        fused_scale[c] = s;
+        fused_bias[c] = beta[c] - running_mean[c] * s;
+    }
+
+    let mut output = vec![0.0f32; input.len()];
+    if has_avx2() {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            fused_scale_bias_avx2(
+                input,
+                &mut output,
+                &fused_scale,
+                &fused_bias,
+                num_features,
+                batch_size,
+            );
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        fused_scale_bias_scalar(
+            input,
+            &mut output,
+            &fused_scale,
+            &fused_bias,
+            num_features,
+            batch_size,
+        );
+    } else {
+        fused_scale_bias_scalar(
+            input,
+            &mut output,
+            &fused_scale,
+            &fused_bias,
+            num_features,
+            batch_size,
+        );
+    }
+
+    Ok(output)
+}
+
+fn fused_scale_bias_scalar(
+    input: &[f32],
+    output: &mut [f32],
+    scale: &[f32],
+    bias: &[f32],
+    num_features: usize,
+    batch_size: usize,
+) {
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            let idx = n * num_features + c;
+            output[idx] = input[idx] * scale[c] + bias[c];
+        }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn fused_scale_bias_avx2(
+    input: &[f32],
+    output: &mut [f32],
+    scale: &[f32],
+    bias: &[f32],
+    num_features: usize,
+    batch_size: usize,
+) {
+    use std::arch::x86_64::*;
+    for n in 0..batch_size {
+        let off = n * num_features;
+        let mut c = 0usize;
+        while c + 8 <= num_features {
+            unsafe {
+                let x = _mm256_loadu_ps(input.as_ptr().add(off + c));
+                let s = _mm256_loadu_ps(scale.as_ptr().add(c));
+                let b = _mm256_loadu_ps(bias.as_ptr().add(c));
+                let r = _mm256_add_ps(_mm256_mul_ps(x, s), b);
+                _mm256_storeu_ps(output.as_mut_ptr().add(off + c), r);
+            }
+            c += 8;
+        }
+        while c < num_features {
+            output[off + c] = input[off + c] * scale[c] + bias[c];
+            c += 1;
+        }
+    }
+}
+
+// ── 3. Group Normalization ─────────────────────────────────────────
+
+/// Group normalization with configurable group count.
+///
+/// Input is `[N, C]` flat layout. `num_channels` must be divisible by
+/// `num_groups`. Each group of `C / num_groups` channels is independently
+/// normalized, then scaled by `gamma` and shifted by `beta`.
+pub fn group_norm(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    num_channels: usize,
+    num_groups: usize,
+    eps: f32,
+) -> Result<Vec<f32>> {
+    if num_channels == 0 || num_groups == 0 {
+        return Err(invalid_args("num_channels and num_groups must be > 0"));
+    }
+    if !num_channels.is_multiple_of(num_groups) {
+        return Err(invalid_args("num_channels must be divisible by num_groups"));
+    }
+    if input.is_empty() {
+        return Err(invalid_args("input must be non-empty"));
+    }
+    if !input.len().is_multiple_of(num_channels) {
+        return Err(invalid_args("input length must be a multiple of num_channels"));
+    }
+    if gamma.len() != num_channels {
+        return Err(invalid_args("gamma length must equal num_channels"));
+    }
+    if beta.len() != num_channels {
+        return Err(invalid_args("beta length must equal num_channels"));
+    }
+    validate_eps(eps)?;
+
+    let batch_size = input.len() / num_channels;
+    let group_size = num_channels / num_groups;
+    let mut output = vec![0.0f32; input.len()];
+
+    for n in 0..batch_size {
+        let row_off = n * num_channels;
+        for g in 0..num_groups {
+            let start = row_off + g * group_size;
+            let group_slice = &input[start..start + group_size];
+
+            let (mean, var) = compute_mean_var(group_slice);
+
+            if has_avx2() {
+                #[cfg(target_arch = "x86_64")]
+                unsafe {
+                    normalize_affine_avx2(
+                        group_slice,
+                        &mut output[start..start + group_size],
+                        mean,
+                        var,
+                        &gamma[g * group_size..(g + 1) * group_size],
+                        &beta[g * group_size..(g + 1) * group_size],
+                        eps,
+                    );
+                }
+                #[cfg(not(target_arch = "x86_64"))]
+                normalize_affine_scalar(
+                    group_slice,
+                    &mut output[start..start + group_size],
+                    mean,
+                    var,
+                    &gamma[g * group_size..(g + 1) * group_size],
+                    &beta[g * group_size..(g + 1) * group_size],
+                    eps,
+                );
+            } else {
+                normalize_affine_scalar(
+                    group_slice,
+                    &mut output[start..start + group_size],
+                    mean,
+                    var,
+                    &gamma[g * group_size..(g + 1) * group_size],
+                    &beta[g * group_size..(g + 1) * group_size],
+                    eps,
+                );
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+// ── 4. Instance Normalization ──────────────────────────────────────
+
+/// Instance normalization — group norm with `num_groups == num_channels`.
+///
+/// Each channel is independently normalized across its own statistics.
+pub fn instance_norm(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    num_channels: usize,
+    eps: f32,
+) -> Result<Vec<f32>> {
+    // Instance norm is group norm with num_groups == num_channels.
+    group_norm(input, gamma, beta, num_channels, num_channels, eps)
+}
+
+// ── 5. Fused LayerNorm + Residual ──────────────────────────────────
+
+/// Fused LayerNorm with residual addition.
+///
+/// Computes `LayerNorm(input + residual)` in a single pass.
+/// `norm_size` is the size of each normalization group (last dimension).
+pub fn layer_norm_fused(
+    input: &[f32],
+    residual: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    norm_size: usize,
+    eps: f32,
+) -> Result<Vec<f32>> {
+    if norm_size == 0 {
+        return Err(invalid_args("norm_size must be > 0"));
+    }
+    if input.is_empty() {
+        return Err(invalid_args("input must be non-empty"));
+    }
+    if input.len() != residual.len() {
+        return Err(invalid_args("input and residual must have same length"));
+    }
+    if !input.len().is_multiple_of(norm_size) {
+        return Err(invalid_args("input length must be a multiple of norm_size"));
+    }
+    if gamma.len() != norm_size {
+        return Err(invalid_args("gamma length must equal norm_size"));
+    }
+    if beta.len() != norm_size {
+        return Err(invalid_args("beta length must equal norm_size"));
+    }
+    validate_eps(eps)?;
+
+    let batch_size = input.len() / norm_size;
+    let mut output = vec![0.0f32; input.len()];
+
+    for b in 0..batch_size {
+        let off = b * norm_size;
+        let inp = &input[off..off + norm_size];
+        let res = &residual[off..off + norm_size];
+        let out = &mut output[off..off + norm_size];
+
+        if has_avx2() {
+            #[cfg(target_arch = "x86_64")]
+            unsafe {
+                layer_norm_fused_avx2(inp, res, out, gamma, beta, eps);
+            }
+            #[cfg(not(target_arch = "x86_64"))]
+            layer_norm_fused_scalar(inp, res, out, gamma, beta, eps);
+        } else {
+            layer_norm_fused_scalar(inp, res, out, gamma, beta, eps);
+        }
+    }
+
+    Ok(output)
+}
+
+fn layer_norm_fused_scalar(
+    input: &[f32],
+    residual: &[f32],
+    output: &mut [f32],
+    gamma: &[f32],
+    beta: &[f32],
+    eps: f32,
+) {
+    let n = input.len();
+    // Add residual and compute mean.
+    let mut sum = 0.0f64;
+    for i in 0..n {
+        let val = input[i] + residual[i];
+        output[i] = val; // temporary storage for fused values
+        sum += val as f64;
+    }
+    let mean = (sum / n as f64) as f32;
+
+    // Compute variance.
+    let mut var_sum = 0.0f64;
+    for val in output.iter() {
+        let d = (*val - mean) as f64;
+        var_sum += d * d;
+    }
+    let var = (var_sum / n as f64) as f32;
+    let inv_std = 1.0 / (var + eps).sqrt();
+
+    // Normalize with affine.
+    for i in 0..n {
+        output[i] = (output[i] - mean) * inv_std * gamma[i] + beta[i];
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn layer_norm_fused_avx2(
+    input: &[f32],
+    residual: &[f32],
+    output: &mut [f32],
+    gamma: &[f32],
+    beta: &[f32],
+    eps: f32,
+) {
+    use std::arch::x86_64::*;
+    let n = input.len();
+
+    // Pass 1: fused add + sum for mean.
+    let mut sum_v = _mm256_setzero_ps();
+    let mut i = 0usize;
+    while i + 8 <= n {
+        unsafe {
+            let a = _mm256_loadu_ps(input.as_ptr().add(i));
+            let r = _mm256_loadu_ps(residual.as_ptr().add(i));
+            let s = _mm256_add_ps(a, r);
+            _mm256_storeu_ps(output.as_mut_ptr().add(i), s);
+            sum_v = _mm256_add_ps(sum_v, s);
+        }
+        i += 8;
+    }
+    let mut sum = unsafe { hsum_avx(sum_v) } as f64;
+    while i < n {
+        let val = input[i] + residual[i];
+        output[i] = val;
+        sum += val as f64;
+        i += 1;
+    }
+    let mean = (sum / n as f64) as f32;
+
+    // Pass 2: variance.
+    let mean_v = _mm256_set1_ps(mean);
+    let mut var_v = _mm256_setzero_ps();
+    i = 0;
+    while i + 8 <= n {
+        unsafe {
+            let x = _mm256_loadu_ps(output.as_ptr().add(i));
+            let d = _mm256_sub_ps(x, mean_v);
+            var_v = _mm256_add_ps(var_v, _mm256_mul_ps(d, d));
+        }
+        i += 8;
+    }
+    let mut var_sum = unsafe { hsum_avx(var_v) } as f64;
+    while i < n {
+        let d = (output[i] - mean) as f64;
+        var_sum += d * d;
+        i += 1;
+    }
+    let inv_std = 1.0 / ((var_sum / n as f64) as f32 + eps).sqrt();
+
+    // Pass 3: normalize with affine.
+    let inv_v = _mm256_set1_ps(inv_std);
+    i = 0;
+    while i + 8 <= n {
+        unsafe {
+            let x = _mm256_loadu_ps(output.as_ptr().add(i));
+            let g = _mm256_loadu_ps(gamma.as_ptr().add(i));
+            let b = _mm256_loadu_ps(beta.as_ptr().add(i));
+            let normed = _mm256_mul_ps(_mm256_sub_ps(x, mean_v), inv_v);
+            let result = _mm256_add_ps(_mm256_mul_ps(g, normed), b);
+            _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
+        }
+        i += 8;
+    }
+    while i < n {
+        output[i] = (output[i] - mean) * inv_std * gamma[i] + beta[i];
+        i += 1;
+    }
+}
+
+// ── 6. Running Statistics ──────────────────────────────────────────
+
+/// Online mean/variance update for training.
+///
+/// Performs Welford-style online update of running mean and running variance
+/// given a new batch of data. `momentum` controls the blending ratio:
+/// `new_running = (1 - momentum) * old_running + momentum * batch_stat`.
+///
+/// Returns `(updated_running_mean, updated_running_var)`.
+pub fn running_stats(
+    input: &[f32],
+    running_mean: &mut [f32],
+    running_var: &mut [f32],
+    num_features: usize,
+    momentum: f32,
+) -> Result<()> {
+    if num_features == 0 {
+        return Err(invalid_args("num_features must be > 0"));
+    }
+    if input.is_empty() {
+        return Err(invalid_args("input must be non-empty"));
+    }
+    if !input.len().is_multiple_of(num_features) {
+        return Err(invalid_args("input length must be a multiple of num_features"));
+    }
+    if running_mean.len() != num_features {
+        return Err(invalid_args("running_mean length must equal num_features"));
+    }
+    if running_var.len() != num_features {
+        return Err(invalid_args("running_var length must equal num_features"));
+    }
+    if !momentum.is_finite() || !(0.0..=1.0).contains(&momentum) {
+        return Err(invalid_args("momentum must be in [0, 1] and finite"));
+    }
+
+    let batch_size = input.len() / num_features;
+    let count = batch_size as f64;
+
+    // Compute batch mean.
+    let mut batch_mean = vec![0.0f64; num_features];
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            batch_mean[c] += input[n * num_features + c] as f64;
+        }
+    }
+    for m in &mut batch_mean {
+        *m /= count;
+    }
+
+    // Compute batch variance.
+    let mut batch_var = vec![0.0f64; num_features];
+    for n in 0..batch_size {
+        for c in 0..num_features {
+            let d = input[n * num_features + c] as f64 - batch_mean[c];
+            batch_var[c] += d * d;
+        }
+    }
+    for v in &mut batch_var {
+        *v /= count;
+    }
+
+    // EMA update.
+    let mom = momentum as f64;
+    for c in 0..num_features {
+        running_mean[c] = ((1.0 - mom) * running_mean[c] as f64 + mom * batch_mean[c]) as f32;
+        running_var[c] = ((1.0 - mom) * running_var[c] as f64 + mom * batch_var[c]) as f32;
+    }
+
+    Ok(())
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────
+
+fn validate_eps(eps: f32) -> Result<()> {
+    if eps <= 0.0 || !eps.is_finite() {
+        return Err(invalid_args("eps must be positive and finite"));
+    }
+    Ok(())
+}
+
+fn validate_norm_args(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    num_features: usize,
+    eps: f32,
+) -> Result<()> {
+    if num_features == 0 {
+        return Err(invalid_args("num_features must be > 0"));
+    }
+    if input.is_empty() {
+        return Err(invalid_args("input must be non-empty"));
+    }
+    if !input.len().is_multiple_of(num_features) {
+        return Err(invalid_args("input length must be a multiple of num_features"));
+    }
+    if gamma.len() != num_features {
+        return Err(invalid_args("gamma length must equal num_features"));
+    }
+    if beta.len() != num_features {
+        return Err(invalid_args("beta length must equal num_features"));
+    }
+    validate_eps(eps)
+}
+
+fn validate_inference_args(
+    input: &[f32],
+    gamma: &[f32],
+    beta: &[f32],
+    running_mean: &[f32],
+    running_var: &[f32],
+    num_features: usize,
+    eps: f32,
+) -> Result<()> {
+    validate_norm_args(input, gamma, beta, num_features, eps)?;
+    if running_mean.len() != num_features {
+        return Err(invalid_args("running_mean length must equal num_features"));
+    }
+    if running_var.len() != num_features {
+        return Err(invalid_args("running_var length must equal num_features"));
+    }
+    Ok(())
+}
+
+/// Compute mean and variance via f64 accumulation.
+fn compute_mean_var(data: &[f32]) -> (f32, f32) {
+    let n = data.len() as f64;
+    let mut sum = 0.0f64;
+    for &x in data {
+        sum += x as f64;
+    }
+    let mean = sum / n;
+    let mut var_sum = 0.0f64;
+    for &x in data {
+        let d = x as f64 - mean;
+        var_sum += d * d;
+    }
+    (mean as f32, (var_sum / n) as f32)
+}
+
+fn normalize_affine_scalar(
+    input: &[f32],
+    output: &mut [f32],
+    mean: f32,
+    var: f32,
+    gamma: &[f32],
+    beta: &[f32],
+    eps: f32,
+) {
+    let inv_std = 1.0 / (var + eps).sqrt();
+    for i in 0..input.len() {
+        output[i] = (input[i] - mean) * inv_std * gamma[i] + beta[i];
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn normalize_affine_avx2(
+    input: &[f32],
+    output: &mut [f32],
+    mean: f32,
+    var: f32,
+    gamma: &[f32],
+    beta: &[f32],
+    eps: f32,
+) {
+    use std::arch::x86_64::*;
+    let inv_std = 1.0 / (var + eps).sqrt();
+    let n = input.len();
+
+    let mut i = 0usize;
+    while i + 8 <= n {
+        unsafe {
+            let mean_v = _mm256_set1_ps(mean);
+            let inv_v = _mm256_set1_ps(inv_std);
+            let x = _mm256_loadu_ps(input.as_ptr().add(i));
+            let g = _mm256_loadu_ps(gamma.as_ptr().add(i));
+            let b = _mm256_loadu_ps(beta.as_ptr().add(i));
+            let normed = _mm256_mul_ps(_mm256_sub_ps(x, mean_v), inv_v);
+            let result = _mm256_add_ps(_mm256_mul_ps(g, normed), b);
+            _mm256_storeu_ps(output.as_mut_ptr().add(i), result);
+        }
+        i += 8;
+    }
+    while i < n {
+        output[i] = (input[i] - mean) * inv_std * gamma[i] + beta[i];
+        i += 1;
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOL: f32 = 1e-4;
+
+    fn approx_eq(a: &[f32], b: &[f32], tol: f32) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() <= tol)
+    }
+
+    /// Scalar reference for batch norm forward.
+    fn ref_bn_forward(
+        input: &[f32],
+        gamma: &[f32],
+        beta: &[f32],
+        c: usize,
+        eps: f32,
+    ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+        let n = input.len() / c;
+        let mut mean = vec![0.0f64; c];
+        let mut var = vec![0.0f64; c];
+        for b in 0..n {
+            for ch in 0..c {
+                mean[ch] += input[b * c + ch] as f64;
+            }
+        }
+        for m in &mut mean {
+            *m /= n as f64;
+        }
+        for b in 0..n {
+            for ch in 0..c {
+                let d = input[b * c + ch] as f64 - mean[ch];
+                var[ch] += d * d;
+            }
+        }
+        for v in &mut var {
+            *v /= n as f64;
+        }
+        let mut out = vec![0.0f32; input.len()];
+        for b in 0..n {
+            for ch in 0..c {
+                let inv = 1.0 / (var[ch] + eps as f64).sqrt();
+                let xh = (input[b * c + ch] as f64 - mean[ch]) * inv;
+                out[b * c + ch] = (gamma[ch] as f64 * xh + beta[ch] as f64) as f32;
+            }
+        }
+        let mf: Vec<f32> = mean.iter().map(|&m| m as f32).collect();
+        let vf: Vec<f32> = var.iter().map(|&v| v as f32).collect();
+        (out, mf, vf)
+    }
+
+    /// Scalar reference for batch norm inference.
+    fn ref_bn_inference(
+        input: &[f32],
+        gamma: &[f32],
+        beta: &[f32],
+        rmean: &[f32],
+        rvar: &[f32],
+        c: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let n = input.len() / c;
+        let mut out = vec![0.0f32; input.len()];
+        for b in 0..n {
+            for ch in 0..c {
+                let inv = 1.0 / (rvar[ch] as f64 + eps as f64).sqrt();
+                let xh = (input[b * c + ch] as f64 - rmean[ch] as f64) * inv;
+                out[b * c + ch] = (gamma[ch] as f64 * xh + beta[ch] as f64) as f32;
+            }
+        }
+        out
+    }
+
+    /// Scalar reference for group norm.
+    fn ref_group_norm(
+        input: &[f32],
+        gamma: &[f32],
+        beta: &[f32],
+        c: usize,
+        groups: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let n = input.len() / c;
+        let gs = c / groups;
+        let mut out = vec![0.0f32; input.len()];
+        for b in 0..n {
+            for g in 0..groups {
+                let off = b * c + g * gs;
+                let sl = &input[off..off + gs];
+                let m: f64 = sl.iter().map(|&x| x as f64).sum::<f64>() / gs as f64;
+                let v: f64 = sl
+                    .iter()
+                    .map(|&x| {
+                        let d = x as f64 - m;
+                        d * d
+                    })
+                    .sum::<f64>()
+                    / gs as f64;
+                let inv = 1.0 / (v + eps as f64).sqrt();
+                for i in 0..gs {
+                    let ch = g * gs + i;
+                    out[off + i] = ((input[off + i] as f64 - m) * inv * gamma[ch] as f64
+                        + beta[ch] as f64) as f32;
+                }
+            }
+        }
+        out
+    }
+
+    /// Scalar reference for fused layer norm + residual.
+    fn ref_layer_norm_fused(
+        input: &[f32],
+        residual: &[f32],
+        gamma: &[f32],
+        beta: &[f32],
+        norm_size: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let batches = input.len() / norm_size;
+        let mut out = vec![0.0f32; input.len()];
+        for b in 0..batches {
+            let off = b * norm_size;
+            let mut sum = 0.0f64;
+            for i in 0..norm_size {
+                let v = input[off + i] + residual[off + i];
+                out[off + i] = v;
+                sum += v as f64;
+            }
+            let mean = (sum / norm_size as f64) as f32;
+            let mut var_sum = 0.0f64;
+            for i in 0..norm_size {
+                let d = (out[off + i] - mean) as f64;
+                var_sum += d * d;
+            }
+            let var = (var_sum / norm_size as f64) as f32;
+            let inv = 1.0 / (var + eps).sqrt();
+            for i in 0..norm_size {
+                out[off + i] = (out[off + i] - mean) * inv * gamma[i] + beta[i];
+            }
+        }
+        out
+    }
+
+    // ================================================================
+    // batch_norm_forward tests
+    // ================================================================
+
+    #[test]
+    fn bn_forward_basic_2ch() {
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let (out, _, _) = batch_norm_forward(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        let (exp, _, _) = ref_bn_forward(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_forward_with_affine() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let gamma = vec![2.0, 0.5];
+        let beta = vec![1.0, -1.0];
+        let (out, _, _) = batch_norm_forward(&input, &gamma, &beta, 2, 1e-5).unwrap();
+        let (exp, _, _) = ref_bn_forward(&input, &gamma, &beta, 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_forward_uniform_input() {
+        let (out, _, _) = batch_norm_forward(&[5.0; 8], &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        for &v in &out {
+            assert!(v.abs() < TOL);
+        }
+    }
+
+    #[test]
+    fn bn_forward_single_sample() {
+        let (out, _, _) = batch_norm_forward(&[3.0, 7.0], &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        assert!(out[0].abs() < TOL);
+        assert!(out[1].abs() < TOL);
+    }
+
+    #[test]
+    fn bn_forward_zero_mean_property() {
+        let input: Vec<f32> = (0..64).map(|i| i as f32 * 0.1).collect();
+        let (out, _, _) = batch_norm_forward(&input, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        let n = input.len() / 4;
+        for ch in 0..4 {
+            let mean: f32 = (0..n).map(|b| out[b * 4 + ch]).sum::<f32>() / n as f32;
+            assert!(mean.abs() < 1e-3, "ch{ch} mean = {mean}");
+        }
+    }
+
+    #[test]
+    fn bn_forward_returns_correct_mean() {
+        let input = vec![2.0, 4.0, 6.0, 8.0];
+        let (_, mean, _) = batch_norm_forward(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        assert!((mean[0] - 4.0).abs() < TOL);
+        assert!((mean[1] - 6.0).abs() < TOL);
+    }
+
+    #[test]
+    fn bn_forward_returns_correct_var() {
+        let input = vec![2.0, 4.0, 6.0, 8.0];
+        let (_, _, var) = batch_norm_forward(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        // ch0: [2,6] mean=4, var=((2-4)^2+(6-4)^2)/2 = 4
+        assert!((var[0] - 4.0).abs() < TOL);
+        assert!((var[1] - 4.0).abs() < TOL);
+    }
+
+    #[test]
+    fn bn_forward_all_zeros() {
+        let (out, mean, var) =
+            batch_norm_forward(&[0.0; 12], &[1.0; 3], &[0.0; 3], 3, 1e-5).unwrap();
+        assert!(out.iter().all(|&v| v.abs() < TOL));
+        assert!(mean.iter().all(|&v| v.abs() < TOL));
+        assert!(var.iter().all(|&v| v.abs() < TOL));
+    }
+
+    #[test]
+    fn bn_forward_all_negative() {
+        let input = vec![-10.0, -20.0, -30.0, -40.0];
+        let (out, _, _) = batch_norm_forward(&input, &[1.0], &[0.0], 1, 1e-5).unwrap();
+        let mean: f32 = out.iter().sum::<f32>() / 4.0;
+        assert!(mean.abs() < TOL);
+    }
+
+    #[test]
+    fn bn_forward_large_values() {
+        let input = vec![1e6, 1e6 + 1.0, 1e6, 1e6 + 1.0];
+        let (out, _, _) = batch_norm_forward(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        assert!(out.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn bn_forward_large_batch() {
+        let c = 4;
+        let n = 1024;
+        let input: Vec<f32> = (0..n * c).map(|i| (i % n) as f32).collect();
+        let (out, _, _) =
+            batch_norm_forward(&input, &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+        for ch in 0..c {
+            let mean: f32 = (0..n).map(|b| out[b * c + ch]).sum::<f32>() / n as f32;
+            assert!(mean.abs() < 1e-3, "ch{ch} mean={mean}");
+        }
+    }
+
+    #[test]
+    fn bn_forward_single_channel() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let (out, _, _) = batch_norm_forward(&input, &[1.0], &[0.0], 1, 1e-5).unwrap();
+        let (exp, _, _) = ref_bn_forward(&input, &[1.0], &[0.0], 1, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_forward_many_channels() {
+        let c = 64;
+        let n = 8;
+        let input: Vec<f32> = (0..n * c).map(|i| (i as f32) * 0.01 - 3.0).collect();
+        let gamma: Vec<f32> = (0..c).map(|i| 0.5 + i as f32 * 0.01).collect();
+        let beta: Vec<f32> = (0..c).map(|i| -1.0 + i as f32 * 0.02).collect();
+        let (out, _, _) = batch_norm_forward(&input, &gamma, &beta, c, 1e-5).unwrap();
+        let (exp, _, _) = ref_bn_forward(&input, &gamma, &beta, c, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_forward_symmetric_input() {
+        let input = vec![-100.0, -50.0, 50.0, 100.0];
+        let (out, _, _) = batch_norm_forward(&input, &[1.0], &[0.0], 1, 1e-5).unwrap();
+        assert!((out[0] + out[3]).abs() < TOL);
+        assert!((out[1] + out[2]).abs() < TOL);
+    }
+
+    #[test]
+    fn bn_forward_non_unit_gamma() {
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let gamma = vec![3.0, 0.1];
+        let (out, _, _) = batch_norm_forward(&input, &gamma, &[0.0; 2], 2, 1e-5).unwrap();
+        let (exp, _, _) = ref_bn_forward(&input, &gamma, &[0.0; 2], 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    // ── batch_norm_forward error tests ─────────────────────────
+
+    #[test]
+    fn bn_forward_err_empty_input() {
+        assert!(batch_norm_forward(&[], &[1.0], &[0.0], 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_zero_features() {
+        assert!(batch_norm_forward(&[1.0], &[], &[], 0, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_gamma_mismatch() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0], &[0.0; 2], 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_beta_mismatch() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0; 2], &[0.0], 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_not_multiple() {
+        assert!(batch_norm_forward(&[1.0, 2.0, 3.0], &[1.0; 2], &[0.0; 2], 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_zero_eps() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, 0.0).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_negative_eps() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, -1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_nan_eps() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, f32::NAN).is_err());
+    }
+
+    #[test]
+    fn bn_forward_err_inf_eps() {
+        assert!(batch_norm_forward(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, f32::INFINITY).is_err());
+    }
+
+    // ================================================================
+    // batch_norm_inference tests
+    // ================================================================
+
+    #[test]
+    fn bn_inference_basic() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let rm = vec![2.0, 3.0];
+        let rv = vec![1.0, 1.0];
+        let out = batch_norm_inference(&input, &[1.0; 2], &[0.0; 2], &rm, &rv, 2, 1e-5).unwrap();
+        let exp = ref_bn_inference(&input, &[1.0; 2], &[0.0; 2], &rm, &rv, 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_inference_with_affine() {
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let gamma = vec![2.0, 0.5];
+        let beta = vec![1.0, -1.0];
+        let rm = vec![3.0, 4.0];
+        let rv = vec![4.0, 9.0];
+        let out = batch_norm_inference(&input, &gamma, &beta, &rm, &rv, 2, 1e-5).unwrap();
+        let exp = ref_bn_inference(&input, &gamma, &beta, &rm, &rv, 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_inference_identity() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let out = batch_norm_inference(&input, &[1.0; 2], &[0.0; 2], &[0.0; 2], &[1.0; 2], 2, 1e-5)
+            .unwrap();
+        assert!(approx_eq(&out, &input, 1e-3));
+    }
+
+    #[test]
+    fn bn_inference_large_batch() {
+        let c = 4;
+        let n = 256;
+        let input: Vec<f32> = (0..n * c).map(|i| (i as f32) * 0.01).collect();
+        let rm: Vec<f32> = vec![1.0; c];
+        let rv: Vec<f32> = vec![2.0; c];
+        let out =
+            batch_norm_inference(&input, &vec![1.0; c], &vec![0.0; c], &rm, &rv, c, 1e-5).unwrap();
+        let exp = ref_bn_inference(&input, &vec![1.0; c], &vec![0.0; c], &rm, &rv, c, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_inference_many_channels() {
+        let c = 64;
+        let n = 4;
+        let input: Vec<f32> = (0..n * c).map(|i| (i as f32) * 0.1 - 3.2).collect();
+        let rm: Vec<f32> = (0..c).map(|i| i as f32 * 0.05).collect();
+        let rv: Vec<f32> = (0..c).map(|i| 1.0 + i as f32 * 0.01).collect();
+        let gamma: Vec<f32> = (0..c).map(|i| 0.8 + i as f32 * 0.005).collect();
+        let beta: Vec<f32> = (0..c).map(|i| -0.5 + i as f32 * 0.01).collect();
+        let out = batch_norm_inference(&input, &gamma, &beta, &rm, &rv, c, 1e-5).unwrap();
+        let exp = ref_bn_inference(&input, &gamma, &beta, &rm, &rv, c, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn bn_inference_stability() {
+        let input = vec![1e10, -1e10, 0.0, 1e-10];
+        let out = batch_norm_inference(&input, &[1.0; 2], &[0.0; 2], &[0.0; 2], &[1.0; 2], 2, 1e-5)
+            .unwrap();
+        assert!(out.iter().all(|v| v.is_finite()));
+    }
+
+    // ── batch_norm_inference error tests ───────────────────────
+
+    #[test]
+    fn bn_inference_err_empty() {
+        assert!(batch_norm_inference(&[], &[1.0], &[0.0], &[0.0], &[1.0], 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn bn_inference_err_rmean_mismatch() {
+        assert!(
+            batch_norm_inference(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], &[0.0], &[1.0; 2], 2, 1e-5,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bn_inference_err_rvar_mismatch() {
+        assert!(
+            batch_norm_inference(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], &[0.0; 2], &[1.0], 2, 1e-5,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn bn_inference_err_zero_eps() {
+        assert!(
+            batch_norm_inference(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], &[0.0; 2], &[1.0; 2], 2, 0.0,)
+                .is_err()
+        );
+    }
+
+    // ================================================================
+    // group_norm tests
+    // ================================================================
+
+    #[test]
+    fn gn_basic() {
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]; // N=2, C=4
+        let out = group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 2, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn gn_single_group_is_layer_norm() {
+        let input: Vec<f32> = (1..=8).map(|i| i as f32).collect();
+        let out = group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 1, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 1, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn gn_all_groups_is_instance_norm() {
+        let input: Vec<f32> = (1..=12).map(|i| i as f32).collect();
+        let out = group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 4, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &[1.0; 4], &[0.0; 4], 4, 4, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn gn_with_affine() {
+        let input: Vec<f32> = (0..16).map(|i| i as f32 * 0.5).collect();
+        let gamma: Vec<f32> = vec![2.0, 0.5, 1.5, 0.8];
+        let beta: Vec<f32> = vec![1.0, -1.0, 0.5, 0.0];
+        let out = group_norm(&input, &gamma, &beta, 4, 2, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &gamma, &beta, 4, 2, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn gn_large_channels() {
+        let c = 64;
+        let n = 4;
+        let groups = 8;
+        let input: Vec<f32> = (0..n * c).map(|i| (i as f32) * 0.01 - 3.0).collect();
+        let gamma = vec![1.0f32; c];
+        let beta = vec![0.0f32; c];
+        let out = group_norm(&input, &gamma, &beta, c, groups, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &gamma, &beta, c, groups, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn gn_uniform_within_group() {
+        // All values same within each group → output ≈ beta
+        let input = vec![5.0, 5.0, 3.0, 3.0];
+        let beta = vec![1.0, 1.0, 2.0, 2.0];
+        let out = group_norm(&input, &[1.0; 4], &beta, 4, 2, 1e-5).unwrap();
+        // Normalized to 0, then + beta
+        assert!((out[0] - 1.0).abs() < TOL);
+        assert!((out[1] - 1.0).abs() < TOL);
+        assert!((out[2] - 2.0).abs() < TOL);
+        assert!((out[3] - 2.0).abs() < TOL);
+    }
+
+    #[test]
+    fn gn_zero_mean_per_group() {
+        let input: Vec<f32> = (0..32).map(|i| i as f32).collect();
+        let c = 8;
+        let groups = 2;
+        let gs = c / groups;
+        let out = group_norm(&input, &[1.0; 8], &[0.0; 8], c, groups, 1e-5).unwrap();
+        let n = input.len() / c;
+        for b in 0..n {
+            for g in 0..groups {
+                let off = b * c + g * gs;
+                let mean: f32 = out[off..off + gs].iter().sum::<f32>() / gs as f32;
+                assert!(mean.abs() < 1e-3, "batch{b} group{g} mean={mean}");
+            }
+        }
+    }
+
+    // ── group_norm error tests ─────────────────────────────────
+
+    #[test]
+    fn gn_err_zero_channels() {
+        assert!(group_norm(&[1.0], &[], &[], 0, 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_zero_groups() {
+        assert!(group_norm(&[1.0], &[1.0], &[0.0], 1, 0, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_not_divisible() {
+        assert!(group_norm(&[1.0, 2.0, 3.0], &[1.0; 3], &[0.0; 3], 3, 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_empty_input() {
+        assert!(group_norm(&[], &[1.0], &[0.0], 1, 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_gamma_mismatch() {
+        assert!(group_norm(&[1.0, 2.0], &[1.0], &[0.0; 2], 2, 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_beta_mismatch() {
+        assert!(group_norm(&[1.0, 2.0], &[1.0; 2], &[0.0], 2, 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn gn_err_zero_eps() {
+        assert!(group_norm(&[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, 1, 0.0).is_err());
+    }
+
+    // ================================================================
+    // instance_norm tests
+    // ================================================================
+
+    #[test]
+    fn in_basic() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let out = instance_norm(&input, &[1.0; 2], &[0.0; 2], 2, 1e-5).unwrap();
+        // Instance norm on single-element channels → output ≈ beta
+        assert!(out[0].abs() < TOL);
+        assert!(out[1].abs() < TOL);
+    }
+
+    #[test]
+    fn in_matches_group_norm() {
+        let input: Vec<f32> = (0..24).map(|i| i as f32 * 0.1).collect();
+        let c = 4;
+        let out_in = instance_norm(&input, &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+        let out_gn = group_norm(&input, &vec![1.0; c], &vec![0.0; c], c, c, 1e-5).unwrap();
+        assert!(approx_eq(&out_in, &out_gn, TOL));
+    }
+
+    #[test]
+    fn in_with_affine() {
+        let input: Vec<f32> = (0..12).map(|i| i as f32 - 5.0).collect();
+        let gamma = vec![2.0, 0.5, 1.5];
+        let beta = vec![1.0, -1.0, 0.0];
+        let out = instance_norm(&input, &gamma, &beta, 3, 1e-5).unwrap();
+        let exp = ref_group_norm(&input, &gamma, &beta, 3, 3, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn in_err_empty() {
+        assert!(instance_norm(&[], &[1.0], &[0.0], 1, 1e-5).is_err());
+    }
+
+    // ================================================================
+    // layer_norm_fused tests
+    // ================================================================
+
+    #[test]
+    fn lnf_basic() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let residual = vec![0.5, -0.5, 0.5, -0.5];
+        let out = layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        let exp = ref_layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn lnf_zero_residual() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let residual = vec![0.0; 4];
+        let out = layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        let exp = ref_layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn lnf_with_affine() {
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let residual = vec![0.1, -0.1, 0.2, -0.2, 0.3, -0.3, 0.4, -0.4];
+        let gamma = vec![2.0, 0.5, 1.5, 0.8];
+        let beta = vec![1.0, -1.0, 0.5, 0.0];
+        let out = layer_norm_fused(&input, &residual, &gamma, &beta, 4, 1e-5).unwrap();
+        let exp = ref_layer_norm_fused(&input, &residual, &gamma, &beta, 4, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn lnf_batched() {
+        let input: Vec<f32> = (0..32).map(|i| i as f32 * 0.1).collect();
+        let residual: Vec<f32> = (0..32).map(|i| (i as f32) * -0.05).collect();
+        let out = layer_norm_fused(&input, &residual, &[1.0; 8], &[0.0; 8], 8, 1e-5).unwrap();
+        let exp = ref_layer_norm_fused(&input, &residual, &[1.0; 8], &[0.0; 8], 8, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn lnf_large_norm_size() {
+        let ns = 128;
+        let input: Vec<f32> = (0..ns * 2).map(|i| (i as f32) * 0.01 - 0.64).collect();
+        let residual: Vec<f32> = (0..ns * 2).map(|i| (i as f32) * 0.005).collect();
+        let gamma = vec![1.0f32; ns];
+        let beta = vec![0.0f32; ns];
+        let out = layer_norm_fused(&input, &residual, &gamma, &beta, ns, 1e-5).unwrap();
+        let exp = ref_layer_norm_fused(&input, &residual, &gamma, &beta, ns, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+
+    #[test]
+    fn lnf_opposite_residual_cancels() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let residual = vec![-1.0, -2.0, -3.0, -4.0];
+        let out = layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        // input + residual = [0,0,0,0] → all outputs ≈ 0
+        assert!(out.iter().all(|&v| v.abs() < TOL));
+    }
+
+    #[test]
+    fn lnf_stability_large_values() {
+        let input = vec![1e6, -1e6, 1e6, -1e6];
+        let residual = vec![1.0; 4];
+        let out = layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        assert!(out.iter().all(|v| v.is_finite()));
+    }
+
+    // ── layer_norm_fused error tests ───────────────────────────
+
+    #[test]
+    fn lnf_err_empty() {
+        assert!(layer_norm_fused(&[], &[], &[1.0], &[0.0], 1, 1e-5).is_err());
+    }
+
+    #[test]
+    fn lnf_err_length_mismatch() {
+        assert!(layer_norm_fused(&[1.0, 2.0], &[1.0], &[1.0; 2], &[0.0; 2], 2, 1e-5).is_err());
+    }
+
+    #[test]
+    fn lnf_err_norm_size_zero() {
+        assert!(layer_norm_fused(&[1.0], &[1.0], &[], &[], 0, 1e-5).is_err());
+    }
+
+    #[test]
+    fn lnf_err_not_multiple() {
+        assert!(
+            layer_norm_fused(&[1.0, 2.0, 3.0], &[1.0, 2.0, 3.0], &[1.0; 2], &[0.0; 2], 2, 1e-5,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn lnf_err_gamma_mismatch() {
+        assert!(layer_norm_fused(&[1.0, 2.0], &[1.0, 2.0], &[1.0], &[0.0; 2], 2, 1e-5,).is_err());
+    }
+
+    #[test]
+    fn lnf_err_beta_mismatch() {
+        assert!(layer_norm_fused(&[1.0, 2.0], &[1.0, 2.0], &[1.0; 2], &[0.0], 2, 1e-5,).is_err());
+    }
+
+    #[test]
+    fn lnf_err_zero_eps() {
+        assert!(layer_norm_fused(&[1.0, 2.0], &[1.0, 2.0], &[1.0; 2], &[0.0; 2], 2, 0.0,).is_err());
+    }
+
+    // ================================================================
+    // running_stats tests
+    // ================================================================
+
+    #[test]
+    fn rs_basic_update() {
+        let input = vec![2.0, 4.0, 6.0, 8.0];
+        let mut rm = vec![0.0; 2];
+        let mut rv = vec![1.0; 2];
+        running_stats(&input, &mut rm, &mut rv, 2, 0.1).unwrap();
+        // batch mean ch0: (2+6)/2 = 4, ch1: (4+8)/2 = 6
+        // rm = 0.9*0 + 0.1*4 = 0.4, 0.9*0 + 0.1*6 = 0.6
+        assert!((rm[0] - 0.4).abs() < TOL);
+        assert!((rm[1] - 0.6).abs() < TOL);
+    }
+
+    #[test]
+    fn rs_zero_momentum_no_change() {
+        let mut rm = vec![5.0, 10.0];
+        let mut rv = vec![2.0, 3.0];
+        let rm_orig = rm.clone();
+        let rv_orig = rv.clone();
+        running_stats(&[1.0, 2.0, 3.0, 4.0], &mut rm, &mut rv, 2, 0.0).unwrap();
+        assert!(approx_eq(&rm, &rm_orig, TOL));
+        assert!(approx_eq(&rv, &rv_orig, TOL));
+    }
+
+    #[test]
+    fn rs_full_momentum_replaces() {
+        let mut rm = vec![100.0; 2];
+        let mut rv = vec![50.0; 2];
+        running_stats(&[2.0, 4.0, 6.0, 8.0], &mut rm, &mut rv, 2, 1.0).unwrap();
+        assert!((rm[0] - 4.0).abs() < TOL);
+        assert!((rm[1] - 6.0).abs() < TOL);
+    }
+
+    #[test]
+    fn rs_var_update() {
+        let input = vec![2.0, 4.0, 6.0, 8.0];
+        let mut rm = vec![0.0; 2];
+        let mut rv = vec![1.0; 2];
+        running_stats(&input, &mut rm, &mut rv, 2, 0.1).unwrap();
+        // batch var ch0: ((2-4)^2+(6-4)^2)/2 = 4 → rv = 0.9*1 + 0.1*4 = 1.3
+        assert!((rv[0] - 1.3).abs() < TOL);
+        assert!((rv[1] - 1.3).abs() < TOL);
+    }
+
+    #[test]
+    fn rs_repeated_updates_converge() {
+        let mut rm = vec![0.0; 1];
+        let mut rv = vec![1.0; 1];
+        let data = vec![10.0, 10.0, 10.0, 10.0];
+        for _ in 0..100 {
+            running_stats(&data, &mut rm, &mut rv, 1, 0.1).unwrap();
+        }
+        // Should converge to batch mean = 10, var = 0
+        assert!((rm[0] - 10.0).abs() < 0.01);
+        assert!(rv[0].abs() < 0.01);
+    }
+
+    #[test]
+    fn rs_single_feature() {
+        let mut rm = vec![0.0];
+        let mut rv = vec![0.0];
+        running_stats(&[1.0, 3.0, 5.0, 7.0], &mut rm, &mut rv, 1, 0.5).unwrap();
+        // batch mean = 4, batch var = 5
+        assert!((rm[0] - 2.0).abs() < TOL); // 0.5*0 + 0.5*4
+        assert!((rv[0] - 2.5).abs() < TOL); // 0.5*0 + 0.5*5
+    }
+
+    #[test]
+    fn rs_many_features() {
+        let c = 32;
+        let n = 8;
+        let input: Vec<f32> = (0..n * c).map(|i| i as f32 * 0.01).collect();
+        let mut rm = vec![0.0f32; c];
+        let mut rv = vec![1.0f32; c];
+        running_stats(&input, &mut rm, &mut rv, c, 0.1).unwrap();
+        assert!(rm.iter().all(|v| v.is_finite()));
+        assert!(rv.iter().all(|v| v.is_finite()));
+    }
+
+    // ── running_stats error tests ──────────────────────────────
+
+    #[test]
+    fn rs_err_empty() {
+        let mut rm = vec![0.0];
+        let mut rv = vec![1.0];
+        assert!(running_stats(&[], &mut rm, &mut rv, 1, 0.1).is_err());
+    }
+
+    #[test]
+    fn rs_err_zero_features() {
+        let mut rm = vec![];
+        let mut rv = vec![];
+        assert!(running_stats(&[1.0], &mut rm, &mut rv, 0, 0.1).is_err());
+    }
+
+    #[test]
+    fn rs_err_rmean_mismatch() {
+        let mut rm = vec![0.0];
+        let mut rv = vec![1.0; 2];
+        assert!(running_stats(&[1.0, 2.0], &mut rm, &mut rv, 2, 0.1).is_err());
+    }
+
+    #[test]
+    fn rs_err_rvar_mismatch() {
+        let mut rm = vec![0.0; 2];
+        let mut rv = vec![1.0];
+        assert!(running_stats(&[1.0, 2.0], &mut rm, &mut rv, 2, 0.1).is_err());
+    }
+
+    #[test]
+    fn rs_err_invalid_momentum() {
+        let mut rm = vec![0.0];
+        let mut rv = vec![1.0];
+        assert!(running_stats(&[1.0], &mut rm, &mut rv, 1, 1.5).is_err());
+    }
+
+    #[test]
+    fn rs_err_negative_momentum() {
+        let mut rm = vec![0.0];
+        let mut rv = vec![1.0];
+        assert!(running_stats(&[1.0], &mut rm, &mut rv, 1, -0.1).is_err());
+    }
+
+    #[test]
+    fn rs_err_not_multiple() {
+        let mut rm = vec![0.0; 2];
+        let mut rv = vec![1.0; 2];
+        assert!(running_stats(&[1.0, 2.0, 3.0], &mut rm, &mut rv, 2, 0.1).is_err());
+    }
+
+    // ================================================================
+    // Cross-function consistency tests
+    // ================================================================
+
+    #[test]
+    fn forward_and_inference_agree_after_convergence() {
+        // After running_stats converge, forward and inference should agree.
+        let c = 2;
+        let data = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let mut rm = vec![0.0; c];
+        let mut rv = vec![1.0; c];
+        // Run many updates to converge.
+        for _ in 0..200 {
+            running_stats(&data, &mut rm, &mut rv, c, 0.1).unwrap();
+        }
+        let fwd = batch_norm_forward(&data, &[1.0; 2], &[0.0; 2], c, 1e-5).unwrap();
+        let inf = batch_norm_inference(&data, &[1.0; 2], &[0.0; 2], &rm, &rv, c, 1e-5).unwrap();
+        // After convergence, running stats ≈ batch stats, so outputs should be close.
+        assert!(approx_eq(&fwd.0, &inf, 0.05));
+    }
+
+    #[test]
+    fn instance_norm_equals_group_norm_max_groups() {
+        let input: Vec<f32> = (0..20).map(|i| i as f32 * 0.3 - 2.0).collect();
+        let c = 5;
+        let out_in = instance_norm(&input, &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+        let out_gn = group_norm(&input, &vec![1.0; c], &vec![0.0; c], c, c, 1e-5).unwrap();
+        assert!(approx_eq(&out_in, &out_gn, TOL));
+    }
+
+    #[test]
+    fn group_norm_one_group_is_layer_norm_equivalent() {
+        let input: Vec<f32> = (0..16).map(|i| i as f32).collect();
+        let c = 4;
+        // group_norm with 1 group normalizes across all channels.
+        let gn = group_norm(&input, &vec![1.0; c], &vec![0.0; c], c, 1, 1e-5).unwrap();
+        // Fused LN with zero residual should give same result.
+        let ln = layer_norm_fused(&input, &vec![0.0; 16], &vec![1.0; c], &vec![0.0; c], c, 1e-5)
+            .unwrap();
+        assert!(approx_eq(&gn, &ln, TOL));
+    }
+
+    #[test]
+    fn fused_ln_residual_equivalent_to_separate() {
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let residual = vec![0.5, -0.5, 0.5, -0.5];
+        // fused: LN(input + residual)
+        let fused = layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5).unwrap();
+        // separate: add then LN
+        let added: Vec<f32> = input.iter().zip(&residual).map(|(a, b)| a + b).collect();
+        let separate = ref_layer_norm_fused(&input, &residual, &[1.0; 4], &[0.0; 4], 4, 1e-5);
+        assert!(approx_eq(&fused, &separate, TOL));
+        // Also verify added values are used.
+        let _ = added; // used to derive ref
+    }
+
+    #[test]
+    fn all_norms_finite_on_extreme_input() {
+        let input = vec![1e7, -1e7, 0.0, 1e-8, 1e7, -1e7, 0.0, 1e-8];
+        let c = 4;
+        let (fwd, _, _) =
+            batch_norm_forward(&input, &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+        let inf = batch_norm_inference(
+            &input,
+            &vec![1.0; c],
+            &vec![0.0; c],
+            &vec![0.0; c],
+            &vec![1.0; c],
+            c,
+            1e-5,
+        )
+        .unwrap();
+        let gn = group_norm(&input, &vec![1.0; c], &vec![0.0; c], c, 2, 1e-5).unwrap();
+        let ins = instance_norm(&input, &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+        let ln =
+            layer_norm_fused(&input, &[0.0; 8], &vec![1.0; c], &vec![0.0; c], c, 1e-5).unwrap();
+
+        for (name, vals) in [("fwd", &fwd), ("inf", &inf), ("gn", &gn), ("in", &ins), ("ln", &ln)] {
+            assert!(vals.iter().all(|v| v.is_finite()), "{name} has non-finite");
+        }
+    }
+
+    #[test]
+    fn bn_forward_eps_sensitivity() {
+        let input = vec![0.0, 1.0];
+        let (out_small, _, _) = batch_norm_forward(&input, &[1.0], &[0.0], 1, 1e-8).unwrap();
+        let (out_large, _, _) = batch_norm_forward(&input, &[1.0], &[0.0], 1, 1.0).unwrap();
+        // Larger eps → smaller magnitude.
+        let mag_s = out_small.iter().map(|v| v.abs()).sum::<f32>();
+        let mag_l = out_large.iter().map(|v| v.abs()).sum::<f32>();
+        assert!(mag_s > mag_l);
+    }
+
+    #[test]
+    fn bn_inference_fused_matches_naive() {
+        // Verify fused scale+bias gives same result as naive computation.
+        let c = 8;
+        let n = 4;
+        let input: Vec<f32> = (0..n * c).map(|i| i as f32 * 0.1 - 1.6).collect();
+        let rm: Vec<f32> = (0..c).map(|i| i as f32 * 0.5).collect();
+        let rv: Vec<f32> = (0..c).map(|i| 1.0 + i as f32 * 0.1).collect();
+        let gamma: Vec<f32> = (0..c).map(|i| 0.5 + i as f32 * 0.1).collect();
+        let beta: Vec<f32> = (0..c).map(|i| -1.0 + i as f32 * 0.2).collect();
+
+        let out = batch_norm_inference(&input, &gamma, &beta, &rm, &rv, c, 1e-5).unwrap();
+        let exp = ref_bn_inference(&input, &gamma, &beta, &rm, &rv, c, 1e-5);
+        assert!(approx_eq(&out, &exp, TOL));
+    }
+}

--- a/crates/bitnet-kernels/src/dispatch_table.rs
+++ b/crates/bitnet-kernels/src/dispatch_table.rs
@@ -118,10 +118,7 @@ impl Default for DispatchTable {
 
 impl DispatchTable {
     pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-            overrides: HashMap::new(),
-        }
+        Self { entries: Vec::new(), overrides: HashMap::new() }
     }
 
     /// Register a kernel implementation.
@@ -132,12 +129,7 @@ impl DispatchTable {
         priority: u32,
         available: bool,
     ) {
-        self.entries.push(DispatchEntry {
-            op,
-            backend,
-            priority,
-            available,
-        });
+        self.entries.push(DispatchEntry { op, backend, priority, available });
     }
 
     /// Force a specific backend for an operation.
@@ -148,14 +140,10 @@ impl DispatchTable {
     /// Resolve the best backend for an operation.
     pub fn resolve(&self, op: KernelOp) -> Option<DispatchBackend> {
         // Check overrides first
-        if let Some(&backend) = self.overrides.get(&op) {
-            if self
-                .entries
-                .iter()
-                .any(|e| e.op == op && e.backend == backend && e.available)
-            {
-                return Some(backend);
-            }
+        if let Some(&backend) = self.overrides.get(&op)
+            && self.entries.iter().any(|e| e.op == op && e.backend == backend && e.available)
+        {
+            return Some(backend);
         }
 
         // Find highest-priority available entry
@@ -168,11 +156,7 @@ impl DispatchTable {
 
     /// List all available backends for an operation.
     pub fn available_backends(&self, op: KernelOp) -> Vec<DispatchBackend> {
-        self.entries
-            .iter()
-            .filter(|e| e.op == op && e.available)
-            .map(|e| e.backend)
-            .collect()
+        self.entries.iter().filter(|e| e.op == op && e.available).map(|e| e.backend).collect()
     }
 
     /// Total registered entries.
@@ -182,11 +166,7 @@ impl DispatchTable {
 
     /// Operations with no available backend.
     pub fn unsupported_ops(&self) -> Vec<KernelOp> {
-        KernelOp::all()
-            .iter()
-            .filter(|&&op| self.resolve(op).is_none())
-            .copied()
-            .collect()
+        KernelOp::all().iter().filter(|&&op| self.resolve(op).is_none()).copied().collect()
     }
 
     /// Build default CPU dispatch table.

--- a/crates/bitnet-models/src/comparison_report.rs
+++ b/crates/bitnet-models/src/comparison_report.rs
@@ -64,41 +64,13 @@ pub fn compare_specs(a: &ModelSpec, b: &ModelSpec) -> Vec<SpecDiff> {
     };
 
     check("family", &a.family, &b.family);
-    check(
-        "params_millions",
-        &a.params_millions.to_string(),
-        &b.params_millions.to_string(),
-    );
-    check(
-        "hidden_size",
-        &a.hidden_size.to_string(),
-        &b.hidden_size.to_string(),
-    );
-    check(
-        "num_layers",
-        &a.num_layers.to_string(),
-        &b.num_layers.to_string(),
-    );
-    check(
-        "num_heads",
-        &a.num_heads.to_string(),
-        &b.num_heads.to_string(),
-    );
-    check(
-        "num_kv_heads",
-        &a.num_kv_heads.to_string(),
-        &b.num_kv_heads.to_string(),
-    );
-    check(
-        "vocab_size",
-        &a.vocab_size.to_string(),
-        &b.vocab_size.to_string(),
-    );
-    check(
-        "max_context",
-        &a.max_context.to_string(),
-        &b.max_context.to_string(),
-    );
+    check("params_millions", &a.params_millions.to_string(), &b.params_millions.to_string());
+    check("hidden_size", &a.hidden_size.to_string(), &b.hidden_size.to_string());
+    check("num_layers", &a.num_layers.to_string(), &b.num_layers.to_string());
+    check("num_heads", &a.num_heads.to_string(), &b.num_heads.to_string());
+    check("num_kv_heads", &a.num_kv_heads.to_string(), &b.num_kv_heads.to_string());
+    check("vocab_size", &a.vocab_size.to_string(), &b.vocab_size.to_string());
+    check("max_context", &a.max_context.to_string(), &b.max_context.to_string());
     check("activation", &a.activation, &b.activation);
     check("norm_type", &a.norm_type, &b.norm_type);
     check("weight_dtype", &a.weight_dtype, &b.weight_dtype);
@@ -315,11 +287,7 @@ mod tests {
 
     #[test]
     fn test_three_model_report() {
-        let r = ComparisonReport::build(vec![
-            phi4_spec(),
-            llama3_8b_spec(),
-            bitnet_2b_spec(),
-        ]);
+        let r = ComparisonReport::build(vec![phi4_spec(), llama3_8b_spec(), bitnet_2b_spec()]);
         assert_eq!(r.model_count(), 3);
         let diff = r.differing_fields();
         assert!(diff.len() > 3); // many fields differ

--- a/crates/bitnet-models/src/layer_inspector.rs
+++ b/crates/bitnet-models/src/layer_inspector.rs
@@ -93,12 +93,11 @@ pub fn inspect_layers(tensor_names: &[String]) -> ModelStructure {
 /// Extract layer index from a tensor name.
 fn extract_layer_index(name: &str) -> Option<usize> {
     for prefix in &["model.layers.", "blk.", "layers.", "encoder.layer.", "decoder.layer."] {
-        if let Some(rest) = name.strip_prefix(prefix) {
-            if let Some(idx_str) = rest.split('.').next() {
-                if let Ok(idx) = idx_str.parse::<usize>() {
-                    return Some(idx);
-                }
-            }
+        if let Some(rest) = name.strip_prefix(prefix)
+            && let Some(idx_str) = rest.split('.').next()
+            && let Ok(idx) = idx_str.parse::<usize>()
+        {
+            return Some(idx);
         }
     }
     None

--- a/crates/bitnet-models/src/loading_progress.rs
+++ b/crates/bitnet-models/src/loading_progress.rs
@@ -31,7 +31,7 @@ pub struct LoadingProgress {
     shards_done: usize,
     total_tensors: usize,
     tensors_done: usize,
-    total_bytes: u64,
+    _total_bytes: u64,
     bytes_done: u64,
     events: Vec<LoadEvent>,
 }
@@ -44,7 +44,7 @@ impl LoadingProgress {
             shards_done: 0,
             total_tensors: 0,
             tensors_done: 0,
-            total_bytes: 0,
+            _total_bytes: 0,
             bytes_done: 0,
             events: Vec::new(),
         }

--- a/crates/bitnet-models/src/registry_query.rs
+++ b/crates/bitnet-models/src/registry_query.rs
@@ -76,35 +76,35 @@ impl RegistryFilter {
     }
 
     pub fn matches(&self, entry: &RegistryEntry) -> bool {
-        if let Some(ref arch) = self.architecture {
-            if !entry.architecture.eq_ignore_ascii_case(arch) {
-                return false;
-            }
+        if let Some(ref arch) = self.architecture
+            && !entry.architecture.eq_ignore_ascii_case(arch)
+        {
+            return false;
         }
-        if let Some(max) = self.max_params {
-            if entry.param_count > max {
-                return false;
-            }
+        if let Some(max) = self.max_params
+            && entry.param_count > max
+        {
+            return false;
         }
-        if let Some(min) = self.min_params {
-            if entry.param_count < min {
-                return false;
-            }
+        if let Some(min) = self.min_params
+            && entry.param_count < min
+        {
+            return false;
         }
-        if let Some(ref qt) = self.quant_type {
-            if !entry.quant_type.eq_ignore_ascii_case(qt) {
-                return false;
-            }
+        if let Some(ref qt) = self.quant_type
+            && !entry.quant_type.eq_ignore_ascii_case(qt)
+        {
+            return false;
         }
-        if let Some(ref fmt) = self.format {
-            if !entry.format.eq_ignore_ascii_case(fmt) {
-                return false;
-            }
+        if let Some(ref fmt) = self.format
+            && !entry.format.eq_ignore_ascii_case(fmt)
+        {
+            return false;
         }
-        if let Some(ref tag) = self.tag {
-            if !entry.tags.iter().any(|t| t.eq_ignore_ascii_case(tag)) {
-                return false;
-            }
+        if let Some(ref tag) = self.tag
+            && !entry.tags.iter().any(|t| t.eq_ignore_ascii_case(tag))
+        {
+            return false;
         }
         true
     }

--- a/crates/bitnet-quantization/tests/quantization_pipeline_edge_cases.rs
+++ b/crates/bitnet-quantization/tests/quantization_pipeline_edge_cases.rs
@@ -114,7 +114,7 @@ fn i2s_boundary_values_minus_one_zero_one() {
     let deq_data = dequantized.to_vec().unwrap();
     // Each dequantized value should be in [-1, 1] range
     for &v in &deq_data {
-        assert!(v >= -1.5 && v <= 1.5, "dequantized {v} out of range");
+        assert!((-1.5..=1.5).contains(&v), "dequantized {v} out of range");
     }
 }
 
@@ -739,7 +739,7 @@ fn simd_capabilities_best_strategy() {
 fn simd_capabilities_optimal_block_size() {
     let caps = SimdCapabilities::detect();
     let block_size = caps.optimal_block_size();
-    assert!(block_size >= 32 && block_size <= 256, "block size {block_size} out of range");
+    assert!((32..=256).contains(&block_size), "block size {block_size} out of range");
 }
 
 // ===========================================================================

--- a/crates/bitnet-quantization/tests/quantization_types_edge_cases.rs
+++ b/crates/bitnet-quantization/tests/quantization_types_edge_cases.rs
@@ -416,8 +416,8 @@ fn qk256_tolerance_large() {
 
 #[test]
 fn qk256_size_tolerance_constant() {
-    assert!(bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT > 0.0);
-    assert!(bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT < 1.0);
+    const { assert!(bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT > 0.0) };
+    const { assert!(bitnet_quantization::QK256_SIZE_TOLERANCE_PERCENT < 1.0) };
 }
 
 // ===========================================================================

--- a/crates/bitnet-tokenizers/src/bench_utils.rs
+++ b/crates/bitnet-tokenizers/src/bench_utils.rs
@@ -102,11 +102,7 @@ where
 }
 
 /// Run a complete benchmark with encode+decode, returning results.
-pub fn run_benchmark<E, D>(
-    corpus: &BenchCorpus,
-    mut encode_fn: E,
-    mut decode_fn: D,
-) -> BenchResult
+pub fn run_benchmark<E, D>(corpus: &BenchCorpus, mut encode_fn: E, mut decode_fn: D) -> BenchResult
 where
     E: FnMut(&str) -> Vec<u32>,
     D: FnMut(&[u32]) -> String,
@@ -114,11 +110,7 @@ where
     let (enc_us, tokens) = time_encode(&corpus.text, &mut encode_fn);
     let (dec_us, _decoded) = time_decode(&tokens, &mut decode_fn);
 
-    let tps = if enc_us > 0 {
-        tokens.len() as f64 / (enc_us as f64 / 1_000_000.0)
-    } else {
-        0.0
-    };
+    let tps = if enc_us > 0 { tokens.len() as f64 / (enc_us as f64 / 1_000_000.0) } else { 0.0 };
 
     BenchResult {
         corpus_name: corpus.name.clone(),
@@ -163,11 +155,7 @@ pub fn summarize(results: &[BenchResult]) -> BenchSummary {
     let total_encode_us: u64 = results.iter().map(|r| r.encode_us).sum();
     let total_decode_us: u64 = results.iter().map(|r| r.decode_us).sum();
 
-    let avg_bpt = if total_tokens > 0 {
-        total_bytes as f32 / total_tokens as f32
-    } else {
-        0.0
-    };
+    let avg_bpt = if total_tokens > 0 { total_bytes as f32 / total_tokens as f32 } else { 0.0 };
     let avg_tps = if total_encode_us > 0 {
         total_tokens as f64 / (total_encode_us as f64 / 1_000_000.0)
     } else {
@@ -203,37 +191,25 @@ mod tests {
 
     #[test]
     fn test_time_encode() {
-        let (us, tokens) = time_encode("hello", |s| {
-            s.bytes().map(|b| b as u32).collect()
-        });
+        let (us, tokens) = time_encode("hello", |s| s.bytes().map(|b| b as u32).collect());
         assert_eq!(tokens.len(), 5);
         assert!(us < 1_000_000); // < 1 second
     }
 
     #[test]
     fn test_time_decode() {
-        let (us, text) = time_decode(&[104, 105], |t| {
-            t.iter().map(|&b| b as u8 as char).collect()
-        });
+        let (us, text) = time_decode(&[104, 105], |t| t.iter().map(|&b| b as u8 as char).collect());
         assert_eq!(text, "hi");
         assert!(us < 1_000_000);
     }
 
     #[test]
     fn test_run_benchmark() {
-        let corpus = BenchCorpus {
-            name: "test".into(),
-            text: "hello world".into(),
-            expected_min_tokens: 2,
-        };
+        let corpus =
+            BenchCorpus { name: "test".into(), text: "hello world".into(), expected_min_tokens: 2 };
         let result = run_benchmark(
             &corpus,
-            |s| {
-                s.split_whitespace()
-                    .enumerate()
-                    .map(|(i, _)| i as u32)
-                    .collect()
-            },
+            |s| s.split_whitespace().enumerate().map(|(i, _)| i as u32).collect(),
             |_t| "hello world".into(),
         );
         assert_eq!(result.token_count, 2);
@@ -313,11 +289,7 @@ mod tests {
 
     #[test]
     fn test_bench_result_fields() {
-        let corpus = BenchCorpus {
-            name: "x".into(),
-            text: "abc".into(),
-            expected_min_tokens: 1,
-        };
+        let corpus = BenchCorpus { name: "x".into(), text: "abc".into(), expected_min_tokens: 1 };
         let r = run_benchmark(&corpus, |_| vec![1, 2, 3], |_| "abc".into());
         assert_eq!(r.corpus_name, "x");
         assert_eq!(r.token_count, 3);


### PR DESCRIPTION
## Summary

Add `crates/bitnet-kernels/src/cpu/simd_batch_norm.rs` — six AVX2-accelerated normalization kernels with automatic scalar fallback.

## New Functions

| Function | Description |
|---|---|
| `batch_norm_forward` | Vectorized batch norm forward pass with per-channel statistics |
| `batch_norm_inference` | Fused scale+bias for inference mode (single multiply-add per element) |
| `group_norm` | Group normalization with configurable group count |
| `instance_norm` | Instance normalization (per-channel, delegates to group_norm) |
| `layer_norm_fused` | Fused LayerNorm with residual addition in a single pass |
| `running_stats` | Online mean/variance EMA update for training |

## Design

- **f64 accumulation** for mean/variance computation (numerical stability)
- **Fused scale+bias** in inference mode pre-computes `scale = gamma / sqrt(var + eps)` and `bias = beta - mean * scale` for optimal throughput
- **AVX2 inner loops** process 8 f32 lanes per iteration with scalar tail handling

## Tests

87 comprehensive tests covering:
- Forward pass correctness against scalar reference
- Inference mode with fused optimization
- Group/instance norm equivalence properties
- Fused LayerNorm + residual correctness
- Running statistics convergence
- Error handling (dimension mismatches, invalid eps/momentum)
- Numerical stability with extreme values
- Cross-function consistency (e.g., instance_norm == group_norm with max groups)

## Changes

- **New**: `crates/bitnet-kernels/src/cpu/simd_batch_norm.rs`
- **Modified**: `crates/bitnet-kernels/src/cpu/mod.rs` (module registration)