### PR TITLE
Extract MinimalJson into dedicated SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ version = "0.2.1-dev"
 dependencies = [
  "bitnet-http-auth-core",
  "bitnet-layer-index-core",
+ "bitnet-minimal-json-core",
  "bitnet-tokenizer-text-core",
  "insta",
  "log",
@@ -1067,6 +1068,10 @@ dependencies = [
 
 [[package]]
 name = "bitnet-metal"
+version = "0.2.1-dev"
+
+[[package]]
+name = "bitnet-minimal-json-core"
 version = "0.2.1-dev"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ members = [
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
+  "crates/bitnet-minimal-json-core", # SRP: minimal flat JSON object field extraction
   "crates/bitnet-http-auth-core", # SRP: reusable Authorization Bearer parsing helpers
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer
   "crates/bitnet-nvidia",        # SRP: NVIDIA-specific tuning heuristics
@@ -437,6 +438,7 @@ bitnet-quantization-bits = { path = "crates/bitnet-quantization-bits", version =
 bitnet-warn-once = { path = "crates/bitnet-warn-once", version = "0.2.1-dev" }
 bitnet-thread-config-core = { path = "crates/bitnet-thread-config-core", version = "0.2.1-dev" }
 bitnet-atomic-file-core = { path = "crates/bitnet-atomic-file-core", version = "0.2.1-dev" }
+bitnet-minimal-json-core = { path = "crates/bitnet-minimal-json-core", version = "0.2.1-dev" }
 # Core dependencies
 anyhow = "1.0.100"
 log = "0.4.28"

--- a/crates/bitnet-gpu-hal/Cargo.toml
+++ b/crates/bitnet-gpu-hal/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 bitnet-tokenizer-text-core = { path = "../bitnet-tokenizer-text-core", version = "0.2.1-dev" }
+bitnet-minimal-json-core = { path = "../bitnet-minimal-json-core", version = "0.2.1-dev" }
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
 bitnet-layer-index-core = { path = "../bitnet-layer-index-core", version = "0.2.1-dev" }
 tokio = { workspace = true }

--- a/crates/bitnet-gpu-hal/src/api_gateway.rs
+++ b/crates/bitnet-gpu-hal/src/api_gateway.rs
@@ -9,6 +9,7 @@ use std::fmt;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bitnet_http_auth_core::strip_bearer_prefix;
+use bitnet_minimal_json_core::MinimalJson;
 
 // ── Configuration ───────────────────────────────────────────────────────────
 
@@ -905,97 +906,6 @@ fn strip_bearer(val: &str) -> String {
     strip_bearer_prefix(val).to_string()
 }
 
-// ── Minimal JSON helper (no serde dependency) ───────────────────────────────
-
-/// Extremely basic JSON field extractor. Handles flat objects only — enough
-/// for OpenAI-compatible request bodies in this crate.
-#[derive(Debug)]
-struct MinimalJson {
-    fields: HashMap<String, String>,
-}
-
-impl MinimalJson {
-    fn parse(text: &str) -> Result<Self, String> {
-        let trimmed = text.trim();
-        if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
-            return Err("expected JSON object".to_string());
-        }
-        let inner = &trimmed[1..trimmed.len() - 1];
-        let mut fields = HashMap::new();
-
-        for part in Self::split_top_level(inner) {
-            let part = part.trim();
-            if part.is_empty() {
-                continue;
-            }
-            if let Some((k, v)) = part.split_once(':') {
-                let key = k.trim().trim_matches('"').to_string();
-                let val = v.trim().to_string();
-                // Strip surrounding quotes from string values.
-                let val = if val.starts_with('"') && val.ends_with('"') && val.len() >= 2 {
-                    val[1..val.len() - 1].to_string()
-                } else {
-                    val
-                };
-                fields.insert(key, val);
-            }
-        }
-        Ok(Self { fields })
-    }
-
-    /// Split on commas that are not inside braces/brackets/quotes.
-    fn split_top_level(s: &str) -> Vec<String> {
-        let mut parts = Vec::new();
-        let mut current = String::new();
-        let mut depth = 0i32;
-        let mut in_string = false;
-        let mut prev = '\0';
-        for ch in s.chars() {
-            if ch == '"' && prev != '\\' {
-                in_string = !in_string;
-            }
-            if !in_string {
-                match ch {
-                    '{' | '[' => depth += 1,
-                    '}' | ']' => depth -= 1,
-                    ',' if depth == 0 => {
-                        parts.push(std::mem::take(&mut current));
-                        prev = ch;
-                        continue;
-                    }
-                    _ => {}
-                }
-            }
-            current.push(ch);
-            prev = ch;
-        }
-        if !current.trim().is_empty() {
-            parts.push(current);
-        }
-        parts
-    }
-
-    fn get_str(&self, key: &str) -> Option<String> {
-        self.fields.get(key).cloned()
-    }
-
-    fn get_u32(&self, key: &str) -> Option<u32> {
-        self.fields.get(key)?.parse().ok()
-    }
-
-    fn get_f32(&self, key: &str) -> Option<f32> {
-        self.fields.get(key)?.parse().ok()
-    }
-
-    fn get_bool(&self, key: &str) -> Option<bool> {
-        match self.fields.get(key)?.as_str() {
-            "true" => Some(true),
-            "false" => Some(false),
-            _ => None,
-        }
-    }
-}
-
 // ══════════════════════════════════════════════════════════════════════════════
 // Tests
 // ══════════════════════════════════════════════════════════════════════════════
@@ -1882,50 +1792,6 @@ mod tests {
         let body = gw.transform_response(&resp);
         let s = String::from_utf8(body).unwrap();
         assert!(s.contains("world"));
-    }
-
-    // ── MinimalJson tests ──────────────────────────────────────────────
-
-    #[test]
-    fn test_minimal_json_parse_string() {
-        let j = MinimalJson::parse(r#"{"key":"value"}"#).unwrap();
-        assert_eq!(j.get_str("key").unwrap(), "value");
-    }
-
-    #[test]
-    fn test_minimal_json_parse_number() {
-        let j = MinimalJson::parse(r#"{"n":42}"#).unwrap();
-        assert_eq!(j.get_u32("n").unwrap(), 42);
-    }
-
-    #[test]
-    fn test_minimal_json_parse_float() {
-        let j = MinimalJson::parse(r#"{"f":0.7}"#).unwrap();
-        assert!((j.get_f32("f").unwrap() - 0.7).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_minimal_json_parse_bool() {
-        let j = MinimalJson::parse(r#"{"b":true}"#).unwrap();
-        assert_eq!(j.get_bool("b"), Some(true));
-    }
-
-    #[test]
-    fn test_minimal_json_missing_key() {
-        let j = MinimalJson::parse(r#"{"a":"b"}"#).unwrap();
-        assert!(j.get_str("missing").is_none());
-    }
-
-    #[test]
-    fn test_minimal_json_empty_object() {
-        let j = MinimalJson::parse("{}").unwrap();
-        assert!(j.get_str("anything").is_none());
-    }
-
-    #[test]
-    fn test_minimal_json_invalid() {
-        assert!(MinimalJson::parse("not json").is_err());
-        assert!(MinimalJson::parse("[1,2]").is_err());
     }
 
     // ── Helpers tests ──────────────────────────────────────────────────

--- a/crates/bitnet-minimal-json-core/Cargo.toml
+++ b/crates/bitnet-minimal-json-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-minimal-json-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP microcrate for minimal flat JSON field extraction"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-minimal-json-core/src/lib.rs
+++ b/crates/bitnet-minimal-json-core/src/lib.rs
@@ -1,0 +1,148 @@
+//! Extremely small JSON field extractor for flat-object payloads.
+//!
+//! This parser is intentionally limited and dependency-free:
+//! - Top-level JSON object only
+//! - Field values are stored as strings
+//! - Commas inside nested arrays/objects/strings are preserved
+
+use std::collections::HashMap;
+
+/// Extremely basic JSON field extractor. Handles flat objects only.
+#[derive(Debug)]
+pub struct MinimalJson {
+    fields: HashMap<String, String>,
+}
+
+impl MinimalJson {
+    /// Parse a JSON object string into a [`MinimalJson`] map.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        let trimmed = text.trim();
+        if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+            return Err("expected JSON object".to_string());
+        }
+        let inner = &trimmed[1..trimmed.len() - 1];
+        let mut fields = HashMap::new();
+
+        for part in Self::split_top_level(inner) {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+            if let Some((k, v)) = part.split_once(':') {
+                let key = k.trim().trim_matches('"').to_string();
+                let val = v.trim();
+                let val = if val.starts_with('"') && val.ends_with('"') && val.len() >= 2 {
+                    val[1..val.len() - 1].to_string()
+                } else {
+                    val.to_string()
+                };
+                fields.insert(key, val);
+            }
+        }
+        Ok(Self { fields })
+    }
+
+    /// Split on commas that are not inside braces/brackets/quotes.
+    fn split_top_level(s: &str) -> Vec<String> {
+        let mut parts = Vec::new();
+        let mut current = String::new();
+        let mut depth = 0_i32;
+        let mut in_string = false;
+        let mut prev = '\0';
+        for ch in s.chars() {
+            if ch == '"' && prev != '\\' {
+                in_string = !in_string;
+            }
+            if !in_string {
+                match ch {
+                    '{' | '[' => depth += 1,
+                    '}' | ']' => depth -= 1,
+                    ',' if depth == 0 => {
+                        parts.push(std::mem::take(&mut current));
+                        prev = ch;
+                        continue;
+                    }
+                    _ => {}
+                }
+            }
+            current.push(ch);
+            prev = ch;
+        }
+        if !current.trim().is_empty() {
+            parts.push(current);
+        }
+        parts
+    }
+
+    #[must_use]
+    pub fn get_str(&self, key: &str) -> Option<String> {
+        self.fields.get(key).cloned()
+    }
+
+    #[must_use]
+    pub fn get_u32(&self, key: &str) -> Option<u32> {
+        self.fields.get(key)?.parse().ok()
+    }
+
+    #[must_use]
+    pub fn get_f32(&self, key: &str) -> Option<f32> {
+        self.fields.get(key)?.parse().ok()
+    }
+
+    #[must_use]
+    pub fn get_bool(&self, key: &str) -> Option<bool> {
+        match self.fields.get(key)?.as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_string_fields() {
+        let j = MinimalJson::parse(r#"{"key":"value"}"#).unwrap();
+        assert_eq!(j.get_str("key"), Some("value".to_string()));
+    }
+
+    #[test]
+    fn parses_u32_fields() {
+        let j = MinimalJson::parse(r#"{"n":42}"#).unwrap();
+        assert_eq!(j.get_u32("n"), Some(42));
+    }
+
+    #[test]
+    fn parses_f32_fields() {
+        let j = MinimalJson::parse(r#"{"f":0.7}"#).unwrap();
+        assert_eq!(j.get_f32("f"), Some(0.7));
+    }
+
+    #[test]
+    fn parses_bool_fields() {
+        let j = MinimalJson::parse(r#"{"b":true}"#).unwrap();
+        assert_eq!(j.get_bool("b"), Some(true));
+    }
+
+    #[test]
+    fn preserves_nested_values_as_raw_strings() {
+        let j = MinimalJson::parse(r#"{"obj":{"a":1},"arr":[1,2,3]}"#).unwrap();
+        assert_eq!(j.get_str("obj"), Some("{\"a\":1}".to_string()));
+        assert_eq!(j.get_str("arr"), Some("[1,2,3]".to_string()));
+    }
+
+    #[test]
+    fn handles_missing_keys() {
+        let j = MinimalJson::parse("{}").unwrap();
+        assert_eq!(j.get_str("missing"), None);
+    }
+
+    #[test]
+    fn rejects_non_object_json() {
+        assert!(MinimalJson::parse("not json").is_err());
+        assert!(MinimalJson::parse("[1,2]").is_err());
+    }
+}


### PR DESCRIPTION
### Motivation
- The inline `MinimalJson` parser in `bitnet-gpu-hal::api_gateway` had a single, well-scoped responsibility (flat top-level JSON field extraction) that made it a good candidate for extraction. 
- Centralizing this logic reduces duplication and makes the parser reusable by other crates without dragging `serde` or extra code into consumers. 
- Moving the utility into its own microcrate improves SRP boundaries and keeps `bitnet-gpu-hal` focused on GPU/HTTP gateway concerns. 

### Description
- Added a new microcrate `crates/bitnet-minimal-json-core` which exposes `MinimalJson` with `parse`, `split_top_level`, and typed getters, and includes focused unit tests (`crates/bitnet-minimal-json-core/src/lib.rs`).
- Wired the new microcrate into the workspace members and workspace dependency table in `Cargo.toml` so it is available to other crates.
- Updated `crates/bitnet-gpu-hal` to depend on `bitnet-minimal-json-core` and replaced the previous inline `MinimalJson` implementation by importing `use bitnet_minimal_json_core::MinimalJson;` from the microcrate (`crates/bitnet-gpu-hal/src/api_gateway.rs`).
- Removed the duplicated helper implementation from `api_gateway.rs` and kept the test harness intact.

### Testing
- Ran `cargo fmt --all` to ensure formatting consistency, which completed successfully. 
- Ran `cargo test -p bitnet-minimal-json-core`, and all unit tests passed (`7 passed; 0 failed`).
- Ran `cargo check -p bitnet-gpu-hal`, which completed successfully and validated the new dependency integration. 
- Ran `cargo test -p bitnet-gpu-hal api_gateway -- --nocapture` as an exercised compile/test invocation which completed successfully (no failing tests; the filter matched no runtime tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a921a22fb88333bcfa30ee51a916b8)