### PR TITLE
fix(deps): pin proptest <1.10.0 to avoid float sampler panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -471,7 +471,7 @@ cudarc = "0.17.8"
 
 # Testing and benchmarking
 criterion = { version = "0.7.0", features = ["html_reports"] }
-proptest = "1.9.0"
+proptest = ">=1.9.0, <1.10.0"
 insta = { version = "1.43.2", features = ["yaml", "json", "redactions", "filters"] }
 tempfile = "3.23.0"
 serial_test = "3.2.0"


### PR DESCRIPTION
## P0: Flaky CI fix

proptest 1.10.0 has a bug in `float_samplers.rs` where an assertion randomly fails during f32 range test input generation:
```
assertion failed: self.low - result < self.intervals.step
```

This causes sporadic CI failures in any proptest using float ranges (e.g. `min_p_never_removes_max_token` in bitnet-logits).

### Changes
- Pin workspace proptest dependency to `>=1.9.0, <1.10.0` (was `1.9.0` which allowed 1.10.0)
- Update Cargo.lock to downgrade from 1.10.0 → 1.9.0

### Testing
- All bitnet-logits tests pass locally
- Verified proptest version downgraded in Cargo.lock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraints for more precise compatibility management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->