### PR TITLE
fix(clippy): escape OpenCL in doc comment for doc_markdown lint

### DIFF
--- a/crates/bitnet-spirv/src/lib.rs
+++ b/crates/bitnet-spirv/src/lib.rs
@@ -1,6 +1,6 @@
 //! SPIR-V compilation pipeline and utilities.
 //!
-//! Provides offline compilation of OpenCL kernel sources to SPIR-V binary,
+//! Provides offline compilation of `OpenCL` kernel sources to SPIR-V binary,
 //! runtime compiler detection (`clang`, `ocloc`), lightweight validation,
 //! and a thread-safe in-memory cache.
 


### PR DESCRIPTION
## P0 CI Fix

Fixes `doc_markdown` Clippy lint in `bitnet-spirv` that blocks ALL PRs.

### Change
- Wrap `OpenCL` in backticks in the crate-level doc comment (`crates/bitnet-spirv/src/lib.rs:3`)

### Impact
- Unblocks 87+ Apple Silicon PRs and all other open PRs that inherit this file from main
- 1-line change, zero functional impact