### PR TITLE
⚡ Bolt: Optimize apply_repetition_penalty

### DIFF
--- a/crates/bitnet-logits/src/lib.rs
+++ b/crates/bitnet-logits/src/lib.rs
@@ -151,13 +151,17 @@ pub fn apply_repetition_penalty(logits: &mut [f32], token_ids: &[u32], penalty: 
     if penalty <= 0.0 || !penalty.is_finite() || penalty == 1.0 || token_ids.is_empty() {
         return;
     }
+    // Optimization: Pre-calculate 1.0 / penalty outside the loop to replace division with multiplication,
+    // as strict IEEE-754 compliance prevents the Rust compiler from doing this automatically.
+    let inv_penalty = 1.0 / penalty;
     for &id in token_ids {
         let idx = id as usize;
-        if idx < logits.len() {
-            if logits[idx] > 0.0 {
-                logits[idx] /= penalty;
+        // Optimization: Use get_mut to eliminate redundant bounds checking
+        if let Some(logit) = logits.get_mut(idx) {
+            if *logit > 0.0 {
+                *logit *= inv_penalty;
             } else {
-                logits[idx] *= penalty;
+                *logit *= penalty;
             }
         }
     }


### PR DESCRIPTION
💡 What: Optimized `apply_repetition_penalty` in `crates/bitnet-logits/src/lib.rs` by pre-calculating the inverse penalty and using `.get_mut()`.
🎯 Why: Floating-point division is slower than multiplication. Because of strict IEEE-754 compliance, the Rust compiler cannot automatically convert division by a constant into multiplication by its inverse. Doing this manually inside the hot loop improves performance. Furthermore, using `.get_mut()` is more idiomatic and eliminates redundant compiler-inserted bounds checks compared to manual array indexing.
📊 Impact: Minor measurable speedup during token generation when repetition penalty is applied, especially for long histories.
🔬 Measurement: Verified with `cargo test -p bitnet-logits` and existing benchmarks.

---
*PR created automatically by Jules for task [8516799805535005569](https://jules.google.com/task/8516799805535005569) started by @EffortlessSteven*