### PR TITLE
ci(coverage): scope report generation to workspace

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,8 +89,8 @@ jobs:
               cargo llvm-cov clean --workspace
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
-              cargo llvm-cov report --json --output-path coverage.json
-              cargo llvm-cov report --text | tee coverage.txt
+              cargo llvm-cov report --workspace --json --output-path coverage.json
+              cargo llvm-cov report --workspace --text | tee coverage.txt
             '
 
       - name: Disk usage after coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -89,8 +89,8 @@ jobs:
               cargo llvm-cov clean --workspace
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
-              cargo llvm-cov report --workspace --json --output-path coverage.json
-              cargo llvm-cov report --workspace --text | tee coverage.txt
+              cargo llvm-cov --workspace --json --output-path coverage.json --no-run
+              cargo llvm-cov --workspace --text --no-run | tee coverage.txt
             '
 
       - name: Disk usage after coverage


### PR DESCRIPTION
Aligns coverage report scope with the existing workspace-wide test execution using the supported cargo-llvm-cov command shape.

Changes:
- keep `cargo llvm-cov nextest --workspace ... --no-report` for test execution
- generate `coverage.json` with `cargo llvm-cov --workspace --json --output-path coverage.json --no-run`
- generate `coverage.txt` with `cargo llvm-cov --workspace --text --no-run`

Why this exists:
- `#3440` proved coverage can run inside the rust-ci image
- the successful PR artifact reported only 1 file / 16 lines
- `cargo llvm-cov report --workspace` is not supported by the current tool version, so the workspace scope has to be expressed with top-level flags during the report-only pass

Non-goals:
- no runner or image changes
- no threshold policy changes
- no product code changes

Validation:
- workflow YAML parses locally
- the updated `cargo llvm-cov` command shape parses locally
- add the `coverage` label so the updated coverage job runs on this PR