### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation Vulnerability in Model Loading

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -227,8 +227,8 @@ impl SecurityValidator {
             return Err(ValidationError::MissingField("model_path".to_string()));
         }
 
-        // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        // Prevent path traversal attacks and path truncation
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -710,5 +710,24 @@ mod tests {
             validator.validate_model_request(legit.to_str().unwrap()).is_ok(),
             "Legitimate path inside allowed directory must be accepted"
         );
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        // Legitimate paths
+        assert!(validator.validate_model_request("model.gguf").is_ok());
+
+        // Paths with null bytes
+        assert!(matches!(
+            validator.validate_model_request("model.gguf\0.txt"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+        assert!(matches!(
+            validator.validate_model_request("\0model.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
     }
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function validated file extensions using Rust's string `.ends_with()` but did not check for null bytes (`\0`). This allows path truncation attacks when the path is passed to underlying C-based libraries (like llama.cpp) or OS APIs, as the null byte terminates the string early.
🎯 Impact: An attacker could bypass the `.gguf` / `.safetensors` file extension restrictions by appending a null byte followed by the allowed extension (e.g., `sensitive_file.txt\0.gguf`). This could allow loading arbitrary files and potentially lead to sensitive data exposure.
🔧 Fix: Added a check to explicitly reject any model path containing a null byte (`\0`) in `crates/bitnet-server/src/security.rs`.
✅ Verification: Added `test_model_path_null_byte_rejection` in the security tests module. Verified the fix locally by running `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection`, `cargo fmt --all`, and `cargo clippy -p bitnet-server -- -D warnings`.

---
*PR created automatically by Jules for task [10821680292327955436](https://jules.google.com/task/10821680292327955436) started by @EffortlessSteven*