### PR TITLE
feat(kernels): add CUDA launch configuration utilities

### DIFF
--- a/crates/bitnet-kernels/src/cuda_launch_config.rs
+++ b/crates/bitnet-kernels/src/cuda_launch_config.rs
@@ -1,0 +1,899 @@
+//! CUDA kernel launch configuration utilities.
+//!
+//! Provides types and functions for computing grid/block dimensions,
+//! validating launch parameters against device limits, and selecting
+//! optimal block sizes for 1-D, 2-D, and 3-D kernel launches.
+
+use std::fmt;
+
+// ── Constants ────────────────────────────────────────────────────────
+
+/// Maximum grid dimension on any single axis (CUDA spec).
+pub const MAX_GRID_DIM_X: u32 = 2_147_483_647; // 2^31 - 1
+pub const MAX_GRID_DIM_YZ: u32 = 65_535;
+
+/// Default warp size on all current NVIDIA architectures.
+pub const WARP_SIZE: u32 = 32;
+
+// ── Error type ───────────────────────────────────────────────────────
+
+/// Errors that can occur when building or validating a launch config.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LaunchError {
+    /// Total threads per block exceeds device maximum.
+    ExceedsMaxThreadsPerBlock { requested: u32, limit: u32 },
+    /// A grid dimension exceeds the device maximum.
+    ExceedsMaxGridDim { axis: &'static str, requested: u32, limit: u32 },
+    /// Shared memory request exceeds device capacity.
+    ExceedsSharedMemory { requested: usize, limit: usize },
+    /// A block dimension is zero.
+    ZeroBlockDim { axis: &'static str },
+    /// Total work size is zero.
+    ZeroWorkSize,
+    /// Block dimension is not a multiple of warp size.
+    NotWarpAligned { block_dim_x: u32, warp_size: u32 },
+}
+
+impl fmt::Display for LaunchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExceedsMaxThreadsPerBlock { requested, limit } => {
+                write!(f, "threads per block {requested} exceeds limit {limit}")
+            }
+            Self::ExceedsMaxGridDim { axis, requested, limit } => {
+                write!(f, "grid dim {axis}={requested} exceeds limit {limit}")
+            }
+            Self::ExceedsSharedMemory { requested, limit } => {
+                write!(f, "shared memory {requested} B exceeds limit {limit} B")
+            }
+            Self::ZeroBlockDim { axis } => {
+                write!(f, "block dim {axis} is zero")
+            }
+            Self::ZeroWorkSize => write!(f, "total work size is zero"),
+            Self::NotWarpAligned { block_dim_x, warp_size } => {
+                write!(
+                    f,
+                    "block_dim.x={block_dim_x} not aligned to warp \
+                     size {warp_size}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for LaunchError {}
+
+// ── Core types ───────────────────────────────────────────────────────
+
+/// Full CUDA launch configuration (grid, block, shared memory, stream).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaunchConfig {
+    pub grid_dim: (u32, u32, u32),
+    pub block_dim: (u32, u32, u32),
+    pub shared_mem_bytes: usize,
+    pub stream_id: Option<u32>,
+}
+
+impl LaunchConfig {
+    /// Total number of threads this configuration will launch.
+    pub fn total_threads(&self) -> u64 {
+        let grid = self.grid_dim.0 as u64 * self.grid_dim.1 as u64 * self.grid_dim.2 as u64;
+        let block = self.block_dim.0 as u64 * self.block_dim.1 as u64 * self.block_dim.2 as u64;
+        grid * block
+    }
+
+    /// Threads per block as a single number.
+    pub fn threads_per_block(&self) -> u32 {
+        self.block_dim.0 * self.block_dim.1 * self.block_dim.2
+    }
+}
+
+/// Compiler-directed launch bounds (mirrors `__launch_bounds__`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaunchBounds {
+    pub max_threads_per_block: u32,
+    pub min_blocks_per_sm: u32,
+}
+
+/// Describes how work is distributed across the GPU.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkDistribution {
+    pub total_elements: usize,
+    pub threads_per_block: u32,
+    pub blocks: u32,
+}
+
+impl WorkDistribution {
+    /// Number of "wasted" threads (launched but beyond `total_elements`).
+    pub fn excess_threads(&self) -> usize {
+        let launched = self.threads_per_block as usize * self.blocks as usize;
+        launched.saturating_sub(self.total_elements)
+    }
+}
+
+// ── Device limits ────────────────────────────────────────────────────
+
+/// Hardware limits of a specific CUDA device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeviceLimits {
+    pub max_threads_per_block: u32,
+    pub max_grid_dims: (u32, u32, u32),
+    pub max_shared_memory: usize,
+    pub warp_size: u32,
+    pub max_warps_per_sm: u32,
+    pub sm_count: u32,
+}
+
+impl DeviceLimits {
+    /// NVIDIA RTX 5070 Ti (SM 8.9, Blackwell-consumer).
+    pub fn rtx_5070ti() -> Self {
+        Self {
+            max_threads_per_block: 1024,
+            max_grid_dims: (MAX_GRID_DIM_X, MAX_GRID_DIM_YZ, MAX_GRID_DIM_YZ),
+            max_shared_memory: 100 * 1024, // 100 KiB
+            warp_size: WARP_SIZE,
+            max_warps_per_sm: 48,
+            sm_count: 70,
+        }
+    }
+
+    /// NVIDIA A100 (SM 8.0, Ampere data-centre).
+    pub fn a100() -> Self {
+        Self {
+            max_threads_per_block: 1024,
+            max_grid_dims: (MAX_GRID_DIM_X, MAX_GRID_DIM_YZ, MAX_GRID_DIM_YZ),
+            max_shared_memory: 164 * 1024, // 164 KiB configurable
+            warp_size: WARP_SIZE,
+            max_warps_per_sm: 64,
+            sm_count: 108,
+        }
+    }
+
+    /// Generic SM 8.9 (Ada Lovelace / Blackwell consumer).
+    pub fn generic_sm89() -> Self {
+        Self {
+            max_threads_per_block: 1024,
+            max_grid_dims: (MAX_GRID_DIM_X, MAX_GRID_DIM_YZ, MAX_GRID_DIM_YZ),
+            max_shared_memory: 100 * 1024,
+            warp_size: WARP_SIZE,
+            max_warps_per_sm: 48,
+            sm_count: 128,
+        }
+    }
+
+    /// Conservative limits that should work on any sm_50+ device.
+    pub fn conservative() -> Self {
+        Self {
+            max_threads_per_block: 1024,
+            max_grid_dims: (MAX_GRID_DIM_X, MAX_GRID_DIM_YZ, MAX_GRID_DIM_YZ),
+            max_shared_memory: 48 * 1024,
+            warp_size: WARP_SIZE,
+            max_warps_per_sm: 32,
+            sm_count: 1,
+        }
+    }
+}
+
+impl Default for DeviceLimits {
+    fn default() -> Self {
+        Self::conservative()
+    }
+}
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/// Compute a 1-D launch configuration.
+///
+/// `blocks = ceil(total_elements / threads_per_block)`.
+pub fn compute_launch_config(total_elements: usize, threads_per_block: u32) -> LaunchConfig {
+    assert!(threads_per_block > 0, "threads_per_block must be > 0");
+    let blocks = div_ceil(total_elements, threads_per_block as usize) as u32;
+    LaunchConfig {
+        grid_dim: (blocks.max(1), 1, 1),
+        block_dim: (threads_per_block, 1, 1),
+        shared_mem_bytes: 0,
+        stream_id: None,
+    }
+}
+
+/// Convenience wrapper: 1-D launch with explicit block size.
+pub fn compute_1d_launch(n: usize, block_size: u32) -> LaunchConfig {
+    compute_launch_config(n, block_size)
+}
+
+/// 2-D launch: each block is `(block_x, block_y)` threads.
+pub fn compute_2d_launch(rows: usize, cols: usize, block_x: u32, block_y: u32) -> LaunchConfig {
+    assert!(block_x > 0 && block_y > 0, "block dims must be > 0");
+    let grid_x = div_ceil(cols, block_x as usize) as u32;
+    let grid_y = div_ceil(rows, block_y as usize) as u32;
+    LaunchConfig {
+        grid_dim: (grid_x.max(1), grid_y.max(1), 1),
+        block_dim: (block_x, block_y, 1),
+        shared_mem_bytes: 0,
+        stream_id: None,
+    }
+}
+
+/// 3-D launch.
+pub fn compute_3d_launch(
+    x: usize,
+    y: usize,
+    z: usize,
+    block_dims: (u32, u32, u32),
+) -> LaunchConfig {
+    assert!(block_dims.0 > 0 && block_dims.1 > 0 && block_dims.2 > 0, "block dims must be > 0");
+    let gx = div_ceil(x, block_dims.0 as usize) as u32;
+    let gy = div_ceil(y, block_dims.1 as usize) as u32;
+    let gz = div_ceil(z, block_dims.2 as usize) as u32;
+    LaunchConfig {
+        grid_dim: (gx.max(1), gy.max(1), gz.max(1)),
+        block_dim: block_dims,
+        shared_mem_bytes: 0,
+        stream_id: None,
+    }
+}
+
+/// Choose a block size that maximises occupancy heuristically.
+///
+/// Returns a warp-aligned power-of-two block size in `[32, 1024]`.
+pub fn optimal_block_size(elements: usize, shared_mem_per_thread: usize) -> u32 {
+    // Heuristic: start from 256 threads (good default), step down if
+    // shared memory pressure is high, step down further for tiny problems.
+    let max_candidate = if shared_mem_per_thread > 0 {
+        // Rough cap so shared mem stays under 48 KiB (conservative).
+        let cap = 48 * 1024 / shared_mem_per_thread.max(1);
+        next_pow2_down(cap as u32).min(1024)
+    } else {
+        1024
+    };
+
+    // For small problems, don't over-launch.
+    let size_cap = next_pow2_up(elements as u32).min(max_candidate);
+
+    // Clamp to warp size.
+    clamp_to_warp(size_cap)
+}
+
+/// Validate a `LaunchConfig` against concrete `DeviceLimits`.
+pub fn validate_launch_config(
+    config: &LaunchConfig,
+    limits: &DeviceLimits,
+) -> Result<(), LaunchError> {
+    // Block dims must be non-zero.
+    if config.block_dim.0 == 0 {
+        return Err(LaunchError::ZeroBlockDim { axis: "x" });
+    }
+    if config.block_dim.1 == 0 {
+        return Err(LaunchError::ZeroBlockDim { axis: "y" });
+    }
+    if config.block_dim.2 == 0 {
+        return Err(LaunchError::ZeroBlockDim { axis: "z" });
+    }
+
+    let tpb = config.threads_per_block();
+    if tpb > limits.max_threads_per_block {
+        return Err(LaunchError::ExceedsMaxThreadsPerBlock {
+            requested: tpb,
+            limit: limits.max_threads_per_block,
+        });
+    }
+
+    // Grid dim checks.
+    if config.grid_dim.0 > limits.max_grid_dims.0 {
+        return Err(LaunchError::ExceedsMaxGridDim {
+            axis: "x",
+            requested: config.grid_dim.0,
+            limit: limits.max_grid_dims.0,
+        });
+    }
+    if config.grid_dim.1 > limits.max_grid_dims.1 {
+        return Err(LaunchError::ExceedsMaxGridDim {
+            axis: "y",
+            requested: config.grid_dim.1,
+            limit: limits.max_grid_dims.1,
+        });
+    }
+    if config.grid_dim.2 > limits.max_grid_dims.2 {
+        return Err(LaunchError::ExceedsMaxGridDim {
+            axis: "z",
+            requested: config.grid_dim.2,
+            limit: limits.max_grid_dims.2,
+        });
+    }
+
+    // Shared memory.
+    if config.shared_mem_bytes > limits.max_shared_memory {
+        return Err(LaunchError::ExceedsSharedMemory {
+            requested: config.shared_mem_bytes,
+            limit: limits.max_shared_memory,
+        });
+    }
+
+    Ok(())
+}
+
+/// Build a `WorkDistribution` for a 1-D problem.
+pub fn work_distribution(total_elements: usize, threads_per_block: u32) -> WorkDistribution {
+    let blocks = div_ceil(total_elements, threads_per_block as usize) as u32;
+    WorkDistribution { total_elements, threads_per_block, blocks: blocks.max(1) }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn div_ceil(a: usize, b: usize) -> usize {
+    a.div_ceil(b)
+}
+
+/// Round *down* to the nearest power of two (≥ 1).
+fn next_pow2_down(v: u32) -> u32 {
+    if v == 0 {
+        return 1;
+    }
+    1 << (31 - v.leading_zeros())
+}
+
+/// Round *up* to the nearest power of two (≥ 1).
+fn next_pow2_up(v: u32) -> u32 {
+    if v <= 1 {
+        return 1;
+    }
+    1u32.checked_shl(32 - (v - 1).leading_zeros()).unwrap_or(1 << 31)
+}
+
+/// Clamp to `[WARP_SIZE, 1024]` and round down to warp multiple.
+fn clamp_to_warp(v: u32) -> u32 {
+    let v = v.clamp(WARP_SIZE, 1024);
+    (v / WARP_SIZE) * WARP_SIZE
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- LaunchConfig basic ----------------------------------------
+
+    #[test]
+    fn test_launch_config_total_threads_1d() {
+        let cfg = compute_launch_config(1024, 256);
+        assert_eq!(cfg.total_threads(), 1024);
+    }
+
+    #[test]
+    fn test_launch_config_threads_per_block() {
+        let cfg = compute_launch_config(512, 128);
+        assert_eq!(cfg.threads_per_block(), 128);
+    }
+
+    #[test]
+    fn test_launch_config_stream_none() {
+        let cfg = compute_launch_config(64, 32);
+        assert_eq!(cfg.stream_id, None);
+    }
+
+    #[test]
+    fn test_launch_config_shared_mem_default_zero() {
+        let cfg = compute_launch_config(128, 64);
+        assert_eq!(cfg.shared_mem_bytes, 0);
+    }
+
+    // -- compute_launch_config / 1-D --------------------------------
+
+    #[test]
+    fn test_1d_exact_multiple() {
+        let cfg = compute_launch_config(256, 256);
+        assert_eq!(cfg.grid_dim, (1, 1, 1));
+        assert_eq!(cfg.block_dim, (256, 1, 1));
+    }
+
+    #[test]
+    fn test_1d_non_exact_rounds_up() {
+        let cfg = compute_launch_config(257, 256);
+        assert_eq!(cfg.grid_dim, (2, 1, 1));
+    }
+
+    #[test]
+    fn test_1d_single_element() {
+        let cfg = compute_launch_config(1, 32);
+        assert_eq!(cfg.grid_dim, (1, 1, 1));
+    }
+
+    #[test]
+    fn test_1d_large_problem() {
+        let cfg = compute_launch_config(1_000_000, 512);
+        assert_eq!(cfg.grid_dim.0, 1954); // ceil(1M/512)
+    }
+
+    #[test]
+    fn test_compute_1d_launch_alias() {
+        let a = compute_launch_config(500, 128);
+        let b = compute_1d_launch(500, 128);
+        assert_eq!(a, b);
+    }
+
+    // -- compute_2d_launch ------------------------------------------
+
+    #[test]
+    fn test_2d_exact_tiles() {
+        let cfg = compute_2d_launch(32, 64, 16, 16);
+        assert_eq!(cfg.grid_dim, (4, 2, 1));
+        assert_eq!(cfg.block_dim, (16, 16, 1));
+    }
+
+    #[test]
+    fn test_2d_non_exact_tiles() {
+        let cfg = compute_2d_launch(33, 65, 16, 16);
+        assert_eq!(cfg.grid_dim, (5, 3, 1));
+    }
+
+    #[test]
+    fn test_2d_single_pixel() {
+        let cfg = compute_2d_launch(1, 1, 16, 16);
+        assert_eq!(cfg.grid_dim, (1, 1, 1));
+    }
+
+    #[test]
+    fn test_2d_wide_image() {
+        let cfg = compute_2d_launch(1, 4096, 32, 1);
+        assert_eq!(cfg.grid_dim, (128, 1, 1));
+        assert_eq!(cfg.block_dim, (32, 1, 1));
+    }
+
+    #[test]
+    fn test_2d_tall_image() {
+        let cfg = compute_2d_launch(4096, 1, 1, 32);
+        assert_eq!(cfg.grid_dim, (1, 128, 1));
+    }
+
+    // -- compute_3d_launch ------------------------------------------
+
+    #[test]
+    fn test_3d_exact() {
+        let cfg = compute_3d_launch(8, 8, 8, (8, 8, 8));
+        assert_eq!(cfg.grid_dim, (1, 1, 1));
+    }
+
+    #[test]
+    fn test_3d_non_exact() {
+        let cfg = compute_3d_launch(9, 9, 9, (8, 8, 8));
+        assert_eq!(cfg.grid_dim, (2, 2, 2));
+    }
+
+    #[test]
+    fn test_3d_flat_z() {
+        let cfg = compute_3d_launch(256, 256, 1, (16, 16, 1));
+        assert_eq!(cfg.grid_dim, (16, 16, 1));
+    }
+
+    #[test]
+    fn test_3d_block_dims_preserved() {
+        let cfg = compute_3d_launch(10, 20, 30, (4, 8, 16));
+        assert_eq!(cfg.block_dim, (4, 8, 16));
+    }
+
+    // -- optimal_block_size -----------------------------------------
+
+    #[test]
+    fn test_optimal_no_shared_mem_large() {
+        let bs = optimal_block_size(1_000_000, 0);
+        assert!(bs >= WARP_SIZE);
+        assert!(bs <= 1024);
+        assert_eq!(bs % WARP_SIZE, 0);
+    }
+
+    #[test]
+    fn test_optimal_no_shared_mem_small() {
+        let bs = optimal_block_size(16, 0);
+        assert_eq!(bs, WARP_SIZE); // clamped to warp size
+    }
+
+    #[test]
+    fn test_optimal_high_shared_mem() {
+        // 1 KiB per thread → only ~48 threads fit in 48 KiB.
+        let bs = optimal_block_size(10_000, 1024);
+        assert!(bs <= 64);
+        assert!(bs >= WARP_SIZE);
+    }
+
+    #[test]
+    fn test_optimal_is_warp_aligned() {
+        for elems in [1, 7, 33, 100, 500, 10_000, 1_000_000] {
+            let bs = optimal_block_size(elems, 0);
+            assert_eq!(bs % WARP_SIZE, 0, "elems={elems}");
+        }
+    }
+
+    #[test]
+    fn test_optimal_moderate_shared_mem() {
+        let bs = optimal_block_size(50_000, 64);
+        assert!(bs >= WARP_SIZE);
+        assert!(bs <= 1024);
+    }
+
+    // -- validate_launch_config -------------------------------------
+
+    #[test]
+    fn test_validate_ok() {
+        let cfg = compute_launch_config(1024, 256);
+        let limits = DeviceLimits::a100();
+        assert!(validate_launch_config(&cfg, &limits).is_ok());
+    }
+
+    #[test]
+    fn test_validate_exceeds_threads_per_block() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (2048, 1, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        let limits = DeviceLimits::a100();
+        let err = validate_launch_config(&cfg, &limits).unwrap_err();
+        assert_eq!(err, LaunchError::ExceedsMaxThreadsPerBlock { requested: 2048, limit: 1024 });
+    }
+
+    #[test]
+    fn test_validate_exceeds_grid_y() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 70_000, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        let limits = DeviceLimits::a100();
+        let err = validate_launch_config(&cfg, &limits).unwrap_err();
+        assert!(matches!(err, LaunchError::ExceedsMaxGridDim { axis: "y", .. }));
+    }
+
+    #[test]
+    fn test_validate_exceeds_grid_z() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 70_000),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        let limits = DeviceLimits::a100();
+        assert!(matches!(
+            validate_launch_config(&cfg, &limits).unwrap_err(),
+            LaunchError::ExceedsMaxGridDim { axis: "z", .. }
+        ));
+    }
+
+    #[test]
+    fn test_validate_exceeds_shared_memory() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 200 * 1024,
+            stream_id: None,
+        };
+        let limits = DeviceLimits::a100();
+        assert!(matches!(
+            validate_launch_config(&cfg, &limits).unwrap_err(),
+            LaunchError::ExceedsSharedMemory { .. }
+        ));
+    }
+
+    #[test]
+    fn test_validate_zero_block_x() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (0, 1, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        assert!(matches!(
+            validate_launch_config(&cfg, &DeviceLimits::default()).unwrap_err(),
+            LaunchError::ZeroBlockDim { axis: "x" }
+        ));
+    }
+
+    #[test]
+    fn test_validate_zero_block_y() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (32, 0, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        assert!(matches!(
+            validate_launch_config(&cfg, &DeviceLimits::default()).unwrap_err(),
+            LaunchError::ZeroBlockDim { axis: "y" }
+        ));
+    }
+
+    #[test]
+    fn test_validate_zero_block_z() {
+        let cfg = LaunchConfig {
+            grid_dim: (1, 1, 1),
+            block_dim: (32, 1, 0),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        assert!(matches!(
+            validate_launch_config(&cfg, &DeviceLimits::default()).unwrap_err(),
+            LaunchError::ZeroBlockDim { axis: "z" }
+        ));
+    }
+
+    #[test]
+    fn test_validate_at_exact_limits() {
+        let limits = DeviceLimits {
+            max_threads_per_block: 256,
+            max_grid_dims: (100, 100, 100),
+            max_shared_memory: 1024,
+            warp_size: 32,
+            max_warps_per_sm: 32,
+            sm_count: 1,
+        };
+        let cfg = LaunchConfig {
+            grid_dim: (100, 100, 100),
+            block_dim: (256, 1, 1),
+            shared_mem_bytes: 1024,
+            stream_id: None,
+        };
+        assert!(validate_launch_config(&cfg, &limits).is_ok());
+    }
+
+    // -- DeviceLimits presets ---------------------------------------
+
+    #[test]
+    fn test_a100_preset_sane() {
+        let a = DeviceLimits::a100();
+        assert_eq!(a.max_threads_per_block, 1024);
+        assert_eq!(a.sm_count, 108);
+        assert_eq!(a.warp_size, WARP_SIZE);
+    }
+
+    #[test]
+    fn test_rtx_5070ti_preset_sane() {
+        let r = DeviceLimits::rtx_5070ti();
+        assert_eq!(r.max_threads_per_block, 1024);
+        assert_eq!(r.sm_count, 70);
+    }
+
+    #[test]
+    fn test_generic_sm89_preset_sane() {
+        let g = DeviceLimits::generic_sm89();
+        assert_eq!(g.sm_count, 128);
+        assert_eq!(g.max_warps_per_sm, 48);
+    }
+
+    #[test]
+    fn test_conservative_preset_sane() {
+        let c = DeviceLimits::conservative();
+        assert_eq!(c.sm_count, 1);
+        assert!(c.max_shared_memory >= 48 * 1024);
+    }
+
+    #[test]
+    fn test_default_is_conservative() {
+        assert_eq!(DeviceLimits::default(), DeviceLimits::conservative());
+    }
+
+    // -- WorkDistribution -------------------------------------------
+
+    #[test]
+    fn test_work_distribution_exact() {
+        let wd = work_distribution(1024, 256);
+        assert_eq!(wd.blocks, 4);
+        assert_eq!(wd.excess_threads(), 0);
+    }
+
+    #[test]
+    fn test_work_distribution_with_excess() {
+        let wd = work_distribution(1000, 256);
+        assert_eq!(wd.blocks, 4); // 4 * 256 = 1024
+        assert_eq!(wd.excess_threads(), 24);
+    }
+
+    #[test]
+    fn test_work_distribution_single_element() {
+        let wd = work_distribution(1, 256);
+        assert_eq!(wd.blocks, 1);
+        assert_eq!(wd.excess_threads(), 255);
+    }
+
+    // -- LaunchBounds -----------------------------------------------
+
+    #[test]
+    fn test_launch_bounds_construction() {
+        let lb = LaunchBounds { max_threads_per_block: 256, min_blocks_per_sm: 2 };
+        assert_eq!(lb.max_threads_per_block, 256);
+        assert_eq!(lb.min_blocks_per_sm, 2);
+    }
+
+    // -- Error display ----------------------------------------------
+
+    #[test]
+    fn test_error_display_threads() {
+        let e = LaunchError::ExceedsMaxThreadsPerBlock { requested: 2048, limit: 1024 };
+        let s = format!("{e}");
+        assert!(s.contains("2048"));
+        assert!(s.contains("1024"));
+    }
+
+    #[test]
+    fn test_error_display_grid() {
+        let e = LaunchError::ExceedsMaxGridDim { axis: "y", requested: 70_000, limit: 65_535 };
+        assert!(format!("{e}").contains("y"));
+    }
+
+    #[test]
+    fn test_error_display_shared_mem() {
+        let e = LaunchError::ExceedsSharedMemory { requested: 200_000, limit: 164_000 };
+        assert!(format!("{e}").contains("200000"));
+    }
+
+    #[test]
+    fn test_error_display_zero_block() {
+        let e = LaunchError::ZeroBlockDim { axis: "x" };
+        assert!(format!("{e}").contains("x"));
+    }
+
+    #[test]
+    fn test_error_display_zero_work() {
+        let e = LaunchError::ZeroWorkSize;
+        assert!(format!("{e}").contains("zero"));
+    }
+
+    #[test]
+    fn test_error_display_warp_aligned() {
+        let e = LaunchError::NotWarpAligned { block_dim_x: 100, warp_size: 32 };
+        assert!(format!("{e}").contains("100"));
+    }
+
+    // -- helpers ----------------------------------------------------
+
+    #[test]
+    fn test_next_pow2_up() {
+        assert_eq!(next_pow2_up(0), 1);
+        assert_eq!(next_pow2_up(1), 1);
+        assert_eq!(next_pow2_up(2), 2);
+        assert_eq!(next_pow2_up(3), 4);
+        assert_eq!(next_pow2_up(255), 256);
+        assert_eq!(next_pow2_up(256), 256);
+        assert_eq!(next_pow2_up(257), 512);
+    }
+
+    #[test]
+    fn test_next_pow2_down() {
+        assert_eq!(next_pow2_down(0), 1);
+        assert_eq!(next_pow2_down(1), 1);
+        assert_eq!(next_pow2_down(2), 2);
+        assert_eq!(next_pow2_down(3), 2);
+        assert_eq!(next_pow2_down(255), 128);
+        assert_eq!(next_pow2_down(256), 256);
+        assert_eq!(next_pow2_down(1023), 512);
+    }
+
+    #[test]
+    fn test_clamp_to_warp_below() {
+        assert_eq!(clamp_to_warp(1), WARP_SIZE);
+        assert_eq!(clamp_to_warp(0), WARP_SIZE);
+    }
+
+    #[test]
+    fn test_clamp_to_warp_above() {
+        assert_eq!(clamp_to_warp(2048), 1024);
+    }
+
+    #[test]
+    fn test_clamp_to_warp_rounds_down() {
+        assert_eq!(clamp_to_warp(100), 96); // 3*32
+    }
+
+    // -- integration-style ------------------------------------------
+
+    #[test]
+    fn test_end_to_end_validate_computed_config() {
+        let cfg = compute_launch_config(50_000, 256);
+        assert!(validate_launch_config(&cfg, &DeviceLimits::a100()).is_ok());
+    }
+
+    #[test]
+    fn test_end_to_end_2d_validate() {
+        let cfg = compute_2d_launch(1080, 1920, 16, 16);
+        assert!(validate_launch_config(&cfg, &DeviceLimits::rtx_5070ti()).is_ok());
+    }
+
+    #[test]
+    fn test_end_to_end_3d_validate() {
+        let cfg = compute_3d_launch(64, 64, 64, (8, 8, 8));
+        assert!(validate_launch_config(&cfg, &DeviceLimits::generic_sm89()).is_ok());
+    }
+
+    #[test]
+    fn test_optimal_then_launch_then_validate() {
+        let bs = optimal_block_size(100_000, 0);
+        let cfg = compute_launch_config(100_000, bs);
+        assert!(validate_launch_config(&cfg, &DeviceLimits::a100()).is_ok());
+    }
+
+    #[test]
+    fn test_work_distribution_matches_config() {
+        let n = 9999;
+        let bs = 256u32;
+        let cfg = compute_launch_config(n, bs);
+        let wd = work_distribution(n, bs);
+        assert_eq!(cfg.grid_dim.0, wd.blocks);
+        assert_eq!(cfg.block_dim.0, wd.threads_per_block);
+    }
+
+    // -- edge cases -------------------------------------------------
+
+    #[test]
+    fn test_2d_launch_large_grid() {
+        let cfg = compute_2d_launch(65_535, 65_535, 1, 1);
+        assert_eq!(cfg.grid_dim.0, 65_535);
+        assert_eq!(cfg.grid_dim.1, 65_535);
+    }
+
+    #[test]
+    fn test_3d_launch_one_each() {
+        let cfg = compute_3d_launch(1, 1, 1, (1, 1, 1));
+        assert_eq!(cfg.grid_dim, (1, 1, 1));
+        assert_eq!(cfg.block_dim, (1, 1, 1));
+    }
+
+    #[test]
+    fn test_launch_config_with_custom_shared_mem() {
+        let mut cfg = compute_launch_config(1024, 256);
+        cfg.shared_mem_bytes = 4096;
+        assert_eq!(cfg.shared_mem_bytes, 4096);
+        assert!(validate_launch_config(&cfg, &DeviceLimits::a100()).is_ok());
+    }
+
+    #[test]
+    fn test_launch_config_with_stream() {
+        let mut cfg = compute_launch_config(512, 128);
+        cfg.stream_id = Some(7);
+        assert_eq!(cfg.stream_id, Some(7));
+    }
+
+    #[test]
+    fn test_total_threads_2d() {
+        let cfg = compute_2d_launch(4, 8, 2, 2);
+        // grid=(4,2,1), block=(2,2,1) → 4*2*1 * 2*2*1 = 32
+        assert_eq!(cfg.total_threads(), 32);
+    }
+
+    #[test]
+    fn test_total_threads_3d() {
+        let cfg = compute_3d_launch(4, 6, 8, (2, 3, 4));
+        // grid=(2,2,2), block=(2,3,4) → 8 * 24 = 192
+        assert_eq!(cfg.total_threads(), 192);
+    }
+
+    #[test]
+    fn test_validate_grid_x_boundary() {
+        let cfg = LaunchConfig {
+            grid_dim: (MAX_GRID_DIM_X, 1, 1),
+            block_dim: (1, 1, 1),
+            shared_mem_bytes: 0,
+            stream_id: None,
+        };
+        assert!(validate_launch_config(&cfg, &DeviceLimits::a100()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_all_presets_accept_typical() {
+        let cfg = compute_launch_config(10_000, 256);
+        for limits in [
+            DeviceLimits::a100(),
+            DeviceLimits::rtx_5070ti(),
+            DeviceLimits::generic_sm89(),
+            DeviceLimits::conservative(),
+        ] {
+            assert!(validate_launch_config(&cfg, &limits).is_ok(), "failed for {limits:?}");
+        }
+    }
+
+    #[test]
+    fn test_launch_error_is_std_error() {
+        let e: Box<dyn std::error::Error> = Box::new(LaunchError::ZeroWorkSize);
+        assert!(!e.to_string().is_empty());
+    }
+}

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -14,6 +14,7 @@ pub mod capability_matrix;
 pub mod convolution;
 pub mod cpu;
 pub mod cuda;
+pub mod cuda_launch_config;
 pub mod device_aware;
 pub mod device_features;
 #[cfg(feature = "ffi")]

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 


### PR DESCRIPTION
## Summary

Add `cuda_launch_config` module to `bitnet-kernels` with CUDA kernel launch configuration utilities.

### Types
- **`LaunchConfig`** — grid/block dims, shared memory, stream ID
- **`LaunchBounds`** — compiler-directed launch bounds (`__launch_bounds__` equivalent)
- **`LaunchError`** — validation error enum (threads, grid, shared mem, zero dims, warp alignment)
- **`WorkDistribution`** — describes how work maps to GPU threads/blocks
- **`DeviceLimits`** — hardware limits with presets

### Functions
- `compute_launch_config` / `compute_1d_launch` — 1-D grid/block calculation
- `compute_2d_launch` — 2-D tiled launch
- `compute_3d_launch` — 3-D volumetric launch
- `optimal_block_size` — heuristic block size selection (warp-aligned, shared-mem-aware)
- `validate_launch_config` — validate config against device limits
- `work_distribution` — compute excess-thread metrics

### Device Presets
- `DeviceLimits::rtx_5070ti()` — SM 8.9 consumer
- `DeviceLimits::a100()` — SM 8.0 data-centre
- `DeviceLimits::generic_sm89()` — generic Ada Lovelace
- `DeviceLimits::conservative()` — safe for any sm_50+ device

### Tests
66 unit tests covering all public API, error paths, device presets, helpers, and end-to-end validation flows.