### PR TITLE
🎨 Palette: Make scrollable output regions accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-23 - Accessible Scrollable Regions
+**Learning:** Using `<label>` tags for non-interactive containers (like generic scrollable `div`s) is invalid HTML and fails accessibility audits, as `<label>` is strictly for form controls. Additionally, screen readers cannot access content inside generic scrollable `div`s with `overflow-y: auto` unless they are made focusable.
+**Action:** To make generic scrollable containers accessible, convert invalid `<label>` tags to styled `div`s (e.g., `<div class="section-label" id="my-label">`), and link them to the container via `aria-labelledby`, ensuring the container itself has `tabindex="0"` and `role="region"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .section-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -172,6 +172,11 @@
             font-family: 'Courier New', monospace;
             min-height: 200px;
             overflow-y: auto;
+        }
+
+        .output:focus-visible, .streaming-output:focus-visible {
+            outline: 3px solid #0056b3;
+            outline-offset: 2px;
         }
 
         .worker-status {
@@ -296,10 +301,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div class="section-label" id="output-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" role="region" tabindex="0" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +326,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div class="section-label" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" tabindex="0" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +369,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div class="section-label" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" tabindex="0" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +392,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div class="section-label" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" tabindex="0" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted invalid `<label>` tags pointing to non-form `<div class="output">` containers into styled `.section-label` `<div>`s, linked via `aria-labelledby`. Added `tabindex="0"`, `role="region"`, and `:focus-visible` styles to the output containers.
🎯 Why: Scrollable containers must be keyboard-focusable so keyboard-only and screen reader users can scroll them. The `<label>` tag is strictly for form inputs; using it on a generic `div` is invalid HTML and fails accessibility audits.
📸 Before/After: Outputs are now keyboard focusable with a clear visual outline, and screen readers will announce their purpose correctly.
♿ Accessibility: Resolves invalid `<label>` usage, ensures scrollable regions are focusable, and establishes proper ARIA labeling for non-interactive containers.

---
*PR created automatically by Jules for task [2907128792806888325](https://jules.google.com/task/2907128792806888325) started by @EffortlessSteven*