### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation vulnerability in model path validation

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));

--- a/crates/bitnet-server/tests/server_security_tests.rs
+++ b/crates/bitnet-server/tests/server_security_tests.rs
@@ -480,10 +480,7 @@ fn test_model_path_empty_rejected_as_missing_field() {
 #[test]
 fn test_model_path_null_byte_rejected() {
     let v = validator(false, false);
-    assert!(
-        v.validate_model_request("/etc/passwd\0.gguf").is_err(),
-        "null bytes must be rejected"
-    );
+    assert!(v.validate_model_request("/etc/passwd\0.gguf").is_err(), "null bytes must be rejected");
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/bitnet-server/tests/server_security_tests.rs
+++ b/crates/bitnet-server/tests/server_security_tests.rs
@@ -477,6 +477,15 @@ fn test_model_path_empty_rejected_as_missing_field() {
     );
 }
 
+#[test]
+fn test_model_path_null_byte_rejected() {
+    let v = validator(false, false);
+    assert!(
+        v.validate_model_request("/etc/passwd\0.gguf").is_err(),
+        "null bytes must be rejected"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Health endpoint
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path truncation via null byte (`\0`) injection in `validate_model_request`. The validation logic checked for valid extensions like `.gguf` using string operations, but when interacting with underlying OS APIs, the path could be truncated at the null byte, potentially allowing loading of arbitrary files (e.g., `/etc/passwd\0.gguf`).
🎯 Impact: A malicious actor could bypass path validation checks and load arbitrary files from the filesystem.
🔧 Fix: Explicitly check for and reject null bytes (`\0`) in `model_path` validation.
✅ Verification: Ran `cargo test -p bitnet-server test_model_path_null_byte_rejected` and verified the new `test_model_path_null_byte_rejected` unit test passes.

---
*PR created automatically by Jules for task [12406287902880760740](https://jules.google.com/task/12406287902880760740) started by @EffortlessSteven*