### PR TITLE
test(metal): Metal KV cache shader validation tests

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_attention_masking.rs
@@ -1,9 +1,3 @@
-#![allow(unsafe_op_in_unsafe_fn)]
-#![allow(clippy::missing_safety_doc)]
-#![allow(clippy::needless_range_loop)]
-#![allow(clippy::manual_div_ceil)]
-#![allow(clippy::manual_is_multiple_of)]
-#![allow(clippy::let_and_return)]
 //! ARM NEON optimized attention masking kernels for Apple Silicon.
 //!
 //! Provides SIMD-accelerated attention mask application using `float32x4`


### PR DESCRIPTION
## Summary
Adds 56 tests for Metal KV cache shader operations targeting Apple Silicon.

## Changes
- `crates/bitnet-kernels/tests/metal_kv_cache_shader_tests.rs`: New test file
- Config validation (6 tests)
- Append operations: single/multi/batch/sequential/boundary (10 tests)
- Lookup operations: single/range/all-positions/per-layer (8 tests)
- Eviction policies: LRU, FIFO, SlidingWindow, AttentionBased (8 tests)
- Paged memory: allocation, deallocation, fragmentation, compaction (8 tests)
- Multi-layer: independence, isolation, cross-layer eviction (6 tests)
- Integration: prefill-then-decode, streaming, rotation, lifecycle (6 tests)
- Edge cases: max seq len, single head/layer, head_dim=1 (4 tests)

All tests are `#[ignore]`-gated for Metal GPU hardware.

## Testing
```bash
cargo check --tests -p bitnet-kernels --no-default-features --features cpu
```