### PR TITLE
fix: correct formatting and clippy violations across workspace [P0]

### DIFF
--- a/crates/bitnet-common/src/thread_config.rs
+++ b/crates/bitnet-common/src/thread_config.rs
@@ -101,7 +101,7 @@ pub fn partition_work(total: usize, num_threads: usize) -> Vec<WorkPartition> {
 pub fn optimal_threads(work_items: usize, min_items_per_thread: usize) -> usize {
     let max_threads = available_parallelism();
     let min_per = min_items_per_thread.max(1);
-    let needed = (work_items + min_per - 1) / min_per;
+    let needed = work_items.div_ceil(min_per);
     needed.clamp(1, max_threads)
 }
 

--- a/crates/bitnet-common/tests/snapshot_wave27.rs
+++ b/crates/bitnet-common/tests/snapshot_wave27.rs
@@ -7,7 +7,7 @@ use bitnet_common::error::{
     BitNetError, InferenceError, KernelError, ModelError, QuantizationError, SecurityError,
     ValidationErrorDetails,
 };
-use bitnet_common::kernel_registry::{KernelBackend, KernelCapabilities, SimdLevel};
+use bitnet_common::kernel_registry::{KernelBackend, SimdLevel};
 use bitnet_common::tensor_validation::ShapeError;
 use bitnet_common::types::{Device, ModelMetadata, PerformanceMetrics, QuantizationType};
 
@@ -197,13 +197,8 @@ fn snapshot_kernel_backend_display_all() {
 
 #[test]
 fn snapshot_simd_level_ordering() {
-    let mut levels = vec![
-        SimdLevel::Avx512,
-        SimdLevel::Scalar,
-        SimdLevel::Avx2,
-        SimdLevel::Neon,
-        SimdLevel::Sse42,
-    ];
+    let mut levels =
+        [SimdLevel::Avx512, SimdLevel::Scalar, SimdLevel::Avx2, SimdLevel::Neon, SimdLevel::Sse42];
     levels.sort();
     let sorted: Vec<String> = levels.iter().map(|l| l.to_string()).collect();
     insta::assert_debug_snapshot!("simd_level_sorted_order", sorted);

--- a/crates/bitnet-inference/src/rope_config.rs
+++ b/crates/bitnet-inference/src/rope_config.rs
@@ -3,29 +3,18 @@
 //! Configure RoPE parameters for different model architectures:
 //! base frequency, scaling, NTK-aware extensions, and YaRN.
 
-
 /// RoPE scaling strategy.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum RopeScaling {
     /// No scaling (standard RoPE).
+    #[default]
     None,
     /// Linear frequency scaling.
     Linear { factor: f64 },
     /// Dynamic NTK-aware scaling.
     DynamicNtk { factor: f64, original_max_pos: usize },
     /// YaRN (Yet another RoPE extension).
-    Yarn {
-        factor: f64,
-        attention_factor: f64,
-        beta_fast: f64,
-        beta_slow: f64,
-    },
-}
-
-impl Default for RopeScaling {
-    fn default() -> Self {
-        Self::None
-    }
+    Yarn { factor: f64, attention_factor: f64, beta_fast: f64, beta_slow: f64 },
 }
 
 /// Full RoPE configuration.
@@ -39,12 +28,7 @@ pub struct RopeConfig {
 
 impl RopeConfig {
     pub fn new(head_dim: usize) -> Self {
-        Self {
-            head_dim,
-            base_freq: 10000.0,
-            max_seq_len: 4096,
-            scaling: RopeScaling::None,
-        }
+        Self { head_dim, base_freq: 10000.0, max_seq_len: 4096, scaling: RopeScaling::None }
     }
 
     pub fn with_base_freq(mut self, freq: f64) -> Self {
@@ -80,10 +64,7 @@ impl RopeConfig {
         match &self.scaling {
             RopeScaling::None => self.base_freq,
             RopeScaling::Linear { factor } => self.base_freq * factor,
-            RopeScaling::DynamicNtk {
-                factor,
-                original_max_pos,
-            } => {
+            RopeScaling::DynamicNtk { factor, original_max_pos } => {
                 let dim = self.head_dim as f64;
                 self.base_freq
                     * ((factor * self.max_seq_len as f64 / *original_max_pos as f64)
@@ -91,9 +72,7 @@ impl RopeConfig {
                         - 1.0)
                         .max(1.0)
             }
-            RopeScaling::Yarn { factor, .. } => {
-                self.base_freq * factor
-            }
+            RopeScaling::Yarn { factor, .. } => self.base_freq * factor,
         }
     }
 
@@ -122,9 +101,7 @@ impl RopeConfig {
 
 /// Preset: BitNet-2B RoPE (standard, 4K context).
 pub fn bitnet_rope(head_dim: usize) -> RopeConfig {
-    RopeConfig::new(head_dim)
-        .with_base_freq(10000.0)
-        .with_max_seq_len(4096)
+    RopeConfig::new(head_dim).with_base_freq(10000.0).with_max_seq_len(4096)
 }
 
 /// Preset: Phi-4 RoPE (extended 16K context).
@@ -132,17 +109,12 @@ pub fn phi4_rope(head_dim: usize) -> RopeConfig {
     RopeConfig::new(head_dim)
         .with_base_freq(10000.0)
         .with_max_seq_len(16384)
-        .with_scaling(RopeScaling::DynamicNtk {
-            factor: 4.0,
-            original_max_pos: 4096,
-        })
+        .with_scaling(RopeScaling::DynamicNtk { factor: 4.0, original_max_pos: 4096 })
 }
 
 /// Preset: LLaMA-3 RoPE (extended 8K context).
 pub fn llama3_rope(head_dim: usize) -> RopeConfig {
-    RopeConfig::new(head_dim)
-        .with_base_freq(500000.0)
-        .with_max_seq_len(8192)
+    RopeConfig::new(head_dim).with_base_freq(500000.0).with_max_seq_len(8192)
 }
 
 #[cfg(test)]
@@ -192,8 +164,7 @@ mod tests {
     #[test]
     fn test_linear_scaling() {
         let base = RopeConfig::new(128);
-        let scaled = RopeConfig::new(128)
-            .with_scaling(RopeScaling::Linear { factor: 2.0 });
+        let scaled = RopeConfig::new(128).with_scaling(RopeScaling::Linear { factor: 2.0 });
         assert!((scaled.effective_base() - base.effective_base() * 2.0).abs() < 1e-6);
     }
 

--- a/crates/bitnet-inference/tests/snapshot_wave27.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave27.rs
@@ -1,8 +1,7 @@
 //! Snapshot wave 27 — bitnet-inference config/profiler output stability.
 
 use bitnet_inference::config_builder::{
-    GenerationConfig, HardwareConfig, InferenceConfig, InferenceConfigBuilder, InferencePreset,
-    SamplingConfig,
+    GenerationConfig, HardwareConfig, InferenceConfigBuilder, InferencePreset, SamplingConfig,
 };
 use bitnet_inference::profiler::{
     LayerProfile, LayerStats, MemorySnapshot, ProfileReport, ProfilerConfig,

--- a/crates/bitnet-kernels/src/simd_detect.rs
+++ b/crates/bitnet-kernels/src/simd_detect.rs
@@ -97,11 +97,7 @@ impl SimdCapabilities {
             features.push(SimdFeatureLevel::Neon);
         }
 
-        let best = features
-            .iter()
-            .copied()
-            .max()
-            .unwrap_or(SimdFeatureLevel::Scalar);
+        let best = features.iter().copied().max().unwrap_or(SimdFeatureLevel::Scalar);
         Self { features, best }
     }
 
@@ -113,11 +109,7 @@ impl SimdCapabilities {
         format!(
             "best={}, available=[{}]",
             self.best.as_str(),
-            self.features
-                .iter()
-                .map(|f| f.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
+            self.features.iter().map(|f| f.as_str()).collect::<Vec<_>>().join(", ")
         )
     }
 }

--- a/crates/bitnet-kernels/tests/metal_encoder_validation_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_encoder_validation_tests.rs
@@ -380,7 +380,7 @@ impl MockComputeEncoder {
         if slot >= MAX_BUFFER_SLOTS {
             return Err(EncoderError::BufferSlotOutOfRange { slot, max: MAX_BUFFER_SLOTS - 1 });
         }
-        if offset % BUFFER_OFFSET_ALIGNMENT != 0 {
+        if !offset.is_multiple_of(BUFFER_OFFSET_ALIGNMENT) {
             return Err(EncoderError::BufferOffsetMisaligned {
                 offset,
                 alignment: BUFFER_OFFSET_ALIGNMENT,
@@ -404,7 +404,7 @@ impl MockComputeEncoder {
         if slot >= MAX_BUFFER_SLOTS {
             return Err(EncoderError::BufferSlotOutOfRange { slot, max: MAX_BUFFER_SLOTS - 1 });
         }
-        if offset % BUFFER_OFFSET_ALIGNMENT != 0 {
+        if !offset.is_multiple_of(BUFFER_OFFSET_ALIGNMENT) {
             return Err(EncoderError::BufferOffsetMisaligned {
                 offset,
                 alignment: BUFFER_OFFSET_ALIGNMENT,
@@ -578,7 +578,7 @@ fn pipeline_with_max_threads(n: usize) -> MockComputePipelineState {
 
 /// Helper: warp-aligned threadgroup size (Apple GPU warp = 32).
 fn warp_aligned_size(threads: usize) -> usize {
-    ((threads + 31) / 32) * 32
+    threads.div_ceil(32) * 32
 }
 
 // ============================================================================
@@ -1520,7 +1520,7 @@ fn test_matmul_dispatch_pattern() {
 
     let tile_m = 16;
     let tile_n = 16;
-    let grid = Size3D::new((n + tile_n - 1) / tile_n, (m + tile_m - 1) / tile_m, 1);
+    let grid = Size3D::new(n.div_ceil(tile_n), m.div_ceil(tile_m), 1);
     let tg = Size3D::new(tile_n, tile_m, 1);
 
     encoder.dispatch_threadgroups(grid, tg).unwrap();
@@ -1580,7 +1580,7 @@ fn test_elementwise_add_dispatch() {
     encoder.set_buffer(&buf_c, 0, 2).unwrap();
 
     let tg_size = 256_usize;
-    let grid_x = (n + tg_size - 1) / tg_size;
+    let grid_x = n.div_ceil(tg_size);
     encoder.dispatch_threadgroups(Size3D::new(grid_x, 1, 1), Size3D::new(tg_size, 1, 1)).unwrap();
     encoder.end_encoding().unwrap();
 
@@ -1597,7 +1597,7 @@ fn test_reduction_sum_dispatch() {
 
     // Pass 1: reduce chunks
     let tg_size = 256_usize;
-    let num_groups = (n + tg_size - 1) / tg_size;
+    let num_groups = n.div_ceil(tg_size);
 
     let mut enc1 = cmd_buf.make_compute_encoder();
     enc1.begin_encoding().unwrap();
@@ -1656,7 +1656,7 @@ fn test_attention_compute_dispatch() {
     enc1.set_buffer_with_usage(&buf_scores, 0, 2, ResourceUsage::Write).unwrap();
 
     let tg = Size3D::new(16, 16, 1);
-    let grid = Size3D::new((seq_len + 15) / 16, (seq_len + 15) / 16, batch * heads);
+    let grid = Size3D::new(seq_len.div_ceil(16), seq_len.div_ceil(16), batch * heads);
     enc1.dispatch_threadgroups(grid, tg).unwrap();
     enc1.end_encoding().unwrap();
 
@@ -1687,7 +1687,7 @@ fn test_attention_compute_dispatch() {
     enc3.set_buffer_with_usage(&buf_v, 0, 1, ResourceUsage::Read).unwrap();
     enc3.set_buffer_with_usage(&buf_out, 0, 2, ResourceUsage::Write).unwrap();
     enc3.dispatch_threadgroups(
-        Size3D::new((head_dim + 15) / 16, (seq_len + 15) / 16, batch * heads),
+        Size3D::new(head_dim.div_ceil(16), seq_len.div_ceil(16), batch * heads),
         Size3D::new(16, 16, 1),
     )
     .unwrap();
@@ -1743,7 +1743,7 @@ fn test_gelu_activation_dispatch() {
     encoder.set_buffer_with_usage(&buf_inout, 0, 0, ResourceUsage::ReadWrite).unwrap();
 
     let tg_size = 256_usize;
-    let grid_x = (n + tg_size - 1) / tg_size;
+    let grid_x = n.div_ceil(tg_size);
     encoder.dispatch_threadgroups(Size3D::new(grid_x, 1, 1), Size3D::new(tg_size, 1, 1)).unwrap();
     encoder.end_encoding().unwrap();
 

--- a/crates/bitnet-kernels/tests/metal_matmul_v2_shader_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_matmul_v2_shader_tests.rs
@@ -334,7 +334,7 @@ fn align_to_metal(byte_len: usize) -> usize {
 
 /// Compute workgroup dispatch count: ceil(dim / group_size).
 fn dispatch_count(dim: u32, group_size: u32) -> u32 {
-    (dim + group_size - 1) / group_size
+    dim.div_ceil(group_size)
 }
 
 /// Compute theoretical FLOPs for a GEMM of dimensions M×N×K.

--- a/crates/bitnet-kernels/tests/metal_resource_binding_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_resource_binding_tests.rs
@@ -65,7 +65,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 
 /// Run a simple copy-dispatch and return the GPU-side result.
 fn run_copy_dispatch(device: &wgpu::Device, queue: &wgpu::Queue, data: &[f32]) -> Vec<f32> {
-    let byte_len = (data.len() * std::mem::size_of::<f32>()) as u64;
+    let byte_len = std::mem::size_of_val(data) as u64;
 
     let input_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("input"),
@@ -151,7 +151,7 @@ fn run_copy_dispatch(device: &wgpu::Device, queue: &wgpu::Queue, data: &[f32]) -
         });
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
-        pass.dispatch_workgroups(((data.len() as u32) + 63) / 64, 1, 1);
+        pass.dispatch_workgroups((data.len() as u32).div_ceil(64), 1, 1);
     }
     encoder.copy_buffer_to_buffer(&output_buf, 0, &staging_buf, 0, byte_len);
     queue.submit(Some(encoder.finish()));
@@ -672,7 +672,7 @@ fn test_heap_type_tracking() {
         usage: wgpu::BufferUsages,
         size: u64,
     }
-    let entries = vec![
+    let entries = [
         HeapEntry { usage: wgpu::BufferUsages::STORAGE, size: 512 },
         HeapEntry { usage: wgpu::BufferUsages::UNIFORM, size: 256 },
         HeapEntry { usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::STORAGE, size: 1024 },

--- a/crates/bitnet-kernels/tests/metal_synchronization_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_synchronization_tests.rs
@@ -1454,7 +1454,7 @@ mod multi_queue_coordination {
 
     #[test]
     fn priority_based_scheduling_order() {
-        let mut queues = vec![
+        let mut queues = [
             CommandQueue::new("low", QueuePriority::Low),
             CommandQueue::new("normal", QueuePriority::Normal),
             CommandQueue::new("high", QueuePriority::High),
@@ -1692,7 +1692,7 @@ mod ring_buffer_patterns {
     #[test]
     fn ring_buffer_with_fence_sync() {
         let mut rb = RingBuffer::new(2, 256);
-        let mut fences = vec![Fence::new(0, "slot-0"), Fence::new(1, "slot-1")];
+        let mut fences = [Fence::new(0, "slot-0"), Fence::new(1, "slot-1")];
 
         // Frame 0: acquire slot 0, submit GPU work.
         let s0 = rb.acquire().unwrap();

--- a/crates/bitnet-models/src/pruning_analysis.rs
+++ b/crates/bitnet-models/src/pruning_analysis.rs
@@ -191,7 +191,7 @@ mod tests {
         let threshold = threshold_for_sparsity(&weights, 0.5);
         // ~50% of values should be below this threshold
         let below = weights.iter().filter(|&&w| w.abs() < threshold).count();
-        assert!(below >= 45 && below <= 55);
+        assert!((45..=55).contains(&below));
     }
 
     #[test]

--- a/crates/bitnet-server/src/api_versioning.rs
+++ b/crates/bitnet-server/src/api_versioning.rs
@@ -110,10 +110,10 @@ impl VersionRange {
 /// Extract API version from a URL path prefix like "/v1/..." or "/api/v1.0/...".
 pub fn extract_version_from_path(path: &str) -> Option<ApiVersion> {
     for segment in path.split('/') {
-        if let Some(version) = ApiVersion::parse(segment) {
-            if version.major > 0 {
-                return Some(version);
-            }
+        if let Some(version) = ApiVersion::parse(segment)
+            && version.major > 0
+        {
+            return Some(version);
         }
     }
     None


### PR DESCRIPTION
## P0: Main is RED

Main CI is failing on formatting check due to recently merged PRs (#3174, #3178, #3179).

## Fixes
- **Format**: `rope_config.rs` extra blank line and struct variant formatting
- **Clippy**: `RopeScaling` derivable Default (derive instead of manual impl)
- **Clippy**: `thread_config.rs` manual `div_ceil` → `.div_ceil()`
- **Clippy**: `api_versioning.rs` collapsible if-let
- **Clippy**: `pruning_analysis.rs` `RangeInclusive::contains`
- **Clippy**: snapshot test unused import + useless vec
- **Clippy**: auto-fixed metal test file suggestions

## Verification
```
cargo fmt --all -- --check  ✅
cargo clippy --lib -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --no-default-features --features cpu  ✅
cargo clippy --lib -p bitnet-prompt-templates -p bitnet-receipts -p bitnet-sampling  ✅
```

## Priority
P0 — unblocks all open PRs by making main green again.