### PR TITLE
test(metal): add Metal shader performance TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/metal_shader_perf_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_shader_perf_tests.rs
@@ -1,0 +1,279 @@
+#![cfg(feature = "cpu")]
+//! Metal shader performance TDD scaffold tests for Apple Silicon.
+//!
+//! These tests cover Metal shader compilation, pipeline state creation,
+//! dispatch latency, threadgroup memory bandwidth, SIMD-group occupancy,
+//! register pressure, memory access patterns, texture vs buffer performance,
+//! command buffer encoding, GPU/CPU synchronization, indirect dispatch,
+//! and Apple GPU tile memory utilisation.
+//!
+//! All tests are TDD scaffolds gated behind `#[ignore]` with justification
+//! strings. They will be implemented once the Metal backend is available.
+
+// ---------------------------------------------------------------------------
+// Shader compilation time benchmarks
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark MSL → GPU binary compilation"]
+fn metal_shader_compilation_time_simple_kernel() {
+    // Measure wall-clock time to compile a minimal MSL compute kernel to GPU binary.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark complex shader compilation"]
+fn metal_shader_compilation_time_complex_matmul_kernel() {
+    // Measure compilation time for a complex matrix-multiply MSL kernel with
+    // multiple threadgroup memory allocations and SIMD-group intrinsics.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark shader library caching"]
+fn metal_shader_library_cache_hit_latency() {
+    // Measure latency of reusing a previously compiled MTLLibrary versus
+    // recompiling from source.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline state creation overhead
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure pipeline state creation"]
+fn metal_pipeline_state_creation_overhead() {
+    // Measure time to create a MTLComputePipelineState from a compiled function.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark pipeline state caching"]
+fn metal_pipeline_state_cache_reuse() {
+    // Verify that reusing a cached pipeline state is significantly faster
+    // than creating a new one.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch latency
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure empty kernel dispatch latency"]
+fn metal_dispatch_latency_empty_kernel() {
+    // Dispatch an empty compute kernel and measure round-trip latency
+    // (encode → commit → waitUntilCompleted).
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure minimal-work dispatch latency"]
+fn metal_dispatch_latency_minimal_work() {
+    // Dispatch a single-threadgroup kernel writing one value to a buffer
+    // and measure end-to-end latency.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Threadgroup memory bandwidth utilisation
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark threadgroup memory bandwidth"]
+fn metal_threadgroup_memory_bandwidth_sequential() {
+    // Measure sequential read/write bandwidth of threadgroup (shared) memory
+    // within a single threadgroup.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark threadgroup memory bank conflicts"]
+fn metal_threadgroup_memory_bank_conflict_impact() {
+    // Compare throughput with and without bank conflicts in threadgroup memory
+    // access patterns.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// SIMD-group (wavefront) occupancy optimisation
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure SIMD-group occupancy"]
+fn metal_simd_group_occupancy_full_utilisation() {
+    // Verify that a kernel designed for full SIMD-group occupancy achieves
+    // near-peak ALU throughput on Apple GPU.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure partial SIMD-group occupancy impact"]
+fn metal_simd_group_occupancy_partial_waves() {
+    // Measure throughput degradation when threadgroup size does not evenly
+    // divide into SIMD-groups (partial waves).
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Register pressure impact on occupancy
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure register pressure effects"]
+fn metal_register_pressure_low_occupancy() {
+    // Deploy a kernel with high register usage and measure occupancy drop
+    // relative to a low-register-pressure variant.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure register spill impact"]
+fn metal_register_spill_to_device_memory() {
+    // Measure performance impact when register pressure causes spills to
+    // device memory on Apple GPU.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Memory access patterns (coalesced vs strided)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark coalesced memory access"]
+fn metal_memory_access_coalesced_reads() {
+    // Measure device memory read bandwidth with fully coalesced access
+    // (consecutive threads reading consecutive addresses).
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark strided memory access"]
+fn metal_memory_access_strided_reads() {
+    // Measure device memory read bandwidth with strided access patterns
+    // and quantify the penalty relative to coalesced access.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Texture vs buffer performance comparison
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to compare texture vs buffer read throughput"]
+fn metal_texture_vs_buffer_read_throughput() {
+    // Compare read throughput of equivalent data stored in a MTLTexture (2D)
+    // versus a MTLBuffer with manual indexing.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark texture sampling with interpolation"]
+fn metal_texture_bilinear_sampling_overhead() {
+    // Measure the overhead of bilinear texture sampling compared to
+    // nearest-neighbour on Apple GPU texture units.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Compute pipeline vs render pipeline overhead
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to compare compute vs render pipeline overhead"]
+fn metal_compute_vs_render_pipeline_dispatch_overhead() {
+    // Compare dispatch overhead of a compute pipeline versus an equivalent
+    // render pipeline performing the same ALU work via vertex/fragment shaders.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Command buffer encoding time
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark command buffer encoding"]
+fn metal_command_buffer_encoding_time_single_dispatch() {
+    // Measure time to encode a single compute dispatch into a command buffer.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark batched command encoding"]
+fn metal_command_buffer_encoding_time_batched_dispatches() {
+    // Measure encoding time for a command buffer containing 100+ sequential
+    // compute dispatches to quantify per-dispatch encoding overhead.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// GPU/CPU synchronisation overhead (fence, event)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure fence synchronisation overhead"]
+fn metal_gpu_cpu_sync_fence_latency() {
+    // Measure round-trip latency of MTLFence-based GPU → CPU synchronisation.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure shared event synchronisation overhead"]
+fn metal_gpu_cpu_sync_shared_event_latency() {
+    // Measure round-trip latency of MTLSharedEvent-based GPU → CPU
+    // synchronisation and compare with fence-based approach.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Indirect dispatch overhead
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark indirect dispatch overhead"]
+fn metal_indirect_dispatch_overhead() {
+    // Compare dispatch latency of dispatchThreadgroups (direct) versus
+    // dispatchThreadgroupsWithIndirectBuffer (indirect) for identical work.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Tiled vs non-tiled memory access / Apple GPU tile memory
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark tiled memory access patterns"]
+fn metal_tiled_vs_linear_memory_access() {
+    // Compare throughput of tiled (block-wise) memory access versus linear
+    // (row-major) access for matrix operations on Apple GPU.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure Apple GPU tile memory utilisation"]
+fn metal_apple_gpu_tile_memory_utilisation() {
+    // Measure tile memory bandwidth on Apple GPU using imageblock / tile
+    // shading and compare with standard device memory throughput.
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent dispatch (multiple command queues)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to benchmark concurrent command queue dispatch"]
+fn metal_concurrent_dispatch_multiple_queues() {
+    // Submit independent compute work to two MTLCommandQueues simultaneously
+    // and measure whether the GPU overlaps execution.
+    unimplemented!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal runtime to measure queue contention under saturation"]
+fn metal_concurrent_dispatch_queue_contention() {
+    // Saturate the GPU with work from multiple command queues and measure
+    // throughput degradation relative to a single-queue baseline.
+    unimplemented!()
+}


### PR DESCRIPTION
## Summary

25 TDD scaffold tests for Metal shader performance characteristics on Apple Silicon.

Covers:
- Shader compilation time
- Pipeline state creation overhead
- Dispatch latency
- Threadgroup memory bandwidth
- SIMD-group occupancy
- Register pressure
- Memory access patterns
- Texture vs buffer performance
- Command buffer encoding
- GPU/CPU synchronization
- Indirect dispatch
- Apple GPU tile memory

All tests are TDD scaffolds with `#[ignore]` and justification strings.

## Test Plan

`cargo nextest run --workspace --no-default-features --features cpu` — all new tests skipped via `#[ignore]`.

Labels: apple-silicon, test, metal