### PR TITLE
⚡ Bolt: Optimize apply_typical to avoid redundant ln() and allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-05 - Hot Loop Allocations in Token Sampling
 **Learning:** Allocating memory in the hot path of LLM token generation (e.g., `logits.to_vec()` or creating `HashMap`s per token) significantly degrades performance due to repeated allocation overhead of vocabulary-sized vectors (often 128K+ elements). Additionally, mathematically equivalent iterative multiplication (`logit *= inv_penalty`) can replace `HashMap` counting and `.powi(count)`, completely eliminating O(N) memory allocations per token.
 **Action:** When working on generation loops, use buffer pooling (e.g. storing a `Vec` in the generator state and using `std::mem::take` to bypass borrow checker limitations) and avoid `HashMap` allocations for simple counting if an iterative scalar approach is mathematically equivalent.
+
+## 2026-03-05 - Expensive operations in sort comparator
+**Learning:** When optimizing operations that involve sorting (e.g., \`apply_typical\` in logits filtering), placing expensive computations like transcendental functions (e.g., \`.ln()\`) inside the sort comparator or evaluating them twice (once for sum and once for mapping) is highly inefficient. They are evaluated multiple times or redundantly.
+**Action:** Always calculate and cache these expensive values in an initial pass, and if needed, mutate the collection in-place prior to sorting to avoid redundant computations and intermediate allocations.

--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,22 +92,26 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
+    let mut entropy = 0.0f32;
+    let mut deviations: Vec<(usize, f32, f32)> = probs
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|&(_, p)| p > 0.0)
+        .map(|(i, p)| {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            (i, p, surprise)
+        })
+        .collect();
+
+    if deviations.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+    for item in &mut deviations {
+        item.2 = (item.2 - entropy).abs();
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Fused the initial filtering pass and the deviations mapping pass in `apply_typical`, computing entropy cumulatively and mutating the collection in-place prior to sorting.
🎯 Why: Previously, `ln()` was called twice per token (once for entropy sum, once for deviation calculation), and an intermediate `Vec` was allocated.
📊 Impact: Reduces allocations by 1 `Vec` per inference step and halves the number of expensive transcendental `.ln()` calls in the typical filtering hot path.
🔬 Measurement: Verified with `cargo test -p bitnet-logits-filters` and `cargo clippy -p bitnet-logits-filters`.

---
*PR created automatically by Jules for task [8894043951599598943](https://jules.google.com/task/8894043951599598943) started by @EffortlessSteven*