### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-04-20 - Path Truncation Vulnerability
+**Vulnerability:** Found a Path Truncation vulnerability in `validate_model_request` where null bytes (`\0`) in `model_path` were not rejected.
+**Learning:** Standard string validation methods like `.ends_with()` are insufficient to prevent Path Truncation vulnerabilities in underlying C/OS APIs (like `llama.cpp` opening the model file) because C strings are null-terminated. A path like `model\0.safetensors.gguf` passes the `.ends_with(".gguf")` check in Rust, but the OS opens the file `model`.
+**Prevention:** Always explicitly reject null bytes (`\0`) in the validation logic for file paths derived from user input before passing them to C APIs or using them in file operations.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));

--- a/crates/bitnet-server/tests/server_security_tests.rs
+++ b/crates/bitnet-server/tests/server_security_tests.rs
@@ -477,6 +477,18 @@ fn test_model_path_empty_rejected_as_missing_field() {
     );
 }
 
+#[test]
+fn test_model_path_null_byte_rejected() {
+    let v = validator(false, false);
+    assert!(
+        matches!(
+            v.validate_model_request("model\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(_))
+        ),
+        "null byte in model path must be rejected"
+    );
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Health endpoint
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Found a Path Truncation vulnerability in `validate_model_request` where null bytes (`\0`) in `model_path` were not explicitly rejected. Since underlying APIs (like `llama.cpp`) use null-terminated C strings, a path like `model\0.safetensors.gguf` would bypass the `.ends_with(".gguf")` check in Rust but be interpreted as `model` by the OS, allowing an attacker to load arbitrary files.
🎯 Impact: Attackers could potentially bypass the file extension restriction and load arbitrary files from the allowed model directories, which could lead to unauthorized access or execution if a malicious file was placed there.
🔧 Fix: Added a check to explicitly reject null bytes (`\0`) in `model_path` within `validate_model_request`.
✅ Verification: Run `cargo test -p bitnet-server test_model_path_null_byte_rejected`

---
*PR created automatically by Jules for task [3944287865470007223](https://jules.google.com/task/3944287865470007223) started by @EffortlessSteven*