### PR TITLE
fix: correct module ordering and NUMA plan_thread_pinning overflow

### DIFF
--- a/crates/bitnet-kernels/src/cpu/numa_aware_ops.rs
+++ b/crates/bitnet-kernels/src/cpu/numa_aware_ops.rs
@@ -559,7 +559,7 @@ pub fn plan_thread_pinning(
     let mut assigned = 0;
     for (i, node) in topology.nodes.iter().enumerate() {
         let share = if i == n - 1 {
-            num_workers - assigned
+            num_workers.saturating_sub(assigned)
         } else {
             let fraction = node.cpus.len() as f64 / total_cpus as f64;
             (num_workers as f64 * fraction).round() as usize

--- a/crates/bitnet-tokenizers/src/lib.rs
+++ b/crates/bitnet-tokenizers/src/lib.rs
@@ -36,8 +36,8 @@ pub mod fallback;
 pub mod strategy;
 pub mod utils;
 pub mod vocab_analyzer;
-pub mod vocab_index;
 pub mod vocab_encoding;
+pub mod vocab_index;
 pub mod vocab_stats;
 pub mod vocabulary;
 


### PR DESCRIPTION
Two P0 fixes for main:

1. **cargo fmt**: vocab_encoding must come before vocab_index in bitnet-tokenizers/src/lib.rs
2. **proptest overflow**: `plan_thread_pinning` subtracted with overflow when rounding caused over-assignment (`num_workers.saturating_sub(assigned)`)

Unblocks CI Core Success on main and all open PRs.

2 files, 2 lines changed.