### PR TITLE
⚡ Bolt: Optimize typical sampling by fusing math passes

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,22 +92,31 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
+    // Performance optimization: Combine probability filtering, entropy calculation,
+    // and deviation mapping into a single pass to avoid redundant O(N) allocations
+    // and expensive re-computation of `p.ln()`.
+    let mut entropy = 0.0f32;
+    // We pre-allocate with len() as an upper bound, but often this slice has many zeros
+    // (e.g. from top-k/top-p filtering) so avoiding `Vec::new` reallocations is beneficial.
+    let mut deviations = Vec::with_capacity(probs.len());
+
+    for (i, &p) in probs.iter().enumerate() {
+        if p > 0.0 {
+            let ln_p = p.ln();
+            entropy -= p * ln_p; // accumulate entropy inline
+            deviations.push((i, p, ln_p)); // cache ln_p for the deviation pass
+        }
+    }
+
+    if deviations.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+    // Fast pass to finalize the deviation scores using the pre-computed entropy and ln_p
+    for entry in &mut deviations {
+        let surprise = -entry.2;
+        entry.2 = (surprise - entropy).abs();
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Optimize the probability filtering and mapping process in `apply_typical` by combining the multi-pass `.filter()`, `.sum()` and `.map()` iterations into a single loop.

🎯 Why: The original `apply_typical` first gathered probabilities > 0, iterated again over them to find the `sum` of `(-p * p.ln())` (the entropy), and iterated a third time calculating `-p.ln()` again to determine the deviations. Fusing these calculations avoids intermediate `Vec` allocations and redundant calculations of expensive transcendental functions like `.ln()`.

📊 Impact: Reduces computational complexity and memory allocations. `.ln()` is only called once per valid token, significantly improving speed across larger valid vocabularies. Expected performance improvement is evident since it eliminates duplicate loop iterations and redundant `f32::ln()` calls.

🔬 Measurement: Cargo tests for typical keep at least one token still passes. Benchmarking `apply_typical` should show speed improvements for lists containing non-zero probabilities.

---
*PR created automatically by Jules for task [4347659488058132506](https://jules.google.com/task/4347659488058132506) started by @EffortlessSteven*