### PR TITLE
🎨 Palette: Make scrollable output containers keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2026-04-04 - Accessible Scrollable Regions using Pseudo-Labels
+**Learning:** In HTML, `<label>` elements are strictly reserved for form controls (inputs, textareas, etc). When trying to make a generic scrollable container (like a `<div>` with `overflow-y: auto`) accessible, using a `<label>` pointing to it is invalid HTML and causes screen reader confusion.
+**Action:** When creating scrollable, non-interactive output containers that need to be focusable (`tabindex="0"`, `role="region"`), never use `<label>`. Instead, use a styled `<div>` (e.g., `<div class="pseudo-label" id="container-label">`) and link it to the container using `aria-labelledby="container-label"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .pseudo-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div class="pseudo-label" id="output-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" role="region" aria-labelledby="output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div class="pseudo-label" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div class="pseudo-label" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div class="pseudo-label" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -82,7 +82,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .pseudo-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div class="pseudo-label" id="output-label">Output:</div>
+                <div id="output" class="output" role="region" aria-labelledby="output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div class="pseudo-label" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div class="pseudo-label" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div class="pseudo-label" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
### 💡 What
Replaced `<label>` elements pointing to generic scrollable `<div>` containers with styled `<div class="pseudo-label">` elements. Added `role="region"`, `tabindex="0"`, and `aria-labelledby` to the scrollable output containers across the browser examples (`crates/bitnet-wasm/examples/browser/index.html` and `examples/wasm/browser/index.html`).

### 🎯 Why
In HTML, `<label>` tags are strictly reserved for labeling form controls (like inputs or textareas). Using them for generic containers is invalid and causes screen readers to misunderstand the relationship. Additionally, scrollable containers must be focusable so that keyboard users can scroll through the generated output without relying on a mouse.

### 📸 Before/After
**Before:**
Output containers could only be scrolled via mouse/touch. Screen readers encountered invalid label associations.

**After:**
Output containers can be focused via the `Tab` key (displaying a clear focus ring) and scrolled using keyboard arrow keys. Screen readers correctly announce the region names based on the associated pseudo-labels.

### ♿ Accessibility
- Fixed invalid `<label>` usage for non-interactive elements.
- Ensured scrollable output text is navigable for keyboard-only users (`tabindex="0"`).
- Provided proper semantic context for screen readers (`role="region"` and `aria-labelledby`).

---
*PR created automatically by Jules for task [1688769065577430257](https://jules.google.com/task/1688769065577430257) started by @EffortlessSteven*