### PR TITLE
🛡️ Sentinel: [HIGH] Fix null byte injection in model path validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+## 2025-06-03 - Path Truncation Vulnerability via Null Bytes
+**Vulnerability:** The model path validation did not check for null bytes (`\0`). When validating `.gguf` extensions, it checked the Rust string which included the null byte, but underlying C/OS APIs would truncate the path at the null byte, potentially allowing loading of unintended files (e.g. `/tmp/secret\0.gguf` would load `/tmp/secret`).
+**Learning:** Standard string validation methods like `.ends_with()` in Rust are insufficient to prevent Path Truncation vulnerabilities in underlying APIs.
+**Prevention:** Always explicitly reject null bytes (`\0`) in the path validation logic for user-provided paths.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -600,6 +600,17 @@ mod tests {
 
         let config = SecurityConfig { trust_forwarded_headers: true, ..Default::default() };
         assert_eq!(extract_client_ip(&request, &config), Some(IpAddr::from([203, 0, 113, 1])));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("/tmp/model\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The model path validation logic failed to reject paths containing null bytes (`\0`).
🎯 Impact: An attacker could potentially bypass the `.gguf` or `.safetensors` extension checks by appending a null byte and the required extension (e.g., `path/to/secret\0.gguf`). Underlying C APIs (like those in `llama.cpp`) would truncate the string at the null byte, potentially allowing the loading or probing of unauthorized files.
🔧 Fix: Added an explicit check for `\0` alongside existing path traversal checks (`..`, `~`) in `validate_model_request`. Also added a dedicated unit test.
✅ Verification:
- Run `cargo fmt --all`
- Run `cargo clippy -p bitnet-server -- -D warnings`
- Run `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection`

---
*PR created automatically by Jules for task [11783689505968440449](https://jules.google.com/task/11783689505968440449) started by @EffortlessSteven*