### PR TITLE
test(metal): add Metal buffer management TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/metal_buffer_mgmt_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_buffer_mgmt_tests.rs
@@ -1,0 +1,242 @@
+#![cfg(feature = "cpu")]
+#![allow(dead_code, unused_imports, unused_variables)]
+//! Metal GPU buffer management TDD scaffolds for Apple Silicon.
+//!
+//! Covers buffer allocation strategies, alignment requirements, lifecycle
+//! management, zero-copy sharing, pool/slab patterns, large buffer handling,
+//! hazard tracking, triple buffering, argument buffers, and contents validation.
+//!
+//! All tests are `#[ignore]` with justification strings — these are TDD
+//! scaffolds for features that require a Metal-capable GPU at runtime.
+
+// ---------------------------------------------------------------------------
+// Buffer allocation strategies
+// ---------------------------------------------------------------------------
+
+/// Verify that device-local (MTLStorageModePrivate) buffers can be allocated
+/// and are not CPU-accessible.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for MTLStorageModePrivate allocation"]
+fn test_buffer_alloc_device_local_private_storage() {
+    unimplemented!()
+}
+
+/// Verify that shared-memory (MTLStorageModeShared) buffers are accessible
+/// from both CPU and GPU without explicit synchronisation.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for MTLStorageModeShared allocation"]
+fn test_buffer_alloc_shared_memory() {
+    unimplemented!()
+}
+
+/// Verify that managed-memory (MTLStorageModeManaged) buffers correctly
+/// track dirty regions and synchronise on demand.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for MTLStorageModeManaged allocation"]
+fn test_buffer_alloc_managed_memory_sync() {
+    unimplemented!()
+}
+
+// ---------------------------------------------------------------------------
+// Buffer alignment requirements
+// ---------------------------------------------------------------------------
+
+/// Ensure 4-byte-aligned buffer allocations satisfy minimum Metal alignment.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify 4-byte alignment guarantees"]
+fn test_buffer_alignment_4_byte() {
+    panic!("not yet implemented")
+}
+
+/// Ensure 16-byte-aligned allocations for SIMD / float4 access patterns.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify 16-byte SIMD alignment"]
+fn test_buffer_alignment_16_byte_simd() {
+    panic!("not yet implemented")
+}
+
+/// Ensure page-aligned allocations for MTLBuffer `newBufferWithBytesNoCopy`.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify page-aligned no-copy buffers"]
+fn test_buffer_alignment_page_aligned_no_copy() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Buffer lifecycle management
+// ---------------------------------------------------------------------------
+
+/// Round-trip: create buffer → fill from CPU → read back and verify contents.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for buffer create-fill-readback lifecycle"]
+fn test_buffer_lifecycle_create_fill_readback() {
+    unimplemented!()
+}
+
+/// Ensure released buffers are reclaimed and do not leak GPU memory.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify buffer release / deallocation"]
+fn test_buffer_lifecycle_release_no_leak() {
+    unimplemented!()
+}
+
+/// Validate that double-release of a buffer is a no-op or safely handled.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify idempotent buffer release"]
+fn test_buffer_lifecycle_double_release_safety() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Zero-copy buffer sharing between CPU and GPU
+// ---------------------------------------------------------------------------
+
+/// CPU writes into a shared buffer and GPU reads the same contents without a
+/// copy step.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for zero-copy CPU-to-GPU sharing"]
+fn test_zero_copy_cpu_write_gpu_read() {
+    unimplemented!()
+}
+
+/// GPU writes results into a shared buffer and CPU reads them back without an
+/// explicit blit/copy.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for zero-copy GPU-to-CPU read-back"]
+fn test_zero_copy_gpu_write_cpu_read() {
+    unimplemented!()
+}
+
+/// Concurrent CPU and GPU access to disjoint regions of a shared buffer must
+/// not corrupt either region.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for disjoint-region concurrent access"]
+fn test_zero_copy_disjoint_region_concurrent_access() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Buffer pool / slab allocation patterns
+// ---------------------------------------------------------------------------
+
+/// A pool should reuse previously released buffers of the same size class.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for buffer pool reuse verification"]
+fn test_buffer_pool_reuse_same_size_class() {
+    unimplemented!()
+}
+
+/// Pool should coalesce small allocations into a slab to reduce Metal API
+/// overhead.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for slab coalescing strategy"]
+fn test_buffer_pool_slab_coalescing() {
+    unimplemented!()
+}
+
+/// Pool eviction policy should free idle buffers under memory pressure.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for pool eviction under memory pressure"]
+fn test_buffer_pool_eviction_under_pressure() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Large buffer handling
+// ---------------------------------------------------------------------------
+
+/// Allocate a buffer exceeding 256 MB and verify that Metal does not silently
+/// fail.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU with ≥512 MB VRAM for large buffer allocation"]
+fn test_large_buffer_alloc_over_256mb() {
+    unimplemented!()
+}
+
+/// Attempting to allocate beyond the device's `maxBufferLength` should return
+/// a clear error rather than UB.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime to verify max buffer length error path"]
+fn test_large_buffer_exceeds_device_max_length() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Buffer hazard tracking
+// ---------------------------------------------------------------------------
+
+/// Read-after-write: GPU compute writes buffer A, then a second dispatch reads
+/// A.  A memory barrier must ensure the read observes the write.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for read-after-write barrier validation"]
+fn test_hazard_read_after_write_barrier() {
+    unimplemented!()
+}
+
+/// Write-after-read: GPU reads buffer B, then a subsequent dispatch overwrites
+/// B.  Proper fencing must prevent the overwrite from clobbering the earlier
+/// read.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for write-after-read barrier validation"]
+fn test_hazard_write_after_read_barrier() {
+    unimplemented!()
+}
+
+/// Write-after-write: two dispatches write to the same buffer — the final
+/// contents must reflect the second write only.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for write-after-write ordering validation"]
+fn test_hazard_write_after_write_ordering() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Triple buffering for command buffer overlap
+// ---------------------------------------------------------------------------
+
+/// Three in-flight command buffers each use a distinct buffer slice; verify
+/// no data corruption across overlapping submissions.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for triple-buffer overlap validation"]
+fn test_triple_buffer_no_corruption() {
+    unimplemented!()
+}
+
+/// Ring-buffer index wraps correctly after cycling through all three slots.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for triple-buffer ring index wraparound"]
+fn test_triple_buffer_ring_index_wraparound() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Argument buffers for indirect dispatches
+// ---------------------------------------------------------------------------
+
+/// Encode buffer pointers into an argument buffer and dispatch a compute
+/// kernel indirectly.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for argument buffer indirect dispatch"]
+fn test_argument_buffer_indirect_dispatch() {
+    unimplemented!()
+}
+
+/// Argument buffer with mixed resource types (buffer + texture handle) must
+/// keep both resources resident.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for mixed-resource argument buffer residency"]
+fn test_argument_buffer_mixed_resource_residency() {
+    panic!("not yet implemented")
+}
+
+// ---------------------------------------------------------------------------
+// Buffer contents validation after compute passes
+// ---------------------------------------------------------------------------
+
+/// Run a trivial compute shader (e.g., multiply-by-two) and validate the
+/// output buffer matches expected values.
+#[test]
+#[ignore = "TDD scaffold: requires Metal GPU runtime for post-compute buffer validation"]
+fn test_contents_validation_after_compute_pass() {
+    unimplemented!()
+}


### PR DESCRIPTION
## Summary

25 TDD scaffold tests for Metal GPU buffer management on Apple Silicon.

Covers:
- Buffer allocation strategies (device-local, shared, managed)
- Alignment requirements (4B, 16B, page-aligned)
- Buffer lifecycle (create, fill, read-back, release)
- Zero-copy CPU/GPU sharing
- Pool/slab allocation
- Large buffer handling (>256MB)
- Hazard tracking (RAW, WAR barriers)
- Triple buffering
- Argument buffers
- Contents validation

All tests are TDD scaffolds with `#[ignore]` and justification strings.

## Test Plan

`cargo nextest run --workspace --no-default-features --features cpu` — all new tests skipped via `#[ignore]`.