### PR TITLE
feat(kernels): add cuda_tensor_ops module with CPU reference implementations

### DIFF
--- a/crates/bitnet-kernels/src/cuda_tensor_ops.rs
+++ b/crates/bitnet-kernels/src/cuda_tensor_ops.rs
@@ -1,0 +1,793 @@
+//! CUDA-style element-wise tensor operations with CPU reference implementations.
+//!
+//! Provides unary/binary elementwise ops, fused multiply-add, broadcasting,
+//! and tensor comparison utilities suitable for cross-validation against GPU kernels.
+
+use std::fmt;
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by tensor operations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TensorOpError {
+    /// Operand shapes are incompatible for the requested broadcast.
+    ShapeMismatch { a_len: usize, b_len: usize },
+    /// An input slice was unexpectedly empty.
+    EmptyTensor,
+    /// Division by zero encountered at the given index.
+    DivisionByZero { index: usize },
+    /// A domain error (e.g. log of negative number).
+    DomainError { op: String, index: usize, value: f32 },
+}
+
+impl fmt::Display for TensorOpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ShapeMismatch { a_len, b_len } => {
+                write!(f, "shape mismatch: a.len()={a_len}, b.len()={b_len}")
+            }
+            Self::EmptyTensor => write!(f, "empty tensor"),
+            Self::DivisionByZero { index } => {
+                write!(f, "division by zero at index {index}")
+            }
+            Self::DomainError { op, index, value } => {
+                write!(f, "domain error in {op} at index {index}: value={value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TensorOpError {}
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/// Element-wise operations supported on tensors.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TensorOp {
+    // Binary arithmetic
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Max,
+    Min,
+
+    // Unary
+    Abs,
+    Neg,
+    Sqrt,
+    Rsqrt,
+    Exp,
+    Log,
+    Tanh,
+    Sigmoid,
+    Gelu,
+    Silu,
+    Relu,
+    LeakyRelu(f32),
+    Clamp { min: f32, max: f32 },
+}
+
+/// Broadcasting rules for binary operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BroadcastRule {
+    /// Both tensors have the same length – no broadcast needed.
+    NoBroadcast,
+    /// `b` is a scalar (len 1) broadcast to the shape of `a`.
+    ScalarB,
+    /// `a` is a scalar (len 1) broadcast to the shape of `b`.
+    ScalarA,
+}
+
+/// Result of comparing two tensors element-wise.
+#[derive(Debug, Clone)]
+pub struct ComparisonResult {
+    pub all_close: bool,
+    pub max_abs_diff: f32,
+    pub max_rel_diff: f32,
+    pub num_mismatches: usize,
+    pub first_mismatch_index: Option<usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Broadcast helpers
+// ---------------------------------------------------------------------------
+
+/// Determine the broadcast rule for two slices, or return an error.
+pub fn resolve_broadcast(a: &[f32], b: &[f32]) -> Result<BroadcastRule, TensorOpError> {
+    if a.len() == b.len() {
+        Ok(BroadcastRule::NoBroadcast)
+    } else if b.len() == 1 {
+        Ok(BroadcastRule::ScalarB)
+    } else if a.len() == 1 {
+        Ok(BroadcastRule::ScalarA)
+    } else {
+        Err(TensorOpError::ShapeMismatch { a_len: a.len(), b_len: b.len() })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core math helpers (scalar)
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn sigmoid_f32(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+#[inline]
+fn gelu_f32(x: f32) -> f32 {
+    // Approximation: x * 0.5 * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+    let c = (2.0_f32 / std::f32::consts::PI).sqrt();
+    x * 0.5 * (1.0 + (c * (x + 0.044715 * x * x * x)).tanh())
+}
+
+#[inline]
+fn silu_f32(x: f32) -> f32 {
+    x * sigmoid_f32(x)
+}
+
+// ---------------------------------------------------------------------------
+// Unary operations
+// ---------------------------------------------------------------------------
+
+/// Apply a unary [`TensorOp`] element-wise to `input`.
+///
+/// Returns `Err` for binary-only ops (`Add`, `Sub`, `Mul`, `Div`, `Max`, `Min`).
+pub fn elementwise_unary(op: &TensorOp, input: &[f32]) -> Result<Vec<f32>, TensorOpError> {
+    let out = match op {
+        TensorOp::Abs => input.iter().map(|x| x.abs()).collect(),
+        TensorOp::Neg => input.iter().map(|x| -x).collect(),
+        TensorOp::Sqrt => input.iter().map(|x| x.sqrt()).collect(),
+        TensorOp::Rsqrt => input.iter().map(|x| 1.0 / x.sqrt()).collect(),
+        TensorOp::Exp => input.iter().map(|x| x.exp()).collect(),
+        TensorOp::Log => input.iter().map(|x| x.ln()).collect(),
+        TensorOp::Tanh => input.iter().map(|x| x.tanh()).collect(),
+        TensorOp::Sigmoid => input.iter().map(|x| sigmoid_f32(*x)).collect(),
+        TensorOp::Gelu => input.iter().map(|x| gelu_f32(*x)).collect(),
+        TensorOp::Silu => input.iter().map(|x| silu_f32(*x)).collect(),
+        TensorOp::Relu => input.iter().map(|x| x.max(0.0)).collect(),
+        TensorOp::LeakyRelu(alpha) => {
+            let a = *alpha;
+            input.iter().map(|x| if *x >= 0.0 { *x } else { a * x }).collect()
+        }
+        TensorOp::Clamp { min, max } => input.iter().map(|x| x.clamp(*min, *max)).collect(),
+        // Binary-only ops are not valid for unary application.
+        TensorOp::Add
+        | TensorOp::Sub
+        | TensorOp::Mul
+        | TensorOp::Div
+        | TensorOp::Max
+        | TensorOp::Min => {
+            return Err(TensorOpError::DomainError { op: format!("{op:?}"), index: 0, value: 0.0 });
+        }
+    };
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Binary operations
+// ---------------------------------------------------------------------------
+
+/// Apply a binary [`TensorOp`] element-wise to `a` and `b`, with broadcasting.
+pub fn elementwise_binary(op: &TensorOp, a: &[f32], b: &[f32]) -> Result<Vec<f32>, TensorOpError> {
+    let rule = resolve_broadcast(a, b)?;
+
+    let len = match rule {
+        BroadcastRule::NoBroadcast | BroadcastRule::ScalarB => a.len(),
+        BroadcastRule::ScalarA => b.len(),
+    };
+
+    let mut out = Vec::with_capacity(len);
+    for i in 0..len {
+        let va = match rule {
+            BroadcastRule::ScalarA => a[0],
+            _ => a[i],
+        };
+        let vb = match rule {
+            BroadcastRule::ScalarB => b[0],
+            _ => b[i],
+        };
+        let val = match op {
+            TensorOp::Add => va + vb,
+            TensorOp::Sub => va - vb,
+            TensorOp::Mul => va * vb,
+            TensorOp::Div => va / vb,
+            TensorOp::Max => va.max(vb),
+            TensorOp::Min => va.min(vb),
+            // Unary ops: apply op(a) and ignore b (lenient).
+            TensorOp::Abs => va.abs(),
+            TensorOp::Neg => -va,
+            TensorOp::Sqrt => va.sqrt(),
+            TensorOp::Rsqrt => 1.0 / va.sqrt(),
+            TensorOp::Exp => va.exp(),
+            TensorOp::Log => va.ln(),
+            TensorOp::Tanh => va.tanh(),
+            TensorOp::Sigmoid => sigmoid_f32(va),
+            TensorOp::Gelu => gelu_f32(va),
+            TensorOp::Silu => silu_f32(va),
+            TensorOp::Relu => va.max(0.0),
+            TensorOp::LeakyRelu(alpha) => {
+                if va >= 0.0 {
+                    va
+                } else {
+                    alpha * va
+                }
+            }
+            TensorOp::Clamp { min, max } => va.clamp(*min, *max),
+        };
+        out.push(val);
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Fused / compound operations
+// ---------------------------------------------------------------------------
+
+/// Fused multiply-add: `a * b + c` element-wise (all same length).
+pub fn fused_multiply_add(a: &[f32], b: &[f32], c: &[f32]) -> Result<Vec<f32>, TensorOpError> {
+    if a.len() != b.len() || b.len() != c.len() {
+        return Err(TensorOpError::ShapeMismatch { a_len: a.len(), b_len: b.len() });
+    }
+    Ok(a.iter().zip(b.iter()).zip(c.iter()).map(|((&va, &vb), &vc)| va.mul_add(vb, vc)).collect())
+}
+
+/// `input * scale + shift` element-wise (all same length).
+pub fn scale_and_shift(
+    input: &[f32],
+    scale: &[f32],
+    shift: &[f32],
+) -> Result<Vec<f32>, TensorOpError> {
+    fused_multiply_add(input, scale, shift)
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+/// Compare two tensors element-wise with relative and absolute tolerance.
+pub fn compare_tensors(
+    a: &[f32],
+    b: &[f32],
+    rtol: f32,
+    atol: f32,
+) -> Result<ComparisonResult, TensorOpError> {
+    if a.len() != b.len() {
+        return Err(TensorOpError::ShapeMismatch { a_len: a.len(), b_len: b.len() });
+    }
+
+    let mut max_abs_diff: f32 = 0.0;
+    let mut max_rel_diff: f32 = 0.0;
+    let mut num_mismatches: usize = 0;
+    let mut first_mismatch_index: Option<usize> = None;
+
+    for (i, (&va, &vb)) in a.iter().zip(b.iter()).enumerate() {
+        let abs_diff = (va - vb).abs();
+        let rel_diff = if va.abs() > f32::EPSILON { abs_diff / va.abs() } else { abs_diff };
+        if abs_diff > max_abs_diff {
+            max_abs_diff = abs_diff;
+        }
+        if rel_diff > max_rel_diff {
+            max_rel_diff = rel_diff;
+        }
+        let close = abs_diff <= atol + rtol * vb.abs();
+        if !close {
+            num_mismatches += 1;
+            if first_mismatch_index.is_none() {
+                first_mismatch_index = Some(i);
+            }
+        }
+    }
+
+    Ok(ComparisonResult {
+        all_close: num_mismatches == 0,
+        max_abs_diff,
+        max_rel_diff,
+        num_mismatches,
+        first_mismatch_index,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Batch operations
+// ---------------------------------------------------------------------------
+
+/// Apply a sequence of independent unary operations, returning one output per entry.
+pub fn batch_elementwise(ops: &[(&TensorOp, &[f32])]) -> Result<Vec<Vec<f32>>, TensorOpError> {
+    ops.iter().map(|(op, data)| elementwise_unary(op, data)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── helpers ──────────────────────────────────────────────────────────
+
+    fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+        (a - b).abs() <= tol || (a.is_nan() && b.is_nan())
+    }
+
+    fn assert_vec_approx(actual: &[f32], expected: &[f32], tol: f32) {
+        assert_eq!(actual.len(), expected.len(), "length mismatch");
+        for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!(approx_eq(*a, *e, tol), "index {i}: actual={a}, expected={e}, tol={tol}");
+        }
+    }
+
+    // ── unary ops ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_abs() {
+        let r = elementwise_unary(&TensorOp::Abs, &[-1.0, 0.0, 3.5]).unwrap();
+        assert_vec_approx(&r, &[1.0, 0.0, 3.5], 1e-6);
+    }
+
+    #[test]
+    fn test_neg() {
+        let r = elementwise_unary(&TensorOp::Neg, &[1.0, -2.0, 0.0]).unwrap();
+        assert_vec_approx(&r, &[-1.0, 2.0, 0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_sqrt() {
+        let r = elementwise_unary(&TensorOp::Sqrt, &[4.0, 9.0, 0.0]).unwrap();
+        assert_vec_approx(&r, &[2.0, 3.0, 0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_rsqrt() {
+        let r = elementwise_unary(&TensorOp::Rsqrt, &[4.0, 16.0]).unwrap();
+        assert_vec_approx(&r, &[0.5, 0.25], 1e-6);
+    }
+
+    #[test]
+    fn test_exp() {
+        let r = elementwise_unary(&TensorOp::Exp, &[0.0, 1.0]).unwrap();
+        assert_vec_approx(&r, &[1.0, std::f32::consts::E], 1e-5);
+    }
+
+    #[test]
+    fn test_log() {
+        let r = elementwise_unary(&TensorOp::Log, &[1.0, std::f32::consts::E]).unwrap();
+        assert_vec_approx(&r, &[0.0, 1.0], 1e-5);
+    }
+
+    #[test]
+    fn test_tanh() {
+        let r = elementwise_unary(&TensorOp::Tanh, &[0.0, 1.0, -1.0]).unwrap();
+        assert_vec_approx(&r, &[0.0, 1.0_f32.tanh(), (-1.0_f32).tanh()], 1e-6);
+    }
+
+    #[test]
+    fn test_sigmoid() {
+        let r = elementwise_unary(&TensorOp::Sigmoid, &[0.0]).unwrap();
+        assert_vec_approx(&r, &[0.5], 1e-6);
+    }
+
+    #[test]
+    fn test_sigmoid_extremes() {
+        let r = elementwise_unary(&TensorOp::Sigmoid, &[100.0, -100.0]).unwrap();
+        assert!(r[0] > 0.999);
+        assert!(r[1] < 0.001);
+    }
+
+    #[test]
+    fn test_gelu() {
+        // GELU(0) == 0
+        let r = elementwise_unary(&TensorOp::Gelu, &[0.0, 1.0]).unwrap();
+        assert_vec_approx(&r, &[0.0, gelu_f32(1.0)], 1e-5);
+    }
+
+    #[test]
+    fn test_silu() {
+        let r = elementwise_unary(&TensorOp::Silu, &[0.0, 1.0, -1.0]).unwrap();
+        assert_vec_approx(&r, &[0.0, silu_f32(1.0), silu_f32(-1.0)], 1e-6);
+    }
+
+    #[test]
+    fn test_relu() {
+        let r = elementwise_unary(&TensorOp::Relu, &[-2.0, 0.0, 3.0]).unwrap();
+        assert_vec_approx(&r, &[0.0, 0.0, 3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_leaky_relu() {
+        let r = elementwise_unary(&TensorOp::LeakyRelu(0.1), &[-10.0, 0.0, 5.0]).unwrap();
+        assert_vec_approx(&r, &[-1.0, 0.0, 5.0], 1e-6);
+    }
+
+    #[test]
+    fn test_clamp() {
+        let r = elementwise_unary(&TensorOp::Clamp { min: -1.0, max: 1.0 }, &[-5.0, 0.5, 10.0])
+            .unwrap();
+        assert_vec_approx(&r, &[-1.0, 0.5, 1.0], 1e-6);
+    }
+
+    // ── binary ops ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_add() {
+        let r = elementwise_binary(&TensorOp::Add, &[1.0, 2.0], &[3.0, 4.0]).unwrap();
+        assert_vec_approx(&r, &[4.0, 6.0], 1e-6);
+    }
+
+    #[test]
+    fn test_sub() {
+        let r = elementwise_binary(&TensorOp::Sub, &[5.0, 3.0], &[1.0, 2.0]).unwrap();
+        assert_vec_approx(&r, &[4.0, 1.0], 1e-6);
+    }
+
+    #[test]
+    fn test_mul() {
+        let r = elementwise_binary(&TensorOp::Mul, &[2.0, 3.0], &[4.0, 5.0]).unwrap();
+        assert_vec_approx(&r, &[8.0, 15.0], 1e-6);
+    }
+
+    #[test]
+    fn test_div() {
+        let r = elementwise_binary(&TensorOp::Div, &[6.0, 9.0], &[2.0, 3.0]).unwrap();
+        assert_vec_approx(&r, &[3.0, 3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_max_binary() {
+        let r = elementwise_binary(&TensorOp::Max, &[1.0, 5.0], &[3.0, 2.0]).unwrap();
+        assert_vec_approx(&r, &[3.0, 5.0], 1e-6);
+    }
+
+    #[test]
+    fn test_min_binary() {
+        let r = elementwise_binary(&TensorOp::Min, &[1.0, 5.0], &[3.0, 2.0]).unwrap();
+        assert_vec_approx(&r, &[1.0, 2.0], 1e-6);
+    }
+
+    // ── broadcasting ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_broadcast_scalar_b() {
+        let r = elementwise_binary(&TensorOp::Add, &[1.0, 2.0, 3.0], &[10.0]).unwrap();
+        assert_vec_approx(&r, &[11.0, 12.0, 13.0], 1e-6);
+    }
+
+    #[test]
+    fn test_broadcast_scalar_a() {
+        let r = elementwise_binary(&TensorOp::Mul, &[2.0], &[3.0, 4.0, 5.0]).unwrap();
+        assert_vec_approx(&r, &[6.0, 8.0, 10.0], 1e-6);
+    }
+
+    #[test]
+    fn test_broadcast_shape_mismatch() {
+        let r = elementwise_binary(&TensorOp::Add, &[1.0, 2.0], &[3.0, 4.0, 5.0]);
+        assert!(r.is_err());
+        match r.unwrap_err() {
+            TensorOpError::ShapeMismatch { a_len, b_len } => {
+                assert_eq!(a_len, 2);
+                assert_eq!(b_len, 3);
+            }
+            e => panic!("unexpected error: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_broadcast_no_broadcast() {
+        assert_eq!(
+            resolve_broadcast(&[1.0, 2.0], &[3.0, 4.0]).unwrap(),
+            BroadcastRule::NoBroadcast
+        );
+    }
+
+    #[test]
+    fn test_resolve_broadcast_scalar_b() {
+        assert_eq!(resolve_broadcast(&[1.0, 2.0], &[5.0]).unwrap(), BroadcastRule::ScalarB);
+    }
+
+    #[test]
+    fn test_resolve_broadcast_scalar_a() {
+        assert_eq!(resolve_broadcast(&[5.0], &[1.0, 2.0]).unwrap(), BroadcastRule::ScalarA);
+    }
+
+    // ── fused_multiply_add / scale_and_shift ────────────────────────────
+
+    #[test]
+    fn test_fused_multiply_add() {
+        let r = fused_multiply_add(&[2.0, 3.0], &[4.0, 5.0], &[1.0, 1.0]).unwrap();
+        assert_vec_approx(&r, &[9.0, 16.0], 1e-6);
+    }
+
+    #[test]
+    fn test_fma_shape_mismatch() {
+        let r = fused_multiply_add(&[1.0], &[2.0, 3.0], &[4.0]);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_scale_and_shift() {
+        let r = scale_and_shift(&[1.0, 2.0], &[3.0, 4.0], &[0.5, 0.5]).unwrap();
+        // 1*3+0.5, 2*4+0.5
+        assert_vec_approx(&r, &[3.5, 8.5], 1e-6);
+    }
+
+    // ── compare_tensors ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_compare_identical() {
+        let a = [1.0, 2.0, 3.0];
+        let r = compare_tensors(&a, &a, 1e-5, 1e-8).unwrap();
+        assert!(r.all_close);
+        assert_eq!(r.num_mismatches, 0);
+    }
+
+    #[test]
+    fn test_compare_within_tol() {
+        let a = [1.0, 2.0, 3.0];
+        let b = [1.0 + 1e-7, 2.0, 3.0];
+        let r = compare_tensors(&a, &b, 1e-5, 1e-6).unwrap();
+        assert!(r.all_close);
+    }
+
+    #[test]
+    fn test_compare_mismatch() {
+        let a = [1.0, 2.0, 3.0];
+        let b = [1.0, 2.5, 3.0];
+        let r = compare_tensors(&a, &b, 1e-5, 1e-5).unwrap();
+        assert!(!r.all_close);
+        assert_eq!(r.num_mismatches, 1);
+        assert_eq!(r.first_mismatch_index, Some(1));
+    }
+
+    #[test]
+    fn test_compare_shape_mismatch() {
+        let r = compare_tensors(&[1.0], &[1.0, 2.0], 0.0, 0.0);
+        assert!(r.is_err());
+    }
+
+    // ── batch_elementwise ───────────────────────────────────────────────
+
+    #[test]
+    fn test_batch_elementwise_basic() {
+        let ops: Vec<(&TensorOp, &[f32])> =
+            vec![(&TensorOp::Abs, &[-1.0, -2.0]), (&TensorOp::Relu, &[-1.0, 3.0])];
+        let results = batch_elementwise(&ops).unwrap();
+        assert_vec_approx(&results[0], &[1.0, 2.0], 1e-6);
+        assert_vec_approx(&results[1], &[0.0, 3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_batch_elementwise_empty_list() {
+        let ops: Vec<(&TensorOp, &[f32])> = vec![];
+        let results = batch_elementwise(&ops).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_batch_fails_on_binary_op() {
+        let ops: Vec<(&TensorOp, &[f32])> = vec![(&TensorOp::Add, &[1.0])];
+        assert!(batch_elementwise(&ops).is_err());
+    }
+
+    // ── edge cases: empty tensors ───────────────────────────────────────
+
+    #[test]
+    fn test_unary_empty() {
+        let r = elementwise_unary(&TensorOp::Relu, &[]).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn test_binary_empty() {
+        let r = elementwise_binary(&TensorOp::Add, &[], &[]).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn test_fma_empty() {
+        let r = fused_multiply_add(&[], &[], &[]).unwrap();
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn test_compare_empty() {
+        let r = compare_tensors(&[], &[], 0.0, 0.0).unwrap();
+        assert!(r.all_close);
+        assert_eq!(r.num_mismatches, 0);
+    }
+
+    // ── edge cases: NaN / Inf ───────────────────────────────────────────
+
+    #[test]
+    fn test_nan_propagation_add() {
+        let r = elementwise_binary(&TensorOp::Add, &[f32::NAN], &[1.0]).unwrap();
+        assert!(r[0].is_nan());
+    }
+
+    #[test]
+    fn test_inf_add() {
+        let r = elementwise_binary(&TensorOp::Add, &[f32::INFINITY], &[1.0]).unwrap();
+        assert!(r[0].is_infinite() && r[0].is_sign_positive());
+    }
+
+    #[test]
+    fn test_neg_inf_relu() {
+        let r = elementwise_unary(&TensorOp::Relu, &[f32::NEG_INFINITY]).unwrap();
+        assert_eq!(r[0], 0.0);
+    }
+
+    #[test]
+    fn test_sqrt_negative_nan() {
+        let r = elementwise_unary(&TensorOp::Sqrt, &[-1.0]).unwrap();
+        assert!(r[0].is_nan());
+    }
+
+    #[test]
+    fn test_log_zero() {
+        let r = elementwise_unary(&TensorOp::Log, &[0.0]).unwrap();
+        assert!(r[0].is_infinite() && r[0].is_sign_negative());
+    }
+
+    #[test]
+    fn test_div_by_zero_inf() {
+        let r = elementwise_binary(&TensorOp::Div, &[1.0], &[0.0]).unwrap();
+        assert!(r[0].is_infinite());
+    }
+
+    #[test]
+    fn test_exp_large() {
+        let r = elementwise_unary(&TensorOp::Exp, &[1000.0]).unwrap();
+        assert!(r[0].is_infinite());
+    }
+
+    #[test]
+    fn test_tanh_large() {
+        let r = elementwise_unary(&TensorOp::Tanh, &[100.0, -100.0]).unwrap();
+        assert!((r[0] - 1.0).abs() < 1e-6);
+        assert!((r[1] + 1.0).abs() < 1e-6);
+    }
+
+    // ── misc ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_leaky_relu_zero_alpha() {
+        let r = elementwise_unary(&TensorOp::LeakyRelu(0.0), &[-5.0, 0.0, 5.0]).unwrap();
+        assert_vec_approx(&r, &[0.0, 0.0, 5.0], 1e-6);
+    }
+
+    #[test]
+    fn test_clamp_wide_range() {
+        let r =
+            elementwise_unary(&TensorOp::Clamp { min: -100.0, max: 100.0 }, &[-200.0, 0.0, 200.0])
+                .unwrap();
+        assert_vec_approx(&r, &[-100.0, 0.0, 100.0], 1e-6);
+    }
+
+    #[test]
+    fn test_gelu_negative() {
+        let r = elementwise_unary(&TensorOp::Gelu, &[-3.0]).unwrap();
+        // GELU(-3) ≈ -0.00404 (very small negative)
+        assert!(r[0] < 0.0);
+        assert!(r[0] > -0.1);
+    }
+
+    #[test]
+    fn test_silu_negative() {
+        let r = elementwise_unary(&TensorOp::Silu, &[-5.0]).unwrap();
+        assert!(r[0] < 0.0);
+    }
+
+    #[test]
+    fn test_binary_unary_op_uses_a() {
+        // Binary call with a unary op applies op to `a` values only.
+        let r = elementwise_binary(&TensorOp::Abs, &[-3.0, 4.0], &[99.0, 99.0]).unwrap();
+        assert_vec_approx(&r, &[3.0, 4.0], 1e-6);
+    }
+
+    #[test]
+    fn test_error_display() {
+        let e = TensorOpError::ShapeMismatch { a_len: 2, b_len: 3 };
+        let s = format!("{e}");
+        assert!(s.contains("2"));
+        assert!(s.contains("3"));
+    }
+
+    #[test]
+    fn test_comparison_result_fields() {
+        let a = [0.0, 1.0, 2.0, 3.0];
+        let b = [0.0, 1.0, 2.0, 4.0];
+        let r = compare_tensors(&a, &b, 0.0, 0.0).unwrap();
+        assert!(!r.all_close);
+        assert_eq!(r.max_abs_diff, 1.0);
+        assert_eq!(r.first_mismatch_index, Some(3));
+    }
+
+    #[test]
+    fn test_scale_and_shift_identity() {
+        let input = [1.0, 2.0, 3.0];
+        let ones = [1.0, 1.0, 1.0];
+        let zeros = [0.0, 0.0, 0.0];
+        let r = scale_and_shift(&input, &ones, &zeros).unwrap();
+        assert_vec_approx(&r, &input, 1e-6);
+    }
+
+    #[test]
+    fn test_fma_with_negative() {
+        let r = fused_multiply_add(&[-1.0], &[2.0], &[3.0]).unwrap();
+        assert_vec_approx(&r, &[1.0], 1e-6);
+    }
+
+    // ── proptest ────────────────────────────────────────────────────────
+
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            /// relu(x) >= 0 for all finite x.
+            #[test]
+            fn relu_non_negative(x in -1e6_f32..1e6_f32) {
+                let r = elementwise_unary(&TensorOp::Relu, &[x]).unwrap();
+                prop_assert!(r[0] >= 0.0, "relu({x}) = {} < 0", r[0]);
+            }
+
+            /// sigmoid(x) ∈ [0, 1] for all finite x.
+            #[test]
+            fn sigmoid_range(x in -500.0_f32..500.0_f32) {
+                let r = elementwise_unary(&TensorOp::Sigmoid, &[x]).unwrap();
+                prop_assert!(r[0] >= 0.0 && r[0] <= 1.0,
+                    "sigmoid({x}) = {} outside [0,1]", r[0]);
+            }
+
+            /// add is commutative: a + b == b + a.
+            #[test]
+            fn add_commutative(
+                a in proptest::collection::vec(-1e4_f32..1e4, 1..64),
+                b in proptest::collection::vec(-1e4_f32..1e4, 1..64),
+            ) {
+                // Only test when lengths match.
+                if a.len() == b.len() {
+                    let ab = elementwise_binary(&TensorOp::Add, &a, &b).unwrap();
+                    let ba = elementwise_binary(&TensorOp::Add, &b, &a).unwrap();
+                    for (i, (x, y)) in ab.iter().zip(ba.iter()).enumerate() {
+                        prop_assert!((x - y).abs() < 1e-4,
+                            "commutative violation at {i}: {x} vs {y}");
+                    }
+                }
+            }
+
+            /// fma(a,b,c) ≈ a*b + c for finite values.
+            #[test]
+            fn fma_matches_manual(
+                vals in proptest::collection::vec(-100.0_f32..100.0, 3..33),
+            ) {
+                let n = vals.len() / 3;
+                if n == 0 { return Ok(()); }
+                let a = &vals[..n];
+                let b = &vals[n..2*n];
+                let c = &vals[2*n..3*n];
+                let fma_result = fused_multiply_add(a, b, c).unwrap();
+                for i in 0..n {
+                    let expected = a[i] * b[i] + c[i];
+                    prop_assert!((fma_result[i] - expected).abs() < 1e-3,
+                        "fma mismatch at {i}: {} vs {expected}", fma_result[i]);
+                }
+            }
+
+            /// abs(x) >= 0 and abs(x) == abs(-x) for all finite x.
+            #[test]
+            fn abs_symmetry(x in -1e6_f32..1e6_f32) {
+                let pos = elementwise_unary(&TensorOp::Abs, &[x]).unwrap();
+                let neg = elementwise_unary(&TensorOp::Abs, &[-x]).unwrap();
+                prop_assert!(pos[0] >= 0.0);
+                prop_assert!((pos[0] - neg[0]).abs() < 1e-6,
+                    "|{x}|={} != |{}|={}", pos[0], -x, neg[0]);
+            }
+        }
+    }
+}

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -14,6 +14,7 @@ pub mod capability_matrix;
 pub mod convolution;
 pub mod cpu;
 pub mod cuda;
+pub mod cuda_tensor_ops;
 pub mod device_aware;
 pub mod device_features;
 #[cfg(feature = "ffi")]

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 


### PR DESCRIPTION
## Summary

Add `crates/bitnet-kernels/src/cuda_tensor_ops.rs` — CUDA-style element-wise tensor operations with CPU reference implementations for cross-validation against GPU kernels.

### Types
- **`TensorOp`** enum: Add, Sub, Mul, Div, Max, Min, Abs, Neg, Sqrt, Rsqrt, Exp, Log, Tanh, Sigmoid, Gelu, Silu, Relu, LeakyRelu(f32), Clamp{min, max}
- **`BroadcastRule`** enum: NoBroadcast, ScalarA, ScalarB
- **`TensorOpError`** enum: ShapeMismatch, EmptyTensor, DivisionByZero, DomainError
- **`ComparisonResult`** struct for tolerance-based tensor comparison

### Functions
- `elementwise_unary(op, input)` — all unary ops
- `elementwise_binary(op, a, b)` — all binary ops with scalar broadcasting
- `fused_multiply_add(a, b, c)` — FMA via `f32::mul_add`
- `scale_and_shift(input, scale, shift)` — affine transform
- `compare_tensors(a, b, rtol, atol)` — element-wise tolerance comparison
- `batch_elementwise(ops)` — batched unary operations

### Tests (62 total)
- All 19 tensor ops covered individually
- Edge cases: NaN propagation, ±inf, empty tensors, broadcasting shapes, shape mismatches
- 5 proptest properties: relu non-negative, sigmoid range, add commutativity, FMA correctness, abs symmetry

### Validation
- `cargo test -p bitnet-kernels --no-default-features --features cpu --lib -- cuda_tensor_ops`: **62 passed**
- `cargo clippy -p bitnet-kernels --no-default-features --features cpu --lib -- -D warnings`: **clean**