### PR TITLE
test(apple-silicon): add Metal adapter detection TDD scaffolds [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/tests/metal_adapter_detection_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_adapter_detection_tests.rs
@@ -1,0 +1,156 @@
+//! TDD scaffolds for Metal/wgpu adapter selection and device capability
+//! detection on Apple Silicon.
+//!
+//! These tests validate that the wgpu Metal backend correctly enumerates
+//! Apple GPU adapters, reports device limits, and meets alignment and
+//! workgroup constraints required by the bitnet-kernels compute pipeline.
+//!
+//! All tests are `#[ignore]` scaffolds pending full wgpu Metal integration.
+
+#![cfg(all(target_os = "macos", target_arch = "aarch64"))]
+
+// ---------------------------------------------------------------------------
+// Adapter enumeration
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal backend validation"]
+fn metal_adapter_enumerates_apple_gpu() {
+    // Verify that wgpu enumerates at least one Metal adapter whose name
+    // contains "Apple" on an Apple Silicon host.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal backend validation"]
+fn metal_adapter_backend_is_metal() {
+    // The selected adapter must report `wgpu::Backend::Metal`.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu Metal backend validation"]
+fn metal_adapter_is_not_software_renderer() {
+    // Ensure the adapter's device type is `DeviceType::IntegratedGpu`,
+    // not `DeviceType::Cpu` (software fallback).
+    todo!()
+}
+
+// ---------------------------------------------------------------------------
+// Device limits
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu device limits query on Metal"]
+fn metal_max_buffer_size_at_least_256mb() {
+    // Apple Silicon GPUs must report `max_buffer_size >= 256 MiB`
+    // to accommodate quantized weight buffers.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu device limits query on Metal"]
+fn metal_max_compute_workgroup_size_x() {
+    // Metal on Apple Silicon supports at least 1024 threads per
+    // workgroup in the X dimension.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu device limits query on Metal"]
+fn metal_max_compute_workgroup_size_y() {
+    // Metal on Apple Silicon supports at least 1024 threads per
+    // workgroup in the Y dimension.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu device limits query on Metal"]
+fn metal_max_compute_workgroup_size_z() {
+    // Metal on Apple Silicon supports at least 1024 threads per
+    // workgroup in the Z dimension.
+    todo!()
+}
+
+// ---------------------------------------------------------------------------
+// Apple Silicon specific features
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu feature detection on Metal"]
+fn metal_supports_shader_model_for_compute() {
+    // The adapter must advertise a shader model sufficient for
+    // bitnet compute kernels (at minimum MSL 2.3 / shader-f16).
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu feature detection on Metal"]
+fn metal_supports_float16() {
+    // Apple Silicon GPUs natively support float16 arithmetic; verify
+    // that wgpu exposes `Features::SHADER_F16`.
+    todo!()
+}
+
+// ---------------------------------------------------------------------------
+// Buffer alignment
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu buffer allocation on Metal"]
+fn metal_buffer_alignment_256_bytes() {
+    // Metal requires a minimum 256-byte alignment for buffer offsets
+    // used in bind groups. Verify `min_storage_buffer_offset_alignment`.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu buffer allocation on Metal"]
+fn metal_uniform_buffer_alignment() {
+    // Verify `min_uniform_buffer_offset_alignment` meets Metal's
+    // 256-byte requirement for uniform buffer dynamic offsets.
+    todo!()
+}
+
+// ---------------------------------------------------------------------------
+// Compute pipeline / workgroup validation
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu compute pipeline creation on Metal"]
+fn metal_compute_workgroup_total_threads() {
+    // The product of workgroup dimensions must not exceed
+    // `max_compute_invocations_per_workgroup` (typically 1024 on
+    // Apple Silicon).
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires wgpu compute pipeline creation on Metal"]
+fn metal_compute_workgroup_size_power_of_two() {
+    // Validate that chosen workgroup sizes are powers of two, which
+    // is preferred for optimal occupancy on Apple GPU cores.
+    todo!()
+}
+
+// ---------------------------------------------------------------------------
+// Device memory
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal device memory query via wgpu or objc"]
+fn metal_device_reports_unified_memory_size() {
+    // Apple Silicon uses unified memory; verify that the device
+    // reports a non-zero memory size suitable for model weight
+    // residency.
+    todo!()
+}
+
+#[test]
+#[ignore = "TDD scaffold: requires Metal device memory query via wgpu or objc"]
+fn metal_device_memory_sufficient_for_2b_model() {
+    // A 2-billion-parameter 1-bit model requires ~250 MiB of weight
+    // storage. Verify that the device's reported memory comfortably
+    // exceeds this threshold.
+    todo!()
+}


### PR DESCRIPTION
## Summary

Add TDD scaffold tests for Metal/wgpu adapter selection and device capability detection on Apple Silicon.

## Tests Added

16 new `#[ignore]` scaffold tests in `crates/bitnet-kernels/tests/metal_adapter_detection_tests.rs`:

**Adapter enumeration (3 tests)**
- Metal adapter enumerates Apple GPU
- Adapter backend is Metal
- Adapter is not software renderer

**Device limits (4 tests)**
- Max buffer size ≥ 256 MiB
- Max compute workgroup size X/Y/Z

**Apple Silicon features (2 tests)**
- Shader model sufficient for compute
- Float16 support (`SHADER_F16`)

**Buffer alignment (2 tests)**
- 256-byte storage buffer alignment
- 256-byte uniform buffer alignment

**Compute pipeline (2 tests)**
- Total workgroup thread count validation
- Power-of-two workgroup size preference

**Device memory (2 tests)**
- Unified memory size reporting
- Sufficient memory for 2B model (~250 MiB)

## Notes

- No new dependencies added (no wgpu dep yet)
- Tests will be implemented when wgpu Metal backend is fully integrated