### PR TITLE
feat: proptest wave 33 — inference, models, common property tests

### DIFF
--- a/crates/bitnet-common/tests/proptest_wave33.rs
+++ b/crates/bitnet-common/tests/proptest_wave33.rs
@@ -1,0 +1,160 @@
+//! Wave 33 property tests: common types, validation, and error invariants.
+//!
+//! Properties tested (5):
+//! 1. Device::is_gpu() XOR Device::is_cpu() (mutually exclusive)
+//! 2. QuantizationType round-trip through Display → serde string
+//! 3. Tensor shape validation: broadcast_shape rejects incompatible dims
+//! 4. warn_once key deduplication (same key → idempotent insert)
+//! 5. Error Display is non-empty for all error variants
+
+use bitnet_common::{
+    BitNetError, InferenceError, KernelError, ModelError, QuantizationError, SecurityError,
+    tensor_validation::{broadcast_shape, validate_matmul_shapes},
+    types::{Device, QuantizationType},
+};
+use proptest::prelude::*;
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/// Strategy producing every `Device` variant.
+fn any_device() -> impl Strategy<Value = Device> {
+    prop_oneof![
+        Just(Device::Cpu),
+        (0usize..8).prop_map(Device::Cuda),
+        (0usize..4).prop_map(Device::Hip),
+        Just(Device::Npu),
+        Just(Device::Metal),
+        (0usize..4).prop_map(Device::OpenCL),
+    ]
+}
+
+/// Strategy producing every `QuantizationType` variant.
+fn any_quant_type() -> impl Strategy<Value = QuantizationType> {
+    prop_oneof![
+        Just(QuantizationType::I2S),
+        Just(QuantizationType::TL1),
+        Just(QuantizationType::TL2),
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    // ── 1. Device: is_cpu XOR is_gpu ────────────────────────────────────
+
+    /// For every `Device` variant, `is_cpu()` and any of the GPU-like
+    /// predicates (cuda, hip, opencl, metal, npu) are mutually exclusive
+    /// with `is_cpu()`: a device is either CPU or non-CPU.
+    #[test]
+    fn prop_device_cpu_xor_non_cpu(device in any_device()) {
+        let is_cpu = device.is_cpu();
+        let is_non_cpu = device.is_cuda()
+            || device.is_hip()
+            || device.is_npu()
+            || device.is_opencl()
+            || matches!(device, Device::Metal);
+
+        prop_assert!(
+            is_cpu ^ is_non_cpu,
+            "Device {:?}: is_cpu={} is_non_cpu={} — must be mutually exclusive",
+            device,
+            is_cpu,
+            is_non_cpu,
+        );
+    }
+
+    // ── 2. QuantizationType Display → serde round-trip ──────────────────
+
+    /// `Display` produces a non-empty string, and serde JSON round-trip
+    /// preserves the variant.
+    #[test]
+    fn prop_quant_type_display_and_serde_roundtrip(qt in any_quant_type()) {
+        let display = format!("{qt}");
+        prop_assert!(!display.is_empty(), "Display should be non-empty");
+
+        // Serde round-trip.
+        let json = serde_json::to_string(&qt).expect("serialize");
+        let back: QuantizationType = serde_json::from_str(&json).expect("deserialize");
+        prop_assert_eq!(qt, back, "serde round-trip failed");
+    }
+
+    // ── 3. broadcast_shape rejects truly incompatible dimensions ────────
+
+    /// Two shapes that differ in a non-1 dimension are incompatible.
+    #[test]
+    fn prop_broadcast_rejects_incompatible(
+        a_dim in 2usize..=8,
+        b_dim in 2usize..=8,
+    ) {
+        // Ensure the two dims differ and neither is 1.
+        prop_assume!(a_dim != b_dim);
+        let a = vec![a_dim];
+        let b = vec![b_dim];
+        prop_assert!(
+            broadcast_shape(&a, &b).is_err(),
+            "shapes [{a_dim}] and [{b_dim}] should be incompatible",
+        );
+    }
+
+    /// Matmul shape validation rejects mismatched inner dimensions.
+    #[test]
+    fn prop_matmul_rejects_mismatched_inner(
+        m in 1usize..=16,
+        k1 in 1usize..=16,
+        k2 in 1usize..=16,
+        n in 1usize..=16,
+    ) {
+        prop_assume!(k1 != k2);
+        let a = vec![m, k1];
+        let b = vec![k2, n];
+        prop_assert!(
+            validate_matmul_shapes(&a, &b).is_err(),
+            "matmul [{m},{k1}] × [{k2},{n}] should fail when k1≠k2",
+        );
+    }
+
+    // ── 4. warn_once key deduplication ──────────────────────────────────
+
+    /// Inserting the same key into a `HashSet` twice always results in a
+    /// single entry — this mirrors the `warn_once` deduplication logic
+    /// without touching global state.
+    #[test]
+    fn prop_warn_once_key_dedup(key in "[a-z_]{1,32}") {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        let first = seen.insert(key.clone());
+        let second = seen.insert(key.clone());
+
+        prop_assert!(first, "first insert should return true");
+        prop_assert!(!second, "second insert should return false (dup)");
+        prop_assert_eq!(seen.len(), 1, "set should contain exactly one entry");
+    }
+
+    // ── 5. Error Display is non-empty for all variants ──────────────────
+
+    /// Every `BitNetError` variant produces a non-empty Display string.
+    #[test]
+    fn prop_bitnet_error_display_non_empty(variant_idx in 0u32..6) {
+        let err: BitNetError = match variant_idx {
+            0 => BitNetError::Model(ModelError::NotFound {
+                path: "test.gguf".into(),
+            }),
+            1 => BitNetError::Quantization(QuantizationError::UnsupportedType {
+                qtype: "Q99".into(),
+            }),
+            2 => BitNetError::Kernel(KernelError::NoProvider),
+            3 => BitNetError::Inference(InferenceError::GenerationFailed {
+                reason: "oom".into(),
+            }),
+            4 => BitNetError::Config("bad config".into()),
+            5 => BitNetError::Security(SecurityError::InputValidation {
+                reason: "overflow".into(),
+            }),
+            _ => unreachable!(),
+        };
+
+        let display = format!("{err}");
+        prop_assert!(!display.is_empty(), "error Display should be non-empty");
+        prop_assert!(display.len() > 3, "error message too short: '{display}'");
+    }
+}

--- a/crates/bitnet-inference/tests/proptest_wave33.rs
+++ b/crates/bitnet-inference/tests/proptest_wave33.rs
@@ -1,0 +1,166 @@
+//! Wave 33 property tests: inference sampling invariants.
+//!
+//! Properties tested (5):
+//! 1. SamplingStrategy::sample always returns a valid token index (< vocab_size)
+//! 2. Temperature=0 always selects argmax
+//! 3. top_k filtering keeps at most k candidates
+//! 4. Repetition penalty decreases probability of repeated tokens
+//! 5. Greedy decode is deterministic with same seed
+
+use bitnet_sampling::{
+    SamplingConfig, SamplingStrategy, apply_repetition_penalty, apply_top_k, greedy_sample,
+};
+use proptest::prelude::*;
+
+/// Non-empty f32 logits vector with finite values.
+fn logits_vec(max_len: usize) -> impl Strategy<Value = Vec<f32>> {
+    prop::collection::vec(-10.0f32..10.0f32, 2..=max_len)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    // ── 1. sample always returns a valid token index ────────────────────
+
+    /// Stochastic sampling always returns a token ID strictly less than
+    /// the vocabulary size (logits length).
+    #[test]
+    fn prop_sample_returns_valid_index(
+        logits in logits_vec(64),
+        seed in 0u64..10_000,
+    ) {
+        let vocab_size = logits.len();
+        let config = SamplingConfig {
+            temperature: 0.8,
+            seed: Some(seed),
+            ..Default::default()
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&logits, &[]).unwrap();
+        prop_assert!(
+            (token as usize) < vocab_size,
+            "token {} >= vocab_size {}",
+            token,
+            vocab_size,
+        );
+    }
+
+    // ── 2. Temperature=0 always selects argmax ──────────────────────────
+
+    /// Greedy decoding (temperature=0) must agree with `argmax`.
+    #[test]
+    fn prop_temp_zero_is_argmax(
+        logits in logits_vec(32),
+        seed in 0u64..10_000,
+    ) {
+        let config = SamplingConfig {
+            temperature: 0.0,
+            seed: Some(seed),
+            ..Default::default()
+        };
+        let mut strategy = SamplingStrategy::new(config);
+        let token = strategy.sample(&logits, &[]).unwrap();
+        let expected = greedy_sample(&logits).unwrap();
+        prop_assert_eq!(
+            token, expected,
+            "temperature=0 should always pick argmax",
+        );
+    }
+
+    // ── 3. top_k filtering keeps at most k candidates ───────────────────
+
+    /// After `apply_top_k`, at most `k` entries remain finite;
+    /// the rest are `NEG_INFINITY`.
+    #[test]
+    fn prop_top_k_keeps_at_most_k(
+        logits in logits_vec(64),
+        k in 1usize..=32,
+    ) {
+        let mut filtered = logits.clone();
+        let effective_k = k.min(filtered.len());
+        apply_top_k(&mut filtered, effective_k);
+
+        let finite_count = filtered.iter().filter(|v| v.is_finite()).count();
+        prop_assert!(
+            finite_count <= effective_k,
+            "finite_count {} > k {}",
+            finite_count,
+            effective_k,
+        );
+
+        // Everything that survived must be one of the original top-k values.
+        let mut sorted = logits.clone();
+        sorted.sort_by(|a, b| b.partial_cmp(a).unwrap());
+        let threshold = sorted[effective_k.min(sorted.len()) - 1];
+
+        for (i, &v) in filtered.iter().enumerate() {
+            if v.is_finite() {
+                prop_assert!(
+                    logits[i] >= threshold,
+                    "surviving logit {} at idx {} < threshold {}",
+                    logits[i],
+                    i,
+                    threshold,
+                );
+            }
+        }
+    }
+
+    // ── 4. Repetition penalty decreases probability of repeated tokens ──
+
+    /// Applying repetition penalty > 1.0 to positive logits makes them
+    /// smaller (less likely).
+    #[test]
+    fn prop_repetition_penalty_decreases_positive_logits(
+        base_logit in 0.01f32..10.0,
+        penalty in 1.01f32..3.0,
+        count in 1u32..5,
+    ) {
+        let vocab_size = 8usize;
+        let mut logits = vec![base_logit; vocab_size];
+        let repeated_token = 0u32;
+
+        // Build context with `count` occurrences of token 0.
+        let context: Vec<u32> = std::iter::repeat_n(repeated_token, count as usize).collect();
+
+        let original = logits[repeated_token as usize];
+        apply_repetition_penalty(&mut logits, &context, penalty);
+
+        prop_assert!(
+            logits[repeated_token as usize] < original,
+            "penalty should decrease positive logit: {} -> {}",
+            original,
+            logits[repeated_token as usize],
+        );
+
+        // Unpenalized tokens should be unchanged.
+        for &v in &logits[1..] {
+            prop_assert_eq!(v, base_logit, "unpenalized token should stay the same");
+        }
+    }
+
+    // ── 5. Greedy decode is deterministic with same seed ────────────────
+
+    /// Two `SamplingStrategy` instances with the same seed and temperature=0
+    /// must produce identical tokens for the same logits.
+    #[test]
+    fn prop_greedy_deterministic_same_seed(
+        logits in logits_vec(32),
+        seed in 0u64..100_000,
+    ) {
+        let make = || {
+            SamplingStrategy::new(SamplingConfig {
+                temperature: 0.0,
+                seed: Some(seed),
+                ..Default::default()
+            })
+        };
+
+        let mut s1 = make();
+        let mut s2 = make();
+
+        let t1 = s1.sample(&logits, &[]).unwrap();
+        let t2 = s2.sample(&logits, &[]).unwrap();
+        prop_assert_eq!(t1, t2, "same seed + greedy must be deterministic");
+    }
+}

--- a/crates/bitnet-kernels/src/perf_tracker.rs
+++ b/crates/bitnet-kernels/src/perf_tracker.rs
@@ -14,12 +14,7 @@ pub struct KernelTiming {
 
 impl KernelTiming {
     pub fn new(name: &str, duration: Duration, elements: usize) -> Self {
-        Self {
-            kernel_name: name.to_string(),
-            duration,
-            input_elements: elements,
-            flops: None,
-        }
+        Self { kernel_name: name.to_string(), duration, input_elements: elements, flops: None }
     }
 
     pub fn with_flops(mut self, flops: u64) -> Self {
@@ -37,8 +32,7 @@ impl KernelTiming {
 
     /// GFLOPS (if flops were provided).
     pub fn gflops(&self) -> Option<f64> {
-        self.flops
-            .map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
+        self.flops.map(|f| f as f64 / self.duration.as_secs_f64() / 1e9)
     }
 }
 
@@ -88,19 +82,15 @@ impl PerfTracker {
         let mut stats: Vec<KernelStats> = grouped
             .into_iter()
             .map(|(name, timings)| {
-                let durations: Vec<Duration> =
-                    timings.iter().map(|t| t.duration).collect();
+                let durations: Vec<Duration> = timings.iter().map(|t| t.duration).collect();
                 let total: Duration = durations.iter().sum();
                 let count = durations.len();
                 let avg = total / count as u32;
                 let mut sorted = durations.clone();
                 sorted.sort();
-                let min =
-                    sorted.first().copied().unwrap_or(Duration::ZERO);
-                let max =
-                    sorted.last().copied().unwrap_or(Duration::ZERO);
-                let total_elements: usize =
-                    timings.iter().map(|t| t.input_elements).sum();
+                let min = sorted.first().copied().unwrap_or(Duration::ZERO);
+                let max = sorted.last().copied().unwrap_or(Duration::ZERO);
+                let total_elements: usize = timings.iter().map(|t| t.input_elements).sum();
                 KernelStats {
                     name,
                     count,
@@ -152,14 +142,8 @@ impl KernelStats {
 /// Format tracker results as text.
 pub fn format_perf_report(tracker: &PerfTracker) -> String {
     let mut out = format!("=== Kernel Performance Report ===\n");
-    out.push_str(&format!(
-        "Total kernels: {}\n",
-        tracker.count()
-    ));
-    out.push_str(&format!(
-        "Total time:    {:.2?}\n\n",
-        tracker.total_time()
-    ));
+    out.push_str(&format!("Total kernels: {}\n", tracker.count()));
+    out.push_str(&format!("Total time:    {:.2?}\n\n", tracker.total_time()));
 
     let stats = tracker.kernel_stats();
     out.push_str(&format!(
@@ -188,8 +172,7 @@ mod tests {
 
     #[test]
     fn test_timing_new() {
-        let t =
-            KernelTiming::new("matmul", Duration::from_millis(10), 1024);
+        let t = KernelTiming::new("matmul", Duration::from_millis(10), 1024);
         assert_eq!(t.kernel_name, "matmul");
         assert_eq!(t.input_elements, 1024);
     }
@@ -208,15 +191,13 @@ mod tests {
 
     #[test]
     fn test_timing_with_flops() {
-        let t = KernelTiming::new("test", Duration::from_secs(1), 1000)
-            .with_flops(1_000_000_000);
+        let t = KernelTiming::new("test", Duration::from_secs(1), 1000).with_flops(1_000_000_000);
         assert!((t.gflops().unwrap() - 1.0).abs() < 0.01);
     }
 
     #[test]
     fn test_timing_no_flops() {
-        let t =
-            KernelTiming::new("test", Duration::from_millis(1), 100);
+        let t = KernelTiming::new("test", Duration::from_millis(1), 100);
         assert!(t.gflops().is_none());
     }
 
@@ -230,38 +211,22 @@ mod tests {
     #[test]
     fn test_tracker_record() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         assert_eq!(t.count(), 1);
     }
 
     #[test]
     fn test_tracker_total_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(20), 200));
         assert_eq!(t.total_time(), Duration::from_millis(30));
     }
 
     #[test]
     fn test_tracker_clear() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_millis(5),
-            100,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_millis(5), 100));
         t.clear();
         assert_eq!(t.count(), 0);
     }
@@ -269,21 +234,9 @@ mod tests {
     #[test]
     fn test_tracker_by_kernel() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            50,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(15),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 50));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(15), 200));
         let grouped = t.by_kernel();
         assert_eq!(grouped["matmul"].len(), 2);
         assert_eq!(grouped["softmax"].len(), 1);
@@ -292,16 +245,8 @@ mod tests {
     #[test]
     fn test_kernel_stats() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(20),
-            200,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 100));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(20), 200));
         let stats = t.kernel_stats();
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].count, 2);
@@ -311,16 +256,8 @@ mod tests {
     #[test]
     fn test_kernel_stats_sorted_by_time() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "fast",
-            Duration::from_millis(1),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "slow",
-            Duration::from_millis(100),
-            100,
-        ));
+        t.record(KernelTiming::new("fast", Duration::from_millis(1), 100));
+        t.record(KernelTiming::new("slow", Duration::from_millis(100), 100));
         let stats = t.kernel_stats();
         assert_eq!(stats[0].name, "slow");
     }
@@ -328,21 +265,9 @@ mod tests {
     #[test]
     fn test_slowest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "c",
-            Duration::from_millis(10),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
+        t.record(KernelTiming::new("c", Duration::from_millis(10), 100));
         let slowest = t.slowest().unwrap();
         assert_eq!(slowest.kernel_name, "b");
     }
@@ -350,16 +275,8 @@ mod tests {
     #[test]
     fn test_fastest() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "a",
-            Duration::from_millis(5),
-            100,
-        ));
-        t.record(KernelTiming::new(
-            "b",
-            Duration::from_millis(50),
-            100,
-        ));
+        t.record(KernelTiming::new("a", Duration::from_millis(5), 100));
+        t.record(KernelTiming::new("b", Duration::from_millis(50), 100));
         let fastest = t.fastest().unwrap();
         assert_eq!(fastest.kernel_name, "a");
     }
@@ -373,11 +290,7 @@ mod tests {
     #[test]
     fn test_kernel_stats_avg_throughput() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "test",
-            Duration::from_secs(1),
-            1000,
-        ));
+        t.record(KernelTiming::new("test", Duration::from_secs(1), 1000));
         let stats = t.kernel_stats();
         assert!((stats[0].avg_throughput() - 1000.0).abs() < 0.1);
     }
@@ -385,16 +298,8 @@ mod tests {
     #[test]
     fn test_format_report() {
         let mut t = PerfTracker::new();
-        t.record(KernelTiming::new(
-            "matmul",
-            Duration::from_millis(10),
-            1024,
-        ));
-        t.record(KernelTiming::new(
-            "softmax",
-            Duration::from_millis(5),
-            512,
-        ));
+        t.record(KernelTiming::new("matmul", Duration::from_millis(10), 1024));
+        t.record(KernelTiming::new("softmax", Duration::from_millis(5), 512));
         let out = format_perf_report(&t);
         assert!(out.contains("Kernel Performance Report"));
         assert!(out.contains("matmul"));

--- a/crates/bitnet-models/src/model_fingerprint.rs
+++ b/crates/bitnet-models/src/model_fingerprint.rs
@@ -80,8 +80,12 @@ impl ModelFingerprint {
     pub fn compact_id(&self) -> String {
         format!(
             "{}-L{}-H{}-A{}-V{}-{}",
-            self.architecture, self.num_layers, self.hidden_size,
-            self.num_heads, self.vocab_size, self.quant_type
+            self.architecture,
+            self.num_layers,
+            self.hidden_size,
+            self.num_heads,
+            self.vocab_size,
+            self.quant_type
         )
     }
 
@@ -100,10 +104,7 @@ impl ModelFingerprint {
 
     /// Whether this is a quantized model (less than 16 bits per param).
     pub fn is_quantized(&self) -> bool {
-        matches!(
-            self.quant_type.as_str(),
-            "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0"
-        )
+        matches!(self.quant_type.as_str(), "i2s" | "i2_s" | "i4" | "q4_0" | "q4_1" | "i8" | "q8_0")
     }
 
     /// Whether two fingerprints represent the same architecture.
@@ -223,10 +224,7 @@ pub fn identify_model(fp: &ModelFingerprint) -> Option<&'static str> {
         ("SmolLM2-1.7B", "smollm2", 24, 2048),
     ];
     for (name, arch, layers, hidden) in known {
-        if fp.architecture == arch
-            && fp.num_layers == layers
-            && fp.hidden_size == hidden
-        {
+        if fp.architecture == arch && fp.num_layers == layers && fp.hidden_size == hidden {
             return Some(name);
         }
     }
@@ -271,25 +269,22 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f16() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f16");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f16");
         assert_eq!(fp.estimated_weight_bytes(), 2_000_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_i2s() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(2_000_000_000)
-            .with_quant_type("i2s");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(2_000_000_000).with_quant_type("i2s");
         assert_eq!(fp.estimated_weight_bytes(), 500_000_000);
     }
 
     #[test]
     fn test_estimated_weight_bytes_q4() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(7_000_000_000)
-            .with_quant_type("q4_0");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(7_000_000_000).with_quant_type("q4_0");
         assert_eq!(fp.estimated_weight_bytes(), 3_500_000_000);
     }
 
@@ -303,10 +298,8 @@ mod tests {
 
     #[test]
     fn test_same_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
         let b = ModelFingerprint::new("llama")
             .with_layers(32)
             .with_hidden_size(4096)
@@ -317,14 +310,9 @@ mod tests {
 
     #[test]
     fn test_different_architecture() {
-        let a = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096)
-            .with_heads(32);
-        let b = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120)
-            .with_heads(40);
+        let a =
+            ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096).with_heads(32);
+        let b = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120).with_heads(40);
         assert!(!a.same_architecture(&b));
     }
 
@@ -386,9 +374,8 @@ mod tests {
 
     #[test]
     fn test_with_tag() {
-        let fp = ModelFingerprint::new("test")
-            .with_tag("name", "my-model")
-            .with_tag("source", "hf");
+        let fp =
+            ModelFingerprint::new("test").with_tag("name", "my-model").with_tag("source", "hf");
         assert_eq!(fp.tags["name"], "my-model");
         assert_eq!(fp.tags["source"], "hf");
     }
@@ -403,25 +390,19 @@ mod tests {
 
     #[test]
     fn test_identify_model_phi4() {
-        let fp = ModelFingerprint::new("phi")
-            .with_layers(40)
-            .with_hidden_size(5120);
+        let fp = ModelFingerprint::new("phi").with_layers(40).with_hidden_size(5120);
         assert_eq!(identify_model(&fp), Some("phi-4"));
     }
 
     #[test]
     fn test_identify_model_llama() {
-        let fp = ModelFingerprint::new("llama")
-            .with_layers(32)
-            .with_hidden_size(4096);
+        let fp = ModelFingerprint::new("llama").with_layers(32).with_hidden_size(4096);
         assert_eq!(identify_model(&fp), Some("llama-3.1-8B"));
     }
 
     #[test]
     fn test_identify_model_unknown() {
-        let fp = ModelFingerprint::new("unknown")
-            .with_layers(99)
-            .with_hidden_size(9999);
+        let fp = ModelFingerprint::new("unknown").with_layers(99).with_hidden_size(9999);
         assert_eq!(identify_model(&fp), None);
     }
 
@@ -438,9 +419,8 @@ mod tests {
 
     #[test]
     fn test_estimated_weight_bytes_f32() {
-        let fp = ModelFingerprint::new("test")
-            .with_param_count(1_000_000_000)
-            .with_quant_type("f32");
+        let fp =
+            ModelFingerprint::new("test").with_param_count(1_000_000_000).with_quant_type("f32");
         assert_eq!(fp.estimated_weight_bytes(), 4_000_000_000);
     }
 

--- a/crates/bitnet-models/tests/proptest_wave33.rs
+++ b/crates/bitnet-models/tests/proptest_wave33.rs
@@ -1,0 +1,217 @@
+//! Wave 33 property tests: model configuration and naming invariants.
+//!
+//! Properties tested (5):
+//! 1. GGUF header round-trip (write→read preserves metadata)
+//! 2. Tensor name sanitization (normalize_name) is idempotent
+//! 3. Model config validation rejects invalid dimensions (zero fields)
+//! 4. Layer count must match architecture spec (num_kv_heads ≤ num_heads)
+//! 5. Embedding dimension must be positive and divisible by num_heads
+
+#![cfg(all(test, feature = "cpu"))]
+
+use bitnet_models::config::GgufModelConfig;
+use bitnet_models::gguf_writer::GgufBuilder;
+use bitnet_models::names::{is_layernorm_weight, is_projection_weight};
+use proptest::prelude::*;
+use std::io::Cursor;
+
+// ── helpers ─────────────────────────────────────────────────────────────
+
+/// Build a valid `GgufModelConfig` from parameters, computing head_dim.
+fn make_config(
+    hidden_size: usize,
+    num_heads: usize,
+    num_kv_heads: usize,
+    num_layers: usize,
+) -> GgufModelConfig {
+    GgufModelConfig {
+        architecture: "llama".to_string(),
+        model_name: None,
+        vocab_size: 32_000,
+        hidden_size,
+        num_layers,
+        num_heads,
+        num_kv_heads,
+        head_dim: if num_heads > 0 { hidden_size / num_heads } else { 0 },
+        intermediate_size: 11_008,
+        max_seq_len: 2048,
+        rope_theta: 10_000.0,
+        rope_scaling: None,
+        quantization: Default::default(),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    // ── 1. GGUF header round-trip ───────────────────────────────────────
+
+    /// Writing metadata with GgufBuilder and reading it back via the GGUF
+    /// parser preserves the architecture string and u32 metadata values.
+    #[test]
+    fn prop_gguf_metadata_round_trip(
+        arch in "[a-z]{3,8}",
+        vocab in 1u32..200_000,
+        layers in 1u32..128,
+    ) {
+        let mut buf = Cursor::new(Vec::new());
+
+        let builder = GgufBuilder::new()
+            .architecture(&arch)
+            .metadata_string("general.architecture", &arch)
+            .metadata_u32(&format!("{arch}.vocab_size"), vocab)
+            .metadata_u32(&format!("{arch}.block_count"), layers);
+
+        buf = builder.write(buf).expect("write should succeed");
+        let data = buf.into_inner();
+
+        // Parse back with the low-level GGUF reader.
+        let reader = bitnet_models::formats::gguf::GgufReader::new(&data)
+            .expect("reader should parse written data");
+
+        let read_arch = reader
+            .get_string_metadata("general.architecture")
+            .expect("architecture metadata should exist");
+        prop_assert_eq!(&read_arch, &arch);
+
+        let key_vocab = format!("{arch}.vocab_size");
+        let read_vocab = reader
+            .get_u32_metadata(&key_vocab)
+            .expect("vocab_size metadata should exist");
+        prop_assert_eq!(read_vocab, vocab);
+
+        let key_layers = format!("{arch}.block_count");
+        let read_layers = reader
+            .get_u32_metadata(&key_layers)
+            .expect("block_count metadata should exist");
+        prop_assert_eq!(read_layers, layers);
+    }
+
+    // ── 2. Tensor name classification is idempotent ─────────────────────
+
+    /// `is_layernorm_weight` and `is_projection_weight` are stable
+    /// predicates: calling them twice on the same name returns the same
+    /// answer, and the two categories are mutually exclusive for known
+    /// names.
+    #[test]
+    fn prop_name_classification_idempotent(
+        layer_idx in 0u32..64,
+        suffix in prop_oneof![
+            Just("attn_norm.weight"),
+            Just("ffn_norm.weight"),
+            Just("attn_q.weight"),
+            Just("attn_k.weight"),
+            Just("attn_v.weight"),
+            Just("attn_output.weight"),
+            Just("ffn_gate.weight"),
+            Just("ffn_up.weight"),
+            Just("ffn_down.weight"),
+        ],
+    ) {
+        let name = format!("blk.{layer_idx}.{suffix}");
+        let ln1 = is_layernorm_weight(&name);
+        let ln2 = is_layernorm_weight(&name);
+        prop_assert_eq!(ln1, ln2, "is_layernorm_weight must be idempotent");
+
+        let proj1 = is_projection_weight(&name);
+        let proj2 = is_projection_weight(&name);
+        prop_assert_eq!(proj1, proj2, "is_projection_weight must be idempotent");
+
+        // Known names are either LN or projection, never both.
+        prop_assert!(
+            !(ln1 && proj1),
+            "name '{}' classified as both layernorm AND projection",
+            name,
+        );
+    }
+
+    // ── 3. Validation rejects zero dimensions ───────────────────────────
+
+    /// Setting any critical dimension to zero should cause `validate()` to
+    /// return an error.
+    #[test]
+    fn prop_validate_rejects_zero_dims(
+        field_idx in 0usize..5,
+    ) {
+        // Start with a valid config.
+        let mut cfg = make_config(4096, 32, 32, 32);
+
+        // Zero out one field at a time.
+        match field_idx {
+            0 => cfg.vocab_size = 0,
+            1 => { cfg.hidden_size = 0; cfg.head_dim = 0; },
+            2 => cfg.num_layers = 0,
+            3 => { cfg.num_heads = 0; cfg.head_dim = 0; },
+            4 => cfg.intermediate_size = 0,
+            _ => unreachable!(),
+        }
+
+        prop_assert!(
+            cfg.validate().is_err(),
+            "zeroed field_idx={} should fail validation",
+            field_idx,
+        );
+    }
+
+    // ── 4. num_kv_heads must be ≤ num_heads ─────────────────────────────
+
+    /// If `num_kv_heads > num_heads`, validation must reject the config.
+    #[test]
+    fn prop_kv_heads_le_num_heads(
+        num_heads in 1u32..=64,
+        extra in 1u32..=32,
+    ) {
+        let hidden = (num_heads as usize) * 128;
+        let num_kv = (num_heads + extra) as usize; // strictly > num_heads
+        let cfg = make_config(hidden, num_heads as usize, num_kv, 32);
+
+        prop_assert!(
+            cfg.validate().is_err(),
+            "num_kv_heads ({}) > num_heads ({}) should fail",
+            num_kv,
+            num_heads,
+        );
+    }
+
+    // ── 5. hidden_size must be divisible by num_heads ───────────────────
+
+    /// Validation must reject configs where `hidden_size % num_heads != 0`.
+    #[test]
+    fn prop_hidden_divisible_by_heads(
+        num_heads in 2usize..=64,
+        offset in 1usize..=127,
+    ) {
+        // Pick a hidden_size that is NOT divisible by num_heads.
+        let base = num_heads * 64;
+        let hidden = base + (offset % num_heads).max(1); // ensure remainder != 0
+        // Intentionally set head_dim to an incorrect value to trigger validation.
+        let cfg = GgufModelConfig {
+            architecture: "llama".to_string(),
+            model_name: None,
+            vocab_size: 32_000,
+            hidden_size: hidden,
+            num_layers: 32,
+            num_heads,
+            num_kv_heads: num_heads,
+            head_dim: hidden / num_heads, // integer division, won't match hidden/num_heads exactly
+            intermediate_size: 11_008,
+            max_seq_len: 2048,
+            rope_theta: 10_000.0,
+            rope_scaling: None,
+            quantization: Default::default(),
+        };
+
+        // Either hidden_size % num_heads != 0 triggers error,
+        // or head_dim != hidden_size / num_heads triggers error.
+        if hidden % num_heads != 0 {
+            prop_assert!(
+                cfg.validate().is_err(),
+                "hidden_size {} not divisible by num_heads {} should fail",
+                hidden,
+                num_heads,
+            );
+        }
+        // If it happens to be divisible (offset % num_heads == 0 was guarded
+        // above via .max(1), but just in case), validation may pass — that's OK.
+    }
+}


### PR DESCRIPTION
## Summary

Add 16 property-based tests across three crates with low proptest coverage.

### bitnet-inference (5 properties)
- `sample` always returns valid token index (< vocab_size)
- Temperature=0 always selects argmax
- `top_k` filtering keeps at most k candidates
- Repetition penalty decreases probability of repeated tokens
- Greedy decode is deterministic with same seed

### bitnet-models (5 properties)
- GGUF header round-trip (write→read preserves metadata)
- Tensor name classification is idempotent and mutually exclusive
- Model config validation rejects zero dimensions
- `num_kv_heads` must be ≤ `num_heads`
- `hidden_size` must be divisible by `num_heads`

### bitnet-common (6 properties)
- Device `is_cpu` XOR non-CPU (mutually exclusive)
- QuantizationType Display + serde round-trip
- `broadcast_shape` rejects incompatible dimensions
- Matmul shape validation rejects mismatched inner dims
- `warn_once` key deduplication
- Error Display is non-empty for all variants

### Testing
All 16 tests pass with `cargo test --no-default-features --features cpu`. No clippy warnings in new files.