### PR TITLE
Extract shared Bearer parsing into new bitnet-http-auth-core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,6 +830,7 @@ dependencies = [
 name = "bitnet-gpu-hal"
 version = "0.2.1-dev"
 dependencies = [
+ "bitnet-http-auth-core",
  "insta",
  "log",
  "proptest",
@@ -847,6 +848,10 @@ dependencies = [
  "insta",
  "proptest",
 ]
+
+[[package]]
+name = "bitnet-http-auth-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-http-retry"
@@ -1352,6 +1357,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-device-config-core",
  "bitnet-eval-core",
+ "bitnet-http-auth-core",
  "bitnet-inference",
  "bitnet-kernels",
  "bitnet-models",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
+  "crates/bitnet-http-auth-core", # SRP: reusable Authorization Bearer parsing helpers
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-nvidia",        # SRP: NVIDIA-specific tuning heuristics
   "crates/bitnet-opencl",        # OpenCL backend for Intel Arc GPU inference

--- a/crates/bitnet-gpu-hal/Cargo.toml
+++ b/crates/bitnet-gpu-hal/Cargo.toml
@@ -12,6 +12,7 @@ description = "GPU hardware abstraction layer for BitNet inference"
 rust-version.workspace = true
 
 [dependencies]
+bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
 tokio = { workspace = true }
 log.workspace = true
 serde = { workspace = true }

--- a/crates/bitnet-gpu-hal/src/api_gateway.rs
+++ b/crates/bitnet-gpu-hal/src/api_gateway.rs
@@ -8,6 +8,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+use bitnet_http_auth_core::strip_bearer_prefix;
+
 // ── Configuration ───────────────────────────────────────────────────────────
 
 /// Top-level gateway configuration.
@@ -897,7 +899,7 @@ fn generate_api_key() -> String {
 
 /// Strip `"Bearer "` prefix from a header value.
 fn strip_bearer(val: &str) -> String {
-    val.strip_prefix("Bearer ").unwrap_or(val).to_string()
+    strip_bearer_prefix(val).to_string()
 }
 
 // ── Minimal JSON helper (no serde dependency) ───────────────────────────────

--- a/crates/bitnet-http-auth-core/Cargo.toml
+++ b/crates/bitnet-http-auth-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-http-auth-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for HTTP Authorization Bearer token parsing"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-http-auth-core/src/lib.rs
+++ b/crates/bitnet-http-auth-core/src/lib.rs
@@ -1,0 +1,38 @@
+//! SRP helpers for HTTP Authorization Bearer-token parsing.
+
+/// Returns the bearer token when the header is in the `Bearer <token>` format.
+#[must_use]
+pub fn bearer_token(header_value: &str) -> Option<&str> {
+    header_value.strip_prefix("Bearer ").filter(|token| !token.is_empty())
+}
+
+/// Strips a `Bearer ` prefix when present, otherwise returns the original value.
+#[must_use]
+pub fn strip_bearer_prefix(value: &str) -> &str {
+    bearer_token(value).unwrap_or(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bearer_token_parses_prefixed_value() {
+        assert_eq!(bearer_token("Bearer abc123"), Some("abc123"));
+    }
+
+    #[test]
+    fn bearer_token_rejects_other_schemes() {
+        assert_eq!(bearer_token("Token abc123"), None);
+    }
+
+    #[test]
+    fn bearer_token_rejects_empty_token() {
+        assert_eq!(bearer_token("Bearer "), None);
+    }
+
+    #[test]
+    fn strip_bearer_prefix_leaves_unprefixed_value() {
+        assert_eq!(strip_bearer_prefix("abc123"), "abc123");
+    }
+}

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -24,6 +24,7 @@ axum.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-device-config-core = { path = "../bitnet-device-config-core", version = "0.2.1-dev" }
 bitnet-eval-core = { path = "../bitnet-eval-core", version = "0.2.1-dev" }
+bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-server/src/auth.rs
+++ b/crates/bitnet-server/src/auth.rs
@@ -3,6 +3,7 @@
 //! Validate Bearer tokens and API keys from request headers.
 //! Supports multiple keys, key rotation, and usage tracking.
 
+use bitnet_http_auth_core::bearer_token;
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -156,7 +157,7 @@ impl KeyStore {
 
     /// Extract bearer token from Authorization header value.
     pub fn extract_bearer(header_value: &str) -> Option<&str> {
-        header_value.strip_prefix("Bearer ")
+        bearer_token(header_value)
     }
 
     /// Get usage stats.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -7,6 +7,7 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use bitnet_http_auth_core::bearer_token;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::net::IpAddr;
@@ -285,12 +286,7 @@ pub async fn auth_middleware(
         .and_then(|h| h.to_str().ok())
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    // Check if it's a Bearer token
-    if !auth_header.starts_with("Bearer ") {
-        return Err(StatusCode::UNAUTHORIZED);
-    }
-
-    let token = &auth_header[7..]; // Remove "Bearer " prefix
+    let token = bearer_token(auth_header).ok_or(StatusCode::UNAUTHORIZED)?;
 
     // Validate JWT token
     if let Some(jwt_secret) = &auth_state.jwt_secret {


### PR DESCRIPTION
### Motivation
- Consolidate duplicated HTTP Authorization Bearer parsing into a single SRP microcrate to reduce code duplication and improve reuse across runtime crates.
- Provide a focused, well-tested API surface for small but commonly used auth helpers so other crates can rely on a stable, shrinking-scope contract.

### Description
- Add a new microcrate `crates/bitnet-http-auth-core` exporting `bearer_token` and `strip_bearer_prefix` and accompanying unit tests for accepted/rejected header formats.
- Register the new crate in the workspace `Cargo.toml` and add it as a dependency of `crates/bitnet-server` and `crates/bitnet-gpu-hal` so both consume the shared implementation.
- Replace inline Bearer parsing logic calls in `crates/bitnet-server/src/auth.rs` and `crates/bitnet-server/src/security.rs` with `bitnet_http_auth_core::bearer_token` and switch `crates/bitnet-gpu-hal/src/api_gateway.rs` to use `strip_bearer_prefix`.

### Testing
- Ran formatting with `cargo fmt` (completed successfully).
- Ran unit tests for the new microcrate with `cargo test -p bitnet-http-auth-core` and all tests passed.
- Ran targeted tests in dependent crates with `cargo test -p bitnet-server test_extract_bearer -- --nocapture` and `cargo test -p bitnet-gpu-hal test_strip_bearer -- --nocapture`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7e587eb648333a0409cfc86eeeec6)