### PR TITLE
🎨 Palette: Improve keyboard accessibility for scrollable output areas

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="font-weight: 500; margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converts invalid `<label>` tags for non-form elements into styled `<div>`s, adds `role="region"` and `tabindex="0"` to the output areas, and links them via `aria-labelledby`.
🎯 Why: `<label>` tags should strictly label form elements. Additionally, making non-interactive but scrollable areas (like log outputs) focusable allows keyboard-only users to scroll through generated text.
📸 Before/After: Visually verified; the changes are purely structural with no visual regressions.
♿ Accessibility: Fixes screen reader invalid ARIA labeling patterns and adds keyboard scroll accessibility to text outputs.

---
*PR created automatically by Jules for task [15342609777455482310](https://jules.google.com/task/15342609777455482310) started by @EffortlessSteven*