### PR TITLE
test(neon): add NEON attention mask TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/neon_attention_mask_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_attention_mask_tests.rs
@@ -1,0 +1,225 @@
+#![cfg(feature = "cpu")]
+#![allow(
+    dead_code,
+    unused_imports,
+    unused_variables,
+    clippy::needless_range_loop,
+    clippy::assertions_on_constants
+)]
+//! TDD scaffold tests for NEON-optimized attention mask operations on Apple Silicon.
+//!
+//! These tests cover causal masks, padding masks, sliding-window masks,
+//! ALiBi biases, block-sparse patterns, broadcasting, inversion,
+//! `-inf` fill, boolean↔float conversion, variable-length masking,
+//! Flash Attention–compatible formats, and mask caching/reuse.
+//!
+//! All tests are `#[ignore]` with justification strings — implement the
+//! corresponding kernel, then remove the `#[ignore]`.
+
+// ---------------------------------------------------------------------------
+// Causal (lower-triangular) mask generation
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON causal mask generation not yet implemented"]
+fn test_neon_causal_mask_square() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON causal mask for non-square (seq_len != kv_len) not yet implemented"]
+fn test_neon_causal_mask_rectangular() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON causal mask alignment to 4-element NEON lanes not yet implemented"]
+fn test_neon_causal_mask_alignment() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Padding mask application
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON padding mask from variable-length sequences not yet implemented"]
+fn test_neon_padding_mask_basic() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON padding mask with batch of different lengths not yet implemented"]
+fn test_neon_padding_mask_batched() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Combined causal + padding mask
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON combined causal and padding mask not yet implemented"]
+fn test_neon_combined_causal_padding_mask() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON combined mask with batched variable-length inputs not yet implemented"]
+fn test_neon_combined_mask_batched_variable_length() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Sliding window attention mask
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON sliding window mask generation not yet implemented"]
+fn test_neon_sliding_window_mask() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON sliding window mask with window size larger than sequence not yet implemented"]
+fn test_neon_sliding_window_mask_large_window() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// ALiBi (Attention with Linear Biases) mask
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON ALiBi slope computation per attention head not yet implemented"]
+fn test_neon_alibi_slopes() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON ALiBi bias matrix generation not yet implemented"]
+fn test_neon_alibi_bias_matrix() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Block-sparse attention mask patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON block-sparse mask with fixed block size not yet implemented"]
+fn test_neon_block_sparse_mask_fixed() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON block-sparse mask with local + global tokens not yet implemented"]
+fn test_neon_block_sparse_mask_local_global() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Mask broadcasting across batch / heads
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON mask broadcast from [1, 1, S, S] to [B, H, S, S] not yet implemented"]
+fn test_neon_mask_broadcast_batch_heads() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON per-head mask broadcast (different mask per head) not yet implemented"]
+fn test_neon_mask_broadcast_per_head() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Mask inversion (complement)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON boolean mask bitwise inversion not yet implemented"]
+fn test_neon_mask_inversion_bool() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON float mask inversion (0↔-inf) not yet implemented"]
+fn test_neon_mask_inversion_float() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Attention score masking with -inf fill
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON masked fill with -inf for f32 scores not yet implemented"]
+fn test_neon_masked_fill_neg_inf_f32() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON masked fill with -inf for f16 scores not yet implemented"]
+fn test_neon_masked_fill_neg_inf_f16() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Boolean mask to float mask conversion
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON bool-to-float mask conversion (true→0, false→-inf) not yet implemented"]
+fn test_neon_bool_to_float_mask() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON float-to-bool mask threshold conversion not yet implemented"]
+fn test_neon_float_to_bool_mask() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Variable-length sequence masking
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON variable-length mask from cu_seqlens offsets not yet implemented"]
+fn test_neon_variable_length_mask_cu_seqlens() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON variable-length mask with ragged batch not yet implemented"]
+fn test_neon_variable_length_mask_ragged() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Flash Attention compatible mask format
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON Flash Attention packed mask layout not yet implemented"]
+fn test_neon_flash_attention_packed_mask() {
+    unimplemented!();
+}
+
+// ---------------------------------------------------------------------------
+// Mask caching and reuse patterns
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: NEON cached causal mask reuse across decode steps not yet implemented"]
+fn test_neon_mask_cache_reuse() {
+    unimplemented!();
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON incremental mask extension for autoregressive decoding not yet implemented"]
+fn test_neon_mask_incremental_extension() {
+    unimplemented!();
+}


### PR DESCRIPTION
25 TDD scaffold tests for NEON-optimized attention mask operations on Apple Silicon. All #[ignore] with justifications.