### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation via Null Bytes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-06-03 - [Path Truncation via Null Bytes]
+**Vulnerability:** The server validated user input file paths (e.g. model endpoints) against ".." and "~" and checked extensions, but allowed null bytes (`\0`). This exposed a Path Truncation vulnerability where underlying OS file operations could truncate the path at the null byte, potentially bypassing extension checks and leading to unauthorized access.
+**Learning:** Checking for malicious characters like ".." and "~" or specific extensions is insufficient validation for user input paths; always explicitly reject null bytes (`\0`) to prevent OS-level Path Truncation vulnerabilities.
+**Prevention:** In any path validation logic, check for and block the null byte character (`\0`) before passing the string to file system API functions.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The server validated user input file paths (`model_path`) against ".." and "~" and checked for expected file extensions (e.g., `.gguf`), but it allowed null bytes (`\0`). This exposed a classic Path Truncation vulnerability, where an underlying OS-level operation could terminate the string at the null byte, potentially bypassing the extension checks and leading to unauthorized access.
🎯 **Impact:** Potential unauthorized read access to server files, enabling path traversal beyond intended directories if combined with a payload that gets truncated before extension validation is effectively enforced.
🔧 **Fix:** Added an explicit check for `\0` in `validate_model_request` alongside the existing path traversal guards. Documented the vulnerability and learning in `.jules/sentinel.md`.
✅ **Verification:** Verified compilation and no regressions in test suites via `cargo check`, `cargo test --lib`, and `cargo clippy` in `bitnet-server`.

---
*PR created automatically by Jules for task [818466337897874288](https://jules.google.com/task/818466337897874288) started by @EffortlessSteven*