### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in RateLimitBucket

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -13,3 +13,8 @@
 **Vulnerability:** Input validation in `sanitize_input` blocks carriage return (`\r`) characters, categorizing them as invalid control characters.
 **Learning:** This restricts valid payloads coming from environments (like Windows) or protocols (like HTTP standard format) that use CRLF for newlines, leading to unintentional denial of service for these valid requests.
 **Prevention:** Explicitly allow `\r` alongside `\n` and `\t` when filtering out control characters in text payloads.
+
+## 2025-06-03 - [TOCTOU in RateLimitBucket leads to bypass via integer underflow]
+**Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
+**Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
+**Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.

--- a/crates/bitnet-server/src/concurrency.rs
+++ b/crates/bitnet-server/src/concurrency.rs
@@ -64,13 +64,11 @@ impl RateLimitBucket {
     async fn try_consume(&self, tokens: u64) -> bool {
         self.refill().await;
 
-        let current_tokens = self.tokens.load(Ordering::Relaxed);
-        if current_tokens >= tokens {
-            self.tokens.fetch_sub(tokens, Ordering::Relaxed);
-            true
-        } else {
-            false
-        }
+        let result = self.tokens.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+            if current >= tokens { Some(current - tokens) } else { None }
+        });
+
+        result.is_ok()
     }
 
     async fn refill(&self) {
@@ -80,10 +78,11 @@ impl RateLimitBucket {
 
         if elapsed.as_secs() > 0 {
             let tokens_to_add = elapsed.as_secs() * self.refill_rate;
-            let current_tokens = self.tokens.load(Ordering::Relaxed);
-            let new_tokens = (current_tokens + tokens_to_add).min(self.capacity);
 
-            self.tokens.store(new_tokens, Ordering::Relaxed);
+            let _ = self.tokens.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                Some((current + tokens_to_add).min(self.capacity))
+            });
+
             *last_refill = now;
         }
     }
@@ -585,5 +584,31 @@ mod tests {
 
         let stats = manager.get_stats().await;
         assert_eq!(stats.per_ip_limiter_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiter_toctou() {
+        // Create a bucket with 5 tokens
+        let bucket = Arc::new(RateLimitBucket::new(5, 1));
+
+        let mut handles = vec![];
+
+        // Spawn 10 concurrent tasks trying to consume tokens
+        for _ in 0..10 {
+            let bucket_clone = Arc::clone(&bucket);
+            handles.push(tokio::spawn(async move { bucket_clone.try_consume(1).await }));
+        }
+
+        let mut successful_consumptions = 0;
+        for handle in handles {
+            if handle.await.unwrap() {
+                successful_consumptions += 1;
+            }
+        }
+
+        // At most 5 requests should have succeeded, and underflow should not happen
+        assert!(successful_consumptions <= 5);
+        let remaining_tokens = bucket.tokens.load(Ordering::Relaxed);
+        assert!(remaining_tokens <= 5); // Should be 0, but definitely not a huge number due to underflow
     }
 }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A Time-of-Check to Time-of-Use (TOCTOU) integer underflow bug existed in `RateLimitBucket::try_consume`. Because checking tokens and consuming tokens were split across two non-atomic operations (`load` then `fetch_sub`), concurrent requests could simultaneously observe positive available tokens, pass the threshold condition, and concurrently decrement the token counter into integer underflow. This bypassed the rate limiter. Additionally, `RateLimitBucket::refill` was subject to a data race that could cause stale capacity calculations to overwrite consumed tokens.
🎯 **Impact:** Allowed an attacker to completely bypass the application's global and per-IP rate limits using highly concurrent requests.
🔧 **Fix:** Changed `try_consume` and `refill` to utilize `fetch_update`, strictly enforcing read-modify-write atomicity and eliminating the data race condition.
✅ **Verification:** Verified by a new test `test_rate_limiter_toctou` which explicitly spawns 10 concurrent tasks aggressively pulling tokens from a 5-capacity bucket to ensure integer underflow is impossible. Included documentation in the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [5658271503621514036](https://jules.google.com/task/5658271503621514036) started by @EffortlessSteven*