### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation in Model Loading

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,21 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig {
+            allowed_model_directories: vec!["/models".to_string()],
+            ..Default::default()
+        };
+        let validator = SecurityValidator::new(config).unwrap();
+
+        // Path truncation attempt via null byte
+        assert!(matches!(
+            validator.validate_model_request("/models/allowed\0.gguf"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Truncation via Null Byte Injection. The `validate_model_request` function validated file extensions (e.g., `.gguf`) and directory prefixes using standard Rust string functions. However, if a path contained a null byte (e.g., `/etc/passwd\0.gguf`), Rust's `ends_with` would succeed, but the underlying OS system calls (`open`) would terminate at the null byte. This effectively allowed attackers to bypass the `.gguf`/`.safetensors` extension restriction and potentially load arbitrary files from the filesystem.
🎯 **Impact:** Potential arbitrary file read/loading if an attacker supplies a crafted model path, circumventing the intended directory and extension restrictions. 
🔧 **Fix:** Added an explicit check to reject any `model_path` containing a null byte (`\0`).
✅ **Verification:** Added `test_model_path_null_byte_rejection` to assert that paths with null bytes are explicitly rejected with an "Invalid characters" error.

---
*PR created automatically by Jules for task [8290569313827838833](https://jules.google.com/task/8290569313827838833) started by @EffortlessSteven*