### PR TITLE
docs: update ignored test count (~1,050  ~2,800)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,10 +94,11 @@ fn test_qk256_full_model_inference() { ... }
 ```
 
 ### TDD scaffolding
-~1070 `#[ignore]` tests across the workspace (all with justification strings) represent
-intentional scaffolding, not bugs. ~112 in core crates, ~129 in the integration test
-crate, ~652 in xtask, ~173 in crossval. Categories: real-model tests, CUDA tests, slow
-mock-inference tests, crossval tests, and TDD scaffolds for unimplemented features.
+~2,800 `#[ignore]` tests across the workspace (all with justification strings) represent
+intentional scaffolding, not bugs. ~1,900 in crates (mostly bitnet-kernels), ~44 in the
+integration test crate, ~665 in xtask, ~164 in crossval. Categories: real-model tests,
+CUDA tests, slow mock-inference tests, crossval tests, and TDD scaffolds for unimplemented
+features.
 
 ### Rate-limited logging
 Use `warn_once!` from `bitnet_common` for hot-path warnings that would otherwise spam logs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Essential guidance for working with the bitnet-rs neural network inference codeb
   output in some configurations. This is a known model quality issue, not an
   inference bug.
 
-- **Test Scaffolding**: ~1,050+ tests skipped in full `--workspace` runs (TDD scaffolds, resource-gated, slow, CUDA, crossval, and network-dependent tests), all with `#[ignore = "..."]` justification
+- **Test Scaffolding**: ~2,800+ tests skipped in full `--workspace` runs (TDD scaffolds, resource-gated, slow, CUDA, crossval, and network-dependent tests), all with `#[ignore = "..."]` justification
 
 ## Quick Reference
 
@@ -901,7 +901,7 @@ bitnet-rs maintains a healthy test suite. All `#[ignore]` attributes include a
 justification string (enforced by pre-commit hooks):
 
 - Run `cargo nextest run --workspace --no-default-features --features cpu` for current counts.
-- **~1,050+ tests skipped** at last count — all with `#[ignore = "reason"]` justification
+- **~2,800+ tests skipped** at last count — all with `#[ignore = "reason"]` justification
 - All enabled tests pass in a normal `cargo nextest run --workspace --no-default-features --features cpu` run
 - **Zero bare `#[ignore]`** attributes (no un-reasoned skips)
 
@@ -1179,7 +1179,7 @@ cargo test -p bitnet-models --no-default-features --features cpu
 **Current State**:
 
 - Run `cargo nextest run --workspace --no-default-features --features cpu` for current pass counts
-- ~1,050+ tests intentionally skipped at last count; all have `#[ignore = "reason"]` justification strings
+- ~2,800+ tests intentionally skipped at last count; all have `#[ignore = "reason"]` justification strings
 - Categories: real-model tests, CUDA tests, slow tests, crossval tests, TDD scaffolds, network-dependent tests
 - Complete test infrastructure: fixtures, receipts, strict mode, environment isolation, snapshot tests, property tests, fuzz
 
@@ -1213,7 +1213,7 @@ cargo build --no-default-features --features cpu
 - **Use xtask for operations**: `cargo run -p xtask --` instead of scripts
 - **Check compatibility**: Review `COMPATIBILITY.md` before API changes
 - **Never modify GGUF in-place**: Use `bitnet-compat export-fixed` for new files
-- **Expect test scaffolding for unimplemented features**: ~1,050+ tests skipped across the workspace (TDD scaffolds, resource-gated, slow, CUDA, crossval, network-dependent); all have justification strings
+- **Expect test scaffolding for unimplemented features**: ~2,800+ tests skipped across the workspace (TDD scaffolds, resource-gated, slow, CUDA, crossval, network-dependent); all have justification strings
 - **unimplemented!() in tests is not a bug**: It's TDD scaffolding for planned features
 - **Use `#[serial(bitnet_env)]` for env-mutating tests**: Prevents race conditions in parallel execution
 - **Check `#[ignore = "..."]` justification before investigating**: The reason tells you exactly what's needed to unblock


### PR DESCRIPTION
## Summary

Update stale test scaffolding count in CLAUDE.md and .github/copilot-instructions.md.

### What changed
- Updated all 4 occurrences of ~1,050+ to ~2,800+ in CLAUDE.md
- Updated TDD scaffolding section in .github/copilot-instructions.md with accurate per-directory breakdown

### Actual counts (verified via grep)

| Directory | #[ignore] count |
|-----------|----------------|
| crates/ | 1,943 (bitnet-kernels: 1,891) |
| tests/ | 44 |
| xtask/ | 665 |
| crossval/ | 164 |
| **Total** | **2,817** |

### Agent receipt
- **What changed**: 5 text replacements across 2 files (CLAUDE.md, .github/copilot-instructions.md)
- **What I ran locally**: \Select-String '#\[ignore' *.rs\ recursive count across all directories
- **CI relied on**: docs-only change; CI Core for gate
- **Docs touched**: CLAUDE.md test scaffolding count (lines 59, 904, 1182, 1216); copilot-instructions.md TDD scaffolding section (lines 97-100)
- **Risks**: None; docs-only change
- **Triage class**: A (merge now)