### PR TITLE
🎨 Palette: [UX improvement] Fix accessibility of output containers

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="label-output" style="margin-bottom: 0; font-weight: bold;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="label-output">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="label-streaming-output" style="font-weight: bold; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="label-streaming-output">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="label-worker-output" style="font-weight: bold; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="label-worker-output">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="label-benchmark-output" style="font-weight: bold; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="label-benchmark-output">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 **What:**
Replaced semantic `<label>` elements pointing to output `<div>` containers with styled `<div>` elements acting as visual labels. Additionally, added `role="region"`, `tabindex="0"`, and `aria-labelledby` attributes to the actual output display areas.

🎯 **Why:**
`<label>` elements should strictly be used for form controls (inputs, selects, textareas). When applied to a standard `<div>`, it fails validation and misleads assistive technologies. Furthermore, because these output areas have `overflow-y: auto` and contain potentially long blocks of generated text, they must be keyboard-focusable so screen reader users and keyboard-only users can navigate and scroll through the content properly.

📸 **Before/After:**
*(Visual styling remains unchanged, preserving the exact "bold text next to a copy button" appearance from before)*

♿ **Accessibility:**
- Output areas (`#output`, `#streaming-output`, `#worker-output`, `#benchmark-output`) are now accessible via `tabindex="0"`.
- Output areas are semantically defined as `role="region"`.
- Screen readers will now announce the output regions correctly using their corresponding `aria-labelledby` connections.

---
*PR created automatically by Jules for task [16001497844986305494](https://jules.google.com/task/16001497844986305494) started by @EffortlessSteven*