### PR TITLE
🎨 Palette: Improve accessibility of scrollable output containers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Semantic Accessibility of Scrollable Output Containers
+**Learning:** Using `<label>` tags to identify non-interactive scrollable containers (like `div`s with `overflow-y: auto` containing terminal output) violates HTML semantics, as `<label>` is strictly for form controls. This can confuse screen readers.
+**Action:** Replace `<label>` with a visually identical styled `<div>` given a unique ID. Link it to the output container using `aria-labelledby`. Ensure the output container has `tabindex="0"` for keyboard scrollability and `role="region"` so screen readers announce its semantic purpose as a landmark.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="margin-bottom: 0; font-weight: 500;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="margin-bottom: 5px; font-weight: 500;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="margin-bottom: 5px; font-weight: 500;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="margin-bottom: 5px; font-weight: 500;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 **What**: Replaced `<label>` elements pointing to non-interactive scrollable output `<div>`s with styled `<div>` elements serving as labels, and added `tabindex="0"`, `role="region"`, and `aria-labelledby` attributes to the output containers.

🎯 **Why**: `<label>` tags should only be used for form controls. By using `role="region"` and `tabindex="0"` along with `aria-labelledby`, keyboard users can focus and scroll through the output containers, and screen readers will correctly announce the container's purpose.

📸 **Before/After**: N/A (Visuals remain the same).

♿ **Accessibility**: Non-interactive scrollable containers are now properly reachable via keyboard navigation and correctly labeled for screen readers.

---
*PR created automatically by Jules for task [6297616421159934875](https://jules.google.com/task/6297616421159934875) started by @EffortlessSteven*