### PR TITLE
fix(workspace): remove duplicate bitnet-download-core member entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ members = [
   "crates/bitnet-test-fixtures-core",
   "crates/bitnet-validation",    # SRP: LayerNorm/projection validation rules (shared)
   "crates/bitnet-atomic-file-core", # SRP: shared atomic file write primitive
-  "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
   "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives


### PR DESCRIPTION
### Motivation
- Clean up the workspace `members` list by removing an accidental duplicate `crates/bitnet-download-core` entry to avoid ambiguity and potential tooling issues.

### Description
- Removed the duplicate `"crates/bitnet-download-core"` line from the `members` array in the repository root `Cargo.toml` so each workspace member is declared only once.

### Testing
- Ran `cargo metadata --no-deps --format-version 1` and a small Python check (`python - <<'PY' ...`) to verify `workspace_members` contains no duplicates, which reported zero duplicates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894eeca0083339155d8a31104873f)