### PR TITLE
fix: clippy + formatting wave 13 (token_validation + request_types)

### DIFF
--- a/crates/bitnet-inference/src/lib.rs
+++ b/crates/bitnet-inference/src/lib.rs
@@ -32,8 +32,8 @@ pub mod metrics;
 pub mod npu;
 pub mod production_engine; // always available (sync parser)
 pub mod prompt_template; // Chat and instruct format templates
-pub mod request_types;
 pub mod receipts; // AC4: Inference receipt generation
+pub mod request_types;
 pub mod run_metrics;
 pub mod thread_pool;
 pub mod tool_templates; // Tool-use / function-calling prompt templates

--- a/crates/bitnet-inference/src/request_types.rs
+++ b/crates/bitnet-inference/src/request_types.rs
@@ -40,22 +40,44 @@ impl Default for InferenceRequest {
 
 impl InferenceRequest {
     pub fn new(prompt: &str) -> Self {
-        Self {
-            prompt: prompt.to_string(),
-            ..Default::default()
-        }
+        Self { prompt: prompt.to_string(), ..Default::default() }
     }
 
-    pub fn with_id(mut self, id: &str) -> Self { self.id = id.to_string(); self }
-    pub fn with_max_tokens(mut self, n: usize) -> Self { self.max_tokens = n; self }
-    pub fn with_temperature(mut self, t: f32) -> Self { self.temperature = t; self }
-    pub fn with_top_p(mut self, p: f32) -> Self { self.top_p = p; self }
-    pub fn with_top_k(mut self, k: usize) -> Self { self.top_k = k; self }
-    pub fn with_seed(mut self, s: u64) -> Self { self.seed = Some(s); self }
-    pub fn with_stream(mut self, s: bool) -> Self { self.stream = s; self }
+    pub fn with_id(mut self, id: &str) -> Self {
+        self.id = id.to_string();
+        self
+    }
+    pub fn with_max_tokens(mut self, n: usize) -> Self {
+        self.max_tokens = n;
+        self
+    }
+    pub fn with_temperature(mut self, t: f32) -> Self {
+        self.temperature = t;
+        self
+    }
+    pub fn with_top_p(mut self, p: f32) -> Self {
+        self.top_p = p;
+        self
+    }
+    pub fn with_top_k(mut self, k: usize) -> Self {
+        self.top_k = k;
+        self
+    }
+    pub fn with_seed(mut self, s: u64) -> Self {
+        self.seed = Some(s);
+        self
+    }
+    pub fn with_stream(mut self, s: bool) -> Self {
+        self.stream = s;
+        self
+    }
 
-    pub fn is_greedy(&self) -> bool { self.temperature <= 0.01 }
-    pub fn is_deterministic(&self) -> bool { self.seed.is_some() }
+    pub fn is_greedy(&self) -> bool {
+        self.temperature <= 0.01
+    }
+    pub fn is_deterministic(&self) -> bool {
+        self.seed.is_some()
+    }
 }
 
 /// Inference response.
@@ -99,7 +121,11 @@ pub struct UsageInfo {
 
 impl UsageInfo {
     pub fn new(prompt: usize, completion: usize) -> Self {
-        Self { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion }
+        Self {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            total_tokens: prompt + completion,
+        }
     }
 }
 
@@ -151,10 +177,7 @@ mod tests {
 
     #[test]
     fn test_builder_chain() {
-        let r = InferenceRequest::new("Hi")
-            .with_max_tokens(64)
-            .with_temperature(0.0)
-            .with_seed(42);
+        let r = InferenceRequest::new("Hi").with_max_tokens(64).with_temperature(0.0).with_seed(42);
         assert_eq!(r.max_tokens, 64);
         assert!(r.is_greedy());
         assert!(r.is_deterministic());

--- a/crates/bitnet-tokenizers/src/token_validation.rs
+++ b/crates/bitnet-tokenizers/src/token_validation.rs
@@ -75,14 +75,14 @@ pub fn validate_tokens(tokens: &[u32], config: &ValidationConfig) -> Result<(), 
         }
     }
 
-    if config.require_bos {
-        if let Some(bos) = config.bos_token_id {
-            let bos_count = tokens.iter().filter(|&&t| t == bos).count();
-            if bos_count == 0 {
-                errors.push(TokenError::MissingBos);
-            } else if bos_count > 1 {
-                errors.push(TokenError::DuplicateBos { count: bos_count });
-            }
+    if config.require_bos
+        && let Some(bos) = config.bos_token_id
+    {
+        let bos_count = tokens.iter().filter(|&&t| t == bos).count();
+        if bos_count == 0 {
+            errors.push(TokenError::MissingBos);
+        } else if bos_count > 1 {
+            errors.push(TokenError::DuplicateBos { count: bos_count });
         }
     }
 
@@ -120,13 +120,15 @@ pub fn truncate(tokens: &[u32], max_length: usize, bos_id: Option<u32>) -> Vec<u
     }
 
     // If first token is BOS, keep it
-    if let Some(bos) = bos_id {
-        if !tokens.is_empty() && tokens[0] == bos && max_length >= 2 {
-            let mut result = vec![bos];
-            let skip = tokens.len() - (max_length - 1);
-            result.extend_from_slice(&tokens[skip..]);
-            return result;
-        }
+    if let Some(bos) = bos_id
+        && !tokens.is_empty()
+        && tokens[0] == bos
+        && max_length >= 2
+    {
+        let mut result = vec![bos];
+        let skip = tokens.len() - (max_length - 1);
+        result.extend_from_slice(&tokens[skip..]);
+        return result;
     }
 
     tokens[tokens.len() - max_length..].to_vec()
@@ -240,3 +242,4 @@ mod tests {
         assert!(e.to_string().contains("50000"));
     }
 }
+


### PR DESCRIPTION
## P0: Unblock merge queue

Fixes clippy and formatting issues from recently-merged PRs:
- `token_validation.rs`: 2 collapsible_if → let-chains (from #2840)
- `request_types.rs` + `lib.rs`: cargo fmt (from #2849)

3 files, formatting + clippy only, no logic changes.

**Apple Silicon Team** 🍎