### PR TITLE
refactor(models): extract weight alias normalization into SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "bitnet-test-support",
  "bitnet-trace",
  "bitnet-transformer",
+ "bitnet-weight-alias-core",
  "bitnet-weight-name-core",
  "bytemuck",
  "candle-core",
@@ -1988,6 +1989,10 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
 ]
+
+[[package]]
+name = "bitnet-weight-alias-core"
+version = "0.2.1-dev"
 
 [[package]]
 name = "bitnet-weight-name-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-tokenizer-text-core", # SRP: tokenizer pre-tokenization/normalization primitives
   "crates/bitnet-weight-name-core", # SRP: vendor weight-name canonicalization helpers
+  "crates/bitnet-weight-alias-core", # SRP: exporter alias drift normalization helpers
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",
@@ -154,6 +155,7 @@ default-members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-models",
   "crates/bitnet-tokenizers",
+  "crates/bitnet-weight-alias-core", # SRP: exporter alias drift normalization helpers
   "crates/bitnet-token-merge-core", # SRP: reusable token span merge/split primitives
   "crates/bitnet-tokenizer-model-core",
   "crates/bitnet-tokenizer-discovery-core",

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -20,6 +20,7 @@ bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-weight-name-core = { path = "../bitnet-weight-name-core", version = "0.2.1-dev" }
+bitnet-weight-alias-core = { path = "../bitnet-weight-alias-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/weight_mapper.rs
+++ b/crates/bitnet-models/src/weight_mapper.rs
@@ -1,7 +1,6 @@
 use bitnet_common::Result;
 use candle_core::{DType, Device, Tensor};
 // Weight mapping utilities for loading model weights from various formats
-use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Model dimensions for tensor shape validation and transposition
@@ -126,21 +125,8 @@ pub fn remap_gguf_weights(tensors: &HashMap<String, Tensor>) -> Result<HashMap<S
 }
 
 /// Normalize exporter name drift to our canonical names.
-/// Known drifts:
-///  - attn_sub_norm <-> attention_sub_norm
-///  - ffn_sub_norm  <-> mlp_sub_layernorm
-fn normalize_name(name: &str) -> Cow<'_, str> {
-    if name.contains("attention_sub_norm") {
-        // Map Microsoft's variation to our canonical name
-        let s = name.replace("attention_sub_norm", "attn_sub_norm");
-        return Cow::Owned(s);
-    }
-    if name.contains("mlp_sub_layernorm") {
-        // Map to our canonical FFN sub norm
-        let s = name.replace("mlp_sub_layernorm", "ffn_sub_norm");
-        return Cow::Owned(s);
-    }
-    Cow::Borrowed(name)
+fn normalize_name(name: &str) -> std::borrow::Cow<'_, str> {
+    bitnet_weight_alias_core::normalize_weight_alias(name)
 }
 
 /// Helper to get 2D tensor dimensions

--- a/crates/bitnet-weight-alias-core/Cargo.toml
+++ b/crates/bitnet-weight-alias-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-weight-alias-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP weight-name alias normalization primitives"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-weight-alias-core/src/lib.rs
+++ b/crates/bitnet-weight-alias-core/src/lib.rs
@@ -1,0 +1,41 @@
+//! Exporter weight-name alias normalization helpers.
+//!
+//! This crate owns low-level string drift normalization for weight keys,
+//! independent from tensor parsing/mapping logic.
+
+use std::borrow::Cow;
+
+/// Normalize known exporter naming drifts to canonical BitNet naming.
+pub fn normalize_weight_alias(name: &str) -> Cow<'_, str> {
+    if name.contains("attention_sub_norm") {
+        return Cow::Owned(name.replace("attention_sub_norm", "attn_sub_norm"));
+    }
+    if name.contains("mlp_sub_layernorm") {
+        return Cow::Owned(name.replace("mlp_sub_layernorm", "ffn_sub_norm"));
+    }
+    Cow::Borrowed(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_weight_alias;
+
+    #[test]
+    fn normalizes_attention_sub_norm_alias() {
+        let normalized = normalize_weight_alias("layers.0.attention_sub_norm.weight");
+        assert_eq!(normalized.as_ref(), "layers.0.attn_sub_norm.weight");
+    }
+
+    #[test]
+    fn normalizes_mlp_sub_layernorm_alias() {
+        let normalized = normalize_weight_alias("layers.3.mlp_sub_layernorm.weight");
+        assert_eq!(normalized.as_ref(), "layers.3.ffn_sub_norm.weight");
+    }
+
+    #[test]
+    fn leaves_canonical_name_unchanged() {
+        let input = "layers.1.attn_sub_norm.weight";
+        let normalized = normalize_weight_alias(input);
+        assert_eq!(normalized.as_ref(), input);
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce `bitnet-models::weight_mapper` responsibility by extracting exporter alias drift normalization into a single-responsibility microcrate so canonicalization logic is easier to reuse and reason about.
- Make alias normalization independent from vendor-key canonicalization to improve SRP decomposition and future reuse across loaders.

### Description
- Add a new SRP microcrate `crates/bitnet-weight-alias-core` that exposes `normalize_weight_alias` for low-level exporter alias rewrites. 
- Wire the new crate into the workspace (`Cargo.toml` members and `default-members`) and add it as a dependency of `crates/bitnet-models` (`bitnet-models/Cargo.toml`).
- Update `crates/bitnet-models/src/weight_mapper.rs` to delegate alias normalization to `bitnet_weight_alias_core::normalize_weight_alias` and remove the local alias-normalization code.
- Include focused unit tests in `bitnet-weight-alias-core` validating `attention_sub_norm` → `attn_sub_norm` and `mlp_sub_layernorm` → `ffn_sub_norm` behavior.

### Testing
- Ran `cargo test -p bitnet-weight-alias-core` and the unit test suite completed successfully (`3 passed`).
- Ran `cargo test -p bitnet-models --test weight_mapper_edge_cases` and targeted tests such as `vendor_key_blk_attn_q` passed as expected.
- Ran `cargo fmt` to ensure workspace formatting and committed the updated `Cargo.toml`, `bitnet-models` changes, and the new crate files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a97d02cfd48333bc82b6100d40ad93)