### PR TITLE
test(metal): add Metal inference pipeline TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/metal_inference_pipeline_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_inference_pipeline_tests.rs
@@ -1,0 +1,282 @@
+//! Metal inference pipeline end-to-end tests for Apple Silicon.
+//!
+//! Tests validate the complete inference pipeline on Metal GPU:
+//! forward pass, KV cache management, token generation, mixed
+//! CPU/GPU execution, batching, streaming, and error recovery.
+//!
+//! All tests are TDD scaffolds (`#[ignore]`) — they require a
+//! Metal inference pipeline implementation to run.
+
+#![cfg(target_os = "macos")]
+
+// ── Pipeline configuration ─────────────────────────────────────
+
+/// Minimal model configuration for inference pipeline tests.
+#[derive(Debug, Clone)]
+struct PipelineModelConfig {
+    vocab_size: usize,
+    hidden_size: usize,
+    num_heads: usize,
+    num_layers: usize,
+    max_seq_len: usize,
+    intermediate_size: usize,
+}
+
+impl PipelineModelConfig {
+    /// Tiny config: 128 vocab, 64 hidden, 4 heads, 2 layers.
+    fn tiny() -> Self {
+        Self {
+            vocab_size: 128,
+            hidden_size: 64,
+            num_heads: 4,
+            num_layers: 2,
+            max_seq_len: 128,
+            intermediate_size: 256,
+        }
+    }
+
+    /// Small config: 256 vocab, 128 hidden, 8 heads, 4 layers.
+    fn small() -> Self {
+        Self {
+            vocab_size: 256,
+            hidden_size: 128,
+            num_heads: 8,
+            num_layers: 4,
+            max_seq_len: 256,
+            intermediate_size: 512,
+        }
+    }
+}
+
+// ── Full forward pass ──────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_full_forward_pass_embedding_to_logits() {
+    // Validate: embedding → attention → FFN → output projection
+    // on Metal GPU produces logits with correct vocab dimension.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_forward_pass_numerical_sanity() {
+    // Verify logits from Metal forward pass are finite, non-NaN,
+    // and within a sane numerical range.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Multi-layer transformer execution ──────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_multi_layer_transformer_on_gpu() {
+    // Run a 4-layer transformer entirely on Metal and verify
+    // output shape matches (batch, seq_len, vocab_size).
+    let _cfg = PipelineModelConfig::small();
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_layer_outputs_differ_per_layer() {
+    // Verify each transformer layer produces distinct hidden
+    // states (no identity passthrough).
+    let _cfg = PipelineModelConfig::small();
+    unimplemented!()
+}
+
+// ── KV cache management ────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_kv_cache_grows_with_tokens() {
+    // After generating N tokens the KV cache sequence length
+    // should equal prompt_len + N.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_kv_cache_metal_buffer_alignment() {
+    // Metal requires 256-byte aligned buffers; verify the
+    // KV cache backing storage satisfies this constraint.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Token generation loop ──────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_autoregressive_token_generation() {
+    // Run a 4-token autoregressive loop on Metal and verify
+    // each step produces a valid token id in [0, vocab_size).
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_deterministic_generation_with_seed() {
+    // Two runs with identical seed produce the same token
+    // sequence on Metal (greedy decoding).
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Mixed CPU/GPU execution ────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_mixed_cpu_gpu_layer_split() {
+    // First N layers on CPU, remaining layers on Metal GPU.
+    // Verify output matches full-GPU execution within tolerance.
+    let _cfg = PipelineModelConfig::small();
+    unimplemented!()
+}
+
+// ── Pipeline warm-up and first-token latency ───────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_pipeline_warmup_reduces_latency() {
+    // Measure first-token latency before and after a warm-up
+    // pass; warmed-up latency should be lower.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Batch inference ────────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_batch_inference_multiple_sequences() {
+    // Run inference on a batch of 4 sequences simultaneously
+    // and verify each produces independent logits.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Pipeline state management ──────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_pipeline_state_persists_between_tokens() {
+    // Internal pipeline state (KV cache, position counters)
+    // must persist across autoregressive steps.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Memory pressure ────────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_long_sequence_memory_pressure() {
+    // Generate tokens up to max_seq_len and verify the
+    // pipeline handles memory limits gracefully (no crash).
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Error recovery ─────────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_shader_compilation_failure_recovery() {
+    // Simulate a shader compilation failure and verify the
+    // pipeline returns a descriptive error, not a panic.
+    unimplemented!()
+}
+
+// ── Concurrent pipeline instances ──────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_concurrent_pipeline_instances() {
+    // Two independent pipeline instances running on the same
+    // Metal device must not interfere with each other.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Throughput measurement ─────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_pipeline_throughput_tokens_per_second() {
+    // Generate 16 tokens and record throughput; verify
+    // the measurement is positive and plausible (> 0 tok/s).
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── GPU → CPU logits transfer ──────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_gpu_to_cpu_logits_transfer() {
+    // After a Metal forward pass the logits must be readable
+    // on the CPU with correct shape and finite values.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Pipeline configuration validation ──────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_pipeline_rejects_invalid_config() {
+    // A config with 0 layers or 0 heads must be rejected at
+    // pipeline construction time, not at inference time.
+    unimplemented!()
+}
+
+// ── Streaming token output ─────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_streaming_token_output() {
+    // Tokens are yielded one-by-one through a streaming
+    // iterator/channel rather than collected in bulk.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Checkpoint / resume ────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_pipeline_checkpoint_and_resume() {
+    // Checkpoint pipeline state after 4 tokens, resume from
+    // the checkpoint and verify continued generation matches.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Model loading to Metal buffers ─────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_model_weights_loaded_to_metal_buffers() {
+    // After loading a model, all weight tensors reside in
+    // Metal shared-memory buffers (MTLResourceStorageModeShared).
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}
+
+// ── Quantized weights on Metal ─────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal inference pipeline implementation"]
+fn test_i2s_quantized_weights_on_metal() {
+    // I2_S quantized weights are dequantized in a Metal
+    // compute shader and produce the same logits (within
+    // tolerance) as CPU dequantization.
+    let _cfg = PipelineModelConfig::tiny();
+    unimplemented!()
+}


### PR DESCRIPTION
## Summary
Add 22 TDD scaffold tests for Metal inference pipeline operations including full forward pass, transformer layers, KV cache, token generation, mixed CPU/GPU execution, memory pressure, and streaming output.

## Changes
- New test file: `crates/bitnet-kernels/tests/metal_inference_pipeline_tests.rs`
- 22 tests covering end-to-end pipeline validation
- All tests use `#[ignore = "TDD scaffold: ..."]` pattern

## Test Categories
- Full forward pass (embedding→logits, numerical sanity)
- Multi-layer transformer validation
- KV cache Metal buffer alignment
- Autoregressive token generation
- Mixed CPU/GPU execution paths
- Pipeline warm-up/latency
- Batch inference, streaming output
- Memory pressure, concurrent pipelines
- GPU→CPU transfer, checkpoint/resume

## Labels
apple-silicon, tests