### PR TITLE
🎨 Palette: Improve accessibility of scrollable output regions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-23 - Accessible Scrollable Regions
+**Learning:** In HTML, `<label>` tags are strictly reserved for labellable form controls. Using them for generic containers (like scrollable `div`s) is semantically incorrect and inaccessible.
+**Action:** To make scrollable, non-interactive generic containers accessible, use a styled `div` for the text label and link it to the container via `aria-labelledby`, while ensuring the container has `tabindex="0"` and `role="region"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .pseudo-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div class="pseudo-label" id="output-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div class="pseudo-label" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div class="pseudo-label" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div class="pseudo-label" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted incorrectly used `<label>` elements for output regions to styled `div`s and linked them via `aria-labelledby`. Added `tabindex="0"` and `role="region"` to the output `div`s.
🎯 Why: `<label>` tags are only for form controls. Using them for generic `div`s violates accessibility standards. Adding `tabindex="0"` and `role="region"` makes these scrollable areas keyboard accessible and identifiable to screen readers.
📸 Before/After: Visual appearance is unchanged, but semantic structure and keyboard navigation are vastly improved.
♿ Accessibility: Fixed incorrect `<label>` usage, added keyboard navigation (`tabindex="0"`) to scrollable areas, and provided screen reader context (`role="region"` and `aria-labelledby`).

---
*PR created automatically by Jules for task [14481894385163465906](https://jules.google.com/task/14481894385163465906) started by @EffortlessSteven*