### PR TITLE
🎨 Palette: [UX improvement] Make scrollable outputs keyboard accessible

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="font-weight: 500; margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 **What:** Replaced the semantically incorrect `<label>` elements on the 4 output `div` containers in the browser example with styled `<div>` elements having IDs. Then, linked these new label `div`s to the scrollable output containers using `aria-labelledby`, and added `tabindex="0"` and `role="region"` to the containers themselves.

🎯 **Why:** `<label>` tags are strictly meant to wrap or link via `for`/`id` to form control inputs (`<input>`, `<textarea>`, `<select>`). Applying them to `<div>` elements is semantically incorrect and ignored by screen readers. Furthermore, because these output regions are scrollable (`overflow-y: auto`) but contain no interactive elements, keyboard-only users were previously unable to scroll through the generated output or benchmark logs.

📸 **Before/After:** The output boxes now display a visible focus ring when navigated via the Tab key, indicating to the user that they can scroll the content using their arrow keys.

♿ **Accessibility:**
- Corrected invalid HTML semantics (removed `<label>` pointing to `<div>`).
- Made long, scrollable outputs focusable via keyboard (`tabindex="0"`).
- Assigned `role="region"` and accessible names (`aria-labelledby`) so screen readers announce the regions contextually upon focus.

---
*PR created automatically by Jules for task [17533446187237885157](https://jules.google.com/task/17533446187237885157) started by @EffortlessSteven*