### PR TITLE
feat(neon): NEON quantized matmul v3 kernel (72 tests) [apple-silicon]

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_quantized_matmul_v3.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_quantized_matmul_v3.rs
@@ -1,0 +1,1718 @@
+//! NEON-optimized quantized matrix multiplication for ternary {-1, 0, 1} weights.
+//!
+//! Six operations, each with a NEON fast path, scalar fallback, and public
+//! dispatcher that selects the best implementation at runtime.
+//!
+//! Ternary matvec insight: for each output row, accumulate `+input[j]` where
+//! `weight == 1` and `-input[j]` where `weight == -1`; skip zeros.
+//!
+//! Matrix layout: row-major — `weights[row * cols + col]`.
+//!
+//! Packed ternary encoding (2 bits per weight, 4 weights per byte, LSB-first):
+//! - `0b00` → 0
+//! - `0b01` → +1
+//! - `0b11` → −1
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::*;
+
+/// NEON lane count for f32x4 vectors.
+const LANES: usize = 4;
+
+// ═══════════════════════════════════════════════════════════════════════
+// 1. ternary_matvec_f32 — ternary matrix × f32 vector
+// ═══════════════════════════════════════════════════════════════════════
+
+/// NEON ternary matvec: output[row] = Σ weights[row,j] * input[j]
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_ternary_matvec_f32(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut acc = unsafe { vdupq_n_f32(0.0) };
+        let mut col = 0usize;
+
+        while col + LANES <= cols {
+            // Load 4 weights as i8, branch per weight value.
+            let inp = unsafe { vld1q_f32(input.as_ptr().add(col)) };
+            for lane in 0..LANES {
+                let w = weights[row_offset + col + lane];
+                if w == 1 {
+                    acc = vaddq_f32(acc, inp);
+                    // Only first iteration matters — we reload per-lane below.
+                    // Actually we need per-lane handling; fall through to scalar tail.
+                    break;
+                } else if w == -1 {
+                    acc = vsubq_f32(acc, inp);
+                    break;
+                }
+                // w == 0 → skip
+            }
+            // The per-lane approach above is incorrect for mixed lanes.
+            // Use the scalar loop for correctness and NEON for accumulation.
+            // Re-do: accumulate positive and negative masks separately.
+            // Reset and redo properly:
+            break;
+        }
+
+        // Proper NEON approach: iterate in chunks of LANES, for each lane
+        // add/sub individually. We can still benefit from NEON load/store.
+        let mut pos_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut neg_acc = unsafe { vdupq_n_f32(0.0) };
+        col = 0;
+
+        while col + LANES <= cols {
+            let inp = unsafe { vld1q_f32(input.as_ptr().add(col)) };
+            // Build masks: for each lane, check weight value.
+            let mut pos_mask = [0.0f32; LANES];
+            let mut neg_mask = [0.0f32; LANES];
+            for lane in 0..LANES {
+                let w = weights[row_offset + col + lane];
+                if w == 1 {
+                    pos_mask[lane] = 1.0;
+                } else if w == -1 {
+                    neg_mask[lane] = 1.0;
+                }
+            }
+            let pos_v = unsafe { vld1q_f32(pos_mask.as_ptr()) };
+            let neg_v = unsafe { vld1q_f32(neg_mask.as_ptr()) };
+            pos_acc = vfmaq_f32(pos_acc, inp, pos_v);
+            neg_acc = vfmaq_f32(neg_acc, inp, neg_v);
+            col += LANES;
+        }
+
+        // Horizontal sum of (pos_acc - neg_acc)
+        let diff = vsubq_f32(pos_acc, neg_acc);
+        let mut sum = unsafe { vaddvq_f32(diff) };
+
+        // Scalar tail
+        for c in col..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] = sum;
+    }
+}
+
+/// Scalar fallback for ternary matvec.
+fn scalar_ternary_matvec_f32(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut sum = 0.0f32;
+        for c in 0..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] = sum;
+    }
+}
+
+/// Ternary matrix × f32 vector multiplication.
+///
+/// `weights` is `rows × cols` row-major with values in {-1, 0, 1}.
+/// `input` has length `cols`, `output` has length `rows`.
+pub fn ternary_matvec_f32(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    assert!(weights.len() >= rows * cols);
+    assert!(input.len() >= cols);
+    assert!(output.len() >= rows);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            // SAFETY: feature detection passed.
+            unsafe {
+                neon_ternary_matvec_f32(weights, input, output, rows, cols);
+            }
+            return;
+        }
+    }
+    scalar_ternary_matvec_f32(weights, input, output, rows, cols);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 2. ternary_matmul_f32 — ternary matrix × f32 matrix
+// ═══════════════════════════════════════════════════════════════════════
+
+/// NEON ternary matmul: C[m,n] = Σ_k A[m,k] * B[k,n]
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_ternary_matmul_f32(
+    a: &[i8],
+    b: &[f32],
+    output: &mut [f32],
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    for row in 0..m {
+        for col_start in (0..n).step_by(LANES) {
+            let remaining = (n - col_start).min(LANES);
+            let mut acc = unsafe { vdupq_n_f32(0.0) };
+
+            if remaining == LANES {
+                for ki in 0..k {
+                    let w = a[row * k + ki];
+                    if w == 0 {
+                        continue;
+                    }
+                    let b_vec = unsafe { vld1q_f32(b.as_ptr().add(ki * n + col_start)) };
+                    if w == 1 {
+                        acc = vaddq_f32(acc, b_vec);
+                    } else {
+                        acc = vsubq_f32(acc, b_vec);
+                    }
+                }
+                unsafe {
+                    vst1q_f32(output.as_mut_ptr().add(row * n + col_start), acc);
+                }
+            } else {
+                // Scalar tail for remaining < LANES columns
+                for col in col_start..col_start + remaining {
+                    let mut sum = 0.0f32;
+                    for ki in 0..k {
+                        let w = a[row * k + ki];
+                        if w == 1 {
+                            sum += b[ki * n + col];
+                        } else if w == -1 {
+                            sum -= b[ki * n + col];
+                        }
+                    }
+                    output[row * n + col] = sum;
+                }
+            }
+        }
+    }
+}
+
+/// Scalar fallback for ternary matmul.
+fn scalar_ternary_matmul_f32(
+    a: &[i8],
+    b: &[f32],
+    output: &mut [f32],
+    m: usize,
+    n: usize,
+    k: usize,
+) {
+    for row in 0..m {
+        for col in 0..n {
+            let mut sum = 0.0f32;
+            for ki in 0..k {
+                let w = a[row * k + ki];
+                if w == 1 {
+                    sum += b[ki * n + col];
+                } else if w == -1 {
+                    sum -= b[ki * n + col];
+                }
+            }
+            output[row * n + col] = sum;
+        }
+    }
+}
+
+/// Ternary matrix × f32 matrix multiplication.
+///
+/// `a` is `m × k` ternary row-major, `b` is `k × n` f32 row-major,
+/// `output` is `m × n` f32 row-major.
+pub fn ternary_matmul_f32(a: &[i8], b: &[f32], output: &mut [f32], m: usize, n: usize, k: usize) {
+    assert!(a.len() >= m * k);
+    assert!(b.len() >= k * n);
+    assert!(output.len() >= m * n);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                neon_ternary_matmul_f32(a, b, output, m, n, k);
+            }
+            return;
+        }
+    }
+    scalar_ternary_matmul_f32(a, b, output, m, n, k);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 3. packed_ternary_matvec — 2-bit packed ternary matvec
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Decode a single 2-bit ternary code.
+#[inline(always)]
+fn decode_packed(bits: u8) -> f32 {
+    match bits & 0x03 {
+        0b01 => 1.0,
+        0b11 => -1.0,
+        _ => 0.0,
+    }
+}
+
+/// NEON packed ternary matvec.
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_packed_ternary_matvec(
+    packed_weights: &[u8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    let bytes_per_row = (cols + 3) / 4;
+    for row in 0..rows {
+        let row_offset = row * bytes_per_row;
+        let mut pos_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut neg_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut col = 0usize;
+
+        // Process 4 columns per byte, NEON-accelerate in groups of LANES columns
+        // Since each byte has 4 values and LANES=4, process one byte at a time with NEON
+        let full_bytes = cols / 4;
+        for bi in 0..full_bytes {
+            let byte = packed_weights[row_offset + bi];
+            let base_col = bi * 4;
+            if base_col + LANES <= cols {
+                let inp = unsafe { vld1q_f32(input.as_ptr().add(base_col)) };
+                let mut pos_mask = [0.0f32; LANES];
+                let mut neg_mask = [0.0f32; LANES];
+                for lane in 0..LANES {
+                    let bits = (byte >> (lane * 2)) & 0x03;
+                    if bits == 0b01 {
+                        pos_mask[lane] = 1.0;
+                    } else if bits == 0b11 {
+                        neg_mask[lane] = 1.0;
+                    }
+                }
+                let pos_v = unsafe { vld1q_f32(pos_mask.as_ptr()) };
+                let neg_v = unsafe { vld1q_f32(neg_mask.as_ptr()) };
+                pos_acc = vfmaq_f32(pos_acc, inp, pos_v);
+                neg_acc = vfmaq_f32(neg_acc, inp, neg_v);
+            }
+            col = base_col + 4;
+        }
+
+        let diff = vsubq_f32(pos_acc, neg_acc);
+        let mut sum = unsafe { vaddvq_f32(diff) };
+
+        // Scalar tail for remaining columns
+        if col < cols {
+            let byte = packed_weights[row_offset + full_bytes];
+            for j in 0..(cols - full_bytes * 4) {
+                let bits = (byte >> (j * 2)) & 0x03;
+                let w = decode_packed(bits);
+                sum += w * input[full_bytes * 4 + j];
+            }
+        }
+        output[row] = sum;
+    }
+}
+
+/// Scalar fallback for packed ternary matvec.
+fn scalar_packed_ternary_matvec(
+    packed_weights: &[u8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    let bytes_per_row = (cols + 3) / 4;
+    for row in 0..rows {
+        let row_offset = row * bytes_per_row;
+        let mut sum = 0.0f32;
+        for c in 0..cols {
+            let byte_idx = c / 4;
+            let bit_offset = (c % 4) * 2;
+            let bits = (packed_weights[row_offset + byte_idx] >> bit_offset) & 0x03;
+            let w = decode_packed(bits);
+            sum += w * input[c];
+        }
+        output[row] = sum;
+    }
+}
+
+/// Packed 2-bit ternary matrix × f32 vector multiplication.
+///
+/// `packed_weights` encodes `rows × cols` ternary values at 2 bits each
+/// (4 per byte, LSB-first). Encoding: 0b00=0, 0b01=+1, 0b11=−1.
+pub fn packed_ternary_matvec(
+    packed_weights: &[u8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    let bytes_per_row = (cols + 3) / 4;
+    assert!(packed_weights.len() >= rows * bytes_per_row);
+    assert!(input.len() >= cols);
+    assert!(output.len() >= rows);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                neon_packed_ternary_matvec(packed_weights, input, output, rows, cols);
+            }
+            return;
+        }
+    }
+    scalar_packed_ternary_matvec(packed_weights, input, output, rows, cols);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 4. ternary_matvec_with_scale — matvec with per-row scale
+// ═══════════════════════════════════════════════════════════════════════
+
+/// NEON ternary matvec with per-row scale.
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_ternary_matvec_with_scale(
+    weights: &[i8],
+    input: &[f32],
+    scales: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut pos_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut neg_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut col = 0usize;
+
+        while col + LANES <= cols {
+            let inp = unsafe { vld1q_f32(input.as_ptr().add(col)) };
+            let mut pos_mask = [0.0f32; LANES];
+            let mut neg_mask = [0.0f32; LANES];
+            for lane in 0..LANES {
+                let w = weights[row_offset + col + lane];
+                if w == 1 {
+                    pos_mask[lane] = 1.0;
+                } else if w == -1 {
+                    neg_mask[lane] = 1.0;
+                }
+            }
+            let pos_v = unsafe { vld1q_f32(pos_mask.as_ptr()) };
+            let neg_v = unsafe { vld1q_f32(neg_mask.as_ptr()) };
+            pos_acc = vfmaq_f32(pos_acc, inp, pos_v);
+            neg_acc = vfmaq_f32(neg_acc, inp, neg_v);
+            col += LANES;
+        }
+
+        let diff = vsubq_f32(pos_acc, neg_acc);
+        let mut sum = unsafe { vaddvq_f32(diff) };
+
+        for c in col..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] = sum * scales[row];
+    }
+}
+
+/// Scalar fallback for ternary matvec with per-row scale.
+fn scalar_ternary_matvec_with_scale(
+    weights: &[i8],
+    input: &[f32],
+    scales: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut sum = 0.0f32;
+        for c in 0..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] = sum * scales[row];
+    }
+}
+
+/// Ternary matvec with per-row scaling factor.
+///
+/// `output[row] = scales[row] * Σ weights[row,j] * input[j]`
+pub fn ternary_matvec_with_scale(
+    weights: &[i8],
+    input: &[f32],
+    scales: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    assert!(weights.len() >= rows * cols);
+    assert!(input.len() >= cols);
+    assert!(scales.len() >= rows);
+    assert!(output.len() >= rows);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                neon_ternary_matvec_with_scale(weights, input, scales, output, rows, cols);
+            }
+            return;
+        }
+    }
+    scalar_ternary_matvec_with_scale(weights, input, scales, output, rows, cols);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 5. ternary_matvec_accumulate — matvec accumulating into output (+=)
+// ═══════════════════════════════════════════════════════════════════════
+
+/// NEON ternary matvec with accumulation.
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_ternary_matvec_accumulate(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut pos_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut neg_acc = unsafe { vdupq_n_f32(0.0) };
+        let mut col = 0usize;
+
+        while col + LANES <= cols {
+            let inp = unsafe { vld1q_f32(input.as_ptr().add(col)) };
+            let mut pos_mask = [0.0f32; LANES];
+            let mut neg_mask = [0.0f32; LANES];
+            for lane in 0..LANES {
+                let w = weights[row_offset + col + lane];
+                if w == 1 {
+                    pos_mask[lane] = 1.0;
+                } else if w == -1 {
+                    neg_mask[lane] = 1.0;
+                }
+            }
+            let pos_v = unsafe { vld1q_f32(pos_mask.as_ptr()) };
+            let neg_v = unsafe { vld1q_f32(neg_mask.as_ptr()) };
+            pos_acc = vfmaq_f32(pos_acc, inp, pos_v);
+            neg_acc = vfmaq_f32(neg_acc, inp, neg_v);
+            col += LANES;
+        }
+
+        let diff = vsubq_f32(pos_acc, neg_acc);
+        let mut sum = unsafe { vaddvq_f32(diff) };
+
+        for c in col..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] += sum;
+    }
+}
+
+/// Scalar fallback for ternary matvec with accumulation.
+fn scalar_ternary_matvec_accumulate(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    for row in 0..rows {
+        let row_offset = row * cols;
+        let mut sum = 0.0f32;
+        for c in 0..cols {
+            let w = weights[row_offset + c];
+            if w == 1 {
+                sum += input[c];
+            } else if w == -1 {
+                sum -= input[c];
+            }
+        }
+        output[row] += sum;
+    }
+}
+
+/// Ternary matvec that accumulates into the output buffer (`output[i] += ...`).
+///
+/// Unlike [`ternary_matvec_f32`], this does **not** overwrite `output`; it adds
+/// the result of the matvec to the existing values.
+pub fn ternary_matvec_accumulate(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+) {
+    assert!(weights.len() >= rows * cols);
+    assert!(input.len() >= cols);
+    assert!(output.len() >= rows);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                neon_ternary_matvec_accumulate(weights, input, output, rows, cols);
+            }
+            return;
+        }
+    }
+    scalar_ternary_matvec_accumulate(weights, input, output, rows, cols);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// 6. blocked_ternary_matvec — cache-friendly blocked matvec
+// ═══════════════════════════════════════════════════════════════════════
+
+/// NEON blocked ternary matvec.
+///
+/// # Safety
+/// Caller must ensure NEON is available at runtime.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn neon_blocked_ternary_matvec(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+    block_size: usize,
+) {
+    // Zero output first
+    for v in output.iter_mut().take(rows) {
+        *v = 0.0;
+    }
+
+    // Process columns in blocks for cache locality
+    let mut col_start = 0usize;
+    while col_start < cols {
+        let col_end = (col_start + block_size).min(cols);
+
+        for row in 0..rows {
+            let row_offset = row * cols;
+            let mut pos_acc = unsafe { vdupq_n_f32(0.0) };
+            let mut neg_acc = unsafe { vdupq_n_f32(0.0) };
+            let mut col = col_start;
+
+            while col + LANES <= col_end {
+                let inp = unsafe { vld1q_f32(input.as_ptr().add(col)) };
+                let mut pos_mask = [0.0f32; LANES];
+                let mut neg_mask = [0.0f32; LANES];
+                for lane in 0..LANES {
+                    let w = weights[row_offset + col + lane];
+                    if w == 1 {
+                        pos_mask[lane] = 1.0;
+                    } else if w == -1 {
+                        neg_mask[lane] = 1.0;
+                    }
+                }
+                let pos_v = unsafe { vld1q_f32(pos_mask.as_ptr()) };
+                let neg_v = unsafe { vld1q_f32(neg_mask.as_ptr()) };
+                pos_acc = vfmaq_f32(pos_acc, inp, pos_v);
+                neg_acc = vfmaq_f32(neg_acc, inp, neg_v);
+                col += LANES;
+            }
+
+            let diff = vsubq_f32(pos_acc, neg_acc);
+            let mut sum = unsafe { vaddvq_f32(diff) };
+
+            for c in col..col_end {
+                let w = weights[row_offset + c];
+                if w == 1 {
+                    sum += input[c];
+                } else if w == -1 {
+                    sum -= input[c];
+                }
+            }
+            output[row] += sum;
+        }
+        col_start = col_end;
+    }
+}
+
+/// Scalar fallback for blocked ternary matvec.
+fn scalar_blocked_ternary_matvec(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+    block_size: usize,
+) {
+    for v in output.iter_mut().take(rows) {
+        *v = 0.0;
+    }
+
+    let mut col_start = 0usize;
+    while col_start < cols {
+        let col_end = (col_start + block_size).min(cols);
+        for row in 0..rows {
+            let row_offset = row * cols;
+            let mut sum = 0.0f32;
+            for c in col_start..col_end {
+                let w = weights[row_offset + c];
+                if w == 1 {
+                    sum += input[c];
+                } else if w == -1 {
+                    sum -= input[c];
+                }
+            }
+            output[row] += sum;
+        }
+        col_start = col_end;
+    }
+}
+
+/// Cache-friendly blocked ternary matvec.
+///
+/// Processes columns in blocks of `block_size` to improve cache locality
+/// on large matrices. The result is identical to [`ternary_matvec_f32`].
+pub fn blocked_ternary_matvec(
+    weights: &[i8],
+    input: &[f32],
+    output: &mut [f32],
+    rows: usize,
+    cols: usize,
+    block_size: usize,
+) {
+    assert!(weights.len() >= rows * cols);
+    assert!(input.len() >= cols);
+    assert!(output.len() >= rows);
+    assert!(block_size > 0);
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if std::arch::is_aarch64_feature_detected!("neon") {
+            unsafe {
+                neon_blocked_ternary_matvec(weights, input, output, rows, cols, block_size);
+            }
+            return;
+        }
+    }
+    scalar_blocked_ternary_matvec(weights, input, output, rows, cols, block_size);
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Helper: pack ternary weights into 2-bit representation
+// ═══════════════════════════════════════════════════════════════════════
+
+/// Pack ternary i8 weights {-1, 0, 1} into 2-bit packed format.
+///
+/// Used in tests; 4 values per byte, LSB-first.
+/// Encoding: 0→0b00, +1→0b01, -1→0b11.
+pub fn pack_ternary(weights: &[i8]) -> Vec<u8> {
+    let num_bytes = (weights.len() + 3) / 4;
+    let mut packed = vec![0u8; num_bytes];
+    for (i, &w) in weights.iter().enumerate() {
+        let byte_idx = i / 4;
+        let bit_offset = (i % 4) * 2;
+        let code: u8 = match w {
+            1 => 0b01,
+            -1 => 0b11,
+            _ => 0b00,
+        };
+        packed[byte_idx] |= code << bit_offset;
+    }
+    packed
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    fn assert_close(a: &[f32], b: &[f32], tol: f32) {
+        assert_eq!(a.len(), b.len(), "length mismatch");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!((x - y).abs() <= tol, "index {i}: {x} vs {y} (diff {})", (x - y).abs());
+        }
+    }
+
+    /// Reference scalar matvec for cross-checking.
+    fn reference_matvec(weights: &[i8], input: &[f32], rows: usize, cols: usize) -> Vec<f32> {
+        let mut out = vec![0.0f32; rows];
+        for row in 0..rows {
+            for c in 0..cols {
+                out[row] += weights[row * cols + c] as f32 * input[c];
+            }
+        }
+        out
+    }
+
+    // ── 1. ternary_matvec_f32 tests ────────────────────────────────────
+
+    #[test]
+    fn test_matvec_identity_like() {
+        // Diagonal 1s — output should equal input
+        let n = 4;
+        let mut weights = vec![0i8; n * n];
+        for i in 0..n {
+            weights[i * n + i] = 1;
+        }
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let mut output = vec![0.0f32; n];
+        ternary_matvec_f32(&weights, &input, &mut output, n, n);
+        assert_close(&output, &input, 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_all_zeros_weights() {
+        let (rows, cols) = (4, 8);
+        let weights = vec![0i8; rows * cols];
+        let input = vec![1.0; cols];
+        let mut output = vec![999.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        assert_close(&output, &vec![0.0; rows], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_all_ones_weights() {
+        let (rows, cols) = (3, 5);
+        let weights = vec![1i8; rows * cols];
+        let input: Vec<f32> = (1..=5).map(|x| x as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected_sum: f32 = input.iter().sum();
+        assert_close(&output, &vec![expected_sum; rows], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_all_negative_weights() {
+        let (rows, cols) = (3, 5);
+        let weights = vec![-1i8; rows * cols];
+        let input: Vec<f32> = (1..=5).map(|x| x as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected_sum: f32 = -input.iter().sum::<f32>();
+        assert_close(&output, &vec![expected_sum; rows], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_mixed_weights() {
+        // [1, -1, 0, 1] · [1.0, 2.0, 3.0, 4.0] = 1 - 2 + 0 + 4 = 3
+        let weights = vec![1i8, -1, 0, 1];
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_f32(&weights, &input, &mut output, 1, 4);
+        assert_close(&output, &[3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_1x1() {
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_f32(&[1], &[42.0], &mut output, 1, 1);
+        assert_close(&output, &[42.0], 1e-6);
+
+        ternary_matvec_f32(&[-1], &[42.0], &mut output, 1, 1);
+        assert_close(&output, &[-42.0], 1e-6);
+
+        ternary_matvec_f32(&[0], &[42.0], &mut output, 1, 1);
+        assert_close(&output, &[0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_1xn() {
+        let cols = 17;
+        let weights: Vec<i8> = (0..cols).map(|i| if i % 3 == 0 { 1 } else { 0 }).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i + 1) as f32).collect();
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_f32(&weights, &input, &mut output, 1, cols);
+        let expected = reference_matvec(&weights, &input, 1, cols);
+        assert_close(&output, &expected, 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_nx1() {
+        let rows = 17;
+        let weights: Vec<i8> = (0..rows).map(|i| [1, -1, 0][i % 3]).collect();
+        let input = vec![5.0f32];
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, 1);
+        let expected = reference_matvec(&weights, &input, rows, 1);
+        assert_close(&output, &expected, 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_dim_15() {
+        let (rows, cols) = (15, 15);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [0, 1, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.1).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_16() {
+        let (rows, cols) = (16, 16);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.5).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_17() {
+        let (rows, cols) = (17, 17);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [-1, 1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32).sin()).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_31() {
+        let (rows, cols) = (4, 31);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 0][i % 4]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| 1.0 + i as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_32() {
+        let (rows, cols) = (4, 32);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1, 1][i % 4]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| 0.01 * i as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_33() {
+        let (rows, cols) = (4, 33);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [0, 1, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.3).cos()).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_dim_64() {
+        let (rows, cols) = (8, 64);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 1, 0, -1][i % 6]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-4);
+    }
+
+    #[test]
+    fn test_matvec_dim_128() {
+        let (rows, cols) = (4, 128);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32) * 0.01).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-4);
+    }
+
+    #[test]
+    fn test_matvec_zero_input() {
+        let (rows, cols) = (4, 8);
+        let weights = vec![1i8; rows * cols];
+        let input = vec![0.0f32; cols];
+        let mut output = vec![999.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        assert_close(&output, &vec![0.0; rows], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_scalar_vs_dispatcher() {
+        let (rows, cols) = (5, 20);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 0, 1][i % 5]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.7).collect();
+        let mut out_scalar = vec![0.0f32; rows];
+        let mut out_dispatch = vec![0.0f32; rows];
+        scalar_ternary_matvec_f32(&weights, &input, &mut out_scalar, rows, cols);
+        ternary_matvec_f32(&weights, &input, &mut out_dispatch, rows, cols);
+        assert_close(&out_scalar, &out_dispatch, 1e-6);
+    }
+
+    // ── 2. ternary_matmul_f32 tests ────────────────────────────────────
+
+    #[test]
+    fn test_matmul_identity_like() {
+        let n = 4;
+        let mut a = vec![0i8; n * n];
+        for i in 0..n {
+            a[i * n + i] = 1;
+        }
+        let b: Vec<f32> = (0..n * n).map(|i| i as f32).collect();
+        let mut output = vec![0.0f32; n * n];
+        ternary_matmul_f32(&a, &b, &mut output, n, n, n);
+        assert_close(&output, &b, 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_all_zeros() {
+        let (m, n, k) = (3, 4, 5);
+        let a = vec![0i8; m * k];
+        let b = vec![1.0f32; k * n];
+        let mut output = vec![999.0f32; m * n];
+        ternary_matmul_f32(&a, &b, &mut output, m, n, k);
+        assert_close(&output, &vec![0.0; m * n], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_all_ones() {
+        let (m, n, k) = (2, 3, 4);
+        let a = vec![1i8; m * k];
+        let b = vec![1.0f32; k * n];
+        let mut output = vec![0.0f32; m * n];
+        ternary_matmul_f32(&a, &b, &mut output, m, n, k);
+        // Each element should be k (sum of k ones)
+        assert_close(&output, &vec![k as f32; m * n], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_1x1() {
+        let a = vec![1i8];
+        let b = vec![7.0f32];
+        let mut output = vec![0.0f32; 1];
+        ternary_matmul_f32(&a, &b, &mut output, 1, 1, 1);
+        assert_close(&output, &[7.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_known_result() {
+        // A = [[1, -1], [0, 1]], B = [[1.0, 2.0], [3.0, 4.0]]
+        // C = [[1-3, 2-4], [0+3, 0+4]] = [[-2, -2], [3, 4]]
+        let a = vec![1i8, -1, 0, 1];
+        let b = vec![1.0, 2.0, 3.0, 4.0];
+        let mut output = vec![0.0f32; 4];
+        ternary_matmul_f32(&a, &b, &mut output, 2, 2, 2);
+        assert_close(&output, &[-2.0, -2.0, 3.0, 4.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_non_square() {
+        let (m, n, k) = (2, 5, 3);
+        let a: Vec<i8> = (0..m * k).map(|i| [1, -1, 0][i % 3]).collect();
+        let b: Vec<f32> = (0..k * n).map(|i| i as f32).collect();
+        let mut output = vec![0.0f32; m * n];
+        let mut expected = vec![0.0f32; m * n];
+        scalar_ternary_matmul_f32(&a, &b, &mut expected, m, n, k);
+        ternary_matmul_f32(&a, &b, &mut output, m, n, k);
+        assert_close(&output, &expected, 1e-5);
+    }
+
+    #[test]
+    fn test_matmul_scalar_vs_dispatcher() {
+        let (m, n, k) = (4, 8, 6);
+        let a: Vec<i8> = (0..m * k).map(|i| [1, 0, -1, 1][i % 4]).collect();
+        let b: Vec<f32> = (0..k * n).map(|i| i as f32 * 0.1).collect();
+        let mut out_scalar = vec![0.0f32; m * n];
+        let mut out_dispatch = vec![0.0f32; m * n];
+        scalar_ternary_matmul_f32(&a, &b, &mut out_scalar, m, n, k);
+        ternary_matmul_f32(&a, &b, &mut out_dispatch, m, n, k);
+        assert_close(&out_scalar, &out_dispatch, 1e-5);
+    }
+
+    // ── 3. packed_ternary_matvec tests ────────────────────────────────
+
+    #[test]
+    fn test_packed_basic() {
+        let weights = vec![1i8, -1, 0, 1];
+        let packed = pack_ternary(&weights);
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let mut output = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut output, 1, 4);
+        // 1 - 2 + 0 + 4 = 3
+        assert_close(&output, &[3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_all_zeros() {
+        let weights = vec![0i8; 8];
+        let packed = pack_ternary(&weights);
+        let input = vec![1.0; 8];
+        let mut output = vec![999.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut output, 1, 8);
+        assert_close(&output, &[0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_all_positive() {
+        let cols = 8;
+        let weights = vec![1i8; cols];
+        let packed = pack_ternary(&weights);
+        let input: Vec<f32> = (1..=cols).map(|x| x as f32).collect();
+        let mut output = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut output, 1, cols);
+        let expected: f32 = input.iter().sum();
+        assert_close(&output, &[expected], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_all_negative() {
+        let cols = 8;
+        let weights = vec![-1i8; cols];
+        let packed = pack_ternary(&weights);
+        let input: Vec<f32> = (1..=cols).map(|x| x as f32).collect();
+        let mut output = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut output, 1, cols);
+        let expected: f32 = -input.iter().sum::<f32>();
+        assert_close(&output, &[expected], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_roundtrip_vs_direct() {
+        let (rows, cols) = (4, 16);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1, 1, -1, 0][i % 6]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.5).collect();
+
+        let mut direct_out = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut direct_out, rows, cols);
+
+        // Pack rows individually
+        let bytes_per_row = (cols + 3) / 4;
+        let mut packed = vec![0u8; rows * bytes_per_row];
+        for r in 0..rows {
+            let row_weights = &weights[r * cols..(r + 1) * cols];
+            let row_packed = pack_ternary(row_weights);
+            packed[r * bytes_per_row..(r + 1) * bytes_per_row]
+                .copy_from_slice(&row_packed[..bytes_per_row]);
+        }
+        let mut packed_out = vec![0.0f32; rows];
+        packed_ternary_matvec(&packed, &input, &mut packed_out, rows, cols);
+
+        assert_close(&direct_out, &packed_out, 1e-5);
+    }
+
+    #[test]
+    fn test_packed_odd_cols() {
+        // 5 columns — tests remainder handling (5 % 4 = 1)
+        let weights = vec![1i8, -1, 1, 0, -1];
+        let packed = pack_ternary(&weights);
+        let input = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+        let mut output = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut output, 1, 5);
+        // 1 - 2 + 3 + 0 - 5 = -3
+        assert_close(&output, &[-3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_multi_row() {
+        let (rows, cols) = (3, 8);
+        let weights: Vec<i8> = vec![
+            1, 1, 1, 1, 0, 0, 0, 0, // row 0: sum of first 4
+            0, 0, 0, 0, 1, 1, 1, 1, // row 1: sum of last 4
+            -1, -1, -1, -1, -1, -1, -1, -1, // row 2: negative sum
+        ];
+        let input: Vec<f32> = (1..=8).map(|x| x as f32).collect();
+
+        let bytes_per_row = 2; // 8/4
+        let mut packed = vec![0u8; rows * bytes_per_row];
+        for r in 0..rows {
+            let row_w = &weights[r * cols..(r + 1) * cols];
+            let rp = pack_ternary(row_w);
+            packed[r * bytes_per_row..(r + 1) * bytes_per_row]
+                .copy_from_slice(&rp[..bytes_per_row]);
+        }
+
+        let mut output = vec![0.0f32; rows];
+        packed_ternary_matvec(&packed, &input, &mut output, rows, cols);
+        // row0: 1+2+3+4 = 10, row1: 5+6+7+8 = 26, row2: -(1+...+8) = -36
+        assert_close(&output, &[10.0, 26.0, -36.0], 1e-5);
+    }
+
+    #[test]
+    fn test_packed_scalar_vs_dispatcher() {
+        let (rows, cols) = (3, 12);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let bytes_per_row = (cols + 3) / 4;
+        let mut packed = vec![0u8; rows * bytes_per_row];
+        for r in 0..rows {
+            let rw = &weights[r * cols..(r + 1) * cols];
+            let rp = pack_ternary(rw);
+            packed[r * bytes_per_row..(r + 1) * bytes_per_row]
+                .copy_from_slice(&rp[..bytes_per_row]);
+        }
+
+        let mut out_scalar = vec![0.0f32; rows];
+        let mut out_dispatch = vec![0.0f32; rows];
+        scalar_packed_ternary_matvec(&packed, &input, &mut out_scalar, rows, cols);
+        packed_ternary_matvec(&packed, &input, &mut out_dispatch, rows, cols);
+        assert_close(&out_scalar, &out_dispatch, 1e-6);
+    }
+
+    // ── 4. ternary_matvec_with_scale tests ─────────────────────────────
+
+    #[test]
+    fn test_scale_basic() {
+        let weights = vec![1i8, 1, 1, 1];
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let scales = vec![2.0];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, 1, 4);
+        // (1+2+3+4) * 2 = 20
+        assert_close(&output, &[20.0], 1e-6);
+    }
+
+    #[test]
+    fn test_scale_zero() {
+        let weights = vec![1i8; 8];
+        let input = vec![1.0; 8];
+        let scales = vec![0.0];
+        let mut output = vec![999.0f32; 1];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, 1, 8);
+        assert_close(&output, &[0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_scale_negative() {
+        let weights = vec![1i8, 1];
+        let input = vec![3.0, 4.0];
+        let scales = vec![-1.0];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, 1, 2);
+        assert_close(&output, &[-7.0], 1e-6);
+    }
+
+    #[test]
+    fn test_scale_per_row() {
+        let (rows, cols) = (3, 4);
+        let weights = vec![1i8; rows * cols];
+        let input = vec![1.0; cols];
+        let scales = vec![1.0, 2.0, 0.5];
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, rows, cols);
+        // Each row dot = 4.0, scaled by [1, 2, 0.5]
+        assert_close(&output, &[4.0, 8.0, 2.0], 1e-6);
+    }
+
+    #[test]
+    fn test_scale_with_mixed_weights() {
+        let weights = vec![1i8, -1, 0, 1];
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let scales = vec![3.0];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, 1, 4);
+        // (1 - 2 + 0 + 4) * 3 = 9
+        assert_close(&output, &[9.0], 1e-6);
+    }
+
+    #[test]
+    fn test_scale_scalar_vs_dispatcher() {
+        let (rows, cols) = (4, 20);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.3).collect();
+        let scales: Vec<f32> = (0..rows).map(|i| 0.5 + i as f32 * 0.1).collect();
+        let mut out_scalar = vec![0.0f32; rows];
+        let mut out_dispatch = vec![0.0f32; rows];
+        scalar_ternary_matvec_with_scale(&weights, &input, &scales, &mut out_scalar, rows, cols);
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut out_dispatch, rows, cols);
+        assert_close(&out_scalar, &out_dispatch, 1e-5);
+    }
+
+    #[test]
+    fn test_scale_large_dim() {
+        let (rows, cols) = (8, 64);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 1][i % 4]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32).sin()).collect();
+        let scales: Vec<f32> = (0..rows).map(|i| 1.0 + i as f32 * 0.5).collect();
+        let mut out_scalar = vec![0.0f32; rows];
+        let mut out_dispatch = vec![0.0f32; rows];
+        scalar_ternary_matvec_with_scale(&weights, &input, &scales, &mut out_scalar, rows, cols);
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut out_dispatch, rows, cols);
+        assert_close(&out_scalar, &out_dispatch, 1e-4);
+    }
+
+    // ── 5. ternary_matvec_accumulate tests ─────────────────────────────
+
+    #[test]
+    fn test_accumulate_basic() {
+        let weights = vec![1i8, 1, 1, 1];
+        let input = vec![1.0, 2.0, 3.0, 4.0];
+        let mut output = vec![10.0f32]; // pre-existing value
+        ternary_matvec_accumulate(&weights, &input, &mut output, 1, 4);
+        // 10 + (1+2+3+4) = 20
+        assert_close(&output, &[20.0], 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_zero_weights() {
+        let mut output = vec![5.0, 10.0, 15.0];
+        let weights = vec![0i8; 12];
+        let input = vec![1.0; 4];
+        ternary_matvec_accumulate(&weights, &input, &mut output, 3, 4);
+        assert_close(&output, &[5.0, 10.0, 15.0], 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_double_call() {
+        let weights = vec![1i8; 4];
+        let input = vec![1.0, 1.0, 1.0, 1.0];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_accumulate(&weights, &input, &mut output, 1, 4);
+        ternary_matvec_accumulate(&weights, &input, &mut output, 1, 4);
+        // 0 + 4 + 4 = 8
+        assert_close(&output, &[8.0], 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_negative_pre_existing() {
+        let weights = vec![1i8, -1];
+        let input = vec![3.0, 1.0];
+        let mut output = vec![-5.0f32];
+        ternary_matvec_accumulate(&weights, &input, &mut output, 1, 2);
+        // -5 + (3 - 1) = -3
+        assert_close(&output, &[-3.0], 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_matches_matvec_from_zero() {
+        let (rows, cols) = (4, 16);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.2).collect();
+
+        let mut out_matvec = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_matvec, rows, cols);
+
+        let mut out_accum = vec![0.0f32; rows];
+        ternary_matvec_accumulate(&weights, &input, &mut out_accum, rows, cols);
+
+        assert_close(&out_matvec, &out_accum, 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_scalar_vs_dispatcher() {
+        let (rows, cols) = (3, 20);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+        let init = vec![1.0, 2.0, 3.0];
+        let mut out_scalar = init.clone();
+        let mut out_dispatch = init;
+        scalar_ternary_matvec_accumulate(&weights, &input, &mut out_scalar, rows, cols);
+        ternary_matvec_accumulate(&weights, &input, &mut out_dispatch, rows, cols);
+        assert_close(&out_scalar, &out_dispatch, 1e-5);
+    }
+
+    // ── 6. blocked_ternary_matvec tests ────────────────────────────────
+
+    #[test]
+    fn test_blocked_vs_non_blocked() {
+        let (rows, cols) = (4, 32);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 1][i % 4]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.1).collect();
+
+        let mut out_direct = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_direct, rows, cols);
+
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 8);
+
+        assert_close(&out_direct, &out_blocked, 1e-5);
+    }
+
+    #[test]
+    fn test_blocked_block_size_1() {
+        let (rows, cols) = (2, 8);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1][i % 2]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let mut out_direct = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_direct, rows, cols);
+
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 1);
+
+        assert_close(&out_direct, &out_blocked, 1e-5);
+    }
+
+    #[test]
+    fn test_blocked_block_larger_than_cols() {
+        let (rows, cols) = (3, 10);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let mut out_direct = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_direct, rows, cols);
+
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 1024);
+
+        assert_close(&out_direct, &out_blocked, 1e-5);
+    }
+
+    #[test]
+    fn test_blocked_various_block_sizes() {
+        let (rows, cols) = (4, 64);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 0, 1, -1][i % 6]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32).sin()).collect();
+
+        let mut out_ref = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_ref, rows, cols);
+
+        for block_size in [4, 8, 16, 32, 64, 128] {
+            let mut out_blocked = vec![0.0f32; rows];
+            blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, block_size);
+            assert_close(&out_ref, &out_blocked, 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_blocked_all_zeros() {
+        let (rows, cols) = (3, 16);
+        let weights = vec![0i8; rows * cols];
+        let input = vec![1.0; cols];
+        let mut output = vec![999.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut output, rows, cols, 4);
+        assert_close(&output, &vec![0.0; rows], 1e-6);
+    }
+
+    #[test]
+    fn test_blocked_scalar_vs_dispatcher() {
+        let (rows, cols) = (4, 24);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32 * 0.5).collect();
+        let mut out_scalar = vec![0.0f32; rows];
+        let mut out_dispatch = vec![0.0f32; rows];
+        scalar_blocked_ternary_matvec(&weights, &input, &mut out_scalar, rows, cols, 8);
+        blocked_ternary_matvec(&weights, &input, &mut out_dispatch, rows, cols, 8);
+        assert_close(&out_scalar, &out_dispatch, 1e-5);
+    }
+
+    #[test]
+    fn test_blocked_large_matrix() {
+        let (rows, cols) = (16, 128);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, 0, -1, 1, -1][i % 5]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.01).cos()).collect();
+
+        let mut out_ref = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_ref, rows, cols);
+
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 16);
+
+        assert_close(&out_ref, &out_blocked, 1e-4);
+    }
+
+    // ── Cross-operation tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_pack_ternary_encoding() {
+        // Verify encoding: 0→0b00, +1→0b01, -1→0b11
+        let packed = pack_ternary(&[0, 1, -1, 0]);
+        // byte = 0b00_11_01_00 = 0x0C + 0x04 = bits: 00 01 11 00 = 0b00110100
+        assert_eq!(packed[0], 0b00_11_01_00);
+    }
+
+    #[test]
+    fn test_pack_ternary_roundtrip() {
+        let weights: Vec<i8> = vec![1, -1, 0, 1, -1, -1, 0, 0, 1];
+        let packed = pack_ternary(&weights);
+        // Decode back
+        let mut decoded = vec![0i8; weights.len()];
+        for (i, &w) in weights.iter().enumerate() {
+            let byte_idx = i / 4;
+            let bit_offset = (i % 4) * 2;
+            let bits = (packed[byte_idx] >> bit_offset) & 0x03;
+            decoded[i] = match bits {
+                0b01 => 1,
+                0b11 => -1,
+                _ => 0,
+            };
+            assert_eq!(decoded[i], w, "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn test_matmul_as_batched_matvec() {
+        // matmul with n=1 should equal matvec
+        let (m, k) = (4, 8);
+        let a: Vec<i8> = (0..m * k).map(|i| [1, -1, 0][i % 3]).collect();
+        let b: Vec<f32> = (0..k).map(|i| i as f32 * 0.5).collect();
+
+        let mut out_matmul = vec![0.0f32; m];
+        ternary_matmul_f32(&a, &b, &mut out_matmul, m, 1, k);
+
+        let mut out_matvec = vec![0.0f32; m];
+        ternary_matvec_f32(&a, &b, &mut out_matvec, m, k);
+
+        assert_close(&out_matmul, &out_matvec, 1e-5);
+    }
+
+    #[test]
+    fn test_scale_one_equals_no_scale() {
+        let (rows, cols) = (4, 16);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+        let scales = vec![1.0f32; rows];
+
+        let mut out_plain = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_plain, rows, cols);
+
+        let mut out_scaled = vec![0.0f32; rows];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut out_scaled, rows, cols);
+
+        assert_close(&out_plain, &out_scaled, 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_is_additive() {
+        let (rows, cols) = (2, 8);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1][i % 2]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        // Compute expected
+        let mut expected = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut expected, rows, cols);
+
+        // Accumulate twice from zero → should be 2× the result
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_accumulate(&weights, &input, &mut output, rows, cols);
+        ternary_matvec_accumulate(&weights, &input, &mut output, rows, cols);
+
+        let doubled: Vec<f32> = expected.iter().map(|x| x * 2.0).collect();
+        assert_close(&output, &doubled, 1e-5);
+    }
+
+    #[test]
+    fn test_all_positive_weights_large() {
+        let (rows, cols) = (8, 33);
+        let weights = vec![1i8; rows * cols];
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+        let expected_sum: f32 = input.iter().sum();
+
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        for &v in &output {
+            assert!((v - expected_sum).abs() < 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_all_negative_weights_large() {
+        let (rows, cols) = (8, 33);
+        let weights = vec![-1i8; rows * cols];
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+        let expected_sum: f32 = -input.iter().sum::<f32>();
+
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        for &v in &output {
+            assert!((v - expected_sum).abs() < 1e-4);
+        }
+    }
+
+    #[test]
+    fn test_matvec_alternating_pattern() {
+        let cols = 32;
+        let weights: Vec<i8> = (0..cols).map(|i| if i % 2 == 0 { 1 } else { -1 }).collect();
+        let input = vec![1.0f32; cols];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_f32(&weights, &input, &mut output, 1, cols);
+        // Half +1, half -1 → 16 - 16 = 0
+        assert_close(&output, &[0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matvec_alternating_odd() {
+        let cols = 33;
+        let weights: Vec<i8> = (0..cols).map(|i| if i % 2 == 0 { 1 } else { -1 }).collect();
+        let input = vec![1.0f32; cols];
+        let mut output = vec![0.0f32; 1];
+        ternary_matvec_f32(&weights, &input, &mut output, 1, cols);
+        // 17 * 1 + 16 * (-1) = 1
+        assert_close(&output, &[1.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_negative_identity() {
+        let n = 4;
+        let mut a = vec![0i8; n * n];
+        for i in 0..n {
+            a[i * n + i] = -1;
+        }
+        let b: Vec<f32> = (0..n * n).map(|i| i as f32).collect();
+        let mut output = vec![0.0f32; n * n];
+        ternary_matmul_f32(&a, &b, &mut output, n, n, n);
+        let expected: Vec<f32> = b.iter().map(|x| -x).collect();
+        assert_close(&output, &expected, 1e-6);
+    }
+
+    #[test]
+    fn test_blocked_block_exact_multiple() {
+        let (rows, cols) = (4, 16);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0, 1][i % 4]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let mut out_ref = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_ref, rows, cols);
+
+        // block_size = 4, cols = 16 → exact multiple
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 4);
+        assert_close(&out_ref, &out_blocked, 1e-5);
+    }
+
+    #[test]
+    fn test_blocked_block_not_multiple() {
+        let (rows, cols) = (4, 17);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let mut out_ref = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut out_ref, rows, cols);
+
+        // block_size = 5, cols = 17 → not exact multiple
+        let mut out_blocked = vec![0.0f32; rows];
+        blocked_ternary_matvec(&weights, &input, &mut out_blocked, rows, cols, 5);
+        assert_close(&out_ref, &out_blocked, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_sparse_weights() {
+        // Only a few non-zero weights
+        let (rows, cols) = (4, 32);
+        let mut weights = vec![0i8; rows * cols];
+        weights[0 * cols + 5] = 1;
+        weights[1 * cols + 10] = -1;
+        weights[2 * cols + 0] = 1;
+        weights[2 * cols + 31] = -1;
+        weights[3 * cols + 15] = 1;
+        let input: Vec<f32> = (0..cols).map(|i| (i + 1) as f32).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-6);
+    }
+
+    #[test]
+    fn test_packed_1x1() {
+        let packed = pack_ternary(&[1]);
+        let mut output = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &[5.0], &mut output, 1, 1);
+        assert_close(&output, &[5.0], 1e-6);
+    }
+
+    #[test]
+    fn test_packed_dim_15() {
+        let cols = 15;
+        let weights: Vec<i8> = (0..cols).map(|i| [1, -1, 0][i % 3]).collect();
+        let packed = pack_ternary(&weights);
+        let input: Vec<f32> = (0..cols).map(|i| i as f32).collect();
+
+        let mut direct_out = vec![0.0f32; 1];
+        ternary_matvec_f32(&weights, &input, &mut direct_out, 1, cols);
+
+        let mut packed_out = vec![0.0f32; 1];
+        packed_ternary_matvec(&packed, &input, &mut packed_out, 1, cols);
+
+        assert_close(&direct_out, &packed_out, 1e-5);
+    }
+
+    #[test]
+    fn test_scale_with_zero_weights() {
+        let (rows, cols) = (2, 4);
+        let weights = vec![0i8; rows * cols];
+        let input = vec![1.0; cols];
+        let scales = vec![100.0, 200.0];
+        let mut output = vec![999.0f32; rows];
+        ternary_matvec_with_scale(&weights, &input, &scales, &mut output, rows, cols);
+        assert_close(&output, &[0.0, 0.0], 1e-6);
+    }
+
+    #[test]
+    fn test_accumulate_multi_row() {
+        let (rows, cols) = (3, 4);
+        let weights = vec![1i8; rows * cols];
+        let input = vec![1.0; cols];
+        let mut output = vec![10.0, 20.0, 30.0];
+        ternary_matvec_accumulate(&weights, &input, &mut output, rows, cols);
+        // 10+4=14, 20+4=24, 30+4=34
+        assert_close(&output, &[14.0, 24.0, 34.0], 1e-6);
+    }
+
+    #[test]
+    fn test_matmul_wide_output() {
+        let (m, n, k) = (2, 16, 4);
+        let a: Vec<i8> = (0..m * k).map(|i| [1, -1, 0, 1][i % 4]).collect();
+        let b: Vec<f32> = (0..k * n).map(|i| i as f32 * 0.1).collect();
+        let mut out_scalar = vec![0.0f32; m * n];
+        let mut out_dispatch = vec![0.0f32; m * n];
+        scalar_ternary_matmul_f32(&a, &b, &mut out_scalar, m, n, k);
+        ternary_matmul_f32(&a, &b, &mut out_dispatch, m, n, k);
+        assert_close(&out_scalar, &out_dispatch, 1e-5);
+    }
+
+    #[test]
+    fn test_matvec_reference_consistency() {
+        // Cross-check our dispatcher against the reference implementation
+        let (rows, cols) = (6, 25);
+        let weights: Vec<i8> = (0..rows * cols).map(|i| [0, 1, -1, 1, 0, -1][i % 6]).collect();
+        let input: Vec<f32> = (0..cols).map(|i| (i as f32 * 0.7).sin()).collect();
+        let mut output = vec![0.0f32; rows];
+        ternary_matvec_f32(&weights, &input, &mut output, rows, cols);
+        let expected = reference_matvec(&weights, &input, rows, cols);
+        assert_close(&output, &expected, 1e-5);
+    }
+}


### PR DESCRIPTION
## Summary
NEON quantized ternary matmul v3 kernel for Apple Silicon.

### Changes
- 6 ternary matmul operations with NEON/scalar/dispatcher variants
- ternary_matvec_f32, ternary_matmul_f32, packed_ternary_matvec
- ternary_matvec_with_scale, ternary_matvec_accumulate, blocked_ternary_matvec
- 72 comprehensive tests

### Testing
- `cargo test -p bitnet-kernels --features cpu -- neon_quantized_matmul_v3`
- All 72 tests pass locally on Apple Silicon

Apple Silicon enablement PR.

**Labels:** apple-silicon, neon, kernel