### PR TITLE
🎨 Palette: Make scrollable text containers accessible and correctly labeled

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,6 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+## 2024-05-23 - Fix accessibility for generic scrollable containers
+**Learning:** Using `<label>` tags for non-interactive scrollable containers (like `<div>` with `overflow-y: auto`) violates HTML semantics, as `<label>` is exclusively for form controls.
+**Action:** Replace the `<label>` with a styled `<div>`, assign it an `id`, and add `tabindex="0"`, `role="region"`, and `aria-labelledby` linking to that `id` on the scrollable container to ensure screen reader and keyboard accessibility.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="label-output" style="font-weight: 500; margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="label-output">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="label-streaming-output" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="label-streaming-output">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="label-worker-output" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="label-worker-output">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="label-benchmark-output" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="label-benchmark-output">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="label-output" style="font-weight: 500; margin-bottom: 5px;">Output:</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="label-output">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="label-streaming-output" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="label-streaming-output">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="label-worker-output" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="label-worker-output">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="label-benchmark-output" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="label-benchmark-output">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What
Replaced invalid `<label>` tags pointing to non-interactive scrollable output `<div>`s with styled text `<div>`s. Added `tabindex="0"`, `role="region"`, and `aria-labelledby` to all scrollable text output containers (Basic Inference, Streaming, Worker, and Benchmark results).

🎯 Why
HTML `<label>` tags are strictly meant for form controls. Pointing them to a non-interactive `<div>` via visual alignment without proper linking doesn't help screen readers. By using `role="region"` and `aria-labelledby`, screen readers can correctly announce the container's purpose, and `tabindex="0"` ensures keyboard users can focus and scroll the long text outputs.

📸 Before/After
No visual changes; the fake labels were styled to look identical to real ones.

♿ Accessibility
- Fixed HTML validation errors (label pointing to a div).
- Enabled keyboard scrolling for long output areas (`tabindex="0"`).
- Enabled screen reader announcement of output regions (`role="region"`, `aria-labelledby`).

---
*PR created automatically by Jules for task [16289955981913849680](https://jules.google.com/task/16289955981913849680) started by @EffortlessSteven*