### PR TITLE
test(neon): add NEON KV cache optimization TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/neon_kv_cache_optimization_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_kv_cache_optimization_tests.rs
@@ -23,7 +23,7 @@
 //! All tests are `#[ignore]` with justification — they represent planned
 //! implementation work for optimized KV cache on ARM64 platforms.
 
-use std::alloc::{alloc, dealloc, Layout};
+use std::alloc::{Layout, alloc, dealloc};
 use std::ptr::NonNull;
 
 // =============================================================================


### PR DESCRIPTION
Add 30 TDD scaffold tests for NEON KV cache optimizations on Apple Silicon. All tests #[ignore] with justifications.