### PR TITLE
🎨 Palette: Improve accessibility of scrollable output regions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+## $(date +%Y-%m-%d) - Accessible Scrollable Regions
+**Learning:** In HTML, `<label>` tags are strictly reserved for labellable form controls. To make scrollable, non-interactive generic containers (like outputs with `overflow-y: auto`) accessible to screen readers and keyboard users, they must not be labelled with `<label>`.
+**Action:** Use a styled `<div>` for the text label and link it to the container via `aria-labelledby`, while ensuring the scrollable container has `tabindex="0"` and `role="region"`.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .fake-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="basic-output-label" class="fake-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" role="region" aria-labelledby="basic-output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" class="fake-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" class="fake-label">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" class="fake-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -82,7 +82,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .fake-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="basic-output-label" class="fake-label">Output:</div>
+                <div id="output" class="output" role="region" aria-labelledby="basic-output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" class="fake-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" class="fake-label">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" class="fake-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted generic `<div>` output blocks with `overflow-y: auto` to use `role="region"`, `tabindex="0"`, and `aria-labelledby` linked to `<div>` labels instead of `<label>` tags.
🎯 Why: `<label>` tags are only valid for labellable form controls. Screen readers may ignore them when paired with generic `<div>` elements. Making the scrollable regions focusable ensures keyboard users can scroll them.
📸 Before/After: Visuals are identical, but under the hood, the markup correctly associates the "labels" with their respective content areas for assistive technologies.
♿ Accessibility: Ensures that keyboard-only users can focus and scroll through long model generation outputs, and that screen readers correctly announce the region names.

---
*PR created automatically by Jules for task [15736208067410586540](https://jules.google.com/task/15736208067410586540) started by @EffortlessSteven*