### PR TITLE
test: proptest wave 31 — property tests across common, quantization, models, tokenizers

### DIFF
--- a/crates/bitnet-common/tests/proptest_shape_validator.rs
+++ b/crates/bitnet-common/tests/proptest_shape_validator.rs
@@ -1,0 +1,271 @@
+//! Property-based tests for shape validation, tensor size calculations,
+//! and Device enum serde round-trips (proptest wave 31).
+
+use bitnet_common::tensor_validation::{
+    broadcast_shape, can_broadcast, validate_matmul_shapes, validate_reshape,
+};
+use bitnet_common::types::Device;
+use proptest::prelude::*;
+
+// ── Helper strategies ─────────────────────────────────────────────────────────
+
+fn small_shape(max_ndim: usize, max_dim: usize) -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(1usize..=max_dim, 0..=max_ndim)
+}
+
+fn nonzero_shape(ndim: usize, max_dim: usize) -> impl Strategy<Value = Vec<usize>> {
+    prop::collection::vec(1usize..=max_dim, ndim)
+}
+
+fn device_strategy() -> impl Strategy<Value = Device> {
+    prop_oneof![
+        Just(Device::Cpu),
+        (0usize..8).prop_map(Device::Cuda),
+        (0usize..4).prop_map(Device::Hip),
+        Just(Device::Npu),
+        Just(Device::Metal),
+        (0usize..4).prop_map(Device::OpenCL),
+    ]
+}
+
+// ── Broadcasting rules ────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Broadcasting a shape with itself always succeeds and returns the same shape.
+    #[test]
+    fn broadcast_self_is_identity(shape in small_shape(4, 16)) {
+        let result = broadcast_shape(&shape, &shape);
+        prop_assert!(result.is_ok(), "broadcasting self should succeed: {shape:?}");
+        prop_assert_eq!(result.unwrap(), shape);
+    }
+
+    /// Broadcasting is commutative: broadcast(a,b) == broadcast(b,a).
+    #[test]
+    fn broadcast_is_commutative(
+        a in small_shape(4, 8),
+        b in small_shape(4, 8),
+    ) {
+        let ab = broadcast_shape(&a, &b);
+        let ba = broadcast_shape(&b, &a);
+        match (ab, ba) {
+            (Ok(r1), Ok(r2)) => prop_assert_eq!(r1, r2),
+            (Err(_), Err(_)) => {} // both fail — fine
+            _ => prop_assert!(false, "broadcast commutativity violated"),
+        }
+    }
+
+    /// Broadcasting with a scalar (empty shape) always succeeds.
+    #[test]
+    fn broadcast_with_scalar(shape in small_shape(4, 16)) {
+        let result = broadcast_shape(&shape, &[]);
+        prop_assert!(result.is_ok());
+        prop_assert_eq!(result.unwrap(), shape);
+    }
+
+    /// Broadcasting with all-ones shape succeeds and returns the other shape.
+    #[test]
+    fn broadcast_with_ones(shape in nonzero_shape(3, 16)) {
+        let ones = vec![1usize; shape.len()];
+        let result = broadcast_shape(&shape, &ones);
+        prop_assert!(result.is_ok());
+        prop_assert_eq!(result.unwrap(), shape);
+    }
+
+    /// can_broadcast agrees with broadcast_shape.
+    #[test]
+    fn can_broadcast_consistent(
+        a in small_shape(4, 8),
+        b in small_shape(4, 8),
+    ) {
+        let result = broadcast_shape(&a, &b);
+        prop_assert_eq!(can_broadcast(&a, &b), result.is_ok());
+    }
+
+    /// Output ndim is max(a.ndim, b.ndim) when broadcast succeeds.
+    #[test]
+    fn broadcast_output_ndim(
+        a in nonzero_shape(3, 8),
+        b in nonzero_shape(3, 8),
+    ) {
+        if let Ok(out) = broadcast_shape(&a, &b) {
+            let expected_ndim = a.len().max(b.len());
+            prop_assert_eq!(out.len(), expected_ndim);
+        }
+    }
+
+    /// Each output dim is >= max(corresponding input dims).
+    #[test]
+    fn broadcast_output_dims_ge_inputs(
+        a in nonzero_shape(3, 8),
+        b in nonzero_shape(3, 8),
+    ) {
+        if let Ok(out) = broadcast_shape(&a, &b) {
+            let max_ndim = a.len().max(b.len());
+            for i in 0..max_ndim {
+                let da = if i < max_ndim - a.len() { 1 } else { a[i - (max_ndim - a.len())] };
+                let db = if i < max_ndim - b.len() { 1 } else { b[i - (max_ndim - b.len())] };
+                prop_assert!(out[i] >= da);
+                prop_assert!(out[i] >= db);
+            }
+        }
+    }
+
+    /// Incompatible dimensions (neither equal nor 1) must fail.
+    #[test]
+    fn broadcast_incompatible_fails(
+        base in 2usize..16,
+        diff in 1usize..8,
+    ) {
+        let a_dim = base;
+        let b_dim = base + diff;
+        // Neither is 1, and they differ
+        let result = broadcast_shape(&[a_dim], &[b_dim]);
+        prop_assert!(result.is_err());
+    }
+}
+
+// ── Tensor size (element count) calculations ──────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Element count is the product of all dimensions.
+    #[test]
+    fn elem_count_product(dims in nonzero_shape(4, 32)) {
+        let expected: usize = dims.iter().product();
+        prop_assert_eq!(dims.iter().product::<usize>(), expected);
+        prop_assert!(expected >= 1);
+    }
+
+    /// A scalar (empty shape) has 1 element.
+    #[test]
+    fn scalar_has_one_element(_dummy in 0u8..1) {
+        let shape: Vec<usize> = vec![];
+        let count: usize = shape.iter().product();
+        // Product of empty iterator is 1 by convention
+        prop_assert_eq!(count, 1);
+    }
+
+    /// Reshape preserves element count.
+    #[test]
+    fn reshape_preserves_elem_count(
+        d1 in 1usize..=16,
+        d2 in 1usize..=16,
+    ) {
+        let from = vec![d1, d2];
+        let total = d1 * d2;
+        let to = vec![total];
+        let result = validate_reshape(&from, &to);
+        prop_assert!(result.is_ok(), "flatten reshape should succeed");
+    }
+
+    /// Reshape with mismatched element counts must fail.
+    #[test]
+    fn reshape_mismatched_fails(
+        d1 in 2usize..=8,
+        d2 in 2usize..=8,
+        extra in 1usize..=4,
+    ) {
+        let from = vec![d1, d2];
+        let total = d1 * d2 + extra;
+        let to = vec![total];
+        let result = validate_reshape(&from, &to);
+        prop_assert!(result.is_err());
+    }
+}
+
+// ── Matmul shape validation ───────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Standard 2-D matmul with compatible inner dims succeeds.
+    #[test]
+    fn matmul_compatible_2d(
+        m in 1usize..=32,
+        k in 1usize..=32,
+        n in 1usize..=32,
+    ) {
+        let a = vec![m, k];
+        let b = vec![k, n];
+        let result = validate_matmul_shapes(&a, &b);
+        prop_assert!(result.is_ok());
+        let out = result.unwrap();
+        prop_assert_eq!(out, vec![m, n]);
+    }
+
+    /// Matmul with mismatched inner dims fails.
+    #[test]
+    fn matmul_mismatched_inner(
+        m in 1usize..=16,
+        k1 in 1usize..=16,
+        k2 in 1usize..=16,
+        n in 1usize..=16,
+    ) {
+        prop_assume!(k1 != k2);
+        let a = vec![m, k1];
+        let b = vec![k2, n];
+        let result = validate_matmul_shapes(&a, &b);
+        prop_assert!(result.is_err());
+    }
+
+    /// 1-D dot product succeeds when lengths match.
+    #[test]
+    fn matmul_1d_dot(k in 1usize..=64) {
+        let result = validate_matmul_shapes(&[k], &[k]);
+        prop_assert!(result.is_ok());
+        prop_assert_eq!(result.unwrap(), Vec::<usize>::new());
+    }
+}
+
+// ── Device serde round-trip ───────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// Device round-trips through JSON serialization.
+    #[test]
+    fn device_serde_roundtrip(device in device_strategy()) {
+        let json = serde_json::to_string(&device).expect("serialize");
+        let back: Device = serde_json::from_str(&json).expect("deserialize");
+        prop_assert_eq!(device, back);
+    }
+
+    /// Serialized Device is always valid JSON.
+    #[test]
+    fn device_serde_valid_json(device in device_strategy()) {
+        let json = serde_json::to_string(&device).expect("serialize");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("valid json");
+        prop_assert!(!parsed.is_null());
+    }
+
+    /// Device ordering is consistent with equality.
+    #[test]
+    fn device_ord_consistent(d1 in device_strategy(), d2 in device_strategy()) {
+        if d1 == d2 {
+            prop_assert!(d1.cmp(&d2) == std::cmp::Ordering::Equal);
+        }
+    }
+}
+
+// ── QuantizationType serde round-trip ─────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    /// QuantizationType round-trips through JSON.
+    #[test]
+    fn quantization_type_serde_roundtrip(
+        qt in prop_oneof![
+            Just(bitnet_common::QuantizationType::I2S),
+            Just(bitnet_common::QuantizationType::TL1),
+            Just(bitnet_common::QuantizationType::TL2),
+        ]
+    ) {
+        let json = serde_json::to_string(&qt).expect("serialize");
+        let back: bitnet_common::QuantizationType = serde_json::from_str(&json).expect("deserialize");
+        prop_assert_eq!(qt, back);
+    }
+}

--- a/crates/bitnet-models/tests/proptest_format_detection.rs
+++ b/crates/bitnet-models/tests/proptest_format_detection.rs
@@ -1,0 +1,236 @@
+//! Property-based tests for format detection, header parsing robustness,
+//! and tensor name filtering (proptest wave 31).
+
+use bitnet_models::format_detector::ModelFormat;
+use bitnet_models::names::{is_layernorm_weight, is_projection_weight};
+use bitnet_models::weight_loader::{DType, TensorData, TensorInfo, WeightFormat};
+use proptest::prelude::*;
+use std::path::Path;
+
+// ── Format detection determinism ──────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// WeightFormat::detect is deterministic for the same path.
+    #[test]
+    fn weight_format_detect_deterministic(path in ".*\\.(gguf|safetensors|bin|onnx|txt)") {
+        let r1 = WeightFormat::detect(&path);
+        let r2 = WeightFormat::detect(&path);
+        prop_assert_eq!(r1, r2, "format detection must be deterministic");
+    }
+
+    /// ModelFormat::from_extension is deterministic.
+    #[test]
+    fn model_format_from_ext_deterministic(
+        stem in "[a-z]{1,20}",
+        ext in prop_oneof![
+            Just("gguf"), Just("safetensors"), Just("bin"),
+            Just("onnx"), Just("json"), Just("txt"), Just("pt"),
+        ],
+    ) {
+        let path_str = format!("{stem}.{ext}");
+        let path = Path::new(&path_str);
+        let r1 = ModelFormat::from_extension(path);
+        let r2 = ModelFormat::from_extension(path);
+        prop_assert_eq!(r1, r2);
+    }
+
+    /// .gguf extension always detects as Gguf.
+    #[test]
+    fn gguf_extension_detected(stem in "[a-zA-Z0-9_-]{1,30}") {
+        let path = format!("{stem}.gguf");
+        let fmt = WeightFormat::detect(&path);
+        prop_assert_eq!(fmt, Some(WeightFormat::Gguf));
+    }
+
+    /// .safetensors extension always detects as SafeTensors.
+    #[test]
+    fn safetensors_extension_detected(stem in "[a-zA-Z0-9_-]{1,30}") {
+        let path = format!("{stem}.safetensors");
+        let fmt = WeightFormat::detect(&path);
+        prop_assert_eq!(fmt, Some(WeightFormat::SafeTensors));
+    }
+
+    /// Unrecognized extensions return None.
+    #[test]
+    fn unknown_extension_returns_none(stem in "[a-z]{1,10}", ext in "[a-z]{1,4}") {
+        prop_assume!(ext != "gguf" && ext != "safetensors");
+        let path = format!("{stem}.{ext}");
+        let fmt = WeightFormat::detect(&path);
+        prop_assert_eq!(fmt, None);
+    }
+}
+
+// ── Magic-byte header parsing ─────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// from_magic never panics on arbitrary byte slices.
+    #[test]
+    fn from_magic_no_panic(bytes in prop::collection::vec(any::<u8>(), 0..=64)) {
+        let _ = ModelFormat::from_magic(&bytes);
+    }
+
+    /// GGUF magic bytes always produce Gguf format.
+    #[test]
+    fn gguf_magic_detected(trailing in prop::collection::vec(any::<u8>(), 0..=32)) {
+        let mut bytes = vec![0x47, 0x47, 0x55, 0x46]; // "GGUF"
+        bytes.extend_from_slice(&trailing);
+        let fmt = ModelFormat::from_magic(&bytes);
+        prop_assert_eq!(fmt, ModelFormat::Gguf);
+    }
+
+    /// Empty bytes produce Unknown format, no panic.
+    #[test]
+    fn empty_bytes_is_unknown(_dummy in 0u8..1) {
+        let fmt = ModelFormat::from_magic(&[]);
+        prop_assert_eq!(fmt, ModelFormat::Unknown);
+    }
+
+    /// Short bytes (< 4) never produce Gguf.
+    #[test]
+    fn short_bytes_not_gguf(bytes in prop::collection::vec(any::<u8>(), 0..4)) {
+        let fmt = ModelFormat::from_magic(&bytes);
+        prop_assert_ne!(fmt, ModelFormat::Gguf);
+    }
+
+    /// from_magic is deterministic.
+    #[test]
+    fn from_magic_deterministic(bytes in prop::collection::vec(any::<u8>(), 0..=32)) {
+        let r1 = ModelFormat::from_magic(&bytes);
+        let r2 = ModelFormat::from_magic(&bytes);
+        prop_assert_eq!(r1, r2);
+    }
+}
+
+// ── Tensor name filtering is case-sensitive ───────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// LayerNorm matching is case-sensitive — uppercase variants don't match.
+    #[test]
+    fn layernorm_case_sensitive(prefix in "blk\\.[0-9]{1,2}") {
+        let lower = format!("{prefix}.attn_norm.weight");
+        let upper = format!("{prefix}.ATTN_NORM.WEIGHT");
+        prop_assert!(is_layernorm_weight(&lower), "lowercase should match");
+        prop_assert!(!is_layernorm_weight(&upper), "UPPERCASE should NOT match");
+    }
+
+    /// Projection matching is case-sensitive — uppercase variants don't match.
+    #[test]
+    fn projection_case_sensitive(prefix in "blk\\.[0-9]{1,2}") {
+        let lower = format!("{prefix}.attn_q.weight");
+        let upper = format!("{prefix}.ATTN_Q.WEIGHT");
+        prop_assert!(is_projection_weight(&lower), "lowercase should match");
+        prop_assert!(!is_projection_weight(&upper), "UPPERCASE should NOT match");
+    }
+
+    /// Arbitrary strings never panic in is_layernorm_weight.
+    #[test]
+    fn layernorm_no_panic(name in "\\PC{0,100}") {
+        let _ = is_layernorm_weight(&name);
+    }
+
+    /// Arbitrary strings never panic in is_projection_weight.
+    #[test]
+    fn projection_no_panic(name in "\\PC{0,100}") {
+        let _ = is_projection_weight(&name);
+    }
+
+    /// Known LayerNorm patterns always match.
+    #[test]
+    fn known_layernorm_patterns(
+        idx in 0u32..100,
+        suffix in prop_oneof![
+            Just("attn_norm.weight"),
+            Just("ffn_norm.weight"),
+            Just("attention_norm.weight"),
+            Just("input_layernorm.weight"),
+            Just("post_attention_layernorm.weight"),
+        ],
+    ) {
+        let name = format!("blk.{idx}.{suffix}");
+        prop_assert!(is_layernorm_weight(&name), "{name} should be layernorm");
+    }
+
+    /// Known projection patterns always match.
+    #[test]
+    fn known_projection_patterns(
+        idx in 0u32..100,
+        suffix in prop_oneof![
+            Just("attn_q.weight"),
+            Just("attn_k.weight"),
+            Just("attn_v.weight"),
+            Just("attn_output.weight"),
+            Just("ffn_gate.weight"),
+            Just("ffn_up.weight"),
+            Just("ffn_down.weight"),
+        ],
+    ) {
+        let name = format!("blk.{idx}.{suffix}");
+        prop_assert!(is_projection_weight(&name), "{name} should be projection");
+    }
+}
+
+// ── TensorData / TensorInfo consistency ───────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// TensorData numel matches shape product.
+    #[test]
+    fn tensor_data_numel(
+        d1 in 1usize..=64,
+        d2 in 1usize..=64,
+    ) {
+        let shape = vec![d1, d2];
+        let numel = d1 * d2;
+        let data = TensorData {
+            shape: shape.clone(),
+            dtype: DType::F32,
+            data: vec![0u8; numel * 4],
+        };
+        prop_assert_eq!(data.numel(), numel);
+        prop_assert_eq!(data.expected_byte_len(), numel * 4);
+    }
+
+    /// DType element_size is always 1, 2, 4, or 8.
+    #[test]
+    fn dtype_element_size_valid(
+        dt in prop_oneof![
+            Just(DType::F16), Just(DType::BF16), Just(DType::F32), Just(DType::F64),
+            Just(DType::I8), Just(DType::I16), Just(DType::I32),
+            Just(DType::U8), Just(DType::U16), Just(DType::U32),
+        ]
+    ) {
+        let s = dt.element_size();
+        prop_assert!(
+            s == 1 || s == 2 || s == 4 || s == 8,
+            "unexpected element_size {s} for {dt:?}"
+        );
+    }
+
+    /// TensorInfo byte size is consistent with shape and dtype.
+    #[test]
+    fn tensor_info_size_consistent(
+        d1 in 1usize..=32,
+        d2 in 1usize..=32,
+        dt in prop_oneof![
+            Just(DType::F32), Just(DType::F16), Just(DType::I8), Just(DType::U8),
+        ],
+    ) {
+        let shape = vec![d1, d2];
+        let numel: usize = shape.iter().product();
+        let expected_bytes = (numel * dt.element_size()) as u64;
+        let info = TensorInfo {
+            shape,
+            dtype: dt,
+            offset: 0,
+            size: expected_bytes,
+        };
+        prop_assert_eq!(info.size, expected_bytes);
+    }
+}

--- a/crates/bitnet-quantization/tests/proptest_wave31.rs
+++ b/crates/bitnet-quantization/tests/proptest_wave31.rs
@@ -1,0 +1,245 @@
+//! Property-based tests for quantization roundtrips, block sizes, and scale factors
+//! (proptest wave 31).
+
+use bitnet_common::{BitNetTensor, QuantizationType, Tensor};
+use bitnet_quantization::utils::{
+    calculate_grouped_scales, calculate_scale, dequantize_value, quantize_value,
+};
+use bitnet_quantization::{I2SQuantizer, QuantizedTensor, QuantizerTrait, TL1Quantizer};
+use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
+use proptest::prelude::*;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn normal_f32_vec(len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-10.0f32..10.0, len)
+}
+
+// ── Scale factor properties ───────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Scale factor is always finite for normal inputs.
+    #[test]
+    fn scale_always_finite(
+        data in prop::collection::vec(-100.0f32..100.0, 1..=512),
+        bits in 1u8..=4,
+    ) {
+        let s = calculate_scale(&data, bits);
+        prop_assert!(s.is_finite(), "scale must be finite, got {s}");
+    }
+
+    /// Scale factor is non-negative.
+    #[test]
+    fn scale_non_negative(
+        data in prop::collection::vec(-50.0f32..50.0, 1..=256),
+        bits in 1u8..=4,
+    ) {
+        let s = calculate_scale(&data, bits);
+        prop_assert!(s >= 0.0, "scale must be non-negative, got {s}");
+    }
+
+    /// Scale for all-zero data is the safe fallback (1.0).
+    #[test]
+    fn scale_fallback_for_zero_data(len in 1usize..=128, bits in 1u8..=4) {
+        let data = vec![0.0f32; len];
+        let s = calculate_scale(&data, bits);
+        // calculate_scale returns 1.0 as a safe fallback for zero data
+        prop_assert_eq!(s, 1.0);
+    }
+
+    /// Grouped scales have correct count.
+    #[test]
+    fn grouped_scales_count(
+        data in prop::collection::vec(-5.0f32..5.0, 64..=512),
+        bits in 1u8..=4,
+    ) {
+        let block_size = 64;
+        let scales = calculate_grouped_scales(&data, block_size, bits);
+        let expected_blocks = data.len().div_ceil(block_size);
+        prop_assert_eq!(scales.len(), expected_blocks);
+    }
+
+    /// Every grouped scale is finite and non-negative.
+    #[test]
+    fn grouped_scales_all_finite(
+        data in prop::collection::vec(-10.0f32..10.0, 64..=256),
+    ) {
+        let scales = calculate_grouped_scales(&data, 64, 2);
+        for (i, &s) in scales.iter().enumerate() {
+            prop_assert!(s.is_finite(), "scale[{i}] = {s} is not finite");
+            prop_assert!(s >= 0.0, "scale[{i}] = {s} is negative");
+        }
+    }
+}
+
+// ── Quantize → dequantize scalar roundtrip ────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// Scalar quantize→dequantize produces a finite result.
+    #[test]
+    fn scalar_roundtrip_finite(
+        value in -10.0f32..10.0,
+        scale in 0.01f32..10.0,
+    ) {
+        let q = quantize_value(value, scale, 2);
+        let d = dequantize_value(q, scale);
+        prop_assert!(d.is_finite(), "roundtrip should be finite for value={value}, scale={scale}");
+        // Quantized value must be in 2-bit signed range [-2, 1]
+        prop_assert!(q >= -2 && q <= 1, "2-bit quantized value {q} out of range");
+    }
+
+    /// Scalar roundtrip error is bounded by the scale for small values.
+    #[test]
+    fn scalar_roundtrip_bounded_error(
+        scale in 0.5f32..10.0,
+    ) {
+        // For value = 0, roundtrip must be exact
+        let q = quantize_value(0.0, scale, 2);
+        let d = dequantize_value(q, scale);
+        prop_assert!((d - 0.0).abs() < 1e-6, "zero should roundtrip exactly");
+    }
+
+    /// Dequantized value is always finite.
+    #[test]
+    fn dequantize_always_finite(
+        q in -2i8..=2,
+        scale in 0.001f32..100.0,
+    ) {
+        let d = dequantize_value(q, scale);
+        prop_assert!(d.is_finite(), "dequantize({q}, {scale}) = {d} not finite");
+    }
+
+    /// Zero quantizes to zero.
+    #[test]
+    fn zero_quantizes_to_zero(scale in 0.01f32..100.0, bits in 1u8..=4) {
+        let q = quantize_value(0.0, scale, bits);
+        prop_assert_eq!(q, 0);
+    }
+}
+
+// ── I2S quantizer tensor roundtrip ────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    /// I2S quantize→dequantize preserves shape.
+    #[test]
+    fn i2s_roundtrip_preserves_shape(
+        len in (32usize..=256).prop_map(|l| (l / 32) * 32),
+    ) {
+        let data: Vec<f32> = (0..len).map(|i| (i as f32 * 0.1) - 5.0).collect();
+        let tensor = CandleTensor::from_vec(data, &[len], &CandleDevice::Cpu).unwrap();
+        let bt = BitNetTensor::new(tensor);
+
+        let quantizer = I2SQuantizer::new();
+        if let Ok(qt) = quantizer.quantize_tensor(&bt) {
+            prop_assert_eq!(&qt.shape, &[len], "shape mismatch after quantize");
+            if let Ok(deq) = quantizer.dequantize_tensor(&qt) {
+                let deq_shape = deq.shape();
+                // Shape must match
+                prop_assert_eq!(deq_shape[deq_shape.len() - 1], len);
+            }
+        }
+    }
+
+    /// I2S quantization produces correct qtype.
+    #[test]
+    fn i2s_quantize_correct_qtype(
+        len in (32usize..=128).prop_map(|l| (l / 32) * 32),
+    ) {
+        let data = vec![1.0f32; len];
+        let tensor = CandleTensor::from_vec(data, &[len], &CandleDevice::Cpu).unwrap();
+        let bt = BitNetTensor::new(tensor);
+        let quantizer = I2SQuantizer::new();
+        if let Ok(qt) = quantizer.quantize_tensor(&bt) {
+            prop_assert_eq!(qt.qtype, QuantizationType::I2S);
+        }
+    }
+}
+
+// ── Block size divides tensor dimensions ──────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(300))]
+
+    /// Block count * block_size >= numel for QuantizedTensor.
+    #[test]
+    fn block_count_covers_tensor(
+        n_blocks in 1usize..=64,
+        block_size in prop_oneof![Just(32usize), Just(64), Just(128), Just(256)],
+    ) {
+        let numel = n_blocks * block_size;
+        let computed_blocks = numel.div_ceil(block_size);
+        prop_assert_eq!(computed_blocks, n_blocks);
+        prop_assert!(computed_blocks * block_size >= numel);
+    }
+
+    /// QuantizedTensor numel equals product of shape dims.
+    #[test]
+    fn quantized_tensor_numel(
+        d1 in 1usize..=64,
+        d2 in 1usize..=64,
+    ) {
+        let shape = vec![d1, d2];
+        let expected = d1 * d2;
+        let qt = QuantizedTensor::new(
+            vec![0u8; expected / 4], // dummy data
+            vec![1.0f32; expected / 32], // dummy scales
+            shape.clone(),
+            QuantizationType::I2S,
+        );
+        prop_assert_eq!(qt.numel(), expected);
+    }
+
+    /// Block size 64 evenly divides lengths that are multiples of 64.
+    #[test]
+    fn block64_divides_multiples(multiplier in 1usize..=32) {
+        let len = multiplier * 64;
+        prop_assert_eq!(len % 64, 0);
+        let n_blocks = len / 64;
+        prop_assert_eq!(n_blocks, multiplier);
+    }
+}
+
+// ── TL1 lookup table roundtrip ────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// TL1 quantizer preserves shape through roundtrip.
+    #[test]
+    fn tl1_roundtrip_preserves_shape(
+        len in (64usize..=256).prop_map(|l| (l / 64) * 64),
+    ) {
+        let data: Vec<f32> = (0..len).map(|i| (i as f32 / len as f32) - 0.5).collect();
+        let tensor = CandleTensor::from_vec(data, &[len], &CandleDevice::Cpu).unwrap();
+        let bt = BitNetTensor::new(tensor);
+
+        let quantizer = TL1Quantizer::new();
+        if let Ok(qt) = quantizer.quantize_tensor(&bt) {
+            prop_assert_eq!(&qt.shape, &[len]);
+            prop_assert_eq!(qt.qtype, QuantizationType::TL1);
+        }
+    }
+
+    /// TL1 scales are all finite after quantization.
+    #[test]
+    fn tl1_scales_finite(
+        len in (64usize..=256).prop_map(|l| (l / 64) * 64),
+    ) {
+        let data: Vec<f32> = (0..len).map(|i| (i as f32 * 0.01) - 1.0).collect();
+        let tensor = CandleTensor::from_vec(data, &[len], &CandleDevice::Cpu).unwrap();
+        let bt = BitNetTensor::new(tensor);
+
+        let quantizer = TL1Quantizer::new();
+        if let Ok(qt) = quantizer.quantize_tensor(&bt) {
+            for (i, &s) in qt.scales.iter().enumerate() {
+                prop_assert!(s.is_finite(), "TL1 scale[{i}] = {s} not finite");
+            }
+        }
+    }
+}

--- a/crates/bitnet-tokenizers/tests/proptest_wave31.rs
+++ b/crates/bitnet-tokenizers/tests/proptest_wave31.rs
@@ -1,0 +1,173 @@
+//! Property-based tests for tokenizer encode/decode roundtrips and token ID validity
+//! (proptest wave 31).
+
+use bitnet_tokenizers::{BasicTokenizer, Tokenizer, TokenizerConfig};
+use proptest::prelude::*;
+
+// ── Encode → decode roundtrip ─────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// ASCII encode→decode roundtrip preserves the original string.
+    #[test]
+    fn ascii_roundtrip(text in "[a-zA-Z0-9 ]{1,50}") {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        let decoded = t.decode(&tokens).expect("decode");
+        prop_assert_eq!(&decoded, &text, "roundtrip failed");
+    }
+
+    /// Single-byte ASCII characters survive roundtrip individually.
+    #[test]
+    fn single_ascii_roundtrip(ch in 0u8..128) {
+        let text = String::from(ch as char);
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        let decoded = t.decode(&tokens).expect("decode");
+        prop_assert_eq!(&decoded, &text);
+    }
+
+    /// Encode→decode with BOS strips the BOS from decoded output.
+    #[test]
+    fn roundtrip_with_bos(text in "[a-z]{1,20}", bos_id in 200u32..300) {
+        let t = BasicTokenizer::with_config(50257, Some(bos_id), Some(50256), None);
+        let tokens = t.encode(&text, true, false).expect("encode");
+        // First token should be BOS
+        prop_assert_eq!(tokens[0], bos_id);
+        let decoded = t.decode(&tokens).expect("decode");
+        // BOS is skipped during decode (it's a special token)
+        prop_assert_eq!(&decoded, &text);
+    }
+
+    /// Empty string encodes to empty token list.
+    #[test]
+    fn empty_string_encode(_dummy in 0u8..1) {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode("", false, false).expect("encode");
+        prop_assert!(tokens.is_empty());
+    }
+
+    /// Empty token list decodes to empty string.
+    #[test]
+    fn empty_tokens_decode(_dummy in 0u8..1) {
+        let t = BasicTokenizer::new();
+        let decoded = t.decode(&[]).expect("decode");
+        prop_assert!(decoded.is_empty());
+    }
+}
+
+// ── Token IDs in valid range ──────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(500))]
+
+    /// All encoded token IDs are < vocab_size (excluding special tokens).
+    #[test]
+    fn token_ids_in_range(
+        text in "[a-zA-Z0-9]{1,40}",
+        vocab_size in 256usize..100_000,
+    ) {
+        let t = BasicTokenizer::with_config(vocab_size, None, None, None);
+        let tokens = t.encode(&text, false, false).expect("encode");
+        for &id in &tokens {
+            prop_assert!(
+                (id as usize) < vocab_size,
+                "token ID {id} >= vocab_size {vocab_size}"
+            );
+        }
+    }
+
+    /// Token IDs from ASCII encoding are all < 128.
+    #[test]
+    fn ascii_token_ids_bounded(text in "[a-zA-Z0-9 ]{1,50}") {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        for &id in &tokens {
+            prop_assert!(id < 128, "ASCII token ID {id} should be < 128");
+        }
+    }
+
+    /// BOS token ID, when present, is the first token.
+    #[test]
+    fn bos_is_first_token(
+        text in "[a-z]{1,20}",
+        bos_id in 128u32..256,
+    ) {
+        let t = BasicTokenizer::with_config(50257, Some(bos_id), None, None);
+        let tokens = t.encode(&text, true, false).expect("encode");
+        prop_assert!(!tokens.is_empty());
+        prop_assert_eq!(tokens[0], bos_id, "first token should be BOS");
+    }
+
+    /// EOS token ID, when added via add_special, is the last token.
+    #[test]
+    fn eos_is_last_token(
+        text in "[a-z]{1,20}",
+        eos_id in 128u32..256,
+    ) {
+        let t = BasicTokenizer::with_config(50257, None, Some(eos_id), None);
+        let tokens = t.encode(&text, false, true).expect("encode");
+        prop_assert!(!tokens.is_empty());
+        prop_assert_eq!(*tokens.last().unwrap(), eos_id, "last token should be EOS");
+    }
+
+    /// Token count equals text byte length (for ASCII, no specials).
+    #[test]
+    fn token_count_equals_byte_len(text in "[a-zA-Z0-9]{1,50}") {
+        let t = BasicTokenizer::new();
+        let tokens = t.encode(&text, false, false).expect("encode");
+        prop_assert_eq!(tokens.len(), text.len(),
+            "BasicTokenizer should emit one token per byte");
+    }
+}
+
+// ── Config preservation ───────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// TokenizerConfig fields survive construction.
+    #[test]
+    fn config_round_trip(
+        vocab_size in 100usize..200_000,
+        add_bos in any::<bool>(),
+        add_eos in any::<bool>(),
+        bos_id in proptest::option::of(0u32..1000),
+        eos_id in proptest::option::of(0u32..1000),
+    ) {
+        let cfg = TokenizerConfig {
+            model_type: "bpe".to_string(),
+            vocab_size,
+            add_bos,
+            add_eos,
+            bos_token_id: bos_id,
+            eos_token_id: eos_id,
+            ..Default::default()
+        };
+        prop_assert_eq!(cfg.vocab_size, vocab_size);
+        prop_assert_eq!(cfg.add_bos, add_bos);
+        prop_assert_eq!(cfg.add_eos, add_eos);
+    }
+
+    /// BasicTokenizer::with_config preserves all fields.
+    #[test]
+    fn basic_tokenizer_config_preserved(
+        vocab_size in 256usize..100_000,
+        bos in proptest::option::of(0u32..256),
+        eos in proptest::option::of(0u32..256),
+        pad in proptest::option::of(0u32..256),
+    ) {
+        let t = BasicTokenizer::with_config(vocab_size, bos, eos, pad);
+        prop_assert_eq!(t.vocab_size(), vocab_size);
+        prop_assert_eq!(t.bos_token_id(), bos);
+        prop_assert_eq!(t.eos_token_id(), eos);
+    }
+
+    /// Vocab size from with_config matches vocab_size().
+    #[test]
+    fn vocab_size_consistent(vs in 1usize..200_000) {
+        let t = BasicTokenizer::with_config(vs, None, None, None);
+        prop_assert_eq!(t.vocab_size(), vs);
+    }
+}


### PR DESCRIPTION
Adds 67 property-based tests across 4 crates:

- **bitnet-common** (19 tests): broadcasting rules, tensor size calculations, matmul shape validation, Device/QuantizationType serde round-trips
- **bitnet-quantization** (16 tests): scale factor properties, quantize/dequantize roundtrips, block size invariants, I2S/TL1 tensor roundtrips
- **bitnet-models** (19 tests): format detection determinism, magic-byte header parsing robustness, tensor name filtering case-sensitivity, TensorData/TensorInfo consistency
- **bitnet-tokenizers** (13 tests): ASCII encode/decode roundtrips, token ID range validation, BOS/EOS positioning, config preservation