### PR TITLE
fuzz: wave 33 — 6 fuzz targets for configs, reshape, and headers

### DIFF
--- a/fuzz/fuzz_targets/fuzz_cuda_config_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_cuda_config_parse.rs
@@ -1,0 +1,51 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cuda::matmul::MatmulConfig;
+use bitnet_kernels::cuda::softmax::SoftmaxConfig;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct CudaConfigInput {
+    m: u16,
+    n: u16,
+    k: u16,
+    tile_size: u8,
+    n_cols: u16,
+    n_rows: u16,
+    temperature_byte: u8,
+}
+
+fuzz_target!(|input: CudaConfigInput| {
+    // Fuzz MatmulConfig::for_shape with arbitrary dimensions.
+    let m = input.m as usize;
+    let n = input.n as usize;
+    let k = input.k as usize;
+
+    let _ = MatmulConfig::for_shape(m, n, k);
+
+    // Fuzz with tiled variant and arbitrary tile size.
+    let tile = (input.tile_size as u32 % 128) + 1;
+    let _ = MatmulConfig::for_shape_tiled(m, n, k, tile);
+
+    // Zero dimensions must not panic.
+    let _ = MatmulConfig::for_shape(0, n, k);
+    let _ = MatmulConfig::for_shape(m, 0, k);
+    let _ = MatmulConfig::for_shape(m, n, 0);
+
+    // Fuzz SoftmaxConfig::for_shape with arbitrary rows/cols.
+    let cols = input.n_cols as usize;
+    let rows = input.n_rows as usize;
+    let _ = SoftmaxConfig::for_shape(cols, rows);
+
+    // Chain with_temperature on successful config.
+    if let Ok(cfg) = SoftmaxConfig::for_shape(cols.max(1), rows.max(1)) {
+        let temp = 0.01 + (input.temperature_byte as f32 / 255.0) * 9.99;
+        let _ = cfg.clone().with_temperature(temp);
+        // Extreme temperatures must not panic.
+        let _ = cfg.clone().with_temperature(0.0);
+        let _ = cfg.clone().with_temperature(-1.0);
+        let _ = cfg.clone().with_temperature(f32::MAX);
+        let _ = cfg.clone().with_temperature(f32::NAN);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_model_header_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_model_header_parse.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+use bitnet_gguf::{GgufValueType, check_magic, parse_header, read_version};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Header parsing must handle arbitrary bytes without panicking.
+    let _ = check_magic(data);
+    let _ = read_version(data);
+    let _ = parse_header(data);
+
+    // Exercise GgufValueType discriminant for every 4-byte window.
+    for chunk in data.windows(4) {
+        let disc = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let _ = GgufValueType::from_u32(disc);
+    }
+
+    // Parse with progressively truncated slices to probe boundary conditions.
+    for trim in 1..data.len().min(64) {
+        let _ = parse_header(&data[..data.len() - trim]);
+    }
+
+    // Parse with progressively extended offsets.
+    for offset in 1..data.len().min(16) {
+        let _ = parse_header(&data[offset..]);
+    }
+
+    // Single-byte and empty inputs must not panic.
+    let _ = parse_header(&[]);
+    for &b in data.iter().take(4) {
+        let _ = parse_header(&[b]);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_prompt_template_render.rs
+++ b/fuzz/fuzz_targets/fuzz_prompt_template_render.rs
@@ -1,0 +1,63 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_prompt_templates::{ChatRole, ChatTurn, PromptTemplate, TemplateType};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct TemplateRenderInput {
+    user_raw: Vec<u8>,
+    system_raw: Vec<u8>,
+    tokenizer_name_raw: Vec<u8>,
+    jinja_raw: Vec<u8>,
+    multi_turn_users: Vec<Vec<u8>>,
+    multi_turn_assistants: Vec<Vec<u8>>,
+}
+
+fuzz_target!(|input: TemplateRenderInput| {
+    let user = std::str::from_utf8(&input.user_raw).unwrap_or("");
+    let system_str = std::str::from_utf8(&input.system_raw).unwrap_or("");
+    let system: Option<&str> = if system_str.is_empty() { None } else { Some(system_str) };
+
+    // Test detect with arbitrary tokenizer name and jinja template.
+    let tok_name = std::str::from_utf8(&input.tokenizer_name_raw).ok();
+    let jinja = std::str::from_utf8(&input.jinja_raw).ok();
+    let detected = TemplateType::detect(tok_name, jinja);
+    let _ = detected.apply(user, system);
+
+    // Test all template variants with arbitrary text.
+    for &template in TemplateType::all_variants() {
+        let _ = template.apply(user, system);
+        let _ = template.default_stop_sequences();
+        let _ = template.validate_output(user, user);
+
+        // Single-turn render_chat must not panic.
+        let turn = ChatTurn::new(ChatRole::User, user);
+        let _ = template.render_chat(&[turn], system);
+    }
+
+    // Multi-turn chat must not panic.
+    let turns: Vec<ChatTurn> = input
+        .multi_turn_users
+        .iter()
+        .zip(input.multi_turn_assistants.iter())
+        .take(8)
+        .flat_map(|(u, a)| {
+            let u_str = std::str::from_utf8(u).unwrap_or("");
+            let a_str = std::str::from_utf8(a).unwrap_or("");
+            [ChatTurn::new(ChatRole::User, u_str), ChatTurn::new(ChatRole::Assistant, a_str)]
+        })
+        .collect();
+
+    for &template in TemplateType::all_variants() {
+        let _ = template.render_chat(&turns, system);
+    }
+
+    // PromptTemplate builder API must not panic.
+    let mut pt = PromptTemplate::new(detected);
+    if let Some(s) = system {
+        pt = pt.with_system_prompt(s);
+    }
+    let _ = pt.format(user);
+    let _ = pt.stop_sequences();
+});

--- a/fuzz/fuzz_targets/fuzz_quantization_config.rs
+++ b/fuzz/fuzz_targets/fuzz_quantization_config.rs
@@ -1,0 +1,83 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_quantization::int8_quant::{CalibrationMethod, Int8QuantConfig, quantize_tensor_int8};
+use bitnet_quantization::pipeline::{PipelineConfig, Precision};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct QuantConfigInput {
+    source: u8,
+    target: u8,
+    calibration_samples: u16,
+    error_threshold_bytes: [u8; 8],
+    per_channel: bool,
+    symmetric: bool,
+    calibration_method: u8,
+    percentile_byte: u8,
+    tensor_data: Vec<u8>,
+}
+
+fn pick_precision(v: u8) -> Precision {
+    match v % 4 {
+        0 => Precision::F32,
+        1 => Precision::I2S,
+        2 => Precision::TL1,
+        _ => Precision::TL2,
+    }
+}
+
+fuzz_target!(|input: QuantConfigInput| {
+    // Fuzz PipelineConfig with arbitrary precision combinations.
+    let config = PipelineConfig {
+        source_precision: pick_precision(input.source),
+        target_precision: pick_precision(input.target),
+        calibration_samples: input.calibration_samples as usize,
+        error_threshold: f64::from_le_bytes(input.error_threshold_bytes),
+    };
+    let _ = config.validate();
+
+    // Exhaustive precision pair validation.
+    for s in 0..4u8 {
+        for t in 0..4u8 {
+            let c = PipelineConfig {
+                source_precision: pick_precision(s),
+                target_precision: pick_precision(t),
+                calibration_samples: 1,
+                error_threshold: 0.01,
+            };
+            let _ = c.validate();
+        }
+    }
+
+    // Fuzz Int8QuantConfig with arbitrary calibration methods.
+    let cal_method = match input.calibration_method % 3 {
+        0 => CalibrationMethod::MinMax,
+        1 => CalibrationMethod::Percentile(input.percentile_byte as f32 / 255.0),
+        _ => CalibrationMethod::MSE,
+    };
+    let quant_config = Int8QuantConfig {
+        per_channel: input.per_channel,
+        symmetric: input.symmetric,
+        calibration_method: cal_method,
+    };
+
+    // Decode bytes → f32 for tensor quantization.
+    let aligned = (input.tensor_data.len() / 4) * 4;
+    if aligned > 0 {
+        let data: Vec<f32> = input.tensor_data[..aligned]
+            .chunks_exact(4)
+            .take(1024)
+            .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+            .filter(|v| v.is_finite())
+            .collect();
+        if !data.is_empty() {
+            let _ = quantize_tensor_int8(&data, &quant_config);
+        }
+    }
+
+    // Empty and single-element tensors must not panic.
+    let _ = quantize_tensor_int8(&[], &quant_config);
+    let _ = quantize_tensor_int8(&[0.0], &quant_config);
+    let _ = quantize_tensor_int8(&[f32::MAX, f32::MIN], &quant_config);
+});

--- a/fuzz/fuzz_targets/fuzz_sampling_strategy.rs
+++ b/fuzz/fuzz_targets/fuzz_sampling_strategy.rs
@@ -1,0 +1,88 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_sampling::{SamplingConfig, SamplingStrategy, greedy_sample};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct SamplingStrategyInput {
+    raw_logits: Vec<u8>,
+    context_tokens: Vec<u8>,
+    temperature: f32,
+    top_k: u16,
+    top_p: f32,
+    repetition_penalty: f32,
+    seed: Option<u64>,
+    extreme_temps: Vec<f32>,
+}
+
+fuzz_target!(|input: SamplingStrategyInput| {
+    // Decode bytes → f32 logits.
+    let aligned = (input.raw_logits.len() / 4) * 4;
+    if aligned == 0 {
+        return;
+    }
+    let logits: Vec<f32> = input.raw_logits[..aligned]
+        .chunks_exact(4)
+        .take(32_768)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+    if logits.is_empty() {
+        return;
+    }
+
+    let vocab_size = logits.len();
+    let context: Vec<u32> = input.context_tokens.iter().take(256).map(|&b| b as u32).collect();
+
+    // Fuzz SamplingStrategy with arbitrary parameters.
+    let config = SamplingConfig {
+        temperature: input.temperature,
+        top_k: (input.top_k as u32).min(vocab_size as u32),
+        top_p: input.top_p,
+        repetition_penalty: input.repetition_penalty,
+        seed: input.seed,
+    };
+
+    let mut strategy = SamplingStrategy::new(config);
+    match strategy.sample(&logits, &context) {
+        Ok(token_id) => {
+            assert!(
+                (token_id as usize) < vocab_size,
+                "out-of-bounds token {token_id} for vocab {vocab_size}",
+            );
+        }
+        Err(_) => {}
+    }
+
+    // Reset and re-sample must not panic.
+    strategy.reset();
+    let _ = strategy.sample(&logits, &context);
+
+    // Greedy sample must not panic.
+    let _ = greedy_sample(&logits);
+
+    // Extreme temperature configs must not panic.
+    for &temp in input.extreme_temps.iter().take(8) {
+        let extreme_config = SamplingConfig {
+            temperature: temp,
+            top_k: 0,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(42),
+        };
+        let mut s = SamplingStrategy::new(extreme_config);
+        let _ = s.sample(&logits, &[]);
+    }
+
+    // Edge cases: single-element logits, all-same logits.
+    let single = vec![0.5f32];
+    let _ = greedy_sample(&single);
+    let mut s2 = SamplingStrategy::new(SamplingConfig {
+        temperature: 1.0,
+        top_k: 0,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+        seed: Some(0),
+    });
+    let _ = s2.sample(&single, &[]);
+});

--- a/fuzz/fuzz_targets/fuzz_tensor_reshape.rs
+++ b/fuzz/fuzz_targets/fuzz_tensor_reshape.rs
@@ -1,0 +1,46 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::tensor_validation::{
+    broadcast_shape, can_broadcast, validate_matmul_shapes, validate_reshape,
+    validate_transpose_axes,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ReshapeInput {
+    from_shape: Vec<u16>,
+    to_shape: Vec<u16>,
+    other_shape: Vec<u16>,
+    axes: Vec<u8>,
+}
+
+fuzz_target!(|input: ReshapeInput| {
+    let from: Vec<usize> = input.from_shape.iter().take(8).map(|&d| (d % 256) as usize).collect();
+    let to: Vec<usize> = input.to_shape.iter().take(8).map(|&d| (d % 256) as usize).collect();
+    let other: Vec<usize> = input.other_shape.iter().take(8).map(|&d| (d % 256) as usize).collect();
+
+    // Reshape: must never panic, only return Ok/Err.
+    let _ = validate_reshape(&from, &to);
+
+    // Empty shapes must not panic.
+    let _ = validate_reshape(&[], &to);
+    let _ = validate_reshape(&from, &[]);
+    let _ = validate_reshape(&[], &[]);
+
+    // Shapes with zeros must not panic.
+    let zero_shape = vec![0usize; from.len()];
+    let _ = validate_reshape(&zero_shape, &to);
+    let _ = validate_reshape(&from, &zero_shape);
+
+    // Broadcast must not panic.
+    let _ = broadcast_shape(&from, &other);
+    let _ = can_broadcast(&from, &other);
+
+    // Matmul shapes must not panic.
+    let _ = validate_matmul_shapes(&from, &other);
+
+    // Transpose axes must not panic.
+    let axes: Vec<usize> = input.axes.iter().take(8).map(|&x| x as usize).collect();
+    let _ = validate_transpose_axes(&from, &axes);
+});


### PR DESCRIPTION
Adds 6 new fuzz targets covering CUDA config parsing, tensor reshape, model headers, prompt templates, quantization config, and sampling strategies.