### PR TITLE
⚡ Bolt: optimize logit filtering hot loops

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -76,7 +76,7 @@ pub fn apply_min_p(probs: &mut [f32], min_p: f32) {
     let max_prob = probs.iter().copied().fold(0.0f32, f32::max);
     let threshold = min_p * max_prob;
     for p in probs.iter_mut() {
-        if *p < threshold {
+        if *p > 0.0 && *p < threshold {
             *p = 0.0;
         }
     }
@@ -92,22 +92,28 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
+    let mut entropy = 0.0f32;
+    let mut non_zero_count = 0;
+
+    for &p in probs.iter() {
+        if p > 0.0 {
+            entropy += -p * p.ln();
+            non_zero_count += 1;
+        }
+    }
+
+    if non_zero_count == 0 {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
+    let mut deviations: Vec<(usize, f32, f32)> = Vec::with_capacity(non_zero_count);
+    for (i, &p) in probs.iter().enumerate() {
+        if p > 0.0 {
             let surprise = -p.ln();
             let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+            deviations.push((i, p, deviation));
+        }
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What:
1. In `apply_min_p`, added a check `> 0.0` before writing `0.0` to array elements, preventing redundant zeroing operations on elements that are already filtered or zero.
2. In `apply_typical`, removed the allocation of the intermediate `indexed` `Vec`. Entropy is calculated in a first pass and the `deviations` array is mapped and allocated iteratively in a single step using `Vec::with_capacity()`.

🎯 Why:
1. `apply_min_p` often runs after top-k or top-p, where the probability array is extremely sparse (most elements are `0.0`). Reassigning `0.0` to already zeroed elements causes unnecessary memory writes and cache invalidations in the hot loop of sampling.
2. Allocating a temporary `Vec` (especially in a hot path like `apply_typical` during generation) incurs significant overhead due to memory allocation inside the generation loop. Fusing these mathematical operations eliminates this latency.

📊 Impact:
- Zero intermediate allocations in the math section of `apply_typical`.
- Reduced cache writes in sparse distributions for `apply_min_p`.
- Marginal speedup in single token generation latency which scales across long generation sequences.

🔬 Measurement:
- `cargo test -p bitnet-logits-filters` passes and verified that the mathematical output is identical.
- `cargo clippy -p bitnet-logits-filters` passes with no warnings.

---
*PR created automatically by Jules for task [2888681730112824986](https://jules.google.com/task/2888681730112824986) started by @EffortlessSteven*