### PR TITLE
fix(clippy): fix div_ceil, Default derive, and vec! lint errors [P0]

### DIFF
--- a/crates/bitnet-inference/src/attention_pattern.rs
+++ b/crates/bitnet-inference/src/attention_pattern.rs
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_summarize() {
-        let stats = vec![analyze_head(0, &vec![0.25; 4]), analyze_head(1, &vec![0.25; 4])];
+        let stats = vec![analyze_head(0, &[0.25; 4]), analyze_head(1, &[0.25; 4])];
         let summary = summarize_layer(&stats);
         assert_eq!(summary.num_heads, 2);
         assert!(summary.avg_entropy > 0.0);

--- a/crates/bitnet-kernels/src/matmul_dispatch.rs
+++ b/crates/bitnet-kernels/src/matmul_dispatch.rs
@@ -98,9 +98,9 @@ impl TileConfig {
     }
 
     pub fn num_tiles(&self, shape: &MatmulShape) -> usize {
-        let tm = (shape.m + self.tile_m - 1) / self.tile_m;
-        let tn = (shape.n + self.tile_n - 1) / self.tile_n;
-        let tk = (shape.k + self.tile_k - 1) / self.tile_k;
+        let tm = shape.m.div_ceil(self.tile_m);
+        let tn = shape.n.div_ceil(self.tile_n);
+        let tk = shape.k.div_ceil(self.tile_k);
         tm * tn * tk
     }
 }
@@ -115,25 +115,13 @@ pub struct DispatchDecision {
 }
 
 /// Available hardware features.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct HardwareFeatures {
     pub has_avx2: bool,
     pub has_avx512: bool,
     pub has_neon: bool,
     pub has_cuda: bool,
     pub has_opencl: bool,
-}
-
-impl Default for HardwareFeatures {
-    fn default() -> Self {
-        Self {
-            has_avx2: false,
-            has_avx512: false,
-            has_neon: false,
-            has_cuda: false,
-            has_opencl: false,
-        }
-    }
 }
 
 /// Select the best matmul backend for given shape and hardware.


### PR DESCRIPTION
## P0 - Unblocks ALL PRs

Fixes 4 clippy errors on main that cause CI failures for all PRs:

1. **matmul_dispatch.rs**: Replace manual `(a + b - 1) / b` with `a.div_ceil(b)` (3 instances)
2. **matmul_dispatch.rs**: Derive `Default` for `HardwareFeatures` instead of manual impl

All Clippy CI checks pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test input formats in attention pattern tests.

* **Refactor**
  * Optimized tile calculation logic in matrix multiplication operations.
  * Streamlined default value initialization for hardware feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->