### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation vulnerability

### DIFF
--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,17 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("valid_model.gguf\0.txt"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path Truncation. The `model_path` validation relied on Rust string methods like `.ends_with()`, but failed to reject null bytes (`\0`). An attacker could provide a path such as `secret.txt\0.gguf`, bypassing the `.ends_with(".gguf")` check in Rust while causing the underlying C/OS APIs to load `secret.txt`.
🎯 Impact: This vulnerability allows an attacker to bypass file extension restrictions and potentially read arbitrary files on the system by truncating the path.
🔧 Fix: Explicitly added a check to reject null bytes (`\0`) in the `model_path` within `validate_model_request`.
✅ Verification: Ran `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection` to confirm that paths with null bytes are correctly rejected.

---
*PR created automatically by Jules for task [6730002971294864901](https://jules.google.com/task/6730002971294864901) started by @EffortlessSteven*