### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation via Null Byte Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-06-03 - Path Truncation via Null Byte Injection
+**Vulnerability:** The `validate_model_request` function in `bitnet-server` did not explicitly reject null bytes (`\0`) in the `model_path` argument. Because standard Rust string methods like `.ends_with(".gguf")` operate on bytes, a path like `test.gguf\0` would pass validation but could be truncated when passed to underlying C/OS APIs (like `llama.cpp` or POSIX file system APIs), potentially allowing unauthorized file access or bypassing extension checks.
+**Learning:** Standard string validation methods in Rust are insufficient for paths passed to C-compatible APIs due to differences in how null terminators are handled.
+**Prevention:** Always explicitly reject null bytes (`\0`) in path validation logic derived from user input before further processing or passing to underlying systems.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -227,6 +227,13 @@ impl SecurityValidator {
             return Err(ValidationError::MissingField("model_path".to_string()));
         }
 
+        // Null byte injection protection
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Prevent path traversal attacks
         if model_path.contains("..") || model_path.contains("~") {
             return Err(ValidationError::InvalidFieldValue(
@@ -607,6 +614,11 @@ mod tests {
         // Case 1: No restriction (empty allowed directories)
         let config = SecurityConfig::default();
         let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("test.gguf\0"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Null bytes are not allowed in model path"
+        ));
 
         assert!(validator.validate_model_request("/tmp/model.gguf").is_ok());
         assert!(validator.validate_model_request("relative/model.gguf").is_ok());


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function in `bitnet-server` did not explicitly reject null bytes (`\0`) in the `model_path` argument. Because standard Rust string validation methods (like `.ends_with(".gguf")`) operate on bytes, an attacker could supply a path like `test.gguf\0` which passes the extension check but is truncated when passed to underlying C/OS APIs (e.g., `llama.cpp` or POSIX file system APIs).
🎯 Impact: This could potentially allow an attacker to bypass file extension restrictions and access unauthorized files on the system, depending on how the path is utilized downstream.
🔧 Fix: Added an explicit check `model_path.contains('\0')` in `validate_model_request` to return an `InvalidFieldValue` error if a null byte is detected. Also added a corresponding test case `test_model_path_restriction` to verify this behavior.
✅ Verification:
Run `cargo clippy -p bitnet-server -- -D warnings`
Run `cargo test -p bitnet-server --lib security::tests::test_model_path_restriction`

---
*PR created automatically by Jules for task [7879273047049324277](https://jules.google.com/task/7879273047049324277) started by @EffortlessSteven*