### PR TITLE
ci(coverage): raise workflow timeout budget

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Keeps the image-backed coverage flow unchanged and increases the job budget after the same main Coverage rerun cancelled twice around the 40-minute mark.

Changes:
- raise `timeout-minutes` from 40 to 60 in `.github/workflows/coverage.yml`

Why this exists:
- `#3440` already proved the hosted-runner + host-docker image path
- the main Coverage rerun for commit `1a9030fe8` completed generation work and then cancelled at the workflow budget
- this is a one-line budget fix, not a workflow redesign

Non-goals:
- no image changes
- no threshold changes
- no product code changes

Validation:
- workflow YAML parses locally
- add the `coverage` label so the updated coverage job runs on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CI/CD workflow timeout to improve reliability during automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->