### PR TITLE
fuzz: wave 32 — 6 fuzz targets for validators and trackers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,6 +745,7 @@ dependencies = [
  "bitnet-gguf",
  "bitnet-honest-compute",
  "bitnet-inference",
+ "bitnet-inference-metrics-core",
  "bitnet-kernels",
  "bitnet-logits",
  "bitnet-models",

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -32,6 +32,7 @@ bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev" 
 bitnet-honest-compute = { path = "../crates/bitnet-honest-compute", version = "0.2.1-dev" }
 bitnet-bdd-grid-core = { path = "../crates/bitnet-bdd-grid-core", version = "0.2.1-dev" }
 bitnet-runtime-feature-flags-core = { path = "../crates/bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }
+bitnet-inference-metrics-core = { path = "../crates/bitnet-inference-metrics-core", version = "0.2.1-dev" }
 candle-core = { workspace = true }
 arbitrary = { version = "1.4.2", features = ["derive"] }
 
@@ -609,5 +610,41 @@ doc = false
 [[bin]]
 name = "fuzz_pipeline_parallel_stages"
 path = "fuzz_targets/fuzz_pipeline_parallel_stages.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_shape_validator"
+path = "fuzz_targets/fuzz_shape_validator.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_generation_budget"
+path = "fuzz_targets/fuzz_generation_budget.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_perf_tracker"
+path = "fuzz_targets/fuzz_perf_tracker.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_model_fingerprint"
+path = "fuzz_targets/fuzz_model_fingerprint.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_weight_stats"
+path = "fuzz_targets/fuzz_weight_stats.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_format_detector"
+path = "fuzz_targets/fuzz_format_detector.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/fuzz_format_detector.rs
+++ b/fuzz/fuzz_targets/fuzz_format_detector.rs
@@ -1,0 +1,70 @@
+//! Fuzz format detection with random bytes and filenames.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct FormatInput {
+    /// Raw bytes for magic-based detection
+    magic_bytes: Vec<u8>,
+    /// Filename for extension-based detection
+    filename: String,
+    /// Shard filename for parse_shard_info
+    shard_filename: String,
+    /// File size for DetectedModel
+    size_bytes: u64,
+}
+
+fuzz_target!(|input: FormatInput| {
+    use bitnet_models::format_detector::{
+        DetectedModel, ModelFormat, available_conversions, find_conversion, parse_shard_info,
+    };
+    use std::path::{Path, PathBuf};
+
+    // Magic-byte detection — must not panic on any byte sequence
+    let bytes: &[u8] = if input.magic_bytes.len() > 1024 {
+        &input.magic_bytes[..1024]
+    } else {
+        &input.magic_bytes
+    };
+    let fmt_magic = ModelFormat::from_magic(bytes);
+    let _ = fmt_magic.display_name();
+    let _ = fmt_magic.is_supported();
+    let _ = fmt_magic.needs_conversion();
+    let _ = format!("{fmt_magic}");
+    let _ = format!("{fmt_magic:?}");
+
+    // Extension-based detection — must not panic on any path
+    let fname: String = input.filename.chars().take(256).collect();
+    let fmt_ext = ModelFormat::from_extension(Path::new(&fname));
+    let _ = fmt_ext.display_name();
+    let _ = fmt_ext.is_supported();
+    let _ = fmt_ext.needs_conversion();
+
+    // Shard parsing — must not panic on any string
+    let shard: String = input.shard_filename.chars().take(256).collect();
+    let _ = parse_shard_info(&shard);
+
+    // DetectedModel construction
+    let model = DetectedModel::new(PathBuf::from(&fname), fmt_ext, input.size_bytes);
+    let _ = model.is_sharded();
+    let _ = model.size_mb();
+    let _ = model.size_gb();
+    let _ = format!("{model:?}");
+
+    // Sharded model
+    let sharded =
+        DetectedModel::new(PathBuf::from(&fname), fmt_ext, input.size_bytes).with_shard_info(1, 4);
+    let _ = sharded.is_sharded();
+
+    // Conversion queries — must not panic
+    let _ = available_conversions();
+    let _ = find_conversion(fmt_ext, ModelFormat::Gguf);
+    let _ = find_conversion(fmt_magic, ModelFormat::SafeTensors);
+
+    // Equality
+    let _ = fmt_magic == fmt_ext;
+    let _ = fmt_magic == ModelFormat::Unknown;
+});

--- a/fuzz/fuzz_targets/fuzz_generation_budget.rs
+++ b/fuzz/fuzz_targets/fuzz_generation_budget.rs
@@ -1,0 +1,61 @@
+//! Fuzz generation budget tracking with random token counts and stop criteria.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct BudgetInput {
+    max_new_tokens: u16,
+    seed: Option<u64>,
+    stop_token_ids: Vec<u32>,
+    stop_strings: Vec<String>,
+    max_tokens: u16,
+    eos_token_id: Option<u32>,
+    token_sequence: Vec<u32>,
+    decoded_tail: String,
+}
+
+fuzz_target!(|input: BudgetInput| {
+    use bitnet_generation::{GenerationConfig, StopCriteria, check_stop};
+
+    // Build config — must not panic
+    let _cfg = GenerationConfig {
+        max_new_tokens: input.max_new_tokens as usize,
+        seed: input.seed,
+        stop_criteria: StopCriteria {
+            stop_token_ids: input.stop_token_ids.iter().copied().take(64).collect(),
+            stop_strings: input
+                .stop_strings
+                .iter()
+                .take(16)
+                .map(|s| s.chars().take(128).collect())
+                .collect(),
+            max_tokens: input.max_tokens as usize,
+            eos_token_id: input.eos_token_id,
+        },
+    };
+
+    // Simulate generation loop with stop checking
+    let criteria = &_cfg.stop_criteria;
+    let tokens: Vec<u32> = input.token_sequence.iter().copied().take(256).collect();
+    let tail: String = input.decoded_tail.chars().take(512).collect();
+
+    for (i, &tok) in tokens.iter().enumerate() {
+        let generated = &tokens[..=i];
+        let reason = check_stop(criteria, tok, generated, &tail);
+        // If we got a stop reason, generation loop would break — that's fine
+        if reason.is_some() {
+            break;
+        }
+    }
+
+    // Verify default config doesn't panic
+    let _default = GenerationConfig::default();
+
+    // Verify serde roundtrip doesn't panic
+    if let Ok(json) = serde_json::to_string(&_cfg) {
+        let _: Result<GenerationConfig, _> = serde_json::from_str(&json);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_model_fingerprint.rs
+++ b/fuzz/fuzz_targets/fuzz_model_fingerprint.rs
@@ -1,0 +1,63 @@
+//! Fuzz model fingerprint computation with random metadata.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct FingerprintInput {
+    architecture: String,
+    param_count: u64,
+    num_layers: u32,
+    hidden_size: u32,
+    num_heads: u32,
+    vocab_size: u32,
+    quant_type: String,
+    tags: Vec<(String, String)>,
+}
+
+fuzz_target!(|input: FingerprintInput| {
+    use bitnet_models::model_fingerprint::{ModelFingerprint, identify_model, known_fingerprints};
+
+    // Cap string lengths to avoid OOM
+    let arch: String = input.architecture.chars().take(64).collect();
+    let qt: String = input.quant_type.chars().take(32).collect();
+
+    // Build via builder chain — must not panic
+    let mut fp = ModelFingerprint::new(&arch)
+        .with_param_count(input.param_count)
+        .with_layers(input.num_layers)
+        .with_hidden_size(input.hidden_size)
+        .with_heads(input.num_heads)
+        .with_vocab_size(input.vocab_size)
+        .with_quant_type(&qt);
+
+    for (k, v) in input.tags.iter().take(16) {
+        let key: String = k.chars().take(32).collect();
+        let val: String = v.chars().take(64).collect();
+        fp = fp.with_tag(&key, &val);
+    }
+
+    // Derived computations — must not panic
+    let _ = fp.compact_id();
+    let _ = fp.estimated_weight_bytes();
+    let _ = fp.is_quantized();
+    let _ = fp.size_label();
+    let _ = format!("{fp}");
+    let _ = format!("{fp:?}");
+
+    // Identification — must not panic
+    let _ = identify_model(&fp);
+
+    // Cross-comparison with known fingerprints
+    let known = known_fingerprints();
+    for k in &known {
+        let _ = fp.same_architecture(k);
+        let _ = fp.same_model_different_quant(k);
+    }
+
+    // Clone + equality — must not panic
+    let fp2 = fp.clone();
+    let _ = fp == fp2;
+});

--- a/fuzz/fuzz_targets/fuzz_perf_tracker.rs
+++ b/fuzz/fuzz_targets/fuzz_perf_tracker.rs
@@ -1,0 +1,62 @@
+//! Fuzz perf tracker with random kernel timings and throughput values.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct PerfInput {
+    prefill_ms: Option<u64>,
+    decode_ms: Option<u64>,
+    tokenization_encode_ms: Option<u64>,
+    tokenization_decode_ms: Option<u64>,
+    total_ms: u64,
+    prefill_tps: Option<f64>,
+    decode_tps: Option<f64>,
+    e2e_tps: f64,
+    total_tokens: usize,
+}
+
+fuzz_target!(|input: PerfInput| {
+    use bitnet_inference_metrics_core::{ThroughputMetrics, TimingMetrics};
+
+    // Build timing metrics — must not panic
+    let timing = TimingMetrics {
+        prefill_ms: input.prefill_ms,
+        decode_ms: input.decode_ms,
+        tokenization_encode_ms: input.tokenization_encode_ms,
+        tokenization_decode_ms: input.tokenization_decode_ms,
+        total_ms: input.total_ms,
+    };
+
+    // Build throughput metrics with potentially adversarial floats (NaN, Inf)
+    let throughput = ThroughputMetrics {
+        prefill_tokens_per_sec: input.prefill_tps,
+        decode_tokens_per_sec: input.decode_tps,
+        end_to_end_tokens_per_sec: input.e2e_tps,
+        total_tokens: input.total_tokens,
+    };
+
+    // Serde roundtrip — must not panic
+    if let Ok(json) = serde_json::to_string(&timing) {
+        let _: Result<TimingMetrics, _> = serde_json::from_str(&json);
+    }
+    if let Ok(json) = serde_json::to_string(&throughput) {
+        let _: Result<ThroughputMetrics, _> = serde_json::from_str(&json);
+    }
+
+    // Clone and equality — must not panic
+    let _t2 = timing.clone();
+    let _p2 = throughput.clone();
+    let _ = timing == _t2;
+    let _ = throughput == _p2;
+
+    // Debug formatting — must not panic
+    let _ = format!("{timing:?}");
+    let _ = format!("{throughput:?}");
+
+    // Default — must not panic
+    let _ = TimingMetrics::default();
+    let _ = ThroughputMetrics::default();
+});

--- a/fuzz/fuzz_targets/fuzz_shape_validator.rs
+++ b/fuzz/fuzz_targets/fuzz_shape_validator.rs
@@ -1,0 +1,58 @@
+//! Fuzz shape validation with random shapes and parameters.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ShapeInput {
+    shape_a: Vec<u16>,
+    shape_b: Vec<u16>,
+    dim: u8,
+    expected_size: u16,
+    expected_rank: u8,
+    expected_elements: u32,
+    hidden_size: u16,
+    num_heads: u8,
+}
+
+fuzz_target!(|input: ShapeInput| {
+    // Cap dimensions to avoid huge allocations
+    let a: Vec<usize> = input.shape_a.iter().take(8).map(|&v| v as usize).collect();
+    let b: Vec<usize> = input.shape_b.iter().take(8).map(|&v| v as usize).collect();
+
+    // shape equality — must not panic regardless of input
+    let _ = bitnet_common::shape_validator::assert_shape_eq("fuzz", &a, &b);
+
+    // rank check
+    let _ = bitnet_common::shape_validator::assert_rank("fuzz", &a, input.expected_rank as usize);
+
+    // dimension check
+    let _ = bitnet_common::shape_validator::assert_dim(
+        "fuzz",
+        &a,
+        input.dim as usize,
+        input.expected_size as usize,
+    );
+
+    // matmul compatibility
+    let _ = bitnet_common::shape_validator::assert_matmul_compat("fuzz", &a, &b);
+
+    // broadcastable
+    let _ = bitnet_common::shape_validator::assert_broadcastable("fuzz", &a, &b);
+
+    // element count
+    let _ = bitnet_common::shape_validator::assert_element_count(
+        "fuzz",
+        &a,
+        input.expected_elements as usize,
+    );
+
+    // head divisibility
+    let _ = bitnet_common::shape_validator::assert_head_divisible(
+        "fuzz",
+        input.hidden_size as usize,
+        input.num_heads as usize,
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_weight_stats.rs
+++ b/fuzz/fuzz_targets/fuzz_weight_stats.rs
@@ -1,0 +1,55 @@
+//! Fuzz weight statistics analyzer with random tensor data.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct WeightStatsInput {
+    name: String,
+    shape: Vec<u16>,
+    /// Raw bytes reinterpreted as f32 values — gives us NaN, Inf, subnormals, etc.
+    raw_bytes: Vec<u8>,
+}
+
+fuzz_target!(|input: WeightStatsInput| {
+    use bitnet_models::weight_stats::{TensorStats, detect_anomalies, generate_report};
+
+    let name: String = input.name.chars().take(64).collect();
+    let shape: Vec<usize> = input.shape.iter().take(6).map(|&v| v as usize).collect();
+
+    // Reinterpret raw bytes as f32 — gives adversarial float values
+    let data: Vec<f32> = input
+        .raw_bytes
+        .chunks_exact(4)
+        .take(4096) // cap at 4K elements to limit time
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect();
+
+    // from_f32 — must not panic on NaN/Inf/subnormal/zero data
+    let stats = TensorStats::from_f32(&name, &shape, &data);
+
+    // Derived metrics — must not panic
+    let _ = stats.std_dev();
+    let _ = stats.has_anomalies();
+    let _ = stats.sparsity();
+    let _ = stats.is_sparse();
+    let _ = format!("{stats}");
+    let _ = format!("{stats:?}");
+
+    // Anomaly detection — must not panic
+    let anomalies = detect_anomalies(&stats);
+    for a in &anomalies {
+        let _ = format!("{a}");
+    }
+
+    // Report generation with single tensor
+    let report = generate_report(&[stats.clone()]);
+    let _ = format!("{report:?}");
+    assert!(report.tensor_count == 1);
+
+    // Empty report
+    let empty = generate_report(&[]);
+    assert!(empty.tensor_count == 0);
+});


### PR DESCRIPTION
## Fuzz Wave 32

Adds 6 new fuzz targets exercising recently added modules:

| Target | Module | Coverage |
|--------|--------|----------|
| `fuzz_shape_validator` | `bitnet-common::shape_validator` | All 7 shape validation functions with random shapes/ranks/dims |
| `fuzz_generation_budget` | `bitnet-generation` | GenerationConfig + StopCriteria + check_stop with random token sequences |
| `fuzz_perf_tracker` | `bitnet-inference-metrics-core` | TimingMetrics + ThroughputMetrics with adversarial floats (NaN/Inf) |
| `fuzz_model_fingerprint` | `bitnet-models::model_fingerprint` | Builder chain, compact_id, identification, cross-comparison |
| `fuzz_weight_stats` | `bitnet-models::weight_stats` | TensorStats::from_f32 with NaN/Inf/subnormal injection + anomaly detection |
| `fuzz_format_detector` | `bitnet-models::format_detector` | Magic-byte and extension detection + shard parsing with random bytes |

All targets use `arbitrary::Arbitrary` for structured fuzzing and are designed to never crash on malformed input.

**Verified**: All 6 targets compile cleanly with `cargo check`.