### PR TITLE
Extract client IP header parsing into bitnet-client-ip-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-client-ip-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-common"
 version = "0.2.1-dev"
 dependencies = [
@@ -1379,6 +1383,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "bitnet-client-ip-core",
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
   "crates/bitnet-probability",  # SRP: probability normalization and categorical sampling primitives
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
+  "crates/bitnet-client-ip-core", # SRP: reusable client IP extraction from forwarding headers
   "crates/bitnet-server-health-types-core", # SRP: reusable server health endpoint contract types
   "crates/bitnet-request-context-core", # SRP: reusable request context metadata contracts
   "crates/bitnet-server",

--- a/crates/bitnet-client-ip-core/Cargo.toml
+++ b/crates/bitnet-client-ip-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-client-ip-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Reusable client IP header parsing helpers for server middleware"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-client-ip-core/src/lib.rs
+++ b/crates/bitnet-client-ip-core/src/lib.rs
@@ -1,0 +1,53 @@
+//! Reusable client IP extraction helpers.
+
+use std::net::IpAddr;
+
+/// Extract the client IP address from canonical forwarding headers.
+///
+/// `x_forwarded_for` takes precedence over `x_real_ip`.
+#[must_use]
+pub fn extract_client_ip(x_forwarded_for: Option<&str>, x_real_ip: Option<&str>) -> Option<IpAddr> {
+    x_forwarded_for.and_then(parse_x_forwarded_for).or_else(|| x_real_ip.and_then(parse_ip))
+}
+
+/// Parse an `X-Forwarded-For` header value and return the first valid IP if present.
+#[must_use]
+pub fn parse_x_forwarded_for(value: &str) -> Option<IpAddr> {
+    value.split(',').next().and_then(parse_ip)
+}
+
+/// Parse a single IP value, trimming surrounding whitespace.
+#[must_use]
+pub fn parse_ip(value: &str) -> Option<IpAddr> {
+    value.trim().parse::<IpAddr>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn x_forwarded_for_takes_precedence() {
+        let ip = extract_client_ip(Some("203.0.113.42, 10.0.0.1"), Some("192.0.2.15"));
+        assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 42))));
+    }
+
+    #[test]
+    fn fallback_to_x_real_ip() {
+        let ip = extract_client_ip(None, Some("192.0.2.15"));
+        assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 15))));
+    }
+
+    #[test]
+    fn parses_ipv6_and_whitespace() {
+        let ip = extract_client_ip(Some(" 2001:db8::1 "), None);
+        assert_eq!(ip, Some(IpAddr::V6(Ipv6Addr::from(0x20010db8000000000000000000000001_u128))));
+    }
+
+    #[test]
+    fn invalid_values_return_none() {
+        assert_eq!(extract_client_ip(Some("not-an-ip"), None), None);
+        assert_eq!(extract_client_ip(None, Some("bad")), None);
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -32,6 +32,7 @@ bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 bitnet-request-context-core = { path = "../bitnet-request-context-core", version = "0.2.1-dev" }
 bitnet-server-health-types-core = { path = "../bitnet-server-health-types-core", version = "0.2.1-dev" }
+bitnet-client-ip-core = { path = "../bitnet-client-ip-core", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true
 clap.workspace = true

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -7,6 +7,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use bitnet_client_ip_core::extract_client_ip as extract_client_ip_core;
 use bitnet_http_auth_core::bearer_token;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -348,25 +349,10 @@ fn extract_client_ip(request: &Request) -> Option<IpAddr> {
 
 /// Extract client IP from headers (shared utility)
 pub fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
-    // Try X-Forwarded-For header first (for reverse proxies)
-    if let Some(forwarded) = headers.get("x-forwarded-for")
-        && let Ok(forwarded_str) = forwarded.to_str()
-        && let Some(first_ip) = forwarded_str.split(',').next()
-        && let Ok(ip) = first_ip.trim().parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
+    let x_forwarded_for = headers.get("x-forwarded-for").and_then(|value| value.to_str().ok());
+    let x_real_ip = headers.get("x-real-ip").and_then(|value| value.to_str().ok());
 
-    // Try X-Real-IP header
-    if let Some(real_ip) = headers.get("x-real-ip")
-        && let Ok(ip_str) = real_ip.to_str()
-        && let Ok(ip) = ip_str.parse::<IpAddr>()
-    {
-        return Some(ip);
-    }
-
-    // Fall back to connection info (would need to be passed from the server)
-    None
+    extract_client_ip_core(x_forwarded_for, x_real_ip)
 }
 
 /// CORS middleware configuration


### PR DESCRIPTION
### Motivation

- Isolate and centralize client IP extraction from forwarding headers into a single-responsibility microcrate to reduce duplicated parsing logic and make header-parsing behavior easier to test and reuse across server components.

### Description

- Added a new microcrate `crates/bitnet-client-ip-core` that exposes `extract_client_ip`, `parse_x_forwarded_for`, and `parse_ip` along with focused unit tests for IPv4/IPv6/invalid inputs.
- Registered the new crate in the workspace `Cargo.toml` and added a dependency on it from `crates/bitnet-server/Cargo.toml` so the server can reuse the logic.
- Replaced inline header parsing in `crates/bitnet-server/src/security.rs` with a delegation to `bitnet_client_ip_core::extract_client_ip`, preserving the original `X-Forwarded-For` precedence semantics.
- Ran `cargo fmt --all` and updated the `Cargo.lock` to reflect the workspace changes.

### Testing

- Ran `cargo test -p bitnet-client-ip-core` and all unit tests passed (4 passed, 0 failed).
- Ran `cargo test -p bitnet-server --test server_security_tests test_extract_ip_from_x_forwarded_for` and the targeted test passed (1 passed, 0 failed).
- Executed `cargo fmt --all` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e58611b483339e688677d548af2e)