### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation Vulnerability

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -227,8 +227,8 @@ impl SecurityValidator {
             return Err(ValidationError::MissingField("model_path".to_string()));
         }
 
-        // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        // Prevent path traversal attacks and null byte injection
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -600,6 +600,17 @@ mod tests {
 
         let config = SecurityConfig { trust_forwarded_headers: true, ..Default::default() };
         assert_eq!(extract_client_ip(&request, &config), Some(IpAddr::from([203, 0, 113, 1])));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("malicious.txt\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The model path validation logic in `SecurityValidator::validate_model_request` did not explicitly reject null bytes (`\0`). This could allow an attacker to bypass file extension restrictions (e.g., `.ends_with(".gguf")`) by appending a null byte followed by a valid extension (e.g., `malicious.txt\0.gguf`). When passed to underlying C libraries (like `llama.cpp`) or OS file APIs, the path would be truncated at the null byte, resulting in the loading of `malicious.txt`.
🎯 Impact: An attacker could potentially load arbitrary files from the filesystem (within allowed directories) by tricking the server into reading files with non-allowed extensions, potentially leading to unauthorized data disclosure or arbitrary code execution if a maliciously crafted file is loaded as a model.
🔧 Fix: Updated the validation logic in `validate_model_request` to explicitly reject any model path containing a null byte (`\0`). Added a comprehensive test case `test_model_path_null_byte_rejection` to ensure this behavior is enforced.
✅ Verification: Tested locally via `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection`.

---
*PR created automatically by Jules for task [1572519263387752588](https://jules.google.com/task/1572519263387752588) started by @EffortlessSteven*