### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation Vulnerability

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The model path validation did not check for null bytes (\0), which can be used to truncate file paths in underlying OS operations.
🎯 Impact: Attackers could bypass file extension checks (e.g., .gguf) and read arbitrary files by appending \0.
🔧 Fix: Explicitly rejected null bytes in the model_path.
✅ Verification: Added a check for '\0' during path validation.

---
*PR created automatically by Jules for task [3505133947220839553](https://jules.google.com/task/3505133947220839553) started by @EffortlessSteven*