### PR TITLE
🎨 Palette: Fix accessibility of output containers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Replacing Labels for Generic Containers
+**Learning:** When implementing scrollable, non-interactive generic containers (e.g., `<div>` with `overflow-y: auto`), do not label them using `<label>` tags, as those are strictly for form controls.
+**Action:** Instead, use a styled `<div>` for the text label and link it to the container via `aria-labelledby`, ensuring the container has `tabindex="0"` and `role="region"` for screen reader and keyboard accessibility.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="margin-bottom: 0; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" role="region" aria-labelledby="output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output-label" style="margin-bottom: 5px; font-weight: 500;">Output:</div>
+                <div id="output" class="output" role="region" aria-labelledby="output-label" tabindex="0">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" role="region" aria-labelledby="streaming-output-label" tabindex="0">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" role="region" aria-labelledby="worker-output-label" tabindex="0">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" role="region" aria-labelledby="benchmark-output-label" tabindex="0">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted invalid `<label>` tags to styled `<div>` elements for non-form output containers, and added `role="region"`, `tabindex="0"`, and `aria-labelledby` to the containers.
🎯 Why: `<label>` elements are strictly meant for form controls. Using them for generic containers violates HTML semantics and can confuse screen readers. Furthermore, scrollable containers must have a `tabindex` to be accessible to keyboard-only users.
📸 Before/After: Visuals remain identical (the `<label>` text was replaced by an identically styled `<div>`).
♿ Accessibility: Scrollable text blocks like the "Output", "Streaming Output", "Worker Output", and "Benchmark Results" areas can now be focused by keyboard and read correctly by screen readers.

---
*PR created automatically by Jules for task [3932785029419337228](https://jules.google.com/task/3932785029419337228) started by @EffortlessSteven*