### PR TITLE
Extract server CORS middleware policy into new SRP core microcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,6 +618,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-cors-policy-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-cpu-activations"
 version = "0.2.1-dev"
 dependencies = [
@@ -1404,6 +1408,7 @@ dependencies = [
  "bitnet-api-versioning-core",
  "bitnet-client-ip-core",
  "bitnet-common",
+ "bitnet-cors-policy-core",
  "bitnet-device-config-core",
  "bitnet-eval-core",
  "bitnet-http-auth-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
   "crates/bitnet-eval-core",     # SRP: deterministic eval/scoring math helpers
   "crates/bitnet-feature-matrix",
   "crates/bitnet-client-ip-core", # SRP: reusable client IP extraction from forwarding headers
+  "crates/bitnet-cors-policy-core", # SRP: reusable CORS policy primitives for middleware stacks
   "crates/bitnet-api-versioning-core", # SRP: reusable API version negotiation and routing helpers
   "crates/bitnet-api-key-auth-core", # SRP: API key auth policy/store primitives
   "crates/bitnet-server-health-types-core", # SRP: reusable server health endpoint contract types

--- a/crates/bitnet-cors-policy-core/Cargo.toml
+++ b/crates/bitnet-cors-policy-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-cors-policy-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "SRP core CORS policy primitives for server middleware configuration"
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-cors-policy-core/src/lib.rs
+++ b/crates/bitnet-cors-policy-core/src/lib.rs
@@ -1,0 +1,58 @@
+//! SRP CORS policy primitives for middleware configuration.
+
+use std::time::Duration;
+
+/// Shared CORS policy settings for middleware stacks.
+#[derive(Debug, Clone)]
+pub struct CorsPolicy {
+    pub allowed_origins: Vec<String>,
+    pub allow_credentials: bool,
+    pub max_age: Duration,
+}
+
+impl Default for CorsPolicy {
+    fn default() -> Self {
+        Self {
+            allowed_origins: vec!["*".into()],
+            allow_credentials: false,
+            max_age: Duration::from_secs(3600),
+        }
+    }
+}
+
+impl CorsPolicy {
+    /// Restrictive profile allowing only explicit origins.
+    #[must_use]
+    pub fn restrictive(origins: Vec<String>) -> Self {
+        Self {
+            allowed_origins: origins,
+            allow_credentials: true,
+            max_age: Duration::from_secs(600),
+        }
+    }
+
+    /// Returns true when wildcard origin is configured.
+    #[must_use]
+    pub fn is_wildcard(&self) -> bool {
+        self.allowed_origins.iter().any(|o| o == "*")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CorsPolicy;
+
+    #[test]
+    fn default_policy_uses_wildcard_without_credentials() {
+        let policy = CorsPolicy::default();
+        assert!(policy.is_wildcard());
+        assert!(!policy.allow_credentials);
+    }
+
+    #[test]
+    fn restrictive_policy_disables_wildcard_and_enables_credentials() {
+        let policy = CorsPolicy::restrictive(vec!["https://example.com".to_string()]);
+        assert!(!policy.is_wildcard());
+        assert!(policy.allow_credentials);
+    }
+}

--- a/crates/bitnet-cors-policy-core/src/lib.rs
+++ b/crates/bitnet-cors-policy-core/src/lib.rs
@@ -23,7 +23,7 @@ impl Default for CorsPolicy {
 impl CorsPolicy {
     /// Restrictive profile allowing only explicit origins.
     #[must_use]
-    pub fn restrictive(origins: Vec<String>) -> Self {
+    pub const fn restrictive(origins: Vec<String>) -> Self {
         Self {
             allowed_origins: origins,
             allow_credentials: true,

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -35,6 +35,7 @@ bitnet-request-context-core = { path = "../bitnet-request-context-core", version
 bitnet-api-versioning-core = { path = "../bitnet-api-versioning-core", version = "0.2.1-dev" }
 bitnet-server-health-types-core = { path = "../bitnet-server-health-types-core", version = "0.2.1-dev" }
 bitnet-client-ip-core = { path = "../bitnet-client-ip-core", version = "0.2.1-dev" }
+bitnet-cors-policy-core = { path = "../bitnet-cors-policy-core", version = "0.2.1-dev" }
 bitnet-startup-contract-guard = { path = "../bitnet-startup-contract-guard", version = "0.2.1-dev" }
 chrono.workspace = true
 clap.workspace = true

--- a/crates/bitnet-server/src/middleware_config.rs
+++ b/crates/bitnet-server/src/middleware_config.rs
@@ -18,37 +18,8 @@ impl Default for RateLimitConfig {
     }
 }
 
-/// CORS configuration.
-#[derive(Debug, Clone)]
-pub struct CorsConfig {
-    pub allowed_origins: Vec<String>,
-    pub allow_credentials: bool,
-    pub max_age: Duration,
-}
-
-impl Default for CorsConfig {
-    fn default() -> Self {
-        Self {
-            allowed_origins: vec!["*".into()],
-            allow_credentials: false,
-            max_age: Duration::from_secs(3600),
-        }
-    }
-}
-
-impl CorsConfig {
-    pub fn restrictive(origins: Vec<String>) -> Self {
-        Self {
-            allowed_origins: origins,
-            allow_credentials: true,
-            max_age: Duration::from_secs(600),
-        }
-    }
-
-    pub fn is_wildcard(&self) -> bool {
-        self.allowed_origins.iter().any(|o| o == "*")
-    }
-}
+/// CORS configuration re-exported from `bitnet-cors-policy-core`.
+pub use bitnet_cors_policy_core::CorsPolicy as CorsConfig;
 
 /// Request validation config.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
### Motivation
- Reduce duplication by extracting shared CORS middleware policy primitives into an SRP microcrate so multiple HTTP surface crates can reuse the same policy logic.
- Make the server middleware configuration leaner by moving policy semantics out of `bitnet-server` and exposing a small, well-tested policy contract.

### Description
- Added a new crate `bitnet-cors-policy-core` that implements `CorsPolicy` with `Default`, `restrictive`, and `is_wildcard` helpers and unit tests (`crates/bitnet-cors-policy-core/src/lib.rs`).
- Wired the new microcrate into the workspace `Cargo.toml` and added it as a dependency of `bitnet-server` (`crates/bitnet-server/Cargo.toml`).
- Refactored `crates/bitnet-server/src/middleware_config.rs` to remove the duplicated CORS struct and instead `pub use bitnet_cors_policy_core::CorsPolicy as CorsConfig` to preserve the public API and tests.
- Added lightweight crate manifest `crates/bitnet-cors-policy-core/Cargo.toml` and updated workspace lockfile to include the new microcrate.

### Testing
- Ran `cargo test -p bitnet-cors-policy-core` and all unit tests passed (2 passed; 0 failed).
- Ran `cargo test -p bitnet-server test_cors_default` to validate server integration of the re-export and the targeted test passed.
- Ran `cargo fmt --all -- --check` to verify formatting and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b5927dac8333bbce1f1818572830)