### PR TITLE
🎨 Palette: Make scrollable output regions keyboard accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Making Scrollable Output Regions Accessible
+**Learning:** Using `<label>` tags for non-interactive, scrollable `div` elements (like text output areas) is invalid HTML and not properly announced by screen readers. Scrollable areas need explicit focusability and context.
+**Action:** Replace `<label>` with a styled `div` for the label text, add an `id`, and link it to the scrollable container using `aria-labelledby`. Ensure the scrollable container has `tabindex="0"` and `role="region"` so keyboard and screen reader users can access and scroll the content.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div style="font-weight: 500; margin-bottom: 0;" id="output-label">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="output-label">Output:</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="streaming-output-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="worker-output-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div style="font-weight: 500; margin-bottom: 5px;" id="benchmark-output-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What
Converted invalid `<label>` tags wrapping non-interactive output regions into styled `div`s with `id`s, and added `tabindex="0"`, `role="region"`, and `aria-labelledby` to the scrollable output containers across browser WASM examples.

🎯 Why
Using `<label>` for non-form controls is invalid HTML. More importantly, the output `div`s use `overflow-y: auto`, meaning their content can scroll. Without `tabindex="0"`, keyboard-only users cannot focus the region to scroll it using arrow keys, making long outputs inaccessible.

📸 Before/After
Before: Output regions were unfocusable by keyboard, and used invalid `<label>` tags.
After: Output regions can receive keyboard focus to allow scrolling, and use valid ARIA labelling semantics for screen readers.

♿ Accessibility
- Fixed invalid HTML structure (removed `<label>` for non-form elements).
- Added `tabindex="0"` to allow keyboard navigation and scrolling of overflowing content.
- Added `role="region"` and `aria-labelledby` to properly announce the region's purpose to screen reader users.

---
*PR created automatically by Jules for task [11126914773992388177](https://jules.google.com/task/11126914773992388177) started by @EffortlessSteven*