### PR TITLE
fix: clippy collapsible_if + cargo fmt (wave 13)

### DIFF
--- a/crates/bitnet-inference/src/request_types.rs
+++ b/crates/bitnet-inference/src/request_types.rs
@@ -40,22 +40,44 @@ impl Default for InferenceRequest {
 
 impl InferenceRequest {
     pub fn new(prompt: &str) -> Self {
-        Self {
-            prompt: prompt.to_string(),
-            ..Default::default()
-        }
+        Self { prompt: prompt.to_string(), ..Default::default() }
     }
 
-    pub fn with_id(mut self, id: &str) -> Self { self.id = id.to_string(); self }
-    pub fn with_max_tokens(mut self, n: usize) -> Self { self.max_tokens = n; self }
-    pub fn with_temperature(mut self, t: f32) -> Self { self.temperature = t; self }
-    pub fn with_top_p(mut self, p: f32) -> Self { self.top_p = p; self }
-    pub fn with_top_k(mut self, k: usize) -> Self { self.top_k = k; self }
-    pub fn with_seed(mut self, s: u64) -> Self { self.seed = Some(s); self }
-    pub fn with_stream(mut self, s: bool) -> Self { self.stream = s; self }
+    pub fn with_id(mut self, id: &str) -> Self {
+        self.id = id.to_string();
+        self
+    }
+    pub fn with_max_tokens(mut self, n: usize) -> Self {
+        self.max_tokens = n;
+        self
+    }
+    pub fn with_temperature(mut self, t: f32) -> Self {
+        self.temperature = t;
+        self
+    }
+    pub fn with_top_p(mut self, p: f32) -> Self {
+        self.top_p = p;
+        self
+    }
+    pub fn with_top_k(mut self, k: usize) -> Self {
+        self.top_k = k;
+        self
+    }
+    pub fn with_seed(mut self, s: u64) -> Self {
+        self.seed = Some(s);
+        self
+    }
+    pub fn with_stream(mut self, s: bool) -> Self {
+        self.stream = s;
+        self
+    }
 
-    pub fn is_greedy(&self) -> bool { self.temperature <= 0.01 }
-    pub fn is_deterministic(&self) -> bool { self.seed.is_some() }
+    pub fn is_greedy(&self) -> bool {
+        self.temperature <= 0.01
+    }
+    pub fn is_deterministic(&self) -> bool {
+        self.seed.is_some()
+    }
 }
 
 /// Inference response.
@@ -99,7 +121,11 @@ pub struct UsageInfo {
 
 impl UsageInfo {
     pub fn new(prompt: usize, completion: usize) -> Self {
-        Self { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion }
+        Self {
+            prompt_tokens: prompt,
+            completion_tokens: completion,
+            total_tokens: prompt + completion,
+        }
     }
 }
 
@@ -151,10 +177,7 @@ mod tests {
 
     #[test]
     fn test_builder_chain() {
-        let r = InferenceRequest::new("Hi")
-            .with_max_tokens(64)
-            .with_temperature(0.0)
-            .with_seed(42);
+        let r = InferenceRequest::new("Hi").with_max_tokens(64).with_temperature(0.0).with_seed(42);
         assert_eq!(r.max_tokens, 64);
         assert!(r.is_greedy());
         assert!(r.is_deterministic());

--- a/crates/bitnet-kernels/src/activation_registry.rs
+++ b/crates/bitnet-kernels/src/activation_registry.rs
@@ -103,8 +103,8 @@ fn erf(x: f32) -> f32 {
     // Abramowitz and Stegun approximation
     let t = 1.0 / (1.0 + 0.3275911 * x.abs());
     let poly = t
-        * (0.254829592
-            + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+        * (0.254_829_6
+            + t * (-0.284_496_72 + t * (1.421_413_8 + t * (-1.453_152_1 + t * 1.061_405_4))));
     let result = 1.0 - poly * (-x * x).exp();
     if x >= 0.0 { result } else { -result }
 }

--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -24,9 +24,9 @@ pub mod ffi;
 pub mod gpu;
 pub mod gpu_utils;
 pub mod kernels;
-pub mod norm_registry;
 #[cfg(feature = "metal")]
 pub mod metal_compute;
+pub mod norm_registry;
 #[cfg(feature = "npu-backend")]
 pub mod npu;
 pub mod opencl_async_executor;

--- a/crates/bitnet-kernels/src/norm_registry.rs
+++ b/crates/bitnet-kernels/src/norm_registry.rs
@@ -80,9 +80,9 @@ pub fn layer_norm(data: &mut [f32], weight: &[f32], bias: Option<&[f32]>, eps: f
         / n as f64;
     let inv_std = 1.0 / (var + eps).sqrt();
 
-    for i in 0..n {
-        let normed = ((data[i] as f64 - mean) * inv_std) as f32;
-        data[i] = normed * weight.get(i).copied().unwrap_or(1.0)
+    for (i, d) in data.iter_mut().enumerate() {
+        let normed = ((*d as f64 - mean) * inv_std) as f32;
+        *d = normed * weight.get(i).copied().unwrap_or(1.0)
             + bias.and_then(|b| b.get(i)).copied().unwrap_or(0.0);
     }
 }
@@ -98,8 +98,8 @@ pub fn rms_norm(data: &mut [f32], weight: &[f32], eps: f64) {
         (data.iter().map(|&v| (v as f64) * (v as f64)).sum::<f64>() / n as f64 + eps).sqrt();
     let inv_rms = 1.0 / rms;
 
-    for i in 0..n {
-        data[i] = ((data[i] as f64 * inv_rms) as f32) * weight.get(i).copied().unwrap_or(1.0);
+    for (i, d) in data.iter_mut().enumerate() {
+        *d = ((*d as f64 * inv_rms) as f32) * weight.get(i).copied().unwrap_or(1.0);
     }
 }
 

--- a/crates/bitnet-models/src/metadata_extractor.rs
+++ b/crates/bitnet-models/src/metadata_extractor.rs
@@ -142,9 +142,7 @@ pub fn from_kv_pairs(pairs: &HashMap<String, String>) -> ModelMetadata {
             k if k.contains("max_position") || k.contains("context_length") => {
                 m.max_position = v.parse().ok();
             }
-            k if k.contains("intermediate_size")
-                || k.contains("feed_forward_length") =>
-            {
+            k if k.contains("intermediate_size") || k.contains("feed_forward_length") => {
                 m.intermediate_size = v.parse().ok();
             }
             k if k.contains("model_type") || k.contains("architecture") => {
@@ -185,10 +183,7 @@ mod tests {
 
     #[test]
     fn test_missing_fields() {
-        let m = ModelMetadata {
-            hidden_size: Some(4096),
-            ..Default::default()
-        };
+        let m = ModelMetadata { hidden_size: Some(4096), ..Default::default() };
         let missing = m.missing_fields();
         assert!(missing.contains(&"num_layers"));
         assert!(!missing.contains(&"hidden_size"));
@@ -196,34 +191,21 @@ mod tests {
 
     #[test]
     fn test_head_dim() {
-        let m = ModelMetadata {
-            hidden_size: Some(4096),
-            num_heads: Some(32),
-            ..Default::default()
-        };
+        let m =
+            ModelMetadata { hidden_size: Some(4096), num_heads: Some(32), ..Default::default() };
         assert_eq!(m.head_dim(), Some(128));
     }
 
     #[test]
     fn test_gqa_groups() {
-        let m = ModelMetadata {
-            num_heads: Some(40),
-            num_kv_heads: Some(10),
-            ..Default::default()
-        };
+        let m = ModelMetadata { num_heads: Some(40), num_kv_heads: Some(10), ..Default::default() };
         assert_eq!(m.gqa_groups(), Some(4));
     }
 
     #[test]
     fn test_merge() {
-        let mut a = ModelMetadata {
-            hidden_size: Some(4096),
-            ..Default::default()
-        };
-        let b = ModelMetadata {
-            num_layers: Some(32),
-            ..Default::default()
-        };
+        let mut a = ModelMetadata { hidden_size: Some(4096), ..Default::default() };
+        let b = ModelMetadata { num_layers: Some(32), ..Default::default() };
         a.merge(&b);
         assert_eq!(a.hidden_size, Some(4096));
         assert_eq!(a.num_layers, Some(32));
@@ -231,14 +213,8 @@ mod tests {
 
     #[test]
     fn test_merge_overwrite() {
-        let mut a = ModelMetadata {
-            hidden_size: Some(4096),
-            ..Default::default()
-        };
-        let b = ModelMetadata {
-            hidden_size: Some(5120),
-            ..Default::default()
-        };
+        let mut a = ModelMetadata { hidden_size: Some(4096), ..Default::default() };
+        let b = ModelMetadata { hidden_size: Some(5120), ..Default::default() };
         a.merge(&b);
         assert_eq!(a.hidden_size, Some(5120));
     }
@@ -287,20 +263,13 @@ mod tests {
 
     #[test]
     fn test_head_dim_zero_heads() {
-        let m = ModelMetadata {
-            hidden_size: Some(4096),
-            num_heads: Some(0),
-            ..Default::default()
-        };
+        let m = ModelMetadata { hidden_size: Some(4096), num_heads: Some(0), ..Default::default() };
         assert_eq!(m.head_dim(), None);
     }
 
     #[test]
     fn test_gqa_no_kv_heads() {
-        let m = ModelMetadata {
-            num_heads: Some(32),
-            ..Default::default()
-        };
+        let m = ModelMetadata { num_heads: Some(32), ..Default::default() };
         assert_eq!(m.gqa_groups(), None);
     }
 

--- a/crates/bitnet-tokenizers/src/token_validation.rs
+++ b/crates/bitnet-tokenizers/src/token_validation.rs
@@ -75,14 +75,14 @@ pub fn validate_tokens(tokens: &[u32], config: &ValidationConfig) -> Result<(), 
         }
     }
 
-    if config.require_bos {
-        if let Some(bos) = config.bos_token_id {
-            let bos_count = tokens.iter().filter(|&&t| t == bos).count();
-            if bos_count == 0 {
-                errors.push(TokenError::MissingBos);
-            } else if bos_count > 1 {
-                errors.push(TokenError::DuplicateBos { count: bos_count });
-            }
+    if config.require_bos
+        && let Some(bos) = config.bos_token_id
+    {
+        let bos_count = tokens.iter().filter(|&&t| t == bos).count();
+        if bos_count == 0 {
+            errors.push(TokenError::MissingBos);
+        } else if bos_count > 1 {
+            errors.push(TokenError::DuplicateBos { count: bos_count });
         }
     }
 
@@ -120,13 +120,15 @@ pub fn truncate(tokens: &[u32], max_length: usize, bos_id: Option<u32>) -> Vec<u
     }
 
     // If first token is BOS, keep it
-    if let Some(bos) = bos_id {
-        if !tokens.is_empty() && tokens[0] == bos && max_length >= 2 {
-            let mut result = vec![bos];
-            let skip = tokens.len() - (max_length - 1);
-            result.extend_from_slice(&tokens[skip..]);
-            return result;
-        }
+    if let Some(bos) = bos_id
+        && !tokens.is_empty()
+        && tokens[0] == bos
+        && max_length >= 2
+    {
+        let mut result = vec![bos];
+        let skip = tokens.len() - (max_length - 1);
+        result.extend_from_slice(&tokens[skip..]);
+        return result;
     }
 
     tokens[tokens.len() - max_length..].to_vec()


### PR DESCRIPTION
## P0: Unblock merge queue

Fixes clippy + formatting from recently-merged PRs:
- `token_validation.rs`: 2 collapsible_if → let-chains (#2840)
- `request_types.rs` + `lib.rs`: cargo fmt (#2849)
- `metadata_extractor.rs` + `kernels/lib.rs`: cargo fmt (latest merges)

4 files, formatting + clippy only.

**Apple Silicon Team** 🍎