### PR TITLE
⚡ Bolt: [performance improvement] Eliminate unnecessary `Vec` allocation in `apply_typical`

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -76,7 +76,7 @@ pub fn apply_min_p(probs: &mut [f32], min_p: f32) {
     let max_prob = probs.iter().copied().fold(0.0f32, f32::max);
     let threshold = min_p * max_prob;
     for p in probs.iter_mut() {
-        if *p < threshold {
+        if *p > 0.0 && *p < threshold {
             *p = 0.0;
         }
     }
@@ -92,22 +92,26 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
-        return;
+    let mut entropy = 0.0f32;
+    for p in probs.iter().copied().filter(|&p| p > 0.0) {
+        entropy += -p * p.ln();
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
+    let mut deviations: Vec<(usize, f32, f32)> = probs
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|&(_, p)| p > 0.0)
         .map(|(i, p)| {
             let surprise = -p.ln();
             let deviation = (surprise - entropy).abs();
             (i, p, deviation)
         })
         .collect();
+
+    if deviations.is_empty() {
+        return;
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Fused passes in `apply_typical` to completely eliminate a vocabulary-sized vector allocation (`indexed`). Added an early out in `apply_min_p` to prevent overwriting `0.0` values with `0.0`.
🎯 Why: Token generation is a hot loop, and doing memory allocations proportional to the vocabulary size per token is notoriously expensive. `apply_typical` used `indexed: Vec<(usize, f32)>` purely as a temporary structure to compute entropy and build a secondary `deviations` list. This optimization bypasses it entirely.
📊 Impact: Eliminates O(k) heap allocations and population per generated token in typical sampling. Reduces CPU cache invalidation overhead when filtering sparsely zeroed probability slices in min_p sampling.
🔬 Measurement: Verify with `cargo test -p bitnet-logits-filters`. You should observe 0 functionality changes with reduced allocations.

---
*PR created automatically by Jules for task [3717327462492842191](https://jules.google.com/task/3717327462492842191) started by @EffortlessSteven*