### PR TITLE
perf(inference): store &'static str in KernelRecorder to avoid hot-path allocations

### DIFF
--- a/crates/bitnet-inference/src/kernel_recorder.rs
+++ b/crates/bitnet-inference/src/kernel_recorder.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 /// providing verifiable evidence for honest compute gates in CI/CD.
 #[derive(Debug, Clone)]
 pub struct KernelRecorder {
-    inner: Arc<Mutex<Vec<String>>>,
+    inner: Arc<Mutex<Vec<&'static str>>>,
 }
 
 impl KernelRecorder {
@@ -26,7 +26,7 @@ impl KernelRecorder {
     /// IDs should be static strings like "i2s_gemv", "gemm_fp16", etc.
     pub fn record(&self, id: &'static str) {
         if let Ok(mut kernels) = self.inner.lock() {
-            kernels.push(id.to_string());
+            kernels.push(id);
         }
     }
 
@@ -37,7 +37,7 @@ impl KernelRecorder {
         if let Ok(kernels) = self.inner.lock() {
             // Keep insertion order but deduplicate
             let mut seen = std::collections::HashSet::new();
-            kernels.iter().filter(|k| seen.insert(k.as_str())).cloned().collect()
+            kernels.iter().copied().filter(|k| seen.insert(*k)).map(|k| k.to_string()).collect()
         } else {
             Vec::new()
         }


### PR DESCRIPTION
## Summary

\KernelRecorder.record()\ is called 6 times per token per layer. Previously it converted each \&'static str\ kernel name to an owned \String\ on every call, creating unnecessary allocations in the hot path.

## Changes

Changed internal storage from \Vec<String>\ to \Vec<&'static str>\ so \ecord()\ is a zero-allocation push. String conversion is deferred to \snapshot()\, which runs once at receipt generation time (cold path) and only allocates for deduplicated entries.

**3 lines changed in 1 file**  minimal, surgical fix.

## Public API

Unchanged:
- \ecord()\ still takes \&'static str\
- \snapshot()\ still returns \Vec<String>\

## Testing

All 5 \kernel_recorder\ unit tests pass (basic, deduplication, count, clear, thread_safe).

Closes #3227