### PR TITLE
test(neon): add NEON pooling regression tests [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/neon_pooling_regression_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_pooling_regression_tests.rs
@@ -1,0 +1,245 @@
+//! NEON pooling operation regression tests for Apple Silicon.
+//!
+//! TDD scaffolding for ARM NEON SIMD pooling operations including
+//! global average pooling, max pooling, adaptive pooling, masked
+//! pooling, and related reduction operations. All tests are
+//! `#[ignore]` until the NEON pooling kernel implementations land.
+
+#![cfg(target_arch = "aarch64")]
+
+// -----------------------------------------------------------------
+// Global average pooling
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_global_avg_pool_neon_f32_basic() {
+    // Global average pooling over a (batch=1, seq=8, dim=128) tensor
+    // using NEON vectorized horizontal add + lane reduction.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_global_avg_pool_neon_f32_single_element() {
+    // Edge case: seq_len=1 should return the input unchanged.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Max pooling
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_max_pool_neon_lane_reduction() {
+    // Find maximum across NEON float32x4 lanes using vmaxvq_f32,
+    // then reduce across the full sequence dimension.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_max_pool_neon_negative_values() {
+    // All-negative input: max pool must select the least-negative
+    // value, not zero.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Adaptive average pooling
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_adaptive_avg_pool_variable_length() {
+    // Adaptive average pooling that maps variable-length input
+    // sequences to a fixed output size (e.g., seq=37 → out=8).
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Masked (padding-aware) pooling
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_with_padding_mask() {
+    // Average pooling that ignores padding tokens indicated by a
+    // boolean mask. Divisor should be count of non-pad tokens only.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_with_mixed_length_sequences() {
+    // Batch of sequences with different valid lengths; each should
+    // be pooled independently using its own mask.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Mean pooling across sequence dimension
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_mean_pool_sequence_dimension() {
+    // Mean pooling along the sequence axis: output shape should be
+    // (batch, dim), computed with NEON vaddq_f32 accumulation and
+    // scalar division by seq_len.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Weighted pooling with attention scores
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_weighted_pool_attention_scores() {
+    // Weighted average pooling where each token embedding is scaled
+    // by its attention score before summation. Weights sum to 1.0.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Pooling gradient (backward pass)
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_avg_pool_gradient_backward() {
+    // Backward pass: gradient of average pooling distributes
+    // upstream grad equally (grad / seq_len) to each input token.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Pooling with stride and kernel size
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pool_stride_and_kernel_size() {
+    // 1-D average pooling with kernel_size=4, stride=2 along
+    // the sequence dimension. Validates output length and values.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Multi-head pooling
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_multi_head_pooling_independent() {
+    // Each attention head is pooled independently. Input shape
+    // (batch, heads, seq, head_dim) → (batch, heads, head_dim).
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// CLS token extraction vs pooling comparison
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_cls_token_vs_mean_pooling() {
+    // Compare CLS-token extraction (first token) against mean
+    // pooling. Both must produce (batch, dim) output; values
+    // will differ but shapes must match.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Numerical stability
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_numerical_stability_large_values() {
+    // Pooling with f32::MAX-scale inputs should not overflow.
+    // Uses compensated (Kahan) summation or equivalent.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_numerical_stability_small_values() {
+    // Pooling with subnormal / near-zero inputs should not
+    // collapse to ±0 due to catastrophic cancellation.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Batch pooling (multiple sequences in parallel)
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_batch_pooling_parallel() {
+    // Pool a batch of N sequences in parallel. Output shape
+    // (batch=N, dim) must equal per-sequence pooling results.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Output shape validation
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_output_shape_validation() {
+    // Verify that pooling reduces (batch, seq, dim) → (batch, dim)
+    // and rejects mismatched input dimensions with a clear error.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Non-contiguous memory layout
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_non_contiguous_memory() {
+    // Pooling over a tensor whose sequence-dimension stride ≠ dim.
+    // Validates that the NEON kernel handles non-unit strides.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// NEON lane reduction operations
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_neon_lane_horizontal_sum_reduction() {
+    // Horizontal sum reduction of float32x4 lanes via vaddvq_f32.
+    // Verifies scalar parity for random 128-bit vectors.
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Reproducibility (determinism)
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_reproducibility_deterministic() {
+    // Two identical pooling calls with the same input must produce
+    // bit-identical output (no non-deterministic reductions).
+    unimplemented!()
+}
+
+// -----------------------------------------------------------------
+// Performance baseline
+// -----------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires NEON pooling operation implementation"]
+fn test_pooling_performance_baseline() {
+    // Smoke-test that NEON pooling of a (1, 512, 768) tensor
+    // completes within a generous wall-clock budget (< 50 ms).
+    unimplemented!()
+}


### PR DESCRIPTION
## Summary
Add 20 TDD scaffold tests for NEON pooling operations on ARM64/Apple Silicon.

## Changes
- New test file: `crates/bitnet-kernels/tests/neon_pooling_regression_tests.rs`
- 20 tests covering pooling kernel validation

## Test Categories
- Global average pool, max pool, adaptive pool
- Masked pooling, mean pool, weighted pool
- Stride/kernel configurations
- Multi-head attention pooling
- CLS token vs pooling comparison
- Numerical stability (large values)
- Batch pooling, shape validation
- Non-contiguous memory layouts
- Lane reduction operations
- Reproducibility verification
- Mixed-length sequence handling
- Performance baseline

## Labels
apple-silicon, tests