### PR TITLE
opencl: implement runtime device discovery and expose API

### DIFF
--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -33,6 +33,7 @@ pub use spirv::{
 pub use spirv_kernels::{KernelSource, SpirvKernelRegistry};
 pub mod model_validator;
 pub mod numerical_validator;
+pub mod runtime;
 
 pub use model_validator::{
     GpuDeviceCapabilities, ModelMetadata, ModelValidator, ModelWeights, ProjectionWeight,
@@ -41,6 +42,7 @@ pub use model_validator::{
 pub use numerical_validator::{
     ComparisonResult, DistributionStats, DivergencePoint, NumericalValidator,
 };
+pub use runtime::discover_devices;
 pub mod diagnostics;
 pub mod system_info;
 

--- a/crates/bitnet-opencl/src/runtime.rs
+++ b/crates/bitnet-opencl/src/runtime.rs
@@ -1,9 +1,59 @@
 //! OpenCL runtime: platform/device discovery via the OpenCL ICD loader.
 
-/// Placeholder for OpenCL runtime discovery.
+#[cfg(feature = "oneapi")]
+use opencl3::device::{CL_DEVICE_TYPE_ALL, Device};
+#[cfg(feature = "oneapi")]
+use opencl3::platform::get_platforms;
+
+/// Discover OpenCL devices as `"platform :: device"` display strings.
 ///
-/// Requires the `opencl-runtime` feature and a working OpenCL ICD loader.
+/// When the `oneapi` feature is disabled or the OpenCL ICD loader is not
+/// available at runtime, this returns an empty list.
 pub fn discover_devices() -> Vec<String> {
-    // TODO: enumerate OpenCL platforms and devices via opencl3
-    Vec::new()
+    #[cfg(feature = "oneapi")]
+    {
+        let mut discovered = Vec::new();
+        let Ok(platforms) = get_platforms() else {
+            return discovered;
+        };
+
+        for platform in platforms {
+            let platform_name =
+                platform.name().unwrap_or_else(|_| String::from("unknown-platform"));
+            let Ok(device_ids) = platform.get_devices(CL_DEVICE_TYPE_ALL) else {
+                continue;
+            };
+
+            for id in device_ids {
+                let device = Device::new(id);
+                let device_name = device.name().unwrap_or_else(|_| String::from("unknown-device"));
+                discovered.push(format!("{platform_name} :: {device_name}"));
+            }
+        }
+
+        discovered.sort_unstable();
+        discovered.dedup();
+        discovered
+    }
+    #[cfg(not(feature = "oneapi"))]
+    {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::discover_devices;
+
+    #[cfg(not(feature = "oneapi"))]
+    #[test]
+    fn discover_devices_is_empty_without_oneapi_feature() {
+        assert!(discover_devices().is_empty());
+    }
+
+    #[cfg(feature = "oneapi")]
+    #[test]
+    fn discover_devices_never_panics_with_oneapi_feature() {
+        let _ = discover_devices();
+    }
 }


### PR DESCRIPTION
### Motivation

- Replace a TODO stub with a working OpenCL device discovery implementation so the crate can report available OpenCL platforms/devices.
- Provide a safe, non-failing API that higher-level code can call to detect OpenCL availability without hard errors when the runtime or feature is unavailable.
- Make discovery results stable and consumable by other crates by returning human-readable labels.

### Description

- Implemented `discover_devices()` in `crates/bitnet-opencl/src/runtime.rs` using `opencl3` behind the existing `oneapi` feature gate to enumerate platforms and devices.
- Return normalized `"platform :: device"` strings and perform `sort_unstable()` + `dedup()` for stable results, and fall back to an empty `Vec` when the feature is disabled or discovery fails.
- Added targeted unit tests controlling behavior when `oneapi` is enabled/disabled and kept the discovery function non-panicking.
- Wire the new `runtime` module into the public API by adding `pub mod runtime;` and `pub use runtime::discover_devices;` in `crates/bitnet-opencl/src/lib.rs`.

### Testing

- Ran `cargo fmt --all` and applied formatting successfully.
- Ran `cargo test -p bitnet-opencl runtime::tests::discover_devices_is_empty_without_oneapi_feature -q` and the test passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895048dac833396cab00b4e38be70)