### PR TITLE
docs: README feature flags reality pass [Kaby Lake]

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,10 @@ nix develop && nix build .#bitnet-cli && nix flake check
 | `cuda` | CUDA acceleration (preferred; requires CUDA 12.x); backward-compat alias for `gpu` |
 | `metal` | Metal GPU backend (macOS/iOS Apple Silicon) |
 | `vulkan` | Vulkan compute backend (cross-platform) |
-| `oneapi` | Intel oneAPI (sub-crate feature in `bitnet-kernels`; use `opencl` for root-level Intel GPU) |
 | `ffi` | C++ FFI bridge for cross-validation |
 | `fixtures` | GGUF fixture-based integration tests (test-only) |
 | `full-cli` | Enable all CLI subcommands |
-| `rocm` | AMD ROCm detection (device probe; inference kernels not yet validated) |
+| `rocm` | AMD ROCm/HIP inference backend (experimental; kernels not yet validated end-to-end) |
 | `npu` | NPU detection via `bitnet-device-probe` |
 | `opencl` | Intel Arc OpenCL backend (experimental; `bitnet-opencl` crate) |
 


### PR DESCRIPTION
## Summary

Docs reality pass: verified README.md feature flag table against root \Cargo.toml [features]\.

### Changes

1. **Removed \oneapi\ from root feature table**  \oneapi\ only exists as a sub-crate feature (in \itnet-kernels\, \itnet-inference\, etc.), not in the root \Cargo.toml\. Users running \--features oneapi\ at root would get a compile error. The \opencl\ entry already covers Intel GPU at the root level.

2. **Fixed \ocm\ description**  Was described as \AMD ROCm detection (device probe)\ but the actual feature enables full inference pipeline (\kernels\, \inference\, \	okenizers\, \itnet-kernels/rocm\, \itnet-inference/rocm\, \itnet-quantization/rocm\). Updated to \AMD ROCm/HIP inference backend (experimental; kernels not yet validated end-to-end)\.

### Verified correct (no changes needed)

- MSRV badge (1.92.0) matches \ust-toolchain.toml\
- Edition badge (2024) matches \Cargo.toml\
- All 10 remaining features in the table exist in root \Cargo.toml\
- All build command examples use correct \--no-default-features --features\ syntax
- GPU Multi-Backend table feature flags all match root features