### PR TITLE
docs: update architecture overview and kernel module reference

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -4,7 +4,16 @@ This document provides a high-level overview of BitNet-rs architecture, design p
 
 ## Workspace Structure
 
-BitNet-rs is organized as a Rust workspace with specialized crates:
+BitNet-rs is organized as a Rust workspace with **110 crates** (as of this writing):
+
+```
+bitnet-tokenizers → bitnet-models (GGUF loader) → bitnet-quantization → bitnet-kernels → bitnet-inference → bitnet-server / bitnet-cli
+                                                                              ↑
+                          bitnet-logits → bitnet-sampling → bitnet-generation ─┘
+                          bitnet-gguf, bitnet-device-probe, bitnet-engine-core
+                          bitnet-prompt-templates, bitnet-receipts, bitnet-honest-compute
+                          bitnet-runtime-feature-flags, bitnet-simd, bitnet-rope
+```
 
 ### Core Library
 - **`bitnet`** (root): Main library with unified public API and production-ready GGUF weight loading
@@ -22,21 +31,51 @@ BitNet-rs is organized as a Rust workspace with specialized crates:
 These small, single-responsibility crates reduce coupling in `bitnet-inference` and are re-exported from their original locations for zero breaking changes.
 
 - **`bitnet-logits`**: Pure logit-transform functions (`apply_temperature`, `apply_top_k`, `apply_top_p`, `softmax_in_place`, `apply_repetition_penalty`, `argmax`) — no external dependencies, suitable for `no_std`
+- **`bitnet-logits-filters`**: Extended logit filtering (min-p, tail-free sampling, typical sampling)
 - **`bitnet-sampling`**: Token-sampling strategies (greedy, temperature, top-k, top-p, repetition penalty) built on `bitnet-logits`; seeded with `ChaCha8Rng` for reproducibility
 - **`bitnet-generation`**: Decode-loop contracts: `StopCriteria`, `check_stop` priority logic, `StopReason`, `GenerationConfig`, streaming `StreamEvent` / `GenerationStats`
 - **`bitnet-engine-core`**: Session/orchestration contracts: `SessionConfig`, `SessionMetrics`, `BackendInfo`
 - **`bitnet-device-probe`**: OS/GPU probing and capability snapshot (`gpu_compiled()`, `gpu_available_runtime()`, `detect_simd_level()`, `DeviceCapabilities`) — respects `BITNET_GPU_FAKE` and `BITNET_STRICT_MODE`
 - **`bitnet-gguf`**: GGUF parser surface with property and fuzz tests
-- **`bitnet-prompt-templates`**: Chat template types (`PromptTemplate`, `TemplateType`, `ChatTurn`) and formatters
-- **`bitnet-receipts`**: Honest-compute receipt schema v1.0.0 and serialization
+- **`bitnet-prompt-templates`** / **`bitnet-prompt-templates-core`**: Chat template types (`PromptTemplate`, `TemplateType`, `ChatTurn`) and formatters
+- **`bitnet-receipts`** / **`bitnet-receipts-core`**: Honest-compute receipt schema v1.0.0 and serialization
 - **`bitnet-honest-compute`**: `compute_path=real` enforcement and kernel-ID hygiene policy (no-mock gate)
-- **`bitnet-runtime-feature-flags`**: Runtime snapshot of compiled features (`cpu`, `gpu`, `cuda` flags reported independently)
+- **`bitnet-runtime-feature-flags`** / **`bitnet-runtime-feature-flags-core`**: Runtime snapshot of compiled features (`cpu`, `gpu`, `cuda` flags reported independently)
+- **`bitnet-simd`**: Portable SIMD abstraction layer
+- **`bitnet-rope`**: RoPE positional-embedding table generation
+- **`bitnet-math`**: Numerically-stable math primitives (log-sum-exp, softmax helpers)
+- **`bitnet-validation`**: Production tensor shape/dtype validation
+- **`bitnet-warn-once`**: `warn_once!` macro for rate-limited hot-path logging
+- **`bitnet-cpu-detect`**: Runtime CPU feature detection (AVX2, AVX-512, NEON)
+- **`bitnet-cpu-activations`**: CPU activation functions (GELU, SiLU, etc.)
+- **`bitnet-qk256-dispatch`**: QK256 format dispatch with scalar/AVX2 runtime selection
+- **`bitnet-transformer`**: Transformer block contracts and layer composition
+- **`bitnet-runtime-bootstrap`**: Runtime initialization and startup sequencing
+- **`bitnet-runtime-context`** / **`bitnet-runtime-context-core`**: Runtime execution context
+- **`bitnet-runtime-profile`** / **`bitnet-runtime-profile-core`**: Runtime profiling framework
 
-### Testing / CI microcrates
+### GPU Backend Crates
+
+- **`bitnet-gpu-hal`**: Unified GPU hardware abstraction layer with backend selector, async runtime, checkpoint manager, and deployment manager
+- **`bitnet-opencl`**: Intel Arc OpenCL backend with built-in kernel registry and work-size optimization (experimental; feature `opencl`)
+- **`bitnet-metal`**: Metal GPU backend for macOS/iOS Apple Silicon (feature `metal`)
+- **`bitnet-vulkan`** / **`bitnet-vulkan-shaders`**: Vulkan compute backend (feature `vulkan`)
+- **`bitnet-spirv`**: SPIR-V shader compilation support
+- **`bitnet-nvidia`**: NVIDIA-specific GPU utilities
+- **`bitnet-rocm`**: AMD ROCm detection and device probe (feature `rocm`)
+- **`bitnet-intel-gpu-id`**: Intel GPU identification utilities
+- **`bitnet-webgpu`** / **`bitnet-wgpu`** / **`bitnet-wgpu-runner`** / **`bitnet-wgpu-bench`** / **`bitnet-wgpu-shaders`** / **`bitnet-wgpu-shaders-i2s`**: WebGPU/wgpu compute backends and I2_S shader kernels
+
+### Testing / CI Microcrates
 
 - **`bitnet-bdd-grid`** / **`bitnet-bdd-grid-core`**: BDD compatibility grid with compile-coverage enforcement (`xtask grid-check`)
 - **`bitnet-feature-matrix`** / **`bitnet-feature-contract`**: Feature-lattice contracts and enforcement tests
-- **`bitnet-testing-policy-core`** / **`bitnet-testing-scenarios-core`** / **`bitnet-runtime-profile-core`**: Test policy and scenario primitives
+- **`bitnet-testing-policy`** / **`bitnet-testing-policy-core`** / **`bitnet-testing-policy-runtime`** / **`bitnet-testing-policy-kit`**: Test policy framework and runtime enforcement
+- **`bitnet-testing-scenarios`** / **`bitnet-testing-scenarios-core`**: Test scenario definitions
+- **`bitnet-testing-profile`** / **`bitnet-runtime-profile-contract`**: Testing profile primitives
+- **`bitnet-test-fixtures-core`**: Shared test fixtures (GGUF fixtures, mock tensors)
+- **`bitnet-test-env`** / **`bitnet-test-support`**: Environment isolation and test helpers
+- **`bitnet-bench-receipts`** / **`bitnet-bench-regression-core`**: Benchmark receipt validation and regression detection
 
 ### Application Layer
 - **`bitnet-server`**: **Production HTTP/REST inference server** providing scalable inference endpoints with batch processing, model hot-swapping capabilities, comprehensive health monitoring (liveness/readiness/startup probes), real-time system metrics collection (CPU, memory, disk, network I/O), Prometheus metrics integration, OpenTelemetry observability, streaming inference support, and deployment-ready configurations for Docker and Kubernetes environments
@@ -51,6 +90,86 @@ These small, single-responsibility crates reduce coupling in `bitnet-inference` 
 ### Cross-Validation
 - **`crossval`**: Framework for testing against C++ implementation
 - Tests use `BITNET_GGUF` or `CROSSVAL_GGUF` environment variable for model path
+
+## Kernel Module Architecture
+
+The `bitnet-kernels` crate contains **58 source files** organized into backend-specific subdirectories. See [Kernel Module Reference](reference/kernel-modules.md) for the complete module table.
+
+### CPU Kernels (`cpu/` — 66 modules)
+
+Generic compute kernels with platform-specific SIMD accelerations:
+
+- **Core ops**: `matmul`, `softmax`, `layernorm`, `attention`, `ffn`, `embedding`, `rope`, `gating`, `pooling`, `convolution`, `transpose`, `reduction`, `residual`, `loss`
+- **x86 SIMD** (`x86.rs`): AVX2/AVX-512 paths for QK256 dequantization and GEMV; property tests in `x86_qk256_property_tests.rs`
+- **ARM NEON** (24 modules): `neon_activations`, `neon_quantized_gemm`, `neon_quantized_matmul`, `neon_rope`, `neon_softmax`, `neon_layernorm`, `neon_kv_cache`, `neon_scatter_gather`, `neon_sliding_window_attention`, `neon_batch_norm`, `neon_elementwise`, `neon_reductions`, `neon_transpose`, `neon_inference_bridge`, among others
+- **Scatter/gather** (`scatter_gather.rs`, `cpu/scatter_gather.rs`): Memory-layout-aware data movement
+- **Fusion**: `layer_fusion.rs`, `fusion.rs` for fused attention and FFN passes
+- **Parallelism**: `pipeline_parallel.rs`, `tensor_parallel.rs` for multi-device distribution
+
+### CUDA Kernels (`cuda/` — 39 modules)
+
+GPU compute kernels targeting NVIDIA CUDA, gated behind `#[cfg(any(feature = "gpu", feature = "cuda"))]`:
+
+- **Core ops**: `matmul`, `softmax`, `layernorm`, `rmsnorm`, `attention`, `fused_attention`, `multi_head_attention`, `ffn`, `embedding`, `rope`, `gating`, `linear`, `dequant`, `quantize`
+- **Quantized**: `quantized_gemm`, `quantized_matmul`, `qk256_gemv` for 2-bit GEMV
+- **Memory management**: `memory_pool` (device memory pooling), `kv_cache`, `kv_cache_gpu`
+- **Execution management**: `stream_mgmt` (CUDA stream manager), `warp_ops` (warp-level primitives), `cooperative_groups`
+- **Optimization**: `graph_exec` (CUDA graph execution), `shader_cache`, `profiling`, `sparse`
+- **Other ops**: `batch_norm`, `conv1d`, `elementwise`, `pooling`, `residual`, `loss`, `transpose`, `fusion`
+
+### OpenCL Modules (42 modules)
+
+Experimental Intel Arc / OpenCL backend, each as a top-level module in `bitnet-kernels/src/`:
+
+- **Compute**: `opencl_attention`, `opencl_flash_attention`, `opencl_gqa`, `opencl_ffn`, `opencl_layer_norm`, `opencl_reductions`, `opencl_softmax_variants`, `opencl_elementwise`, `opencl_embedding`, `opencl_token_embed`
+- **Quantized**: `opencl_quantized`, `opencl_quantized_matmul`, `opencl_matmul_variants`, `opencl_mixed_precision`
+- **Infrastructure**: `opencl_context`, `opencl_cmd_queue`, `opencl_buffer`, `opencl_memory`, `opencl_device_caps`, `opencl_work_size`, `opencl_kernel_sources`, `opencl_program_cache`, `opencl_registry`
+- **Pipeline**: `opencl_pipeline`, `opencl_continuous_batch`, `opencl_graph_compiler`, `opencl_layer_compose`, `opencl_transformer`, `opencl_engine_bridge`, `opencl_model_converter`
+- **Caching**: `opencl_cache`, `opencl_prefix_cache`, `opencl_kv_cache`, `opencl_rope_cache`
+- **Utilities**: `opencl_autotuner`, `opencl_profiling`, `opencl_telemetry`, `opencl_async_executor`, `opencl_numerical_stability`, `opencl_weight_manager`, `opencl_token_gen`
+
+### Other Backend Modules
+
+| Module | Feature gate | Purpose |
+|--------|-------------|---------|
+| `metal_compute` | `feature = "metal"` | Apple Metal compute kernels |
+| `rocm/` (4 modules) | `feature = "rocm"` | AMD ROCm attention, QK256 GEMV, RMSNorm |
+| `npu/` | `feature = "npu-backend"` | NPU bridge (C++ interop) |
+| `gpu/` (mixed-backend) | `feature = "gpu"` | Shared GPU utilities, OpenCL dispatch, validation, benchmarks |
+
+### Shared Kernel Infrastructure
+
+| Module | Purpose |
+|--------|---------|
+| `kernels.rs` | `KernelManager` — runtime provider selection (CUDA > CPU fallback) |
+| `capability_matrix.rs` | Kernel capability reporting per backend |
+| `device_aware.rs` | Device-aware kernel dispatch |
+| `device_features.rs` | `gpu_compiled()`, `gpu_available_runtime()` helpers |
+| `convolution.rs` | Generic convolution ops |
+| `reduction.rs` / `shaped_reduction.rs` | Reduction primitives |
+| `scatter_gather.rs` | Top-level scatter/gather |
+| `tl_lut.rs` | Table-lookup (TL1/TL2) LUT generation |
+| `simd_diagnostics.rs` | SIMD feature detection and diagnostics |
+| `perf_tracker.rs` | Kernel performance tracking |
+| `gpu_utils.rs` | GPU utility functions |
+| `stubs.rs` | Stub implementations for disabled backends |
+| `ffi.rs` / `ffi/` | C++ FFI bridge (feature `ffi`) |
+
+## Test Infrastructure
+
+BitNet-rs has comprehensive test infrastructure spanning multiple strategies:
+
+| Strategy | Scope | Details |
+|----------|-------|---------|
+| **Property-based (proptest)** | 63 crates | Randomized invariant testing across quantization, tokenization, KV-cache, tensor shapes |
+| **Snapshot (insta)** | 49 crates, ~1 233 `.snap` files | Struct/output stability for serialization, CLI output, receipt schemas |
+| **Fuzz (cargo-fuzz)** | 98 targets | Nightly `nightly-fuzz.yml`: RoPE table gen, tokenizer encode, softmax stability, embedding lookup, memory layout, and more |
+| **BDD grid** | `bitnet-bdd-grid` | Compile-coverage matrix (`xtask grid-check`) |
+| **Feature-lattice** | `bitnet-feature-matrix` | Orthogonal feature-gate contracts |
+| **Fixture-based** | `bitnet-models`, `bitnet-test-fixtures-core` | GGUF dual-flavor detection, alignment (12/12 passing) |
+| **Environment isolation** | `EnvGuard` + `#[serial(bitnet_env)]` | Parallel-safe env mutation via `temp_env` |
+| **CPU golden-path E2E** | `tests/` | 7 deterministic tests always in PR CI (no model download) |
+| **Criterion benchmarks** | `benches/srp_ops.rs` | logits pipeline, top-k, repetition penalty, argmax, RoPE, KV cache |
 
 ## Production-Ready GGUF Weight Loading Architecture
 
@@ -337,6 +456,15 @@ We maintain strict compatibility with llama.cpp while providing enhanced validat
 - Robust handling of malformed GGUF files with detailed error messages
 - See COMPATIBILITY.md for detailed guarantees
 
+## Current Limitations
+
+- **Pre-Alpha Status**: Correctness, performance, and validation are ongoing. Do not use in production.
+- **QK256 Performance**: Scalar kernels only (~0.1 tok/s for 2B models). AVX2 nibble-LUT + FMA tiling planned for ≥3× uplift. Limit to `--max-tokens 4-16` for validation.
+- **GPU Backends**: Metal, Vulkan, oneAPI, ROCm, OpenCL, and WebGPU backends are scaffolded but not validated end-to-end. CUDA is the furthest along.
+- **OpenCL Modules**: 42 OpenCL modules in `bitnet-kernels` are experimental (Intel Arc focus); API surface may change.
+- **Model Quality**: microsoft-bitnet-b1.58-2B-4T-gguf produces non-sensical output in some configurations (known model quality issue, not an inference bug).
+- **Test Scaffolding**: ~466 `#[ignore]` tests across the workspace, all with justification strings. Categories: real-model, CUDA, slow mock-inference, crossval, and TDD scaffolds.
+
 ## Development Workflow
 
 1. **Making Changes**: Always run tests for affected crates
@@ -345,6 +473,7 @@ We maintain strict compatibility with llama.cpp while providing enhanced validat
 4. **Compatibility**: Check COMPATIBILITY.md before changing public APIs
 
 For detailed information on specific components, see:
+- [Kernel Module Reference](reference/kernel-modules.md)
 - [Quantization Support](reference/quantization-support.md)
 - [GPU Development Guide](development/gpu-development.md)
 - [Tokenizer Architecture](tokenizer-architecture.md)

--- a/docs/reference/kernel-modules.md
+++ b/docs/reference/kernel-modules.md
@@ -1,0 +1,236 @@
+# Kernel Module Reference
+
+Complete reference for all kernel modules in `bitnet-kernels` (58 source files in `src/`, plus backend subdirectories).
+
+## CPU Modules (`cpu/` — 66 files)
+
+### Generic (architecture-independent)
+
+| Module | Purpose |
+|--------|---------|
+| `activations.rs` | Activation functions (GELU, SiLU, ReLU) |
+| `attention.rs` | Multi-head / grouped-query attention |
+| `attention_mask.rs` | Causal and padding mask generation |
+| `batch.rs` | Batch-level utilities |
+| `batch_norm.rs` / `batch_normalization.rs` | Batch normalization |
+| `cache_matmul.rs` | KV-cache-aware matrix multiply |
+| `concat.rs` | Tensor concatenation |
+| `conv2d.rs` / `convolution.rs` | 2-D convolution kernels |
+| `dequant.rs` | Dequantization (I2_S → float) |
+| `elementwise_ops.rs` | Element-wise add, mul, etc. |
+| `embedding.rs` | Token embedding lookup |
+| `fallback.rs` | Scalar fallback implementations |
+| `ffn.rs` | Feed-forward network (SwiGLU) |
+| `fusion.rs` / `layer_fusion.rs` | Fused attention + FFN passes |
+| `gather.rs` / `scatter_gather.rs` | Memory-layout-aware data movement |
+| `gating.rs` | Gating mechanisms |
+| `kv_cache.rs` | KV-cache append and eviction |
+| `layer_norm.rs` | LayerNorm / RMSNorm |
+| `linear.rs` | Dense linear layers |
+| `loss.rs` | Loss computation |
+| `matrix_ops.rs` | Generic matrix operations |
+| `pipeline_parallel.rs` | Pipeline parallelism |
+| `pooling.rs` | Pooling operations |
+| `quantize.rs` | Float → quantized encoding |
+| `quantized_matmul.rs` | Quantized GEMV/GEMM |
+| `quantized_pipeline.rs` | End-to-end quantized inference pipeline |
+| `reduction.rs` | Sum, max, argmax reductions |
+| `residual.rs` | Residual connections |
+| `rope.rs` / `rope_simd.rs` | RoPE positional embeddings (scalar + SIMD) |
+| `simd_math.rs` / `simd_matmul.rs` | SIMD math helpers and matmul |
+| `softmax.rs` | Numerically-stable softmax |
+| `tensor_parallel.rs` | Tensor parallelism |
+| `transpose.rs` | Matrix transpose |
+
+### x86 SIMD (AVX2 / AVX-512)
+
+| Module | Feature gate | Purpose |
+|--------|-------------|---------|
+| `x86.rs` | `feature = "avx2"` or `feature = "avx512"` | AVX2/AVX-512 GEMV and dequantization |
+| `x86_qk256_property_tests.rs` | `feature = "avx2"` | Property-based correctness tests for QK256 AVX2 path |
+
+### ARM NEON (24 modules)
+
+All NEON modules are gated on `target_arch = "aarch64"` and `feature = "neon"`.
+
+| Module | Purpose |
+|--------|---------|
+| `arm.rs` | ARM architecture detection |
+| `neon_activations.rs` / `neon_activation_suite.rs` | NEON-accelerated activations |
+| `neon_batch_norm.rs` / `neon_batch_norm_v2.rs` | NEON batch normalization |
+| `neon_batch_scheduler.rs` | NEON batch scheduling |
+| `neon_convolution.rs` | NEON convolution |
+| `neon_data_layout.rs` | NEON data layout transforms |
+| `neon_elementwise.rs` | NEON element-wise ops |
+| `neon_inference_bridge.rs` | NEON ↔ inference engine bridge |
+| `neon_kv_cache.rs` | NEON KV-cache operations |
+| `neon_layernorm.rs` | NEON LayerNorm |
+| `neon_multi_head_linear.rs` | NEON multi-head linear projection |
+| `neon_online_softmax.rs` | NEON online (streaming) softmax |
+| `neon_padding_clipping.rs` | NEON padding and clipping |
+| `neon_pooling.rs` | NEON pooling |
+| `neon_quantized_gemm.rs` / `neon_quantized_matmul.rs` | NEON quantized GEMM/GEMV |
+| `neon_reductions.rs` | NEON reductions |
+| `neon_rope.rs` | NEON RoPE |
+| `neon_scatter_gather.rs` | NEON scatter/gather |
+| `neon_sliding_window_attention.rs` | NEON sliding-window attention |
+| `neon_softmax.rs` | NEON softmax |
+| `neon_transpose.rs` | NEON transpose |
+
+## CUDA Modules (`cuda/` — 39 files)
+
+Feature gate: `#[cfg(any(feature = "gpu", feature = "cuda"))]`
+
+### Core Compute
+
+| Module | Purpose |
+|--------|---------|
+| `matmul.rs` | Dense matrix multiply |
+| `softmax.rs` | GPU softmax |
+| `layernorm.rs` / `rmsnorm.rs` | LayerNorm and RMSNorm |
+| `attention.rs` / `fused_attention.rs` / `multi_head_attention.rs` | Attention variants |
+| `ffn.rs` | Feed-forward network |
+| `embedding.rs` / `embedding_ops.rs` | Embedding lookup |
+| `rope.rs` | RoPE positional embeddings |
+| `gating.rs` | Gating mechanisms |
+| `linear.rs` | Dense linear layers |
+| `dequant.rs` / `quantize.rs` | Quantization/dequantization |
+| `elementwise.rs` | Element-wise ops |
+| `batch_norm.rs` | Batch normalization |
+| `conv1d.rs` | 1-D convolution |
+| `pooling.rs` | Pooling |
+| `residual.rs` | Residual connections |
+| `loss.rs` | Loss computation |
+| `transpose.rs` | Transpose |
+| `fusion.rs` | Fused operations |
+| `sparse.rs` | Sparse tensor operations |
+
+### Quantized Compute
+
+| Module | Purpose |
+|--------|---------|
+| `quantized_gemm.rs` | Quantized general matrix multiply |
+| `quantized_matmul.rs` | Quantized matmul variants |
+| `qk256_gemv.rs` | QK256 2-bit GEMV kernel |
+
+### GPU Infrastructure
+
+| Module | Purpose |
+|--------|---------|
+| `memory_pool.rs` | Device memory pooling and allocation |
+| `stream_mgmt.rs` | CUDA stream creation and synchronization |
+| `warp_ops.rs` | Warp-level primitives (shuffle, reduce) |
+| `cooperative_groups.rs` | Cooperative group operations |
+| `graph_exec.rs` | CUDA graph capture and replay |
+| `shader_cache.rs` | Compiled kernel caching |
+| `profiling.rs` | Kernel timing and profiling |
+| `kv_cache.rs` / `kv_cache_gpu.rs` | GPU KV-cache management |
+
+## OpenCL Modules (42 top-level files)
+
+Experimental Intel Arc backend. All modules are at `bitnet-kernels/src/opencl_*.rs`.
+
+### Compute
+
+| Module | Purpose |
+|--------|---------|
+| `opencl_attention.rs` / `opencl_flash_attention.rs` / `opencl_gqa.rs` | Attention kernels |
+| `opencl_ffn.rs` | Feed-forward network |
+| `opencl_layer_norm.rs` | LayerNorm |
+| `opencl_reductions.rs` | Reduction operations |
+| `opencl_softmax_variants.rs` | Softmax variants |
+| `opencl_elementwise.rs` | Element-wise operations |
+| `opencl_embedding.rs` / `opencl_token_embed.rs` | Embedding lookup |
+| `opencl_quantized.rs` / `opencl_quantized_matmul.rs` / `opencl_matmul_variants.rs` | Quantized compute |
+| `opencl_mixed_precision.rs` | Mixed-precision operations |
+
+### Infrastructure
+
+| Module | Purpose |
+|--------|---------|
+| `opencl_context.rs` | OpenCL context management |
+| `opencl_cmd_queue.rs` | Command queue management |
+| `opencl_buffer.rs` / `opencl_memory.rs` | Buffer and memory management |
+| `opencl_device_caps.rs` | Device capability detection |
+| `opencl_work_size.rs` | Work-size optimization (Intel Arc tuned) |
+| `opencl_kernel_sources.rs` | Built-in kernel source registry |
+| `opencl_program_cache.rs` | Compiled program caching |
+| `opencl_registry.rs` | Kernel registry |
+
+### Pipeline
+
+| Module | Purpose |
+|--------|---------|
+| `opencl_pipeline.rs` | Inference pipeline |
+| `opencl_continuous_batch.rs` | Continuous batching |
+| `opencl_graph_compiler.rs` | Graph compilation |
+| `opencl_layer_compose.rs` | Layer composition |
+| `opencl_transformer.rs` | Full transformer forward pass |
+| `opencl_engine_bridge.rs` | Engine integration |
+| `opencl_model_converter.rs` | Model format conversion |
+| `opencl_token_gen.rs` | Token generation |
+
+### Caching and Utilities
+
+| Module | Purpose |
+|--------|---------|
+| `opencl_cache.rs` / `opencl_prefix_cache.rs` | General and prefix caching |
+| `opencl_kv_cache.rs` / `opencl_rope_cache.rs` | KV-cache and RoPE caching |
+| `opencl_autotuner.rs` | Auto-tuning kernel parameters |
+| `opencl_profiling.rs` / `opencl_telemetry.rs` | Profiling and telemetry |
+| `opencl_async_executor.rs` | Async kernel execution |
+| `opencl_numerical_stability.rs` | Numerical stability guards |
+| `opencl_weight_manager.rs` | Weight loading and management |
+
+## Other Backend Modules
+
+| Backend | Location | Feature gate | Modules |
+|---------|----------|-------------|---------|
+| Metal | `metal_compute.rs` | `feature = "metal"` | Apple Metal compute |
+| ROCm | `rocm/` (4 files) | `feature = "rocm"` | `attention`, `qk256_gemv`, `rmsnorm` |
+| NPU | `npu/` (2 files) | `feature = "npu-backend"` | C++ bridge (`bridge.rs`, `cpp_bridge.cpp`) |
+| Mixed GPU | `gpu/` (14 files) | `feature = "gpu"` | Shared GPU utils, OpenCL dispatch, validation, benchmarks, SPIR-V cache |
+
+## Shared Infrastructure
+
+| Module | Purpose |
+|--------|---------|
+| `lib.rs` | Crate root, module declarations, `KernelProvider` trait, `KernelManager` |
+| `kernels.rs` | Runtime kernel provider selection (CUDA > CPU fallback) |
+| `capability_matrix.rs` | Per-backend capability reporting |
+| `device_aware.rs` | Device-aware kernel dispatch |
+| `device_features.rs` | `gpu_compiled()`, `gpu_available_runtime()` helpers |
+| `convolution.rs` | Generic convolution |
+| `reduction.rs` / `shaped_reduction.rs` | Reduction primitives |
+| `scatter_gather.rs` | Top-level scatter/gather |
+| `tl_lut.rs` | Table-lookup LUT generation (TL1/TL2) |
+| `simd_diagnostics.rs` | SIMD feature detection diagnostics |
+| `perf_tracker.rs` | Kernel performance tracking |
+| `gpu_utils.rs` | GPU utility helpers |
+| `stubs.rs` | Stub implementations for disabled backends |
+| `ffi.rs` | C++ FFI bridge (feature `ffi`) |
+| `benchmarks/` | Kernel micro-benchmarks |
+
+## Feature Gate Summary
+
+| Feature | Enables |
+|---------|---------|
+| `cpu` | CPU kernels, SIMD paths |
+| `gpu` | CUDA + shared GPU modules |
+| `cuda` | Alias for `gpu` (backward compat) |
+| `avx2` | x86 AVX2 SIMD kernels |
+| `avx512` | x86 AVX-512 SIMD kernels |
+| `neon` | ARM NEON SIMD kernels |
+| `metal` | Apple Metal backend |
+| `vulkan` | Vulkan compute backend |
+| `rocm` | AMD ROCm backend |
+| `opencl` | Intel Arc OpenCL backend |
+| `oneapi` | Intel oneAPI backend |
+| `npu-backend` | NPU C++ bridge |
+| `ffi` | C++ FFI bridge |
+
+Always use the unified GPU predicate in code:
+
+```rust
+#[cfg(any(feature = "gpu", feature = "cuda"))]
+```


### PR DESCRIPTION
## Summary

Updates architecture documentation to reflect the current state of the codebase.

### Changes to `docs/architecture-overview.md`

- **Crate dependency diagram**: Updated with 110 crates and full SRP microcrate listing
- **GPU backend crates**: New section covering gpu-hal, opencl, metal, vulkan, rocm, webgpu, and related crates
- **Kernel Module Architecture**: New section documenting CPU (66 modules), CUDA (39 modules), OpenCL (42 modules), and other backend modules with feature gates
- **Test infrastructure**: New summary table — 98 fuzz targets, 63 proptest crates, ~1,233 snapshot files, 49 insta crates
- **Current Limitations**: New section documenting pre-alpha status, QK256 performance, GPU backend maturity, and test scaffolding
- **Testing/CI microcrates**: Expanded listing of all testing policy, scenarios, and benchmark crates

### New file: `docs/reference/kernel-modules.md`

Complete kernel module reference with:
- Full table of all CPU modules (generic, x86 SIMD, ARM NEON)
- Full table of all CUDA modules (core compute, quantized, infrastructure)
- Full table of all OpenCL modules (compute, infrastructure, pipeline, caching)
- Other backends (Metal, ROCm, NPU, mixed GPU)
- Feature gate summary table
