### PR TITLE
🛡️ Sentinel: [HIGH] Fix Path Truncation vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -14,6 +14,11 @@
 **Learning:** This restricts valid payloads coming from environments (like Windows) or protocols (like HTTP standard format) that use CRLF for newlines, leading to unintentional denial of service for these valid requests.
 **Prevention:** Explicitly allow `\r` alongside `\n` and `\t` when filtering out control characters in text payloads.
 
+## 2026-03-11 - [Path Truncation Vulnerability via Null Bytes]
+**Vulnerability:** The `validate_model_request` function in `bitnet-server`'s security validator checked that the model path ended with `.gguf` or `.safetensors`, and didn't contain `..` or `~`. However, it did not check for null bytes (`\0`). An attacker could provide a path like `/etc/passwd\0.gguf` which would pass the validation but be truncated by the OS file system operations, allowing arbitrary file reading.
+**Learning:** Checking file extensions or validating specific characters is insufficient if the string can contain null bytes, which cause path truncation when passed to underlying OS or C-level APIs.
+**Prevention:** Always explicitly check for and reject null bytes (`\0`) in any user-provided string that will be used as a file path or passed to a C API.
+
 ## 2025-06-03 - [TOCTOU in RateLimitBucket leads to bypass via integer underflow]
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -223,7 +223,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));

--- a/crates/bitnet-server/tests/server_security_tests.rs
+++ b/crates/bitnet-server/tests/server_security_tests.rs
@@ -429,6 +429,18 @@ fn test_content_filter_disabled_allows_blocked_keywords() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 #[test]
+fn test_model_path_null_byte_rejected() {
+    let v = validator(false, false);
+    assert!(
+        matches!(
+            v.validate_model_request("/models/llama\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(_))
+        ),
+        "null byte in model path must be rejected"
+    );
+}
+
+#[test]
 fn test_model_path_tilde_rejected() {
     let v = validator(false, false);
     assert!(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `validate_model_request` function in `bitnet-server`'s security validator checked that the model path ended with `.gguf` or `.safetensors` and didn't contain `..` or `~`, but did not check for null bytes (`\0`). An attacker could provide a path like `/etc/passwd\0.gguf` which would pass the validation but be truncated by underlying OS file system operations, allowing arbitrary file reading.
🎯 **Impact:** Path truncation could allow an attacker to bypass directory restrictions and file extension checks, potentially reading sensitive files from the server.
🔧 **Fix:** Added an explicit check to reject model paths containing null bytes (`\0`) in `validate_model_request`.
✅ **Verification:** Added `test_model_path_null_byte_rejected` unit test in `crates/bitnet-server/tests/server_security_tests.rs`. All tests pass successfully. Also documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1184413060407970432](https://jules.google.com/task/1184413060407970432) started by @EffortlessSteven*