### PR TITLE
feat(kernels): add SIMD feature detection module

### DIFF
--- a/crates/bitnet-kernels/src/simd_detect.rs
+++ b/crates/bitnet-kernels/src/simd_detect.rs
@@ -1,177 +1,136 @@
-//! Runtime SIMD feature detection.
+//! SIMD feature detection and capability reporting.
 //!
-//! Detect available SIMD instruction sets at runtime on x86_64 and aarch64.
+//! Runtime detection of CPU SIMD capabilities, feature level
+//! classification, and capability summaries.
 
-/// SIMD instruction set level.
+/// SIMD feature level (ordered from lowest to highest capability).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum SimdLevel {
-    None,
+pub enum SimdFeatureLevel {
+    /// No SIMD (scalar only).
+    Scalar,
+    /// SSE2 (128-bit, baseline x86-64).
     Sse2,
-    Sse42,
+    /// SSE4.1/4.2 (improved 128-bit).
+    Sse4,
+    /// AVX (256-bit float).
     Avx,
+    /// AVX2 + FMA (256-bit integer + fused multiply-add).
     Avx2,
+    /// AVX-512F (512-bit).
     Avx512,
+    /// ARM NEON (128-bit).
     Neon,
+    /// ARM NEON + dotprod.
+    NeonDotprod,
 }
 
-impl SimdLevel {
+impl SimdFeatureLevel {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::None => "none",
+            Self::Scalar => "scalar",
             Self::Sse2 => "sse2",
-            Self::Sse42 => "sse4.2",
+            Self::Sse4 => "sse4",
             Self::Avx => "avx",
             Self::Avx2 => "avx2",
             Self::Avx512 => "avx512",
             Self::Neon => "neon",
+            Self::NeonDotprod => "neon+dotprod",
         }
     }
 
-    pub fn vector_width_bits(&self) -> usize {
+    /// Register width in bits.
+    pub fn register_bits(&self) -> usize {
         match self {
-            Self::None => 0,
-            Self::Sse2 | Self::Sse42 => 128,
+            Self::Scalar => 64,
+            Self::Sse2 | Self::Sse4 => 128,
             Self::Avx | Self::Avx2 => 256,
             Self::Avx512 => 512,
-            Self::Neon => 128,
+            Self::Neon | Self::NeonDotprod => 128,
         }
     }
 
-    pub fn vector_width_f32(&self) -> usize {
-        self.vector_width_bits() / 32
+    /// Floats per register (f32).
+    pub fn f32_lanes(&self) -> usize {
+        self.register_bits() / 32
     }
 
-    pub fn is_x86(&self) -> bool {
-        matches!(self, Self::Sse2 | Self::Sse42 | Self::Avx | Self::Avx2 | Self::Avx512)
-    }
-
-    pub fn is_arm(&self) -> bool {
-        matches!(self, Self::Neon)
+    /// Whether FMA (fused multiply-add) is likely available.
+    pub fn has_fma(&self) -> bool {
+        matches!(self, Self::Avx2 | Self::Avx512)
     }
 }
 
-/// All SIMD features detected on this machine.
+/// Detected SIMD capabilities on the current CPU.
 #[derive(Debug, Clone)]
 pub struct SimdCapabilities {
-    pub has_sse2: bool,
-    pub has_sse42: bool,
-    pub has_avx: bool,
-    pub has_avx2: bool,
-    pub has_fma: bool,
-    pub has_avx512f: bool,
-    pub has_avx512bw: bool,
-    pub has_avx512vnni: bool,
-    pub has_neon: bool,
+    pub features: Vec<SimdFeatureLevel>,
+    pub best: SimdFeatureLevel,
 }
 
 impl SimdCapabilities {
     /// Detect available SIMD features at runtime.
     pub fn detect() -> Self {
+        let mut features = vec![SimdFeatureLevel::Scalar];
+
         #[cfg(target_arch = "x86_64")]
         {
-            Self {
-                has_sse2: std::arch::is_x86_feature_detected!("sse2"),
-                has_sse42: std::arch::is_x86_feature_detected!("sse4.2"),
-                has_avx: std::arch::is_x86_feature_detected!("avx"),
-                has_avx2: std::arch::is_x86_feature_detected!("avx2"),
-                has_fma: std::arch::is_x86_feature_detected!("fma"),
-                has_avx512f: std::arch::is_x86_feature_detected!("avx512f"),
-                has_avx512bw: std::arch::is_x86_feature_detected!("avx512bw"),
-                has_avx512vnni: std::arch::is_x86_feature_detected!("avx512vnni"),
-                has_neon: false,
+            // SSE2 is baseline on x86-64
+            features.push(SimdFeatureLevel::Sse2);
+
+            if std::arch::is_x86_feature_detected!("sse4.1") {
+                features.push(SimdFeatureLevel::Sse4);
+            }
+            if std::arch::is_x86_feature_detected!("avx") {
+                features.push(SimdFeatureLevel::Avx);
+            }
+            if std::arch::is_x86_feature_detected!("avx2") {
+                features.push(SimdFeatureLevel::Avx2);
+            }
+            if std::arch::is_x86_feature_detected!("avx512f") {
+                features.push(SimdFeatureLevel::Avx512);
             }
         }
+
         #[cfg(target_arch = "aarch64")]
         {
-            Self {
-                has_sse2: false,
-                has_sse42: false,
-                has_avx: false,
-                has_avx2: false,
-                has_fma: false,
-                has_avx512f: false,
-                has_avx512bw: false,
-                has_avx512vnni: false,
-                has_neon: true, // NEON is mandatory on aarch64
-            }
+            // NEON is baseline on aarch64
+            features.push(SimdFeatureLevel::Neon);
         }
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-        {
-            Self {
-                has_sse2: false,
-                has_sse42: false,
-                has_avx: false,
-                has_avx2: false,
-                has_fma: false,
-                has_avx512f: false,
-                has_avx512bw: false,
-                has_avx512vnni: false,
-                has_neon: false,
-            }
-        }
+
+        let best = features
+            .iter()
+            .copied()
+            .max()
+            .unwrap_or(SimdFeatureLevel::Scalar);
+        Self { features, best }
     }
 
-    /// Best available SIMD level.
-    pub fn best_level(&self) -> SimdLevel {
-        if self.has_avx512f {
-            SimdLevel::Avx512
-        } else if self.has_avx2 {
-            SimdLevel::Avx2
-        } else if self.has_avx {
-            SimdLevel::Avx
-        } else if self.has_sse42 {
-            SimdLevel::Sse42
-        } else if self.has_sse2 {
-            SimdLevel::Sse2
-        } else if self.has_neon {
-            SimdLevel::Neon
-        } else {
-            SimdLevel::None
-        }
+    pub fn has(&self, level: SimdFeatureLevel) -> bool {
+        self.features.contains(&level)
     }
 
-    /// All levels supported (from lowest to highest).
-    pub fn supported_levels(&self) -> Vec<SimdLevel> {
-        let mut levels = Vec::new();
-        if self.has_sse2 {
-            levels.push(SimdLevel::Sse2);
-        }
-        if self.has_sse42 {
-            levels.push(SimdLevel::Sse42);
-        }
-        if self.has_avx {
-            levels.push(SimdLevel::Avx);
-        }
-        if self.has_avx2 {
-            levels.push(SimdLevel::Avx2);
-        }
-        if self.has_avx512f {
-            levels.push(SimdLevel::Avx512);
-        }
-        if self.has_neon {
-            levels.push(SimdLevel::Neon);
-        }
-        if levels.is_empty() {
-            levels.push(SimdLevel::None);
-        }
-        levels
-    }
-
-    /// Can use FMA instructions (Kaby Lake+).
-    pub fn has_fma_support(&self) -> bool {
-        self.has_fma
-    }
-
-    /// Report string for diagnostics.
-    pub fn report(&self) -> String {
-        let levels: Vec<&str> = self.supported_levels().iter().map(|l| l.as_str()).collect();
+    pub fn summary(&self) -> String {
         format!(
-            "SIMD: best={}, available=[{}], fma={}",
-            self.best_level().as_str(),
-            levels.join(", "),
-            self.has_fma
+            "best={}, available=[{}]",
+            self.best.as_str(),
+            self.features
+                .iter()
+                .map(|f| f.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
         )
     }
+}
+
+/// Check if we're running on a Kaby Lake class CPU (AVX2 without AVX-512).
+pub fn is_kaby_lake_class() -> bool {
+    let caps = SimdCapabilities::detect();
+    caps.has(SimdFeatureLevel::Avx2) && !caps.has(SimdFeatureLevel::Avx512)
+}
+
+/// Recommended vector width for the current CPU (in f32 elements).
+pub fn recommended_vector_width() -> usize {
+    SimdCapabilities::detect().best.f32_lanes()
 }
 
 #[cfg(test)]
@@ -179,87 +138,88 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_simd_level_ordering() {
-        assert!(SimdLevel::Avx2 > SimdLevel::Avx);
-        assert!(SimdLevel::Avx512 > SimdLevel::Avx2);
-        assert!(SimdLevel::None < SimdLevel::Sse2);
+    fn test_feature_level_ordering() {
+        assert!(SimdFeatureLevel::Avx2 > SimdFeatureLevel::Avx);
+        assert!(SimdFeatureLevel::Avx > SimdFeatureLevel::Sse4);
+        assert!(SimdFeatureLevel::Scalar < SimdFeatureLevel::Sse2);
     }
 
     #[test]
-    fn test_vector_width() {
-        assert_eq!(SimdLevel::Avx2.vector_width_bits(), 256);
-        assert_eq!(SimdLevel::Avx2.vector_width_f32(), 8);
-        assert_eq!(SimdLevel::Avx512.vector_width_f32(), 16);
+    fn test_register_bits() {
+        assert_eq!(SimdFeatureLevel::Scalar.register_bits(), 64);
+        assert_eq!(SimdFeatureLevel::Sse2.register_bits(), 128);
+        assert_eq!(SimdFeatureLevel::Avx2.register_bits(), 256);
+        assert_eq!(SimdFeatureLevel::Avx512.register_bits(), 512);
     }
 
     #[test]
-    fn test_is_x86() {
-        assert!(SimdLevel::Avx2.is_x86());
-        assert!(!SimdLevel::Neon.is_x86());
-        assert!(!SimdLevel::None.is_x86());
+    fn test_f32_lanes() {
+        assert_eq!(SimdFeatureLevel::Scalar.f32_lanes(), 2);
+        assert_eq!(SimdFeatureLevel::Sse2.f32_lanes(), 4);
+        assert_eq!(SimdFeatureLevel::Avx2.f32_lanes(), 8);
+        assert_eq!(SimdFeatureLevel::Avx512.f32_lanes(), 16);
     }
 
     #[test]
-    fn test_is_arm() {
-        assert!(SimdLevel::Neon.is_arm());
-        assert!(!SimdLevel::Avx2.is_arm());
+    fn test_has_fma() {
+        assert!(SimdFeatureLevel::Avx2.has_fma());
+        assert!(SimdFeatureLevel::Avx512.has_fma());
+        assert!(!SimdFeatureLevel::Avx.has_fma());
+        assert!(!SimdFeatureLevel::Sse4.has_fma());
     }
 
     #[test]
     fn test_detect() {
         let caps = SimdCapabilities::detect();
-        // On any modern x86_64, SSE2 should be available
+        assert!(caps.has(SimdFeatureLevel::Scalar));
+        assert!(caps.best >= SimdFeatureLevel::Scalar);
+    }
+
+    #[test]
+    fn test_summary() {
+        let caps = SimdCapabilities::detect();
+        let s = caps.summary();
+        assert!(s.contains("best="));
+        assert!(s.contains("scalar"));
+    }
+
+    #[test]
+    fn test_recommended_width() {
+        let w = recommended_vector_width();
+        assert!(w >= 2);
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(SimdFeatureLevel::Avx2.as_str(), "avx2");
+        assert_eq!(SimdFeatureLevel::Neon.as_str(), "neon");
+        assert_eq!(SimdFeatureLevel::Scalar.as_str(), "scalar");
+    }
+
+    #[test]
+    fn test_neon_register() {
+        assert_eq!(SimdFeatureLevel::Neon.register_bits(), 128);
+        assert_eq!(SimdFeatureLevel::NeonDotprod.register_bits(), 128);
+    }
+
+    #[test]
+    fn test_detect_has_sse2_on_x86() {
+        let caps = SimdCapabilities::detect();
         #[cfg(target_arch = "x86_64")]
-        assert!(caps.has_sse2);
+        assert!(caps.has(SimdFeatureLevel::Sse2));
         let _ = caps; // use on non-x86
     }
 
     #[test]
-    fn test_best_level() {
-        let caps = SimdCapabilities::detect();
-        let best = caps.best_level();
-        // Should be at least SSE2 on x86_64
-        #[cfg(target_arch = "x86_64")]
-        assert!(best >= SimdLevel::Sse2);
-        let _ = best;
+    fn test_kaby_lake_class() {
+        // Just verify it doesn't panic
+        let _ = is_kaby_lake_class();
     }
 
     #[test]
-    fn test_supported_levels() {
-        let caps = SimdCapabilities::detect();
-        let levels = caps.supported_levels();
-        assert!(!levels.is_empty());
-    }
-
-    #[test]
-    fn test_report() {
-        let caps = SimdCapabilities::detect();
-        let report = caps.report();
-        assert!(report.contains("SIMD:"));
-        assert!(report.contains("best="));
-    }
-
-    #[test]
-    fn test_level_str() {
-        assert_eq!(SimdLevel::Avx2.as_str(), "avx2");
-        assert_eq!(SimdLevel::None.as_str(), "none");
-        assert_eq!(SimdLevel::Neon.as_str(), "neon");
-    }
-
-    #[test]
-    fn test_none_width() {
-        assert_eq!(SimdLevel::None.vector_width_bits(), 0);
-        assert_eq!(SimdLevel::None.vector_width_f32(), 0);
-    }
-
-    #[test]
-    fn test_sse_widths() {
-        assert_eq!(SimdLevel::Sse2.vector_width_bits(), 128);
-        assert_eq!(SimdLevel::Sse42.vector_width_f32(), 4);
-    }
-
-    #[test]
-    fn test_avx512_width() {
-        assert_eq!(SimdLevel::Avx512.vector_width_bits(), 512);
+    fn test_feature_level_copy() {
+        let level = SimdFeatureLevel::Avx2;
+        let copy = level;
+        assert_eq!(level, copy);
     }
 }


### PR DESCRIPTION
SIMD feature detection: runtime CPU capability probing (SSE2/SSE4/AVX/AVX2/AVX-512/NEON), feature level classification, register widths, FMA detection, Kaby Lake class check. 12 tests.