### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix hardcoded API keys in Actix examples

### DIFF
--- a/examples/integrations/actix_server.rs
+++ b/examples/integrations/actix_server.rs
@@ -226,9 +226,10 @@ async fn initialize_app_state() -> Result<AppState> {
 
     // Load API keys from environment
     let api_keys = std::env::var("BITNET_API_KEYS")
-        .unwrap_or_else(|_| "demo-key-123,test-key-456".to_string())
+        .unwrap_or_else(|_| "".to_string())
         .split(',')
         .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .collect();
 
     info!("Application state initialized successfully");

--- a/examples/web/actix_server.rs
+++ b/examples/web/actix_server.rs
@@ -226,9 +226,10 @@ async fn initialize_app_state() -> Result<AppState> {
 
     // Load API keys from environment
     let api_keys = std::env::var("BITNET_API_KEYS")
-        .unwrap_or_else(|_| "demo-key-123,test-key-456".to_string())
+        .unwrap_or_else(|_| "".to_string())
         .split(',')
         .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .collect();
 
     info!("Application state initialized successfully");


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `BITNET_API_KEYS` configuration fell back to hardcoded secrets (`demo-key-123,test-key-456`) when not explicitly provided in the environment.
🎯 Impact: Attackers could easily authenticate to these API servers using the well-known fallback credentials if they are deployed without overriding the environment variable.
🔧 Fix: Changed the fallback to an empty string and added filtering so that no hardcoded fallback key is allowed.
✅ Verification: `cargo clippy --examples -- -D warnings` and `cargo check --examples` successfully executed.

---
*PR created automatically by Jules for task [7922041288474319516](https://jules.google.com/task/7922041288474319516) started by @EffortlessSteven*