### PR TITLE
test(neon): add NEON softmax edge case TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/neon_softmax_edge_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_softmax_edge_tests.rs
@@ -1,0 +1,202 @@
+//! NEON softmax edge-case TDD scaffolds for Apple Silicon (aarch64).
+//!
+//! ~25 ignored TDD scaffold tests covering numerical stability, NaN/Inf
+//! handling, dimension edge cases, NEON-vs-scalar parity, in-place vs
+//! out-of-place computation, and temperature scaling edge cases.
+
+#![cfg(feature = "cpu")]
+#![allow(dead_code, unused_imports)]
+
+// ── Numerical stability: overflow / underflow ──────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with f32::MAX input should not overflow to Inf"]
+fn neon_softmax_f32_max_no_overflow() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with f32::MIN input should not underflow to zero distribution"]
+fn neon_softmax_f32_min_no_underflow() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with mixed extreme magnitudes should produce valid distribution"]
+fn neon_softmax_mixed_extreme_magnitudes() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with all-identical large values should yield uniform distribution"]
+fn neon_softmax_identical_large_values_uniform() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with subnormal floats should not produce NaN"]
+fn neon_softmax_subnormal_inputs() {
+    panic!("not yet implemented");
+}
+
+// ── NaN / Inf handling ─────────────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with single NaN input should propagate NaN correctly"]
+fn neon_softmax_single_nan_propagation() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with positive Inf input should concentrate probability on Inf element"]
+fn neon_softmax_positive_inf_concentration() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with negative Inf input should assign zero probability to that element"]
+fn neon_softmax_negative_inf_zero_prob() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with multiple NaN inputs should propagate NaN throughout"]
+fn neon_softmax_multiple_nan_propagation() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with mixed NaN and Inf should handle both correctly"]
+fn neon_softmax_mixed_nan_inf() {
+    panic!("not yet implemented");
+}
+
+// ── Very small / very large inputs ─────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with logits near -88.7 (exp underflow boundary) should stay stable"]
+fn neon_softmax_near_exp_underflow_boundary() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with logits near 88.7 (exp overflow boundary) should stay stable"]
+fn neon_softmax_near_exp_overflow_boundary() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with all-zero inputs should yield uniform distribution"]
+fn neon_softmax_all_zeros_uniform() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with epsilon-scale differences should preserve ordering"]
+fn neon_softmax_epsilon_differences_preserve_order() {
+    panic!("not yet implemented");
+}
+
+// ── Dimension edge cases ───────────────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with empty slice should return empty without panic"]
+fn neon_softmax_empty_slice() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with single element should return 1.0"]
+fn neon_softmax_single_element() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with length 3 (non-SIMD-aligned) should produce correct output"]
+fn neon_softmax_length_3_non_aligned() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with power-of-2 length (128) should match scalar reference"]
+fn neon_softmax_power_of_2_length_128() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with non-power-of-2 length (127) should match scalar reference"]
+fn neon_softmax_non_power_of_2_length_127() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with length 4 (exact NEON register width) should be correct"]
+fn neon_softmax_exact_neon_register_width() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with large vocab-sized dimension (32000) should produce valid distribution"]
+fn neon_softmax_large_vocab_dimension() {
+    panic!("not yet implemented");
+}
+
+// ── NEON vs scalar numerical parity ────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax output should match scalar within 5e-4 tolerance for random inputs"]
+fn neon_vs_scalar_parity_random_inputs() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax should match scalar for monotonically increasing inputs"]
+fn neon_vs_scalar_parity_monotonic_increasing() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax should match scalar for alternating positive-negative inputs"]
+fn neon_vs_scalar_parity_alternating_sign() {
+    panic!("not yet implemented");
+}
+
+// ── In-place vs out-of-place computation ───────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax in-place should produce identical result to out-of-place"]
+fn neon_softmax_inplace_matches_out_of_place() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax in-place should not corrupt adjacent memory"]
+fn neon_softmax_inplace_no_adjacent_memory_corruption() {
+    panic!("not yet implemented");
+}
+
+// ── Temperature scaling edge cases ─────────────────────────────────────
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with temperature=0.0 should behave like argmax (one-hot)"]
+fn neon_softmax_temperature_zero_argmax() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with very high temperature should approach uniform distribution"]
+fn neon_softmax_temperature_very_high_uniform() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with temperature=1.0 should match unscaled softmax"]
+fn neon_softmax_temperature_one_identity() {
+    panic!("not yet implemented");
+}
+
+#[test]
+#[ignore = "TDD scaffold: NEON softmax with negative temperature should handle gracefully"]
+fn neon_softmax_temperature_negative() {
+    panic!("not yet implemented");
+}


### PR DESCRIPTION
Adds ~25 ignored TDD scaffold tests for NEON softmax edge case testing on Apple Silicon. All tests are TDD scaffolds with panic bodies.