### PR TITLE
fix(inference): resolve 8 pre-existing clippy warnings [CPU]

### DIFF
--- a/crates/bitnet-inference/src/cache_eviction.rs
+++ b/crates/bitnet-inference/src/cache_eviction.rs
@@ -82,6 +82,10 @@ impl LruTracker {
         self.order.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.order.is_empty()
+    }
+
     pub fn is_full(&self) -> bool {
         self.order.len() >= self.max_size
     }

--- a/crates/bitnet-inference/src/inference_metrics.rs
+++ b/crates/bitnet-inference/src/inference_metrics.rs
@@ -216,7 +216,7 @@ mod tests {
         }
         let p50 = m.percentile_first_token_ms(50.0);
         // Median of [10,20,..,100] → 50 or 60 depending on rounding
-        assert!(p50 >= 50.0 && p50 <= 60.0);
+        assert!((50.0..=60.0).contains(&p50));
     }
 
     #[test]
@@ -227,8 +227,8 @@ mod tests {
         }
         let p95 = m.percentile_first_token_ms(95.0);
         let p99 = m.percentile_first_token_ms(99.0);
-        assert!(p95 >= 94.0 && p95 <= 96.0);
-        assert!(p99 >= 98.0 && p99 <= 100.0);
+        assert!((94.0..=96.0).contains(&p95));
+        assert!((98.0..=100.0).contains(&p99));
     }
 
     #[test]

--- a/crates/bitnet-inference/src/prompt_formatter.rs
+++ b/crates/bitnet-inference/src/prompt_formatter.rs
@@ -134,9 +134,7 @@ pub fn detect_template(model_name: &str) -> TemplateFormat {
         TemplateFormat::Phi
     } else if lower.contains("llama-3") || lower.contains("llama3") {
         TemplateFormat::Llama3
-    } else if lower.contains("qwen") || lower.contains("chatml") {
-        TemplateFormat::ChatMl
-    } else if lower.contains("bitnet") {
+    } else if lower.contains("qwen") || lower.contains("chatml") || lower.contains("bitnet") {
         TemplateFormat::ChatMl
     } else {
         TemplateFormat::SimpleInstruct
@@ -146,7 +144,7 @@ pub fn detect_template(model_name: &str) -> TemplateFormat {
 /// Count tokens approximately (word-based estimate).
 pub fn estimate_token_count(text: &str) -> usize {
     // Rough estimate: ~4 chars per token
-    (text.len() + 3) / 4
+    text.len().div_ceil(4)
 }
 
 #[cfg(test)]

--- a/crates/bitnet-inference/tests/proptest_wave30_inference.rs
+++ b/crates/bitnet-inference/tests/proptest_wave30_inference.rs
@@ -472,13 +472,13 @@ proptest! {
     #[test]
     fn argmax_within_bounds(logits in finite_f32_vec(1, 200)) {
         let idx = argmax(&logits);
-        prop_assert!((idx as usize) < logits.len());
+        prop_assert!(idx < logits.len());
     }
 
     /// argmax picks the actual maximum value.
     #[test]
     fn argmax_picks_max(logits in finite_f32_vec(1, 200)) {
-        let idx = argmax(&logits) as usize;
+        let idx = argmax(&logits);
         let max_val = logits.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
         prop_assert!((logits[idx] - max_val).abs() < f32::EPSILON);
     }

--- a/crates/bitnet-inference/tests/snapshot_wave28.rs
+++ b/crates/bitnet-inference/tests/snapshot_wave28.rs
@@ -57,6 +57,7 @@ fn snapshot_generation_config_default() {
 }
 
 #[test]
+#[allow(clippy::field_reassign_with_default)]
 fn snapshot_generation_config_custom() {
     let mut cfg = GenerationConfig::default();
     cfg.max_new_tokens = 128;


### PR DESCRIPTION
Fix 8 pre-existing clippy warnings in bitnet-inference. Unblocks PRs failing on Build full clippy.