### PR TITLE
🎨 Palette: Enhance tab accessibility and keyboard navigation

### DIFF
--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -188,14 +188,36 @@
             margin-bottom: 20px;
         }
 
-        .tab {
-            padding: 12px 20px;
-            cursor: pointer;
-            border-bottom: 2px solid transparent;
-            transition: all 0.2s;
+        button:focus-visible {
+            outline: 3px solid #0056b3;
+            outline-offset: 2px;
         }
 
-        .tab.active {
+        button.tab:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: -2px;
+        }
+
+        /* Tab button styles - higher specificity to override generic button styles */
+        button.tab {
+            background: transparent;
+            border: none;
+            border-bottom: 2px solid transparent;
+            padding: 12px 20px;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-family: inherit;
+            font-size: 1rem;
+            color: inherit;
+            outline: none;
+            border-radius: 0;
+        }
+
+        button.tab:hover:not(:disabled) {
+            background-color: rgba(0,0,0,0.05);
+        }
+
+        button.tab.active {
             border-bottom-color: #007bff;
             color: #007bff;
         }
@@ -225,16 +247,16 @@
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Application Sections">
+        <button type="button" class="tab active" role="tab" aria-selected="true" aria-controls="basic-tab" id="tab-basic" tabindex="0" onclick="switchTab('basic', this)">Basic Inference</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="streaming-tab" id="tab-streaming" tabindex="-1" onclick="switchTab('streaming', this)">Streaming</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="worker-tab" id="tab-worker" tabindex="-1" onclick="switchTab('worker', this)">Web Workers</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="benchmark-tab" id="tab-benchmark" tabindex="-1" onclick="switchTab('benchmark', this)">Benchmarks</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="settings-tab" id="tab-settings" tabindex="-1" onclick="switchTab('settings', this)">Settings</button>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -281,7 +303,7 @@
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -319,7 +341,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -347,7 +369,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -389,7 +411,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -21,6 +21,9 @@ let benchmarkSuite = null;
 // Initialize the application
 async function initApp() {
     try {
+        // Setup keyboard navigation for tabs
+        setupTabNavigation();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -445,22 +448,30 @@ function createGenerationConfig() {
 }
 
 // Tab switching
-function switchTab(tabName) {
+function switchTab(tabName, element) {
     // Hide all tab contents
     document.querySelectorAll('.tab-content').forEach(tab => {
         tab.classList.remove('active');
     });
 
-    // Remove active class from all tabs
+    // Remove active class, reset aria-selected, and remove from tab order for all tabs
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class, set aria-selected, and add to tab order for selected tab
+    // Fallback to event.target if element is not provided (backwards compatibility)
+    const target = element || (typeof event !== 'undefined' ? event.target : null);
+    if (target) {
+        target.classList.add('active');
+        target.setAttribute('aria-selected', 'true');
+        target.setAttribute('tabindex', '0');
+    }
 }
 
 // Settings management
@@ -543,6 +554,44 @@ document.getElementById('temperature').addEventListener('input', function() {
 document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
+
+// Setup keyboard navigation for tabs
+function setupTabNavigation() {
+    const tabsContainer = document.querySelector('.tabs');
+    if (!tabsContainer) return;
+
+    tabsContainer.addEventListener('keydown', (e) => {
+        const tabs = Array.from(document.querySelectorAll('.tab'));
+        const activeTab = document.activeElement;
+        const index = tabs.indexOf(activeTab);
+
+        if (index === -1) return; // Focus not on a tab
+
+        let nextIndex = index;
+        let handled = false;
+
+        if (e.key === 'ArrowRight') {
+            nextIndex = (index + 1) % tabs.length;
+            handled = true;
+        } else if (e.key === 'ArrowLeft') {
+            nextIndex = (index - 1 + tabs.length) % tabs.length;
+            handled = true;
+        } else if (e.key === 'Home') {
+            nextIndex = 0;
+            handled = true;
+        } else if (e.key === 'End') {
+            nextIndex = tabs.length - 1;
+            handled = true;
+        }
+
+        if (handled) {
+            e.preventDefault();
+            const nextTab = tabs[nextIndex];
+            nextTab.focus();
+            nextTab.click(); // Activate the tab
+        }
+    });
+}
 
 // Make functions globally available
 window.loadModel = loadModel;

--- a/test_a11y.py
+++ b/test_a11y.py
@@ -1,0 +1,22 @@
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page()
+    page.goto('file://' + __import__('os').path.abspath('examples/wasm/browser/index.html'))
+
+    # Check tab structure
+    tabs_html = page.evaluate('document.querySelector(".tabs").outerHTML')
+    print("TABS HTML:\n", tabs_html)
+
+    # Check what role and tab index they have
+    tab_details = page.evaluate('''() => {
+        return Array.from(document.querySelectorAll('.tab')).map(t => ({
+            text: t.textContent,
+            role: t.getAttribute('role'),
+            tabindex: t.getAttribute('tabindex')
+        }));
+    }''')
+    print("TAB DETAILS:\n", tab_details)
+
+    browser.close()


### PR DESCRIPTION
💡 What: Converted custom `div` tabs to accessible `<button>` elements with ARIA roles and implemented full keyboard navigation support (Arrow keys, Home, End).
🎯 Why: Screen readers and keyboard-only users could not interact with the tabs because they lacked semantic meaning and keyboard focus events.
📸 Before/After: Visuals remain unchanged due to a CSS reset, but keyboard focus ring is now visible.
♿ Accessibility: Added `role='tablist'`, `role='tab'`, `role='tabpanel'`, `aria-selected`, `aria-controls`, and `aria-labelledby`. Ensured `tabindex` is correctly updated during navigation.

---
*PR created automatically by Jules for task [610727262607891974](https://jules.google.com/task/610727262607891974) started by @EffortlessSteven*