### PR TITLE
docs: fix CPU golden path test count (7  5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Essential guidance for working with the bitnet-rs neural network inference codeb
 - **Receipt Verification** - Schema v1.0.0 with 8 validation gates (160+ tests across receipt crates)
 - **Strict Mode Runtime Guards** - Production safety enforcement (12/12 tests passing)
 - **Runtime Backend Selection** - `BackendStartupSummary` emits `requested=X detected=[…] selected=Y` at startup; `BackendCapabilities` snapshot captured in receipts (#771)
-- **CPU Golden Path E2E Tests** - 7 deterministic end-to-end tests always running in PR CI (no model download); includes reproducibility (seed=42 identical tokens) and pinned-output regression guard [140,459,459,459] (#790)
+- **CPU Golden Path E2E Tests** - 5 deterministic end-to-end tests always running in PR CI (no model download); includes deterministic output, reproducibility (seed=42 identical tokens), kernel-ID recording, and receipt invariants. Separate `e2e_cpu_golden_path.rs` adds pinned-output regression guard [140,459,459,459] (#790)
 - **SRP Microcrate Ecosystem** - `bitnet-logits`, `bitnet-gguf`, `bitnet-generation`, `bitnet-device-probe`, `bitnet-engine-core` wired into CI
 - **Feature Lattice** - `gpu` umbrella + `cuda` backend; orthogonal runtime reporting; CUDA-first but non-CUDA-ready
 - **Kernel Registry** - Centralized `KernelBackend`/`KernelCapabilities`/`SimdLevel` in `bitnet-common`
@@ -1000,7 +1000,7 @@ These test suites pass reliably (run `cargo nextest run --workspace --no-default
 - **receipt verification tests**: Schema v1.0.0 with 8 gates (160+ tests passing)
 - **strict mode tests**: Runtime guards and enforcement (12/12 passing)
 - **environment isolation tests**: EnvGuard parallel safety (serial + temp_env)
-- **CPU golden path E2E tests**: Deterministic inference with receipt invariants (7 tests passing)
+- **CPU golden path E2E tests**: Deterministic inference with receipt invariants (5 tests passing in `cpu_golden_path.rs`)
 - **SRP microcrate tests**: bitnet-logits (280+), bitnet-gguf (370+), bitnet-generation (210+), bitnet-device-probe (400+), bitnet-engine-core (240+)
 - **KVCache property tests**: 5 new shape-invariant properties (after N appends, layer independence, layer count, head divisibility, seq_len monotonicity) (#784)
 - **tokenizer property tests**: 5 new encode/decode properties (BOS/EOS prepend, decode never panics, word preservation, config serde round-trip, EOS ID bounds) (#785)


### PR DESCRIPTION
## Docs-Reality Pass: CPU Golden Path Test Count

### What was verified

Ran the exact CI command from \ci-core.yml\ Phase 5:

\\\ash
cargo test --locked -p bitnet-inference --test cpu_golden_path --no-default-features --features cpu
\\\

**Result:** 5/5 tests passed, 0 failed, 0 ignored.

### What was wrong

CLAUDE.md claimed **7** deterministic end-to-end tests in the CPU golden path suite (lines 23 and 1003). The actual count in \cpu_golden_path.rs\ is **5**:

1. \	est_cpu_golden_path_deterministic_output\
2. \	est_cpu_golden_path_reproducible\
3. \	est_cpu_golden_path_kernel_ids_recorded\
4. \	est_cpu_golden_path_receipt_honest_compute\
5. \	est_cpu_golden_path_receipt_invariants\

The pinned-output regression guard \[140,459,459,459]\ lives in the **separate** \2e_cpu_golden_path.rs\ file, which is not executed in \ci-core.yml\ Phase 5.

### What was fixed

- Updated count from 7  5 in both occurrences
- Clarified that \2e_cpu_golden_path.rs\ (with the pinned-output test) is a separate file not run in CI Phase 5
- Added the actual test names covered (deterministic output, reproducibility, kernel-ID recording, receipt invariants)

### Also verified (no changes needed)

- The \cargo test --workspace --no-default-features --features cpu\ command syntax is correct
- The \cargo build --no-default-features --features cpu\ command works
- \BITNET_SKIP_SLOW_TESTS\ is used in CI workflows and source code consistently