### PR TITLE
test(fuzz): add fuzz targets wave 40

### DIFF
--- a/crates/bitnet-models/src/conversion_pipeline.rs
+++ b/crates/bitnet-models/src/conversion_pipeline.rs
@@ -196,17 +196,12 @@ pub fn supported_conversions() -> HashMap<SourceFormat, Vec<TargetFormat>> {
             TargetFormat::GgufQ8,
         ],
     );
-    map.insert(
-        SourceFormat::PyTorch,
-        vec![TargetFormat::GgufF16, TargetFormat::GgufF32],
-    );
+    map.insert(SourceFormat::PyTorch, vec![TargetFormat::GgufF16, TargetFormat::GgufF32]);
     map
 }
 
 pub fn is_supported(source: SourceFormat, target: TargetFormat) -> bool {
-    supported_conversions()
-        .get(&source)
-        .is_some_and(|targets| targets.contains(&target))
+    supported_conversions().get(&source).is_some_and(|targets| targets.contains(&target))
 }
 
 #[cfg(test)]
@@ -215,18 +210,9 @@ mod tests {
 
     #[test]
     fn test_source_from_ext() {
-        assert_eq!(
-            SourceFormat::from_extension("safetensors"),
-            Some(SourceFormat::SafeTensors)
-        );
-        assert_eq!(
-            SourceFormat::from_extension("gguf"),
-            Some(SourceFormat::Gguf)
-        );
-        assert_eq!(
-            SourceFormat::from_extension("pt"),
-            Some(SourceFormat::PyTorch)
-        );
+        assert_eq!(SourceFormat::from_extension("safetensors"), Some(SourceFormat::SafeTensors));
+        assert_eq!(SourceFormat::from_extension("gguf"), Some(SourceFormat::Gguf));
+        assert_eq!(SourceFormat::from_extension("pt"), Some(SourceFormat::PyTorch));
         assert!(SourceFormat::from_extension("txt").is_none());
     }
 
@@ -239,12 +225,8 @@ mod tests {
 
     #[test]
     fn test_plan_safetensors_f16() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16,
-            1_000_000_000,
-            200,
-        );
+        let plan =
+            plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufF16, 1_000_000_000, 200);
         assert_eq!(plan.source, SourceFormat::SafeTensors);
         assert!(!plan.requires_quantization);
         assert!(plan.step_count() >= 3);
@@ -252,49 +234,29 @@ mod tests {
 
     #[test]
     fn test_plan_with_quantization() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufQ4,
-            1_000_000_000,
-            200,
-        );
+        let plan =
+            plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufQ4, 1_000_000_000, 200);
         assert!(plan.requires_quantization);
         assert!(plan.steps.iter().any(|s| s.name == "quantize"));
     }
 
     #[test]
     fn test_plan_gguf_to_gguf() {
-        let plan = plan_conversion(
-            SourceFormat::Gguf,
-            TargetFormat::GgufF16,
-            500_000_000,
-            100,
-        );
+        let plan = plan_conversion(SourceFormat::Gguf, TargetFormat::GgufF16, 500_000_000, 100);
         // No convert_types step for GGUF→GGUF
         assert!(!plan.steps.iter().any(|s| s.name == "convert_types"));
     }
 
     #[test]
     fn test_memory_estimate() {
-        let plan = plan_conversion(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16,
-            1_000_000,
-            10,
-        );
+        let plan = plan_conversion(SourceFormat::SafeTensors, TargetFormat::GgufF16, 1_000_000, 10);
         assert_eq!(plan.memory_estimate_bytes, 2_000_000);
     }
 
     #[test]
     fn test_supported() {
-        assert!(is_supported(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufF16
-        ));
-        assert!(is_supported(
-            SourceFormat::SafeTensors,
-            TargetFormat::GgufI2S
-        ));
+        assert!(is_supported(SourceFormat::SafeTensors, TargetFormat::GgufF16));
+        assert!(is_supported(SourceFormat::SafeTensors, TargetFormat::GgufI2S));
         assert!(!is_supported(SourceFormat::Onnx, TargetFormat::GgufF16));
     }
 

--- a/crates/bitnet-quantization/src/calibrator.rs
+++ b/crates/bitnet-quantization/src/calibrator.rs
@@ -61,8 +61,7 @@ impl TensorStats {
         }
         if self.count > 0 {
             self.mean = self.sum / self.count as f64;
-            self.variance =
-                (self.sum_sq / self.count as f64) - self.mean * self.mean;
+            self.variance = (self.sum_sq / self.count as f64) - self.mean * self.mean;
         }
     }
 
@@ -112,18 +111,12 @@ pub fn compute_params(
 
     if symmetric {
         let absmax = max_val.abs().max(min_val.abs());
-        let scale =
-            if absmax == 0.0 { 1.0 } else { absmax / qmax as f64 };
+        let scale = if absmax == 0.0 { 1.0 } else { absmax / qmax as f64 };
         CalibrationResult { scale, zero_point: 0, bits, symmetric: true }
     } else {
         let range = max_val - min_val;
-        let scale = if range == 0.0 {
-            1.0
-        } else {
-            range / (qmax - qmin) as f64
-        };
-        let zero_point =
-            (qmin as f64 - min_val / scale).round() as i64;
+        let scale = if range == 0.0 { 1.0 } else { range / (qmax - qmin) as f64 };
+        let zero_point = (qmin as f64 - min_val / scale).round() as i64;
         CalibrationResult { scale, zero_point, bits, symmetric: false }
     }
 }
@@ -138,11 +131,7 @@ pub struct Calibrator {
 }
 
 impl Calibrator {
-    pub fn new(
-        method: CalibrationMethod,
-        bits: u32,
-        symmetric: bool,
-    ) -> Self {
+    pub fn new(method: CalibrationMethod, bits: u32, symmetric: bool) -> Self {
         Self { method, bits, symmetric, stats: Vec::new() }
     }
 
@@ -155,9 +144,7 @@ impl Calibrator {
     }
 
     pub fn observe(&mut self, name: &str, values: &[f32]) {
-        if let Some(s) =
-            self.stats.iter_mut().find(|s| s.name == name)
-        {
+        if let Some(s) = self.stats.iter_mut().find(|s| s.name == name) {
             s.update(values);
         } else {
             let mut s = TensorStats::new(name);
@@ -173,17 +160,7 @@ impl Calibrator {
     pub fn calibrate(&self) -> Vec<(String, CalibrationResult)> {
         self.stats
             .iter()
-            .map(|s| {
-                (
-                    s.name.clone(),
-                    compute_params(
-                        s,
-                        self.bits,
-                        self.symmetric,
-                        self.method,
-                    ),
-                )
-            })
+            .map(|s| (s.name.clone(), compute_params(s, self.bits, self.symmetric, self.method)))
             .collect()
     }
 
@@ -231,8 +208,7 @@ mod tests {
     fn test_symmetric_int8() {
         let mut s = TensorStats::new("test");
         s.update(&[-1.0, 0.5, 1.0]);
-        let result =
-            compute_params(&s, 8, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, true, CalibrationMethod::MinMax);
         assert!(result.symmetric);
         assert_eq!(result.zero_point, 0);
         assert_eq!(result.bits, 8);
@@ -243,8 +219,7 @@ mod tests {
     fn test_asymmetric_int8() {
         let mut s = TensorStats::new("test");
         s.update(&[0.0, 1.0, 2.0]);
-        let result =
-            compute_params(&s, 8, false, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, false, CalibrationMethod::MinMax);
         assert!(!result.symmetric);
     }
 
@@ -252,8 +227,7 @@ mod tests {
     fn test_int4_params() {
         let mut s = TensorStats::new("test");
         s.update(&[-8.0, 7.0]);
-        let result =
-            compute_params(&s, 4, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 4, true, CalibrationMethod::MinMax);
         assert_eq!(result.bits, 4);
     }
 
@@ -288,12 +262,7 @@ mod tests {
     fn test_percentile_method() {
         let mut s = TensorStats::new("test");
         s.update(&[-10.0, -1.0, 0.0, 1.0, 10.0]);
-        let result = compute_params(
-            &s,
-            8,
-            true,
-            CalibrationMethod::Percentile,
-        );
+        let result = compute_params(&s, 8, true, CalibrationMethod::Percentile);
         assert!(result.scale > 0.0);
     }
 
@@ -307,8 +276,7 @@ mod tests {
     fn test_zero_range() {
         let mut s = TensorStats::new("test");
         s.update(&[5.0, 5.0, 5.0]);
-        let result =
-            compute_params(&s, 8, true, CalibrationMethod::MinMax);
+        let result = compute_params(&s, 8, true, CalibrationMethod::MinMax);
         assert!(result.scale > 0.0); // should not be zero
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -611,3 +611,33 @@ name = "fuzz_pipeline_parallel_stages"
 path = "fuzz_targets/fuzz_pipeline_parallel_stages.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_quantization_calibration"
+path = "fuzz_targets/fuzz_quantization_calibration.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_download_manifest_parse"
+path = "fuzz_targets/fuzz_download_manifest_parse.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_capability_check"
+path = "fuzz_targets/fuzz_capability_check.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_conversion_pipeline"
+path = "fuzz_targets/fuzz_conversion_pipeline.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_tensor_layout"
+path = "fuzz_targets/fuzz_tensor_layout.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/fuzz_capability_check.rs
+++ b/fuzz/fuzz_targets/fuzz_capability_check.rs
@@ -1,0 +1,64 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_models::capability_check::{ModelCapability, check_requirements, detect_capabilities};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct CapabilityInput {
+    model_family: String,
+    hidden_size: usize,
+    num_layers: usize,
+    vocab_size: usize,
+    /// Extra model family variants to test.
+    extra_families: Vec<String>,
+}
+
+fuzz_target!(|input: CapabilityInput| {
+    // Invariant 1: detect_capabilities must never panic on arbitrary strings
+    let report = detect_capabilities(&input.model_family);
+
+    // Invariant 2: TextGeneration is always present
+    assert!(report.has(ModelCapability::TextGeneration), "TextGeneration must always be present");
+
+    // Invariant 3: model_family is preserved in report
+    assert_eq!(report.model_family, input.model_family);
+
+    // Invariant 4: can_chat and can_code must not panic
+    let _ = report.can_chat();
+    let _ = report.can_code();
+
+    // Invariant 5: capability names must not panic
+    let all_caps = [
+        ModelCapability::TextGeneration,
+        ModelCapability::ChatCompletion,
+        ModelCapability::CodeGeneration,
+        ModelCapability::FillInMiddle,
+        ModelCapability::Embedding,
+        ModelCapability::Classification,
+        ModelCapability::ToolUse,
+        ModelCapability::VisionInput,
+        ModelCapability::AudioInput,
+    ];
+    for cap in &all_caps {
+        let name = cap.name();
+        assert!(!name.is_empty());
+    }
+
+    // Invariant 6: check_requirements must never panic with arbitrary values
+    let issues = check_requirements(input.hidden_size, input.num_layers, input.vocab_size);
+    // Issues list must be a valid Vec (no panic on access)
+    let _ = issues.len();
+
+    // Invariant 7: Boundary values for requirements
+    let _ = check_requirements(0, 0, 0);
+    let _ = check_requirements(usize::MAX, usize::MAX, usize::MAX);
+    let _ = check_requirements(1, 1, 1);
+    let _ = check_requirements(64, 1, 100);
+
+    // Invariant 8: Fuzz additional model families
+    for family in input.extra_families.iter().take(8) {
+        let r = detect_capabilities(family);
+        assert!(r.has(ModelCapability::TextGeneration));
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_conversion_pipeline.rs
+++ b/fuzz/fuzz_targets/fuzz_conversion_pipeline.rs
@@ -1,0 +1,103 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_models::conversion::{
+    ConversionConfig, DType, ModelFormat, QuantMethod, QuantizationSpec, estimate_output_size,
+    plan_conversion,
+};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct ConversionInput {
+    source_path: String,
+    source_format_sel: u8,
+    target_format_sel: u8,
+    target_dtype_sel: u8,
+    quant_method_sel: u8,
+    num_params: u64,
+    has_quant_config: bool,
+    per_channel: bool,
+    group_size: u16,
+    calibration_samples: u16,
+}
+
+fn select_format(sel: u8) -> ModelFormat {
+    match sel % 4 {
+        0 => ModelFormat::SafeTensors,
+        1 => ModelFormat::GGUF,
+        2 => ModelFormat::ONNX,
+        _ => ModelFormat::PyTorch,
+    }
+}
+
+fn select_dtype(sel: u8) -> DType {
+    match sel % 5 {
+        0 => DType::F32,
+        1 => DType::F16,
+        2 => DType::BF16,
+        3 => DType::Int8,
+        _ => DType::Int4,
+    }
+}
+
+fn select_quant_method(sel: u8) -> QuantMethod {
+    match sel % 2 {
+        0 => QuantMethod::Symmetric,
+        _ => QuantMethod::Asymmetric,
+    }
+}
+
+fuzz_target!(|input: ConversionInput| {
+    let source_format = select_format(input.source_format_sel);
+    let target_format = select_format(input.target_format_sel);
+    let target_dtype = select_dtype(input.target_dtype_sel);
+
+    // Invariant 1: DType methods must not panic
+    let _ = target_dtype.bytes_per_element();
+    let _ = target_dtype.is_quantized();
+    let _ = target_dtype.display_name();
+
+    // Invariant 2: ModelFormat extension must not panic
+    let _ = source_format.extension();
+    let _ = target_format.extension();
+
+    // Invariant 3: Build ConversionConfig with optional quantization spec
+    let quant_config = if input.has_quant_config {
+        Some(QuantizationSpec {
+            method: select_quant_method(input.quant_method_sel),
+            per_channel: input.per_channel,
+            group_size: if input.group_size > 0 { Some(input.group_size as usize) } else { None },
+            calibration_samples: input.calibration_samples as usize,
+        })
+    } else {
+        None
+    };
+
+    let config = ConversionConfig {
+        source_format,
+        target_format,
+        target_dtype,
+        quantization_config: quant_config,
+    };
+
+    // Invariant 4: plan_conversion must never panic
+    let plan = plan_conversion(&input.source_path, &config);
+
+    // Invariant 5: plan always has steps
+    assert!(!plan.steps.is_empty(), "conversion plan must have at least one step");
+
+    // Invariant 6: plan metadata must be consistent
+    assert_eq!(plan.config.source_format, source_format);
+    assert_eq!(plan.config.target_format, target_format);
+
+    // Invariant 7: estimate_output_size must not panic for any inputs
+    let _ = estimate_output_size(input.num_params, &target_dtype);
+    let _ = estimate_output_size(0, &target_dtype);
+    let _ = estimate_output_size(u64::MAX, &target_dtype);
+
+    // Invariant 8: All DType variants produce non-zero bytes_per_element
+    let all_dtypes = [DType::F32, DType::F16, DType::BF16, DType::Int8, DType::Int4];
+    for dt in &all_dtypes {
+        assert!(dt.bytes_per_element() > 0, "bytes_per_element must be > 0");
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_download_manifest_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_download_manifest_parse.rs
@@ -1,0 +1,88 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_models::download_manager::{
+    DownloadManifest, DownloadProgress, DownloadSpec, known_models, resolve_model,
+    validate_download,
+};
+use libfuzzer_sys::fuzz_target;
+use std::collections::HashMap;
+
+#[derive(Arbitrary, Debug)]
+struct ManifestInput {
+    model_id: String,
+    filenames: Vec<String>,
+    urls: Vec<String>,
+    expected_bytes: Vec<u64>,
+    sha256_values: Vec<String>,
+    actual_sizes: Vec<u64>,
+    /// Progress tracking fields.
+    file_index: usize,
+    total_files: usize,
+    bytes_downloaded: u64,
+    bytes_total: u64,
+}
+
+fuzz_target!(|input: ManifestInput| {
+    // Invariant 1: resolve_model must never panic on arbitrary strings
+    let _ = resolve_model(&input.model_id);
+
+    // Invariant 2: known_models must always return consistent data
+    let models = known_models();
+    for (_, manifest) in &models {
+        assert!(!manifest.model_id.is_empty());
+        assert!(manifest.file_count() > 0);
+    }
+
+    // Invariant 3: Construct manifest from arbitrary data and validate
+    let file_count = input.filenames.len().min(input.urls.len()).min(8);
+    if file_count == 0 {
+        return;
+    }
+
+    let files: Vec<DownloadSpec> = (0..file_count)
+        .map(|i| DownloadSpec {
+            url: input.urls.get(i).cloned().unwrap_or_default(),
+            filename: input.filenames.get(i).cloned().unwrap_or_default(),
+            expected_bytes: input.expected_bytes.get(i).copied(),
+            sha256: input.sha256_values.get(i).cloned(),
+        })
+        .collect();
+
+    let manifest = DownloadManifest {
+        model_id: input.model_id.clone(),
+        files,
+        total_bytes: Some(input.bytes_total),
+    };
+
+    // Invariant 4: file_count matches constructed files
+    assert_eq!(manifest.file_count(), file_count);
+
+    // Invariant 5: total_expected_bytes must not panic
+    let _ = manifest.total_expected_bytes();
+
+    // Invariant 6: has_checksums must not panic
+    let _ = manifest.has_checksums();
+
+    // Invariant 7: validate_download with arbitrary sizes must not panic
+    let mut actual_map = HashMap::new();
+    for (i, filename) in input.filenames.iter().take(file_count).enumerate() {
+        if let Some(&size) = input.actual_sizes.get(i) {
+            actual_map.insert(filename.clone(), size);
+        }
+    }
+    let _ = validate_download(&manifest, &actual_map);
+
+    // Invariant 8: DownloadProgress percent/file_percent must not panic
+    let progress = DownloadProgress {
+        file_index: input.file_index,
+        total_files: input.total_files,
+        bytes_downloaded: input.bytes_downloaded,
+        bytes_total: input.bytes_total,
+        current_file: input.filenames.first().cloned().unwrap_or_default(),
+    };
+    let pct = progress.percent();
+    let fpct = progress.file_percent();
+    assert!(pct >= 0.0, "percent must be non-negative");
+    assert!(fpct >= 0.0, "file_percent must be non-negative");
+});

--- a/fuzz/fuzz_targets/fuzz_quantization_calibration.rs
+++ b/fuzz/fuzz_targets/fuzz_quantization_calibration.rs
@@ -1,0 +1,105 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_quantization::calibrator::{CalibrationMethod, TensorStats};
+use bitnet_quantization::int8_quant::{Int8QuantConfig, Int8QuantParams};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct CalibrationInput {
+    /// Raw bytes interpreted as f32 values.
+    data: Vec<u8>,
+    /// Selector for calibration method.
+    method_selector: u8,
+    /// Percentile value (only used for Percentile method).
+    percentile: u8,
+    /// Per-channel vs per-tensor.
+    per_channel: bool,
+    /// Symmetric vs asymmetric.
+    symmetric: bool,
+    /// Arbitrary scale values.
+    scales: Vec<u8>,
+    /// Arbitrary zero-point values.
+    zero_points: Vec<i8>,
+}
+
+fn bytes_to_f32(data: &[u8], max_elems: usize) -> Vec<f32> {
+    data.chunks_exact(4)
+        .take(max_elems)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect()
+}
+
+fuzz_target!(|input: CalibrationInput| {
+    // Test TensorStats with arbitrary data
+    let values = bytes_to_f32(&input.data, 256);
+    if values.is_empty() {
+        return;
+    }
+
+    // Filter non-finite values
+    let clean: Vec<f32> =
+        values.iter().copied().map(|v| if v.is_finite() { v } else { 0.0 }).collect();
+
+    // Invariant 1: TensorStats::update must never panic
+    let mut stats = TensorStats::new("fuzz_tensor");
+    stats.update(&clean);
+
+    // Invariant 2: After update, count must equal number of values
+    assert_eq!(stats.count, clean.len() as u64);
+
+    // Invariant 3: range and absmax must be non-negative
+    assert!(stats.range() >= 0.0, "range must be non-negative");
+    assert!(stats.absmax() >= 0.0, "absmax must be non-negative");
+
+    // Invariant 4: Multiple updates accumulate correctly
+    let mut stats2 = TensorStats::new("fuzz_tensor_2");
+    for chunk in clean.chunks(4.max(1)) {
+        stats2.update(chunk);
+    }
+    assert_eq!(stats2.count, stats.count);
+
+    // Test Int8QuantConfig construction with arbitrary methods
+    let method = match input.method_selector % 3 {
+        0 => bitnet_quantization::int8_quant::CalibrationMethod::MinMax,
+        1 => {
+            let p = (input.percentile as f32 / 255.0) * 100.0;
+            bitnet_quantization::int8_quant::CalibrationMethod::Percentile(p)
+        }
+        _ => bitnet_quantization::int8_quant::CalibrationMethod::MSE,
+    };
+
+    let config = Int8QuantConfig {
+        per_channel: input.per_channel,
+        symmetric: input.symmetric,
+        calibration_method: method,
+    };
+
+    // Invariant 5: quantize_tensor_int8 with valid config must not panic
+    let _ = bitnet_quantization::int8_quant::quantize_tensor_int8(&clean, &config);
+
+    // Invariant 6: Int8QuantParams with arbitrary scales/zero-points
+    let scales: Vec<f32> = bytes_to_f32(&input.scales, 16);
+    if !scales.is_empty() {
+        let params = Int8QuantParams {
+            scales: scales.clone(),
+            zero_points: input.zero_points.iter().copied().take(scales.len()).collect(),
+            min_vals: vec![0.0; scales.len()],
+            max_vals: vec![1.0; scales.len()],
+        };
+        // Accessing fields must not panic
+        let _ = params.scales.len();
+        let _ = params.zero_points.len();
+    }
+
+    // Test calibrator CalibrationMethod as_str
+    let cal_methods = [
+        CalibrationMethod::MinMax,
+        CalibrationMethod::Percentile,
+        CalibrationMethod::Entropy,
+        CalibrationMethod::Mse,
+    ];
+    for m in &cal_methods {
+        let _ = m.as_str();
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_tensor_layout.rs
+++ b/fuzz/fuzz_targets/fuzz_tensor_layout.rs
@@ -1,0 +1,135 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use bitnet_common::tensor_layout::{LayoutOrder, TensorLayout, broadcastable, compute_strides};
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct LayoutInput {
+    /// Shape dimensions (capped to reasonable sizes).
+    dims: Vec<u16>,
+    /// Element size selector.
+    element_size: u8,
+    /// _Indices placeholder (used via valid_indices below)._
+    _indices: Vec<u16>,
+    /// Second shape for broadcast checking.
+    dims_b: Vec<u16>,
+    /// Dimensions to transpose.
+    transpose_dim0: u8,
+    transpose_dim1: u8,
+    /// New shape for reshape.
+    reshape_dims: Vec<u16>,
+    /// Alignment value.
+    alignment: u16,
+    /// Whether to use column-major order.
+    col_major: bool,
+}
+
+fuzz_target!(|input: LayoutInput| {
+    // Cap dimensions to avoid huge allocations
+    let shape: Vec<usize> = input.dims.iter().take(6).map(|&d| (d as usize % 64) + 1).collect();
+
+    if shape.is_empty() {
+        return;
+    }
+
+    let element_size = (input.element_size as usize % 8) + 1;
+
+    // Invariant 1: compute_strides must never panic
+    let row_strides = compute_strides(&shape, LayoutOrder::RowMajor);
+    let col_strides = compute_strides(&shape, LayoutOrder::ColMajor);
+    assert_eq!(row_strides.len(), shape.len());
+    assert_eq!(col_strides.len(), shape.len());
+
+    // Invariant 2: TensorLayout construction must not panic
+    let layout = if input.col_major {
+        TensorLayout::col_major(&shape, element_size)
+    } else {
+        TensorLayout::contiguous(&shape, element_size)
+    };
+
+    // Invariant 3: numel must equal product of shape
+    let expected_numel: usize = shape.iter().product();
+    assert_eq!(layout.numel(), expected_numel);
+
+    // Invariant 4: byte_size must equal numel * element_size
+    assert_eq!(layout.byte_size(), expected_numel * element_size);
+
+    // Invariant 5: ndim must equal shape length
+    assert_eq!(layout.ndim(), shape.len());
+
+    // Invariant 6: freshly constructed layout is contiguous
+    assert!(layout.is_contiguous());
+
+    // Invariant 7: offset with valid indices must return Some
+    let valid_indices: Vec<usize> = shape.iter().map(|&d| d / 2).collect();
+    let offset = layout.offset(&valid_indices);
+    assert!(offset.is_some(), "valid indices should produce an offset");
+
+    // Invariant 8: offset with out-of-bounds indices must return None
+    let mut oob_indices = valid_indices.clone();
+    if let Some(last) = oob_indices.last_mut() {
+        *last = *shape.last().unwrap();
+    }
+    assert!(layout.offset(&oob_indices).is_none());
+
+    // Invariant 9: offset with wrong rank must return None
+    let wrong_rank: Vec<usize> = vec![0; shape.len() + 1];
+    assert!(layout.offset(&wrong_rank).is_none());
+
+    // Invariant 10: transpose must not panic
+    let dim0 = input.transpose_dim0 as usize;
+    let dim1 = input.transpose_dim1 as usize;
+    match layout.transpose(dim0, dim1) {
+        Some(transposed) => {
+            assert_eq!(transposed.numel(), layout.numel());
+            assert_eq!(transposed.ndim(), layout.ndim());
+            if dim0 != dim1 {
+                assert_eq!(transposed.shape[dim0], layout.shape[dim1]);
+                assert_eq!(transposed.shape[dim1], layout.shape[dim0]);
+            }
+        }
+        None => {
+            // Out-of-bounds dims correctly rejected
+            assert!(dim0 >= layout.ndim() || dim1 >= layout.ndim());
+        }
+    }
+
+    // Invariant 11: reshape must not panic
+    let new_shape: Vec<usize> =
+        input.reshape_dims.iter().take(6).map(|&d| (d as usize % 64) + 1).collect();
+    if !new_shape.is_empty() {
+        match layout.reshape(&new_shape) {
+            Some(reshaped) => {
+                assert_eq!(reshaped.numel(), layout.numel());
+                assert!(reshaped.is_contiguous());
+            }
+            None => {
+                // Reshape only succeeds if numel matches and layout is contiguous
+            }
+        }
+    }
+
+    // Invariant 12: is_aligned must not panic
+    let alignment = input.alignment as usize;
+    let _ = layout.is_aligned(alignment);
+    let _ = layout.is_aligned(0); // edge case: zero alignment
+
+    // Invariant 13: broadcastable must not panic on arbitrary shapes
+    let shape_b: Vec<usize> = input.dims_b.iter().take(6).map(|&d| (d as usize % 64) + 1).collect();
+    if !shape_b.is_empty() {
+        let result = broadcastable(&shape, &shape_b);
+        // broadcastable is symmetric for equal-length shapes with 1s
+        if shape.len() == shape_b.len() {
+            let all_ones_a = shape.iter().all(|&d| d == 1);
+            let all_ones_b = shape_b.iter().all(|&d| d == 1);
+            if all_ones_a || all_ones_b {
+                assert!(result, "all-ones shape should be broadcastable");
+            }
+        }
+    }
+
+    // Invariant 14: empty shape edge cases
+    assert!(compute_strides(&[], LayoutOrder::RowMajor).is_empty());
+    assert!(broadcastable(&[], &[]));
+});


### PR DESCRIPTION
Adds 5 new fuzz targets: quantization calibration, download manifest parsing, capability checking, conversion pipeline, and tensor layout analysis.