### PR TITLE
test: snapshot wave 25 — 107 insta tests across 3 crates

### DIFF
--- a/crates/bitnet-inference/tests/snapshot_wave25.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave25.rs
@@ -1,0 +1,338 @@
+//! Wave 25 snapshot tests for bitnet-inference.
+//!
+//! Covers: Engine configuration snapshots, sampling strategy parameter snapshots,
+//! generation output format snapshots, and token stream state snapshots.
+
+use std::time::Duration;
+
+// =========================================================================
+// Section 1 — Token stream configuration and events
+// =========================================================================
+
+use bitnet_inference::token_stream::{StreamConfig, StreamEvent, StreamStats};
+
+#[test]
+fn w25_stream_config_default_debug() {
+    let cfg = StreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_stream_event_token() {
+    let evt = StreamEvent::Token(42);
+    insta::assert_debug_snapshot!(evt);
+}
+
+#[test]
+fn w25_stream_event_text() {
+    let evt = StreamEvent::Text("Hello, world!".into());
+    insta::assert_debug_snapshot!(evt);
+}
+
+#[test]
+fn w25_stream_event_all_variants() {
+    let events: Vec<StreamEvent> = vec![
+        StreamEvent::Token(100),
+        StreamEvent::Text("hello".into()),
+        StreamEvent::EndOfStream,
+        StreamEvent::Error("invalid UTF-8 sequence".into()),
+    ];
+    insta::assert_debug_snapshot!(events);
+}
+
+#[test]
+fn w25_stream_stats_default() {
+    let stats = StreamStats::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 2 — Warmup configuration and results
+// =========================================================================
+
+use bitnet_inference::warmup::{WarmupConfig, WarmupResult, WarmupStatus};
+
+#[test]
+fn w25_warmup_config_default_debug() {
+    let cfg = WarmupConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_warmup_config_fast_debug() {
+    let cfg = WarmupConfig::fast();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_warmup_config_thorough_debug() {
+    let cfg = WarmupConfig::thorough();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_warmup_config_custom() {
+    let cfg = WarmupConfig::default()
+        .with_iterations(10)
+        .with_seq_len(256)
+        .with_timeout(Duration::from_secs(120));
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_warmup_status_all_variants() {
+    let variants = [WarmupStatus::Complete, WarmupStatus::TimedOut, WarmupStatus::Skipped];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn w25_warmup_result_success() {
+    let result = WarmupResult {
+        iterations_completed: 3,
+        total_time: Duration::from_millis(450),
+        iteration_times: vec![
+            Duration::from_millis(200),
+            Duration::from_millis(150),
+            Duration::from_millis(100),
+        ],
+        timed_out: false,
+        status: WarmupStatus::Complete,
+    };
+    insta::assert_snapshot!(format!(
+        "completed={} avg={:?} success={}",
+        result.iterations_completed,
+        result.avg_iteration_time(),
+        result.is_success()
+    ));
+}
+
+#[test]
+fn w25_warmup_result_timed_out() {
+    let result = WarmupResult {
+        iterations_completed: 1,
+        total_time: Duration::from_secs(30),
+        iteration_times: vec![Duration::from_secs(30)],
+        timed_out: true,
+        status: WarmupStatus::TimedOut,
+    };
+    insta::assert_debug_snapshot!(result);
+}
+
+// =========================================================================
+// Section 3 — Memory pool configuration
+// =========================================================================
+
+use bitnet_inference::memory_pool::{GrowthStrategy, PoolConfig, PoolStatistics};
+
+#[test]
+fn w25_pool_config_default_debug() {
+    let cfg = PoolConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_pool_config_builder_custom() {
+    let cfg = PoolConfig::builder()
+        .initial_size(4 << 20)
+        .growth_strategy(GrowthStrategy::Fixed)
+        .max_pool_size(128 << 20)
+        .max_allocation_size(16 << 20)
+        .build();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_growth_strategy_variants() {
+    let strategies = [GrowthStrategy::Fixed, GrowthStrategy::Double];
+    insta::assert_debug_snapshot!(strategies);
+}
+
+#[test]
+fn w25_pool_statistics_default() {
+    let stats = PoolStatistics::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 4 — KV cache eviction policies
+// =========================================================================
+
+use bitnet_inference::kv_cache_optimized::{CacheEvictionPolicy, CacheMetrics, EvictionConfig};
+
+#[test]
+fn w25_cache_eviction_policy_all_variants() {
+    let policies = [
+        CacheEvictionPolicy::LRU,
+        CacheEvictionPolicy::SlidingWindow,
+        CacheEvictionPolicy::AttentionBased,
+    ];
+    insta::assert_debug_snapshot!(policies);
+}
+
+#[test]
+fn w25_eviction_config_default_debug() {
+    let cfg = EvictionConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_eviction_config_sliding_window() {
+    let cfg = EvictionConfig {
+        policy: CacheEvictionPolicy::SlidingWindow,
+        max_pages: 512,
+        window_size: 32,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_cache_metrics_empty() {
+    let m = CacheMetrics::default();
+    insta::assert_snapshot!(format!("hit_rate={:.4}", m.hit_rate()));
+}
+
+#[test]
+fn w25_cache_metrics_populated() {
+    let m = CacheMetrics { hits: 950, misses: 50, memory_bytes: 33_554_432, evictions: 12 };
+    insta::assert_snapshot!(format!(
+        "hits={} misses={} hit_rate={:.4} evictions={} memory_bytes={}",
+        m.hits,
+        m.misses,
+        m.hit_rate(),
+        m.evictions,
+        m.memory_bytes
+    ));
+}
+
+// =========================================================================
+// Section 5 — Profiler configuration
+// =========================================================================
+
+use bitnet_inference::profiler::{LayerProfile, MemorySnapshot, ProfilerConfig};
+
+#[test]
+fn w25_profiler_config_default_debug() {
+    let cfg = ProfilerConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_profiler_config_disabled_debug() {
+    let cfg = ProfilerConfig::disabled();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_profiler_config_custom() {
+    let cfg = ProfilerConfig::default().with_warmup(5).with_sample_size(100).with_memory(true);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_layer_profile_attention() {
+    let profile = LayerProfile {
+        layer_name: "layer_0.attention".into(),
+        layer_type: "attention".into(),
+        forward_time_us: 1250.5,
+        backward_time_us: 0.0,
+        memory_bytes: 4_194_304,
+        flops_estimate: 805_306_368,
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+#[test]
+fn w25_layer_profile_ffn() {
+    let profile = LayerProfile {
+        layer_name: "layer_0.ffn".into(),
+        layer_type: "ffn".into(),
+        forward_time_us: 850.3,
+        backward_time_us: 0.0,
+        memory_bytes: 8_388_608,
+        flops_estimate: 1_610_612_736,
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+#[test]
+fn w25_memory_snapshot_debug() {
+    let snap = MemorySnapshot {
+        label: "post_attention_layer_5".into(),
+        timestamp_us: 15432.7,
+        memory_bytes: 67_108_864,
+    };
+    insta::assert_debug_snapshot!(snap);
+}
+
+// =========================================================================
+// Section 6 — Streaming configuration
+// =========================================================================
+
+use bitnet_inference::streaming::{GenerationStats, StreamingConfig};
+
+#[test]
+fn w25_streaming_config_default_debug() {
+    let cfg = StreamingConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_generation_stats_default_debug() {
+    let stats = GenerationStats::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 7 — Prefix cache configuration
+// =========================================================================
+
+use bitnet_inference::prefix_cache::{EvictionPolicy, PrefixCacheConfig, PrefixCacheStats};
+
+#[test]
+fn w25_eviction_policy_all_variants() {
+    let policies =
+        [EvictionPolicy::LRU, EvictionPolicy::LFU, EvictionPolicy::FIFO, EvictionPolicy::TTL];
+    insta::assert_debug_snapshot!(policies);
+}
+
+#[test]
+fn w25_prefix_cache_config_default_debug() {
+    let cfg = PrefixCacheConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_prefix_cache_config_custom() {
+    let cfg = PrefixCacheConfig {
+        max_entries: 256,
+        max_memory_bytes: 128 * 1024 * 1024,
+        eviction_policy: EvictionPolicy::LFU,
+        min_prefix_length: 8,
+        ttl_seconds: 7200,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_prefix_cache_stats_snapshot() {
+    let stats = PrefixCacheStats {
+        hit_rate: 0.85,
+        miss_rate: 0.15,
+        eviction_count: 42,
+        memory_usage: 67_108_864,
+        avg_prefix_match_length: 12.5,
+    };
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 8 — Batch configuration
+// =========================================================================
+
+use bitnet_inference::batch::BatchConfig;
+
+#[test]
+fn w25_batch_config_default_debug() {
+    let cfg = BatchConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_batch_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_batch_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+BatchConfig {
+    max_batch_size: 8,
+    timeout: 30s,
+    max_total_tokens: 8192,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_eviction_policy_all_variants.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_eviction_policy_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: policies
+---
+[
+    LRU,
+    SlidingWindow,
+    AttentionBased,
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_metrics_empty.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_metrics_empty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: "format!(\"hit_rate={:.4}\", m.hit_rate())"
+---
+hit_rate=0.0000

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_metrics_populated.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_cache_metrics_populated.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: "format!(\"hits={} misses={} hit_rate={:.4} evictions={} memory_bytes={}\",\nm.hits, m.misses, m.hit_rate(), m.evictions, m.memory_bytes)"
+---
+hits=950 misses=50 hit_rate=0.9500 evictions=12 memory_bytes=33554432

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+EvictionConfig {
+    policy: LRU,
+    max_pages: 1024,
+    window_size: 64,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_config_sliding_window.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_config_sliding_window.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+EvictionConfig {
+    policy: SlidingWindow,
+    max_pages: 512,
+    window_size: 32,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_policy_all_variants.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_eviction_policy_all_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: policies
+---
+[
+    LRU,
+    LFU,
+    FIFO,
+    TTL,
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_generation_stats_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_generation_stats_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: stats
+---
+GenerationStats {
+    tokens_generated: 0,
+    errors_encountered: 0,
+    retries_attempted: 0,
+    cancelled: false,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_growth_strategy_variants.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_growth_strategy_variants.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: strategies
+---
+[
+    Fixed,
+    Double,
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_layer_profile_attention.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_layer_profile_attention.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: profile
+---
+LayerProfile {
+    layer_name: "layer_0.attention",
+    layer_type: "attention",
+    forward_time_us: 1250.5,
+    backward_time_us: 0.0,
+    memory_bytes: 4194304,
+    flops_estimate: 805306368,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_layer_profile_ffn.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_layer_profile_ffn.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: profile
+---
+LayerProfile {
+    layer_name: "layer_0.ffn",
+    layer_type: "ffn",
+    forward_time_us: 850.3,
+    backward_time_us: 0.0,
+    memory_bytes: 8388608,
+    flops_estimate: 1610612736,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_memory_snapshot_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_memory_snapshot_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: snap
+---
+MemorySnapshot {
+    label: "post_attention_layer_5",
+    timestamp_us: 15432.7,
+    memory_bytes: 67108864,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_config_builder_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_config_builder_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+PoolConfig {
+    initial_size: 4194304,
+    growth_strategy: Fixed,
+    max_pool_size: 134217728,
+    max_allocation_size: 16777216,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+PoolConfig {
+    initial_size: 1048576,
+    growth_strategy: Double,
+    max_pool_size: 268435456,
+    max_allocation_size: 67108864,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_statistics_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_pool_statistics_default.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: stats
+---
+PoolStatistics {
+    bytes_allocated: 0,
+    bytes_freed: 0,
+    peak_usage: 0,
+    allocation_count: 0,
+    reset_count: 0,
+    slab_checkouts: 0,
+    slab_returns: 0,
+    total_pool_bytes: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_config_custom.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+PrefixCacheConfig {
+    max_entries: 256,
+    max_memory_bytes: 134217728,
+    eviction_policy: LFU,
+    min_prefix_length: 8,
+    ttl_seconds: 7200,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+PrefixCacheConfig {
+    max_entries: 1024,
+    max_memory_bytes: 536870912,
+    eviction_policy: LRU,
+    min_prefix_length: 4,
+    ttl_seconds: 3600,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_stats_snapshot.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_prefix_cache_stats_snapshot.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: stats
+---
+PrefixCacheStats {
+    hit_rate: 0.85,
+    miss_rate: 0.15,
+    eviction_count: 42,
+    memory_usage: 67108864,
+    avg_prefix_match_length: 12.5,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: true,
+    record_memory: true,
+    warmup_iterations: 5,
+    sample_size: 100,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: true,
+    record_memory: false,
+    warmup_iterations: 0,
+    sample_size: 1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_disabled_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_profiler_config_disabled_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: false,
+    record_memory: false,
+    warmup_iterations: 0,
+    sample_size: 1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+StreamConfig {
+    buffer_size: 8,
+    flush_on_whitespace: true,
+    flush_on_newline: true,
+    max_pending_tokens: 64,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_all_variants.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_all_variants.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: events
+---
+[
+    Token(
+        100,
+    ),
+    Text(
+        "hello",
+    ),
+    EndOfStream,
+    Error(
+        "invalid UTF-8 sequence",
+    ),
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_text.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_text.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: evt
+---
+Text(
+    "Hello, world!",
+)

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_token.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_event_token.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: evt
+---
+Token(
+    42,
+)

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_stats_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_stream_stats_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: stats
+---
+StreamStats {
+    tokens_generated: 0,
+    text_chunks_emitted: 0,
+    avg_tokens_per_chunk: 0.0,
+    total_bytes: 0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_streaming_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_streaming_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+StreamingConfig {
+    buffer_size: 10,
+    flush_interval_ms: 50,
+    max_retries: 3,
+    token_timeout_ms: 5000,
+    cancellable: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_custom.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+WarmupConfig {
+    iterations: 10,
+    seq_len: 256,
+    warmup_kv_cache: true,
+    warmup_kernels: true,
+    timeout: 120s,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_default_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_default_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+WarmupConfig {
+    iterations: 3,
+    seq_len: 32,
+    warmup_kv_cache: true,
+    warmup_kernels: true,
+    timeout: 30s,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_fast_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_fast_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+WarmupConfig {
+    iterations: 1,
+    seq_len: 8,
+    warmup_kv_cache: false,
+    warmup_kernels: true,
+    timeout: 5s,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_thorough_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_config_thorough_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: cfg
+---
+WarmupConfig {
+    iterations: 5,
+    seq_len: 128,
+    warmup_kv_cache: true,
+    warmup_kernels: true,
+    timeout: 60s,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_result_success.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_result_success.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: "format!(\"completed={} avg={:?} success={}\", result.iterations_completed,\nresult.avg_iteration_time(), result.is_success())"
+---
+completed=3 avg=150ms success=true

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_result_timed_out.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_result_timed_out.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: result
+---
+WarmupResult {
+    iterations_completed: 1,
+    total_time: 30s,
+    iteration_times: [
+        30s,
+    ],
+    timed_out: true,
+    status: TimedOut,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_status_all_variants.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave25__w25_warmup_status_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave25.rs
+expression: variants
+---
+[
+    Complete,
+    TimedOut,
+    Skipped,
+]

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-kernels/tests/snapshot_wave25.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave25.rs
@@ -1,0 +1,407 @@
+//! Wave 25 snapshot tests for bitnet-kernels.
+//!
+//! Covers: CUDA kernel launch configurations, CPU SIMD operation results,
+//! kernel registry state, and performance metrics snapshots.
+
+// =========================================================================
+// Section 1 — CUDA fusion launch configurations
+// =========================================================================
+
+use bitnet_kernels::cuda::fusion::{
+    FusedElementwiseLaunchConfig, FusedMatmulLaunchConfig, FusedOp, FusionConfig, FusionError,
+};
+
+#[test]
+fn w25_fusion_config_default_debug() {
+    let cfg = FusionConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_fusion_config_disabled_debug() {
+    let cfg = FusionConfig::disabled();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_fused_op_all_kernel_names() {
+    let ops = [
+        FusedOp::RmsNormLinear,
+        FusedOp::GeluLinear,
+        FusedOp::SoftmaxMask,
+        FusedOp::AddNormalize,
+        FusedOp::ScaleAndAdd,
+    ];
+    let names: Vec<&str> = ops.iter().map(|o| o.kernel_name()).collect();
+    insta::assert_debug_snapshot!(names);
+}
+
+#[test]
+fn w25_fused_op_display_strings() {
+    let ops = [
+        FusedOp::RmsNormLinear,
+        FusedOp::GeluLinear,
+        FusedOp::SoftmaxMask,
+        FusedOp::AddNormalize,
+        FusedOp::ScaleAndAdd,
+    ];
+    let displays: Vec<String> = ops.iter().map(|o| o.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w25_fused_matmul_launch_small() {
+    let cfg = FusedMatmulLaunchConfig::new(64, 32).unwrap();
+    insta::assert_snapshot!(format!(
+        "n={} out_dim={} tpb={} grid={:?} block={:?} shmem={}",
+        cfg.n,
+        cfg.out_dim,
+        cfg.threads_per_block,
+        cfg.grid_dim(),
+        cfg.block_dim(),
+        cfg.shared_mem_bytes()
+    ));
+}
+
+#[test]
+fn w25_fused_matmul_launch_large() {
+    let cfg = FusedMatmulLaunchConfig::new(4096, 2048).unwrap();
+    insta::assert_snapshot!(format!(
+        "n={} out_dim={} tpb={} grid={:?} block={:?} shmem={}",
+        cfg.n,
+        cfg.out_dim,
+        cfg.threads_per_block,
+        cfg.grid_dim(),
+        cfg.block_dim(),
+        cfg.shared_mem_bytes()
+    ));
+}
+
+#[test]
+fn w25_fused_elementwise_launch_small() {
+    let cfg = FusedElementwiseLaunchConfig::new(512).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_fused_elementwise_launch_large() {
+    let cfg = FusedElementwiseLaunchConfig::new(1_048_576).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_fusion_error_dimension_mismatch_display() {
+    let err = FusionError::DimensionMismatch { expected: 768, got: 512 };
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_fusion_error_invalid_config_display() {
+    let err = FusionError::InvalidConfig("min_fusion_size must be > 0".into());
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_fusion_error_empty_input_display() {
+    let err = FusionError::EmptyInput;
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_fusion_config_validate_zero_size() {
+    let cfg = FusionConfig { min_fusion_size: 0, ..FusionConfig::default() };
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+// =========================================================================
+// Section 2 — CUDA matmul launch configurations
+// =========================================================================
+
+use bitnet_kernels::cuda::matmul::{MatmulConfig, MatmulDtype};
+
+#[test]
+fn w25_matmul_config_default_debug() {
+    let cfg = MatmulConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_matmul_config_for_shape_small() {
+    let cfg = MatmulConfig::for_shape(128, 256, 64).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_matmul_config_for_shape_large() {
+    let cfg = MatmulConfig::for_shape(4096, 4096, 4096).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_matmul_dtype_all_variants() {
+    let dtypes = [MatmulDtype::F32, MatmulDtype::F16];
+    insta::assert_debug_snapshot!(dtypes);
+}
+
+// =========================================================================
+// Section 3 — CUDA gating configurations
+// =========================================================================
+
+use bitnet_kernels::cuda::gating::{GatingConfig, GatingType};
+
+#[test]
+fn w25_gating_type_all_variants_debug() {
+    let types = [GatingType::SwiGLU, GatingType::GeGLU, GatingType::ReGLU];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn w25_gating_type_kernel_names() {
+    let names: Vec<&str> = [GatingType::SwiGLU, GatingType::GeGLU, GatingType::ReGLU]
+        .iter()
+        .map(|g| g.kernel_name())
+        .collect();
+    insta::assert_debug_snapshot!(names);
+}
+
+#[test]
+fn w25_gating_config_swiglu() {
+    let cfg = GatingConfig::new(4096, GatingType::SwiGLU).unwrap();
+    insta::assert_snapshot!(format!(
+        "n={} tpb={} gating={:?} grid={:?} block={:?}",
+        cfg.n,
+        cfg.threads_per_block,
+        cfg.gating,
+        cfg.grid_dim(),
+        cfg.block_dim()
+    ));
+}
+
+#[test]
+fn w25_gating_config_geglu() {
+    let cfg = GatingConfig::new(2048, GatingType::GeGLU).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 4 — CUDA memory pool configuration
+// =========================================================================
+
+use bitnet_kernels::cuda::memory_pool::MemoryPoolConfig;
+
+#[test]
+fn w25_memory_pool_config_default_debug() {
+    let cfg = MemoryPoolConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_memory_pool_config_custom() {
+    let cfg = MemoryPoolConfig {
+        initial_size: 128 * 1024 * 1024,
+        max_size: 2 * 1024 * 1024 * 1024,
+        block_size: 512,
+        alignment: 512,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 5 — CUDA attention kernel configuration
+// =========================================================================
+
+use bitnet_kernels::cuda::attention::AttentionKernelConfig;
+
+#[test]
+fn w25_attention_kernel_config_small() {
+    let cfg = AttentionKernelConfig::for_shape(12, 64, 128, 128, true).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_attention_kernel_config_decode() {
+    let cfg = AttentionKernelConfig::for_shape(32, 128, 1, 2048, true).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 6 — CUDA layernorm configuration
+// =========================================================================
+
+use bitnet_kernels::cuda::layernorm::LayerNormConfig;
+
+#[test]
+fn w25_layernorm_config_default_debug() {
+    let cfg = LayerNormConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_layernorm_config_custom_eps() {
+    let cfg = LayerNormConfig::new(1e-6, false).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 7 — CPU fusion (mirroring CUDA fusion)
+// =========================================================================
+
+use bitnet_kernels::cpu::fusion::{
+    FusedOp as CpuFusedOp, FusionConfig as CpuFusionConfig, FusionError as CpuFusionError,
+};
+
+#[test]
+fn w25_cpu_fusion_config_default() {
+    let cfg = CpuFusionConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_cpu_fusion_config_disabled() {
+    let cfg = CpuFusionConfig::disabled();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_cpu_fused_op_all_display() {
+    let ops = [
+        CpuFusedOp::RmsNormLinear,
+        CpuFusedOp::GeluLinear,
+        CpuFusedOp::SoftmaxMask,
+        CpuFusedOp::AddNormalize,
+        CpuFusedOp::ScaleAndAdd,
+    ];
+    let displays: Vec<String> = ops.iter().map(|o| o.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w25_cpu_fusion_error_dimension_mismatch() {
+    let err = CpuFusionError::DimensionMismatch { expected: 1024, got: 768 };
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_cpu_fusion_error_empty_input() {
+    let err = CpuFusionError::EmptyInput;
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_cpu_fusion_validate_zero() {
+    let cfg = CpuFusionConfig { min_fusion_size: 0, ..CpuFusionConfig::default() };
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+// =========================================================================
+// Section 8 — CPU SIMD matmul / tiling
+// =========================================================================
+
+use bitnet_kernels::cpu::simd_matmul::{SimdMatmulConfig, TileConfig};
+
+#[test]
+fn w25_tile_config_default_debug() {
+    let cfg = TileConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_tile_config_custom() {
+    let cfg = TileConfig::new(64, 128, 16);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_simd_matmul_config_square() {
+    let cfg = SimdMatmulConfig::new(512, 512, 512);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_simd_matmul_config_transposed() {
+    let cfg = SimdMatmulConfig {
+        m: 128,
+        n: 256,
+        k: 64,
+        alpha: 2.0,
+        beta: 0.5,
+        transpose_a: true,
+        transpose_b: false,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 9 — OpenCL numerical stability
+// =========================================================================
+
+use bitnet_kernels::opencl_numerical_stability::{NumericalProfile, StabilityConfig};
+
+#[test]
+fn w25_stability_config_default_debug() {
+    let cfg = StabilityConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_numerical_profile_clean_data() {
+    let data: Vec<f32> = (0..100).map(|i| (i as f32 - 50.0) / 50.0).collect();
+    let profile = NumericalProfile::compute(&data);
+    insta::assert_snapshot!(profile.to_string());
+}
+
+#[test]
+fn w25_numerical_profile_empty_data() {
+    let profile = NumericalProfile::compute(&[]);
+    insta::assert_snapshot!(profile.to_string());
+}
+
+#[test]
+fn w25_numerical_profile_with_nans() {
+    let data = vec![1.0, f32::NAN, 2.0, f32::NAN, 3.0];
+    let profile = NumericalProfile::compute(&data);
+    insta::assert_snapshot!(format!(
+        "nan_count={} inf_count={} is_clean={}",
+        profile.nan_count,
+        profile.inf_count,
+        profile.is_clean()
+    ));
+}
+
+#[test]
+fn w25_numerical_profile_with_infs() {
+    let data = vec![f32::INFINITY, f32::NEG_INFINITY, 0.0];
+    let profile = NumericalProfile::compute(&data);
+    insta::assert_snapshot!(format!(
+        "nan_count={} inf_count={} is_clean={}",
+        profile.nan_count,
+        profile.inf_count,
+        profile.is_clean()
+    ));
+}
+
+// =========================================================================
+// Section 10 — CUDA pooling configuration
+// =========================================================================
+
+use bitnet_kernels::cuda::pooling::{CudaPoolType, PoolingConfig};
+
+#[test]
+fn w25_cuda_pool_type_all_variants() {
+    let types = [CudaPoolType::Max, CudaPoolType::Average];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn w25_pooling_config_max_pool() {
+    let cfg = PoolingConfig::new(CudaPoolType::Max, 1024, 3, 2, 1).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_pooling_config_avg_pool() {
+    let cfg = PoolingConfig::new(CudaPoolType::Average, 512, 4, 4, 0).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_attention_kernel_config_decode.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_attention_kernel_config_decode.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+AttentionKernelConfig {
+    tile_q: 1,
+    tile_kv: 64,
+    n_heads: 32,
+    head_dim: 128,
+    seq_len_q: 1,
+    seq_len_kv: 2048,
+    threads_per_block: 256,
+    shared_mem_bytes: 33288,
+    causal: true,
+    scale: 0.088388346,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_attention_kernel_config_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_attention_kernel_config_small.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+AttentionKernelConfig {
+    tile_q: 32,
+    tile_kv: 64,
+    n_heads: 12,
+    head_dim: 64,
+    seq_len_q: 128,
+    seq_len_kv: 128,
+    threads_per_block: 256,
+    shared_mem_bytes: 24832,
+    causal: true,
+    scale: 0.125,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fused_op_all_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fused_op_all_display.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: displays
+---
+[
+    "RmsNormLinear",
+    "GeluLinear",
+    "SoftmaxMask",
+    "AddNormalize",
+    "ScaleAndAdd",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusionConfig {
+    enable_rmsnorm_linear: true,
+    enable_gelu_linear: true,
+    enable_softmax_mask: true,
+    min_fusion_size: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_config_disabled.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_config_disabled.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusionConfig {
+    enable_rmsnorm_linear: false,
+    enable_gelu_linear: false,
+    enable_softmax_mask: false,
+    min_fusion_size: 18446744073709551615,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_error_dimension_mismatch.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_error_dimension_mismatch.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+dimension mismatch: expected 1024, got 768

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_error_empty_input.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_error_empty_input.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+empty input

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_validate_zero.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cpu_fusion_validate_zero.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+invalid config: min_fusion_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cuda_pool_type_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_cuda_pool_type_all_variants.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: types
+---
+[
+    Max,
+    Average,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_elementwise_launch_large.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_elementwise_launch_large.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusedElementwiseLaunchConfig {
+    n: 1048576,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_elementwise_launch_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_elementwise_launch_small.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusedElementwiseLaunchConfig {
+    n: 512,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_matmul_launch_large.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_matmul_launch_large.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: "format!(\"n={} out_dim={} tpb={} grid={:?} block={:?} shmem={}\", cfg.n,\ncfg.out_dim, cfg.threads_per_block, cfg.grid_dim(), cfg.block_dim(),\ncfg.shared_mem_bytes())"
+---
+n=4096 out_dim=2048 tpb=256 grid=(2048, 1, 1) block=(256, 1, 1) shmem=1024

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_matmul_launch_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_matmul_launch_small.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: "format!(\"n={} out_dim={} tpb={} grid={:?} block={:?} shmem={}\", cfg.n,\ncfg.out_dim, cfg.threads_per_block, cfg.grid_dim(), cfg.block_dim(),\ncfg.shared_mem_bytes())"
+---
+n=64 out_dim=32 tpb=64 grid=(32, 1, 1) block=(64, 1, 1) shmem=256

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_op_all_kernel_names.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_op_all_kernel_names.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: names
+---
+[
+    "fused_rmsnorm_linear_f32",
+    "fused_gelu_linear_f32",
+    "fused_softmax_mask_f32",
+    "fused_add_rmsnorm_f32",
+    "fused_scale_add_f32",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_op_display_strings.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fused_op_display_strings.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: displays
+---
+[
+    "RmsNormLinear",
+    "GeluLinear",
+    "SoftmaxMask",
+    "AddNormalize",
+    "ScaleAndAdd",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusionConfig {
+    enable_rmsnorm_linear: true,
+    enable_gelu_linear: true,
+    enable_softmax_mask: true,
+    min_fusion_size: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_disabled_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_disabled_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+FusionConfig {
+    enable_rmsnorm_linear: false,
+    enable_gelu_linear: false,
+    enable_softmax_mask: false,
+    min_fusion_size: 18446744073709551615,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_validate_zero_size.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_config_validate_zero_size.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+invalid config: min_fusion_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_dimension_mismatch_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_dimension_mismatch_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+dimension mismatch: expected 768, got 512

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_empty_input_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_empty_input_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+empty input

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_invalid_config_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_fusion_error_invalid_config_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+invalid config: min_fusion_size must be > 0

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_config_geglu.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_config_geglu.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+GatingConfig {
+    n: 2048,
+    threads_per_block: 256,
+    gating: GeGLU,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_config_swiglu.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_config_swiglu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: "format!(\"n={} tpb={} gating={:?} grid={:?} block={:?}\", cfg.n,\ncfg.threads_per_block, cfg.gating, cfg.grid_dim(), cfg.block_dim())"
+---
+n=4096 tpb=256 gating=SwiGLU grid=(16, 1, 1) block=(256, 1, 1)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_type_all_variants_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_type_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: types
+---
+[
+    SwiGLU,
+    GeGLU,
+    ReGLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_type_kernel_names.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_gating_type_kernel_names.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: names
+---
+[
+    "swiglu_f32",
+    "geglu_f32",
+    "reglu_f32",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_layernorm_config_custom_eps.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_layernorm_config_custom_eps.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+LayerNormConfig {
+    eps: 1e-6,
+    normalized_shape: [],
+    elementwise_affine: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_layernorm_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_layernorm_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+LayerNormConfig {
+    eps: 1e-5,
+    normalized_shape: [],
+    elementwise_affine: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_default_debug.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+MatmulConfig {
+    m: 1,
+    n: 1,
+    k: 1,
+    batch_size: 1,
+    transpose_a: false,
+    transpose_b: false,
+    alpha: 1.0,
+    beta: 0.0,
+    dtype: F32,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_for_shape_large.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_for_shape_large.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+MatmulConfig {
+    m: 4096,
+    n: 4096,
+    k: 4096,
+    batch_size: 1,
+    transpose_a: false,
+    transpose_b: false,
+    alpha: 1.0,
+    beta: 0.0,
+    dtype: F32,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_for_shape_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_config_for_shape_small.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+MatmulConfig {
+    m: 128,
+    n: 256,
+    k: 64,
+    batch_size: 1,
+    transpose_a: false,
+    transpose_b: false,
+    alpha: 1.0,
+    beta: 0.0,
+    dtype: F32,
+    tile_m: 32,
+    tile_n: 32,
+    tile_k: 32,
+    threads_per_block: 256,
+    shared_mem_bytes: 8192,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_dtype_all_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_matmul_dtype_all_variants.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: dtypes
+---
+[
+    F32,
+    F16,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_memory_pool_config_custom.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_memory_pool_config_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+MemoryPoolConfig {
+    initial_size: 134217728,
+    max_size: 2147483648,
+    block_size: 512,
+    alignment: 512,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_memory_pool_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_memory_pool_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+MemoryPoolConfig {
+    initial_size: 67108864,
+    max_size: 1073741824,
+    block_size: 256,
+    alignment: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_clean_data.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_clean_data.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: profile.to_string()
+---
+Profile(n=100, min=-1.0000, max=0.9800, mean=-0.0100, std=0.5773, nan=0, inf=0)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_empty_data.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_empty_data.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: profile.to_string()
+---
+Profile(n=0, min=0.0000, max=0.0000, mean=0.0000, std=0.0000, nan=0, inf=0)

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_with_infs.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_with_infs.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: "format!(\"nan_count={} inf_count={} is_clean={}\", profile.nan_count,\nprofile.inf_count, profile.is_clean())"
+---
+nan_count=0 inf_count=2 is_clean=false

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_with_nans.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_numerical_profile_with_nans.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: "format!(\"nan_count={} inf_count={} is_clean={}\", profile.nan_count,\nprofile.inf_count, profile.is_clean())"
+---
+nan_count=2 inf_count=0 is_clean=false

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_pooling_config_avg_pool.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_pooling_config_avg_pool.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+PoolingConfig {
+    pool_type: Average,
+    input_len: 512,
+    kernel_size: 4,
+    stride: 4,
+    padding: 0,
+    threads_per_block: 128,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_pooling_config_max_pool.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_pooling_config_max_pool.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+PoolingConfig {
+    pool_type: Max,
+    input_len: 1024,
+    kernel_size: 3,
+    stride: 2,
+    padding: 1,
+    threads_per_block: 512,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_simd_matmul_config_square.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_simd_matmul_config_square.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+SimdMatmulConfig {
+    m: 512,
+    n: 512,
+    k: 512,
+    alpha: 1.0,
+    beta: 0.0,
+    transpose_a: false,
+    transpose_b: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_simd_matmul_config_transposed.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_simd_matmul_config_transposed.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+SimdMatmulConfig {
+    m: 128,
+    n: 256,
+    k: 64,
+    alpha: 2.0,
+    beta: 0.5,
+    transpose_a: true,
+    transpose_b: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_stability_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_stability_config_default_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+StabilityConfig {
+    max_value: 65504.0,
+    min_value: -65504.0,
+    nan_replacement: 0.0,
+    inf_replacement: 0.0,
+    atol: 1e-5,
+    rtol: 0.001,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_tile_config_custom.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_tile_config_custom.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+TileConfig {
+    tile_m: 64,
+    tile_n: 128,
+    tile_k: 16,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_tile_config_default_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave25__w25_tile_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave25.rs
+expression: cfg
+---
+TileConfig {
+    tile_m: 64,
+    tile_n: 64,
+    tile_k: 64,
+}

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 

--- a/crates/bitnet-quantization/tests/snapshot_wave25.rs
+++ b/crates/bitnet-quantization/tests/snapshot_wave25.rs
@@ -1,0 +1,314 @@
+//! Wave 25 snapshot tests for bitnet-quantization.
+//!
+//! Covers: Quantization format detection snapshots, block layout snapshots,
+//! scale factor computation snapshots, and error message format snapshots.
+
+use bitnet_common::QuantizationType;
+use bitnet_quantization::device_aware_quantizer::ToleranceConfig;
+use bitnet_quantization::i2s::I2SLayout;
+use bitnet_quantization::int4_quant::{Int4QuantConfig, NibblePacked, quantize_tensor_int4};
+use bitnet_quantization::int8_quant::{CalibrationMethod, Int8QuantConfig};
+use bitnet_quantization::pipeline::{PipelineConfig, Precision, QuantizationStage};
+use bitnet_quantization::simd_ops::{QuantizationStrategy, SimdCapabilities};
+use bitnet_quantization::tl1::TL1Config;
+use bitnet_quantization::tl2::TL2Config;
+
+// =========================================================================
+// Section 1 — Quantization format detection
+// =========================================================================
+
+#[test]
+fn w25_quantization_type_all_variants_debug() {
+    let types = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn w25_quantization_type_display_all() {
+    let types = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    let displays: Vec<String> = types.iter().map(|t| t.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w25_precision_all_variants_debug() {
+    let variants = [Precision::F32, Precision::I2S, Precision::TL1, Precision::TL2];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn w25_quantization_stage_all_debug() {
+    let stages = [
+        QuantizationStage::Calibration,
+        QuantizationStage::Quantization,
+        QuantizationStage::Verification,
+        QuantizationStage::PackingOptimization,
+    ];
+    let labeled: Vec<String> = stages.iter().map(|s| format!("{s:?}={}", *s as u8)).collect();
+    insta::assert_snapshot!(labeled.join(", "));
+}
+
+// =========================================================================
+// Section 2 — Block layout snapshots
+// =========================================================================
+
+#[test]
+fn w25_i2s_layout_default_snapshot() {
+    let layout = I2SLayout::default();
+    insta::assert_snapshot!(format!(
+        "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block
+    ));
+}
+
+#[test]
+fn w25_i2s_layout_field_values() {
+    let layout = I2SLayout::default();
+    insta::assert_snapshot!(format!(
+        "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block
+    ));
+}
+
+#[test]
+fn w25_tl1_config_default_debug() {
+    let cfg = TL1Config::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_tl2_config_default_debug() {
+    let cfg = TL2Config::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_int4_config_default_debug() {
+    let cfg = Int4QuantConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_int4_config_asymmetric() {
+    let cfg = Int4QuantConfig { group_size: 64, symmetric: false, block_wise: true };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_int8_config_default_debug() {
+    let cfg = Int8QuantConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_int8_config_asymmetric_percentile() {
+    let cfg = Int8QuantConfig {
+        per_channel: false,
+        symmetric: false,
+        calibration_method: CalibrationMethod::Percentile(99.9),
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_calibration_method_all_variants() {
+    let methods =
+        [CalibrationMethod::MinMax, CalibrationMethod::Percentile(99.0), CalibrationMethod::MSE];
+    insta::assert_debug_snapshot!(methods);
+}
+
+// =========================================================================
+// Section 3 — Scale factor computation snapshots
+// =========================================================================
+
+#[test]
+fn w25_int4_quantize_uniform() {
+    let data: Vec<f32> = (0..32).map(|i| (i as f32 - 16.0) / 16.0).collect();
+    let cfg = Int4QuantConfig::default();
+    let (packed, params) = quantize_tensor_int4(&data, &cfg);
+    insta::assert_snapshot!(format!(
+        "num_groups={} group_size={} symmetric={} scale_0={:.6} len={}",
+        params.num_groups, params.group_size, params.symmetric, params.scales[0], packed.len
+    ));
+}
+
+#[test]
+fn w25_int4_quantize_zeros() {
+    let data = vec![0.0f32; 64];
+    let cfg = Int4QuantConfig::default();
+    let (packed, params) = quantize_tensor_int4(&data, &cfg);
+    insta::assert_snapshot!(format!(
+        "num_groups={} scale_0={:.6} len={}",
+        params.num_groups, params.scales[0], packed.len
+    ));
+}
+
+#[test]
+fn w25_int4_quantize_empty() {
+    let data: Vec<f32> = vec![];
+    let cfg = Int4QuantConfig::default();
+    let (packed, params) = quantize_tensor_int4(&data, &cfg);
+    insta::assert_snapshot!(format!("num_groups={} len={}", params.num_groups, packed.len));
+}
+
+#[test]
+fn w25_nibble_packed_roundtrip() {
+    let values: Vec<i8> = vec![-8, -4, -1, 0, 1, 4, 7, 3];
+    let packed = NibblePacked::pack(&values);
+    let unpacked = packed.unpack();
+    insta::assert_debug_snapshot!(unpacked);
+}
+
+#[test]
+fn w25_nibble_packed_single_value() {
+    let packed = NibblePacked::pack(&[5]);
+    insta::assert_snapshot!(format!(
+        "len={} data_bytes={} value={}",
+        packed.len,
+        packed.data.len(),
+        packed.get(0)
+    ));
+}
+
+#[test]
+fn w25_tolerance_config_debug() {
+    let cfg = ToleranceConfig {
+        i2s_tolerance: 0.05,
+        tl_tolerance: 0.1,
+        perplexity_tolerance: 0.5,
+        strict_validation: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 4 — Error message format snapshots
+// =========================================================================
+
+#[test]
+fn w25_pipeline_config_f32_target_error() {
+    let cfg = PipelineConfig {
+        source_precision: Precision::F32,
+        target_precision: Precision::F32,
+        calibration_samples: 100,
+        error_threshold: 0.01,
+    };
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_pipeline_config_zero_samples_error() {
+    let cfg = PipelineConfig {
+        source_precision: Precision::F32,
+        target_precision: Precision::I2S,
+        calibration_samples: 0,
+        error_threshold: 0.01,
+    };
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_pipeline_config_zero_threshold_error() {
+    let cfg = PipelineConfig {
+        source_precision: Precision::F32,
+        target_precision: Precision::TL1,
+        calibration_samples: 50,
+        error_threshold: 0.0,
+    };
+    let err = cfg.validate().unwrap_err();
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn w25_pipeline_config_valid_i2s() {
+    let cfg = PipelineConfig {
+        source_precision: Precision::F32,
+        target_precision: Precision::I2S,
+        calibration_samples: 512,
+        error_threshold: 0.05,
+    };
+    assert!(cfg.validate().is_ok());
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w25_pipeline_config_valid_tl2() {
+    let cfg = PipelineConfig {
+        source_precision: Precision::F32,
+        target_precision: Precision::TL2,
+        calibration_samples: 256,
+        error_threshold: 0.1,
+    };
+    assert!(cfg.validate().is_ok());
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 5 — SIMD capabilities and quantization strategy
+// =========================================================================
+
+#[test]
+fn w25_simd_capabilities_detect() {
+    let caps = SimdCapabilities::detect();
+    insta::assert_snapshot!(format!(
+        "avx512={} avx2={} neon={} sse4_1={}",
+        caps.has_avx512, caps.has_avx2, caps.has_neon, caps.has_sse4_1
+    ));
+}
+
+#[test]
+fn w25_quantization_strategy_all_variants() {
+    let strategies = [
+        QuantizationStrategy::Scalar,
+        QuantizationStrategy::SSE4_1,
+        QuantizationStrategy::AVX2,
+        QuantizationStrategy::AVX512,
+        QuantizationStrategy::NEON,
+    ];
+    insta::assert_debug_snapshot!(strategies);
+}
+
+#[test]
+fn w25_simd_best_strategy_and_block_size() {
+    let caps = SimdCapabilities::detect();
+    let strategy = caps.best_quantization_strategy();
+    let block_size = caps.optimal_block_size();
+    insta::assert_snapshot!(format!("strategy={strategy:?} block_size={block_size}"));
+}
+
+// =========================================================================
+// Section 6 — Int4 quantization with asymmetric mode
+// =========================================================================
+
+#[test]
+fn w25_int4_quantize_asymmetric() {
+    let data: Vec<f32> = (0..64).map(|i| i as f32 / 10.0).collect();
+    let cfg = Int4QuantConfig { group_size: 32, symmetric: false, block_wise: true };
+    let (packed, params) = quantize_tensor_int4(&data, &cfg);
+    insta::assert_snapshot!(format!(
+        "num_groups={} symmetric={} scales_len={} len={}",
+        params.num_groups,
+        params.symmetric,
+        params.scales.len(),
+        packed.len
+    ));
+}
+
+#[test]
+fn w25_int4_quantize_per_tensor() {
+    let data: Vec<f32> = (0..16).map(|i| (i as f32 - 8.0) * 0.5).collect();
+    let cfg = Int4QuantConfig { group_size: 128, symmetric: true, block_wise: false };
+    let (packed, params) = quantize_tensor_int4(&data, &cfg);
+    insta::assert_snapshot!(format!(
+        "num_groups={} group_size={} len={}",
+        params.num_groups, params.group_size, packed.len
+    ));
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_calibration_method_all_variants.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_calibration_method_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: methods
+---
+[
+    MinMax,
+    Percentile(
+        99.0,
+    ),
+    MSE,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_i2s_layout_default_snapshot.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_i2s_layout_default_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"block_size={} bytes_per_block={} data_bytes={} scale_bytes={}\",\nlayout.block_size, layout.bytes_per_block, layout.data_bytes_per_block,\nlayout.scale_bytes_per_block)"
+---
+block_size=32 bytes_per_block=10 data_bytes=8 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_i2s_layout_field_values.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_i2s_layout_field_values.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"block_size={} bytes_per_block={} data_bytes={} scale_bytes={}\",\nlayout.block_size, layout.bytes_per_block, layout.data_bytes_per_block,\nlayout.scale_bytes_per_block)"
+---
+block_size=32 bytes_per_block=10 data_bytes=8 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_config_asymmetric.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_config_asymmetric.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+Int4QuantConfig {
+    group_size: 64,
+    symmetric: false,
+    block_wise: true,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_config_default_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+Int4QuantConfig {
+    group_size: 128,
+    symmetric: true,
+    block_wise: true,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_asymmetric.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_asymmetric.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"num_groups={} symmetric={} scales_len={} len={}\", params.num_groups,\nparams.symmetric, params.scales.len(), packed.len)"
+---
+num_groups=2 symmetric=false scales_len=2 len=64

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_empty.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_empty.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"num_groups={} len={}\", params.num_groups, packed.len)"
+---
+num_groups=0 len=0

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_per_tensor.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_per_tensor.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"num_groups={} group_size={} len={}\", params.num_groups,\nparams.group_size, packed.len)"
+---
+num_groups=1 group_size=16 len=16

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_uniform.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_uniform.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"num_groups={} group_size={} symmetric={} scale_0={:.6} len={}\",\nparams.num_groups, params.group_size, params.symmetric, params.scales[0],\npacked.len)"
+---
+num_groups=1 group_size=32 symmetric=true scale_0=0.142857 len=32

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_zeros.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int4_quantize_zeros.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"num_groups={} scale_0={:.6} len={}\", params.num_groups,\nparams.scales[0], packed.len)"
+---
+num_groups=1 scale_0=1.000000 len=64

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int8_config_asymmetric_percentile.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int8_config_asymmetric_percentile.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+Int8QuantConfig {
+    per_channel: false,
+    symmetric: false,
+    calibration_method: Percentile(
+        99.9,
+    ),
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int8_config_default_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_int8_config_default_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+Int8QuantConfig {
+    per_channel: true,
+    symmetric: true,
+    calibration_method: MinMax,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_nibble_packed_roundtrip.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_nibble_packed_roundtrip.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: unpacked
+---
+[
+    -8,
+    -4,
+    -1,
+    0,
+    1,
+    4,
+    7,
+    3,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_nibble_packed_single_value.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_nibble_packed_single_value.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"len={} data_bytes={} value={}\", packed.len, packed.data.len(),\npacked.get(0))"
+---
+len=1 data_bytes=1 value=5

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_f32_target_error.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_f32_target_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+Quantization error: Invalid input dimensions: target precision cannot be F32

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_valid_i2s.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_valid_i2s.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+PipelineConfig {
+    source_precision: F32,
+    target_precision: I2S,
+    calibration_samples: 512,
+    error_threshold: 0.05,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_valid_tl2.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_valid_tl2.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+PipelineConfig {
+    source_precision: F32,
+    target_precision: TL2,
+    calibration_samples: 256,
+    error_threshold: 0.1,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_zero_samples_error.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_zero_samples_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+Quantization error: Invalid input dimensions: calibration_samples must be > 0

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_zero_threshold_error.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_pipeline_config_zero_threshold_error.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: err.to_string()
+---
+Quantization error: Invalid input dimensions: error_threshold must be positive

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_precision_all_variants_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_precision_all_variants_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: variants
+---
+[
+    F32,
+    I2S,
+    TL1,
+    TL2,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_stage_all_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_stage_all_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "labeled.join(\", \")"
+---
+Calibration=0, Quantization=1, Verification=2, PackingOptimization=3

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_strategy_all_variants.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_strategy_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: strategies
+---
+[
+    Scalar,
+    SSE4_1,
+    AVX2,
+    AVX512,
+    NEON,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_type_all_variants_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_type_all_variants_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: types
+---
+[
+    I2S,
+    TL1,
+    TL2,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_type_display_all.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_quantization_type_display_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: displays
+---
+[
+    "I2_S",
+    "TL1",
+    "TL2",
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_simd_best_strategy_and_block_size.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_simd_best_strategy_and_block_size.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"strategy={strategy:?} block_size={block_size}\")"
+---
+strategy=AVX512 block_size=256

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_simd_capabilities_detect.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_simd_capabilities_detect.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: "format!(\"avx512={} avx2={} neon={} sse4_1={}\", caps.has_avx512, caps.has_avx2,\ncaps.has_neon, caps.has_sse4_1)"
+---
+avx512=true avx2=true neon=false sse4_1=true

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tl1_config_default_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tl1_config_default_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+TL1Config {
+    block_size: 64,
+    lookup_table_size: 256,
+    use_asymmetric: false,
+    precision_bits: 2,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tl2_config_default_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tl2_config_default_debug.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+TL2Config {
+    block_size: 128,
+    lookup_table_size: 256,
+    use_avx512: true,
+    use_avx2: true,
+    precision_bits: 2,
+    vectorized_tables: true,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tolerance_config_debug.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave25__w25_tolerance_config_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave25.rs
+expression: cfg
+---
+ToleranceConfig {
+    i2s_tolerance: 0.05,
+    tl_tolerance: 0.1,
+    perplexity_tolerance: 0.5,
+    strict_validation: true,
+}


### PR DESCRIPTION
## Snapshot Wave 25

Adds **107 new insta snapshot tests** across 3 crates:

| Crate | Tests | Coverage |
|-------|-------|----------|
| bitnet-kernels | 44 | CUDA fusion/matmul/gating/attention/layernorm/pooling, CPU fusion/SIMD matmul, OpenCL numerical stability |
| bitnet-inference | 34 | Token stream, warmup, memory pool, KV cache eviction, profiler, streaming, prefix cache, batch config |
| bitnet-quantization | 29 | Quantization types, block layouts, INT4/INT8 configs, pipeline validation, SIMD capabilities, nibble packing |


No Cargo.toml dependency changes — insta was already a dev-dependency in all 3 crates.