### PR TITLE
fix: correct formatting and clippy violations in bitnet-inference [P0]

### DIFF
--- a/crates/bitnet-inference/src/attention_config.rs
+++ b/crates/bitnet-inference/src/attention_config.rs
@@ -132,7 +132,7 @@ impl AttentionConfig {
         if self.num_kv_heads == 0 {
             return Err("num_kv_heads must be > 0".into());
         }
-        if self.num_heads % self.num_kv_heads != 0 {
+        if !self.num_heads.is_multiple_of(self.num_kv_heads) {
             return Err(format!(
                 "num_heads ({}) must be divisible by num_kv_heads ({})",
                 self.num_heads, self.num_kv_heads,

--- a/crates/bitnet-inference/src/batch_coordinator.rs
+++ b/crates/bitnet-inference/src/batch_coordinator.rs
@@ -7,18 +7,13 @@ use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 /// Priority level for inference requests.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Priority {
     Low = 0,
+    #[default]
     Normal = 1,
     High = 2,
     Critical = 3,
-}
-
-impl Default for Priority {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 /// An inference request in the batch queue.
@@ -33,13 +28,7 @@ pub struct BatchRequest {
 
 impl BatchRequest {
     pub fn new(id: u64, token_ids: Vec<u32>, max_tokens: usize) -> Self {
-        Self {
-            id,
-            token_ids,
-            max_tokens,
-            priority: Priority::Normal,
-            enqueued_at: Instant::now(),
-        }
+        Self { id, token_ids, max_tokens, priority: Priority::Normal, enqueued_at: Instant::now() }
     }
 
     pub fn with_priority(mut self, priority: Priority) -> Self {
@@ -127,12 +116,7 @@ pub struct BatchCoordinator {
 
 impl BatchCoordinator {
     pub fn new(config: BatchConfig) -> Self {
-        Self {
-            queue: VecDeque::new(),
-            config,
-            next_id: 0,
-            batches_formed: 0,
-        }
+        Self { queue: VecDeque::new(), config, next_id: 0, batches_formed: 0 }
     }
 
     pub fn with_defaults() -> Self {
@@ -158,11 +142,7 @@ impl BatchCoordinator {
         self.next_id += 1;
         let req = BatchRequest::new(id, token_ids, max_tokens).with_priority(priority);
         // Insert based on priority: higher priority goes earlier
-        let pos = self
-            .queue
-            .iter()
-            .position(|r| r.priority < priority)
-            .unwrap_or(self.queue.len());
+        let pos = self.queue.iter().position(|r| r.priority < priority).unwrap_or(self.queue.len());
         self.queue.insert(pos, req);
         id
     }
@@ -201,10 +181,7 @@ impl BatchCoordinator {
         }
 
         self.batches_formed += 1;
-        Some(Batch {
-            requests,
-            formed_at: Instant::now(),
-        })
+        Some(Batch { requests, formed_at: Instant::now() })
     }
 
     pub fn batches_formed(&self) -> u64 {
@@ -235,10 +212,7 @@ mod tests {
 
     #[test]
     fn test_max_batch_size() {
-        let config = BatchConfig {
-            max_batch_size: 2,
-            ..Default::default()
-        };
+        let config = BatchConfig { max_batch_size: 2, ..Default::default() };
         let mut coord = BatchCoordinator::new(config);
         coord.enqueue(vec![1], 10);
         coord.enqueue(vec![2], 10);
@@ -250,11 +224,7 @@ mod tests {
 
     #[test]
     fn test_max_total_tokens() {
-        let config = BatchConfig {
-            max_batch_size: 100,
-            max_total_tokens: 5,
-            ..Default::default()
-        };
+        let config = BatchConfig { max_batch_size: 100, max_total_tokens: 5, ..Default::default() };
         let mut coord = BatchCoordinator::new(config);
         coord.enqueue(vec![1, 2, 3], 10);
         coord.enqueue(vec![4, 5, 6], 10);

--- a/crates/bitnet-inference/src/generation_state.rs
+++ b/crates/bitnet-inference/src/generation_state.rs
@@ -128,11 +128,11 @@ impl GenerationTracker {
         self.last_token_ids.push(token_id);
 
         // Check EOS
-        if let Some(eos) = self.eos_token_id {
-            if token_id == eos {
-                self.state = GenState::Stopped(StopReason::EndOfSequence);
-                return self.state;
-            }
+        if let Some(eos) = self.eos_token_id
+            && token_id == eos
+        {
+            self.state = GenState::Stopped(StopReason::EndOfSequence);
+            return self.state;
         }
 
         // Check max tokens

--- a/crates/bitnet-inference/src/sampler_config.rs
+++ b/crates/bitnet-inference/src/sampler_config.rs
@@ -127,15 +127,15 @@ impl SamplerConfig {
         if self.temperature < 0.0 {
             issues.push("temperature must be >= 0".into());
         }
-        if let Some(k) = self.top_k {
-            if k == 0 {
-                issues.push("top_k must be > 0".into());
-            }
+        if let Some(k) = self.top_k
+            && k == 0
+        {
+            issues.push("top_k must be > 0".into());
         }
-        if let Some(p) = self.top_p {
-            if !(0.0..=1.0).contains(&p) {
-                issues.push("top_p must be in [0.0, 1.0]".into());
-            }
+        if let Some(p) = self.top_p
+            && !(0.0..=1.0).contains(&p)
+        {
+            issues.push("top_p must be in [0.0, 1.0]".into());
         }
         if self.repetition_penalty < 0.0 {
             issues.push("repetition_penalty must be >= 0".into());


### PR DESCRIPTION
## P0: Format + Clippy Violations on Main

These violations on `main` block ALL PR CI checks (format/clippy step fails).

### Changes
- **batch_coordinator.rs**: Fix struct literal formatting (rustfmt) + derive Default instead of manual impl for Priority
- **attention_config.rs**: Use `is_multiple_of()` instead of manual modulo check
- **generation_state.rs**: Collapse nested if-let into single expression  
- **sampler_config.rs**: Collapse nested if-let blocks

### Validation
- `cargo fmt --all -- --check` ✅
- `cargo clippy -p bitnet-inference --lib -- -D warnings` ✅
- `cargo check --workspace --locked` ✅

Unblocks all open PRs.