### PR TITLE
Extract engine lifecycle state machine into dedicated SRP core crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,12 +689,21 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
+ "bitnet-engine-state-core",
  "bitnet-generation",
  "bitnet-logits",
  "insta",
  "proptest",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "bitnet-engine-state-core"
+version = "0.2.1-dev"
+dependencies = [
+ "proptest",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
   "crates/bitnet-generation-events-core", # SRP: reusable generation stream event/stat contracts
   "crates/bitnet-generation-stop-core", # SRP: reusable stop criteria/check core
   "crates/bitnet-kv-cache-policy-core", # SRP: KV-cache sequence transition decision policy
+  "crates/bitnet-engine-state-core", # SRP: reusable engine lifecycle state machine core
   "crates/bitnet-engine-core",   # SRP: orchestration contracts (traits, session types)
   "crates/bitnet-repl-core",     # SRP: reusable chat REPL state/command primitives
   "crates/bitnet-gguf",          # SRP: lightweight GGUF file format types & header parser

--- a/crates/bitnet-engine-core/Cargo.toml
+++ b/crates/bitnet-engine-core/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-generation = { path = "../bitnet-generation", version = "0.2.1-dev" }
+bitnet-engine-state-core = { path = "../bitnet-engine-state-core", version = "0.2.1-dev" }
 anyhow.workspace = true
 serde.workspace = true
 

--- a/crates/bitnet-engine-core/src/lib.rs
+++ b/crates/bitnet-engine-core/src/lib.rs
@@ -4,6 +4,7 @@
 //! session must do, without prescribing _how_ it does it.  Concrete
 //! implementations live in `bitnet-inference`.
 
+pub use bitnet_engine_state_core::{EngineState, EngineStateError, EngineStateTracker};
 pub use bitnet_generation::{
     GenerationConfig, GenerationStats, StopCriteria, StopReason, StreamEvent, TokenEvent,
 };
@@ -266,110 +267,6 @@ impl SessionId {
 }
 
 // ---------------------------------------------------------------------------
-// Engine state machine
-// ---------------------------------------------------------------------------
-
-/// States an inference engine can be in.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum EngineState {
-    /// Engine is initialised and waiting for work.
-    Idle,
-    /// Engine is actively generating tokens.
-    Running,
-    /// Engine has finished generating and is ready to be discarded.
-    Done,
-}
-
-/// Error produced by invalid [`EngineStateTracker`] transitions.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EngineStateError(pub String);
-
-impl std::fmt::Display for EngineStateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for EngineStateError {}
-
-/// Tracks and enforces valid state transitions for an inference engine.
-///
-/// Valid transitions:
-/// - [`EngineState::Idle`] → [`EngineState::Running`]  via [`start`](Self::start)
-/// - [`EngineState::Running`] → [`EngineState::Done`]  via [`finish`](Self::finish)
-///
-/// All other transitions return [`EngineStateError`].
-///
-/// # Examples
-///
-/// ```
-/// use bitnet_engine_core::{EngineStateTracker, EngineState};
-///
-/// let mut tracker = EngineStateTracker::new();
-/// assert_eq!(tracker.state(), &EngineState::Idle);
-///
-/// tracker.start().unwrap();
-/// assert_eq!(tracker.state(), &EngineState::Running);
-///
-/// tracker.finish().unwrap();
-/// assert_eq!(tracker.state(), &EngineState::Done);
-///
-/// // Invalid transition returns an error.
-/// let err = tracker.finish().unwrap_err();
-/// assert!(!err.to_string().is_empty());
-/// ```
-#[derive(Debug)]
-pub struct EngineStateTracker {
-    state: EngineState,
-}
-
-impl Default for EngineStateTracker {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl EngineStateTracker {
-    /// Create a new tracker in the [`EngineState::Idle`] state.
-    pub const fn new() -> Self {
-        Self { state: EngineState::Idle }
-    }
-
-    /// Return a reference to the current state.
-    pub const fn state(&self) -> &EngineState {
-        &self.state
-    }
-
-    /// Transition `Idle → Running`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`EngineStateError`] if the current state is not [`EngineState::Idle`].
-    pub fn start(&mut self) -> std::result::Result<(), EngineStateError> {
-        if self.state == EngineState::Idle {
-            self.state = EngineState::Running;
-            Ok(())
-        } else {
-            Err(EngineStateError(format!("cannot transition to Running from {:?}", self.state)))
-        }
-    }
-
-    /// Transition `Running → Done`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`EngineStateError`] if the current state is not [`EngineState::Running`].
-    pub fn finish(&mut self) -> std::result::Result<(), EngineStateError> {
-        if self.state == EngineState::Running {
-            self.state = EngineState::Done;
-            Ok(())
-        } else {
-            Err(EngineStateError(format!("cannot transition to Done from {:?}", self.state)))
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Concurrency configuration
 // ---------------------------------------------------------------------------
 
@@ -447,6 +344,14 @@ mod tests {
     fn generation_config_re_exported() {
         let cfg = GenerationConfig::default();
         assert_eq!(cfg.max_new_tokens, 128);
+    }
+
+    #[test]
+    fn engine_state_tracker_re_exported() {
+        let mut tracker = EngineStateTracker::new();
+        assert_eq!(tracker.state(), &EngineState::Idle);
+        tracker.start().expect("idle -> running");
+        assert_eq!(tracker.state(), &EngineState::Running);
     }
 
     #[test]

--- a/crates/bitnet-engine-state-core/Cargo.toml
+++ b/crates/bitnet-engine-state-core/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bitnet-engine-state-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for inference engine state machine transitions"
+rust-version.workspace = true
+
+[dependencies]
+serde.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-engine-state-core/src/lib.rs
+++ b/crates/bitnet-engine-state-core/src/lib.rs
@@ -1,0 +1,129 @@
+//! Engine state machine core.
+//!
+//! This microcrate isolates state transition contracts for inference engines,
+//! keeping transition logic reusable across runtimes and orchestration layers.
+
+use serde::{Deserialize, Serialize};
+
+/// States an inference engine can be in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum EngineState {
+    /// Engine is initialised and waiting for work.
+    Idle,
+    /// Engine is actively generating tokens.
+    Running,
+    /// Engine has finished generating and is ready to be discarded.
+    Done,
+}
+
+/// Error produced by invalid [`EngineStateTracker`] transitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EngineStateError(pub String);
+
+impl std::fmt::Display for EngineStateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for EngineStateError {}
+
+/// Tracks and enforces valid state transitions for an inference engine.
+///
+/// Valid transitions:
+/// - [`EngineState::Idle`] → [`EngineState::Running`] via [`start`](Self::start)
+/// - [`EngineState::Running`] → [`EngineState::Done`] via [`finish`](Self::finish)
+#[derive(Debug)]
+pub struct EngineStateTracker {
+    state: EngineState,
+}
+
+impl Default for EngineStateTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EngineStateTracker {
+    /// Create a new tracker in the [`EngineState::Idle`] state.
+    pub const fn new() -> Self {
+        Self { state: EngineState::Idle }
+    }
+
+    /// Return a reference to the current state.
+    pub const fn state(&self) -> &EngineState {
+        &self.state
+    }
+
+    /// Transition `Idle → Running`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineStateError`] if the current state is not [`EngineState::Idle`].
+    pub fn start(&mut self) -> Result<(), EngineStateError> {
+        if self.state == EngineState::Idle {
+            self.state = EngineState::Running;
+            Ok(())
+        } else {
+            Err(EngineStateError(format!("cannot transition to Running from {:?}", self.state)))
+        }
+    }
+
+    /// Transition `Running → Done`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineStateError`] if the current state is not [`EngineState::Running`].
+    pub fn finish(&mut self) -> Result<(), EngineStateError> {
+        if self.state == EngineState::Running {
+            self.state = EngineState::Done;
+            Ok(())
+        } else {
+            Err(EngineStateError(format!("cannot transition to Done from {:?}", self.state)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracker_starts_idle() {
+        let tracker = EngineStateTracker::new();
+        assert_eq!(tracker.state(), &EngineState::Idle);
+    }
+
+    #[test]
+    fn valid_transition_sequence() {
+        let mut tracker = EngineStateTracker::new();
+        tracker.start().expect("idle -> running should work");
+        assert_eq!(tracker.state(), &EngineState::Running);
+        tracker.finish().expect("running -> done should work");
+        assert_eq!(tracker.state(), &EngineState::Done);
+    }
+
+    #[test]
+    fn invalid_transition_reports_error() {
+        let mut tracker = EngineStateTracker::new();
+        let err = tracker.finish().expect_err("idle -> done should fail");
+        assert!(err.0.contains("Done"));
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn only_idle_can_start(started in proptest::bool::ANY) {
+            let mut tracker = EngineStateTracker::new();
+            if started {
+                tracker.start().expect("first start should work");
+            }
+
+            let result = tracker.start();
+            if started {
+                proptest::prop_assert!(result.is_err());
+            } else {
+                proptest::prop_assert!(result.is_ok());
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Isolate engine lifecycle transition logic into a small SRP microcrate so the state machine can be reused without pulling in broader orchestration contracts.
- Reduce duplication and keep `bitnet-engine-core` focused on orchestration contracts while preserving its public API surface.

### Description
- Added a new microcrate `crates/bitnet-engine-state-core` containing `EngineState`, `EngineStateError`, and `EngineStateTracker` with unit and proptest coverage, and a focused `Cargo.toml` for the crate.
- Removed the state-machine implementation from `crates/bitnet-engine-core` and added a dependency on `bitnet-engine-state-core` via `Cargo.toml`.
- Re-exported `EngineState`, `EngineStateError`, and `EngineStateTracker` from `bitnet-engine-core` using `pub use bitnet_engine_state_core::{...}` so existing consumers keep the same API.
- Added a small re-export test in `bitnet-engine-core` to ensure the extracted types remain accessible through the original crate.

### Testing
- Ran `cargo fmt --all` to apply formatting; it completed successfully.
- Ran `cargo test -p bitnet-engine-state-core -p bitnet-engine-core` and all unit/property tests for both crates passed.
- Ran `cargo test -p bitnet-engine-core --lib -p bitnet-engine-state-core` (library tests + state-core) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e58611b483339e688677d548af2e)