### PR TITLE
fix(client-ip): honor first valid X-Forwarded-For hop

### DIFF
--- a/crates/bitnet-client-ip-core/src/lib.rs
+++ b/crates/bitnet-client-ip-core/src/lib.rs
@@ -13,7 +13,7 @@ pub fn extract_client_ip(x_forwarded_for: Option<&str>, x_real_ip: Option<&str>)
 /// Parse an `X-Forwarded-For` header value and return the first valid IP if present.
 #[must_use]
 pub fn parse_x_forwarded_for(value: &str) -> Option<IpAddr> {
-    value.split(',').next().and_then(parse_ip)
+    value.split(',').find_map(parse_ip)
 }
 
 /// Parse a single IP value, trimming surrounding whitespace.
@@ -37,6 +37,17 @@ mod tests {
     fn fallback_to_x_real_ip() {
         let ip = extract_client_ip(None, Some("192.0.2.15"));
         assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 15))));
+    }
+
+    #[test]
+    fn x_forwarded_for_skips_invalid_first_hop() {
+        let ip = parse_x_forwarded_for("unknown, 203.0.113.7, 10.0.0.4");
+        assert_eq!(ip, Some(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7))));
+    }
+
+    #[test]
+    fn x_forwarded_for_returns_none_when_all_hops_invalid() {
+        assert_eq!(parse_x_forwarded_for("unknown, invalid, ???"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The `X-Forwarded-For` header should yield the first valid client IP, but the previous `parse_x_forwarded_for` only attempted the first comma-separated token and could miss a later valid IP (e.g. when the left-most hop is `unknown`).

### Description
- Change `parse_x_forwarded_for` to scan hops with `value.split(',').find_map(parse_ip)` and add unit tests `x_forwarded_for_skips_invalid_first_hop` and `x_forwarded_for_returns_none_when_all_hops_invalid` in `crates/bitnet-client-ip-core/src/lib.rs`.

### Testing
- Ran `cargo test -p bitnet-client-ip-core -- --nocapture` and the test suite passed (all tests OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8950385088333b0b982e8dae5fab6)