### PR TITLE
⚡ Bolt: Optimize Locally Typical Sampling

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -92,22 +92,28 @@ pub fn apply_typical(probs: &mut [f32], typical_p: f32) {
         return;
     }
 
-    let indexed: Vec<(usize, f32)> =
-        probs.iter().copied().enumerate().filter(|&(_, p)| p > 0.0).collect();
-    if indexed.is_empty() {
+    // ⚡ Bolt: Fused entropy calculation and deviation mapping to avoid redundant .ln() calls
+    // and intermediate vector allocations for sparse probability arrays.
+    let mut entropy = 0.0f32;
+    let mut deviations: Vec<(usize, f32, f32)> = Vec::new();
+
+    for (i, &p) in probs.iter().enumerate() {
+        if p > 0.0 {
+            let surprise = -p.ln();
+            entropy += p * surprise;
+            // Temporarily store surprise in the 3rd tuple slot
+            deviations.push((i, p, surprise));
+        }
+    }
+
+    if deviations.is_empty() {
         return;
     }
 
-    let entropy: f32 = indexed.iter().map(|&(_, p)| -p * p.ln()).sum();
-
-    let mut deviations: Vec<(usize, f32, f32)> = indexed
-        .into_iter()
-        .map(|(i, p)| {
-            let surprise = -p.ln();
-            let deviation = (surprise - entropy).abs();
-            (i, p, deviation)
-        })
-        .collect();
+    // Map surprise to deviation now that entropy is fully calculated
+    for item in &mut deviations {
+        item.2 = (item.2 - entropy).abs();
+    }
 
     deviations.sort_unstable_by(|a, b| f32_ascending(a.2, b.2));
 


### PR DESCRIPTION
💡 What: Fuse the intermediate `indexed` vector into a single allocation and eliminate duplicate `f32::ln()` calls by computing entropy dynamically and temporarily storing surprise.
🎯 Why: `f32::ln()` is an expensive transcendental operation. The previous implementation computed it once to calculate entropy and a second time to calculate deviations. Additionally, creating the `indexed` vector was redundant.
📊 Impact: Halves the number of `.ln()` calculations required and removes one intermediate `Vec` allocation per generation step for typical sampling.
🔬 Measurement: Verify using `cargo test -p bitnet-logits-filters` and confirm behavior of `apply_typical` remains unchanged.

---
*PR created automatically by Jules for task [5965462761875606355](https://jules.google.com/task/5965462761875606355) started by @EffortlessSteven*