### PR TITLE
test(snapshot): wave 26 — 117 insta tests across kernels, common, inference

### DIFF
--- a/crates/bitnet-common/tests/snapshot_wave26_common.rs
+++ b/crates/bitnet-common/tests/snapshot_wave26_common.rs
@@ -1,0 +1,283 @@
+//! Wave 26 snapshot tests for `bitnet-common` — shape errors, tensor
+//! validation errors, model errors, config enums, memory pool stats,
+//! strict mode computation type, and RoPE scaling.
+//!
+//! Pins Debug/Display output so unintentional changes are caught at review.
+
+// =========================================================================
+// Section 1 — ShapeError Display
+// =========================================================================
+
+use bitnet_common::tensor_validation::ShapeError;
+
+#[test]
+fn w26_shape_error_matmul_mismatch_display() {
+    let e = ShapeError::MatmulMismatch { a_inner: 512, b_inner: 768 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_matmul_rank_display() {
+    let e = ShapeError::MatmulRank { a_ndim: 0, b_ndim: 2 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_matmul_batch_mismatch_display() {
+    let e = ShapeError::MatmulBatchMismatch { a_batch: vec![2, 4], b_batch: vec![3, 4] };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_broadcast_incompatible_display() {
+    let e = ShapeError::BroadcastIncompatible { dim: 1, a: 3, b: 5 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_attention_shape_display() {
+    let e = ShapeError::AttentionShape {
+        q: vec![1, 8, 64, 128],
+        k: vec![1, 8, 32, 128],
+        v: vec![1, 8, 32, 64],
+        reason: "V head_dim != K head_dim".into(),
+    };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_reshape_element_count_display() {
+    let e = ShapeError::ReshapeElementCount { from_count: 1024, to: vec![32, 33], to_count: 1056 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_transpose_axis_out_of_range_display() {
+    let e = ShapeError::TransposeAxisOutOfRange { axis: 5, ndim: 3 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_transpose_not_permutation_display() {
+    let e = ShapeError::TransposeNotPermutation { axes: vec![0, 0, 2], ndim: 3 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_empty_shape_display() {
+    let e = ShapeError::EmptyShape;
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_shape_error_all_variants_debug() {
+    let errors: Vec<ShapeError> = vec![
+        ShapeError::MatmulMismatch { a_inner: 64, b_inner: 128 },
+        ShapeError::MatmulRank { a_ndim: 0, b_ndim: 1 },
+        ShapeError::BroadcastIncompatible { dim: 0, a: 1, b: 7 },
+        ShapeError::EmptyShape,
+    ];
+    insta::assert_debug_snapshot!(errors);
+}
+
+// =========================================================================
+// Section 2 — TensorValidationError Display
+// =========================================================================
+
+use bitnet_common::tensor_validation::TensorValidationError;
+
+#[test]
+fn w26_tensor_val_zero_dimension_display() {
+    let e = TensorValidationError::ZeroDimension { axis: 2, shape: vec![8, 4, 0, 16] };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_total_elements_exceeded_display() {
+    let e =
+        TensorValidationError::TotalElementsExceeded { total: 2_000_000_000, max: 1_000_000_000 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_dimensions_exceeded_display() {
+    let e = TensorValidationError::DimensionsExceeded { ndim: 12, max: 8 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_nan_detected_display() {
+    let e = TensorValidationError::NanDetected { index: 42 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_inf_detected_display() {
+    let e = TensorValidationError::InfDetected { index: 99, value: f32::INFINITY };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_value_out_of_range_display() {
+    let e = TensorValidationError::ValueOutOfRange { index: 7, value: 100.5, min: -1.0, max: 1.0 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_stride_inconsistent_display() {
+    let e = TensorValidationError::StrideInconsistent { axis: 1, expected: 128, actual: 64 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_alignment_violation_display() {
+    let e = TensorValidationError::AlignmentViolation { required: 64, actual: 17 };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_tensor_val_all_variants_debug() {
+    let errors: Vec<TensorValidationError> = vec![
+        TensorValidationError::ZeroDimension { axis: 0, shape: vec![0] },
+        TensorValidationError::NanDetected { index: 0 },
+        TensorValidationError::AlignmentViolation { required: 32, actual: 1 },
+    ];
+    insta::assert_debug_snapshot!(errors);
+}
+
+// =========================================================================
+// Section 3 — ModelError Display
+// =========================================================================
+
+use bitnet_common::{ModelError, ValidationErrorDetails};
+
+#[test]
+fn w26_model_error_not_found_display() {
+    let e = ModelError::NotFound { path: "/models/missing.gguf".into() };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_model_error_invalid_format_display() {
+    let e = ModelError::InvalidFormat { format: "safetensors-v99".into() };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_model_error_loading_failed_display() {
+    let e = ModelError::LoadingFailed { reason: "header checksum mismatch".into() };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_model_error_unsupported_version_display() {
+    let e = ModelError::UnsupportedVersion { version: "4.0".into() };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_model_error_gguf_format_display() {
+    let e = ModelError::GGUFFormatError {
+        message: "invalid tensor alignment".into(),
+        details: ValidationErrorDetails {
+            errors: vec!["alignment must be power of 2".into()],
+            warnings: vec!["unusual block size 37".into()],
+            recommendations: vec!["re-export with standard alignment".into()],
+        },
+    };
+    insta::assert_snapshot!(e.to_string());
+}
+
+#[test]
+fn w26_validation_error_details_debug() {
+    let details = ValidationErrorDetails {
+        errors: vec!["bad magic".into(), "truncated header".into()],
+        warnings: vec![],
+        recommendations: vec!["regenerate GGUF".into()],
+    };
+    insta::assert_debug_snapshot!(details);
+}
+
+// =========================================================================
+// Section 4 — Config enums
+// =========================================================================
+
+use bitnet_common::config::{ActivationType, ModelFormat, NormType, RopeScaling};
+
+#[test]
+fn w26_activation_type_all_debug() {
+    let types = vec![ActivationType::Silu, ActivationType::Relu2, ActivationType::Gelu];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn w26_norm_type_all_debug() {
+    let types = vec![NormType::LayerNorm, NormType::RmsNorm];
+    insta::assert_debug_snapshot!(types);
+}
+
+#[test]
+fn w26_model_format_all_debug() {
+    let formats = vec![ModelFormat::Gguf, ModelFormat::SafeTensors, ModelFormat::HuggingFace];
+    insta::assert_debug_snapshot!(formats);
+}
+
+#[test]
+fn w26_rope_scaling_debug() {
+    let rs = RopeScaling { scaling_type: "linear".into(), factor: 4.0 };
+    insta::assert_debug_snapshot!(rs);
+}
+
+#[test]
+fn w26_rope_scaling_dynamic() {
+    let rs = RopeScaling { scaling_type: "dynamic".into(), factor: 2.0 };
+    insta::assert_debug_snapshot!(rs);
+}
+
+// =========================================================================
+// Section 5 — Memory pool stats
+// =========================================================================
+
+use bitnet_common::memory_pool::PoolStats;
+
+#[test]
+fn w26_pool_stats_default() {
+    let stats = PoolStats::default();
+    insta::assert_debug_snapshot!(stats);
+}
+
+#[test]
+fn w26_pool_stats_active() {
+    let stats =
+        PoolStats { hits: 950, misses: 50, pooled_bytes: 8_388_608, active_bytes: 2_097_152 };
+    insta::assert_debug_snapshot!(stats);
+}
+
+#[test]
+fn w26_pool_stats_total_allocations() {
+    let stats = PoolStats { hits: 100, misses: 25, pooled_bytes: 0, active_bytes: 0 };
+    insta::assert_snapshot!(format!("total_allocations={}", stats.total_allocations()));
+}
+
+// =========================================================================
+// Section 6 — Strict mode ComputationType
+// =========================================================================
+
+use bitnet_common::strict_mode::ComputationType;
+
+#[test]
+fn w26_computation_type_real_debug() {
+    insta::assert_debug_snapshot!(ComputationType::Real);
+}
+
+#[test]
+fn w26_computation_type_mock_debug() {
+    insta::assert_debug_snapshot!(ComputationType::Mock);
+}
+
+#[test]
+fn w26_computation_type_serde_roundtrip() {
+    let real = serde_json::to_string(&ComputationType::Real).unwrap();
+    let mock = serde_json::to_string(&ComputationType::Mock).unwrap();
+    insta::assert_snapshot!(format!("real={real} mock={mock}"));
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_activation_type_all_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_activation_type_all_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: types
+---
+[
+    Silu,
+    Relu2,
+    Gelu,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_mock_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_mock_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: "ComputationType::Mock"
+---
+Mock

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_real_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_real_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: "ComputationType::Real"
+---
+Real

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_serde_roundtrip.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_computation_type_serde_roundtrip.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: "format!(\"real={real} mock={mock}\")"
+---
+real="real" mock="mock"

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_gguf_format_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_gguf_format_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+GGUF format error: invalid tensor alignment

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_invalid_format_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_invalid_format_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+Invalid model format: safetensors-v99

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_loading_failed_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_loading_failed_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+Model loading failed: header checksum mismatch

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_not_found_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_not_found_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+Model not found: /models/missing.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_unsupported_version_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_error_unsupported_version_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+Unsupported model version: 4.0

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_format_all_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_model_format_all_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: formats
+---
+[
+    Gguf,
+    SafeTensors,
+    HuggingFace,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_norm_type_all_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_norm_type_all_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: types
+---
+[
+    LayerNorm,
+    RmsNorm,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_active.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_active.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: stats
+---
+PoolStats {
+    hits: 950,
+    misses: 50,
+    pooled_bytes: 8388608,
+    active_bytes: 2097152,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_default.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: stats
+---
+PoolStats {
+    hits: 0,
+    misses: 0,
+    pooled_bytes: 0,
+    active_bytes: 0,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_total_allocations.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_pool_stats_total_allocations.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: "format!(\"total_allocations={}\", stats.total_allocations())"
+---
+total_allocations=125

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_rope_scaling_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_rope_scaling_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: rs
+---
+RopeScaling {
+    scaling_type: "linear",
+    factor: 4.0,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_rope_scaling_dynamic.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_rope_scaling_dynamic.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: rs
+---
+RopeScaling {
+    scaling_type: "dynamic",
+    factor: 2.0,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_all_variants_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_all_variants_debug.snap
@@ -1,0 +1,20 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: errors
+---
+[
+    MatmulMismatch {
+        a_inner: 64,
+        b_inner: 128,
+    },
+    MatmulRank {
+        a_ndim: 0,
+        b_ndim: 1,
+    },
+    BroadcastIncompatible {
+        dim: 0,
+        a: 1,
+        b: 7,
+    },
+    EmptyShape,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_attention_shape_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_attention_shape_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+attention shape mismatch: Q=[1, 8, 64, 128], K=[1, 8, 32, 128], V=[1, 8, 32, 64] — V head_dim != K head_dim

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_broadcast_incompatible_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_broadcast_incompatible_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+broadcast incompatible: dimension 1 has sizes 3 and 5

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_empty_shape_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_empty_shape_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+empty shape is not valid for this operation

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_batch_mismatch_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_batch_mismatch_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+matmul batch dimensions incompatible: a batch [2, 4] vs b batch [3, 4]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_mismatch_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_mismatch_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+matmul shape mismatch: a has 512 columns but b has 768 rows

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_rank_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_matmul_rank_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+matmul requires at least 1-D tensors, got a=0-D and b=2-D

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_reshape_element_count_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_reshape_element_count_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+reshape element count mismatch: source has 1024 elements but target shape [32, 33] requires 1056

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_transpose_axis_out_of_range_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_transpose_axis_out_of_range_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+transpose axis 5 out of range for 3-D tensor

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_transpose_not_permutation_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_shape_error_transpose_not_permutation_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+transpose axes [0, 0, 2] do not form a permutation of 0..3

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_alignment_violation_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_alignment_violation_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+alignment 17 does not meet required 64

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_all_variants_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_all_variants_debug.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: errors
+---
+[
+    ZeroDimension {
+        axis: 0,
+        shape: [
+            0,
+        ],
+    },
+    NanDetected {
+        index: 0,
+    },
+    AlignmentViolation {
+        required: 32,
+        actual: 1,
+    },
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_dimensions_exceeded_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_dimensions_exceeded_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+12 dimensions exceeds maximum 8

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_inf_detected_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_inf_detected_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+Inf detected at index 99, value=inf

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_nan_detected_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_nan_detected_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+NaN detected at index 42

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_stride_inconsistent_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_stride_inconsistent_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+stride mismatch at axis 1: expected 128 (C-contiguous), got 64

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_total_elements_exceeded_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_total_elements_exceeded_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+total elements 2000000000 exceeds maximum 1000000000

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_value_out_of_range_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_value_out_of_range_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+value 100.5 at index 7 outside range [-1, 1]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_zero_dimension_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_tensor_val_zero_dimension_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: e.to_string()
+---
+zero dimension at axis 2 in shape [8, 4, 0, 16]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_validation_error_details_debug.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave26_common__w26_validation_error_details_debug.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave26_common.rs
+expression: details
+---
+ValidationErrorDetails {
+    errors: [
+        "bad magic",
+        "truncated header",
+    ],
+    warnings: [],
+    recommendations: [
+        "regenerate GGUF",
+    ],
+}

--- a/crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave26_inference.rs
@@ -1,0 +1,422 @@
+//! Wave 26 snapshot tests for `bitnet-inference` — generation budget,
+//! stop reasons, profiler configs, memory estimation, layer profiles,
+//! memory snapshots, and performance mode.
+//!
+//! Pins Debug/Display output so unintentional changes are caught at review.
+
+use std::time::Duration;
+
+// =========================================================================
+// Section 1 — GenerationBudget
+// =========================================================================
+
+use bitnet_inference::generation_budget::{BudgetTracker, GenerationBudget, StopReason};
+
+#[test]
+fn w26_generation_budget_default() {
+    let budget = GenerationBudget::default();
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn w26_generation_budget_with_token_limit() {
+    let budget = GenerationBudget::new(128);
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn w26_generation_budget_with_time_limit() {
+    let budget = GenerationBudget::new(64).with_time_limit(Duration::from_secs(30));
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn w26_generation_budget_with_memory_limit() {
+    let budget = GenerationBudget::new(256).with_memory_limit(1_073_741_824);
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn w26_generation_budget_full_limits() {
+    let budget = GenerationBudget::new(512)
+        .with_time_limit(Duration::from_secs(60))
+        .with_memory_limit(2_147_483_648);
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn w26_generation_budget_unlimited() {
+    let budget = GenerationBudget::unlimited();
+    insta::assert_debug_snapshot!(budget);
+}
+
+// =========================================================================
+// Section 2 — StopReason Display
+// =========================================================================
+
+#[test]
+fn w26_stop_reason_all_display() {
+    let reasons = vec![
+        StopReason::MaxTokens,
+        StopReason::TimeLimit,
+        StopReason::MemoryLimit,
+        StopReason::EndOfSequence,
+        StopReason::UserStop,
+    ];
+    let displays: Vec<String> = reasons.iter().map(|r| r.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w26_stop_reason_max_tokens_debug() {
+    insta::assert_debug_snapshot!(StopReason::MaxTokens);
+}
+
+#[test]
+fn w26_stop_reason_eos_debug() {
+    insta::assert_debug_snapshot!(StopReason::EndOfSequence);
+}
+
+// =========================================================================
+// Section 3 — BudgetTracker
+// =========================================================================
+
+#[test]
+fn w26_budget_tracker_fresh() {
+    let budget = GenerationBudget::new(32);
+    let tracker = BudgetTracker::new(budget);
+    // Only check tokens_remaining; start_time is non-deterministic
+    insta::assert_snapshot!(format!("remaining={}", tracker.tokens_remaining()));
+}
+
+#[test]
+fn w26_budget_tracker_after_tokens() {
+    let budget = GenerationBudget::new(100);
+    let mut tracker = BudgetTracker::new(budget);
+    for _ in 0..25 {
+        tracker.record_token();
+    }
+    insta::assert_snapshot!(format!(
+        "generated={} remaining={}",
+        tracker.tokens_generated(),
+        tracker.tokens_remaining()
+    ));
+}
+
+// =========================================================================
+// Section 4 — ProfilerConfig
+// =========================================================================
+
+use bitnet_inference::profiler::ProfilerConfig;
+
+#[test]
+fn w26_profiler_config_default() {
+    let cfg = ProfilerConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_profiler_config_disabled() {
+    let cfg = ProfilerConfig::disabled();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_profiler_config_with_memory() {
+    let cfg = ProfilerConfig {
+        enabled: true,
+        record_memory: true,
+        warmup_iterations: 3,
+        sample_size: 10,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 5 — LayerProfile
+// =========================================================================
+
+use bitnet_inference::profiler::LayerProfile;
+
+#[test]
+fn w26_layer_profile_attention() {
+    let lp = LayerProfile {
+        layer_name: "layer_0.attention".into(),
+        layer_type: "attention".into(),
+        forward_time_us: 1250.5,
+        backward_time_us: 0.0,
+        memory_bytes: 8_388_608,
+        flops_estimate: 2_147_483_648,
+    };
+    insta::assert_debug_snapshot!(lp);
+}
+
+#[test]
+fn w26_layer_profile_ffn() {
+    let lp = LayerProfile {
+        layer_name: "layer_3.ffn".into(),
+        layer_type: "ffn".into(),
+        forward_time_us: 890.2,
+        backward_time_us: 0.0,
+        memory_bytes: 16_777_216,
+        flops_estimate: 4_294_967_296,
+    };
+    insta::assert_debug_snapshot!(lp);
+}
+
+#[test]
+fn w26_layer_profile_norm() {
+    let lp = LayerProfile {
+        layer_name: "layer_7.norm".into(),
+        layer_type: "norm".into(),
+        forward_time_us: 12.3,
+        backward_time_us: 0.0,
+        memory_bytes: 16384,
+        flops_estimate: 8192,
+    };
+    insta::assert_debug_snapshot!(lp);
+}
+
+// =========================================================================
+// Section 6 — MemorySnapshot
+// =========================================================================
+
+use bitnet_inference::profiler::MemorySnapshot;
+
+#[test]
+fn w26_memory_snapshot_init() {
+    let snap = MemorySnapshot {
+        label: "model_loaded".into(),
+        timestamp_us: 0.0,
+        memory_bytes: 536_870_912,
+    };
+    insta::assert_debug_snapshot!(snap);
+}
+
+#[test]
+fn w26_memory_snapshot_peak() {
+    let snap = MemorySnapshot {
+        label: "peak_forward_pass".into(),
+        timestamp_us: 15000.5,
+        memory_bytes: 1_073_741_824,
+    };
+    insta::assert_debug_snapshot!(snap);
+}
+
+// =========================================================================
+// Section 7 — MemoryEstimation
+// =========================================================================
+
+use bitnet_inference::memory_estimation::{
+    KvCacheEstimation, MemoryEstimation, ModelMemoryProfile,
+};
+
+#[test]
+fn w26_memory_estimation_small_model() {
+    let est = MemoryEstimation {
+        model_params_bytes: 268_435_456,
+        kv_cache_bytes: 67_108_864,
+        activation_bytes: 33_554_432,
+        total_bytes: 369_098_752,
+        recommended_gpu_vram_gb: 0.41,
+        recommended_system_ram_gb: 0.52,
+    };
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_memory_estimation_large_model() {
+    let est = MemoryEstimation {
+        model_params_bytes: 4_294_967_296,
+        kv_cache_bytes: 1_073_741_824,
+        activation_bytes: 536_870_912,
+        total_bytes: 5_905_580_032,
+        recommended_gpu_vram_gb: 6.6,
+        recommended_system_ram_gb: 8.25,
+    };
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_kv_cache_estimation_f16() {
+    let est = KvCacheEstimation {
+        per_layer_bytes: 2_097_152,
+        total_bytes: 67_108_864,
+        num_layers: 32,
+        num_kv_heads: 8,
+        head_dim: 128,
+        max_seq_len: 2048,
+        dtype_bytes: 2,
+    };
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_kv_cache_estimation_f32() {
+    let est = KvCacheEstimation {
+        per_layer_bytes: 4_194_304,
+        total_bytes: 100_663_296,
+        num_layers: 24,
+        num_kv_heads: 4,
+        head_dim: 64,
+        max_seq_len: 8192,
+        dtype_bytes: 4,
+    };
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_model_memory_profile_empty() {
+    let profile = ModelMemoryProfile {
+        model_name: "bitnet-2b".into(),
+        architecture: "bitnet".into(),
+        known_profiles: vec![],
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+#[test]
+fn w26_model_memory_profile_with_entries() {
+    let profile = ModelMemoryProfile {
+        model_name: "bitnet-2b-4t".into(),
+        architecture: "bitnet".into(),
+        known_profiles: vec![
+            (
+                512,
+                MemoryEstimation {
+                    model_params_bytes: 500_000_000,
+                    kv_cache_bytes: 16_777_216,
+                    activation_bytes: 8_388_608,
+                    total_bytes: 525_165_824,
+                    recommended_gpu_vram_gb: 0.59,
+                    recommended_system_ram_gb: 0.73,
+                },
+            ),
+            (
+                2048,
+                MemoryEstimation {
+                    model_params_bytes: 500_000_000,
+                    kv_cache_bytes: 67_108_864,
+                    activation_bytes: 33_554_432,
+                    total_bytes: 600_663_296,
+                    recommended_gpu_vram_gb: 0.67,
+                    recommended_system_ram_gb: 0.84,
+                },
+            ),
+        ],
+    };
+    insta::assert_debug_snapshot!(profile);
+}
+
+// =========================================================================
+// Section 8 — PerformanceMode
+// =========================================================================
+
+use bitnet_inference::generation::autoregressive::PerformanceMode;
+
+#[test]
+fn w26_performance_mode_all_debug() {
+    let modes = vec![
+        PerformanceMode::Latency,
+        PerformanceMode::Throughput,
+        PerformanceMode::Balanced,
+        PerformanceMode::Conservative,
+    ];
+    insta::assert_debug_snapshot!(modes);
+}
+
+#[test]
+fn w26_performance_mode_latency() {
+    insta::assert_debug_snapshot!(PerformanceMode::Latency);
+}
+
+#[test]
+fn w26_performance_mode_conservative() {
+    insta::assert_debug_snapshot!(PerformanceMode::Conservative);
+}
+
+// =========================================================================
+// Section 9 — Profiler config JSON serialization
+// =========================================================================
+
+#[test]
+fn w26_profiler_config_json_default() {
+    let cfg = ProfilerConfig::default();
+    let json = serde_json::to_string_pretty(&cfg).unwrap();
+    insta::assert_snapshot!(json);
+}
+
+#[test]
+fn w26_profiler_config_json_custom() {
+    let cfg = ProfilerConfig {
+        enabled: true,
+        record_memory: true,
+        warmup_iterations: 5,
+        sample_size: 20,
+    };
+    let json = serde_json::to_string_pretty(&cfg).unwrap();
+    insta::assert_snapshot!(json);
+}
+
+#[test]
+fn w26_layer_profile_json() {
+    let lp = LayerProfile {
+        layer_name: "layer_0.attention".into(),
+        layer_type: "attention".into(),
+        forward_time_us: 1250.5,
+        backward_time_us: 0.0,
+        memory_bytes: 8_388_608,
+        flops_estimate: 2_147_483_648,
+    };
+    let json = serde_json::to_string_pretty(&lp).unwrap();
+    insta::assert_snapshot!(json);
+}
+
+#[test]
+fn w26_memory_snapshot_json() {
+    let snap = MemorySnapshot {
+        label: "after_layer_0".into(),
+        timestamp_us: 1250.5,
+        memory_bytes: 67_108_864,
+    };
+    let json = serde_json::to_string_pretty(&snap).unwrap();
+    insta::assert_snapshot!(json);
+}
+
+// =========================================================================
+// Section 10 — estimate_kv_cache helper
+// =========================================================================
+
+use bitnet_inference::memory_estimation::estimate_kv_cache;
+
+#[test]
+fn w26_estimate_kv_cache_bitnet_2b() {
+    let est = estimate_kv_cache(24, 8, 128, 2048, 2);
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_estimate_kv_cache_llama_7b() {
+    let est = estimate_kv_cache(32, 32, 128, 4096, 2);
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_estimate_kv_cache_tiny() {
+    let est = estimate_kv_cache(4, 2, 64, 512, 4);
+    insta::assert_debug_snapshot!(est);
+}
+
+#[test]
+fn w26_budget_tracker_exhausted() {
+    let budget = GenerationBudget::new(5);
+    let mut tracker = BudgetTracker::new(budget);
+    for _ in 0..5 {
+        tracker.record_token();
+    }
+    insta::assert_snapshot!(format!(
+        "exhausted={} remaining={}",
+        !tracker.can_continue(),
+        tracker.tokens_remaining()
+    ));
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_after_tokens.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_after_tokens.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "format!(\"generated={} remaining={}\", tracker.tokens_generated(),\ntracker.tokens_remaining())"
+---
+generated=25 remaining=75

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_exhausted.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_exhausted.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "format!(\"exhausted={} remaining={}\", !tracker.can_continue(),\ntracker.tokens_remaining())"
+---
+exhausted=true remaining=0

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_fresh.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_budget_tracker_fresh.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "format!(\"remaining={}\", tracker.tokens_remaining())"
+---
+remaining=32

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_bitnet_2b.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_bitnet_2b.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+KvCacheEstimation {
+    per_layer_bytes: 8388608,
+    total_bytes: 201326592,
+    num_layers: 24,
+    num_kv_heads: 8,
+    head_dim: 128,
+    max_seq_len: 2048,
+    dtype_bytes: 2,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_llama_7b.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_llama_7b.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+KvCacheEstimation {
+    per_layer_bytes: 67108864,
+    total_bytes: 2147483648,
+    num_layers: 32,
+    num_kv_heads: 32,
+    head_dim: 128,
+    max_seq_len: 4096,
+    dtype_bytes: 2,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_tiny.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_estimate_kv_cache_tiny.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+KvCacheEstimation {
+    per_layer_bytes: 524288,
+    total_bytes: 2097152,
+    num_layers: 4,
+    num_kv_heads: 2,
+    head_dim: 64,
+    max_seq_len: 512,
+    dtype_bytes: 4,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 256,
+    max_time: None,
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_full_limits.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_full_limits.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 512,
+    max_time: Some(
+        60s,
+    ),
+    max_memory_bytes: Some(
+        2147483648,
+    ),
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_unlimited.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_unlimited.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 18446744073709551615,
+    max_time: None,
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_memory_limit.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_memory_limit.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 256,
+    max_time: None,
+    max_memory_bytes: Some(
+        1073741824,
+    ),
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_time_limit.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_time_limit.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 64,
+    max_time: Some(
+        30s,
+    ),
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_token_limit.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_generation_budget_with_token_limit.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 128,
+    max_time: None,
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_kv_cache_estimation_f16.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_kv_cache_estimation_f16.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+KvCacheEstimation {
+    per_layer_bytes: 2097152,
+    total_bytes: 67108864,
+    num_layers: 32,
+    num_kv_heads: 8,
+    head_dim: 128,
+    max_seq_len: 2048,
+    dtype_bytes: 2,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_kv_cache_estimation_f32.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_kv_cache_estimation_f32.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+KvCacheEstimation {
+    per_layer_bytes: 4194304,
+    total_bytes: 100663296,
+    num_layers: 24,
+    num_kv_heads: 4,
+    head_dim: 64,
+    max_seq_len: 8192,
+    dtype_bytes: 4,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_attention.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_attention.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: lp
+---
+LayerProfile {
+    layer_name: "layer_0.attention",
+    layer_type: "attention",
+    forward_time_us: 1250.5,
+    backward_time_us: 0.0,
+    memory_bytes: 8388608,
+    flops_estimate: 2147483648,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_ffn.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_ffn.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: lp
+---
+LayerProfile {
+    layer_name: "layer_3.ffn",
+    layer_type: "ffn",
+    forward_time_us: 890.2,
+    backward_time_us: 0.0,
+    memory_bytes: 16777216,
+    flops_estimate: 4294967296,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_json.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: json
+---
+{
+  "layer_name": "layer_0.attention",
+  "layer_type": "attention",
+  "forward_time_us": 1250.5,
+  "backward_time_us": 0.0,
+  "memory_bytes": 8388608,
+  "flops_estimate": 2147483648
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_norm.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_layer_profile_norm.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: lp
+---
+LayerProfile {
+    layer_name: "layer_7.norm",
+    layer_type: "norm",
+    forward_time_us: 12.3,
+    backward_time_us: 0.0,
+    memory_bytes: 16384,
+    flops_estimate: 8192,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_estimation_large_model.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_estimation_large_model.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+MemoryEstimation {
+    model_params_bytes: 4294967296,
+    kv_cache_bytes: 1073741824,
+    activation_bytes: 536870912,
+    total_bytes: 5905580032,
+    recommended_gpu_vram_gb: 6.6,
+    recommended_system_ram_gb: 8.25,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_estimation_small_model.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_estimation_small_model.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: est
+---
+MemoryEstimation {
+    model_params_bytes: 268435456,
+    kv_cache_bytes: 67108864,
+    activation_bytes: 33554432,
+    total_bytes: 369098752,
+    recommended_gpu_vram_gb: 0.41,
+    recommended_system_ram_gb: 0.52,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_init.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_init.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: snap
+---
+MemorySnapshot {
+    label: "model_loaded",
+    timestamp_us: 0.0,
+    memory_bytes: 536870912,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_json.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: json
+---
+{
+  "label": "after_layer_0",
+  "timestamp_us": 1250.5,
+  "memory_bytes": 67108864
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_peak.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_memory_snapshot_peak.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: snap
+---
+MemorySnapshot {
+    label: "peak_forward_pass",
+    timestamp_us: 15000.5,
+    memory_bytes: 1073741824,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_model_memory_profile_empty.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_model_memory_profile_empty.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: profile
+---
+ModelMemoryProfile {
+    model_name: "bitnet-2b",
+    architecture: "bitnet",
+    known_profiles: [],
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_model_memory_profile_with_entries.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_model_memory_profile_with_entries.snap
@@ -1,0 +1,32 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: profile
+---
+ModelMemoryProfile {
+    model_name: "bitnet-2b-4t",
+    architecture: "bitnet",
+    known_profiles: [
+        (
+            512,
+            MemoryEstimation {
+                model_params_bytes: 500000000,
+                kv_cache_bytes: 16777216,
+                activation_bytes: 8388608,
+                total_bytes: 525165824,
+                recommended_gpu_vram_gb: 0.59,
+                recommended_system_ram_gb: 0.73,
+            },
+        ),
+        (
+            2048,
+            MemoryEstimation {
+                model_params_bytes: 500000000,
+                kv_cache_bytes: 67108864,
+                activation_bytes: 33554432,
+                total_bytes: 600663296,
+                recommended_gpu_vram_gb: 0.67,
+                recommended_system_ram_gb: 0.84,
+            },
+        ),
+    ],
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_all_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_all_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: modes
+---
+[
+    Latency,
+    Throughput,
+    Balanced,
+    Conservative,
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_conservative.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_conservative.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "PerformanceMode::Conservative"
+---
+Conservative

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_latency.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_performance_mode_latency.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "PerformanceMode::Latency"
+---
+Latency

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: true,
+    record_memory: false,
+    warmup_iterations: 0,
+    sample_size: 1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_disabled.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_disabled.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: false,
+    record_memory: false,
+    warmup_iterations: 0,
+    sample_size: 1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_json_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_json_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: json
+---
+{
+  "enabled": true,
+  "record_memory": true,
+  "warmup_iterations": 5,
+  "sample_size": 20
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_json_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_json_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: json
+---
+{
+  "enabled": true,
+  "record_memory": false,
+  "warmup_iterations": 0,
+  "sample_size": 1
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_with_memory.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_profiler_config_with_memory.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: cfg
+---
+ProfilerConfig {
+    enabled: true,
+    record_memory: true,
+    warmup_iterations: 3,
+    sample_size: 10,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_all_display.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_all_display.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: displays
+---
+[
+    "max_tokens",
+    "time_limit",
+    "memory_limit",
+    "end_of_sequence",
+    "user_stop",
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_eos_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_eos_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "StopReason::EndOfSequence"
+---
+EndOfSequence

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_max_tokens_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave26_inference__w26_stop_reason_max_tokens_debug.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave26_inference.rs
+expression: "StopReason::MaxTokens"
+---
+MaxTokens

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -32,8 +32,10 @@
 
 pub mod activations;
 pub mod attention;
+pub mod attention_mask;
 pub mod batch_norm;
 pub mod conv1d;
+pub mod dequant;
 pub mod elementwise;
 pub mod embedding;
 pub mod ffn;
@@ -42,15 +44,18 @@ pub mod gating;
 pub mod kv_cache;
 pub mod layernorm;
 pub mod linear;
+pub mod loss;
 pub mod matmul;
 pub mod memory_pool;
 pub mod pooling;
+pub mod profiling;
 pub mod qk256_gemv;
 pub mod quantize;
 pub mod quantized_matmul;
 pub mod rmsnorm;
 pub mod rope;
 pub mod softmax;
+pub mod stream_mgmt;
 pub mod transpose;
 
 pub use activations::{

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
@@ -1,0 +1,518 @@
+//! Wave 26 snapshot tests for `bitnet-kernels` — CUDA attention masks,
+//! dequantization configs, loss configs, stream management, profiling
+//! structs, FFN configs, perf tracker, and GPU benchmark/spirv types.
+//!
+//! Pins Debug/Display output so unintentional changes are caught at review.
+
+use std::time::Duration;
+
+// =========================================================================
+// Section 1 — CUDA attention mask configs
+// =========================================================================
+
+use bitnet_kernels::cuda::attention_mask::{
+    AlibiConfig, AttentionMaskConfig, BlockSparseConfig, PrefixMaskConfig, SlidingWindowConfig,
+};
+
+#[test]
+fn w26_attention_mask_config_debug() {
+    let cfg = AttentionMaskConfig::new(512);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_attention_mask_config_small() {
+    let cfg = AttentionMaskConfig::new(8);
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_sliding_window_config_debug() {
+    let cfg = SlidingWindowConfig::new(1024, 128).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_sliding_window_config_small() {
+    let cfg = SlidingWindowConfig::new(32, 8).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_block_sparse_config_debug() {
+    let cfg = BlockSparseConfig::new(2048, 64).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_alibi_config_debug() {
+    let cfg = AlibiConfig::new(512, 8).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_alibi_config_many_heads() {
+    let cfg = AlibiConfig::new(2048, 32).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_prefix_mask_config_debug() {
+    let cfg = PrefixMaskConfig::new(256, 64).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 2 — CUDA dequantization configs
+// =========================================================================
+
+use bitnet_kernels::cuda::dequant::{DequantConfig, DequantPrecision, QuantBitWidth, ScaleMode};
+
+#[test]
+fn w26_dequant_config_default() {
+    let cfg = DequantConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_dequant_precision_f32() {
+    insta::assert_debug_snapshot!(DequantPrecision::F32);
+}
+
+#[test]
+fn w26_dequant_precision_f16() {
+    insta::assert_debug_snapshot!(DequantPrecision::F16);
+}
+
+#[test]
+fn w26_quant_bit_width_all() {
+    let widths = vec![QuantBitWidth::Int2, QuantBitWidth::Int4, QuantBitWidth::Int8];
+    insta::assert_debug_snapshot!(widths);
+}
+
+#[test]
+fn w26_scale_mode_all() {
+    let modes = vec![ScaleMode::Uniform, ScaleMode::PerBlock, ScaleMode::PerChannel];
+    insta::assert_debug_snapshot!(modes);
+}
+
+#[test]
+fn w26_dequant_config_int4_f16_per_channel() {
+    let cfg = DequantConfig {
+        bit_width: QuantBitWidth::Int4,
+        precision: DequantPrecision::F16,
+        block_size: 128,
+        scale_mode: ScaleMode::PerChannel,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 3 — CUDA loss configs
+// =========================================================================
+
+use bitnet_kernels::cuda::loss::{LossConfig, LossReduction};
+
+#[test]
+fn w26_loss_reduction_all() {
+    let reductions = vec![LossReduction::Mean, LossReduction::Sum, LossReduction::None];
+    insta::assert_debug_snapshot!(reductions);
+}
+
+#[test]
+fn w26_loss_config_classification() {
+    let cfg = LossConfig::new(64, 32000).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_loss_config_with_sum() {
+    let mut cfg = LossConfig::new(128, 50257).unwrap();
+    cfg.reduction = LossReduction::Sum;
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 4 — CUDA FFN configs
+// =========================================================================
+
+use bitnet_kernels::cuda::ffn::{FfnActivationType, FfnConfig, QuantBits, SparseFfnConfig};
+
+#[test]
+fn w26_ffn_activation_all() {
+    let acts = vec![FfnActivationType::SiLU, FfnActivationType::GELU, FfnActivationType::ReLU];
+    insta::assert_debug_snapshot!(acts);
+}
+
+#[test]
+fn w26_quant_bits_all() {
+    let bits = vec![QuantBits::Int2, QuantBits::Int4];
+    insta::assert_debug_snapshot!(bits);
+}
+
+#[test]
+fn w26_ffn_config_llama() {
+    let cfg = FfnConfig::new(1, 4096, 11008, FfnActivationType::SiLU).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_ffn_config_gelu_small() {
+    let cfg = FfnConfig::new(8, 768, 3072, FfnActivationType::GELU).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_sparse_ffn_config_debug() {
+    let base = FfnConfig::new(1, 4096, 11008, FfnActivationType::SiLU).unwrap();
+    let cfg = SparseFfnConfig::new(base, 2).unwrap();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// =========================================================================
+// Section 5 — CUDA stream management
+// =========================================================================
+
+use bitnet_kernels::cuda::stream_mgmt::{
+    DefaultStreamBehavior, PipelineStage, PipelineStageKind, ScheduleStrategy, StreamConfig,
+    StreamPriority,
+};
+
+#[test]
+fn w26_stream_priority_all() {
+    let priorities = vec![StreamPriority::Low, StreamPriority::Normal, StreamPriority::High];
+    insta::assert_debug_snapshot!(priorities);
+}
+
+#[test]
+fn w26_stream_config_default() {
+    let cfg = StreamConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_stream_config_high_perf() {
+    let cfg = StreamConfig {
+        num_streams: 16,
+        priority: StreamPriority::High,
+        default_stream_behavior: DefaultStreamBehavior::Legacy,
+        enable_profiling: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_default_stream_behavior_all() {
+    let behaviors = vec![DefaultStreamBehavior::Legacy, DefaultStreamBehavior::PerThread];
+    insta::assert_debug_snapshot!(behaviors);
+}
+
+#[test]
+fn w26_schedule_strategy_all() {
+    let strategies = vec![
+        ScheduleStrategy::RoundRobin,
+        ScheduleStrategy::LeastLoaded,
+        ScheduleStrategy::PriorityBased,
+    ];
+    insta::assert_debug_snapshot!(strategies);
+}
+
+#[test]
+fn w26_pipeline_stage_kind_all() {
+    let kinds = vec![
+        PipelineStageKind::HostToDevice,
+        PipelineStageKind::Compute,
+        PipelineStageKind::DeviceToHost,
+    ];
+    insta::assert_debug_snapshot!(kinds);
+}
+
+#[test]
+fn w26_pipeline_stage_compute() {
+    let stage = PipelineStage::new(PipelineStageKind::Compute, "matmul_i2s", 5000);
+    insta::assert_debug_snapshot!(stage);
+}
+
+#[test]
+fn w26_pipeline_stage_transfer() {
+    let stage = PipelineStage::new(PipelineStageKind::HostToDevice, "weights_upload", 1200);
+    insta::assert_debug_snapshot!(stage);
+}
+
+// =========================================================================
+// Section 6 — CUDA profiling structs
+// =========================================================================
+
+use bitnet_kernels::cuda::profiling::{
+    AggregateStats, BandwidthMetrics, Bottleneck, ComputeMetrics, OccupancyLimiter, OccupancyResult,
+};
+
+#[test]
+fn w26_bottleneck_all_display() {
+    let bottlenecks = vec![
+        Bottleneck::MemoryBound,
+        Bottleneck::ComputeBound,
+        Bottleneck::LatencyBound,
+        Bottleneck::Unknown,
+    ];
+    let displays: Vec<String> = bottlenecks.iter().map(|b| b.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w26_occupancy_limiter_all_display() {
+    let limiters = vec![
+        OccupancyLimiter::Threads,
+        OccupancyLimiter::Blocks,
+        OccupancyLimiter::SharedMemory,
+        OccupancyLimiter::Registers,
+    ];
+    let displays: Vec<String> = limiters.iter().map(|l| l.to_string()).collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn w26_occupancy_result_high() {
+    let result = OccupancyResult {
+        theoretical: 0.95,
+        active_warps: 48,
+        max_warps: 64,
+        limiter: OccupancyLimiter::Registers,
+    };
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn w26_occupancy_result_low() {
+    let result = OccupancyResult {
+        theoretical: 0.25,
+        active_warps: 8,
+        max_warps: 64,
+        limiter: OccupancyLimiter::SharedMemory,
+    };
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn w26_bandwidth_metrics_debug() {
+    let m = BandwidthMetrics::new(1_048_576, 524_288, Duration::from_micros(100), 900e9);
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w26_compute_metrics_debug() {
+    let m = ComputeMetrics::new(2_000_000_000, Duration::from_millis(10), 15.0e12);
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
+fn w26_aggregate_stats_debug() {
+    let stats = AggregateStats {
+        count: 100,
+        mean: Duration::from_micros(250),
+        min: Duration::from_micros(180),
+        max: Duration::from_micros(420),
+        stddev_secs: 0.000045,
+    };
+    insta::assert_debug_snapshot!(stats);
+}
+
+// =========================================================================
+// Section 7 — Perf tracker
+// =========================================================================
+
+use bitnet_kernels::perf_tracker::{KernelTiming, PerfTracker};
+
+#[test]
+fn w26_kernel_timing_basic() {
+    let t = KernelTiming::new("gemm_i2s", Duration::from_micros(350), 1024 * 1024);
+    insta::assert_debug_snapshot!(t);
+}
+
+#[test]
+fn w26_kernel_timing_with_flops() {
+    let t = KernelTiming::new("matmul_f32", Duration::from_millis(5), 4096 * 4096)
+        .with_flops(137_438_953_472);
+    insta::assert_debug_snapshot!(t);
+}
+
+#[test]
+fn w26_perf_tracker_empty() {
+    let tracker = PerfTracker::new();
+    insta::assert_debug_snapshot!(tracker);
+}
+
+#[test]
+fn w26_perf_tracker_with_records() {
+    let mut tracker = PerfTracker::new();
+    tracker.record(KernelTiming::new("softmax", Duration::from_micros(50), 32768));
+    tracker.record(KernelTiming::new("rope", Duration::from_micros(30), 8192));
+    tracker.record(
+        KernelTiming::new("gemm_i2s", Duration::from_micros(800), 1048576)
+            .with_flops(2_147_483_648),
+    );
+    insta::assert_debug_snapshot!(tracker);
+}
+
+// =========================================================================
+// Section 8 — GPU benchmark / spirv / debug types (feature-gated)
+// =========================================================================
+
+#[cfg(any(feature = "gpu", feature = "cuda", feature = "oneapi"))]
+mod gpu_snapshot_tests {
+    use bitnet_kernels::gpu::benchmark::BenchmarkConfig;
+    use bitnet_kernels::gpu::debug_layer::{Mismatch, Tolerance, ValidationReport};
+    use bitnet_kernels::gpu::spirv_cache::{CacheStatsSnapshot, SpirvCacheConfig};
+    use bitnet_kernels::gpu::validation::PerformanceResult;
+
+    #[test]
+    fn w26_benchmark_config_default() {
+        let cfg = BenchmarkConfig::default();
+        insta::assert_debug_snapshot!(cfg);
+    }
+
+    #[test]
+    fn w26_performance_result_debug() {
+        let result = PerformanceResult {
+            dimensions: (256, 256, 256),
+            cpu_time_ms: 12.5,
+            gpu_time_ms: 0.8,
+            speedup: 15.625,
+            gflops: 41.9,
+        };
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn w26_performance_result_small_matrix() {
+        let result = PerformanceResult {
+            dimensions: (64, 64, 64),
+            cpu_time_ms: 0.3,
+            gpu_time_ms: 0.5,
+            speedup: 0.6,
+            gflops: 1.05,
+        };
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn w26_tolerance_default() {
+        let t = Tolerance::default();
+        insta::assert_debug_snapshot!(t);
+    }
+
+    #[test]
+    fn w26_mismatch_debug() {
+        let m =
+            Mismatch { index: 42, expected: 1.0, got: 1.0001, abs_diff: 0.0001, rel_diff: 0.0001 };
+        insta::assert_debug_snapshot!(m);
+    }
+
+    #[test]
+    fn w26_validation_report_pass() {
+        let report = ValidationReport {
+            operation: "layer_norm".into(),
+            tolerance: Tolerance::default(),
+            mismatches: vec![],
+            total_elements: 1024,
+        };
+        insta::assert_debug_snapshot!(report);
+    }
+
+    #[test]
+    fn w26_validation_report_with_mismatches() {
+        let report = ValidationReport {
+            operation: "matmul_i2s".into(),
+            tolerance: Tolerance { abs_epsilon: 1e-3, rel_epsilon: 1e-2 },
+            mismatches: vec![
+                Mismatch { index: 7, expected: 0.5, got: 0.512, abs_diff: 0.012, rel_diff: 0.024 },
+                Mismatch { index: 99, expected: -1.0, got: -0.98, abs_diff: 0.02, rel_diff: 0.02 },
+            ],
+            total_elements: 4096,
+        };
+        insta::assert_debug_snapshot!(report);
+    }
+
+    #[test]
+    fn w26_spirv_cache_config_custom() {
+        let cfg = SpirvCacheConfig {
+            cache_dir: std::path::PathBuf::from("/tmp/spirv_cache"),
+            max_cache_size_mb: 512,
+            device_fingerprint: "0x10de:0x2684:535.129.03".into(),
+        };
+        insta::assert_debug_snapshot!(cfg);
+    }
+
+    #[test]
+    fn w26_cache_stats_snapshot_empty() {
+        let snap = CacheStatsSnapshot { hits: 0, misses: 0, total_size_bytes: 0, entry_count: 0 };
+        insta::assert_debug_snapshot!(snap);
+    }
+
+    #[test]
+    fn w26_cache_stats_snapshot_active() {
+        let snap = CacheStatsSnapshot {
+            hits: 1500,
+            misses: 200,
+            total_size_bytes: 4_194_304,
+            entry_count: 128,
+        };
+        insta::assert_debug_snapshot!(snap);
+    }
+}
+
+// =========================================================================
+// Section 9 — Additional CUDA memory pool and KV cache tests
+// =========================================================================
+
+use bitnet_kernels::cuda::memory_pool::{MemoryPoolConfig, MemoryStats};
+
+#[test]
+fn w26_cuda_memory_pool_config_custom() {
+    let cfg = MemoryPoolConfig {
+        initial_size: 2 * 1024 * 1024,
+        max_size: 512 * 1024 * 1024,
+        block_size: 512,
+        alignment: 128,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn w26_cuda_memory_stats_fragmented() {
+    let stats = MemoryStats {
+        total: 1_073_741_824,
+        used: 536_870_912,
+        free: 536_870_912,
+        fragmentation: 0.42,
+        num_allocations: 256,
+        num_free_blocks: 64,
+    };
+    insta::assert_debug_snapshot!(stats);
+}
+
+#[test]
+fn w26_cuda_memory_stats_full() {
+    let stats = MemoryStats {
+        total: 268_435_456,
+        used: 268_435_456,
+        free: 0,
+        fragmentation: 0.0,
+        num_allocations: 1,
+        num_free_blocks: 0,
+    };
+    insta::assert_debug_snapshot!(stats);
+}
+
+use bitnet_kernels::cuda::kv_cache::CacheStats;
+
+#[test]
+fn w26_kv_cache_stats_debug() {
+    let stats = CacheStats {
+        entries_per_layer: vec![128, 128, 128, 128],
+        memory_bytes: 16_777_216,
+        hit_rate: 0.95,
+        avg_access_time_us: 0.8,
+    };
+    insta::assert_debug_snapshot!(stats);
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_aggregate_stats_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_aggregate_stats_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stats
+---
+AggregateStats {
+    count: 100,
+    mean: 250µs,
+    min: 180µs,
+    max: 420µs,
+    stddev_secs: 4.5e-5,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_alibi_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_alibi_config_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+AlibiConfig {
+    seq_len: 512,
+    n_heads: 8,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_alibi_config_many_heads.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_alibi_config_many_heads.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+AlibiConfig {
+    seq_len: 2048,
+    n_heads: 32,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_attention_mask_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_attention_mask_config_debug.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+AttentionMaskConfig {
+    seq_len: 512,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_attention_mask_config_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_attention_mask_config_small.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+AttentionMaskConfig {
+    seq_len: 8,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_bandwidth_metrics_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_bandwidth_metrics_debug.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: m
+---
+BandwidthMetrics {
+    bytes_read: 1048576,
+    bytes_written: 524288,
+    duration: 100µs,
+    peak_bandwidth_bytes_per_sec: 900000000000.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_block_sparse_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_block_sparse_config_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+BlockSparseConfig {
+    seq_len: 2048,
+    block_size: 64,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_bottleneck_all_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_bottleneck_all_display.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: displays
+---
+[
+    "memory_bound",
+    "compute_bound",
+    "latency_bound",
+    "unknown",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_compute_metrics_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_compute_metrics_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: m
+---
+ComputeMetrics {
+    flops: 2000000000,
+    duration: 10ms,
+    peak_flops: 15000000000000.0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_pool_config_custom.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_pool_config_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+MemoryPoolConfig {
+    initial_size: 2097152,
+    max_size: 536870912,
+    block_size: 512,
+    alignment: 128,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_stats_fragmented.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_stats_fragmented.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stats
+---
+MemoryStats {
+    total: 1073741824,
+    used: 536870912,
+    free: 536870912,
+    fragmentation: 0.42,
+    num_allocations: 256,
+    num_free_blocks: 64,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_stats_full.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_cuda_memory_stats_full.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stats
+---
+MemoryStats {
+    total: 268435456,
+    used: 268435456,
+    free: 0,
+    fragmentation: 0.0,
+    num_allocations: 1,
+    num_free_blocks: 0,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_default_stream_behavior_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_default_stream_behavior_all.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: behaviors
+---
+[
+    Legacy,
+    PerThread,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+DequantConfig {
+    bit_width: Int2,
+    precision: F32,
+    block_size: 256,
+    scale_mode: PerBlock,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_config_int4_f16_per_channel.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_config_int4_f16_per_channel.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+DequantConfig {
+    bit_width: Int4,
+    precision: F16,
+    block_size: 128,
+    scale_mode: PerChannel,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_precision_f16.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_precision_f16.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: "DequantPrecision::F16"
+---
+F16

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_precision_f32.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_dequant_precision_f32.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: "DequantPrecision::F32"
+---
+F32

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_activation_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_activation_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: acts
+---
+[
+    SiLU,
+    GELU,
+    ReLU,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_config_gelu_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_config_gelu_small.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+FfnConfig {
+    batch_size: 8,
+    hidden_dim: 768,
+    intermediate_dim: 3072,
+    activation: GELU,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_config_llama.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_ffn_config_llama.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+FfnConfig {
+    batch_size: 1,
+    hidden_dim: 4096,
+    intermediate_dim: 11008,
+    activation: SiLU,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kernel_timing_basic.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kernel_timing_basic.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: t
+---
+KernelTiming {
+    kernel_name: "gemm_i2s",
+    duration: 350µs,
+    input_elements: 1048576,
+    flops: None,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kernel_timing_with_flops.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kernel_timing_with_flops.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: t
+---
+KernelTiming {
+    kernel_name: "matmul_f32",
+    duration: 5ms,
+    input_elements: 16777216,
+    flops: Some(
+        137438953472,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kv_cache_stats_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_kv_cache_stats_debug.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stats
+---
+CacheStats {
+    entries_per_layer: [
+        128,
+        128,
+        128,
+        128,
+    ],
+    memory_bytes: 16777216,
+    hit_rate: 0.95,
+    avg_access_time_us: 0.8,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_config_classification.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_config_classification.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+LossConfig {
+    n: 64,
+    n_classes: 32000,
+    threads_per_block: 256,
+    reduction: Mean,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_config_with_sum.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_config_with_sum.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+LossConfig {
+    n: 128,
+    n_classes: 50257,
+    threads_per_block: 256,
+    reduction: Sum,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_reduction_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_loss_reduction_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: reductions
+---
+[
+    Mean,
+    Sum,
+    None,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_limiter_all_display.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_limiter_all_display.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: displays
+---
+[
+    "threads",
+    "blocks",
+    "shared_memory",
+    "registers",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_result_high.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_result_high.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: result
+---
+OccupancyResult {
+    theoretical: 0.95,
+    active_warps: 48,
+    max_warps: 64,
+    limiter: Registers,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_result_low.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_occupancy_result_low.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: result
+---
+OccupancyResult {
+    theoretical: 0.25,
+    active_warps: 8,
+    max_warps: 64,
+    limiter: SharedMemory,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_perf_tracker_empty.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_perf_tracker_empty.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: tracker
+---
+PerfTracker {
+    timings: [],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_perf_tracker_with_records.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_perf_tracker_with_records.snap
@@ -1,0 +1,28 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: tracker
+---
+PerfTracker {
+    timings: [
+        KernelTiming {
+            kernel_name: "softmax",
+            duration: 50µs,
+            input_elements: 32768,
+            flops: None,
+        },
+        KernelTiming {
+            kernel_name: "rope",
+            duration: 30µs,
+            input_elements: 8192,
+            flops: None,
+        },
+        KernelTiming {
+            kernel_name: "gemm_i2s",
+            duration: 800µs,
+            input_elements: 1048576,
+            flops: Some(
+                2147483648,
+            ),
+        },
+    ],
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_compute.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_compute.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stage
+---
+PipelineStage {
+    kind: Compute,
+    label: "matmul_i2s",
+    cost: 5000,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_kind_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_kind_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: kinds
+---
+[
+    HostToDevice,
+    Compute,
+    DeviceToHost,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_transfer.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_pipeline_stage_transfer.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: stage
+---
+PipelineStage {
+    kind: HostToDevice,
+    label: "weights_upload",
+    cost: 1200,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_prefix_mask_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_prefix_mask_config_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+PrefixMaskConfig {
+    seq_len: 256,
+    prefix_len: 64,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_quant_bit_width_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_quant_bit_width_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: widths
+---
+[
+    Int2,
+    Int4,
+    Int8,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_quant_bits_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_quant_bits_all.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: bits
+---
+[
+    Int2,
+    Int4,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_scale_mode_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_scale_mode_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: modes
+---
+[
+    Uniform,
+    PerBlock,
+    PerChannel,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_schedule_strategy_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_schedule_strategy_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: strategies
+---
+[
+    RoundRobin,
+    LeastLoaded,
+    PriorityBased,
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sliding_window_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sliding_window_config_debug.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+SlidingWindowConfig {
+    seq_len: 1024,
+    window_size: 128,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sliding_window_config_small.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sliding_window_config_small.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+SlidingWindowConfig {
+    seq_len: 32,
+    window_size: 8,
+    threads_per_block: 256,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sparse_ffn_config_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_sparse_ffn_config_debug.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+SparseFfnConfig {
+    base: FfnConfig {
+        batch_size: 1,
+        hidden_dim: 4096,
+        intermediate_dim: 11008,
+        activation: SiLU,
+        threads_per_block: 256,
+    },
+    top_k: 2,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_config_default.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+StreamConfig {
+    num_streams: 4,
+    priority: Normal,
+    default_stream_behavior: PerThread,
+    enable_profiling: false,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_config_high_perf.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_config_high_perf.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: cfg
+---
+StreamConfig {
+    num_streams: 16,
+    priority: High,
+    default_stream_behavior: Legacy,
+    enable_profiling: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_priority_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave26_kernels__w26_stream_priority_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave26_kernels.rs
+expression: priorities
+---
+[
+    Low,
+    Normal,
+    High,
+]

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 


### PR DESCRIPTION
## Snapshot Wave 26

Adds **117 new insta snapshot tests** pinning Debug/Display output across three crates.

### bitnet-kernels (45 tests)
- CUDA attention mask configs (causal, sliding window, block sparse, ALiBi, prefix)
- CUDA dequantization configs and enums (DequantPrecision, QuantBitWidth, ScaleMode)
- CUDA loss configs (LossReduction variants, LossConfig)
- CUDA FFN configs (FfnActivationType, QuantBits, FfnConfig, SparseFfnConfig)
- CUDA stream management (StreamPriority, StreamConfig, ScheduleStrategy, PipelineStage)
- CUDA profiling structs (Bottleneck, OccupancyLimiter, OccupancyResult, BandwidthMetrics, ComputeMetrics, AggregateStats)
- PerfTracker and KernelTiming
- GPU benchmark/spirv/debug types (feature-gated behind `gpu`/`cuda`/`oneapi`)
- CUDA memory pool and KV cache stats

### bitnet-common (36 tests)
- ShapeError Display for all 9 variants
- TensorValidationError Display for all 8 variants
- ModelError Display (5 variants + ValidationErrorDetails)
- Config enums (ActivationType, NormType, ModelFormat, RopeScaling)
- PoolStats (default, active, total_allocations)
- ComputationType (Debug + serde roundtrip)

### bitnet-inference (36 tests)
- GenerationBudget (default, token/time/memory limits, unlimited)
- StopReason Display for all 5 variants
- BudgetTracker (fresh, after tokens, exhausted)
- ProfilerConfig (default, disabled, custom + JSON serialization)
- LayerProfile (attention, ffn, norm + JSON serialization)
- MemorySnapshot (init, peak + JSON serialization)
- MemoryEstimation and KvCacheEstimation
- ModelMemoryProfile (empty, with entries)
- PerformanceMode (all 4 variants)
- estimate_kv_cache helper function

### Minor changes
- Exports 5 new CUDA submodules from `cuda/mod.rs`: `attention_mask`, `dequant`, `loss`, `profiling`, `stream_mgmt`

All 117 tests pass with `--no-default-features --features cpu`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>