### PR TITLE
⚡ Bolt: Optimize apply_typical to fuse entropy calculation and avoid redundant transcendental math

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,22 +92,27 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
+    // Combine indexed filtering and surprise/entropy calculation into a single pass
+    let mut indexed = Vec::with_capacity(probs.len());
+    let mut entropy = 0.0f32;
+
+    for (i, &p) in probs.iter().enumerate() {
+        if p > 0.0 {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            indexed.push((i, p, surprise));
+        }
+    }
+
     if indexed.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+    // Convert into deviations, reusing the same vector allocation
+    let mut deviations = indexed;
+    for (_, _, dev) in &mut deviations {
+        *dev = (*dev - entropy).abs();
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Optimize `apply_typical` to calculate surprise, entropy, and deviations in a single pass without redundantly calling `.ln()`.
🎯 Why: Calculating `-p.ln()` was being done twice for every non-zero token probability—once to sum the entropy, and again to map probabilities to deviations. This is a very hot mathematical path. Fusing these calculations avoids intermediate vector allocations and redundant transcendental function evaluations.
📊 Impact: Halves the number of costly `.ln()` calls in the typical filtering hot path, and removes the allocation of a second `Vec` that maps from indexed probabilities to deviations. 
🔬 Measurement: Run the test suite and verify no regressions in functionality (`cargo test -p bitnet-logits-filters`).

---
*PR created automatically by Jules for task [14711547363847893771](https://jules.google.com/task/14711547363847893771) started by @EffortlessSteven*