### PR TITLE
style: fix formatting drift and collapsible_if clippy lint

### DIFF
--- a/crates/bitnet-common/src/op_pool.rs
+++ b/crates/bitnet-common/src/op_pool.rs
@@ -49,12 +49,12 @@ impl OpPool {
         let key = BufferKey::new(shape, dtype);
         let needed = key.elements() * bytes_per_element;
 
-        if let Some(buffers) = self.buffers.get_mut(&key) {
-            if let Some(buf) = buffers.iter_mut().find(|b| !b.in_use) {
-                buf.in_use = true;
-                self.hits += 1;
-                return buf.data.clone();
-            }
+        if let Some(buffers) = self.buffers.get_mut(&key)
+            && let Some(buf) = buffers.iter_mut().find(|b| !b.in_use)
+        {
+            buf.in_use = true;
+            self.hits += 1;
+            return buf.data.clone();
         }
 
         self.misses += 1;
@@ -76,10 +76,10 @@ impl OpPool {
     /// Release a buffer back to the pool.
     pub fn release(&mut self, shape: &[usize], dtype: &str) {
         let key = BufferKey::new(shape, dtype);
-        if let Some(buffers) = self.buffers.get_mut(&key) {
-            if let Some(buf) = buffers.iter_mut().find(|b| b.in_use) {
-                buf.in_use = false;
-            }
+        if let Some(buffers) = self.buffers.get_mut(&key)
+            && let Some(buf) = buffers.iter_mut().find(|b| b.in_use)
+        {
+            buf.in_use = false;
         }
     }
 

--- a/crates/bitnet-common/src/tensor_layout.rs
+++ b/crates/bitnet-common/src/tensor_layout.rs
@@ -85,7 +85,7 @@ impl TensorLayout {
         if alignment == 0 {
             return true;
         }
-        self.offset % alignment == 0
+        self.offset.is_multiple_of(alignment)
     }
 
     /// Transpose (swap last two dims).

--- a/crates/bitnet-models/src/gguf_min.rs
+++ b/crates/bitnet-models/src/gguf_min.rs
@@ -197,7 +197,7 @@ fn parse_header<R: Read + Seek>(r: &mut R) -> Result<Parsed> {
         let ty = read_u32(r)?;
         let offset = read_u64(r)?;
         ensure!(
-            offset % alignment == 0,
+            offset.is_multiple_of(alignment),
             "tensor '{}' offset {} not aligned to {alignment}",
             name,
             offset

--- a/crates/bitnet-models/src/model_catalog.rs
+++ b/crates/bitnet-models/src/model_catalog.rs
@@ -61,9 +61,7 @@ pub struct ModelCatalog {
 
 impl ModelCatalog {
     pub fn new() -> Self {
-        Self {
-            entries: Vec::new(),
-        }
+        Self { entries: Vec::new() }
     }
 
     /// Build catalog with known SLM models.
@@ -206,16 +204,13 @@ impl ModelCatalog {
         self.entries
             .iter()
             .filter(|e| {
-                e.name.to_lowercase().contains(&q)
-                    || e.id.contains(&q)
-                    || e.family.contains(&q)
+                e.name.to_lowercase().contains(&q) || e.id.contains(&q) || e.family.contains(&q)
             })
             .collect()
     }
 
     pub fn families(&self) -> Vec<String> {
-        let mut fams: Vec<_> =
-            self.entries.iter().map(|e| e.family.clone()).collect();
+        let mut fams: Vec<_> = self.entries.iter().map(|e| e.family.clone()).collect();
         fams.sort();
         fams.dedup();
         fams


### PR DESCRIPTION
## Summary
Fix pre-existing CI failures on main affecting all open PRs.

### Changes
- **context_window.rs**: Fix rustfmt line-width formatting
- **model_catalog.rs**: Fix rustfmt line-width formatting  
- **op_pool.rs**: Fix `clippy::collapsible_if` using Rust 2024 let-chains syntax

### Impact
These 3 issues cause Build & Test to fail at the formatting check step for ALL open PRs (merge commit inherits main's formatting issues). Fixing these unblocks ~30+ open PRs.