### PR TITLE
🛡️ Sentinel: CRITICAL Fix Path Truncation in Model Path

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains('\0') || model_path.contains("..") || model_path.contains("~") {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,12 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+
+        // Path truncation attempt
+        assert!(matches!(
+            validator.validate_model_request("/models/secret.gguf\0.safetensors"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function in `security.rs` failed to check for null bytes (`\0`) in the `model_path` user input.
🎯 Impact: An attacker could potentially use a null byte to bypass the `.gguf` and `.safetensors` extension checks and cause underlying OS APIs to read unauthorized files.
🔧 Fix: Explicitly check for and reject paths containing `\0`. Added a test case confirming the truncation attack is prevented.
✅ Verification: Ran `cargo test -p bitnet-server test_model_path_restriction` which successfully passes, confirming the fix works. Cargo clippy passes cleanly.

---
*PR created automatically by Jules for task [15001393115034668681](https://jules.google.com/task/15001393115034668681) started by @EffortlessSteven*