### PR TITLE
feat(models): add model config serialization

### DIFF
--- a/crates/bitnet-models/src/config_serde.rs
+++ b/crates/bitnet-models/src/config_serde.rs
@@ -1,5 +1,6 @@
 //! Model configuration serialization/deserialization.
 
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 /// A portable model configuration.
@@ -172,6 +173,144 @@ pub fn smollm2_config() -> PortableConfig {
     }
 }
 
+/// Serializable model configuration.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SerializableConfig {
+    pub entries: BTreeMap<String, String>,
+}
+
+impl Default for SerializableConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SerializableConfig {
+    pub fn new() -> Self {
+        Self { entries: BTreeMap::new() }
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) -> &mut Self {
+        self.entries.insert(key.to_string(), value.to_string());
+        self
+    }
+
+    pub fn set_usize(&mut self, key: &str, value: usize) -> &mut Self {
+        self.set(key, &value.to_string())
+    }
+
+    pub fn set_f64(&mut self, key: &str, value: f64) -> &mut Self {
+        self.set(key, &value.to_string())
+    }
+
+    pub fn set_bool(&mut self, key: &str, value: bool) -> &mut Self {
+        self.set(key, if value { "true" } else { "false" })
+    }
+
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries.get(key).map(|s| s.as_str())
+    }
+
+    pub fn get_usize(&self, key: &str) -> Option<usize> {
+        self.get(key)?.parse().ok()
+    }
+
+    pub fn get_f64(&self, key: &str) -> Option<f64> {
+        self.get(key)?.parse().ok()
+    }
+
+    pub fn get_bool(&self, key: &str) -> Option<bool> {
+        match self.get(key)? {
+            "true" | "1" | "yes" => Some(true),
+            "false" | "0" | "no" => Some(false),
+            _ => None,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Serialize to key=value text.
+    pub fn to_text(&self) -> String {
+        let mut out = String::new();
+        for (k, v) in &self.entries {
+            out.push_str(k);
+            out.push('=');
+            out.push_str(v);
+            out.push('\n');
+        }
+        out
+    }
+
+    /// Parse from key=value text.
+    pub fn from_text(text: &str) -> Self {
+        let mut cfg = Self::new();
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            if let Some((k, v)) = line.split_once('=') {
+                cfg.entries.insert(k.trim().to_string(), v.trim().to_string());
+            }
+        }
+        cfg
+    }
+
+    /// Merge another config (other wins on conflict).
+    pub fn merge(&mut self, other: &SerializableConfig) {
+        for (k, v) in &other.entries {
+            self.entries.insert(k.clone(), v.clone());
+        }
+    }
+
+    /// Keys that differ between two configs.
+    pub fn diff(&self, other: &SerializableConfig) -> Vec<String> {
+        let mut diffs = Vec::new();
+        for (k, v) in &self.entries {
+            match other.get(k) {
+                Some(ov) if ov != v => diffs.push(k.clone()),
+                None => diffs.push(k.clone()),
+                _ => {}
+            }
+        }
+        for k in other.entries.keys() {
+            if !self.entries.contains_key(k) {
+                diffs.push(k.clone());
+            }
+        }
+        diffs.sort();
+        diffs.dedup();
+        diffs
+    }
+
+    /// Build a standard transformer config.
+    pub fn transformer(
+        arch: &str,
+        layers: usize,
+        hidden: usize,
+        heads: usize,
+        kv_heads: usize,
+        vocab: usize,
+        context: usize,
+    ) -> Self {
+        let mut cfg = Self::new();
+        cfg.set("architecture", arch);
+        cfg.set_usize("num_layers", layers);
+        cfg.set_usize("hidden_size", hidden);
+        cfg.set_usize("num_heads", heads);
+        cfg.set_usize("num_kv_heads", kv_heads);
+        cfg.set_usize("vocab_size", vocab);
+        cfg.set_usize("max_context", context);
+        cfg
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -267,5 +406,112 @@ mod tests {
         let pairs = vec![("model_type".into(), "phi".into())];
         let c = PortableConfig::from_pairs(&pairs);
         assert_eq!(c.architecture, "phi");
+    }
+
+    // SerializableConfig tests
+
+    #[test]
+    fn test_sc_set_get() {
+        let mut cfg = SerializableConfig::new();
+        cfg.set("key", "value");
+        assert_eq!(cfg.get("key"), Some("value"));
+    }
+
+    #[test]
+    fn test_sc_set_usize() {
+        let mut cfg = SerializableConfig::new();
+        cfg.set_usize("layers", 40);
+        assert_eq!(cfg.get_usize("layers"), Some(40));
+    }
+
+    #[test]
+    fn test_sc_set_f64() {
+        let mut cfg = SerializableConfig::new();
+        cfg.set_f64("eps", 1e-5);
+        assert!((cfg.get_f64("eps").unwrap() - 1e-5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_sc_set_bool() {
+        let mut cfg = SerializableConfig::new();
+        cfg.set_bool("bias", false);
+        assert_eq!(cfg.get_bool("bias"), Some(false));
+    }
+
+    #[test]
+    fn test_sc_to_text() {
+        let mut cfg = SerializableConfig::new();
+        cfg.set("a", "1");
+        cfg.set("b", "2");
+        let text = cfg.to_text();
+        assert!(text.contains("a=1"));
+        assert!(text.contains("b=2"));
+    }
+
+    #[test]
+    fn test_sc_from_text() {
+        let text = "layers=40\nhidden=5120\n# comment\n\n";
+        let cfg = SerializableConfig::from_text(text);
+        assert_eq!(cfg.get("layers"), Some("40"));
+        assert_eq!(cfg.get("hidden"), Some("5120"));
+        assert_eq!(cfg.len(), 2);
+    }
+
+    #[test]
+    fn test_sc_roundtrip() {
+        let mut orig = SerializableConfig::new();
+        orig.set("arch", "phi4");
+        orig.set_usize("layers", 40);
+        let text = orig.to_text();
+        let parsed = SerializableConfig::from_text(&text);
+        assert_eq!(orig, parsed);
+    }
+
+    #[test]
+    fn test_sc_merge() {
+        let mut a = SerializableConfig::new();
+        a.set("x", "1");
+        let mut b = SerializableConfig::new();
+        b.set("x", "2");
+        b.set("y", "3");
+        a.merge(&b);
+        assert_eq!(a.get("x"), Some("2")); // b wins
+        assert_eq!(a.get("y"), Some("3"));
+    }
+
+    #[test]
+    fn test_sc_diff() {
+        let mut a = SerializableConfig::new();
+        a.set("x", "1");
+        a.set("y", "2");
+        let mut b = SerializableConfig::new();
+        b.set("x", "1");
+        b.set("y", "3");
+        b.set("z", "4");
+        let d = a.diff(&b);
+        assert!(d.contains(&"y".to_string()));
+        assert!(d.contains(&"z".to_string()));
+        assert!(!d.contains(&"x".to_string()));
+    }
+
+    #[test]
+    fn test_sc_transformer() {
+        let cfg = SerializableConfig::transformer("phi4", 40, 5120, 40, 10, 100352, 16384);
+        assert_eq!(cfg.get("architecture"), Some("phi4"));
+        assert_eq!(cfg.get_usize("num_layers"), Some(40));
+    }
+
+    #[test]
+    fn test_sc_empty() {
+        let cfg = SerializableConfig::new();
+        assert!(cfg.is_empty());
+        assert_eq!(cfg.len(), 0);
+    }
+
+    #[test]
+    fn test_sc_get_missing() {
+        let cfg = SerializableConfig::new();
+        assert_eq!(cfg.get("nope"), None);
+        assert_eq!(cfg.get_usize("nope"), None);
     }
 }


### PR DESCRIPTION
Key-value text format for model configs with typed getters (usize/f64/bool), merge, diff, roundtrip, and transformer preset builder. 12 tests.