### PR TITLE
⚡ Bolt: [performance improvement] Optimize apply_typical to avoid intermediate Vec allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-05 - Hot Loop Allocations in Token Sampling
 **Learning:** Allocating memory in the hot path of LLM token generation (e.g., `logits.to_vec()` or creating `HashMap`s per token) significantly degrades performance due to repeated allocation overhead of vocabulary-sized vectors (often 128K+ elements). Additionally, mathematically equivalent iterative multiplication (`logit *= inv_penalty`) can replace `HashMap` counting and `.powi(count)`, completely eliminating O(N) memory allocations per token.
 **Action:** When working on generation loops, use buffer pooling (e.g. storing a `Vec` in the generator state and using `std::mem::take` to bypass borrow checker limitations) and avoid `HashMap` allocations for simple counting if an iterative scalar approach is mathematically equivalent.
+
+## 2026-03-24 - Expensive Computations in Sort Comparators
+**Learning:** Placing expensive computations like transcendental functions (e.g., `f32::ln()`) inside sort comparators results in severe performance regressions due to being evaluated O(N log N) times.
+**Action:** Always pre-calculate expensive computations in an initial O(N) pass, cache the values in the collection or mutate the existing elements in-place, and then perform the sort using the pre-calculated fields.

--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,28 +92,35 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
+    // Calculate entropy and surprise in a single pass to avoid multiple allocations
+    // and recomputing expensive transcendental functions like `ln()`.
+    let mut entropy = 0.0f32;
+    let mut indexed: Vec<(usize, f32, f32)> = probs
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|&(_, p)| p > 0.0)
+        .map(|(i, p)| {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            (i, p, surprise)
+        })
+        .collect();
+
     if indexed.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
+    // Convert the cached surprise into the final deviation in-place
+    for item in &mut indexed {
+        item.2 = (item.2 - entropy).abs();
+    }
 
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
-
-    deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
+    indexed.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 
     let mut cumsum = 0.0f32;
-    let mut cutoff = deviations.len();
-    for (rank, &(_, p, _)) in deviations.iter().enumerate() {
+    let mut cutoff = indexed.len();
+    for (rank, &(_, p, _)) in indexed.iter().enumerate() {
         cumsum += p;
         if cumsum >= typical_p {
             cutoff = rank + 1;
@@ -121,7 +128,7 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         }
     }
 
-    for &(idx, _, _) in deviations.iter().skip(cutoff) {
+    for &(idx, _, _) in indexed.iter().skip(cutoff) {
         probs[idx] = 0.0;
     }
 }


### PR DESCRIPTION
💡 **What**: Refactored `apply_typical` to compute `entropy` and `surprise` within the initial `.map` iteration, and then update the `deviation` in-place before sorting. 

🎯 **Why**: The original implementation iterated over `indexed` multiple times and allocated an intermediate `deviations` vector (`Vec<(usize, f32, f32)>`). This new version prevents computing `p.ln()` multiple times (which was calculated both for `entropy` and for `surprise` individually previously) and prevents an entire `Vec` allocation by working in-place. Note: placing `p.ln()` directly in the sort closure would compute `ln()` $O(N \log N)$ times causing a severe regression, hence caching it in the tuple.

📊 **Impact**: Reduces dynamic memory allocations and cuts `f32::ln()` calls in half (from $2N$ to $N$), improving typical-P sampling speed for massive vocabularies.

🔬 **Measurement**: Validated using `cargo clippy` and `cargo test -p bitnet-logits-filters`. Run existing sampling benchmarks to measure exact latency improvements per token.

---
*PR created automatically by Jules for task [11724667190003571196](https://jules.google.com/task/11724667190003571196) started by @EffortlessSteven*