### PR TITLE
⚡ Bolt: Optimize Typical Sampling by eliminating redundant logarithm computations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-05 - Hot Loop Allocations in Token Sampling
 **Learning:** Allocating memory in the hot path of LLM token generation (e.g., `logits.to_vec()` or creating `HashMap`s per token) significantly degrades performance due to repeated allocation overhead of vocabulary-sized vectors (often 128K+ elements). Additionally, mathematically equivalent iterative multiplication (`logit *= inv_penalty`) can replace `HashMap` counting and `.powi(count)`, completely eliminating O(N) memory allocations per token.
 **Action:** When working on generation loops, use buffer pooling (e.g. storing a `Vec` in the generator state and using `std::mem::take` to bypass borrow checker limitations) and avoid `HashMap` allocations for simple counting if an iterative scalar approach is mathematically equivalent.
+
+## 2025-04-02 - Fusing Logarithmic Calculations in Typical Sampling
+**Learning:** Computing expected surprise (entropy) and per-token deviation in Locally Typical Sampling normally requires evaluating `.ln()` twice per token. Transcendental math is expensive in hot sampling loops. We can calculate and accumulate entropy while storing the intermediate `surprise` in a single pass, completely eliminating redundant `.ln()` calls.
+**Action:** When calculating aggregations (like entropy or variance) alongside point deviations, look for opportunities to compute the base expensive math (`.ln()`, `.exp()`) once per element, store it, and mutate it in-place during a subsequent pass.

--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,22 +92,26 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
+    let mut entropy = 0.0f32;
+    let mut deviations: Vec<(usize, f32, f32)> = probs
+        .iter()
+        .copied()
+        .enumerate()
+        .filter(|&(_, p)| p > 0.0)
+        .map(|(i, p)| {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            (i, p, surprise)
+        })
+        .collect();
+
+    if deviations.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+    for entry in &mut deviations {
+        entry.2 = (entry.2 - entropy).abs();
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Fused the computation of expected surprise (entropy) and point surprise in `apply_typical` to only require a single `.ln()` evaluation per non-zero token instead of two.
🎯 Why: `p.ln()` is a computationally expensive transcendental function. In typical sampling, it was being calculated twice per valid token (once to sum entropy, once to find the deviation). This halves the required expensive math operations and removes an entire intermediate array mapping step.
📊 Impact: Reduces transcendental function calls by 50% and removes O(n) mapping passes during typical sampling probability filtering.
🔬 Measurement: Verified with `cargo test -p bitnet-logits-filters` and formatting checks.

---
*PR created automatically by Jules for task [16462937900351441391](https://jules.google.com/task/16462937900351441391) started by @EffortlessSteven*