### PR TITLE
test: proptest wave 30 — 128 property tests

### DIFF
--- a/crates/bitnet-common/tests/proptest_wave30_common.rs
+++ b/crates/bitnet-common/tests/proptest_wave30_common.rs
@@ -1,0 +1,458 @@
+//! Property-based tests — wave 30 (common).
+//!
+//! Covers: shape validation properties (broadcastable, element count, head
+//! divisible, matmul compat), error type formatting, Device/QuantizationType
+//! round-trips, GenerationConfig invariants, SecurityLimits defaults,
+//! ModelMetadata construction, and PerformanceMetrics bounds.
+//!
+//! 40+ property tests validating: shape validator correctness, error display
+//! consistency, type enum coverage, config defaults, and security limits.
+
+use bitnet_common::error::{BitNetError, SecurityLimits};
+use bitnet_common::shape_validator::{
+    assert_broadcastable, assert_dim, assert_element_count, assert_head_divisible,
+    assert_matmul_compat, assert_rank, assert_shape_eq,
+};
+use bitnet_common::types::{
+    Device, GenerationConfig, ModelMetadata, PerformanceMetrics, QuantizationType,
+};
+use proptest::prelude::*;
+
+// ── Strategy helpers ────────────────────────────────────────────────────────
+
+fn arb_shape(max_rank: usize, max_dim: usize) -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(1usize..=max_dim, 1..=max_rank)
+}
+
+fn arb_device() -> impl Strategy<Value = Device> {
+    prop_oneof![
+        Just(Device::Cpu),
+        (0usize..8).prop_map(|i| Device::Cuda(i)),
+        (0usize..8).prop_map(|i| Device::Hip(i)),
+        Just(Device::Npu),
+        Just(Device::Metal),
+        (0usize..8).prop_map(|i| Device::OpenCL(i)),
+    ]
+}
+
+fn arb_quant_type() -> impl Strategy<Value = QuantizationType> {
+    prop_oneof![
+        Just(QuantizationType::I2S),
+        Just(QuantizationType::TL1),
+        Just(QuantizationType::TL2),
+    ]
+}
+
+// ── Shape validation: equality ──────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Shape equality is reflexive.
+    #[test]
+    fn shape_eq_reflexive(shape in arb_shape(4, 64)) {
+        prop_assert!(assert_shape_eq("test", &shape, &shape).is_ok());
+    }
+
+    /// Different shapes are not equal.
+    #[test]
+    fn shape_eq_different_fails(
+        a in arb_shape(4, 64),
+        b in arb_shape(4, 64),
+    ) {
+        if a != b {
+            prop_assert!(assert_shape_eq("test", &a, &b).is_err());
+        }
+    }
+
+    /// Rank assertion succeeds for correct rank.
+    #[test]
+    fn rank_assert_correct(shape in arb_shape(4, 64)) {
+        prop_assert!(assert_rank("test", &shape, shape.len()).is_ok());
+    }
+
+    /// Rank assertion fails for wrong rank.
+    #[test]
+    fn rank_assert_wrong_fails(shape in arb_shape(4, 64), extra in 1usize..5) {
+        let wrong_rank = shape.len() + extra;
+        prop_assert!(assert_rank("test", &shape, wrong_rank).is_err());
+    }
+
+    /// Dim assertion succeeds when dimension matches.
+    #[test]
+    fn dim_assert_correct(shape in arb_shape(4, 64)) {
+        for (i, &d) in shape.iter().enumerate() {
+            prop_assert!(assert_dim("test", &shape, i, d).is_ok());
+        }
+    }
+
+    /// Dim assertion fails for wrong size.
+    #[test]
+    fn dim_assert_wrong_fails(shape in arb_shape(4, 64), extra in 1usize..10) {
+        if !shape.is_empty() {
+            let wrong = shape[0] + extra;
+            prop_assert!(assert_dim("test", &shape, 0, wrong).is_err());
+        }
+    }
+}
+
+// ── Shape validation: element count ─────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Element count of shape equals product of dimensions.
+    #[test]
+    fn element_count_product(shape in arb_shape(4, 16)) {
+        let product: usize = shape.iter().product();
+        prop_assert!(assert_element_count("test", &shape, product).is_ok());
+    }
+
+    /// Wrong element count fails.
+    #[test]
+    fn element_count_wrong_fails(shape in arb_shape(4, 16), extra in 1usize..100) {
+        let product: usize = shape.iter().product();
+        prop_assert!(assert_element_count("test", &shape, product + extra).is_err());
+    }
+}
+
+// ── Shape validation: head divisible ────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Hidden size divisible by num_heads succeeds.
+    #[test]
+    fn head_divisible_ok(num_heads in 1usize..32, head_dim in 1usize..128) {
+        let hidden = num_heads * head_dim;
+        prop_assert!(assert_head_divisible("test", hidden, num_heads).is_ok());
+    }
+
+    /// Hidden size not divisible by num_heads fails.
+    #[test]
+    fn head_divisible_fails(num_heads in 2usize..32, head_dim in 1usize..128) {
+        let hidden = num_heads * head_dim + 1;
+        prop_assert!(assert_head_divisible("test", hidden, num_heads).is_err());
+    }
+}
+
+// ── Shape validation: matmul compatibility ──────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// [M, K] × [K, N] is compatible.
+    #[test]
+    fn matmul_compat_valid(m in 1usize..64, k in 1usize..64, n in 1usize..64) {
+        prop_assert!(assert_matmul_compat("test", &[m, k], &[k, n]).is_ok());
+    }
+
+    /// [M, K1] × [K2, N] with K1 != K2 is incompatible.
+    #[test]
+    fn matmul_compat_invalid(m in 1usize..64, k1 in 1usize..64, n in 1usize..64, delta in 1usize..10) {
+        let k2 = k1 + delta;
+        prop_assert!(assert_matmul_compat("test", &[m, k1], &[k2, n]).is_err());
+    }
+}
+
+// ── Shape validation: broadcastable ─────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Any shape is broadcastable with itself.
+    #[test]
+    fn broadcastable_reflexive(shape in arb_shape(4, 16)) {
+        prop_assert!(assert_broadcastable("test", &shape, &shape).is_ok());
+    }
+
+    /// Shape [1, N] is broadcastable with [M, N].
+    #[test]
+    fn broadcastable_unit_dim(m in 2usize..16, n in 1usize..16) {
+        prop_assert!(assert_broadcastable("test", &[1, n], &[m, n]).is_ok());
+    }
+
+    /// Shape [M, 1] is broadcastable with [M, N].
+    #[test]
+    fn broadcastable_trailing_unit(m in 1usize..16, n in 2usize..16) {
+        prop_assert!(assert_broadcastable("test", &[m, 1], &[m, n]).is_ok());
+    }
+}
+
+// ── Device enum properties ──────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Device::Cpu is always CPU.
+    #[test]
+    fn device_cpu_is_cpu(_seed in 0u32..10) {
+        prop_assert!(Device::Cpu.is_cpu());
+        prop_assert!(!Device::Cpu.is_cuda());
+    }
+
+    /// Cuda devices are CUDA but not CPU.
+    #[test]
+    fn device_cuda_is_cuda(idx in 0usize..8) {
+        let dev = Device::Cuda(idx);
+        prop_assert!(dev.is_cuda());
+        prop_assert!(!dev.is_cpu());
+    }
+
+    /// Hip devices are HIP but not CPU or CUDA.
+    #[test]
+    fn device_hip_properties(idx in 0usize..8) {
+        let dev = Device::Hip(idx);
+        prop_assert!(dev.is_hip());
+        prop_assert!(!dev.is_cpu());
+        prop_assert!(!dev.is_cuda());
+    }
+
+    /// OpenCL devices are OpenCL but not CPU.
+    #[test]
+    fn device_opencl_properties(idx in 0usize..8) {
+        let dev = Device::OpenCL(idx);
+        prop_assert!(dev.is_opencl());
+        prop_assert!(!dev.is_cpu());
+    }
+
+    /// NPU device properties.
+    #[test]
+    fn device_npu_properties(_seed in 0u32..10) {
+        prop_assert!(Device::Npu.is_npu());
+        prop_assert!(!Device::Npu.is_cpu());
+    }
+
+    /// Device Debug formatting never panics.
+    #[test]
+    fn device_debug_no_panic(dev in arb_device()) {
+        let s = format!("{:?}", dev);
+        prop_assert!(!s.is_empty());
+    }
+
+    /// Device equality is reflexive.
+    #[test]
+    fn device_eq_reflexive(dev in arb_device()) {
+        prop_assert_eq!(&dev, &dev);
+    }
+}
+
+// ── QuantizationType properties ─────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// QuantizationType Debug formatting is non-empty.
+    #[test]
+    fn quant_type_debug_non_empty(qt in arb_quant_type()) {
+        let dbg = format!("{:?}", qt);
+        prop_assert!(!dbg.is_empty());
+    }
+
+    /// QuantizationType equality is reflexive.
+    #[test]
+    fn quant_type_eq_reflexive(qt in arb_quant_type()) {
+        prop_assert_eq!(qt, qt);
+    }
+
+    /// All three variants are distinct.
+    #[test]
+    fn quant_type_variants_distinct(_seed in 0u32..10) {
+        prop_assert_ne!(QuantizationType::I2S, QuantizationType::TL1);
+        prop_assert_ne!(QuantizationType::TL1, QuantizationType::TL2);
+        prop_assert_ne!(QuantizationType::I2S, QuantizationType::TL2);
+    }
+}
+
+// ── GenerationConfig properties ─────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Default GenerationConfig has valid temperature.
+    #[test]
+    fn gen_config_default_temp_valid(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default();
+        prop_assert!(cfg.temperature >= 0.0);
+    }
+
+    /// Default GenerationConfig has positive max_new_tokens.
+    #[test]
+    fn gen_config_default_max_tokens_positive(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default();
+        prop_assert!(cfg.max_new_tokens > 0);
+    }
+
+    /// Default repetition_penalty is positive.
+    #[test]
+    fn gen_config_default_rep_penalty_positive(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default();
+        prop_assert!(cfg.repetition_penalty > 0.0);
+    }
+}
+
+// ── Error formatting properties ─────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// BitNetError::Config display includes the message.
+    #[test]
+    fn error_config_display_includes_message(msg in "[a-zA-Z ]{1,50}") {
+        let err = BitNetError::Config(msg.clone());
+        let display = format!("{}", err);
+        prop_assert!(display.contains(&msg));
+    }
+
+    /// BitNetError::Validation display includes the message.
+    #[test]
+    fn error_validation_display_includes_message(msg in "[a-zA-Z ]{1,50}") {
+        let err = BitNetError::Validation(msg.clone());
+        let display = format!("{}", err);
+        prop_assert!(display.contains(&msg));
+    }
+
+    /// BitNetError::StrictMode display includes the message.
+    #[test]
+    fn error_strict_mode_display_includes_message(msg in "[a-zA-Z ]{1,50}") {
+        let err = BitNetError::StrictMode(msg.clone());
+        let display = format!("{}", err);
+        prop_assert!(display.contains(&msg));
+    }
+
+    /// BitNetError Debug formatting is non-empty.
+    #[test]
+    fn error_debug_non_empty(msg in "[a-zA-Z ]{1,30}") {
+        let err = BitNetError::Config(msg);
+        let debug = format!("{:?}", err);
+        prop_assert!(!debug.is_empty());
+    }
+}
+
+// ── SecurityLimits properties ───────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// Default SecurityLimits has positive max_tensor_elements.
+    #[test]
+    fn security_limits_default_tensor_positive(_seed in 0u32..10) {
+        let limits = SecurityLimits::default();
+        prop_assert!(limits.max_tensor_elements > 0);
+    }
+
+    /// Default SecurityLimits has positive max_memory_allocation.
+    #[test]
+    fn security_limits_default_memory_positive(_seed in 0u32..10) {
+        let limits = SecurityLimits::default();
+        prop_assert!(limits.max_memory_allocation > 0);
+    }
+
+    /// Default SecurityLimits has positive max_metadata_size.
+    #[test]
+    fn security_limits_default_metadata_positive(_seed in 0u32..10) {
+        let limits = SecurityLimits::default();
+        prop_assert!(limits.max_metadata_size > 0);
+    }
+
+    /// Default SecurityLimits has max_string_length > 0.
+    #[test]
+    fn security_limits_default_string_positive(_seed in 0u32..10) {
+        let limits = SecurityLimits::default();
+        prop_assert!(limits.max_string_length > 0);
+    }
+
+    /// Default SecurityLimits has max_array_length > 0.
+    #[test]
+    fn security_limits_default_array_positive(_seed in 0u32..10) {
+        let limits = SecurityLimits::default();
+        prop_assert!(limits.max_array_length > 0);
+    }
+}
+
+// ── PerformanceMetrics properties ───────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// PerformanceMetrics fields are preserved.
+    #[test]
+    fn perf_metrics_fields_preserved(
+        tps in 0.0f64..10000.0,
+        latency in 0.0f64..10000.0,
+        memory in 0.0f64..100000.0,
+    ) {
+        let m = PerformanceMetrics {
+            tokens_per_second: tps,
+            latency_ms: latency,
+            memory_usage_mb: memory,
+            gpu_utilization: None,
+        };
+        prop_assert!((m.tokens_per_second - tps).abs() < f64::EPSILON);
+        prop_assert!((m.latency_ms - latency).abs() < f64::EPSILON);
+        prop_assert!((m.memory_usage_mb - memory).abs() < f64::EPSILON);
+    }
+
+    /// PerformanceMetrics Debug formatting is non-empty.
+    #[test]
+    fn perf_metrics_debug_non_empty(
+        tps in 0.0f64..100.0,
+        latency in 0.0f64..100.0,
+        memory in 0.0f64..100.0,
+    ) {
+        let m = PerformanceMetrics {
+            tokens_per_second: tps,
+            latency_ms: latency,
+            memory_usage_mb: memory,
+            gpu_utilization: None,
+        };
+        let dbg = format!("{:?}", m);
+        prop_assert!(!dbg.is_empty());
+    }
+}
+
+// ── ModelMetadata properties ────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// ModelMetadata preserves name and architecture.
+    #[test]
+    fn model_metadata_preserves_fields(
+        name in "[a-z]{1,20}",
+        arch in "[a-z]{1,20}",
+        vocab in 1usize..200_000,
+        ctx in 1usize..32768,
+    ) {
+        let m = ModelMetadata {
+            name: name.clone(),
+            version: "1.0".to_string(),
+            architecture: arch.clone(),
+            vocab_size: vocab,
+            context_length: ctx,
+            quantization: None,
+            fingerprint: None,
+            corrections_applied: None,
+        };
+        prop_assert_eq!(&m.name, &name);
+        prop_assert_eq!(&m.architecture, &arch);
+        prop_assert_eq!(m.vocab_size, vocab);
+        prop_assert_eq!(m.context_length, ctx);
+    }
+
+    /// ModelMetadata with quantization type preserves it.
+    #[test]
+    fn model_metadata_preserves_quantization(qt in arb_quant_type()) {
+        let m = ModelMetadata {
+            name: "test".to_string(),
+            version: "1.0".to_string(),
+            architecture: "bitnet".to_string(),
+            vocab_size: 32000,
+            context_length: 2048,
+            quantization: Some(qt),
+            fingerprint: None,
+            corrections_applied: None,
+        };
+        prop_assert_eq!(m.quantization, Some(qt));
+    }
+}

--- a/crates/bitnet-inference/tests/proptest_wave30_inference.rs
+++ b/crates/bitnet-inference/tests/proptest_wave30_inference.rs
@@ -1,0 +1,517 @@
+//! Property-based tests — wave 30 (inference).
+//!
+//! Covers: GenerationConfig builder invariants, InferenceConfig validation,
+//! GenerationBudget tracking, BudgetTracker monotonicity, SamplingConfig
+//! construction, SamplingStrategy determinism, temperature scaling, top-k/top-p
+//! filtering, greedy sampling, and softmax normalization.
+//!
+//! 40+ property tests validating: config builder round-trips, budget tracking
+//! invariants, sampling correctness, and generation config validation.
+
+#![cfg(feature = "cpu")]
+
+use std::time::Duration;
+
+use bitnet_inference::config::{GenerationConfig, InferenceConfig};
+use bitnet_inference::generation_budget::{BudgetTracker, GenerationBudget, StopReason};
+use bitnet_sampling::{
+    SamplingConfig, SamplingStrategy, apply_temperature, argmax, greedy_sample, softmax_in_place,
+};
+use proptest::prelude::*;
+
+// ── Strategy helpers ────────────────────────────────────────────────────────
+
+fn finite_f32_vec(min_len: usize, max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-100.0f32..100.0, min_len..=max_len)
+}
+
+fn arb_sampling_config() -> impl Strategy<Value = SamplingConfig> {
+    (
+        0.0f32..2.0,          // temperature
+        0u32..100,            // top_k
+        0.01f32..1.0,         // top_p
+        0.5f32..2.0,          // repetition_penalty
+        any::<Option<u64>>(), // seed
+    )
+        .prop_map(|(temp, top_k, top_p, rep_pen, seed)| SamplingConfig {
+            temperature: temp,
+            top_k,
+            top_p,
+            repetition_penalty: rep_pen,
+            seed,
+        })
+}
+
+// ── GenerationConfig builder properties ─────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// with_max_tokens sets the value correctly.
+    #[test]
+    fn gen_config_max_tokens_builder(tokens in 1u32..10000) {
+        let cfg = GenerationConfig::default().with_max_tokens(tokens);
+        prop_assert_eq!(cfg.max_new_tokens, tokens);
+    }
+
+    /// with_temperature sets the value correctly.
+    #[test]
+    fn gen_config_temperature_builder(temp in 0.0f32..5.0) {
+        let cfg = GenerationConfig::default().with_temperature(temp);
+        prop_assert!((cfg.temperature - temp).abs() < f32::EPSILON);
+    }
+
+    /// with_top_k sets the value correctly.
+    #[test]
+    fn gen_config_top_k_builder(k in 0u32..200) {
+        let cfg = GenerationConfig::default().with_top_k(k);
+        prop_assert_eq!(cfg.top_k, k);
+    }
+
+    /// with_top_p sets the value correctly.
+    #[test]
+    fn gen_config_top_p_builder(p in 0.01f32..1.0) {
+        let cfg = GenerationConfig::default().with_top_p(p);
+        prop_assert!((cfg.top_p - p).abs() < f32::EPSILON);
+    }
+
+    /// with_repetition_penalty sets the value correctly.
+    #[test]
+    fn gen_config_rep_penalty_builder(pen in 0.1f32..5.0) {
+        let cfg = GenerationConfig::default().with_repetition_penalty(pen);
+        prop_assert!((cfg.repetition_penalty - pen).abs() < f32::EPSILON);
+    }
+
+    /// greedy() preset has temperature 0 and top_k 1.
+    #[test]
+    fn gen_config_greedy_invariants(_seed in 0u32..10) {
+        let cfg = GenerationConfig::greedy();
+        prop_assert!((cfg.temperature - 0.0).abs() < f32::EPSILON);
+        prop_assert_eq!(cfg.top_k, 1);
+    }
+
+    /// creative() preset has temperature > 0.
+    #[test]
+    fn gen_config_creative_has_positive_temp(_seed in 0u32..10) {
+        let cfg = GenerationConfig::creative();
+        prop_assert!(cfg.temperature > 0.0);
+    }
+
+    /// balanced() preset has moderate temperature.
+    #[test]
+    fn gen_config_balanced_moderate_temp(_seed in 0u32..10) {
+        let cfg = GenerationConfig::balanced();
+        prop_assert!(cfg.temperature > 0.0);
+        prop_assert!(cfg.temperature <= 1.0);
+    }
+
+    /// validate() accepts valid configs.
+    #[test]
+    fn gen_config_validate_valid(
+        tokens in 1u32..1000,
+        temp in 0.0f32..3.0,
+        top_p in 0.01f32..1.0,
+        rep_pen in 0.1f32..5.0,
+    ) {
+        let cfg = GenerationConfig::default()
+            .with_max_tokens(tokens)
+            .with_temperature(temp)
+            .with_top_p(top_p)
+            .with_repetition_penalty(rep_pen);
+        prop_assert!(cfg.validate().is_ok());
+    }
+
+    /// validate() rejects zero max_tokens.
+    #[test]
+    fn gen_config_validate_zero_tokens(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default().with_max_tokens(0);
+        prop_assert!(cfg.validate().is_err());
+    }
+
+    /// validate() rejects negative temperature.
+    #[test]
+    fn gen_config_validate_negative_temp(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default().with_temperature(-1.0);
+        prop_assert!(cfg.validate().is_err());
+    }
+
+    /// validate() rejects zero repetition penalty.
+    #[test]
+    fn gen_config_validate_zero_rep_penalty(_seed in 0u32..10) {
+        let cfg = GenerationConfig::default().with_repetition_penalty(0.0);
+        prop_assert!(cfg.validate().is_err());
+    }
+
+    /// Stop token IDs round-trip through builder.
+    #[test]
+    fn gen_config_stop_token_roundtrip(ids in prop::collection::vec(0u32..200000, 0..10)) {
+        let cfg = GenerationConfig::default().with_stop_token_ids(ids.clone());
+        prop_assert_eq!(&cfg.stop_token_ids, &ids);
+    }
+
+    /// is_stop_token returns true for configured stop tokens.
+    #[test]
+    fn gen_config_is_stop_token(ids in prop::collection::vec(1u32..200000, 1..5)) {
+        let mut cfg = GenerationConfig::default().with_stop_token_ids(ids.clone());
+        cfg.rebuild_stop_token_set();
+        for &id in &ids {
+            prop_assert!(cfg.is_stop_token(id));
+        }
+    }
+
+    /// stop_sequences round-trip through builder.
+    #[test]
+    fn gen_config_stop_sequences_roundtrip(seqs in prop::collection::vec("[a-z]{1,10}", 0..5)) {
+        let cfg = GenerationConfig::default().with_stop_sequences(seqs.clone());
+        prop_assert_eq!(&cfg.stop_sequences, &seqs);
+    }
+
+    /// with_eos_token_id sets eos.
+    #[test]
+    fn gen_config_eos_builder(id in 0u32..200000) {
+        let cfg = GenerationConfig::default().with_eos_token_id(Some(id));
+        prop_assert_eq!(cfg.eos_token_id, Some(id));
+    }
+}
+
+// ── InferenceConfig properties ──────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// cpu_optimized() has valid defaults.
+    #[test]
+    fn inference_config_cpu_optimized_valid(_seed in 0u32..10) {
+        let cfg = InferenceConfig::cpu_optimized();
+        prop_assert!(cfg.validate().is_ok());
+    }
+
+    /// gpu_optimized() has valid defaults.
+    #[test]
+    fn inference_config_gpu_optimized_valid(_seed in 0u32..10) {
+        let cfg = InferenceConfig::gpu_optimized();
+        prop_assert!(cfg.validate().is_ok());
+    }
+
+    /// memory_efficient() has valid defaults.
+    #[test]
+    fn inference_config_memory_efficient_valid(_seed in 0u32..10) {
+        let cfg = InferenceConfig::memory_efficient();
+        prop_assert!(cfg.validate().is_ok());
+    }
+
+    /// Builder chain produces valid config.
+    #[test]
+    fn inference_config_builder_chain(
+        threads in 1usize..32,
+        batch in 1usize..64,
+        pool in 1usize..2_000_000_000,
+    ) {
+        let cfg = InferenceConfig::cpu_optimized()
+            .with_threads(threads)
+            .with_batch_size(batch)
+            .with_memory_pool_size(pool);
+        prop_assert!(cfg.validate().is_ok());
+        prop_assert_eq!(cfg.num_threads, threads);
+        prop_assert_eq!(cfg.batch_size, batch);
+    }
+
+    /// Default InferenceConfig has positive num_threads.
+    #[test]
+    fn inference_config_default_threads_positive(_seed in 0u32..10) {
+        let cfg = InferenceConfig::cpu_optimized();
+        prop_assert!(cfg.num_threads > 0);
+    }
+}
+
+// ── GenerationBudget properties ─────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// New budget tracks zero tokens.
+    #[test]
+    fn budget_tracker_starts_at_zero(max_tokens in 1usize..1000) {
+        let budget = GenerationBudget::new(max_tokens);
+        let tracker = BudgetTracker::new(budget);
+        prop_assert_eq!(tracker.tokens_generated(), 0);
+        prop_assert_eq!(tracker.tokens_remaining(), max_tokens);
+        prop_assert!(tracker.can_continue());
+    }
+
+    /// Recording tokens increments count.
+    #[test]
+    fn budget_tracker_increments(max_tokens in 2usize..100, n in 1usize..50) {
+        let n = n.min(max_tokens - 1);
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..n {
+            tracker.record_token();
+        }
+        prop_assert_eq!(tracker.tokens_generated(), n);
+        prop_assert_eq!(tracker.tokens_remaining(), max_tokens - n);
+    }
+
+    /// Tracker stops at max_tokens.
+    #[test]
+    fn budget_tracker_stops_at_max(max_tokens in 1usize..50) {
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..max_tokens {
+            tracker.record_token();
+        }
+        prop_assert!(!tracker.can_continue());
+        prop_assert_eq!(tracker.stop_reason(), Some(StopReason::MaxTokens));
+    }
+
+    /// EOS recording sets stop reason.
+    #[test]
+    fn budget_tracker_eos(max_tokens in 1usize..100) {
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_eos();
+        prop_assert!(!tracker.can_continue());
+        prop_assert_eq!(tracker.stop_reason(), Some(StopReason::EndOfSequence));
+    }
+
+    /// User stop recording sets stop reason.
+    #[test]
+    fn budget_tracker_user_stop(max_tokens in 1usize..100) {
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_user_stop();
+        prop_assert!(!tracker.can_continue());
+        prop_assert_eq!(tracker.stop_reason(), Some(StopReason::UserStop));
+    }
+
+    /// tokens_remaining + tokens_generated == max_tokens.
+    #[test]
+    fn budget_tracker_remaining_plus_generated(
+        max_tokens in 2usize..100,
+        n in 0usize..50,
+    ) {
+        let n = n.min(max_tokens - 1);
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..n {
+            tracker.record_token();
+        }
+        prop_assert_eq!(tracker.tokens_remaining() + tracker.tokens_generated(), max_tokens);
+    }
+
+    /// token_utilization is in [0.0, 1.0].
+    #[test]
+    fn budget_tracker_utilization_bounded(
+        max_tokens in 1usize..100,
+        n in 0usize..50,
+    ) {
+        let n = n.min(max_tokens);
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..n {
+            tracker.record_token();
+        }
+        let util = tracker.token_utilization();
+        prop_assert!(util >= 0.0);
+        prop_assert!(util <= 1.0);
+    }
+
+    /// Summary preserves tokens_generated.
+    #[test]
+    fn budget_summary_preserves_count(max_tokens in 1usize..50, n in 0usize..20) {
+        let n = n.min(max_tokens);
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..n {
+            tracker.record_token();
+        }
+        let summary = tracker.summary();
+        prop_assert_eq!(summary.tokens_generated, n);
+        prop_assert_eq!(summary.max_tokens, max_tokens);
+    }
+
+    /// Unlimited budget allows many tokens.
+    #[test]
+    fn budget_unlimited_allows_many(n in 1usize..1000) {
+        let budget = GenerationBudget::unlimited();
+        let mut tracker = BudgetTracker::new(budget);
+        for _ in 0..n {
+            tracker.record_token();
+        }
+        prop_assert!(tracker.can_continue());
+    }
+
+    /// elapsed is non-negative.
+    #[test]
+    fn budget_elapsed_non_negative(max_tokens in 1usize..100) {
+        let budget = GenerationBudget::new(max_tokens);
+        let tracker = BudgetTracker::new(budget);
+        prop_assert!(tracker.elapsed() >= Duration::ZERO);
+    }
+
+    /// tokens_per_second is non-negative.
+    #[test]
+    fn budget_tps_non_negative(max_tokens in 1usize..100) {
+        let budget = GenerationBudget::new(max_tokens);
+        let mut tracker = BudgetTracker::new(budget);
+        tracker.record_token();
+        prop_assert!(tracker.tokens_per_second() >= 0.0);
+    }
+}
+
+// ── Sampling correctness properties ─────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// greedy_sample returns the argmax index.
+    #[test]
+    fn greedy_sample_is_argmax(logits in finite_f32_vec(2, 200)) {
+        let expected = argmax(&logits) as u32;
+        let result = greedy_sample(&logits);
+        prop_assert!(result.is_ok());
+        prop_assert_eq!(result.unwrap(), expected);
+    }
+
+    /// greedy_sample output is within vocab range.
+    #[test]
+    fn greedy_sample_within_range(logits in finite_f32_vec(2, 200)) {
+        let result = greedy_sample(&logits).unwrap();
+        prop_assert!((result as usize) < logits.len());
+    }
+
+    /// Temperature=0 sampling equals greedy.
+    #[test]
+    fn temp_zero_is_greedy(logits in finite_f32_vec(2, 200), seed in any::<u64>()) {
+        let config = SamplingConfig {
+            temperature: 0.0,
+            top_k: 0,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(seed),
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let result = strategy.sample(&logits, &[]).unwrap();
+        let expected = greedy_sample(&logits).unwrap();
+        prop_assert_eq!(result, expected);
+    }
+
+    /// Sampling output is always within vocab range.
+    #[test]
+    fn sampling_within_vocab_range(
+        logits in finite_f32_vec(2, 200),
+        config in arb_sampling_config(),
+    ) {
+        let mut strategy = SamplingStrategy::new(config);
+        let result = strategy.sample(&logits, &[]).unwrap();
+        prop_assert!((result as usize) < logits.len());
+    }
+
+    /// Same seed produces deterministic output.
+    #[test]
+    fn sampling_seed_determinism(
+        logits in finite_f32_vec(2, 100),
+        seed in any::<u64>(),
+        temp in 0.1f32..2.0,
+    ) {
+        let config1 = SamplingConfig {
+            temperature: temp,
+            top_k: 50,
+            top_p: 0.9,
+            repetition_penalty: 1.0,
+            seed: Some(seed),
+        };
+        let config2 = config1.clone();
+        let mut s1 = SamplingStrategy::new(config1);
+        let mut s2 = SamplingStrategy::new(config2);
+        let r1 = s1.sample(&logits, &[]).unwrap();
+        let r2 = s2.sample(&logits, &[]).unwrap();
+        prop_assert_eq!(r1, r2);
+    }
+
+    /// softmax output sums to ~1.0.
+    #[test]
+    fn softmax_sums_to_one(logits in finite_f32_vec(2, 200)) {
+        let mut probs = logits.clone();
+        softmax_in_place(&mut probs);
+        let sum: f32 = probs.iter().sum();
+        prop_assert!((sum - 1.0).abs() < 1e-4, "softmax sum was {}", sum);
+    }
+
+    /// softmax output is non-negative.
+    #[test]
+    fn softmax_non_negative(logits in finite_f32_vec(2, 200)) {
+        let mut probs = logits.clone();
+        softmax_in_place(&mut probs);
+        for &p in &probs {
+            prop_assert!(p >= 0.0);
+        }
+    }
+
+    /// apply_temperature preserves argmax for positive temperature.
+    #[test]
+    fn temperature_preserves_argmax(logits in finite_f32_vec(2, 200), temp in 0.01f32..10.0) {
+        let original_max = argmax(&logits);
+        let mut scaled = logits.clone();
+        apply_temperature(&mut scaled, temp);
+        let scaled_max = argmax(&scaled);
+        prop_assert_eq!(original_max, scaled_max);
+    }
+
+    /// apply_temperature with temp=1.0 preserves values (identity).
+    #[test]
+    fn temperature_one_is_identity(logits in finite_f32_vec(2, 100)) {
+        let mut scaled = logits.clone();
+        apply_temperature(&mut scaled, 1.0);
+        for (a, b) in logits.iter().zip(scaled.iter()) {
+            prop_assert!((a - b).abs() < 1e-5, "mismatch: {} vs {}", a, b);
+        }
+    }
+
+    /// argmax output is within bounds.
+    #[test]
+    fn argmax_within_bounds(logits in finite_f32_vec(1, 200)) {
+        let idx = argmax(&logits);
+        prop_assert!((idx as usize) < logits.len());
+    }
+
+    /// argmax picks the actual maximum value.
+    #[test]
+    fn argmax_picks_max(logits in finite_f32_vec(1, 200)) {
+        let idx = argmax(&logits) as usize;
+        let max_val = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        prop_assert!((logits[idx] - max_val).abs() < f32::EPSILON);
+    }
+}
+
+// ── StopReason properties ───────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// StopReason variants are distinct.
+    #[test]
+    fn stop_reason_variants_distinct(_seed in 0u32..10) {
+        prop_assert_ne!(StopReason::MaxTokens, StopReason::EndOfSequence);
+        prop_assert_ne!(StopReason::MaxTokens, StopReason::UserStop);
+        prop_assert_ne!(StopReason::MaxTokens, StopReason::TimeLimit);
+        prop_assert_ne!(StopReason::MaxTokens, StopReason::MemoryLimit);
+        prop_assert_ne!(StopReason::EndOfSequence, StopReason::UserStop);
+    }
+
+    /// StopReason Debug formatting is non-empty.
+    #[test]
+    fn stop_reason_debug_non_empty(
+        idx in 0usize..5,
+    ) {
+        let reasons = [
+            StopReason::MaxTokens,
+            StopReason::TimeLimit,
+            StopReason::MemoryLimit,
+            StopReason::EndOfSequence,
+            StopReason::UserStop,
+        ];
+        let dbg = format!("{:?}", reasons[idx]);
+        prop_assert!(!dbg.is_empty());
+    }
+}

--- a/crates/bitnet-kernels/tests/proptest_wave30_kernels.rs
+++ b/crates/bitnet-kernels/tests/proptest_wave30_kernels.rs
@@ -1,0 +1,480 @@
+//! Property-based tests — wave 30 (kernels).
+//!
+//! Covers: perf_tracker aggregation invariants, SIMD diagnostics consistency,
+//! capability matrix queries, kernel timing arithmetic, dispatch
+//! recommendations, and shaped reduction properties.
+//!
+//! 40+ property tests validating: timing arithmetic, tracker monotonicity,
+//! capability matrix consistency, SIMD level ordering, dispatch completeness,
+//! and performance report formatting.
+
+#![cfg(feature = "cpu")]
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use bitnet_kernels::capability_matrix::{
+    CapabilityEntry, CapabilityQuery, CompatibilityReport, DeviceCapabilityMatrix, DeviceClass,
+    DeviceProfile, OperationCategory, PrecisionSupport, SupportLevel,
+};
+use bitnet_kernels::perf_tracker::{KernelTiming, PerfTracker, format_perf_report};
+use bitnet_kernels::simd_diagnostics::{SimdCapabilities, SimdLevel, recommend_dispatch};
+use proptest::prelude::*;
+
+// ── Strategy helpers ────────────────────────────────────────────────────────
+
+fn arb_duration() -> impl Strategy<Value = Duration> {
+    (1u64..10_000_000).prop_map(Duration::from_nanos)
+}
+
+fn arb_kernel_name() -> impl Strategy<Value = String> {
+    prop::string::string_regex("[a-z_]{1,20}").unwrap().prop_filter("non-empty", |s| !s.is_empty())
+}
+
+fn arb_timing() -> impl Strategy<Value = KernelTiming> {
+    (arb_kernel_name(), arb_duration(), 1usize..1_000_000)
+        .prop_map(|(name, dur, elems)| KernelTiming::new(&name, dur, elems))
+}
+
+fn arb_timing_with_flops() -> impl Strategy<Value = KernelTiming> {
+    (arb_kernel_name(), arb_duration(), 1usize..1_000_000, 1u64..1_000_000_000).prop_map(
+        |(name, dur, elems, flops)| KernelTiming::new(&name, dur, elems).with_flops(flops),
+    )
+}
+
+fn arb_simd_caps() -> impl Strategy<Value = SimdCapabilities> {
+    (
+        any::<bool>(), // sse2
+        any::<bool>(), // sse4_1
+        any::<bool>(), // sse4_2
+        any::<bool>(), // avx
+        any::<bool>(), // avx2
+        any::<bool>(), // avx512f
+        any::<bool>(), // avx512bw
+        any::<bool>(), // avx512vnni
+        any::<bool>(), // fma
+        any::<bool>(), // neon
+    )
+        .prop_map(
+            |(sse2, sse4_1, sse4_2, avx, avx2, avx512f, avx512bw, avx512vnni, fma, neon)| {
+                SimdCapabilities {
+                    sse2,
+                    sse4_1,
+                    sse4_2,
+                    avx,
+                    avx2,
+                    avx512f,
+                    avx512bw,
+                    avx512vnni,
+                    fma,
+                    neon,
+                    arch: "x86_64".to_string(),
+                }
+            },
+        )
+}
+
+// ── KernelTiming properties ─────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Throughput is always non-negative for valid timings.
+    #[test]
+    fn timing_throughput_non_negative(t in arb_timing()) {
+        prop_assert!(t.throughput() >= 0.0);
+    }
+
+    /// Throughput is finite for non-zero durations.
+    #[test]
+    fn timing_throughput_finite(t in arb_timing()) {
+        prop_assert!(t.throughput().is_finite());
+    }
+
+    /// GFlops is None when flops not set.
+    #[test]
+    fn timing_no_flops_returns_none(t in arb_timing()) {
+        prop_assert!(t.gflops().is_none());
+    }
+
+    /// GFlops is Some and finite when flops are set.
+    #[test]
+    fn timing_with_flops_returns_finite_gflops(t in arb_timing_with_flops()) {
+        let g = t.gflops();
+        prop_assert!(g.is_some());
+        prop_assert!(g.unwrap().is_finite());
+    }
+
+    /// GFlops value is positive for positive flops and positive duration.
+    #[test]
+    fn timing_gflops_positive(t in arb_timing_with_flops()) {
+        prop_assert!(t.gflops().unwrap() > 0.0);
+    }
+
+    /// Throughput scales linearly with element count.
+    #[test]
+    fn timing_throughput_scales_with_elements(
+        name in arb_kernel_name(),
+        dur in arb_duration(),
+        elems in 1usize..500_000,
+    ) {
+        let t1 = KernelTiming::new(&name, dur, elems);
+        let t2 = KernelTiming::new(&name, dur, elems * 2);
+        let ratio = t2.throughput() / t1.throughput();
+        prop_assert!((ratio - 2.0).abs() < 1e-6);
+    }
+
+    /// Duration is preserved in constructor.
+    #[test]
+    fn timing_preserves_duration(dur_ns in 1u64..10_000_000, elems in 1usize..1000) {
+        let dur = Duration::from_nanos(dur_ns);
+        let t = KernelTiming::new("test", dur, elems);
+        prop_assert_eq!(t.duration, dur);
+    }
+
+    /// Input elements are preserved.
+    #[test]
+    fn timing_preserves_elements(elems in 1usize..1_000_000) {
+        let t = KernelTiming::new("test", Duration::from_nanos(100), elems);
+        prop_assert_eq!(t.input_elements, elems);
+    }
+}
+
+// ── PerfTracker properties ──────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Count equals number of recorded timings.
+    #[test]
+    fn tracker_count_matches_records(timings in prop::collection::vec(arb_timing(), 0..50)) {
+        let mut tracker = PerfTracker::new();
+        for t in &timings {
+            tracker.record(t.clone());
+        }
+        prop_assert_eq!(tracker.count(), timings.len());
+    }
+
+    /// Total time is sum of individual durations.
+    #[test]
+    fn tracker_total_time_is_sum(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        let expected: Duration = timings.iter().map(|t| t.duration).sum();
+        for t in timings {
+            tracker.record(t);
+        }
+        prop_assert_eq!(tracker.total_time(), expected);
+    }
+
+    /// Slowest timing has maximum duration.
+    #[test]
+    fn tracker_slowest_has_max_duration(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        let max_dur = timings.iter().map(|t| t.duration).max().unwrap();
+        for t in timings {
+            tracker.record(t);
+        }
+        prop_assert_eq!(tracker.slowest().unwrap().duration, max_dur);
+    }
+
+    /// Fastest timing has minimum duration.
+    #[test]
+    fn tracker_fastest_has_min_duration(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        let min_dur = timings.iter().map(|t| t.duration).min().unwrap();
+        for t in timings {
+            tracker.record(t);
+        }
+        prop_assert_eq!(tracker.fastest().unwrap().duration, min_dur);
+    }
+
+    /// Clear resets count to zero.
+    #[test]
+    fn tracker_clear_resets(timings in prop::collection::vec(arb_timing(), 1..20)) {
+        let mut tracker = PerfTracker::new();
+        for t in timings {
+            tracker.record(t);
+        }
+        tracker.clear();
+        prop_assert_eq!(tracker.count(), 0);
+        prop_assert_eq!(tracker.total_time(), Duration::ZERO);
+    }
+
+    /// by_kernel groups timings correctly: total entries across groups equals count.
+    #[test]
+    fn tracker_by_kernel_total_matches_count(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        for t in &timings {
+            tracker.record(t.clone());
+        }
+        let grouped = tracker.by_kernel();
+        let total: usize = grouped.values().map(|v| v.len()).sum();
+        prop_assert_eq!(total, tracker.count());
+    }
+
+    /// kernel_stats returns one entry per distinct kernel name.
+    #[test]
+    fn tracker_stats_one_per_kernel(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        let unique_names: HashSet<_> = timings.iter().map(|t| t.kernel_name.clone()).collect();
+        for t in timings {
+            tracker.record(t);
+        }
+        let stats = tracker.kernel_stats();
+        prop_assert_eq!(stats.len(), unique_names.len());
+    }
+
+    /// Each kernel stat's total_time <= tracker total_time.
+    #[test]
+    fn tracker_stat_time_bounded(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        for t in timings {
+            tracker.record(t);
+        }
+        let total = tracker.total_time();
+        for stat in tracker.kernel_stats() {
+            prop_assert!(stat.total_time <= total);
+        }
+    }
+
+    /// Each kernel stat has avg_time between min_time and max_time.
+    #[test]
+    fn tracker_stat_avg_between_min_max(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        for t in timings {
+            tracker.record(t);
+        }
+        for stat in tracker.kernel_stats() {
+            prop_assert!(stat.avg_time >= stat.min_time);
+            prop_assert!(stat.avg_time <= stat.max_time);
+        }
+    }
+
+    /// Each kernel stat count > 0.
+    #[test]
+    fn tracker_stat_count_positive(timings in prop::collection::vec(arb_timing(), 1..30)) {
+        let mut tracker = PerfTracker::new();
+        for t in timings {
+            tracker.record(t);
+        }
+        for stat in tracker.kernel_stats() {
+            prop_assert!(stat.count > 0);
+        }
+    }
+
+    /// format_perf_report does not panic and produces non-empty output for non-empty tracker.
+    #[test]
+    fn tracker_report_non_empty(timings in prop::collection::vec(arb_timing(), 1..10)) {
+        let mut tracker = PerfTracker::new();
+        for t in timings {
+            tracker.record(t);
+        }
+        let report = format_perf_report(&tracker);
+        prop_assert!(!report.is_empty());
+    }
+
+    /// Empty tracker has zero total time.
+    #[test]
+    fn tracker_empty_total_zero(_seed in 0u32..100) {
+        let tracker = PerfTracker::new();
+        prop_assert_eq!(tracker.total_time(), Duration::ZERO);
+        prop_assert_eq!(tracker.count(), 0);
+        prop_assert!(tracker.slowest().is_none());
+        prop_assert!(tracker.fastest().is_none());
+    }
+}
+
+// ── SIMD diagnostics properties ─────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// vector_width_bits is always a power of two >= 64.
+    #[test]
+    fn simd_width_power_of_two(caps in arb_simd_caps()) {
+        let width = caps.vector_width_bits();
+        prop_assert!(width >= 64);
+        prop_assert!(width.is_power_of_two());
+    }
+
+    /// f32_lanes equals vector_width_bits / 32.
+    #[test]
+    fn simd_f32_lanes_consistent(caps in arb_simd_caps()) {
+        prop_assert_eq!(caps.f32_lanes(), caps.vector_width_bits() / 32);
+    }
+
+    /// best_level is Avx512 when avx512f is true.
+    #[test]
+    fn simd_avx512_implies_best_level(mut caps in arb_simd_caps()) {
+        caps.avx512f = true;
+        prop_assert_eq!(caps.best_level(), SimdLevel::Avx512);
+    }
+
+    /// best_level is at least Avx2 when avx2 is true and avx512f is false.
+    #[test]
+    fn simd_avx2_implies_at_least_avx2(mut caps in arb_simd_caps()) {
+        caps.avx512f = false;
+        caps.avx2 = true;
+        prop_assert_eq!(caps.best_level(), SimdLevel::Avx2);
+    }
+
+    /// Scalar level when everything is false.
+    #[test]
+    fn simd_all_false_is_scalar(_seed in 0u32..100) {
+        let caps = SimdCapabilities {
+            sse2: false, sse4_1: false, sse4_2: false,
+            avx: false, avx2: false, avx512f: false,
+            avx512bw: false, avx512vnni: false,
+            fma: false, neon: false,
+            arch: "x86_64".to_string(),
+        };
+        prop_assert_eq!(caps.best_level(), SimdLevel::Scalar);
+        prop_assert_eq!(caps.vector_width_bits(), 64);
+        prop_assert_eq!(caps.f32_lanes(), 2);
+    }
+
+    /// summary() is non-empty for any capability set.
+    #[test]
+    fn simd_summary_non_empty(caps in arb_simd_caps()) {
+        prop_assert!(!caps.summary().is_empty());
+    }
+
+    /// summary() contains the arch string.
+    #[test]
+    fn simd_summary_contains_arch(caps in arb_simd_caps()) {
+        prop_assert!(caps.summary().contains(&caps.arch));
+    }
+
+    /// recommend_dispatch never panics and returns non-empty vec.
+    #[test]
+    fn simd_dispatch_recommendations_non_empty(caps in arb_simd_caps()) {
+        let recs = recommend_dispatch(&caps);
+        prop_assert!(!recs.is_empty());
+    }
+
+    /// All dispatch recommendations have non-empty operation names.
+    #[test]
+    fn simd_dispatch_operations_non_empty(caps in arb_simd_caps()) {
+        let recs = recommend_dispatch(&caps);
+        for rec in &recs {
+            prop_assert!(!rec.operation.is_empty());
+            prop_assert!(!rec.reason.is_empty());
+        }
+    }
+
+    /// SimdLevel ordering: Scalar < Sse2 < Sse42 < Neon < Avx < Avx2 < Avx512.
+    #[test]
+    fn simd_level_ordering(_seed in 0u32..10) {
+        prop_assert!(SimdLevel::Scalar < SimdLevel::Sse2);
+        prop_assert!(SimdLevel::Sse2 < SimdLevel::Sse42);
+        prop_assert!(SimdLevel::Sse42 < SimdLevel::Neon);
+        prop_assert!(SimdLevel::Neon < SimdLevel::Avx);
+        prop_assert!(SimdLevel::Avx < SimdLevel::Avx2);
+        prop_assert!(SimdLevel::Avx2 < SimdLevel::Avx512);
+    }
+
+    /// display_name never returns empty string.
+    #[test]
+    fn simd_level_display_name_non_empty(
+        idx in 0usize..7,
+    ) {
+        let levels = [
+            SimdLevel::Scalar, SimdLevel::Sse2, SimdLevel::Sse42,
+            SimdLevel::Neon, SimdLevel::Avx, SimdLevel::Avx2, SimdLevel::Avx512,
+        ];
+        prop_assert!(!levels[idx].display_name().is_empty());
+    }
+}
+
+// ── Capability matrix properties ────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// Builtin matrix has at least one profile.
+    #[test]
+    fn capability_matrix_has_profiles(_seed in 0u32..10) {
+        let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+        prop_assert!(!matrix.profiles().is_empty());
+    }
+
+    /// Every builtin profile has at least one capability entry.
+    #[test]
+    fn capability_profile_has_entries(_seed in 0u32..10) {
+        let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+        for profile in matrix.profiles() {
+            prop_assert!(!profile.capabilities.is_empty());
+        }
+    }
+
+    /// SupportLevel::Full is always supported.
+    #[test]
+    fn support_level_full_is_supported(eff in 0.0f64..1.0) {
+        prop_assert!(SupportLevel::Full(eff).is_supported());
+    }
+
+    /// SupportLevel::Unsupported is never supported.
+    #[test]
+    fn support_level_unsupported_not_supported(_seed in 0u32..10) {
+        prop_assert!(!SupportLevel::Unsupported.is_supported());
+    }
+
+    /// SupportLevel::Partial is supported.
+    #[test]
+    fn support_level_partial_is_supported(_seed in 0u32..10) {
+        prop_assert!(SupportLevel::Partial("test".to_string()).is_supported());
+    }
+
+    /// SupportLevel::Emulated is supported.
+    #[test]
+    fn support_level_emulated_is_supported(_seed in 0u32..10) {
+        prop_assert!(SupportLevel::Emulated.is_supported());
+    }
+
+    /// SupportLevel::Full efficiency is returned.
+    #[test]
+    fn support_level_full_efficiency(eff in 0.0f64..1.0) {
+        let level = SupportLevel::Full(eff);
+        prop_assert_eq!(level.efficiency(), Some(eff));
+    }
+
+    /// SupportLevel::Unsupported has no efficiency.
+    #[test]
+    fn support_level_unsupported_no_efficiency(_seed in 0u32..10) {
+        prop_assert_eq!(SupportLevel::Unsupported.efficiency(), None);
+    }
+
+    /// full_support_count <= total capabilities for any profile.
+    #[test]
+    fn capability_full_count_bounded(_seed in 0u32..10) {
+        let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+        for profile in matrix.profiles() {
+            prop_assert!(profile.full_support_count() <= profile.capabilities.len());
+        }
+    }
+
+    /// CompatibilityReport.generate never panics for builtin profiles.
+    #[test]
+    fn capability_compat_report_does_not_panic(_seed in 0u32..10) {
+        let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+        let required = &[(OperationCategory::MatrixOps, PrecisionSupport::FP32)];
+        for profile in matrix.profiles() {
+            let report = CompatibilityReport::generate(profile, required);
+            prop_assert!(!report.summary().is_empty());
+        }
+    }
+
+    /// CapabilityQuery.supports is consistent with support_level.
+    #[test]
+    fn capability_query_supports_consistent(_seed in 0u32..10) {
+        let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+        for profile in matrix.profiles() {
+            let query = CapabilityQuery::new(profile);
+            for entry in &profile.capabilities {
+                let supported = query.supports(entry.operation, entry.precision);
+                let level = query.support_level(entry.operation, entry.precision);
+                prop_assert_eq!(supported, level.is_supported());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proptest Wave 30

Adds **128 property tests** across three crates covering modules that recently gained new public APIs.

### bitnet-kernels (42 tests)
- **KernelTiming arithmetic**: throughput non-negative/finite, gflops positive, linear scaling with elements
- **PerfTracker aggregation**: count matches records, total time is sum, slowest/fastest correctness, by_kernel grouping, kernel_stats one-per-kernel, avg between min/max, clear resets
- **SimdCapabilities**: vector_width power of two, f32_lanes consistent, best_level hierarchy, avx512/avx2 implies correct level, summary non-empty, summary contains arch
- **SimdLevel ordering**: Scalar < Sse2 < Sse42 < Neon < Avx < Avx2 < Avx512
- **Capability matrix**: builtin profiles non-empty, SupportLevel consistency, full_support_count bounded, CompatibilityReport generation, CapabilityQuery supports/support_level agreement

### bitnet-common (41 tests)
- **Shape validation**: equality reflexive, rank/dim assertions, element count product, head divisible, matmul compatibility, broadcastable reflexive/unit-dim
- **Device enum**: CPU/CUDA/HIP/OpenCL/NPU property isolation, Debug non-panic, equality reflexive
- **QuantizationType**: Debug non-empty, equality reflexive, all variants distinct
- **GenerationConfig**: default invariants (temp valid, tokens positive, rep_penalty positive)
- **Error formatting**: Config/Validation/StrictMode display includes message, Debug non-empty
- **SecurityLimits**: all defaults positive
- **PerformanceMetrics/ModelMetadata**: field preservation

### bitnet-inference (45 tests)
- **GenerationConfig builder**: max_tokens/temperature/top_k/top_p/rep_penalty round-trip, greedy/creative/balanced presets, validate accepts/rejects, stop token IDs/sequences round-trip, eos builder
- **InferenceConfig**: cpu_optimized/gpu_optimized/memory_efficient all validate, builder chain, positive defaults
- **GenerationBudget**: tracker starts at zero, increments tokens, stops at max, EOS/user stop, remaining+generated=max, utilization bounded, summary preserves count, unlimited allows many, elapsed/tps non-negative
- **Sampling**: greedy_sample is argmax and within range, temp=0 equals greedy, sampling within vocab range, seed determinism, softmax sums to ~1.0 and non-negative, temperature preserves argmax, temp=1.0 is identity, argmax within bounds and picks max
- **StopReason**: variants distinct, Debug non-empty