### PR TITLE
bitnet-vulkan: implement Vulkan device discovery behind feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,9 @@ dependencies = [
 name = "bitnet-vulkan"
 version = "0.2.1-dev"
 dependencies = [
+ "ash",
  "bitnet-vulkan-shaders",
+ "log",
 ]
 
 [[package]]

--- a/crates/bitnet-vulkan/Cargo.toml
+++ b/crates/bitnet-vulkan/Cargo.toml
@@ -13,6 +13,8 @@ rust-version.workspace = true
 
 [dependencies]
 bitnet-vulkan-shaders = { path = "../bitnet-vulkan-shaders", version = "0.2.1-dev" }
+ash = { version = "0.38", default-features = false, features = ["loaded"], optional = true }
+log.workspace = true
 
 [dev-dependencies]
 
@@ -21,6 +23,7 @@ default = []
 cpu = []
 gpu = ["cuda"]
 cuda = []
+vulkan-runtime = ["dep:ash"]
 
 [lints]
 workspace = true

--- a/crates/bitnet-vulkan/src/runtime.rs
+++ b/crates/bitnet-vulkan/src/runtime.rs
@@ -1,9 +1,80 @@
 //! Vulkan runtime: device discovery via the Vulkan loader.
 
-/// Placeholder for Vulkan runtime device discovery.
+/// Discover Vulkan physical devices available through the Vulkan loader.
 ///
-/// Requires the `vulkan-runtime` feature and a working Vulkan loader.
-pub const fn discover_devices() -> Vec<String> {
-    // TODO: enumerate Vulkan physical devices via ash
+/// When the `vulkan-runtime` feature is disabled, this returns an empty list.
+/// When enabled, failures to load or query the runtime are handled gracefully
+/// and also return an empty list.
+#[must_use]
+pub fn discover_devices() -> Vec<String> {
+    discover_devices_impl()
+}
+
+#[cfg(not(feature = "vulkan-runtime"))]
+fn discover_devices_impl() -> Vec<String> {
     Vec::new()
+}
+
+#[cfg(feature = "vulkan-runtime")]
+fn discover_devices_impl() -> Vec<String> {
+    use ash::{Entry, vk};
+    use std::ffi::CStr;
+
+    fn cstr_to_string_lossy(value: &[i8]) -> String {
+        // SAFETY: Vulkan guarantees that fixed-size name fields are null-terminated.
+        let cstr = unsafe { CStr::from_ptr(value.as_ptr()) };
+        cstr.to_string_lossy().into_owned()
+    }
+
+    let entry = {
+        // SAFETY: Loading Vulkan entry points is safe; errors are handled below.
+        let result = unsafe { Entry::load() };
+        match result {
+            Ok(entry) => entry,
+            Err(error) => {
+                log::debug!("Failed to load Vulkan loader during device discovery: {error:?}");
+                return Vec::new();
+            }
+        }
+    };
+    let app_info = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_0);
+    let create_info = vk::InstanceCreateInfo::default().application_info(&app_info);
+
+    let instance = {
+        // SAFETY: `create_info` points to local data that lives until call returns.
+        let result = unsafe { entry.create_instance(&create_info, None) };
+        match result {
+            Ok(instance) => instance,
+            Err(error) => {
+                log::debug!("Failed to create Vulkan instance during device discovery: {error:?}");
+                return Vec::new();
+            }
+        }
+    };
+
+    let result = {
+        // SAFETY: `instance` is valid while this call executes.
+        unsafe { instance.enumerate_physical_devices() }
+    };
+
+    let devices = match result {
+        Ok(physical_devices) => physical_devices
+            .into_iter()
+            .filter_map(|physical_device| {
+                // SAFETY: `physical_device` is returned by Vulkan for this instance.
+                let properties =
+                    unsafe { instance.get_physical_device_properties(physical_device) };
+                let name = cstr_to_string_lossy(&properties.device_name);
+                (!name.is_empty()).then_some(name)
+            })
+            .collect(),
+        Err(error) => {
+            log::debug!("Failed to enumerate Vulkan physical devices: {error:?}");
+            Vec::new()
+        }
+    };
+
+    // SAFETY: Instance was created in this function and no further Vulkan calls follow.
+    unsafe { instance.destroy_instance(None) };
+    devices
 }

--- a/crates/bitnet-vulkan/tests/vulkan_integration_tests.rs
+++ b/crates/bitnet-vulkan/tests/vulkan_integration_tests.rs
@@ -7,7 +7,16 @@ fn shader_reexport_matches_kernels_module() {
 }
 
 #[test]
-fn runtime_discovery_placeholder_is_empty() {
+fn runtime_discovery_is_non_panicking() {
+    let devices = bitnet_vulkan::runtime::discover_devices();
+    // In CI/sandbox environments there may be no Vulkan runtime available.
+    // Discovery should still be safe and deterministic.
+    assert!(devices.iter().all(|name| !name.trim().is_empty()));
+}
+
+#[test]
+#[cfg(not(feature = "vulkan-runtime"))]
+fn runtime_discovery_without_feature_is_empty() {
     let devices = bitnet_vulkan::runtime::discover_devices();
     assert!(devices.is_empty());
 }


### PR DESCRIPTION
### Motivation
- The `bitnet-vulkan` runtime previously contained a no-op placeholder for device discovery which prevented runtime hardware enumeration.
- Add non-panicking, optional runtime discovery so environments that opt into Vulkan can detect physical devices while keeping default builds deterministic and lightweight.

### Description
- Add an optional `ash` dependency and a new `vulkan-runtime` feature and wire the feature to the dependency in `crates/bitnet-vulkan/Cargo.toml`.
- Implement `discover_devices()` to call a feature-gated `discover_devices_impl()` that uses `ash::Entry::load()`, creates a Vulkan instance, enumerates physical devices, converts device names to `String`, and returns them while handling all errors by returning an empty list and logging debug messages.
- Use runtime-loading (`ash` with `loaded` feature) to avoid linking failures and ensure graceful fallback when the Vulkan loader is not present.
- Update integration tests in `crates/bitnet-vulkan/tests/vulkan_integration_tests.rs` to assert discovery is non-panicking and to explicitly check for an empty result when the `vulkan-runtime` feature is disabled.

### Testing
- Ran `cargo test -p bitnet-vulkan -q` and observed the test suite pass successfully.
- Ran `cargo test -p bitnet-vulkan --features vulkan-runtime -q` and observed the test suite pass successfully under the feature.
- Ran `cargo fmt --all` to format changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e895048dac833396cab00b4e38be70)