### PR TITLE
test: snapshot wave 27 — insta tests across 3 crates

### DIFF
--- a/crates/bitnet-common/tests/snapshot_wave27.rs
+++ b/crates/bitnet-common/tests/snapshot_wave27.rs
@@ -1,0 +1,291 @@
+//! Snapshot wave 27 — bitnet-common Display/Debug output stability.
+
+use bitnet_common::backend_selection::{
+    BackendRequest, BackendSelectionError, BackendSelectionResult, BackendStartupSummary,
+};
+use bitnet_common::error::{
+    BitNetError, InferenceError, KernelError, ModelError, QuantizationError, SecurityError,
+    ValidationErrorDetails,
+};
+use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+use bitnet_common::tensor_validation::ShapeError;
+use bitnet_common::types::{Device, ModelMetadata, PerformanceMetrics, QuantizationType};
+
+// ---------------------------------------------------------------------------
+// Device
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_device_debug_all_variants() {
+    let devices = vec![
+        Device::Cpu,
+        Device::Cuda(0),
+        Device::Cuda(3),
+        Device::Hip(1),
+        Device::Npu,
+        Device::Metal,
+        Device::OpenCL(0),
+        Device::OpenCL(7),
+    ];
+    insta::assert_debug_snapshot!("device_debug_all_variants", devices);
+}
+
+#[test]
+fn snapshot_device_default() {
+    let dev = Device::default();
+    insta::assert_debug_snapshot!("device_default", dev);
+}
+
+// ---------------------------------------------------------------------------
+// QuantizationType
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_quantization_type_display_all() {
+    let types = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    let displays: Vec<String> = types.iter().map(|t| t.to_string()).collect();
+    insta::assert_debug_snapshot!("quantization_type_display_all", displays);
+}
+
+#[test]
+fn snapshot_quantization_type_debug_all() {
+    let types = [QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    insta::assert_debug_snapshot!("quantization_type_debug_all", types);
+}
+
+#[test]
+fn snapshot_quantization_type_json() {
+    let qt = QuantizationType::I2S;
+    insta::assert_json_snapshot!("quantization_type_json_i2s", qt);
+}
+
+// ---------------------------------------------------------------------------
+// Error types — Display output
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_model_error_not_found() {
+    let err = ModelError::NotFound { path: "/models/missing.gguf".into() };
+    insta::assert_snapshot!("model_error_not_found", err.to_string());
+}
+
+#[test]
+fn snapshot_model_error_invalid_format() {
+    let err = ModelError::InvalidFormat { format: "safetensors-v3".into() };
+    insta::assert_snapshot!("model_error_invalid_format", err.to_string());
+}
+
+#[test]
+fn snapshot_model_error_gguf_with_details() {
+    let err = ModelError::GGUFFormatError {
+        message: "invalid magic number".into(),
+        details: ValidationErrorDetails {
+            errors: vec!["magic mismatch".into()],
+            warnings: vec!["old format version".into()],
+            recommendations: vec!["re-export with latest converter".into()],
+        },
+    };
+    insta::assert_snapshot!("model_error_gguf_with_details", err.to_string());
+}
+
+#[test]
+fn snapshot_quantization_error_variants() {
+    let errors: Vec<String> = vec![
+        QuantizationError::UnsupportedType { qtype: "Q4_K_M".into() }.to_string(),
+        QuantizationError::InvalidBlockSize { size: 17 }.to_string(),
+        QuantizationError::QuantizationFailed { reason: "overflow in scale".into() }.to_string(),
+        QuantizationError::ResourceLimit { reason: "exceeds 4GB".into() }.to_string(),
+    ];
+    insta::assert_debug_snapshot!("quantization_error_variants", errors);
+}
+
+#[test]
+fn snapshot_kernel_error_variants() {
+    let errors: Vec<String> = vec![
+        KernelError::NoProvider.to_string(),
+        KernelError::ExecutionFailed { reason: "CUDA OOM".into() }.to_string(),
+        KernelError::UnsupportedArchitecture { arch: "wasm32".into() }.to_string(),
+        KernelError::UnsupportedHardware { required: "avx512".into(), available: "avx2".into() }
+            .to_string(),
+    ];
+    insta::assert_debug_snapshot!("kernel_error_variants", errors);
+}
+
+#[test]
+fn snapshot_inference_error_variants() {
+    let errors: Vec<String> = vec![
+        InferenceError::GenerationFailed { reason: "max retries exceeded".into() }.to_string(),
+        InferenceError::InvalidInput { reason: "empty prompt".into() }.to_string(),
+        InferenceError::ContextLengthExceeded { length: 131072 }.to_string(),
+        InferenceError::TokenizationFailed { reason: "unknown BPE token".into() }.to_string(),
+    ];
+    insta::assert_debug_snapshot!("inference_error_variants", errors);
+}
+
+#[test]
+fn snapshot_security_error_variants() {
+    let errors: Vec<String> = vec![
+        SecurityError::InputValidation { reason: "null byte in prompt".into() }.to_string(),
+        SecurityError::MemoryBomb { reason: "tensor claims 1TB".into() }.to_string(),
+        SecurityError::ResourceLimit {
+            resource: "tensor_elements".into(),
+            value: 2_000_000_000,
+            limit: 1_000_000_000,
+        }
+        .to_string(),
+        SecurityError::MalformedData { reason: "cyclic reference in metadata".into() }.to_string(),
+        SecurityError::UnsafeOperation {
+            operation: "mmap".into(),
+            reason: "path traversal".into(),
+        }
+        .to_string(),
+    ];
+    insta::assert_debug_snapshot!("security_error_variants", errors);
+}
+
+#[test]
+fn snapshot_bitnet_error_wrapping() {
+    let inner = ModelError::NotFound { path: "test.gguf".into() };
+    let outer: BitNetError = inner.into();
+    insta::assert_snapshot!("bitnet_error_wrapping_model", outer.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// ShapeError
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_shape_error_matmul_mismatch() {
+    let err = ShapeError::MatmulMismatch { a_inner: 768, b_inner: 512 };
+    insta::assert_snapshot!("shape_error_matmul_mismatch", err.to_string());
+}
+
+#[test]
+fn snapshot_shape_error_broadcast_incompatible() {
+    let err = ShapeError::BroadcastIncompatible { dim: 2, a: 3, b: 5 };
+    insta::assert_snapshot!("shape_error_broadcast", err.to_string());
+}
+
+#[test]
+fn snapshot_shape_error_attention() {
+    let err = ShapeError::AttentionShape {
+        q: vec![1, 8, 64, 96],
+        k: vec![1, 8, 128, 96],
+        v: vec![1, 8, 128, 48],
+        reason: "V head_dim != Q head_dim".into(),
+    };
+    insta::assert_snapshot!("shape_error_attention", err.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// KernelBackend / SimdLevel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_kernel_backend_display_all() {
+    let backends = [
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::OpenCL,
+        KernelBackend::CppFfi,
+    ];
+    let displays: Vec<String> = backends.iter().map(|b| b.to_string()).collect();
+    insta::assert_debug_snapshot!("kernel_backend_display_all", displays);
+}
+
+#[test]
+fn snapshot_simd_level_ordering() {
+    let mut levels = vec![
+        SimdLevel::Avx512,
+        SimdLevel::Scalar,
+        SimdLevel::Avx2,
+        SimdLevel::Neon,
+        SimdLevel::Sse42,
+    ];
+    levels.sort();
+    let sorted: Vec<String> = levels.iter().map(|l| l.to_string()).collect();
+    insta::assert_debug_snapshot!("simd_level_sorted_order", sorted);
+}
+
+// ---------------------------------------------------------------------------
+// BackendStartupSummary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_backend_startup_summary_log_line() {
+    let summary =
+        BackendStartupSummary::new("auto", vec!["cpu-rust".into(), "cuda".into()], "cuda");
+    insta::assert_snapshot!("backend_startup_log_line", summary.log_line());
+}
+
+#[test]
+fn snapshot_backend_startup_summary_json() {
+    let summary = BackendStartupSummary::new("gpu", vec!["cpu-rust".into()], "cpu-rust");
+    insta::assert_json_snapshot!("backend_startup_summary_json", summary);
+}
+
+// ---------------------------------------------------------------------------
+// BackendSelectionResult
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_backend_selection_result_summary() {
+    let result = BackendSelectionResult {
+        requested: BackendRequest::Auto,
+        detected: vec![KernelBackend::CpuRust, KernelBackend::Cuda],
+        selected: KernelBackend::Cuda,
+        rationale: "auto-selected best available backend".into(),
+    };
+    insta::assert_snapshot!("backend_selection_result_summary", result.summary());
+}
+
+#[test]
+fn snapshot_backend_selection_error_display() {
+    let err = BackendSelectionError::RequestedUnavailable {
+        requested: BackendRequest::Cuda,
+        available: vec![KernelBackend::CpuRust],
+    };
+    insta::assert_snapshot!("backend_selection_error_unavailable", err.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// ModelMetadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_model_metadata_json() {
+    let meta = ModelMetadata {
+        name: "bitnet-b1.58-2B-4T".into(),
+        version: "1.0".into(),
+        architecture: "bitnet".into(),
+        vocab_size: 32000,
+        context_length: 4096,
+        quantization: Some(QuantizationType::I2S),
+        fingerprint: Some("sha256-abcdef1234567890".into()),
+        corrections_applied: None,
+    };
+    insta::assert_json_snapshot!("model_metadata_json", meta);
+}
+
+// ---------------------------------------------------------------------------
+// PerformanceMetrics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_performance_metrics_json() {
+    let metrics = PerformanceMetrics {
+        tokens_per_second: 42.5,
+        latency_ms: 23.5,
+        memory_usage_mb: 1024.0,
+        gpu_utilization: Some(0.85),
+    };
+    insta::assert_json_snapshot!("performance_metrics_json", metrics);
+}
+
+#[test]
+fn snapshot_performance_metrics_default() {
+    let metrics = PerformanceMetrics::default();
+    insta::assert_json_snapshot!("performance_metrics_default", metrics);
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_selection_error_unavailable.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_selection_error_unavailable.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+requested backend 'cuda' is not available; compiled backends: [cpu-rust]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_selection_result_summary.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_selection_result_summary.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: result.summary()
+---
+requested=auto detected=[cpu-rust,cuda] selected=cuda

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_startup_log_line.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_startup_log_line.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: summary.log_line()
+---
+requested=auto detected=[cpu-rust, cuda] selected=cuda

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_startup_summary_json.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__backend_startup_summary_json.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: summary
+---
+{
+  "requested": "gpu",
+  "detected": [
+    "cpu-rust"
+  ],
+  "selected": "cpu-rust"
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__bitnet_error_wrapping_model.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__bitnet_error_wrapping_model.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: outer.to_string()
+---
+Model error: Model not found: test.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__device_debug_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__device_debug_all_variants.snap
@@ -1,0 +1,24 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: devices
+---
+[
+    Cpu,
+    Cuda(
+        0,
+    ),
+    Cuda(
+        3,
+    ),
+    Hip(
+        1,
+    ),
+    Npu,
+    Metal,
+    OpenCL(
+        0,
+    ),
+    OpenCL(
+        7,
+    ),
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__device_default.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__device_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: dev
+---
+Cpu

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__inference_error_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__inference_error_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: errors
+---
+[
+    "Generation failed: max retries exceeded",
+    "Invalid input: empty prompt",
+    "Context length exceeded: 131072",
+    "Tokenization failed: unknown BPE token",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__kernel_backend_display_all.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__kernel_backend_display_all.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "cpu-rust",
+    "cuda",
+    "hip",
+    "oneapi",
+    "opencl",
+    "cpp-ffi",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__kernel_error_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__kernel_error_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: errors
+---
+[
+    "No available kernel provider",
+    "Kernel execution failed: CUDA OOM",
+    "Unsupported architecture: wasm32",
+    "Unsupported hardware: required avx512, available avx2",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_gguf_with_details.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_gguf_with_details.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+GGUF format error: invalid magic number

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_invalid_format.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_invalid_format.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+Invalid model format: safetensors-v3

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_not_found.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_error_not_found.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+Model not found: /models/missing.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_metadata_json.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__model_metadata_json.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: meta
+---
+{
+  "name": "bitnet-b1.58-2B-4T",
+  "version": "1.0",
+  "architecture": "bitnet",
+  "vocab_size": 32000,
+  "context_length": 4096,
+  "quantization": "I2S",
+  "fingerprint": "sha256-abcdef1234567890"
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__performance_metrics_default.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__performance_metrics_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: metrics
+---
+{
+  "tokens_per_second": 0.0,
+  "latency_ms": 0.0,
+  "memory_usage_mb": 0.0,
+  "gpu_utilization": null
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__performance_metrics_json.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__performance_metrics_json.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: metrics
+---
+{
+  "tokens_per_second": 42.5,
+  "latency_ms": 23.5,
+  "memory_usage_mb": 1024.0,
+  "gpu_utilization": 0.85
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_error_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_error_variants.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: errors
+---
+[
+    "Unsupported quantization type: Q4_K_M",
+    "Invalid block size: 17",
+    "Quantization failed: overflow in scale",
+    "Resource limit exceeded: exceeds 4GB",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_debug_all.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_debug_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: types
+---
+[
+    I2S,
+    TL1,
+    TL2,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_display_all.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_display_all.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "I2_S",
+    "TL1",
+    "TL2",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_json_i2s.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__quantization_type_json_i2s.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: qt
+---
+"I2S"

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__security_error_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__security_error_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: errors
+---
+[
+    "Input validation failed: null byte in prompt",
+    "Memory allocation attack detected: tensor claims 1TB",
+    "Resource limit exceeded: tensor_elements = 2000000000 exceeds limit 1000000000",
+    "Malformed data structure: cyclic reference in metadata",
+    "Unsafe operation blocked: mmap - path traversal",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_attention.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_attention.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+attention shape mismatch: Q=[1, 8, 64, 96], K=[1, 8, 128, 96], V=[1, 8, 128, 48] — V head_dim != Q head_dim

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_broadcast.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_broadcast.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+broadcast incompatible: dimension 2 has sizes 3 and 5

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_matmul_mismatch.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__shape_error_matmul_mismatch.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: err.to_string()
+---
+matmul shape mismatch: a has 768 columns but b has 512 rows

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave27__simd_level_sorted_order.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave27__simd_level_sorted_order.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave27.rs
+expression: sorted
+---
+[
+    "scalar",
+    "neon",
+    "sse4.2",
+    "avx2",
+    "avx512",
+]

--- a/crates/bitnet-inference/tests/snapshot_wave27.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave27.rs
@@ -1,0 +1,263 @@
+//! Snapshot wave 27 — bitnet-inference config/profiler output stability.
+
+use bitnet_inference::config_builder::{
+    GenerationConfig, HardwareConfig, InferenceConfig, InferenceConfigBuilder, InferencePreset,
+    SamplingConfig,
+};
+use bitnet_inference::profiler::{
+    LayerProfile, LayerStats, MemorySnapshot, ProfileReport, ProfilerConfig,
+};
+
+// ---------------------------------------------------------------------------
+// InferencePreset — all variants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_preset_fast_config_json() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Fast).build().unwrap();
+    insta::assert_json_snapshot!("preset_fast_config", cfg);
+}
+
+#[test]
+fn snapshot_preset_balanced_config_json() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Balanced).build().unwrap();
+    insta::assert_json_snapshot!("preset_balanced_config", cfg);
+}
+
+#[test]
+fn snapshot_preset_quality_config_json() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Quality).build().unwrap();
+    insta::assert_json_snapshot!("preset_quality_config", cfg);
+}
+
+#[test]
+fn snapshot_preset_deterministic_config_json() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Deterministic).build().unwrap();
+    insta::assert_json_snapshot!("preset_deterministic_config", cfg);
+}
+
+#[test]
+fn snapshot_preset_debug_config_json() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Debug).build().unwrap();
+    insta::assert_json_snapshot!("preset_debug_config", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// SamplingConfig defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_sampling_config_default_json() {
+    let cfg = SamplingConfig::default();
+    insta::assert_json_snapshot!("sampling_config_default", cfg);
+}
+
+#[test]
+fn snapshot_sampling_config_debug() {
+    let cfg = SamplingConfig {
+        temperature: 0.0,
+        top_k: 1,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+        seed: Some(42),
+    };
+    insta::assert_debug_snapshot!("sampling_config_greedy", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// GenerationConfig
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_generation_config_default_json() {
+    let cfg = GenerationConfig::default();
+    insta::assert_json_snapshot!("generation_config_default", cfg);
+}
+
+#[test]
+fn snapshot_generation_config_with_stops_json() {
+    let cfg = InferenceConfigBuilder::new()
+        .max_tokens(64)
+        .stop_sequence("</s>")
+        .stop_sequence("\n\nQ:")
+        .stop_token_id(128009)
+        .stop_token_id(128001)
+        .stream(true)
+        .build()
+        .unwrap();
+    insta::assert_json_snapshot!("generation_config_with_stops", cfg.generation);
+}
+
+// ---------------------------------------------------------------------------
+// HardwareConfig
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_hardware_config_default_json() {
+    let cfg = HardwareConfig::default();
+    insta::assert_json_snapshot!("hardware_config_default", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// InferenceConfig — custom build
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_custom_inference_config_json() {
+    let cfg = InferenceConfigBuilder::new()
+        .temperature(0.8)
+        .top_k(40)
+        .top_p(0.95)
+        .repetition_penalty(1.1)
+        .seed(12345)
+        .max_tokens(256)
+        .stop_sequence("</s>")
+        .stop_token_id(128009)
+        .stream(true)
+        .num_threads(4)
+        .memory_limit_mb(4096)
+        .build()
+        .unwrap();
+    insta::assert_json_snapshot!("custom_inference_config", cfg);
+}
+
+#[test]
+fn snapshot_inference_config_debug() {
+    let cfg = InferenceConfigBuilder::new().preset(InferencePreset::Fast).build().unwrap();
+    insta::assert_debug_snapshot!("inference_config_debug_fast", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// InferencePreset serde roundtrip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_preset_enum_json_all() {
+    let presets = vec![
+        InferencePreset::Fast,
+        InferencePreset::Balanced,
+        InferencePreset::Quality,
+        InferencePreset::Deterministic,
+        InferencePreset::Debug,
+    ];
+    insta::assert_json_snapshot!("preset_enum_all_json", presets);
+}
+
+// ---------------------------------------------------------------------------
+// ProfilerConfig
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_profiler_config_default_json() {
+    let cfg = ProfilerConfig::default();
+    insta::assert_json_snapshot!("profiler_config_default", cfg);
+}
+
+#[test]
+fn snapshot_profiler_config_disabled_json() {
+    let cfg = ProfilerConfig::disabled();
+    insta::assert_json_snapshot!("profiler_config_disabled", cfg);
+}
+
+#[test]
+fn snapshot_profiler_config_custom_json() {
+    let cfg = ProfilerConfig::default().with_warmup(3).with_sample_size(10).with_memory(true);
+    insta::assert_json_snapshot!("profiler_config_custom", cfg);
+}
+
+// ---------------------------------------------------------------------------
+// ProfileReport
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_profile_report_empty_json() {
+    let report = ProfileReport {
+        total_time_us: 0.0,
+        per_layer_breakdown: vec![],
+        bottleneck_layers: vec![],
+        memory_peak: 0,
+        estimated_flops: 0,
+        memory_snapshots: vec![],
+        layer_profiles: vec![],
+    };
+    insta::assert_json_snapshot!("profile_report_empty", report);
+}
+
+#[test]
+fn snapshot_profile_report_with_layers_json() {
+    let report = ProfileReport {
+        total_time_us: 2500.0,
+        per_layer_breakdown: vec![
+            LayerStats {
+                layer_name: "layer_0.attention".into(),
+                layer_type: "attention".into(),
+                mean_time_us: 1200.0,
+                std_time_us: 50.0,
+                min_time_us: 1150.0,
+                max_time_us: 1250.0,
+                count: 5,
+                total_memory_bytes: 4_194_304,
+                total_flops: 1_000_000,
+            },
+            LayerStats {
+                layer_name: "layer_0.ffn".into(),
+                layer_type: "ffn".into(),
+                mean_time_us: 800.0,
+                std_time_us: 30.0,
+                min_time_us: 770.0,
+                max_time_us: 830.0,
+                count: 5,
+                total_memory_bytes: 2_097_152,
+                total_flops: 500_000,
+            },
+        ],
+        bottleneck_layers: vec!["layer_0.attention".into()],
+        memory_peak: 8_388_608,
+        estimated_flops: 1_500_000,
+        memory_snapshots: vec![MemorySnapshot {
+            label: "post_attention".into(),
+            timestamp_us: 1200.0,
+            memory_bytes: 8_388_608,
+        }],
+        layer_profiles: vec![
+            LayerProfile {
+                layer_name: "layer_0.attention".into(),
+                layer_type: "attention".into(),
+                forward_time_us: 1200.0,
+                backward_time_us: 0.0,
+                memory_bytes: 4_194_304,
+                flops_estimate: 1_000_000,
+            },
+            LayerProfile {
+                layer_name: "layer_0.ffn".into(),
+                layer_type: "ffn".into(),
+                forward_time_us: 800.0,
+                backward_time_us: 0.0,
+                memory_bytes: 2_097_152,
+                flops_estimate: 500_000,
+            },
+        ],
+    };
+    insta::assert_json_snapshot!("profile_report_with_layers", report);
+}
+
+#[test]
+fn snapshot_profile_report_chrome_trace() {
+    let report = ProfileReport {
+        total_time_us: 500.0,
+        per_layer_breakdown: vec![],
+        bottleneck_layers: vec![],
+        memory_peak: 0,
+        estimated_flops: 0,
+        memory_snapshots: vec![],
+        layer_profiles: vec![LayerProfile {
+            layer_name: "layer_0.norm".into(),
+            layer_type: "norm".into(),
+            forward_time_us: 500.0,
+            backward_time_us: 0.0,
+            memory_bytes: 0,
+            flops_estimate: 0,
+        }],
+    };
+    insta::assert_snapshot!("profile_report_chrome_trace", report.export_chrome_trace());
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__custom_inference_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__custom_inference_config.snap
@@ -1,0 +1,27 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.8,
+    "top_k": 40,
+    "top_p": 0.95,
+    "repetition_penalty": 1.1,
+    "seed": 12345
+  },
+  "generation": {
+    "max_tokens": 256,
+    "stop_sequences": [
+      "</s>"
+    ],
+    "stop_token_ids": [
+      128009
+    ],
+    "stream": true
+  },
+  "hardware": {
+    "num_threads": 4,
+    "memory_limit_mb": 4096
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__generation_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__generation_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "max_tokens": 128,
+  "stop_sequences": [],
+  "stop_token_ids": [],
+  "stream": false
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__generation_config_with_stops.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__generation_config_with_stops.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "max_tokens": 64,
+  "stop_sequences": [
+    "</s>",
+    "\n\nQ:"
+  ],
+  "stop_token_ids": [
+    128009,
+    128001
+  ],
+  "stream": true
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__hardware_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__hardware_config_default.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "num_threads": 0,
+  "memory_limit_mb": 0
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__inference_config_debug_fast.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__inference_config_debug_fast.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+InferenceConfig {
+    sampling: SamplingConfig {
+        temperature: 0.0,
+        top_k: 1,
+        top_p: 1.0,
+        repetition_penalty: 1.0,
+        seed: None,
+    },
+    generation: GenerationConfig {
+        max_tokens: 64,
+        stop_sequences: [],
+        stop_token_ids: [],
+        stream: false,
+    },
+    hardware: HardwareConfig {
+        num_threads: 1,
+        memory_limit_mb: 0,
+    },
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_balanced_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_balanced_config.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.7,
+    "top_k": 50,
+    "top_p": 0.9,
+    "repetition_penalty": 1.05,
+    "seed": null
+  },
+  "generation": {
+    "max_tokens": 128,
+    "stop_sequences": [],
+    "stop_token_ids": [],
+    "stream": false
+  },
+  "hardware": {
+    "num_threads": 0,
+    "memory_limit_mb": 0
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_debug_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_debug_config.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.0,
+    "top_k": 1,
+    "top_p": 1.0,
+    "repetition_penalty": 1.0,
+    "seed": 0
+  },
+  "generation": {
+    "max_tokens": 8,
+    "stop_sequences": [],
+    "stop_token_ids": [],
+    "stream": false
+  },
+  "hardware": {
+    "num_threads": 1,
+    "memory_limit_mb": 256
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_deterministic_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_deterministic_config.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.0,
+    "top_k": 1,
+    "top_p": 1.0,
+    "repetition_penalty": 1.0,
+    "seed": 42
+  },
+  "generation": {
+    "max_tokens": 128,
+    "stop_sequences": [],
+    "stop_token_ids": [],
+    "stream": false
+  },
+  "hardware": {
+    "num_threads": 1,
+    "memory_limit_mb": 0
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_enum_all_json.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_enum_all_json.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: presets
+---
+[
+  "Fast",
+  "Balanced",
+  "Quality",
+  "Deterministic",
+  "Debug"
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_fast_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_fast_config.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.0,
+    "top_k": 1,
+    "top_p": 1.0,
+    "repetition_penalty": 1.0,
+    "seed": null
+  },
+  "generation": {
+    "max_tokens": 64,
+    "stop_sequences": [],
+    "stop_token_ids": [],
+    "stream": false
+  },
+  "hardware": {
+    "num_threads": 1,
+    "memory_limit_mb": 0
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_quality_config.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__preset_quality_config.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "sampling": {
+    "temperature": 0.9,
+    "top_k": 100,
+    "top_p": 0.95,
+    "repetition_penalty": 1.1,
+    "seed": null
+  },
+  "generation": {
+    "max_tokens": 256,
+    "stop_sequences": [],
+    "stop_token_ids": [],
+    "stream": false
+  },
+  "hardware": {
+    "num_threads": 0,
+    "memory_limit_mb": 0
+  }
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_chrome_trace.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_chrome_trace.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: report.export_chrome_trace()
+---
+[
+  {
+    "cat": "norm",
+    "name": "layer_0.norm",
+    "ph": "B",
+    "pid": 1,
+    "tid": 1,
+    "ts": 0.0
+  },
+  {
+    "cat": "norm",
+    "name": "layer_0.norm",
+    "ph": "E",
+    "pid": 1,
+    "tid": 1,
+    "ts": 500.0
+  }
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_empty.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_empty.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: report
+---
+{
+  "total_time_us": 0.0,
+  "per_layer_breakdown": [],
+  "bottleneck_layers": [],
+  "memory_peak": 0,
+  "estimated_flops": 0,
+  "memory_snapshots": [],
+  "layer_profiles": []
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_with_layers.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profile_report_with_layers.snap
@@ -1,0 +1,61 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: report
+---
+{
+  "total_time_us": 2500.0,
+  "per_layer_breakdown": [
+    {
+      "layer_name": "layer_0.attention",
+      "layer_type": "attention",
+      "mean_time_us": 1200.0,
+      "std_time_us": 50.0,
+      "min_time_us": 1150.0,
+      "max_time_us": 1250.0,
+      "count": 5,
+      "total_memory_bytes": 4194304,
+      "total_flops": 1000000
+    },
+    {
+      "layer_name": "layer_0.ffn",
+      "layer_type": "ffn",
+      "mean_time_us": 800.0,
+      "std_time_us": 30.0,
+      "min_time_us": 770.0,
+      "max_time_us": 830.0,
+      "count": 5,
+      "total_memory_bytes": 2097152,
+      "total_flops": 500000
+    }
+  ],
+  "bottleneck_layers": [
+    "layer_0.attention"
+  ],
+  "memory_peak": 8388608,
+  "estimated_flops": 1500000,
+  "memory_snapshots": [
+    {
+      "label": "post_attention",
+      "timestamp_us": 1200.0,
+      "memory_bytes": 8388608
+    }
+  ],
+  "layer_profiles": [
+    {
+      "layer_name": "layer_0.attention",
+      "layer_type": "attention",
+      "forward_time_us": 1200.0,
+      "backward_time_us": 0.0,
+      "memory_bytes": 4194304,
+      "flops_estimate": 1000000
+    },
+    {
+      "layer_name": "layer_0.ffn",
+      "layer_type": "ffn",
+      "forward_time_us": 800.0,
+      "backward_time_us": 0.0,
+      "memory_bytes": 2097152,
+      "flops_estimate": 500000
+    }
+  ]
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_custom.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "enabled": true,
+  "record_memory": true,
+  "warmup_iterations": 3,
+  "sample_size": 10
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "enabled": true,
+  "record_memory": false,
+  "warmup_iterations": 0,
+  "sample_size": 1
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_disabled.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__profiler_config_disabled.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "enabled": false,
+  "record_memory": false,
+  "warmup_iterations": 0,
+  "sample_size": 1
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__sampling_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__sampling_config_default.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+{
+  "temperature": 0.7,
+  "top_k": 50,
+  "top_p": 0.9,
+  "repetition_penalty": 1.0,
+  "seed": null
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave27__sampling_config_greedy.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave27__sampling_config_greedy.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave27.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 0.0,
+    top_k: 1,
+    top_p: 1.0,
+    repetition_penalty: 1.0,
+    seed: Some(
+        42,
+    ),
+}

--- a/crates/bitnet-kernels/tests/snapshot_wave27.rs
+++ b/crates/bitnet-kernels/tests/snapshot_wave27.rs
@@ -1,0 +1,230 @@
+//! Snapshot wave 27 — bitnet-kernels Display/Debug output stability.
+
+use std::time::Duration;
+
+use bitnet_kernels::capability_matrix::{
+    CapabilityEntry, CompatibilityReport, DeviceCapabilityMatrix, DeviceClass, DeviceProfile,
+    OperationCategory, PrecisionSupport, SupportLevel,
+};
+use bitnet_kernels::opencl_registry::{DeviceConstraints, KernelOp, KernelRegistry, KernelVariant};
+use bitnet_kernels::perf_tracker::{KernelTiming, PerfTracker, format_perf_report};
+use bitnet_kernels::simd_diagnostics::SimdCapabilities;
+
+// ---------------------------------------------------------------------------
+// DeviceClass Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_device_class_display_all() {
+    let displays: Vec<String> = DeviceClass::ALL.iter().map(|d| d.to_string()).collect();
+    insta::assert_debug_snapshot!("device_class_display_all", displays);
+}
+
+// ---------------------------------------------------------------------------
+// OperationCategory Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_operation_category_display_all() {
+    let displays: Vec<String> = OperationCategory::ALL.iter().map(|o| o.to_string()).collect();
+    insta::assert_debug_snapshot!("operation_category_display_all", displays);
+}
+
+// ---------------------------------------------------------------------------
+// PrecisionSupport Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_precision_support_display_all() {
+    let displays: Vec<String> = PrecisionSupport::ALL.iter().map(|p| p.to_string()).collect();
+    insta::assert_debug_snapshot!("precision_support_display_all", displays);
+}
+
+// ---------------------------------------------------------------------------
+// SupportLevel Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_support_level_display_variants() {
+    let levels = vec![
+        SupportLevel::Full(0.95),
+        SupportLevel::Full(1.0),
+        SupportLevel::Partial("no FP16 native".into()),
+        SupportLevel::Emulated,
+        SupportLevel::Unsupported,
+    ];
+    let displays: Vec<String> = levels.iter().map(|l| l.to_string()).collect();
+    insta::assert_debug_snapshot!("support_level_display_variants", displays);
+}
+
+// ---------------------------------------------------------------------------
+// CompatibilityReport
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_compatibility_report_ready() {
+    let profile = DeviceProfile {
+        device_class: DeviceClass::NvidiaCuda,
+        name: "NVIDIA RTX 4090".into(),
+        compute_units: 128,
+        memory_gb: 24,
+        capabilities: vec![CapabilityEntry::new(
+            OperationCategory::MatrixOps,
+            PrecisionSupport::FP16,
+            SupportLevel::Full(0.98),
+        )],
+    };
+    let required = vec![(OperationCategory::MatrixOps, PrecisionSupport::FP16)];
+    let report = CompatibilityReport::generate(&profile, &required);
+    insta::assert_snapshot!("compat_report_ready", report.to_string());
+}
+
+#[test]
+fn snapshot_compatibility_report_incomplete() {
+    let profile = DeviceProfile {
+        device_class: DeviceClass::CpuScalar,
+        name: "CPU Scalar".into(),
+        compute_units: 1,
+        memory_gb: 16,
+        capabilities: vec![CapabilityEntry::new(
+            OperationCategory::MatrixOps,
+            PrecisionSupport::FP32,
+            SupportLevel::Full(0.5),
+        )],
+    };
+    let required = vec![
+        (OperationCategory::MatrixOps, PrecisionSupport::FP32),
+        (OperationCategory::QuantizedOps, PrecisionSupport::Binary),
+        (OperationCategory::AttentionOps, PrecisionSupport::FP16),
+    ];
+    let report = CompatibilityReport::generate(&profile, &required);
+    insta::assert_snapshot!("compat_report_incomplete", report.to_string());
+}
+
+#[test]
+fn snapshot_compatibility_report_debug() {
+    let profile = DeviceProfile {
+        device_class: DeviceClass::IntelArc,
+        name: "Intel Arc A770".into(),
+        compute_units: 32,
+        memory_gb: 16,
+        capabilities: vec![
+            CapabilityEntry::new(
+                OperationCategory::MatrixOps,
+                PrecisionSupport::FP16,
+                SupportLevel::Full(0.92),
+            ),
+            CapabilityEntry::new(
+                OperationCategory::NormOps,
+                PrecisionSupport::FP32,
+                SupportLevel::Full(0.85),
+            ),
+        ],
+    };
+    let required = vec![
+        (OperationCategory::MatrixOps, PrecisionSupport::FP16),
+        (OperationCategory::NormOps, PrecisionSupport::FP32),
+    ];
+    let report = CompatibilityReport::generate(&profile, &required);
+    insta::assert_debug_snapshot!("compat_report_debug", report);
+}
+
+// ---------------------------------------------------------------------------
+// DeviceCapabilityMatrix builtin profiles
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_builtin_profiles_names() {
+    let matrix = DeviceCapabilityMatrix::with_builtin_profiles();
+    let names: Vec<&str> = matrix.profiles().iter().map(|p| p.name.as_str()).collect();
+    insta::assert_debug_snapshot!("builtin_profile_names", names);
+}
+
+// ---------------------------------------------------------------------------
+// KernelOp Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_kernel_op_display_all() {
+    let displays: Vec<String> = KernelOp::ALL.iter().map(|o| o.to_string()).collect();
+    insta::assert_debug_snapshot!("kernel_op_display_all", displays);
+}
+
+// ---------------------------------------------------------------------------
+// KernelVariant Display
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_kernel_variant_display_all() {
+    let variants = [
+        KernelVariant::OpenClScalar,
+        KernelVariant::OpenClTiled,
+        KernelVariant::OpenClVectorized,
+        KernelVariant::CpuSimd,
+        KernelVariant::CpuScalar,
+    ];
+    let displays: Vec<String> = variants.iter().map(|v| v.to_string()).collect();
+    insta::assert_debug_snapshot!("kernel_variant_display_all", displays);
+}
+
+// ---------------------------------------------------------------------------
+// KernelRegistry summary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_kernel_registry_a770_summary() {
+    let registry = KernelRegistry::with_default_a770_kernels();
+    insta::assert_snapshot!("kernel_registry_a770_summary", registry.summary());
+}
+
+// ---------------------------------------------------------------------------
+// DeviceConstraints
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_device_constraints_a770_debug() {
+    let constraints = DeviceConstraints::a770_defaults();
+    insta::assert_debug_snapshot!("device_constraints_a770", constraints);
+}
+
+// ---------------------------------------------------------------------------
+// PerfTracker report
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_perf_report_empty() {
+    let tracker = PerfTracker::new();
+    let report = format_perf_report(&tracker);
+    insta::assert_snapshot!("perf_report_empty", report);
+}
+
+#[test]
+fn snapshot_perf_report_with_timings() {
+    let mut tracker = PerfTracker::new();
+    tracker.record(KernelTiming::new("matmul_fp16", Duration::from_micros(1200), 65536));
+    tracker.record(KernelTiming::new("matmul_fp16", Duration::from_micros(1100), 65536));
+    tracker.record(KernelTiming::new("softmax", Duration::from_micros(300), 32000));
+    tracker
+        .record(KernelTiming::new("layer_norm", Duration::from_micros(150), 4096).with_flops(8192));
+    let report = format_perf_report(&tracker);
+    insta::assert_snapshot!("perf_report_with_timings", report);
+}
+
+// ---------------------------------------------------------------------------
+// SimdCapabilities
+// ---------------------------------------------------------------------------
+
+#[test]
+fn snapshot_simd_capabilities_debug() {
+    let caps = SimdCapabilities::detect();
+    // Only snapshot the arch field for stability across machines
+    insta::assert_snapshot!("simd_caps_arch", caps.arch);
+}
+
+#[test]
+fn snapshot_simd_capabilities_summary() {
+    let caps = SimdCapabilities::detect();
+    let summary = caps.summary();
+    // Summary is machine-dependent but should be non-empty
+    assert!(!summary.is_empty());
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__builtin_profile_names.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__builtin_profile_names.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: names
+---
+[
+    "Intel Arc A770",
+    "NVIDIA RTX 4090",
+    "Apple M1",
+    "CPU SIMD (AVX2)",
+    "CPU Scalar",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_debug.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_debug.snap
@@ -1,0 +1,26 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: report
+---
+CompatibilityReport {
+    device_name: "Intel Arc A770",
+    device_class: IntelArc,
+    supported_ops: [
+        (
+            MatrixOps,
+            FP16,
+            Full(
+                0.92,
+            ),
+        ),
+        (
+            NormOps,
+            FP32,
+            Full(
+                0.85,
+            ),
+        ),
+    ],
+    unsupported_ops: [],
+    overall_ready: true,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_incomplete.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_incomplete.snap
@@ -1,0 +1,8 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: report.to_string()
+---
+CPU Scalar (CPU Scalar): INCOMPLETE — 1/3 required ops supported
+  Missing:
+    - Quantized Ops @ Binary
+    - Attention Ops @ FP16

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_ready.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__compat_report_ready.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: report.to_string()
+---
+NVIDIA RTX 4090 (NVIDIA CUDA): READY — 1/1 required ops supported

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__device_class_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__device_class_display_all.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "Intel Arc",
+    "Intel Xe",
+    "NVIDIA CUDA",
+    "AMD ROCm",
+    "Apple Metal",
+    "CPU SIMD",
+    "CPU Scalar",
+    "WebGPU",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__device_constraints_a770.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__device_constraints_a770.snap
@@ -1,0 +1,16 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: constraints
+---
+DeviceConstraints {
+    max_workgroup_size: 1024,
+    max_local_memory: 65536,
+    subgroup_sizes: [
+        8,
+        16,
+        32,
+    ],
+    has_fp16: true,
+    has_int8_dot: true,
+    compute_units: 32,
+}

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_op_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_op_display_all.snap
@@ -1,0 +1,22 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "MatMul",
+    "MatVec",
+    "Softmax",
+    "RmsNorm",
+    "LayerNorm",
+    "RoPE",
+    "Attention",
+    "SiLU",
+    "GELU",
+    "ReLU",
+    "ElementwiseAdd",
+    "ElementwiseMul",
+    "Scale",
+    "Embedding",
+    "Dequantize",
+    "KvCacheAppend",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_registry_a770_summary.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_registry_a770_summary.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: registry.summary()
+---
+KernelRegistry: 16/16 ops available, 100% GPU coverage
+  MatMul: OpenCL-tiled
+  MatVec: OpenCL-tiled
+  Softmax: OpenCL-tiled
+  RmsNorm: OpenCL-tiled
+  LayerNorm: OpenCL-tiled
+  RoPE: OpenCL-tiled
+  Attention: OpenCL-tiled
+  SiLU: OpenCL-tiled
+  GELU: OpenCL-tiled
+  ReLU: OpenCL-tiled
+  ElementwiseAdd: OpenCL-tiled
+  ElementwiseMul: OpenCL-tiled
+  Scale: OpenCL-tiled
+  Embedding: OpenCL-tiled
+  Dequantize: OpenCL-tiled
+  KvCacheAppend: OpenCL-tiled

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_variant_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__kernel_variant_display_all.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "OpenCL-scalar",
+    "OpenCL-tiled",
+    "OpenCL-vec",
+    "CPU-SIMD",
+    "CPU-scalar",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__operation_category_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__operation_category_display_all.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "Matrix Ops",
+    "Norm Ops",
+    "Activation Ops",
+    "Position Encoding",
+    "Quantized Ops",
+    "Attention Ops",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__perf_report_empty.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__perf_report_empty.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: report
+---
+=== Kernel Performance Report ===
+Total kernels: 0
+Total time:    0.00ns
+
+Kernel                Count        Total          Avg   Throughput
+----------------------------------------------------------------------

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__perf_report_with_timings.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__perf_report_with_timings.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: report
+---
+=== Kernel Performance Report ===
+Total kernels: 4
+Total time:    2.75ms
+
+Kernel                Count        Total          Avg   Throughput
+----------------------------------------------------------------------
+matmul_fp16               2       2.30ms       1.15ms   56987826 e/s
+softmax                   1     300.00µs     300.00µs  106666667 e/s
+layer_norm                1     150.00µs     150.00µs   27306667 e/s

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__precision_support_display_all.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__precision_support_display_all.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "FP32",
+    "FP16",
+    "BF16",
+    "INT8",
+    "INT4",
+    "Binary",
+]

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__simd_caps_arch.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__simd_caps_arch.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: caps.arch
+---
+x86_64

--- a/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__support_level_display_variants.snap
+++ b/crates/bitnet-kernels/tests/snapshots/snapshot_wave27__support_level_display_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-kernels/tests/snapshot_wave27.rs
+expression: displays
+---
+[
+    "Full (95%)",
+    "Full (100%)",
+    "Partial (no FP16 native)",
+    "Emulated",
+    "Unsupported",
+]


### PR DESCRIPTION
Adds 60 insta snapshot tests across common, kernels, inference crates.