### PR TITLE
🎨 Palette: Convert generic output labels to accessible div containers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Labelling Generic Scrollable Containers
+**Learning:** In HTML, `<label>` tags are strictly reserved for labellable form controls. Screen readers may ignore them when wrapped around generic containers like `div`s with `overflow-y: auto`, resulting in a loss of context.
+**Action:** To make scrollable, non-interactive generic containers accessible, use a styled `div` for the text label and link it to the container via `aria-labelledby`, ensuring the container has `tabindex="0"` and `role="region"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="margin-bottom: 0; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" role="region" aria-labelledby="output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
🎨 Palette: Convert generic output labels to accessible div containers

**💡 What**
Replaced `<label>` tags with styled `<div>` tags for non-interactive output containers across all tabs in the WASM browser example. Linked the new labels to their respective containers using `aria-labelledby`, added `role="region"`, and applied `tabindex="0"` to the containers. Also recorded a journal entry about this specific HTML/accessibility pattern.

**🎯 Why**
`<label>` tags are semantically meant only for form controls (inputs, textareas, etc). When used for generic containers like scrollable `div`s, screen readers can behave inconsistently or drop context. Converting the label to a standard `div` while retaining its visual style, and linking it using explicit ARIA relationships ensures robust screen reader support. Adding `tabindex="0"` allows keyboard users to scroll these potentially large output boxes.

**📸 Before/After**
*Before:*
`<label>Output:</label> <div id="output">...</div>`
*After:*
`<div id="output-label">Output:</div> <div id="output" role="region" aria-labelledby="output-label" tabindex="0">...</div>`

**♿ Accessibility**
- Fixes semantic misuse of `<label>` element.
- Adds ARIA labeling (`aria-labelledby`) connecting title to content.
- Grants keyboard focus (`tabindex="0"`) to scrollable output containers.
- Adds `role="region"` for better landmark navigation in screen readers.

---
*PR created automatically by Jules for task [7156099908646293596](https://jules.google.com/task/7156099908646293596) started by @EffortlessSteven*