### PR TITLE
🎨 Palette: Add focus indicators to forms and live regions to outputs in BitNet WASM UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+## 2025-04-12 - Focus Indicators and ARIA Live Regions
+**Learning:** Form inputs and dynamically updated output containers lack proper visual focus indicators and accessibility announcements for screen readers.
+**Action:** Always add `:focus-visible` styles to interactive inputs for keyboard accessibility and `aria-live="polite"` to dynamically updating regions so screen readers announce changes.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -106,6 +106,12 @@
             font-size: 14px;
         }
 
+        input:focus-visible, textarea:focus-visible, select:focus-visible {
+            outline: 3px solid #0056b3;
+            outline-offset: 1px;
+            border-color: #0056b3;
+        }
+
         textarea {
             resize: vertical;
             min-height: 100px;
@@ -299,7 +305,7 @@
                     <label style="margin-bottom: 0;">Output:</label>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" aria-live="polite" aria-atomic="true">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -322,7 +328,7 @@
 
             <div class="input-group">
                 <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output" class="streaming-output" aria-live="polite" aria-atomic="true">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -365,7 +371,7 @@
 
             <div class="input-group">
                 <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output" class="output" aria-live="polite" aria-atomic="true">Worker output will appear here...</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
💡 What: Added `:focus-visible` styling to all form inputs and `aria-live` regions to output containers in the BitNet WASM browser example.
🎯 Why: Improves keyboard accessibility by providing clear visual focus indicators on form fields, and ensures screen readers announce dynamically generated output text automatically.
♿ Accessibility: Added explicit focus outlines and `aria-live="polite"` attributes.

---
*PR created automatically by Jules for task [6975243521809777877](https://jules.google.com/task/6975243521809777877) started by @EffortlessSteven*