### PR TITLE
opencl: expose runtime module and implement device discovery

### DIFF
--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -14,6 +14,7 @@ pub mod backend_registry;
 pub mod context_pool;
 pub mod kv_cache;
 pub mod paged_attention;
+pub mod runtime;
 
 pub use backend_dispatcher::{
     BackendCapabilityMatrix, BackendDispatcher, BackendStatus, DispatchDecision, DispatchError,

--- a/crates/bitnet-opencl/src/runtime.rs
+++ b/crates/bitnet-opencl/src/runtime.rs
@@ -2,8 +2,58 @@
 
 /// Placeholder for OpenCL runtime discovery.
 ///
-/// Requires the `opencl-runtime` feature and a working OpenCL ICD loader.
+/// Requires the `oneapi` feature and a working OpenCL ICD loader.
 pub fn discover_devices() -> Vec<String> {
-    // TODO: enumerate OpenCL platforms and devices via opencl3
+    discover_devices_impl()
+}
+
+#[cfg(feature = "oneapi")]
+fn discover_devices_impl() -> Vec<String> {
+    use opencl3::device::Device;
+    use opencl3::platform::get_platforms;
+
+    let mut discovered = Vec::new();
+
+    let Ok(platforms) = get_platforms() else {
+        return discovered;
+    };
+
+    for platform in platforms {
+        let Ok(devices) = platform.get_devices(opencl3::device::CL_DEVICE_TYPE_ALL) else {
+            continue;
+        };
+
+        for device_id in devices {
+            let device = Device::new(device_id);
+
+            let vendor = device.vendor().unwrap_or_else(|_| String::from("Unknown vendor"));
+            let name = device.name().unwrap_or_else(|_| String::from("Unknown device"));
+
+            discovered.push(format!("{vendor} - {name}"));
+        }
+    }
+
+    discovered
+}
+
+#[cfg(not(feature = "oneapi"))]
+fn discover_devices_impl() -> Vec<String> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::discover_devices;
+
+    #[test]
+    fn discover_devices_never_panics() {
+        let _ = discover_devices();
+    }
+
+    #[test]
+    fn discovered_device_names_are_non_empty() {
+        for device in discover_devices() {
+            assert!(!device.trim().is_empty());
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

- Make OpenCL runtime discovery callable from the `bitnet-opencl` crate and replace a placeholder `TODO` with a working device enumeration so backends can detect available OpenCL devices.

### Description

- Exported the `runtime` module from `crates/bitnet-opencl/src/lib.rs` so runtime APIs are part of the public crate surface.
- Implemented `discover_devices()` in `crates/bitnet-opencl/src/runtime.rs` which delegates to a feature-gated `discover_devices_impl()` that enumerates platforms and devices via `opencl3` when the `oneapi` feature is enabled and returns `vendor - name` labels.
- Added safe fallbacks so discovery returns an empty `Vec<String>` when platforms/devices cannot be enumerated or when `oneapi` is not enabled.
- Fixed `opencl3` API usage (switched to `platform.get_devices(...)` and `Device::new`) and added unit tests to validate the discovery path and guard against panics.

### Testing

- Ran `cargo test -p bitnet-opencl runtime::` and the runtime unit tests passed (2 tests, both ok).
- Ran `cargo test -p bitnet-opencl --features oneapi runtime::` and the runtime unit tests passed under the `oneapi` feature (2 tests, both ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8951af34c8333aa708b1f0ea8b503)