### PR TITLE
Extract shared layer-index parsing into new SRP microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ name = "bitnet-gpu-hal"
 version = "0.2.1-dev"
 dependencies = [
  "bitnet-http-auth-core",
+ "bitnet-layer-index-core",
  "bitnet-tokenizer-text-core",
  "insta",
  "log",
@@ -1017,6 +1018,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-layer-index-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-logits"
 version = "0.2.1-dev"
 dependencies = [
@@ -1051,6 +1056,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
+ "bitnet-layer-index-core",
  "bitnet-quantization",
  "bitnet-st2gguf",
  "bitnet-test-fixtures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-tokenizer-text-core", # SRP: tokenizer pre-tokenization/normalization primitives
   "crates/bitnet-weight-name-core", # SRP: vendor weight-name canonicalization helpers
+  "crates/bitnet-layer-index-core", # SRP: shared tensor-name layer index extraction helpers
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",

--- a/crates/bitnet-gpu-hal/Cargo.toml
+++ b/crates/bitnet-gpu-hal/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 bitnet-tokenizer-text-core = { path = "../bitnet-tokenizer-text-core", version = "0.2.1-dev" }
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
+bitnet-layer-index-core = { path = "../bitnet-layer-index-core", version = "0.2.1-dev" }
 tokio = { workspace = true }
 log.workspace = true
 serde = { workspace = true }

--- a/crates/bitnet-gpu-hal/src/weight_loader.rs
+++ b/crates/bitnet-gpu-hal/src/weight_loader.rs
@@ -3,6 +3,7 @@
 //! Provides lazy loading, prefetch scheduling, multi-shard parallel loading,
 //! format detection, and conversion utilities for model weight tensors.
 
+use bitnet_layer_index_core::extract_first_numeric_segment;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, Instant};
@@ -451,12 +452,7 @@ impl PrefetchScheduler {
 
 /// Extract a layer index from a tensor name like `"layers.5.attention.wq"`.
 fn extract_layer_index(name: &str) -> Option<usize> {
-    for part in name.split('.') {
-        if let Ok(idx) = part.parse::<usize>() {
-            return Some(idx);
-        }
-    }
-    None
+    extract_first_numeric_segment(name)
 }
 
 // ── Shard info ──────────────────────────────────────────────────────────────

--- a/crates/bitnet-layer-index-core/Cargo.toml
+++ b/crates/bitnet-layer-index-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-layer-index-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core helpers for extracting layer indices from tensor names"
+
+[lib]
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-layer-index-core/src/lib.rs
+++ b/crates/bitnet-layer-index-core/src/lib.rs
@@ -18,7 +18,10 @@ pub fn extract_first_numeric_segment(name: &str) -> Option<usize> {
 #[must_use]
 pub fn extract_prefixed_layer_index(name: &str, prefixes: &[&str]) -> Option<usize> {
     prefixes.iter().find_map(|prefix| {
-        name.find(prefix).and_then(|pos| parse_usize_prefix(name[pos + prefix.len()..].as_bytes()))
+        name.find(prefix).and_then(|pos| {
+            let start = pos + prefix.len();
+            parse_usize_prefix(&name.as_bytes()[start..])
+        })
     })
 }
 

--- a/crates/bitnet-layer-index-core/src/lib.rs
+++ b/crates/bitnet-layer-index-core/src/lib.rs
@@ -1,0 +1,69 @@
+//! SRP helpers for extracting transformer layer indices from tensor names.
+
+/// Extract the first numeric segment in a dot-separated tensor name.
+///
+/// Examples:
+/// - `"model.layers.12.attn.q_proj"` -> `Some(12)`
+/// - `"layers.0.wq"` -> `Some(0)`
+/// - `"embed_tokens.weight"` -> `None`
+#[must_use]
+pub fn extract_first_numeric_segment(name: &str) -> Option<usize> {
+    name.split('.').find_map(|part| part.parse::<usize>().ok())
+}
+
+/// Extract a layer index immediately following one of the provided prefixes.
+///
+/// This is useful for formats that encode layer IDs directly after tokens such
+/// as `"blk."` or `"layers."`.
+#[must_use]
+pub fn extract_prefixed_layer_index(name: &str, prefixes: &[&str]) -> Option<usize> {
+    prefixes.iter().find_map(|prefix| {
+        name.find(prefix).and_then(|pos| parse_usize_prefix(name[pos + prefix.len()..].as_bytes()))
+    })
+}
+
+/// Parse an unsigned integer from the beginning of `bytes` until the first non-digit.
+#[must_use]
+pub fn parse_usize_prefix(bytes: &[u8]) -> Option<usize> {
+    let mut value: usize = 0;
+    let mut found_any = false;
+
+    for &b in bytes {
+        if b.is_ascii_digit() {
+            value = value.checked_mul(10)?.checked_add((b - b'0') as usize)?;
+            found_any = true;
+        } else {
+            break;
+        }
+    }
+
+    found_any.then_some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_numeric_segment_works() {
+        assert_eq!(extract_first_numeric_segment("model.layers.12.mlp.gate"), Some(12));
+        assert_eq!(extract_first_numeric_segment("layers.0.wq"), Some(0));
+        assert_eq!(extract_first_numeric_segment("embed_tokens.weight"), None);
+    }
+
+    #[test]
+    fn prefixed_layer_index_works() {
+        let prefixes = ["blk.", "layers."];
+        assert_eq!(extract_prefixed_layer_index("blk.39.attn_q.weight", &prefixes), Some(39));
+        assert_eq!(extract_prefixed_layer_index("model.layers.5.attention.wq", &prefixes), Some(5));
+        assert_eq!(extract_prefixed_layer_index("model.lx.5.attention.wq", &prefixes), None);
+    }
+
+    #[test]
+    fn parse_usize_prefix_rejects_overflow() {
+        let huge = format!("{}tail", usize::MAX);
+        assert!(parse_usize_prefix(huge.as_bytes()).is_some());
+        let overflowing = format!("{}0tail", usize::MAX);
+        assert_eq!(parse_usize_prefix(overflowing.as_bytes()), None);
+    }
+}

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -20,6 +20,7 @@ bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-weight-name-core = { path = "../bitnet-weight-name-core", version = "0.2.1-dev" }
+bitnet-layer-index-core = { path = "../bitnet-layer-index-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -3,6 +3,7 @@ use crate::loader::MmapFile;
 use crate::qk256_utils::{detect_qk256_orientation_by_bytes, expected_qk256_shape};
 use crate::quant::i2s_qk256::I2SQk256NoScale;
 use bitnet_common::{BitNetError, Device, QuantizationType, Result};
+use bitnet_layer_index_core::extract_prefixed_layer_index;
 use bitnet_quantization::{QuantizerTrait, TL1Quantizer, TL2Quantizer, qk256_tolerance_bytes};
 use candle_core::{DType, Device as CDevice, Tensor as CandleTensor};
 use std::collections::HashMap;
@@ -799,33 +800,7 @@ fn discover_n_layers_from_tensors(reader: &GgufReader) -> Result<usize> {
 
 /// Extract layer index from tensor name supporting blk.<i>.* and layers.<i>.* patterns
 fn extract_layer_index(name: &str) -> Option<usize> {
-    // Look for "blk.123." or "layers.123." patterns
-    if let Some(pos) = name.find("blk.") {
-        let rest = &name[pos + 4..];
-        parse_usize_prefix(rest.as_bytes())
-    } else if let Some(pos) = name.find("layers.") {
-        let rest = &name[pos + 7..];
-        parse_usize_prefix(rest.as_bytes())
-    } else {
-        None
-    }
-}
-
-/// Parse unsigned integer from start of byte slice until first non-digit
-fn parse_usize_prefix(bytes: &[u8]) -> Option<usize> {
-    let mut value: usize = 0;
-    let mut found_any = false;
-
-    for &b in bytes {
-        if b.is_ascii_digit() {
-            value = value.checked_mul(10)?.checked_add((b - b'0') as usize)?;
-            found_any = true;
-        } else {
-            break;
-        }
-    }
-
-    found_any.then_some(value)
+    extract_prefixed_layer_index(name, &["blk.", "layers."])
 }
 
 /// AC3: Validate that all required transformer tensors are present

--- a/crates/bitnet-models/src/layer_inspector.rs
+++ b/crates/bitnet-models/src/layer_inspector.rs
@@ -3,6 +3,8 @@
 //! Enumerate, classify, and inspect transformer layers and their
 //! constituent tensors for debugging and validation.
 
+use bitnet_layer_index_core::extract_first_numeric_segment;
+
 /// Type of a transformer layer component.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComponentType {
@@ -181,12 +183,7 @@ impl Default for InspectionReport {
 
 /// Extract layer index from tensor name (e.g., "layers.5.attn.q_proj" → Some(5)).
 pub fn extract_layer_index(name: &str) -> Option<usize> {
-    for part in name.split('.') {
-        if let Ok(idx) = part.parse::<usize>() {
-            return Some(idx);
-        }
-    }
-    None
+    extract_first_numeric_segment(name)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Remove duplicated tensor-name layer-index parsing logic scattered across crates and centralize it as a single SRP microcrate for reuse and consistent semantics.
- Make GGUF/tensor-name handling easier to maintain and test by extracting parsing helpers out of domain crates into a focused utility crate.

### Description
- Add new crate `crates/bitnet-layer-index-core` containing `extract_first_numeric_segment`, `extract_prefixed_layer_index`, and `parse_usize_prefix` with unit tests (`src/lib.rs` and `Cargo.toml`).
- Register the new crate in the workspace `Cargo.toml` and update `Cargo.lock` entries to include the microcrate.
- Wire `bitnet-models` and `bitnet-gpu-hal` to depend on `bitnet-layer-index-core` by updating their `Cargo.toml` files.
- Replace duplicated local implementations in `crates/bitnet-models/src/gguf_simple.rs`, `crates/bitnet-models/src/layer_inspector.rs`, and `crates/bitnet-gpu-hal/src/weight_loader.rs` to call the shared helpers and add the necessary `use` imports.

### Testing
- Ran `cargo fmt` to ensure formatting, which completed successfully.
- Ran `cargo test -p bitnet-layer-index-core` and all unit tests in the new crate passed (`3 passed`).
- Ran `cargo test -p bitnet-models layer_inspector::tests::test_extract_layer_index -- --exact` and the targeted test passed.
- Ran `cargo test -p bitnet-gpu-hal extract_layer_index_found -- --exact` and the targeted test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab808c256083338faa2f1256bab00e)