### PR TITLE
fix: clippy + fmt issues from recently merged PRs (wave 14)

### DIFF
--- a/crates/bitnet-inference/src/production_engine.rs
+++ b/crates/bitnet-inference/src/production_engine.rs
@@ -16,7 +16,7 @@ use crate::{GenerationConfig, InferenceEngine};
 #[cfg(feature = "inference")]
 use bitnet_common::KernelCapabilities;
 use bitnet_common::{BackendStartupSummary, BitNetError, Device, InferenceError, Result};
-use bitnet_inference_metrics_core::{ThroughputMetrics, TimingMetrics};
+pub use bitnet_inference_metrics_core::{ThroughputMetrics, TimingMetrics};
 use bitnet_models::Model;
 use bitnet_tokenizers::Tokenizer;
 use std::sync::Arc;

--- a/crates/bitnet-models/src/capability_check.rs
+++ b/crates/bitnet-models/src/capability_check.rs
@@ -115,7 +115,7 @@ pub fn check_requirements(hidden_size: usize, num_layers: usize, vocab_size: usi
     if vocab_size < 100 {
         issues.push(format!("vocab_size {vocab_size} is very small (min recommended: 100)"));
     }
-    if hidden_size % 2 != 0 {
+    if !hidden_size.is_multiple_of(2) {
         issues.push(format!("hidden_size {hidden_size} is odd (should be even for attention)"));
     }
 

--- a/crates/bitnet-models/src/conversion_pipeline.rs
+++ b/crates/bitnet-models/src/conversion_pipeline.rs
@@ -196,17 +196,12 @@ pub fn supported_conversions() -> HashMap<SourceFormat, Vec<TargetFormat>> {
             TargetFormat::GgufQ8,
         ],
     );
-    map.insert(
-        SourceFormat::PyTorch,
-        vec![TargetFormat::GgufF16, TargetFormat::GgufF32],
-    );
+    map.insert(SourceFormat::PyTorch, vec![TargetFormat::GgufF16, TargetFormat::GgufF32]);
     map
 }
 
 pub fn is_supported(source: SourceFormat, target: TargetFormat) -> bool {
-    supported_conversions()
-        .get(&source)
-        .is_some_and(|targets| targets.contains(&target))
+    supported_conversions().get(&source).is_some_and(|targets| targets.contains(&target))
 }
 
 #[cfg(test)]
@@ -215,18 +210,9 @@ mod tests {
 
     #[test]
     fn test_source_from_ext() {
-        assert_eq!(
-            SourceFormat::from_extension("safetensors"),
-            Some(SourceFormat::SafeTensors)
-        );
-        assert_eq!(
-            SourceFormat::from_extension("gguf"),
-            Some(SourceFormat::Gguf)
-        );
-        assert_eq!(
-            SourceFormat::from_extension("pt"),
-            Some(SourceFormat::PyTorch)
-        );
+        assert_eq!(SourceFormat::from_extension("safetensors"), Some(SourceFormat::SafeTensors));
+        assert_eq!(SourceFormat::from_extension("gguf"), Some(SourceFormat::Gguf));
+        assert_eq!(SourceFormat::from_extension("pt"), Some(SourceFormat::PyTorch));
         assert!(SourceFormat::from_extension("txt").is_none());
     }
 
@@ -239,12 +225,8 @@ mod tests {
 
     #[test]
     fn test_plan_safetensors_f16() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16,
-            1_000_000_000,
-            200,
-        );
+        let plan =
+            plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufF16, 1_000_000_000, 200);
         assert_eq!(plan.source, SourceFormat::SafeTensors);
         assert!(!plan.requires_quantization);
         assert!(plan.step_count() >= 3);
@@ -252,49 +234,29 @@ mod tests {
 
     #[test]
     fn test_plan_with_quantization() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufQ4,
-            1_000_000_000,
-            200,
-        );
+        let plan =
+            plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufQ4, 1_000_000_000, 200);
         assert!(plan.requires_quantization);
         assert!(plan.steps.iter().any(|s| s.name == "quantize"));
     }
 
     #[test]
     fn test_plan_gguf_to_gguf() {
-        let plan = plan_conversion(
-            SourceFormat::Gguf,
-            TargetFormat::GgufF16,
-            500_000_000,
-            100,
-        );
+        let plan = plan_conversion(SourceFormat::Gguf, TargetFormat::GgufF16, 500_000_000, 100);
         // No convert_types step for GGUF→GGUF
         assert!(!plan.steps.iter().any(|s| s.name == "convert_types"));
     }
 
     #[test]
     fn test_memory_estimate() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16,
-            1_000_000,
-            10,
-        );
+        let plan = plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufF16, 1_000_000, 10);
         assert_eq!(plan.memory_estimate_bytes, 2_000_000);
     }
 
     #[test]
     fn test_supported() {
-        assert!(is_supported(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16
-        ));
-        assert!(is_supported(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufI2S
-        ));
+        assert!(is_supported(SourceFormat::SafeTensors, TargetFormat::GgufF16));
+        assert!(is_supported(SourceFormat::SafeTensors, TargetFormat::GgufI2S));
         assert!(!is_supported(SourceFormat::Onnx, TargetFormat::GgufF16));
     }
 

--- a/crates/bitnet-models/src/download_manager.rs
+++ b/crates/bitnet-models/src/download_manager.rs
@@ -126,7 +126,7 @@ pub fn validate_download(
             Some(&actual) => {
                 if let Some(expected) = file.expected_bytes {
                     let ratio = actual as f64 / expected as f64;
-                    if ratio < 0.9 || ratio > 1.1 {
+                    if !(0.9..=1.1).contains(&ratio) {
                         issues.push(format!(
                             "{}: size {actual} differs from expected \
                              {expected} (ratio: {ratio:.2})",

--- a/crates/bitnet-quantization/src/calibrator.rs
+++ b/crates/bitnet-quantization/src/calibrator.rs
@@ -61,8 +61,7 @@ impl TensorStats {
         }
         if self.count > 0 {
             self.mean = self.sum / self.count as f64;
-            self.variance =
-                (self.sum_sq / self.count as f64) - self.mean * self.mean;
+            self.variance = (self.sum_sq / self.count as f64) - self.mean * self.mean;
         }
     }
 
@@ -112,18 +111,12 @@ pub fn compute_params(
 
     if symmetric {
         let absmax = max_val.abs().max(min_val.abs());
-        let scale =
-            if absmax == 0.0 { 1.0 } else { absmax / qmax as f64 };
+        let scale = if absmax == 0.0 { 1.0 } else { absmax / qmax as f64 };
         CalibrationResult { scale, zero_point: 0, bits, symmetric: true }
     } else {
         let range = max_val - min_val;
-        let scale = if range == 0.0 {
-            1.0
-        } else {
-            range / (qmax - qmin) as f64
-        };
-        let zero_point =
-            (qmin as f64 - min_val / scale).round() as i64;
+        let scale = if range == 0.0 { 1.0 } else { range / (qmax - qmin) as f64 };
+        let zero_point = (qmin as f64 - min_val / scale).round() as i64;
         CalibrationResult { scale, zero_point, bits, symmetric: false }
     }
 }
@@ -138,11 +131,7 @@ pub struct Calibrator {
 }
 
 impl Calibrator {
-    pub fn new(
-        method: CalibrationMethod,
-        bits: u32,
-        symmetric: bool,
-    ) -> Self {
+    pub fn new(method: CalibrationMethod, bits: u32, symmetric: bool) -> Self {
         Self { method, bits, symmetric, stats: Vec::new() }
     }
 
@@ -155,9 +144,7 @@ impl Calibrator {
     }
 
     pub fn observe(&mut self, name: &str, values: &[f32]) {
-        if let Some(s) =
-            self.stats.iter_mut().find(|s| s.name == name)
-        {
+        if let Some(s) = self.stats.iter_mut().find(|s| s.name == name) {
             s.update(values);
         } else {
             let mut s = TensorStats::new(name);
@@ -173,17 +160,7 @@ impl Calibrator {
     pub fn calibrate(&self) -> Vec<(String, CalibrationResult)> {
         self.stats
             .iter()
-            .map(|s| {
-                (
-                    s.name.clone(),
-                    compute_params(
-                        s,
-                        self.bits,
-                        self.symmetric,
-                        self.method,
-                    ),
-                )
-            })
+            .map(|s| (s.name.clone(), compute_params(s, self.bits, self.symmetric, self.method)))
             .collect()
     }
 
@@ -231,8 +208,7 @@ mod tests {
     fn test_symmetric_int8() {
         let mut s = TensorStats::new("test");
         s.update(&[-1.0, 0.5, 1.0]);
-        let result =
-            compute_params(&s, 8, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, true, CalibrationMethod::MinMax);
         assert!(result.symmetric);
         assert_eq!(result.zero_point, 0);
         assert_eq!(result.bits, 8);
@@ -243,8 +219,7 @@ mod tests {
     fn test_asymmetric_int8() {
         let mut s = TensorStats::new("test");
         s.update(&[0.0, 1.0, 2.0]);
-        let result =
-            compute_params(&s, 8, false, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, false, CalibrationMethod::MinMax);
         assert!(!result.symmetric);
     }
 
@@ -252,8 +227,7 @@ mod tests {
     fn test_int4_params() {
         let mut s = TensorStats::new("test");
         s.update(&[-8.0, 7.0]);
-        let result =
-            compute_params(&s, 4, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 4, true, CalibrationMethod::MinMax);
         assert_eq!(result.bits, 4);
     }
 
@@ -288,12 +262,7 @@ mod tests {
     fn test_percentile_method() {
         let mut s = TensorStats::new("test");
         s.update(&[-10.0, -1.0, 0.0, 1.0, 10.0]);
-        let result = compute_params(
-            &s,
-            8,
-            true,
-            CalibrationMethod::Percentile,
-        );
+        let result = compute_params(&s, 8, true, CalibrationMethod::Percentile);
         assert!(result.scale > 0.0);
     }
 
@@ -307,8 +276,7 @@ mod tests {
     fn test_zero_range() {
         let mut s = TensorStats::new("test");
         s.update(&[5.0, 5.0, 5.0]);
-        let result =
-            compute_params(&s, 8, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, true, CalibrationMethod::MinMax);
         assert!(result.scale > 0.0); // should not be zero
     }
 }


### PR DESCRIPTION
## Summary
Fixes clippy and formatting issues introduced by recently merged PRs.

### Changes
- **bitnet-inference/production_engine.rs**: Make `ThroughputMetrics` and `TimingMetrics` re-exports public (fixes E0603 in integration tests)
- **bitnet-models/capability_check.rs**: Use `.is_multiple_of()` (clippy::manual_is_multiple_of)
- **bitnet-models/download_manager.rs**: Use range `.contains()` (clippy::manual_range_contains)
- **bitnet-models/conversion_pipeline.rs**: cargo fmt formatting

### Testing
- `cargo clippy --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --lib --no-default-features --features cpu -- -D warnings` passes
- `cargo fmt --all --check` passes
- Integration tests compile successfully