### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path truncation vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+## 2024-04-13 - Path Truncation Vulnerability in Model Paths
+**Vulnerability:** The validate_model_request function validated file extensions using .ends_with(), but failed to reject null bytes (\0). This allowed attackers to pass inputs like model\0.gguf which passes the extension check but truncates the path when passed to underlying C/OS APIs, potentially bypassing restrictions.
+**Learning:** Standard string validation methods in Rust (like .ends_with()) do not account for null byte truncation when interacting with C APIs.
+**Prevention:** Always explicitly check for and reject null bytes (\0) when validating file paths or strings that will eventually be passed to C/OS APIs.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -227,6 +227,13 @@ impl SecurityValidator {
             return Err(ValidationError::MissingField("model_path".to_string()));
         }
 
+        // Prevent path truncation attacks (null byte injection)
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Prevent path traversal attacks
         if model_path.contains("..") || model_path.contains("~") {
             return Err(ValidationError::InvalidFieldValue(
@@ -600,6 +607,17 @@ mod tests {
 
         let config = SecurityConfig { trust_forwarded_headers: true, ..Default::default() };
         assert_eq!(extract_client_ip(&request, &config), Some(IpAddr::from([203, 0, 113, 1])));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("/tmp/model\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Null bytes are not allowed in model path"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function validated file extensions using `.ends_with()`, but failed to reject null bytes (`\0`). This allowed attackers to pass inputs like `model\0.gguf` which passes the extension check but truncates the path when passed to underlying C/OS APIs, potentially bypassing directory restrictions.
🎯 Impact: If exploited, this could allow an attacker to read arbitrary files from the server's filesystem by truncating the file extension in a path that passes the initial validation.
🔧 Fix: Added explicit rejection of null bytes in `validate_model_request`.
✅ Verification: Run `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection` to verify the fix.

---
*PR created automatically by Jules for task [10714908133883951932](https://jules.google.com/task/10714908133883951932) started by @EffortlessSteven*