### PR TITLE
⚡ Bolt: Remove unused token_counts HashMap

### DIFF
--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -20,7 +20,6 @@ use anyhow::{Context, Result};
 use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use std::collections::HashMap;
 use tracing::debug;
 
 /// Configuration for sampling strategies.
@@ -70,7 +69,6 @@ impl Default for SamplingConfig {
 pub struct SamplingStrategy {
     config: SamplingConfig,
     rng: ChaCha8Rng,
-    token_counts: HashMap<u32, usize>,
     /// Pre-allocated buffer to avoid allocating on every generation step
     logits_buffer: Vec<f32>,
 }
@@ -96,7 +94,7 @@ impl SamplingStrategy {
             ChaCha8Rng::from_rng(&mut rand::rng())
         };
 
-        Self { config, rng, token_counts: HashMap::new(), logits_buffer: Vec::new() }
+        Self { config, rng, logits_buffer: Vec::new() }
     }
 
     /// Sample the next token from logits.
@@ -164,7 +162,6 @@ impl SamplingStrategy {
         // as Err and breaks ties by lowest token ID for llama.cpp compatibility).
         if self.config.temperature == 0.0 {
             let token = greedy_sample(&buf)?;
-            *self.token_counts.entry(token).or_insert(0) += 1;
             // Restore buffer
             self.logits_buffer = buf;
             return Ok(token);
@@ -192,7 +189,6 @@ impl SamplingStrategy {
         let _ = renormalize_in_place(&mut buf);
 
         let token = self.sample_from_distribution(&buf)?;
-        *self.token_counts.entry(token).or_insert(0) += 1;
 
         // Restore buffer
         self.logits_buffer = buf;
@@ -257,29 +253,12 @@ impl SamplingStrategy {
         Ok(idx as u32)
     }
 
-    /// Reset token counts for a new sequence.
+    /// Reset internal state for a new sequence.
     ///
-    /// Call this between independent generation requests to prevent counts from
-    /// a previous sequence affecting the repetition penalty.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bitnet_sampling::{SamplingConfig, SamplingStrategy};
-    ///
-    /// let config = SamplingConfig { temperature: 0.0, seed: Some(1), ..Default::default() };
-    /// let mut strategy = SamplingStrategy::new(config);
-    ///
-    /// // Generate a token so internal counts are non-empty.
-    /// let logits = vec![0.1f32, 0.9, 0.3];
-    /// let _ = strategy.sample(&logits, &[]).unwrap();
-    ///
-    /// // reset() clears those counts so the next request is independent.
-    /// strategy.reset();
-    /// ```
-    pub fn reset(&mut self) {
-        self.token_counts.clear();
-    }
+    /// (Note: token tracking was removed in a performance optimization, as context
+    /// is now iterated directly for repetition penalties. This method is kept for
+    /// backwards compatibility).
+    pub fn reset(&mut self) {}
 
     /// Update configuration, re-seeding the PRNG if the seed changed.
     pub fn update_config(&mut self, config: SamplingConfig) {


### PR DESCRIPTION
💡 What: Removed `token_counts` HashMap from `SamplingStrategy`.
🎯 Why: The `HashMap` was being populated in the hot sampling path (`self.sample`) but never read from, as the repetition penalty implementation had already been optimized to iterate directly over `context_tokens` without needing the frequency counts from the map. Populating an unused HashMap incurs O(1) hash and allocation overhead per generated token.
📊 Impact: Eliminates unnecessary heap operations per token in the inference hot loop, reducing generation latency.
🔬 Measurement: Verified with `cargo test -p bitnet-sampling` that no tests depend on the `HashMap` and all functionality remains intact.

---
*PR created automatically by Jules for task [14431319692825179629](https://jules.google.com/task/14431319692825179629) started by @EffortlessSteven*