### PR TITLE
fix(kernels): resolve NEON clippy lints on aarch64 [Apple Silicon]

### DIFF
--- a/crates/bitnet-kernels/src/cpu/neon_attention_scoring.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_attention_scoring.rs
@@ -63,7 +63,7 @@ unsafe fn neon_dot_f32(a: *const f32, b: *const f32, len: usize) -> f32 {
     let chunks = len / LANES;
     let remainder = len % LANES;
 
-    let mut acc = unsafe { vdupq_n_f32(0.0) };
+    let mut acc = vdupq_n_f32(0.0);
 
     for i in 0..chunks {
         let offset = i * LANES;
@@ -74,7 +74,7 @@ unsafe fn neon_dot_f32(a: *const f32, b: *const f32, len: usize) -> f32 {
         }
     }
 
-    let mut sum = unsafe { vaddvq_f32(acc) };
+    let mut sum = vaddvq_f32(acc);
 
     let tail_start = chunks * LANES;
     for i in 0..remainder {
@@ -274,8 +274,8 @@ pub unsafe fn neon_clamp_attention_scores(scores: &mut [f32], min_val: f32, max_
     let remainder = len % LANES;
     let ptr = scores.as_mut_ptr();
 
-    let vmin = unsafe { vdupq_n_f32(min_val) };
-    let vmax = unsafe { vdupq_n_f32(max_val) };
+    let vmin = vdupq_n_f32(min_val);
+    let vmax = vdupq_n_f32(max_val);
 
     for i in 0..chunks {
         let offset = i * LANES;
@@ -313,7 +313,7 @@ pub unsafe fn neon_apply_attention_dropout(scores: &mut [f32], mask: &[f32], inv
 
     let s_ptr = scores.as_mut_ptr();
     let m_ptr = mask.as_ptr();
-    let v_scale = unsafe { vdupq_n_f32(inv_keep_prob) };
+    let v_scale = vdupq_n_f32(inv_keep_prob);
 
     for i in 0..chunks {
         let offset = i * LANES;
@@ -354,9 +354,9 @@ pub unsafe fn neon_generate_dropout_mask(
 
     let r_ptr = random_vals.as_ptr();
     let o_ptr = mask_out.as_mut_ptr();
-    let v_thresh = unsafe { vdupq_n_f32(keep_prob) };
-    let v_one = unsafe { vdupq_n_f32(1.0) };
-    let v_zero = unsafe { vdupq_n_f32(0.0) };
+    let v_thresh = vdupq_n_f32(keep_prob);
+    let v_one = vdupq_n_f32(1.0);
+    let v_zero = vdupq_n_f32(0.0);
 
     for i in 0..chunks {
         let offset = i * LANES;

--- a/crates/bitnet-kernels/src/cpu/neon_sparse_matmul.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_sparse_matmul.rs
@@ -27,14 +27,14 @@ pub unsafe fn sparse_matmul_csr_neon(
     _cols: usize,
     dense_cols: usize,
 ) {
-    assert!(row_ptrs.len() >= rows + 1);
+    assert!(row_ptrs.len() > rows);
     assert!(output.len() >= rows * dense_cols);
 
     for i in 0..rows {
         let start = row_ptrs[i];
         let end = row_ptrs[i + 1];
         for dc in 0..dense_cols {
-            let mut acc = unsafe { vdupq_n_f32(0.0) };
+            let mut acc = vdupq_n_f32(0.0);
             let mut scalar_acc: f32 = 0.0;
             let nnz = end - start;
             let chunks = nnz / 4;
@@ -59,7 +59,7 @@ pub unsafe fn sparse_matmul_csr_neon(
                         .as_ptr(),
                     )
                 };
-                acc = unsafe { vfmaq_f32(acc, v, d) };
+                acc = vfmaq_f32(acc, v, d);
             }
 
             for k in 0..rem {
@@ -68,7 +68,7 @@ pub unsafe fn sparse_matmul_csr_neon(
             }
 
             // Horizontal add
-            let sum = unsafe {
+            let sum = {
                 let pair = vpadd_f32(vget_low_f32(acc), vget_high_f32(acc));
                 vget_lane_f32::<0>(vpadd_f32(pair, pair))
             };
@@ -90,7 +90,7 @@ pub fn sparse_matmul_csr_neon(
     _cols: usize,
     dense_cols: usize,
 ) {
-    assert!(row_ptrs.len() >= rows + 1);
+    assert!(row_ptrs.len() > rows);
     assert!(output.len() >= rows * dense_cols);
 
     for i in 0..rows {
@@ -125,7 +125,7 @@ pub unsafe fn sparse_matmul_csc_neon(
     cols: usize,
     dense_cols: usize,
 ) {
-    assert!(col_ptrs.len() >= cols + 1);
+    assert!(col_ptrs.len() > cols);
     assert!(output.len() >= rows * dense_cols);
 
     // Zero output
@@ -141,7 +141,7 @@ pub unsafe fn sparse_matmul_csc_neon(
             if dense_val == 0.0 {
                 continue;
             }
-            let d_vec = unsafe { vdupq_n_f32(dense_val) };
+            let d_vec = vdupq_n_f32(dense_val);
             let nnz = end - start;
             let chunks = nnz / 4;
             let rem = nnz % 4;
@@ -154,7 +154,7 @@ pub unsafe fn sparse_matmul_csc_neon(
                             .as_ptr(),
                     )
                 };
-                let prod = unsafe { vmulq_f32(v, d_vec) };
+                let prod = vmulq_f32(v, d_vec);
                 // Scatter-add to output rows
                 let r0 = row_indices[base];
                 let r1 = row_indices[base + 1];
@@ -188,7 +188,7 @@ pub fn sparse_matmul_csc_neon(
     cols: usize,
     dense_cols: usize,
 ) {
-    assert!(col_ptrs.len() >= cols + 1);
+    assert!(col_ptrs.len() > cols);
     assert!(output.len() >= rows * dense_cols);
 
     for v in output.iter_mut().take(rows * dense_cols) {
@@ -225,7 +225,7 @@ pub unsafe fn sparse_dot_product_neon(
 
     let mut ia = 0;
     let mut ib = 0;
-    let mut acc = unsafe { vdupq_n_f32(0.0) };
+    let mut acc = vdupq_n_f32(0.0);
     let mut buf_a = [0.0f32; 4];
     let mut buf_b = [0.0f32; 4];
     let mut buf_count = 0;
@@ -238,7 +238,7 @@ pub unsafe fn sparse_dot_product_neon(
             if buf_count == 4 {
                 let va = unsafe { vld1q_f32(buf_a.as_ptr()) };
                 let vb = unsafe { vld1q_f32(buf_b.as_ptr()) };
-                acc = unsafe { vfmaq_f32(acc, va, vb) };
+                acc = vfmaq_f32(acc, va, vb);
                 buf_count = 0;
             }
             ia += 1;
@@ -257,7 +257,7 @@ pub unsafe fn sparse_dot_product_neon(
     }
 
     // Horizontal add
-    let sum = unsafe {
+    let sum = {
         let pair = vpadd_f32(vget_low_f32(acc), vget_high_f32(acc));
         vget_lane_f32::<0>(vpadd_f32(pair, pair))
     };
@@ -314,7 +314,7 @@ pub unsafe fn sparse_dense_add_neon(values: &[f32], indices: &[usize], dense: &m
         cur[2] = dense[indices[base + 2]];
         cur[3] = dense[indices[base + 3]];
         let d = unsafe { vld1q_f32(cur.as_ptr()) };
-        let r = unsafe { vaddq_f32(d, v) };
+        let r = vaddq_f32(d, v);
         let mut out = [0.0f32; 4];
         unsafe { vst1q_f32(out.as_mut_ptr(), r) };
         dense[indices[base]] = out[0];
@@ -363,7 +363,7 @@ pub unsafe fn sparse_matmul_block_neon(
     block_size: usize,
 ) {
     let block_rows = (rows + block_size - 1) / block_size;
-    assert!(block_ptrs.len() >= block_rows + 1);
+    assert!(block_ptrs.len() > block_rows);
     assert!(output.len() >= rows * dense_cols);
 
     for v in output.iter_mut().take(rows * dense_cols) {
@@ -385,7 +385,7 @@ pub unsafe fn sparse_matmul_block_neon(
                     break;
                 }
                 for dc in 0..dense_cols {
-                    let mut acc = unsafe { vdupq_n_f32(0.0) };
+                    let mut acc = vdupq_n_f32(0.0);
                     let mut scalar_acc: f32 = 0.0;
                     let chunks = block_size / 4;
                     let rem = block_size % 4;
@@ -415,7 +415,7 @@ pub unsafe fn sparse_matmul_block_neon(
                                 .as_ptr(),
                             )
                         };
-                        acc = unsafe { vfmaq_f32(acc, bv, dv) };
+                        acc = vfmaq_f32(acc, bv, dv);
                     }
 
                     for bj in (chunks * 4)..block_size {
@@ -426,7 +426,7 @@ pub unsafe fn sparse_matmul_block_neon(
                         }
                     }
 
-                    let sum = unsafe {
+                    let sum = {
                         let pair = vpadd_f32(vget_low_f32(acc), vget_high_f32(acc));
                         vget_lane_f32::<0>(vpadd_f32(pair, pair))
                     };
@@ -452,7 +452,7 @@ pub fn sparse_matmul_block_neon(
     block_size: usize,
 ) {
     let block_rows = (rows + block_size - 1) / block_size;
-    assert!(block_ptrs.len() >= block_rows + 1);
+    assert!(block_ptrs.len() > block_rows);
     assert!(output.len() >= rows * dense_cols);
 
     for v in output.iter_mut().take(rows * dense_cols) {


### PR DESCRIPTION
## Apple Silicon Team — NEON Clippy Lint Fixes

This PR fixes clippy lints that only appear when compiling on ARM64/Apple Silicon targets (aarch64). These lints are invisible on x86_64 CI runners because the NEON code paths are behind `#[cfg(target_arch = "aarch64")]`.

### Changes

**`neon_sparse_matmul.rs`**
- Replace `>= x + 1` with `> x` in 6 assert bounds checks (`int_plus_one` lint)
- Remove unnecessary `unsafe` blocks around safe NEON intrinsics (`vdupq_n_f32`, `vfmaq_f32`, `vmulq_f32`, `vaddq_f32`, `vpadd_f32`, `vget_low_f32`, `vget_high_f32`, `vget_lane_f32`)

**`neon_attention_scoring.rs`**
- Remove unnecessary `unsafe` blocks around safe NEON intrinsics (`vdupq_n_f32`, `vaddvq_f32`)

### Why these are safe

In Rust 2024 edition (MSRV 1.92.0), most `std::arch::aarch64` NEON intrinsics are now safe functions. Only load/store intrinsics (`vld1q_f32`, `vst1q_f32`) and raw pointer operations remain unsafe — those `unsafe` blocks are intentionally preserved.

### Verification

```bash
cargo clippy -p bitnet-kernels --no-default-features --features cpu -- -D warnings
```

Confirmed: no `unused-unsafe` or `int_plus_one` errors remain in these two files.