### PR TITLE
🎨 Palette: Make scrollable output areas keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Keyboard Accessible Output Areas
+**Learning:** When non-interactive generic containers like `div` are scrollable (`overflow-y: auto`), they must have `tabindex="0"` to be keyboard accessible. Furthermore, generic containers should be labeled with `aria-labelledby` pointing to a styled text element instead of an improper `<label>` tag, which is reserved strictly for labellable form controls.
+**Action:** Always add `tabindex="0"`, `role="region"`, and link a semantic `<label>` replacement via `aria-labelledby` for custom scrollable output areas.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="basic-output-label" style="margin-bottom: 0; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="basic-output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Replaced improper `<label>` tags with styled `<div>` elements and linked them via `aria-labelledby` to their corresponding scrollable output areas. Added `tabindex="0"` and `role="region"` to the output areas to make them keyboard focusable.
🎯 Why: The scrollable output areas were inaccessible to keyboard-only users and screen readers. Also, `<label>` tags should only be used for actual form controls, not generic `<div>` containers.
📸 Before/After: Before, `<label>` tags were inappropriately styling text, and the boxes were unreachable via the keyboard. After, the output areas can be focused, scrolled via keyboard arrows, and read appropriately by screen readers.
♿ Accessibility: Added `aria-labelledby`, `role="region"`, and `tabindex="0"` to output areas, fixing improper labeling and missing focus management for scrollable regions.

---
*PR created automatically by Jules for task [15284647474968336920](https://jules.google.com/task/15284647474968336920) started by @EffortlessSteven*