### PR TITLE
🎨 Palette: Make output regions accessible to screen readers and keyboard users

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2026-03-22 - Replacing Labels for Non-Interactive Output Divs
+**Learning:** In HTML, standard `<div>` containers (such as scrollable output areas) cannot be labeled directly with `<label>` tags. Screen readers will ignore the label unless it points to an actionable form element. Additionally, `overflow-y: auto` boxes cannot be navigated to by keyboard users unless given a specific focus treatment.
+**Action:** When a scrollable output container needs to be labeled for accessibility, replace `<label>` tags with explicitly styled `<div>` elements having IDs, and link them to the output container using `aria-labelledby="..."`. Provide the output container with `tabindex="0"` and `role="region"` so keyboard users can scroll it and screen readers can read it correctly.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="label-output" style="margin-bottom: 0; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="label-output">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="label-streaming-output" style="margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="label-streaming-output">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="label-worker-output" style="margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="label-worker-output">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="label-benchmark-output" style="margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="label-benchmark-output">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
### 💡 What
Replaced `<label>` tags on non-interactive output `<div>`s with explicitly styled `<div>` elements and linked them via `aria-labelledby="..."`. I also added `tabindex="0"` and `role="region"` to the output containers.

### 🎯 Why
Screen readers will ignore `<label>` elements unless they point directly to an actionable form element (like `<input>` or `<textarea>`). Additionally, because these output containers have `overflow-y: auto`, keyboard-only users were previously unable to scroll through long outputs because the containers couldn't receive focus. 

### 📸 Before/After
Visually, the UI looks completely identical. The labels still look like standard labels.

### ♿ Accessibility
- Screen readers will now correctly announce the names of the output regions ("Output", "Streaming Output", "Worker Output", and "Benchmark Results").
- Keyboard users can now press Tab to focus into the output regions and use arrow keys to scroll through generated text.

---
*PR created automatically by Jules for task [6275944210754677894](https://jules.google.com/task/6275944210754677894) started by @EffortlessSteven*