### PR TITLE
test(snapshot): wave 28 — 45 insta tests across inference, common, quantization

### DIFF
--- a/crates/bitnet-common/tests/snapshot_wave28.rs
+++ b/crates/bitnet-common/tests/snapshot_wave28.rs
@@ -1,0 +1,130 @@
+//! Wave 28 insta snapshot tests for bitnet-common types.
+
+use bitnet_common::{
+    BitNetError, Device, InferenceError, KernelBackend, KernelCapabilities, KernelError,
+    ModelError, QuantizationError, QuantizationType, SimdLevel, ValidationErrorDetails,
+};
+
+// ── Device ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_device_cpu() {
+    insta::assert_debug_snapshot!(Device::Cpu);
+}
+
+#[test]
+fn snapshot_device_cuda_0() {
+    insta::assert_debug_snapshot!(Device::Cuda(0));
+}
+
+#[test]
+fn snapshot_device_cuda_1() {
+    insta::assert_debug_snapshot!(Device::Cuda(1));
+}
+
+// ── QuantizationType ─────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_quantization_type_all_variants() {
+    let variants = vec![QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snapshot_quantization_type_display() {
+    let displays: Vec<String> =
+        vec![QuantizationType::I2S, QuantizationType::TL1, QuantizationType::TL2]
+            .into_iter()
+            .map(|q| q.to_string())
+            .collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+// ── KernelBackend / SimdLevel ────────────────────────────────────────────────
+
+#[test]
+fn snapshot_kernel_backend_variants() {
+    let backends = vec![
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::OpenCL,
+        KernelBackend::CppFfi,
+    ];
+    insta::assert_debug_snapshot!(backends);
+}
+
+#[test]
+fn snapshot_kernel_backend_display() {
+    let displays: Vec<String> = vec![
+        KernelBackend::CpuRust,
+        KernelBackend::Cuda,
+        KernelBackend::Hip,
+        KernelBackend::OneApi,
+        KernelBackend::OpenCL,
+        KernelBackend::CppFfi,
+    ]
+    .into_iter()
+    .map(|b| b.to_string())
+    .collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+#[test]
+fn snapshot_simd_level_all_variants() {
+    let levels = vec![
+        SimdLevel::Scalar,
+        SimdLevel::Neon,
+        SimdLevel::Sse42,
+        SimdLevel::Avx2,
+        SimdLevel::Avx512,
+    ];
+    insta::assert_debug_snapshot!(levels);
+}
+
+#[test]
+fn snapshot_kernel_capabilities_compile_time() {
+    let caps = KernelCapabilities::from_compile_time();
+    insta::assert_debug_snapshot!(caps);
+}
+
+// ── Error Display ────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_bitnet_error_config_display() {
+    let err = BitNetError::Config("missing model path".to_string());
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_bitnet_error_validation_display() {
+    let err = BitNetError::Validation("tensor shape mismatch".to_string());
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_bitnet_error_strict_mode_display() {
+    let err = BitNetError::StrictMode("suspicious LayerNorm gamma".to_string());
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_inference_error_display() {
+    let err = BitNetError::Inference(InferenceError::GenerationFailed {
+        reason: "out of memory".to_string(),
+    });
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_model_error_not_found_display() {
+    let err = BitNetError::Model(ModelError::NotFound { path: "/tmp/missing.gguf".to_string() });
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_quantization_error_invalid_block_display() {
+    let err = BitNetError::Quantization(QuantizationError::InvalidBlockSize { size: 0 });
+    insta::assert_snapshot!(err.to_string());
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_config_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_config_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Configuration error: missing model path

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_strict_mode_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_strict_mode_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Strict mode violation: suspicious LayerNorm gamma

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_validation_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_bitnet_error_validation_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Validation error: tensor shape mismatch

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cpu.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cpu.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: "Device::Cpu"
+---
+Cpu

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cuda_0.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cuda_0.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: "Device::Cuda(0)"
+---
+Cuda(
+    0,
+)

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cuda_1.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_device_cuda_1.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: "Device::Cuda(1)"
+---
+Cuda(
+    1,
+)

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_inference_error_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_inference_error_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Inference error: Generation failed: out of memory

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_backend_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_backend_display.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: displays
+---
+[
+    "cpu-rust",
+    "cuda",
+    "hip",
+    "oneapi",
+    "opencl",
+    "cpp-ffi",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_backend_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_backend_variants.snap
@@ -1,0 +1,12 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: backends
+---
+[
+    CpuRust,
+    Cuda,
+    Hip,
+    OneApi,
+    OpenCL,
+    CppFfi,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_capabilities_compile_time.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_kernel_capabilities_compile_time.snap
@@ -1,0 +1,17 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: caps
+---
+KernelCapabilities {
+    cpu_rust: true,
+    cuda_compiled: false,
+    cuda_runtime: false,
+    hip_compiled: false,
+    hip_runtime: false,
+    oneapi_compiled: false,
+    oneapi_runtime: false,
+    opencl_compiled: false,
+    opencl_runtime: false,
+    cpp_ffi: false,
+    simd_level: Scalar,
+}

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_model_error_not_found_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_model_error_not_found_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Model error: Model not found: /tmp/missing.gguf

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_error_invalid_block_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_error_invalid_block_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Quantization error: Invalid block size: 0

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_type_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_type_all_variants.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: variants
+---
+[
+    I2S,
+    TL1,
+    TL2,
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_type_display.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_quantization_type_display.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: displays
+---
+[
+    "I2_S",
+    "TL1",
+    "TL2",
+]

--- a/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_simd_level_all_variants.snap
+++ b/crates/bitnet-common/tests/snapshots/snapshot_wave28__snapshot_simd_level_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-common/tests/snapshot_wave28.rs
+expression: levels
+---
+[
+    Scalar,
+    Neon,
+    Sse42,
+    Avx2,
+    Avx512,
+]

--- a/crates/bitnet-inference/tests/snapshot_wave28.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave28.rs
@@ -1,0 +1,125 @@
+//! Wave 28 insta snapshot tests for bitnet-inference types.
+
+use bitnet_inference::generation::autoregressive::GenerationConfig;
+use bitnet_inference::generation::sampling::{SamplingConfig, SamplingStrategy};
+use bitnet_inference::generation_budget::{GenerationBudget, StopReason};
+
+// ── SamplingConfig / SamplingStrategy ────────────────────────────────────────
+
+#[test]
+fn snapshot_sampling_config_default() {
+    let cfg = SamplingConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_sampling_strategy_deterministic() {
+    let s = SamplingStrategy::deterministic();
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn snapshot_sampling_strategy_creative() {
+    let s = SamplingStrategy::creative();
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn snapshot_sampling_strategy_balanced() {
+    let s = SamplingStrategy::balanced();
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn snapshot_sampling_strategy_conservative() {
+    let s = SamplingStrategy::conservative();
+    insta::assert_debug_snapshot!(s);
+}
+
+#[test]
+fn snapshot_sampling_config_custom_temperature() {
+    let cfg = SamplingConfig {
+        temperature: 0.42,
+        top_k: Some(10),
+        top_p: Some(0.85),
+        repetition_penalty: 1.3,
+        do_sample: true,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ── GenerationConfig ─────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_generation_config_default() {
+    let cfg = GenerationConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_generation_config_custom() {
+    let mut cfg = GenerationConfig::default();
+    cfg.max_new_tokens = 128;
+    cfg.temperature = 0.7;
+    cfg.top_k = Some(20);
+    cfg.top_p = Some(0.95);
+    cfg.repetition_penalty = 1.05;
+    cfg.do_sample = false;
+    cfg.seed = Some(42);
+    cfg.eos_token_id = 128009;
+    cfg.pad_token_id = 0;
+    cfg.min_length = 1;
+    cfg.max_length = 4096;
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ── GenerationBudget ─────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_generation_budget_default() {
+    let budget = GenerationBudget::default();
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn snapshot_generation_budget_with_limits() {
+    let budget = GenerationBudget::new(1024)
+        .with_time_limit(std::time::Duration::from_secs(60))
+        .with_memory_limit(1024 * 1024 * 512);
+    insta::assert_debug_snapshot!(budget);
+}
+
+#[test]
+fn snapshot_generation_budget_unlimited() {
+    let budget = GenerationBudget::unlimited();
+    insta::assert_debug_snapshot!(budget);
+}
+
+// ── StopReason ───────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_stop_reason_all_variants_debug() {
+    let variants = vec![
+        StopReason::MaxTokens,
+        StopReason::TimeLimit,
+        StopReason::MemoryLimit,
+        StopReason::EndOfSequence,
+        StopReason::UserStop,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snapshot_stop_reason_max_tokens_display() {
+    insta::assert_snapshot!(StopReason::MaxTokens.to_string());
+}
+
+#[test]
+fn snapshot_stop_reason_end_of_sequence_display() {
+    insta::assert_snapshot!(StopReason::EndOfSequence.to_string());
+}
+
+#[test]
+fn snapshot_stop_reason_user_stop_display() {
+    insta::assert_snapshot!(StopReason::UserStop.to_string());
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 256,
+    max_time: None,
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_unlimited.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_unlimited.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 18446744073709551615,
+    max_time: None,
+    max_memory_bytes: None,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_with_limits.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_budget_with_limits.snap
@@ -1,0 +1,13 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: budget
+---
+GenerationBudget {
+    max_tokens: 1024,
+    max_time: Some(
+        60s,
+    ),
+    max_memory_bytes: Some(
+        536870912,
+    ),
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_config_custom.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_config_custom.snap
@@ -1,0 +1,23 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 128,
+    temperature: 0.7,
+    top_k: Some(
+        20,
+    ),
+    top_p: Some(
+        0.95,
+    ),
+    repetition_penalty: 1.05,
+    do_sample: false,
+    seed: Some(
+        42,
+    ),
+    eos_token_id: 128009,
+    pad_token_id: 0,
+    min_length: 1,
+    max_length: 4096,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_generation_config_default.snap
@@ -1,0 +1,21 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: cfg
+---
+GenerationConfig {
+    max_new_tokens: 512,
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+    seed: None,
+    eos_token_id: 2,
+    pad_token_id: 0,
+    min_length: 1,
+    max_length: 2048,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_config_custom_temperature.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_config_custom_temperature.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 0.42,
+    top_k: Some(
+        10,
+    ),
+    top_p: Some(
+        0.85,
+    ),
+    repetition_penalty: 1.3,
+    do_sample: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_config_default.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_config_default.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: cfg
+---
+SamplingConfig {
+    temperature: 1.0,
+    top_k: Some(
+        50,
+    ),
+    top_p: Some(
+        0.9,
+    ),
+    repetition_penalty: 1.1,
+    do_sample: true,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_balanced.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_balanced.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: s
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 0.8,
+        top_k: Some(
+            50,
+        ),
+        top_p: Some(
+            0.95,
+        ),
+        repetition_penalty: 1.1,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.1,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_conservative.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_conservative.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: s
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 0.3,
+        top_k: Some(
+            20,
+        ),
+        top_p: Some(
+            0.8,
+        ),
+        repetition_penalty: 1.05,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.05,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_creative.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_creative.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: s
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 1.2,
+        top_k: Some(
+            100,
+        ),
+        top_p: Some(
+            0.9,
+        ),
+        repetition_penalty: 1.2,
+        do_sample: true,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.2,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_deterministic.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_sampling_strategy_deterministic.snap
@@ -1,0 +1,15 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: s
+---
+SamplingStrategy {
+    config: SamplingConfig {
+        temperature: 1.0,
+        top_k: None,
+        top_p: None,
+        repetition_penalty: 1.0,
+        do_sample: false,
+    },
+    repetition_counts: {},
+    current_repetition_penalty: 1.0,
+}

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_all_variants_debug.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_all_variants_debug.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: variants
+---
+[
+    MaxTokens,
+    TimeLimit,
+    MemoryLimit,
+    EndOfSequence,
+    UserStop,
+]

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_end_of_sequence_display.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_end_of_sequence_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: "StopReason::EndOfSequence.to_string()"
+---
+end_of_sequence

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_max_tokens_display.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_max_tokens_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: "StopReason::MaxTokens.to_string()"
+---
+max_tokens

--- a/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_user_stop_display.snap
+++ b/crates/bitnet-inference/tests/snapshots/snapshot_wave28__snapshot_stop_reason_user_stop_display.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-inference/tests/snapshot_wave28.rs
+expression: "StopReason::UserStop.to_string()"
+---
+user_stop

--- a/crates/bitnet-quantization/tests/snapshot_wave28.rs
+++ b/crates/bitnet-quantization/tests/snapshot_wave28.rs
@@ -1,0 +1,162 @@
+//! Wave 28 insta snapshot tests for bitnet-quantization types.
+
+use bitnet_quantization::device_aware_quantizer::{
+    CPUQuantizer, QuantizationType as DeviceQuantizationType, ToleranceConfig,
+};
+use bitnet_quantization::{I2SLayout, QuantizationConfig};
+
+// ── QuantizationConfig ───────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_quantization_config_default() {
+    let cfg = QuantizationConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_quantization_config_tl1() {
+    let cfg = QuantizationConfig {
+        quantization_type: bitnet_common::QuantizationType::TL1,
+        block_size: 64,
+        precision: 1e-4,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+#[test]
+fn snapshot_quantization_config_tl2() {
+    let cfg = QuantizationConfig {
+        quantization_type: bitnet_common::QuantizationType::TL2,
+        block_size: 128,
+        precision: 1e-3,
+    };
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ── I2SLayout ────────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_i2s_layout_default() {
+    let layout = I2SLayout::default();
+    let desc = format!(
+        "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block,
+    );
+    insta::assert_snapshot!(desc);
+}
+
+#[test]
+fn snapshot_i2s_layout_block_size_256() {
+    let layout = I2SLayout::with_block_size(256);
+    let desc = format!(
+        "block_size={} bytes_per_block={} data_bytes={} scale_bytes={}",
+        layout.block_size,
+        layout.bytes_per_block,
+        layout.data_bytes_per_block,
+        layout.scale_bytes_per_block,
+    );
+    insta::assert_snapshot!(desc);
+}
+
+// ── ToleranceConfig ──────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_tolerance_config_default() {
+    let cfg = ToleranceConfig::default();
+    insta::assert_debug_snapshot!(cfg);
+}
+
+// ── Device-aware QuantizationType ────────────────────────────────────────────
+
+#[test]
+fn snapshot_device_quantization_type_all_variants() {
+    let variants = vec![
+        DeviceQuantizationType::I2S,
+        DeviceQuantizationType::TL1,
+        DeviceQuantizationType::TL2,
+        DeviceQuantizationType::IQ2S,
+        DeviceQuantizationType::FP32,
+    ];
+    insta::assert_debug_snapshot!(variants);
+}
+
+#[test]
+fn snapshot_device_quantization_type_display() {
+    let displays: Vec<String> = vec![
+        DeviceQuantizationType::I2S,
+        DeviceQuantizationType::TL1,
+        DeviceQuantizationType::TL2,
+        DeviceQuantizationType::IQ2S,
+        DeviceQuantizationType::FP32,
+    ]
+    .into_iter()
+    .map(|q| q.to_string())
+    .collect();
+    insta::assert_debug_snapshot!(displays);
+}
+
+// ── Quantize / Dequantize round-trip ─────────────────────────────────────────
+
+#[test]
+fn snapshot_cpu_quantize_i2s_known_input() {
+    let tol = ToleranceConfig::default();
+    let cpu = CPUQuantizer::new(tol);
+    let input: Vec<f32> = vec![0.0, 1.0, -1.0, 0.5, -0.5, 0.25, -0.25, 0.75];
+    let quantized = cpu.quantize_i2s(&input).expect("quantize_i2s");
+    insta::assert_debug_snapshot!(quantized);
+}
+
+#[test]
+fn snapshot_cpu_dequantize_i2s_round_trip() {
+    let tol = ToleranceConfig::default();
+    let cpu = CPUQuantizer::new(tol);
+    let input: Vec<f32> = vec![0.0, 1.0, -1.0, 0.5, -0.5, 0.25, -0.25, 0.75];
+    let quantized = cpu.quantize_i2s(&input).expect("quantize_i2s");
+    let output = cpu.dequantize_i2s(&quantized).expect("dequantize_i2s");
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snapshot_cpu_quantize_tl1_known_input() {
+    let tol = ToleranceConfig::default();
+    let cpu = CPUQuantizer::new(tol);
+    let input: Vec<f32> = vec![0.0, 1.0, -1.0, 0.5, -0.5, 0.25, -0.25, 0.75];
+    let quantized = cpu.quantize_tl1(&input).expect("quantize_tl1");
+    insta::assert_debug_snapshot!(quantized);
+}
+
+#[test]
+fn snapshot_cpu_dequantize_tl1_round_trip() {
+    let tol = ToleranceConfig::default();
+    let cpu = CPUQuantizer::new(tol);
+    let input: Vec<f32> = vec![0.0, 1.0, -1.0, 0.5, -0.5, 0.25, -0.25, 0.75];
+    let quantized = cpu.quantize_tl1(&input).expect("quantize_tl1");
+    let output = cpu.dequantize_tl1(&quantized).expect("dequantize_tl1");
+    insta::assert_debug_snapshot!(output);
+}
+
+#[test]
+fn snapshot_cpu_quantize_tl2_known_input() {
+    let tol = ToleranceConfig::default();
+    let cpu = CPUQuantizer::new(tol);
+    let input: Vec<f32> = vec![0.0, 1.0, -1.0, 0.5, -0.5, 0.25, -0.25, 0.75];
+    let quantized = cpu.quantize_tl2(&input).expect("quantize_tl2");
+    insta::assert_debug_snapshot!(quantized);
+}
+
+// ── Error messages ───────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_quantization_error_invalid_block_size() {
+    let err = bitnet_common::QuantizationError::InvalidBlockSize { size: 0 };
+    insta::assert_snapshot!(err.to_string());
+}
+
+#[test]
+fn snapshot_quantization_error_unsupported_type() {
+    let err = bitnet_common::QuantizationError::UnsupportedType { qtype: "Q4_K_M".to_string() };
+    insta::assert_snapshot!(err.to_string());
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_dequantize_i2s_round_trip.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_dequantize_i2s_round_trip.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: output
+---
+[
+    0.0,
+    1.0,
+    -1.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.0,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_dequantize_tl1_round_trip.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_dequantize_tl1_round_trip.snap
@@ -1,0 +1,14 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: output
+---
+[
+    -0.0667,
+    1.0,
+    -1.0,
+    0.4667,
+    -0.6,
+    0.2,
+    -0.3333,
+    0.7333,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_i2s_known_input.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_i2s_known_input.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: quantized
+---
+QuantizedTensor {
+    data: [
+        52,
+        64,
+    ],
+    qtype: I2S,
+    shape: [
+        8,
+    ],
+    scales: [
+        1.0,
+    ],
+    zero_points: None,
+    block_size: 32,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_tl1_known_input.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_tl1_known_input.snap
@@ -1,0 +1,25 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: quantized
+---
+QuantizedTensor {
+    data: [
+        7,
+        15,
+        0,
+        11,
+        3,
+        9,
+        5,
+        13,
+    ],
+    qtype: TL1,
+    shape: [
+        8,
+    ],
+    scales: [
+        1.0,
+    ],
+    zero_points: None,
+    block_size: 16,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_tl2_known_input.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_cpu_quantize_tl2_known_input.snap
@@ -1,0 +1,19 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: quantized
+---
+QuantizedTensor {
+    data: [
+        141,
+        148,
+    ],
+    qtype: TL2,
+    shape: [
+        8,
+    ],
+    scales: [
+        1.0,
+    ],
+    zero_points: None,
+    block_size: 32,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_device_quantization_type_all_variants.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_device_quantization_type_all_variants.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: variants
+---
+[
+    I2S,
+    TL1,
+    TL2,
+    IQ2S,
+    FP32,
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_device_quantization_type_display.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_device_quantization_type_display.snap
@@ -1,0 +1,11 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: displays
+---
+[
+    "I2_S",
+    "TL1",
+    "TL2",
+    "IQ2_S",
+    "FP32",
+]

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_i2s_layout_block_size_256.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_i2s_layout_block_size_256.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: desc
+---
+block_size=256 bytes_per_block=66 data_bytes=64 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_i2s_layout_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_i2s_layout_default.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: desc
+---
+block_size=32 bytes_per_block=10 data_bytes=8 scale_bytes=2

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_default.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: cfg
+---
+QuantizationConfig {
+    quantization_type: I2S,
+    block_size: 64,
+    precision: 0.0001,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_tl1.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_tl1.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: cfg
+---
+QuantizationConfig {
+    quantization_type: TL1,
+    block_size: 64,
+    precision: 0.0001,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_tl2.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_config_tl2.snap
@@ -1,0 +1,9 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: cfg
+---
+QuantizationConfig {
+    quantization_type: TL2,
+    block_size: 128,
+    precision: 0.001,
+}

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_error_invalid_block_size.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_error_invalid_block_size.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Invalid block size: 0

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_error_unsupported_type.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_quantization_error_unsupported_type.snap
@@ -1,0 +1,5 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: err.to_string()
+---
+Unsupported quantization type: Q4_K_M

--- a/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_tolerance_config_default.snap
+++ b/crates/bitnet-quantization/tests/snapshots/snapshot_wave28__snapshot_tolerance_config_default.snap
@@ -1,0 +1,10 @@
+---
+source: crates/bitnet-quantization/tests/snapshot_wave28.rs
+expression: cfg
+---
+ToleranceConfig {
+    i2s_tolerance: 0.001,
+    tl_tolerance: 0.01,
+    perplexity_tolerance: 0.001,
+    strict_validation: true,
+}


### PR DESCRIPTION
## Summary

Add 45 insta snapshot tests across three crates to lock down Debug/Display output for key types.

### bitnet-inference (15 snapshots)
- SamplingConfig default and custom
- SamplingStrategy presets (deterministic, creative, balanced, conservative)
- GenerationConfig default and custom
- GenerationBudget default, with limits, unlimited
- StopReason all variants (Debug + Display)

### bitnet-common (15 snapshots)
- Device variants (Cpu, Cuda(0), Cuda(1))
- QuantizationType all variants (Debug + Display)
- KernelBackend all variants (Debug + Display)
- SimdLevel all variants
- KernelCapabilities from compile-time
- BitNetError Display for Config, Validation, StrictMode, Inference, Model, Quantization

### bitnet-quantization (15 snapshots)
- QuantizationConfig for I2S (default), TL1, TL2
- I2SLayout default and block_size=256
- ToleranceConfig default
- DeviceQuantizationType all variants (Debug + Display)
- CPU quantize/dequantize round-trips (I2S, TL1, TL2)
- Quantization error messages

### Testing
```bash
cargo test -p bitnet-common --test snapshot_wave28 --no-default-features --features cpu
cargo test -p bitnet-inference --test snapshot_wave28 --no-default-features --features cpu
cargo test -p bitnet-quantization --test snapshot_wave28 --no-default-features --features cpu
```
All 45 tests pass.