### PR TITLE
🎨 Palette: Add tooltips explaining disabled button states

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -271,7 +271,7 @@
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled>Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Please load a model first">Generate Text</button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -297,7 +297,7 @@
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
                     <label style="margin-bottom: 0;">Output:</label>
-                    <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
+                    <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard" title="No text to copy">Copy</button>
                 </div>
                 <div id="output" class="output">Generated text will appear here...</div>
             </div>
@@ -315,8 +315,8 @@
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()">Start Streaming</button>
-                <button id="stop-streaming" onclick="stopStreaming()" disabled>Stop Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Please load a model first">Start Streaming</button>
+                <button id="stop-streaming" onclick="stopStreaming()" disabled title="Not streaming">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
 
@@ -354,8 +354,8 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled>Generate in Worker</button>
-                <button id="terminate-worker" onclick="terminateWorker()" disabled>Terminate Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Please initialize the worker first">Generate in Worker</button>
+                <button id="terminate-worker" onclick="terminateWorker()" disabled title="Please initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">

--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -133,14 +133,20 @@ async function loadModel() {
         // Update UI
         document.getElementById('model-size').textContent = MemoryUtils.format_bytes(file.size);
         document.getElementById('memory-usage').textContent = MemoryUtils.format_bytes(model.get_memory_usage());
-        document.getElementById('generate').disabled = false;
-        document.getElementById('start-streaming').disabled = false;
+        const generateBtn = document.getElementById('generate');
+        generateBtn.disabled = false;
+        generateBtn.removeAttribute('title');
+
+        const startStreamingBtn = document.getElementById('start-streaming');
+        startStreamingBtn.disabled = false;
+        startStreamingBtn.removeAttribute('title');
 
         // Reset copy button
         const copyBtn = document.getElementById('copy-output');
         copyBtn.disabled = true;
         copyBtn.style.backgroundColor = '#6c757d';
         copyBtn.style.cursor = 'not-allowed';
+        copyBtn.title = "No text to copy";
 
         updateStatus('Model loaded successfully!', 'success');
         Logger.info('Model loaded and inference engine initialized');
@@ -200,6 +206,7 @@ async function generateText() {
         // Enable copy button
         const copyBtn = document.getElementById('copy-output');
         copyBtn.disabled = false;
+        copyBtn.removeAttribute('title');
         copyBtn.style.backgroundColor = '#007bff';
         copyBtn.style.cursor = 'pointer';
 
@@ -233,8 +240,10 @@ async function startStreaming() {
     streamingActive = true;
     const originalText = startButton.textContent;
     startButton.disabled = true;
+    startButton.title = 'Streaming in progress...';
     startButton.textContent = 'Generating...';
     stopButton.disabled = false;
+    stopButton.removeAttribute('title');
 
     try {
         const outputEl = document.getElementById('streaming-output');
@@ -285,16 +294,22 @@ async function startStreaming() {
     } finally {
         streamingActive = false;
         startButton.disabled = false;
+        startButton.removeAttribute('title');
         startButton.textContent = originalText;
         stopButton.disabled = true;
+        stopButton.title = 'Not streaming';
     }
 }
 
 // Stop streaming
 function stopStreaming() {
     streamingActive = false;
-    document.getElementById('start-streaming').disabled = false;
-    document.getElementById('stop-streaming').disabled = true;
+    const startButton = document.getElementById('start-streaming');
+    startButton.disabled = false;
+    startButton.removeAttribute('title');
+    const stopButton = document.getElementById('stop-streaming');
+    stopButton.disabled = true;
+    stopButton.title = 'Not streaming';
     updateStatus('Streaming stopped', 'success');
 }
 
@@ -318,8 +333,12 @@ function initWorker() {
                 case 'initialized':
                     document.getElementById('worker-indicator').classList.add('active');
                     document.getElementById('worker-status-text').textContent = 'Worker initialized';
-                    document.getElementById('worker-generate').disabled = false;
-                    document.getElementById('terminate-worker').disabled = false;
+                    const workerGenerateBtn = document.getElementById('worker-generate');
+                    workerGenerateBtn.disabled = false;
+                    workerGenerateBtn.removeAttribute('title');
+                    const terminateWorkerBtn = document.getElementById('terminate-worker');
+                    terminateWorkerBtn.disabled = false;
+                    terminateWorkerBtn.removeAttribute('title');
                     Logger.info('Web Worker initialized successfully');
                     break;
 
@@ -378,8 +397,12 @@ function terminateWorker() {
 
         document.getElementById('worker-indicator').classList.remove('active');
         document.getElementById('worker-status-text').textContent = 'Worker terminated';
-        document.getElementById('worker-generate').disabled = true;
-        document.getElementById('terminate-worker').disabled = true;
+        const workerGenerateBtn = document.getElementById('worker-generate');
+        workerGenerateBtn.disabled = true;
+        workerGenerateBtn.title = "Please initialize the worker first";
+        const terminateWorkerBtn = document.getElementById('terminate-worker');
+        terminateWorkerBtn.disabled = true;
+        terminateWorkerBtn.title = "Please initialize the worker first";
 
         Logger.info('Web Worker terminated');
     }
@@ -612,6 +635,7 @@ function clearOutput() {
     // Reset copy button
     const copyBtn = document.getElementById('copy-output');
     copyBtn.disabled = true;
+    copyBtn.title = "No text to copy";
     copyBtn.style.backgroundColor = '#6c757d';
     copyBtn.style.cursor = 'not-allowed';
 }


### PR DESCRIPTION
💡 What: Added informative `title` tooltips to disabled action buttons (like `#generate`, `#start-streaming`, `#copy-output`, etc.) and dynamically toggled these tooltips in JavaScript when buttons are enabled or disabled. Also fixed the `#start-streaming` button to be initially disabled in HTML since a model must be loaded first.
🎯 Why: To improve usability by explaining to users exactly *why* a button is disabled (e.g., "Please load a model first", "No text to copy", "Worker not initialized"). This reduces user friction and confusion.
📸 Before/After: Disabled buttons previously provided no feedback on hover. Now they explicitly state the required prerequisite action.
♿ Accessibility: Improved cognitive accessibility by making system state and required actions explicit.

---
*PR created automatically by Jules for task [5226673697465030524](https://jules.google.com/task/5226673697465030524) started by @EffortlessSteven*