### PR TITLE
refactor(gpu-hal): wire bearer parsing through bitnet-http-auth-core

### DIFF
--- a/crates/bitnet-gpu-hal/src/api_server.rs
+++ b/crates/bitnet-gpu-hal/src/api_server.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, Instant};
 
+use bitnet_http_auth_core::bearer_token;
+
 // ---------------------------------------------------------------------------
 // ServerConfig
 // ---------------------------------------------------------------------------
@@ -547,7 +549,7 @@ impl AuthMiddleware {
 
     /// Parse a bearer token from an `Authorization` header value.
     pub fn parse_bearer(header: &str) -> Option<&str> {
-        header.strip_prefix("Bearer ")
+        bearer_token(header)
     }
 
     /// Authenticate from a raw `Authorization` header value.
@@ -1657,6 +1659,7 @@ mod tests {
     fn test_auth_parse_bearer() {
         assert_eq!(AuthMiddleware::parse_bearer("Bearer sk-abc"), Some("sk-abc"));
         assert_eq!(AuthMiddleware::parse_bearer("Token sk-abc"), None);
+        assert_eq!(AuthMiddleware::parse_bearer("Bearer "), None);
         assert_eq!(AuthMiddleware::parse_bearer(""), None);
     }
 


### PR DESCRIPTION
### Motivation
- Centralize HTTP Authorization `Bearer` parsing in the existing SRP microcrate to remove duplicated parsing logic and unify semantics across server surfaces.

### Description
- Replaced inline `strip_prefix("Bearer ")` logic in `crates/bitnet-gpu-hal/src/api_server.rs` with a call to `bitnet_http_auth_core::bearer_token` and imported that helper.
- Added a unit assertion in `bitnet-gpu-hal` tests to ensure empty bearer values (`"Bearer "`) are rejected consistently with the core parser.
- Change is limited to `crates/bitnet-gpu-hal/src/api_server.rs` and relies on the existing `bitnet-http-auth-core` microcrate contract.

### Testing
- Ran `cargo test -p bitnet-http-auth-core` and all tests passed.
- Ran `cargo test -p bitnet-gpu-hal test_auth_parse_bearer` and the targeted auth parsing test passed.
- Ran a full `cargo test -p bitnet-gpu-hal` which surfaced an unrelated existing failure (`checkpoint_manager::tests::test_manager_prune_keeps_newest`), indicating the change did not introduce the failing test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a921a22fb88333bcfa30ee51a916b8)