### PR TITLE
Improve BITNET_OFFLINE env handling in bitnet-download-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
 name = "bitnet-download-core"
 version = "0.2.1-dev"
 dependencies = [
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -17,3 +17,4 @@ workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+serial_test.workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -10,7 +10,15 @@ pub enum DownloadValidationError {
 /// Returns true when download logic should operate in offline mode.
 #[must_use]
 pub fn offline_enabled(cli_offline: bool) -> bool {
-    cli_offline || std::env::var("BITNET_OFFLINE").as_deref() == Ok("1")
+    cli_offline || std::env::var("BITNET_OFFLINE").ok().as_deref().is_some_and(is_truthy_env_value)
+}
+
+#[must_use]
+fn is_truthy_env_value(value: &str) -> bool {
+    value.eq_ignore_ascii_case("1")
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
 }
 
 /// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
@@ -67,6 +75,32 @@ mod tests {
     fn parses_content_range_total() {
         assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
         assert_eq!(parse_content_range_total("invalid"), None);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn offline_enabled_accepts_common_truthy_env_values() {
+        unsafe { std::env::remove_var("BITNET_OFFLINE") };
+        assert!(!offline_enabled(false));
+        assert!(offline_enabled(true));
+
+        for truthy in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
+            unsafe { std::env::set_var("BITNET_OFFLINE", truthy) };
+            assert!(
+                offline_enabled(false),
+                "expected truthy value {truthy} to enable offline mode"
+            );
+        }
+
+        for falsey in ["0", "false", "off", "no", ""] {
+            unsafe { std::env::set_var("BITNET_OFFLINE", falsey) };
+            assert!(
+                !offline_enabled(false),
+                "expected falsey value {falsey} to disable offline mode"
+            );
+        }
+
+        unsafe { std::env::remove_var("BITNET_OFFLINE") };
     }
 
     #[test]

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -15,6 +15,7 @@ pub fn offline_enabled(cli_offline: bool) -> bool {
 
 #[must_use]
 fn is_truthy_env_value(value: &str) -> bool {
+    let value = value.trim();
     value.eq_ignore_ascii_case("1")
         || value.eq_ignore_ascii_case("true")
         || value.eq_ignore_ascii_case("yes")
@@ -84,7 +85,7 @@ mod tests {
         assert!(!offline_enabled(false));
         assert!(offline_enabled(true));
 
-        for truthy in ["1", "true", "TRUE", "yes", "YES", "on", "ON"] {
+        for truthy in ["1", "true", "TRUE", " yes ", "YES", "on", "ON"] {
             unsafe { std::env::set_var("BITNET_OFFLINE", truthy) };
             assert!(
                 offline_enabled(false),


### PR DESCRIPTION
### Motivation

- The previous `offline_enabled` logic only recognized the exact string `"1"` for `BITNET_OFFLINE`, which caused surprises when environments set boolean-like values such as `true`, `yes`, or `on`.

### Description

- Expand `offline_enabled(cli_offline: bool)` to accept common truthy environment values by adding a helper `is_truthy_env_value` and using `std::env::var(...).ok().as_deref().is_some_and(...)` to parse `BITNET_OFFLINE`.
- Add a serialized unit test `offline_enabled_accepts_common_truthy_env_values` (uses `#[serial_test::serial]`) that verifies both truthy and falsey `BITNET_OFFLINE` variants and CLI flag precedence.
- Add `serial_test` as a `dev-dependency` in `crates/bitnet-download-core/Cargo.toml` to ensure deterministic environment-var test isolation.
- Update `Cargo.lock` to include the added dev dependency.

### Testing

- Ran `cargo test -p bitnet-download-core -q`, and the package tests completed successfully (`4 passed; 0 failed`).
- Ran `cargo fmt --all` and formatting completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8950385088333b0b982e8dae5fab6)