### PR TITLE
fix(download-core): make atomic_write robust to temp-path conflicts

### DIFF
--- a/crates/bitnet-download-core/Cargo.toml
+++ b/crates/bitnet-download-core/Cargo.toml
@@ -11,9 +11,7 @@ description = "SRP core download helpers for offline mode and content-length val
 
 [dependencies]
 thiserror.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path};
+use std::{io::Write, path::Path};
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -34,17 +34,19 @@ pub const fn validate_downloaded_len(
 
 /// Atomic write helper for small metadata files (etag/last-modified).
 pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
-    let tmp = path.with_extension("tmp");
-    fs::write(&tmp, bytes)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("target path must have a parent directory"))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    tmp.write_all(bytes)?;
+    tmp.flush()?;
 
     #[cfg(unix)]
     {
-        if let Ok(f) = std::fs::File::open(&tmp) {
-            f.sync_all()?;
-        }
+        tmp.as_file().sync_all()?;
     }
 
-    fs::rename(&tmp, path)?;
+    tmp.persist(path).map_err(|err| err.error)?;
 
     #[cfg(unix)]
     {
@@ -88,5 +90,16 @@ mod tests {
 
         atomic_write(&file_path, b"etag-v2").expect("atomic overwrite should succeed");
         assert_eq!(fs::read(&file_path).expect("read file"), b"etag-v2");
+    }
+
+    #[test]
+    fn atomic_write_ignores_preexisting_tmp_extension_path() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let file_path = dir.path().join("etag");
+        let conflicting_tmp_path = file_path.with_extension("tmp");
+        fs::create_dir(&conflicting_tmp_path).expect("create conflicting tmp directory");
+
+        atomic_write(&file_path, b"etag").expect("atomic write should not depend on .tmp path");
+        assert_eq!(fs::read(&file_path).expect("read file"), b"etag");
     }
 }


### PR DESCRIPTION
### Motivation
- The previous `atomic_write` used a deterministic `<target>.tmp` path which could fail when that path already existed (e.g. a stale directory) or under concurrent writers, breaking metadata persistence.

### Description
- Rewrote `atomic_write` to create a unique temporary file in the target directory using `tempfile::NamedTempFile::new_in(parent)` and write via `write_all`/`flush` before persisting with `persist`.
- Preserve durability semantics by syncing the temp file on Unix with `sync_all()` before `persist` and syncing the parent directory after persisting.
- Add regression test `atomic_write_ignores_preexisting_tmp_extension_path` that verifies writes succeed when `<target>.tmp` already exists as a directory.
- Move `tempfile` to the crate `[dependencies]` (was previously only a dev-dependency) and clean up imports.

### Testing
- Ran `cargo test -p bitnet-download-core`; all tests passed (4 passed): `parses_content_range_total`, `validates_downloaded_len`, `atomic_write_persists_contents`, and `atomic_write_ignores_preexisting_tmp_extension_path`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895048dac833396cab00b4e38be70)