### PR TITLE
🎨 Palette: [UX improvement] Make scrollable outputs keyboard accessible

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="basic-output-label" style="margin-bottom: 0; display: block; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="basic-output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="display: block; margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="display: block; margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="display: block; margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
**💡 What:** Replaced invalid `<label>` elements on output `<div>`s with styled `<div>`s and added `tabindex="0"`, `role="region"`, and `aria-labelledby` attributes to the output containers in `crates/bitnet-wasm/examples/browser/index.html`.

**🎯 Why:** The output containers (`#output`, `#streaming-output`, `#worker-output`, `#benchmark-output`) can have overflow content that needs scrolling. By default, standard `<div>` elements cannot receive keyboard focus, meaning keyboard-only or screen-reader users could not scroll through the output or have it properly announced. 

**📸 Before/After:** Before, pressing `Tab` would skip over the output containers entirely. After, pressing `Tab` focuses the containers, displaying a visual focus ring and allowing the arrow keys to scroll the content.

**♿ Accessibility:**
* Fixed invalid semantic HTML (`<label>` elements should only label form controls).
* Added `tabindex="0"` allowing focus to land on the scrolling container for keyboard accessibility.
* Added `role="region"` and `aria-labelledby` ensuring screen readers correctly announce the purpose of the focused output box.

---
*PR created automatically by Jules for task [487472000117539582](https://jules.google.com/task/487472000117539582) started by @EffortlessSteven*