### PR TITLE
fix(workspace): remove duplicate `bitnet-download-core` workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,6 @@ members = [
   "crates/bitnet-atomic-file-core", # SRP: shared atomic file write primitive
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
-  "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-http-auth-core", # SRP: reusable Authorization Bearer parsing helpers
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer


### PR DESCRIPTION
### Motivation
- Remove a duplicated workspace member entry to keep the root `Cargo.toml` canonical and avoid metadata/tooling confusion.

### Description
- Deleted the redundant `"crates/bitnet-download-core"` entry from the root `[workspace].members` list in `Cargo.toml`.

### Testing
- Verified no duplicates remain by running the `python` `tomllib` check that counts workspace members and reports duplicates, which returned no duplicates.
- Confirmed workspace resolution with `cargo metadata --no-deps`, which completed successfully and reported the expected workspace member count.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951af34c8333aa708b1f0ea8b503)