### PR TITLE
🎨 Palette: Improve accessibility of scrollable output regions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Accessible Scrollable Output Containers
+**Learning:** In HTML, `<label>` tags are strictly reserved for labellable form controls. Screen readers may misinterpret or ignore labels attached to non-interactive generic containers like `div`s with `overflow-y: auto`.
+**Action:** To make scrollable, non-interactive generic containers accessible, use a styled `div` for the text label and link it to the container via `aria-labelledby`, while ensuring the container has `tabindex="0"` and `role="region"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .pseudo-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div class="pseudo-label" id="output-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div class="pseudo-label" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div class="pseudo-label" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div class="pseudo-label" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted invalid `<label>` tags pointing to non-interactive scrollable containers into styled `.pseudo-label` `div`s. Linked them via `aria-labelledby` to the scrollable containers, which were updated with `tabindex="0"` and `role="region"`.
🎯 Why: `<label>` tags are strictly reserved for labellable form controls. Screen readers may misinterpret or ignore them on non-interactive containers. Furthermore, keyboard users cannot scroll the container content without `tabindex`.
📸 Before/After: Visual changes are non-existent due to the added `.pseudo-label` CSS mirroring existing `label` styles.
♿ Accessibility: Screen readers now correctly read the label when the region is focused, and keyboard users can tab into the output containers to scroll through long outputs.

---
*PR created automatically by Jules for task [17052846211069954411](https://jules.google.com/task/17052846211069954411) started by @EffortlessSteven*