### PR TITLE
test(metal): add wgpu Metal adapter TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/metal_wgpu_adapter_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_wgpu_adapter_tests.rs
@@ -1,0 +1,262 @@
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#![allow(clippy::assertions_on_constants)]
+
+//! TDD scaffold tests for wgpu Metal adapter selection and capability
+//! detection on Apple Silicon.
+//!
+//! These tests validate adapter enumeration, device limits, feature
+//! detection, memory alignment, error handling, and Apple-Silicon-specific
+//! capability tiers through the wgpu API surface.
+//!
+//! Every test is `#[ignore]` because it requires a live wgpu Metal adapter
+//! running on Apple Silicon hardware.
+
+// ---------------------------------------------------------------------------
+// 1. Adapter enumeration
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_wgpu_instance_creation_with_metal_backend() {
+    // wgpu::Instance::new should succeed with Backends::METAL on macOS/aarch64.
+    // Verify that the instance is created without panicking and that the
+    // Metal backend is among the available backends.
+    panic!(
+        "not yet implemented: Instance::new(InstanceDescriptor {{ backends: Backends::METAL }})"
+    );
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_adapter_request_returns_some_on_apple_silicon() {
+    // instance.request_adapter(&RequestAdapterOptions { power_preference,
+    // compatible_surface: None, force_fallback_adapter: false }) should
+    // return Some(adapter) on Apple Silicon with the Metal backend.
+    panic!("not yet implemented: request_adapter with Metal backend");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_adapter_backend_is_metal() {
+    // adapter.get_info().backend should equal wgpu::Backend::Metal.
+    panic!("not yet implemented: AdapterInfo::backend == Backend::Metal");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_enumerate_adapters_contains_metal() {
+    // instance.enumerate_adapters(Backends::all()) should contain at least
+    // one adapter whose backend is Backend::Metal on Apple Silicon.
+    panic!("not yet implemented: enumerate_adapters filtering for Metal");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_adapter_info_device_name_contains_apple() {
+    // adapter.get_info().name should contain "Apple" on Apple Silicon
+    // (e.g. "Apple M1", "Apple M2 Pro", etc.).
+    panic!("not yet implemented: AdapterInfo::name contains 'Apple'");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Device limits
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_compute_workgroup_size_x() {
+    // adapter.limits().max_compute_workgroup_size_x >= 1024 on Apple Silicon.
+    panic!("not yet implemented: Limits::max_compute_workgroup_size_x");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_compute_workgroup_size_y() {
+    // adapter.limits().max_compute_workgroup_size_y >= 1024.
+    panic!("not yet implemented: Limits::max_compute_workgroup_size_y");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_compute_workgroup_size_z() {
+    // adapter.limits().max_compute_workgroup_size_z >= 64 on Apple Silicon.
+    panic!("not yet implemented: Limits::max_compute_workgroup_size_z");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_buffer_size() {
+    // adapter.limits().max_buffer_size should be at least 256 MB on Apple
+    // Silicon to support large model weight buffers.
+    panic!("not yet implemented: Limits::max_buffer_size >= 256 MiB");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_storage_buffer_binding_size() {
+    // adapter.limits().max_storage_buffer_binding_size should be at least
+    // 128 MB on Apple Silicon for large tensor storage bindings.
+    panic!("not yet implemented: Limits::max_storage_buffer_binding_size >= 128 MiB");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_compute_invocations_per_workgroup() {
+    // adapter.limits().max_compute_invocations_per_workgroup >= 1024.
+    panic!("not yet implemented: Limits::max_compute_invocations_per_workgroup");
+}
+
+// ---------------------------------------------------------------------------
+// 3. Feature detection
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_push_constants_feature() {
+    // adapter.features() should contain Features::PUSH_CONSTANTS on Metal.
+    // Push constants allow small uniform data without a buffer bind.
+    panic!("not yet implemented: Features::PUSH_CONSTANTS");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_storage_resource_binding_array_feature() {
+    // adapter.features() should contain
+    // Features::STORAGE_RESOURCE_BINDING_ARRAY for dynamic tensor binding.
+    panic!("not yet implemented: Features::STORAGE_RESOURCE_BINDING_ARRAY");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_float32_filterable_feature() {
+    // adapter.features() should contain Features::FLOAT32_FILTERABLE for
+    // f32 texture sampling used in activation map reads.
+    panic!("not yet implemented: Features::FLOAT32_FILTERABLE");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_device_creation_with_required_features() {
+    // adapter.request_device(&DeviceDescriptor { required_features,
+    // required_limits, .. }) should succeed when requesting the feature
+    // set needed by the bitnet Metal kernels.
+    panic!("not yet implemented: request_device with bitnet feature set");
+}
+
+// ---------------------------------------------------------------------------
+// 4. Memory alignment
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_min_storage_buffer_offset_alignment() {
+    // adapter.limits().min_storage_buffer_offset_alignment should be at
+    // most 256 bytes on Apple Silicon Metal.
+    panic!("not yet implemented: Limits::min_storage_buffer_offset_alignment <= 256");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_min_uniform_buffer_offset_alignment() {
+    // adapter.limits().min_uniform_buffer_offset_alignment should be at
+    // most 256 bytes on Apple Silicon Metal (Metal spec requires 256).
+    panic!("not yet implemented: Limits::min_uniform_buffer_offset_alignment <= 256");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_buffer_copy_alignment() {
+    // wgpu requires buffer-to-buffer copies to respect
+    // COPY_BUFFER_ALIGNMENT (4 bytes). Verify the constant is accessible
+    // and that our tensor buffer sizes are multiples of 4.
+    panic!("not yet implemented: COPY_BUFFER_ALIGNMENT validation");
+}
+
+// ---------------------------------------------------------------------------
+// 5. Error handling
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_adapter_not_found_with_vulkan_backend_on_macos() {
+    // Requesting an adapter with Backends::VULKAN on macOS should return
+    // None (unless MoltenVK is installed). Validates graceful fallback.
+    panic!("not yet implemented: request_adapter(Backends::VULKAN) returns None");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_device_creation_failure_with_impossible_limits() {
+    // request_device with absurdly high required_limits (e.g.
+    // max_buffer_size = u64::MAX) should return Err.
+    panic!("not yet implemented: request_device with impossible limits returns Err");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_incompatible_features_rejected() {
+    // Requesting a feature not supported by Metal (e.g. a hypothetical
+    // DX12-only feature) should cause request_device to fail gracefully.
+    panic!("not yet implemented: request_device with incompatible features returns Err");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Apple Silicon specific — capability tiers
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_m1_minimum_capability_tier() {
+    // An M1 adapter (gpu_family >= 7) should report at least:
+    //   - max_compute_workgroup_size_x >= 1024
+    //   - max_buffer_size >= 256 MiB
+    //   - supports float16, simd_group_size == 32
+    panic!("not yet implemented: M1 minimum capability tier validation");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_m2_capability_tier_improvements() {
+    // An M2 adapter (gpu_family >= 8) should additionally report:
+    //   - improved memory bandwidth characteristics
+    //   - same or higher max_buffer_size
+    //   - mesh shader support (Features dependent)
+    panic!("not yet implemented: M2 capability tier improvements");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_m3_capability_tier_features() {
+    // An M3 adapter (gpu_family >= 9) should additionally report:
+    //   - dynamic caching / ray tracing extensions
+    //   - hardware-accelerated mesh shading
+    //   - potential for higher max_compute_invocations_per_workgroup
+    panic!("not yet implemented: M3 capability tier features");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_unified_memory_architecture_detection() {
+    // Apple Silicon uses unified memory. Verify that the adapter does
+    // NOT report a separate VRAM limit distinct from system RAM, and
+    // that the reported memory size matches (or closely tracks) the
+    // system's unified memory.
+    panic!("not yet implemented: unified memory architecture detection");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_max_texture_dimension_2d() {
+    // Apple Silicon Metal supports at least 16384×16384 2D textures.
+    // adapter.limits().max_texture_dimension_2d >= 16384.
+    panic!("not yet implemented: Limits::max_texture_dimension_2d >= 16384");
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]
+fn test_adapter_device_queue_creation_round_trip() {
+    // Full round-trip: Instance → Adapter → (Device, Queue).
+    // Verify that device.limits() is a subset of adapter.limits() and
+    // that the Queue can be used to submit an empty CommandEncoder.
+    panic!("not yet implemented: Instance → Adapter → Device → Queue round-trip");
+}


### PR DESCRIPTION
## Summary
Add 25 TDD scaffold tests for wgpu Metal adapter selection and capability detection on Apple Silicon.

### Test Categories (25 tests)
- **Adapter enumeration** (5): instance creation, request_adapter, Metal backend, enumerate all, device name
- **Device limits** (6): workgroup X/Y/Z, max_buffer_size, max_storage_buffer, max_invocations
- **Feature detection** (4): push constants, storage arrays, float32 filterable, device creation
- **Memory alignment** (3): storage buffer offset, uniform buffer offset, copy buffer alignment
- **Error handling** (3): Vulkan-on-macOS, impossible limits, incompatible features
- **Apple Silicon specific** (4): M1/M2/M3 capability tiers, unified memory, texture limits, round-trip

### Details
- File: `crates/bitnet-kernels/tests/metal_wgpu_adapter_tests.rs`
- All tests: `#[ignore = "TDD scaffold: requires wgpu Metal adapter on Apple Silicon"]`
