### PR TITLE
⚡ Bolt: Optimize typical and min_p logits filtering passes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-05 - Hot Loop Allocations in Token Sampling
 **Learning:** Allocating memory in the hot path of LLM token generation (e.g., `logits.to_vec()` or creating `HashMap`s per token) significantly degrades performance due to repeated allocation overhead of vocabulary-sized vectors (often 128K+ elements). Additionally, mathematically equivalent iterative multiplication (`logit *= inv_penalty`) can replace `HashMap` counting and `.powi(count)`, completely eliminating O(N) memory allocations per token.
 **Action:** When working on generation loops, use buffer pooling (e.g. storing a `Vec` in the generator state and using `std::mem::take` to bypass borrow checker limitations) and avoid `HashMap` allocations for simple counting if an iterative scalar approach is mathematically equivalent.
+
+## 2025-01-28 - Optimize typical and min_p logits filtering
+**Learning:** In hot paths like logits filtering, separating mapping and entropy calculations into separate passes creates redundant overhead for expensive operations like `.ln()` and intermediate array allocations. Also, iterating and writing to raw, unfiltered sparse probability arrays without conditional checks like `p > 0.0` leads to unnecessary cache invalidations.
+**Action:** When working on array mappings or aggregations over probability structures, compute all aggregated metrics (like entropy) and related mapped outputs (like surprises) within a single pass. For sparse collections, condition sparse mutations on non-zero thresholds instead of overwriting elements.

--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -76,7 +76,7 @@ pub fn apply_min_p(probs: &mut [f32], min_p: f32) {
     let max_prob = probs.iter().copied().fold(0.0f32, f32::max);
     let threshold = min_p * max_prob;
     for p in probs.iter_mut() {
-        if *p < threshold {
+        if *p > 0.0 && *p < threshold {
             *p = 0.0;
         }
     }
@@ -92,18 +92,31 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
+    // Single pass to collect non-zero probabilities and compute entropy components
+    let mut entropy = 0.0f32;
+    let mut indexed = Vec::with_capacity(probs.len());
+
+    for (i, &p) in probs.iter().enumerate() {
+        if p > 0.0 {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            indexed.push((i, p, surprise));
+        }
+    }
+
     if indexed.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
+    // In rare cases where floating point inaccuracies make sum_p > 0 but
+    // the true sum should be 1.0. We usually expect probability slice to sum to 1.0.
+    // If the slice doesn't sum to 1.0, entropy as calculated above is not the true entropy.
+    // Assuming the probabilities are already softmaxed and sum to 1.0.
 
+    // Map to sortable deviations array reusing capacity without re-evaluating .ln()
     let mut deviations: Vec<(usize, f32, f32)> = indexed
         .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
+        .map(|(i, p, surprise)| {
             let deviation = (surprise - entropy).abs();
             (i, p, deviation)
         })


### PR DESCRIPTION
💡 **What:** 
- In `apply_typical`, the `entropy` calculation and `deviations` array mapping were fused into a single loop. 
- In `apply_min_p`, a `*p > 0.0` check was added before writing `0.0` to array elements.

🎯 **Why:** 
- For `apply_typical`, the original code performed two passes over the non-zero probabilities, calculating the expensive transcendental function `.ln()` twice per element and allocating an intermediate vector.
- For `apply_min_p`, overwriting already-zero probabilities with `0.0` dirties CPU cache lines and consumes memory bandwidth unnecessarily when working with sparse probability arrays.

📊 **Impact:** 
- Reduces operations in `apply_typical` (halves `.ln()` calls and eliminates one `Vec` allocation per token).
- Prevents unnecessary cache invalidation and memory bandwidth usage during sparse logit array iteration in `apply_min_p`.

🔬 **Measurement:** 
- Compiled successfully and tests pass (`cargo test -p bitnet-logits-filters`).
- Passed static analysis via `cargo clippy -p bitnet-logits-filters`.

---
*PR created automatically by Jules for task [18292992935553566112](https://jules.google.com/task/18292992935553566112) started by @EffortlessSteven*