### PR TITLE
fuzz: wave 34 — 6 fuzz targets for KV cache, LayerNorm, RoPE, attention, sampling, weights

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -611,3 +611,33 @@ name = "fuzz_pipeline_parallel_stages"
 path = "fuzz_targets/fuzz_pipeline_parallel_stages.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_kv_cache_operations"
+path = "fuzz_targets/fuzz_kv_cache_operations.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_layer_norm_stability"
+path = "fuzz_targets/fuzz_layer_norm_stability.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_rope_encoding"
+path = "fuzz_targets/fuzz_rope_encoding.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_token_sampling"
+path = "fuzz_targets/fuzz_token_sampling.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_weight_loading"
+path = "fuzz_targets/fuzz_weight_loading.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_attention_scores.rs
+++ b/fuzz/fuzz_targets/fuzz_attention_scores.rs
@@ -1,6 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::attention::{AttentionConfig, AttentionKernel};
 use libfuzzer_sys::fuzz_target;
 
 #[derive(Arbitrary, Debug)]
@@ -11,7 +12,8 @@ struct AttentionInput {
     q_data: Vec<u8>,
     k_data: Vec<u8>,
     v_data: Vec<u8>,
-    use_causal_mask: bool,
+    use_causal: bool,
+    use_multi_head: bool,
 }
 
 fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
@@ -23,140 +25,104 @@ fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
         .collect()
 }
 
-fn softmax(logits: &mut [f32]) {
-    if logits.is_empty() {
-        return;
-    }
-    let max_val = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
-    if !max_val.is_finite() {
-        // Replace non-finite with uniform
-        let uniform = 1.0 / logits.len() as f32;
-        logits.fill(uniform);
-        return;
-    }
-    let mut sum = 0.0f32;
-    for v in logits.iter_mut() {
-        *v = (*v - max_val).exp();
-        sum += *v;
-    }
-    if sum > 0.0 && sum.is_finite() {
-        for v in logits.iter_mut() {
-            *v /= sum;
-        }
-    } else {
-        let uniform = 1.0 / logits.len() as f32;
-        logits.fill(uniform);
-    }
-}
-
-fn attention_scores(
-    q: &[f32],
-    k: &[f32],
-    v: &[f32],
-    seq_len: usize,
-    head_dim: usize,
-    causal: bool,
-) -> Vec<f32> {
-    let scale = 1.0 / (head_dim as f32).sqrt();
-    let mut scores = vec![0.0f32; seq_len * seq_len];
-
-    // Q @ K^T with scaling
-    for i in 0..seq_len {
-        for j in 0..seq_len {
-            let mut dot = 0.0f32;
-            for d in 0..head_dim {
-                dot += q[i * head_dim + d] * k[j * head_dim + d];
-            }
-            scores[i * seq_len + j] = dot * scale;
-        }
-    }
-
-    // Causal mask: set future positions to -inf
-    if causal {
-        for i in 0..seq_len {
-            for j in (i + 1)..seq_len {
-                scores[i * seq_len + j] = f32::NEG_INFINITY;
-            }
-        }
-    }
-
-    // Softmax per row
-    for i in 0..seq_len {
-        let row = &mut scores[i * seq_len..(i + 1) * seq_len];
-        softmax(row);
-    }
-
-    // Scores @ V
-    let mut output = vec![0.0f32; seq_len * head_dim];
-    for i in 0..seq_len {
-        for d in 0..head_dim {
-            let mut sum = 0.0f32;
-            for j in 0..seq_len {
-                sum += scores[i * seq_len + j] * v[j * head_dim + d];
-            }
-            output[i * head_dim + d] = sum;
-        }
-    }
-
-    output
-}
-
 fuzz_target!(|input: AttentionInput| {
-    let seq_len = (input.seq_len as usize % 16) + 1;
+    let seq_len = (input.seq_len as usize % 12) + 1;
     let head_dim = (input.head_dim as usize % 16) + 1;
     let n_heads = (input.n_heads as usize % 4) + 1;
-    let elems_per_head = seq_len * head_dim;
 
-    let q_all = bytes_to_f32(&input.q_data, n_heads * elems_per_head);
-    let k_all = bytes_to_f32(&input.k_data, n_heads * elems_per_head);
-    let v_all = bytes_to_f32(&input.v_data, n_heads * elems_per_head);
+    if input.use_multi_head {
+        // Multi-head attention path.
+        let model_dim = n_heads * head_dim;
+        let total = seq_len * model_dim;
 
-    if q_all.len() < n_heads * elems_per_head
-        || k_all.len() < n_heads * elems_per_head
-        || v_all.len() < n_heads * elems_per_head
-    {
-        return;
-    }
+        let q = bytes_to_f32(&input.q_data, total);
+        let k = bytes_to_f32(&input.k_data, total);
+        let v = bytes_to_f32(&input.v_data, total);
 
-    // Filter out inputs with NaN/inf to test pure numerical stability
-    let has_nonfinite =
-        q_all.iter().chain(k_all.iter()).chain(v_all.iter()).any(|x| !x.is_finite());
-    if has_nonfinite {
-        return;
-    }
+        if q.len() < total || k.len() < total || v.len() < total {
+            return;
+        }
+        if q[..total]
+            .iter()
+            .chain(k[..total].iter())
+            .chain(v[..total].iter())
+            .any(|x| !x.is_finite())
+        {
+            return;
+        }
 
-    for h in 0..n_heads {
-        let offset = h * elems_per_head;
-        let q = &q_all[offset..offset + elems_per_head];
-        let k = &k_all[offset..offset + elems_per_head];
-        let v = &v_all[offset..offset + elems_per_head];
+        let cfg = AttentionConfig {
+            num_heads: n_heads,
+            head_dim,
+            seq_len,
+            causal: input.use_causal,
+            use_alibi: false,
+            scale: None,
+        };
 
-        let output = attention_scores(q, k, v, seq_len, head_dim, input.use_causal_mask);
+        match AttentionKernel::multi_head_attention(&q[..total], &k[..total], &v[..total], &cfg) {
+            Ok(out) => {
+                // Invariant 1: Output shape matches [seq_len, n_heads * head_dim].
+                assert_eq!(out.len(), total, "multi_head output shape mismatch");
+                // Invariant 2: No NaN in output.
+                for (i, &val) in out.iter().enumerate() {
+                    assert!(!val.is_nan(), "multi_head NaN at idx {i}");
+                }
+            }
+            Err(_) => {} // Validation errors are fine.
+        }
+    } else {
+        // Single-head scaled dot-product path.
+        let elems = seq_len * head_dim;
 
-        // Invariant 1: Output shape matches [seq_len, head_dim]
-        assert_eq!(
-            output.len(),
-            elems_per_head,
-            "output shape mismatch: expected {elems_per_head}, got {}",
-            output.len()
-        );
+        let q = bytes_to_f32(&input.q_data, elems);
+        let k = bytes_to_f32(&input.k_data, elems);
+        let v = bytes_to_f32(&input.v_data, elems);
 
-        // Invariant 2: No NaN or Inf in output
-        for (i, &val) in output.iter().enumerate() {
-            assert!(val.is_finite(), "attention output non-finite at index {i}: {val} (head={h})");
+        if q.len() < elems || k.len() < elems || v.len() < elems {
+            return;
+        }
+        if q[..elems]
+            .iter()
+            .chain(k[..elems].iter())
+            .chain(v[..elems].iter())
+            .any(|x| !x.is_finite())
+        {
+            return;
+        }
+
+        let scale = 1.0 / (head_dim as f32).sqrt();
+
+        match AttentionKernel::scaled_dot_product(
+            &q[..elems],
+            &k[..elems],
+            &v[..elems],
+            None,
+            scale,
+            seq_len,
+            seq_len,
+            head_dim,
+        ) {
+            Ok(out) => {
+                // Invariant 3: Output shape matches [seq_len, head_dim].
+                assert_eq!(out.len(), elems, "sdp output shape mismatch");
+                // Invariant 4: No NaN in output.
+                for (i, &val) in out.iter().enumerate() {
+                    assert!(!val.is_nan(), "sdp NaN at idx {i}");
+                }
+            }
+            Err(_) => {}
         }
     }
 
-    // Invariant 3: With causal mask, running with seq_len=1 must match first row
-    if seq_len > 1 && !has_nonfinite {
-        let q_row = &q_all[..head_dim];
-        let k_row = &k_all[..head_dim];
-        let v_row = &v_all[..head_dim];
-
-        let single = attention_scores(q_row, k_row, v_row, 1, head_dim, input.use_causal_mask);
-        assert_eq!(single.len(), head_dim, "single-token output shape mismatch");
-        for &val in &single {
-            assert!(val.is_finite(), "single-token attention produced non-finite");
-        }
-    }
+    // Invariant 5: Zero-dimension configs must error, not panic.
+    let bad_cfg = AttentionConfig {
+        num_heads: 0,
+        head_dim: 0,
+        seq_len: 0,
+        causal: false,
+        use_alibi: false,
+        scale: None,
+    };
+    assert!(bad_cfg.validate().is_err(), "zero-dim config should fail validation");
 });

--- a/fuzz/fuzz_targets/fuzz_kv_cache_operations.rs
+++ b/fuzz/fuzz_targets/fuzz_kv_cache_operations.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_inference::cache::{CacheConfig, EvictionPolicy, KVCache};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct KvCacheOpsInput {
+    eviction_policy: u8,
+    max_size_kb: u8,
+    max_seq_len: u8,
+    ops: Vec<CacheOp>,
+}
+
+#[derive(Arbitrary, Debug)]
+enum CacheOp {
+    Store { layer: u8, position: u8, kv_len: u8 },
+    Get { layer: u8, position: u8 },
+    Contains { layer: u8, position: u8 },
+    Clear,
+    ClearLayer { layer: u8 },
+    CheckStats,
+    CheckSize,
+}
+
+fuzz_target!(|input: KvCacheOpsInput| {
+    let eviction_policy = match input.eviction_policy % 3 {
+        0 => EvictionPolicy::LRU,
+        1 => EvictionPolicy::FIFO,
+        _ => EvictionPolicy::LFU,
+    };
+    let max_size = ((input.max_size_kb as usize) + 1) * 1024;
+    let max_seq = (input.max_seq_len as usize % 64) + 1;
+
+    let config = CacheConfig {
+        max_size_bytes: max_size,
+        max_sequence_length: max_seq,
+        enable_compression: false,
+        eviction_policy,
+        block_size: 64,
+    };
+
+    let mut cache = match KVCache::new(config) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    // Invariant 1: Fresh cache has size 0.
+    assert_eq!(cache.size(), 0, "fresh cache should have size 0");
+
+    for op in input.ops.into_iter().take(256) {
+        match op {
+            CacheOp::Store { layer, position, kv_len } => {
+                let layer = layer as usize % 8;
+                let position = position as usize % max_seq;
+                let len = (kv_len as usize % 32) + 1;
+                let key = vec![1.0f32; len];
+                let value = vec![2.0f32; len];
+                // store must not panic; errors are acceptable.
+                let _ = cache.store(layer, position, key, value);
+            }
+            CacheOp::Get { layer, position } => {
+                let layer = layer as usize % 8;
+                let position = position as usize % max_seq;
+                // get must not panic.
+                let _ = cache.get(layer, position);
+            }
+            CacheOp::Contains { layer, position } => {
+                let layer = layer as usize % 8;
+                let position = position as usize % max_seq;
+                let _ = cache.contains(layer, position);
+            }
+            CacheOp::Clear => {
+                cache.clear();
+                // Invariant 2: After clear, size is 0.
+                assert_eq!(cache.size(), 0, "cache size should be 0 after clear");
+            }
+            CacheOp::ClearLayer { layer } => {
+                let layer = layer as usize % 8;
+                cache.clear_layer(layer);
+            }
+            CacheOp::CheckStats => {
+                let stats = cache.stats();
+                // Invariant 3: Stats fields must be sensible.
+                assert!(stats.hit_rate.is_finite(), "hit_rate must be finite");
+                assert!(stats.memory_efficiency.is_finite(), "memory_efficiency must be finite");
+            }
+            CacheOp::CheckSize => {
+                let _ = cache.size();
+                let pct = cache.usage_percent();
+                assert!(pct.is_finite(), "usage_percent must be finite");
+            }
+        }
+    }
+
+    // Invariant 4: Store then get returns the data.
+    cache.clear();
+    let k = vec![3.14f32; 4];
+    let v = vec![2.72f32; 4];
+    if cache.store(0, 0, k.clone(), v.clone()).is_ok() {
+        if let Some((got_k, got_v)) = cache.get(0, 0) {
+            assert_eq!(got_k, &k, "retrieved key must match stored key");
+            assert_eq!(got_v, &v, "retrieved value must match stored value");
+        }
+    }
+
+    // Invariant 5: contains returns true for stored entry.
+    if cache.contains(0, 0) {
+        assert!(cache.get(0, 0).is_some(), "contains=true but get=None");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_layer_norm_stability.rs
+++ b/fuzz/fuzz_targets/fuzz_layer_norm_stability.rs
@@ -1,0 +1,134 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_kernels::cpu::layer_norm::{LayerNormConfig, layer_norm, rms_norm};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct LayerNormStabilityInput {
+    dim: u8,
+    batch_size: u8,
+    raw_data: Vec<u8>,
+    raw_gamma: Vec<u8>,
+    raw_beta: Vec<u8>,
+    use_rms: bool,
+    /// Which extreme values to inject.
+    extreme_kind: u8,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: LayerNormStabilityInput| {
+    let dim = (input.dim as usize % 64) + 2;
+    let batch_size = (input.batch_size as usize % 4) + 1;
+    let total = batch_size * dim;
+
+    let mut data = bytes_to_f32(&input.raw_data, total);
+    let gamma_raw = bytes_to_f32(&input.raw_gamma, dim);
+    let beta_raw = bytes_to_f32(&input.raw_beta, dim);
+
+    if data.len() < total || gamma_raw.len() < dim || beta_raw.len() < dim {
+        return;
+    }
+
+    // Inject extreme values based on fuzz input to stress numerical stability.
+    match input.extreme_kind % 6 {
+        0 => { /* no injection — use raw fuzz bytes as-is */ }
+        1 => {
+            // Very large values
+            for x in data.iter_mut().take(dim) {
+                *x = f32::MAX / 4.0;
+            }
+        }
+        2 => {
+            // Very small (denormal) values
+            for x in data.iter_mut().take(dim) {
+                *x = f32::MIN_POSITIVE * 0.5;
+            }
+        }
+        3 => {
+            // Mixed large positive and large negative
+            for (i, x) in data.iter_mut().take(dim).enumerate() {
+                *x = if i % 2 == 0 { f32::MAX / 4.0 } else { f32::MIN / 4.0 };
+            }
+        }
+        4 => {
+            // All zeros
+            for x in data.iter_mut().take(dim) {
+                *x = 0.0;
+            }
+        }
+        _ => {
+            // Alternating denormal and large
+            for (i, x) in data.iter_mut().take(dim).enumerate() {
+                *x = if i % 2 == 0 { f32::MIN_POSITIVE * 0.1 } else { 1e30 };
+            }
+        }
+    }
+
+    // Filter out NaN/Inf in any input vector (we only test finite extremes).
+    if data[..total]
+        .iter()
+        .chain(gamma_raw[..dim].iter())
+        .chain(beta_raw[..dim].iter())
+        .any(|x| !x.is_finite())
+    {
+        return;
+    }
+
+    let config = LayerNormConfig::new(vec![dim]);
+    let gamma = &gamma_raw[..dim];
+    let beta = &beta_raw[..dim];
+
+    if input.use_rms {
+        match rms_norm(&data[..total], gamma, &config) {
+            Ok(out) => {
+                // Invariant 1: Output length matches input.
+                assert_eq!(out.len(), total, "rms_norm output length mismatch");
+                // Invariant 2: No NaN in output.
+                for (i, &v) in out.iter().enumerate() {
+                    assert!(!v.is_nan(), "rms_norm produced NaN at idx {i}");
+                }
+            }
+            Err(_) => {} // Errors are fine for invalid config.
+        }
+    } else {
+        match layer_norm(&data[..total], gamma, Some(beta), &config) {
+            Ok(out) => {
+                assert_eq!(out.len(), total, "layer_norm output length mismatch");
+                for (i, &v) in out.iter().enumerate() {
+                    assert!(!v.is_nan(), "layer_norm produced NaN at idx {i}");
+                }
+            }
+            Err(_) => {}
+        }
+
+        // Also test without beta.
+        match layer_norm(&data[..total], gamma, None, &config) {
+            Ok(out) => {
+                assert_eq!(out.len(), total);
+                for (i, &v) in out.iter().enumerate() {
+                    assert!(!v.is_nan(), "layer_norm (no beta) produced NaN at idx {i}");
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    // Invariant 3: Zero input with gamma=1, beta=0 must produce all-zero output.
+    let zero_input = vec![0.0f32; dim];
+    let ones = vec![1.0f32; dim];
+    let zeros = vec![0.0f32; dim];
+    if let Ok(out) = layer_norm(&zero_input, &ones, Some(&zeros), &config) {
+        for (i, &v) in out.iter().enumerate() {
+            assert!(v.is_finite(), "zero-input layer_norm non-finite at idx {i}");
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_rope_encoding.rs
+++ b/fuzz/fuzz_targets/fuzz_rope_encoding.rs
@@ -1,0 +1,111 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_rope::{build_tables, resolve_base};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct RopeEncodingInput {
+    dim: u8,
+    max_seq_len: u8,
+    base: f32,
+    position: u8,
+    vector_data: Vec<u8>,
+    resolve_base_arg: Option<f32>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    let aligned = (data.len() / 4) * 4;
+    data[..aligned]
+        .chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: RopeEncodingInput| {
+    // Exercise resolve_base with arbitrary input.
+    let _resolved = resolve_base(input.resolve_base_arg);
+
+    // Clamp dim to even number >= 2.
+    let dim = (((input.dim as usize) % 32) + 1) * 2;
+    let max_seq_len = (input.max_seq_len as usize % 128) + 1;
+    let position = input.position as usize % max_seq_len;
+
+    // Sanitise base: must be finite and positive for valid tables.
+    let base = input.base.abs();
+    if !base.is_finite() || base <= 0.0 {
+        // Non-finite / non-positive base: build_tables should return error, not panic.
+        let result = build_tables(dim, max_seq_len, input.base);
+        assert!(result.is_err() || result.is_ok(), "build_tables must not panic");
+        return;
+    }
+
+    let tables = match build_tables(dim, max_seq_len, base) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    // Invariant 1: Table dimensions match.
+    let half = tables.half_dim;
+    assert_eq!(half, dim / 2, "half_dim should be dim/2");
+    assert_eq!(tables.sin.len(), max_seq_len * half, "sin table size mismatch");
+    assert_eq!(tables.cos.len(), max_seq_len * half, "cos table size mismatch");
+
+    // Invariant 2: sin²+cos² ≈ 1 for every element.
+    for (s, c) in tables.sin.iter().zip(&tables.cos) {
+        let norm = s * s + c * c;
+        assert!((norm - 1.0).abs() < 1e-4, "sin²+cos²={norm} ≠ 1.0 (sin={s}, cos={c})");
+    }
+
+    // Invariant 3: No NaN or Inf in tables.
+    for &v in tables.sin.iter().chain(tables.cos.iter()) {
+        assert!(v.is_finite(), "table entry non-finite: {v}");
+    }
+
+    // Apply rotation to a fuzz-generated vector.
+    let raw = bytes_to_f32(&input.vector_data, dim);
+    if raw.len() < dim {
+        return;
+    }
+    let vec_data = &raw[..dim];
+    if vec_data.iter().any(|x| !x.is_finite()) {
+        return;
+    }
+
+    let row_offset = position * half;
+    if row_offset + half > tables.sin.len() {
+        return;
+    }
+
+    let sin_row = &tables.sin[row_offset..row_offset + half];
+    let cos_row = &tables.cos[row_offset..row_offset + half];
+
+    let mut rotated = vec![0.0f32; dim];
+    for i in 0..half {
+        let x0 = vec_data[i];
+        let x1 = vec_data[i + half];
+        rotated[i] = x0 * cos_row[i] - x1 * sin_row[i];
+        rotated[i + half] = x0 * sin_row[i] + x1 * cos_row[i];
+    }
+
+    // Invariant 4: No NaN/Inf in rotated output.
+    for (i, &v) in rotated.iter().enumerate() {
+        assert!(v.is_finite(), "rotated output non-finite at idx {i}: {v}");
+    }
+
+    // Invariant 5: Norm preservation.
+    let norm_in: f32 = vec_data.iter().map(|x| x * x).sum();
+    let norm_out: f32 = rotated.iter().map(|x| x * x).sum();
+    if norm_in > 1e-10 {
+        let ratio = norm_out / norm_in;
+        assert!(
+            (ratio - 1.0).abs() < 1e-3,
+            "norm not preserved: in={norm_in} out={norm_out} ratio={ratio}"
+        );
+    }
+
+    // Invariant 6: Zero dim and odd dim should error, not panic.
+    assert!(build_tables(0, max_seq_len, base).is_err(), "dim=0 should error");
+    assert!(build_tables(1, max_seq_len, base).is_err(), "odd dim should error");
+});

--- a/fuzz/fuzz_targets/fuzz_token_sampling.rs
+++ b/fuzz/fuzz_targets/fuzz_token_sampling.rs
@@ -1,0 +1,102 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_sampling::{SamplingConfig, SamplingStrategy, greedy_sample};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct TokenSamplingInput {
+    raw_logits: Vec<u8>,
+    context_tokens: Vec<u8>,
+    temperature: f32,
+    top_k: u16,
+    top_p: f32,
+    repetition_penalty: f32,
+    seed: Option<u64>,
+    try_greedy: bool,
+}
+
+fuzz_target!(|input: TokenSamplingInput| {
+    // Decode raw bytes into f32 logits.
+    let aligned_len = (input.raw_logits.len() / 4) * 4;
+    if aligned_len == 0 {
+        return;
+    }
+    let logits: Vec<f32> = input.raw_logits[..aligned_len]
+        .chunks_exact(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .take(4096)
+        .collect();
+    if logits.is_empty() {
+        return;
+    }
+
+    let vocab_size = logits.len();
+    let context_tokens: Vec<u32> =
+        input.context_tokens.iter().map(|&b| b as u32).take(128).collect();
+
+    // Test greedy sampling path.
+    if input.try_greedy {
+        match greedy_sample(&logits) {
+            Ok(token_id) => {
+                // Invariant 1: Greedy token is in-bounds.
+                assert!(
+                    (token_id as usize) < vocab_size,
+                    "greedy_sample OOB: {token_id} >= {vocab_size}"
+                );
+                // Invariant 2: Greedy selects the argmax when finite.
+                if logits.iter().all(|x| x.is_finite()) {
+                    let expected = logits
+                        .iter()
+                        .enumerate()
+                        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                        .map(|(i, _)| i as u32)
+                        .unwrap();
+                    assert_eq!(token_id, expected, "greedy_sample did not select argmax");
+                }
+            }
+            Err(_) => {}
+        }
+    }
+
+    // Test configurable sampling.
+    let config = SamplingConfig {
+        temperature: input.temperature,
+        top_k: (input.top_k as u32).min(vocab_size as u32),
+        top_p: input.top_p,
+        repetition_penalty: input.repetition_penalty,
+        seed: input.seed,
+    };
+
+    let mut strategy = SamplingStrategy::new(config);
+
+    match strategy.sample(&logits, &context_tokens) {
+        Ok(token_id) => {
+            // Invariant 3: Sampled token is in-bounds.
+            assert!((token_id as usize) < vocab_size, "sample OOB: {token_id} >= {vocab_size}");
+        }
+        // Errors are acceptable (all-NaN input, empty after filtering, etc.).
+        Err(_) => {}
+    }
+
+    // Invariant 4: Deterministic seed produces same result twice.
+    if let Some(seed) = input.seed {
+        let det_config = SamplingConfig {
+            temperature: 1.0,
+            top_k: 0,
+            top_p: 1.0,
+            repetition_penalty: 1.0,
+            seed: Some(seed),
+        };
+        // Only test with all-finite logits for determinism check.
+        if logits.iter().all(|x| x.is_finite()) {
+            let mut s1 = SamplingStrategy::new(det_config.clone());
+            let mut s2 = SamplingStrategy::new(det_config);
+            let r1 = s1.sample(&logits, &[]);
+            let r2 = s2.sample(&logits, &[]);
+            if let (Ok(t1), Ok(t2)) = (r1, r2) {
+                assert_eq!(t1, t2, "same seed should produce same token");
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_weight_loading.rs
+++ b/fuzz/fuzz_targets/fuzz_weight_loading.rs
@@ -1,0 +1,44 @@
+#![no_main]
+
+use bitnet_gguf::kv::parse_header as parse_kv_header;
+use bitnet_gguf::{GgufValueType, check_magic, parse_header, read_version};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    // Fuzz all GGUF parsing entry points with arbitrary / corrupted bytes.
+    // None of these should panic; errors are expected.
+
+    // 1. Magic check.
+    let _ = check_magic(data);
+
+    // 2. Version read.
+    let _ = read_version(data);
+
+    // 3. Top-level header parse.
+    let _ = parse_header(data);
+
+    // 4. KV-layer header parse.
+    let _ = parse_kv_header(data);
+
+    // 5. GgufValueType discriminant for every 4-byte window.
+    for chunk in data.windows(4) {
+        let disc = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let _ = GgufValueType::from_u32(disc);
+    }
+
+    // 6. Progressively truncated slices to probe off-by-one paths.
+    let max_trim = data.len().min(64);
+    for trim in 1..max_trim {
+        let truncated = &data[..data.len() - trim];
+        let _ = parse_header(truncated);
+        let _ = parse_kv_header(truncated);
+    }
+
+    // 7. Byte-shifted slices to stress alignment handling.
+    for offset in 1..data.len().min(8) {
+        let shifted = &data[offset..];
+        let _ = check_magic(shifted);
+        let _ = read_version(shifted);
+        let _ = parse_header(shifted);
+    }
+});


### PR DESCRIPTION
## Summary

Add 6 new fuzz targets (wave 34) exercising core inference, kernel, and parsing APIs.

### New Targets

| Target | Crate Under Test | What It Fuzzes |
|--------|-----------------|----------------|
| `fuzz_kv_cache_operations` | `bitnet-inference` | `KVCache::store/get/clear/clear_layer` with arbitrary op sequences and eviction policies |
| `fuzz_layer_norm_stability` | `bitnet-kernels` | `layer_norm` and `rms_norm` with extreme finite values (MAX/2, denormals, zeros, mixed) |
| `fuzz_rope_encoding` | `bitnet-rope` | `build_tables` + manual rotation with arbitrary dims, positions, base frequencies |
| `fuzz_attention_scores` | `bitnet-kernels` | `AttentionKernel::scaled_dot_product` and `multi_head_attention` (upgraded from hand-rolled impl) |
| `fuzz_token_sampling` | `bitnet-sampling` | `SamplingStrategy::sample` and `greedy_sample` with arbitrary logits/temperatures |
| `fuzz_weight_loading` | `bitnet-gguf` | Header/KV parsing with corrupted, truncated, and byte-shifted byte slices |

### Key Invariants Verified

- **KV Cache**: Store-then-get round-trip, clear zeroes size, contains consistency
- **LayerNorm**: No NaN output for finite extreme inputs, output length preservation
- **RoPE**: sin²+cos²≈1, norm preservation under rotation, error on invalid dims
- **Attention**: Output shape correctness, no NaN for finite inputs, zero-dim validation
- **Sampling**: In-bounds token selection, greedy=argmax, deterministic seed reproducibility
- **GGUF**: All parse functions handle arbitrary/corrupted bytes without panicking

### Verification

```
cargo check --bin fuzz_kv_cache_operations --bin fuzz_layer_norm_stability \
  --bin fuzz_rope_encoding --bin fuzz_attention_scores \
  --bin fuzz_token_sampling --bin fuzz_weight_loading  # ✅ all pass
```
