### PR TITLE
🎨 Palette: Make WASM browser example tabs accessible

### DIFF
--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -188,16 +188,31 @@
             margin-bottom: 20px;
         }
 
-        .tab {
+        button.tab {
+            background: transparent;
+            border: none;
+            border-bottom: 2px solid transparent;
             padding: 12px 20px;
             cursor: pointer;
-            border-bottom: 2px solid transparent;
+            font-family: inherit;
+            font-size: 1rem;
+            color: inherit;
             transition: all 0.2s;
+            border-radius: 0;
         }
 
-        .tab.active {
+        button.tab:hover:not(:disabled) {
+            background-color: rgba(0,0,0,0.05);
+        }
+
+        button.tab.active {
             border-bottom-color: #007bff;
             color: #007bff;
+        }
+
+        button.tab:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: -2px;
         }
 
         .tab-content {
@@ -225,16 +240,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Application Sections">
+        <button type="button" class="tab active" role="tab" aria-selected="true" aria-controls="basic-tab" id="tab-basic" tabindex="0" onclick="switchTab('basic', this)">Basic Inference</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="streaming-tab" id="tab-streaming" tabindex="-1" onclick="switchTab('streaming', this)">Streaming</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="worker-tab" id="tab-worker" tabindex="-1" onclick="switchTab('worker', this)">Web Workers</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="benchmark-tab" id="tab-benchmark" tabindex="-1" onclick="switchTab('benchmark', this)">Benchmarks</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="settings-tab" id="tab-settings" tabindex="-1" onclick="switchTab('settings', this)">Settings</button>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +296,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +334,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +362,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +404,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -21,6 +21,9 @@ let benchmarkSuite = null;
 // Initialize the application
 async function initApp() {
     try {
+        // Setup keyboard navigation for tabs
+        setupTabNavigation();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -445,22 +448,30 @@ function createGenerationConfig() {
 }
 
 // Tab switching
-function switchTab(tabName) {
+function switchTab(tabName, element) {
     // Hide all tab contents
     document.querySelectorAll('.tab-content').forEach(tab => {
         tab.classList.remove('active');
     });
 
-    // Remove active class from all tabs
+    // Remove active class, reset aria-selected, and remove from tab order for all tabs
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class, set aria-selected, and add to tab order for selected tab
+    // Fallback to event.target if element is not provided (backwards compatibility)
+    const target = element || (typeof event !== 'undefined' ? event.target : null);
+    if (target) {
+        target.classList.add('active');
+        target.setAttribute('aria-selected', 'true');
+        target.setAttribute('tabindex', '0');
+    }
 }
 
 // Settings management
@@ -566,3 +577,41 @@ window.importSettings = importSettings;
 
 // Initialize the application when the page loads
 document.addEventListener('DOMContentLoaded', initApp);
+
+// Setup keyboard navigation for tabs
+function setupTabNavigation() {
+    const tabsContainer = document.querySelector('.tabs');
+    if (!tabsContainer) return;
+
+    tabsContainer.addEventListener('keydown', (e) => {
+        const tabs = Array.from(document.querySelectorAll('.tab'));
+        const activeTab = document.activeElement;
+        const index = tabs.indexOf(activeTab);
+
+        if (index === -1) return; // Focus not on a tab
+
+        let nextIndex = index;
+        let handled = false;
+
+        if (e.key === 'ArrowRight') {
+            nextIndex = (index + 1) % tabs.length;
+            handled = true;
+        } else if (e.key === 'ArrowLeft') {
+            nextIndex = (index - 1 + tabs.length) % tabs.length;
+            handled = true;
+        } else if (e.key === 'Home') {
+            nextIndex = 0;
+            handled = true;
+        } else if (e.key === 'End') {
+            nextIndex = tabs.length - 1;
+            handled = true;
+        }
+
+        if (handled) {
+            e.preventDefault();
+            const nextTab = tabs[nextIndex];
+            nextTab.focus();
+            nextTab.click(); // Activate the tab
+        }
+    });
+}


### PR DESCRIPTION
💡 What: Converted interactive tab divs to semantically correct buttons and added keyboard navigation.
🎯 Why: Custom ARIA tablists lack built-in keyboard support; users relying on keyboards/screen readers couldn't navigate between sections.
📸 Before/After: Div tabs were inaccessible via keyboard. Now, they're semantic buttons supporting Arrow/Home/End navigation.
♿ Accessibility: Added `role="tablist"`, `role="tab"`, `aria-selected`, `aria-controls` and arrow-key focus management.

---
*PR created automatically by Jules for task [10686633089233087744](https://jules.google.com/task/10686633089233087744) started by @EffortlessSteven*