### PR TITLE
🛡️ Sentinel: CRITICAL Fix Path Truncation in Model Path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## $(date +%Y-%m-%d) - Path Truncation in Model Path
+**Vulnerability:** The `validate_model_request` function validated file extensions and rejected `..` and `~` sequences, but failed to block null bytes (`\0`). This allowed for a Path Truncation vulnerability, where an attacker could inject a null byte mid-string (e.g., `/allowed/path/evil.txt\0.gguf`) to bypass extension-checking filters before the underlying OS-level system calls truncate the string.
+**Learning:** Checking for malicious sequences and required file extensions via string matching is insufficient when strings are ultimately passed down to zero-terminated C strings within the OS filesystem interfaces.
+**Prevention:** Always explicitly reject null bytes (`\0`) when validating or sanitizing user-provided paths prior to using them in standard library filesystem operations.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -227,8 +227,8 @@ impl SecurityValidator {
             return Err(ValidationError::MissingField("model_path".to_string()));
         }
 
-        // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        // Prevent path traversal attacks and null byte injection
+        if model_path.contains("..") || model_path.contains('~') || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Truncation vulnerability. The `validate_model_request` function validated file extensions and rejected `..` and `~` sequences, but failed to block null bytes (`\0`). This allowed an attacker to inject a null byte mid-string (e.g., `/allowed/path/evil.txt\0.gguf`) to bypass extension-checking filters. The underlying OS-level C-strings are null-terminated and truncate the provided path, resulting in loading unauthorized files.
🎯 **Impact:** An attacker could bypass `.gguf`/`.safetensors` file extension restrictions to load arbitrary file contents, potentially exposing sensitive data.
🔧 **Fix:** Explicitly reject `\0` in `validate_model_request` when checking path characteristics.
✅ **Verification:** Verified that tests pass via `cargo test -p bitnet-server` and verified no new Clippy warnings were introduced via `cargo clippy -p bitnet-server`.

---
*PR created automatically by Jules for task [12980538773972903842](https://jules.google.com/task/12980538773972903842) started by @EffortlessSteven*