### PR TITLE
test(metal): Metal reduction shader validation tests

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
@@ -1,9 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::needless_range_loop)]
-#![allow(clippy::manual_div_ceil)]
-#![allow(clippy::manual_is_multiple_of)]
-#![allow(clippy::let_and_return)]
 //! ARM NEON optimized attention masking kernels for Apple Silicon.
 //!
 //! Provides SIMD-accelerated attention mask application using `float32x4`


### PR DESCRIPTION
## Summary
Adds 56 tests for Metal reduction shader operations on Apple Silicon.

## Changes
- `MetalReductionConfig` with `ReductionOp` enum for 8 operations
- CPU reference implementations for Sum, Max, Min, Mean, Variance, L2Norm, LogSumExp, SoftmaxDenom
- Threadgroup reduction simulation
- Multi-stage reduction pipeline validation
- Workgroup size boundary testing (32, 64, 128, 256)
- 56 unit tests organized by category

## Testing
```bash
cargo check --tests -p bitnet-kernels --no-default-features --features cpu
```
All tests are `#[ignore]` (require Metal GPU on macOS).