### PR TITLE
test(neon): add NEON quantize/dequantize TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/neon_quantize_dequant_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_quantize_dequant_tests.rs
@@ -1,0 +1,218 @@
+#![cfg(feature = "cpu")]
+
+//! TDD scaffolds for NEON-optimized I2_S quantization and dequantization
+//! on Apple Silicon (aarch64).
+
+// ---------------------------------------------------------------------------
+// I2_S 2-bit quantization with NEON
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S quantize packing 4 signed ternary values into one byte"]
+fn neon_i2s_quantize_pack_four_values() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S quantize produces correct bit pattern for known input"]
+fn neon_i2s_quantize_known_bit_pattern() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S quantize clamps values outside {-1, 0, +1} range"]
+fn neon_i2s_quantize_clamp_out_of_range() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// I2_S dequantization
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S dequantize unpacks byte to four f32 values with scale"]
+fn neon_i2s_dequantize_unpack_and_scale() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S dequantize reconstructs known vector from packed bytes"]
+fn neon_i2s_dequantize_known_vector() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip accuracy
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: quantize then dequantize round-trip preserves sign for ternary inputs"]
+fn neon_roundtrip_preserves_sign() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: quantize-dequantize round-trip error within expected tolerance"]
+fn neon_roundtrip_error_tolerance() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Scale factor computation (per-block absmax)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON per-block absmax scale factor matches scalar reference"]
+fn neon_scale_factor_absmax_matches_scalar() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON absmax scale factor correct for non-power-of-two block lengths"]
+fn neon_scale_factor_non_power_of_two() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Block size variants
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize with 32-element BitNet32 blocks"]
+fn neon_quantize_bitnet32_block_size() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize with 256-element QK256 blocks"]
+fn neon_quantize_qk256_block_size() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON dequantize with 32-element BitNet32 blocks"]
+fn neon_dequantize_bitnet32_block_size() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON dequantize with 256-element QK256 blocks"]
+fn neon_dequantize_qk256_block_size() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Symmetric vs asymmetric quantization
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON symmetric quantization zero-point is always zero"]
+fn neon_symmetric_quantize_zero_point() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON asymmetric quantization applies per-block offset"]
+fn neon_asymmetric_quantize_offset() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Quantization error bounds
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: max absolute deviation within 0.5 * scale for I2_S quantization"]
+fn neon_quantize_max_absolute_deviation() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize all-zero input produces all-zero packed output"]
+fn neon_quantize_all_zeros() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize all-same-value input produces uniform ternary codes"]
+fn neon_quantize_all_same_value() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize handles NaN inputs gracefully without panic"]
+fn neon_quantize_nan_handling() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize handles Inf inputs gracefully without panic"]
+fn neon_quantize_inf_handling() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// NEON SIMD lane utilization
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize uses all 4 f32 lanes per vector register"]
+fn neon_quantize_simd_lane_utilization() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON dequantize result matches scalar reference across all lanes"]
+fn neon_dequantize_lane_parity_with_scalar() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Batch quantization
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON batch quantize processes multiple vectors in sequence"]
+fn neon_batch_quantize_multiple_vectors() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Mixed-precision dequantization
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S dequantize to f32 matches expected precision"]
+fn neon_dequantize_i2s_to_f32() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON I2_S dequantize to f16 matches expected precision"]
+fn neon_dequantize_i2s_to_f16() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Alignment requirements
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize requires 16-byte aligned input for vld1q_f32"]
+fn neon_quantize_alignment_requirement() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Performance baseline
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON quantize throughput baseline for 4096-element vector"]
+fn neon_quantize_throughput_baseline() {
+    unimplemented!();
+}


### PR DESCRIPTION
## Summary

25 TDD scaffold tests for NEON-optimized I2_S quantization and dequantization on Apple Silicon.

Covers:
- I2_S 2-bit quantization with NEON
- Dequantization and round-trip accuracy
- Scale factor computation
- Block size variants (BitNet32, QK256)
- Edge cases (zeros, NaN, Inf)
- SIMD lane utilization
- Batch quantization
- Mixed-precision dequant
- Alignment requirements

All tests are TDD scaffolds with `#[ignore]` and justification strings.

## Test Plan

`cargo nextest run --workspace --no-default-features --features cpu` — all new tests skipped via `#[ignore]`.

Labels: apple-silicon, test, neon