### PR TITLE
fix(clippy): collapse nested if in model_compare.rs [P0]

### DIFF
--- a/crates/bitnet-models/src/model_compare.rs
+++ b/crates/bitnet-models/src/model_compare.rs
@@ -190,14 +190,14 @@ pub fn compare_shapes(
     let right_map: std::collections::HashMap<_, _> = right.iter().cloned().collect();
     let mut diffs = Vec::new();
     for (name, lshape) in left {
-        if let Some(rshape) = right_map.get(name) {
-            if lshape != rshape {
-                diffs.push(ShapeDiff {
-                    tensor_name: name.clone(),
-                    left_shape: lshape.clone(),
-                    right_shape: rshape.clone(),
-                });
-            }
+        if let Some(rshape) = right_map.get(name)
+            && lshape != rshape
+        {
+            diffs.push(ShapeDiff {
+                tensor_name: name.clone(),
+                left_shape: lshape.clone(),
+                right_shape: rshape.clone(),
+            });
         }
     }
     diffs


### PR DESCRIPTION
## P0 Fix

Fixes `clippy::collapsible_if` warning in `model_compare.rs:193` that blocks CI Core Success on ALL open PRs.

### Change
- Collapse nested `if let` + `if` into single `if let && condition` pattern

This was introduced by #2981 and affects all CI runs since that merge.