### PR TITLE
Fix case-insensitive Bearer parsing and whitespace handling

### DIFF
--- a/crates/bitnet-http-auth-core/src/lib.rs
+++ b/crates/bitnet-http-auth-core/src/lib.rs
@@ -3,7 +3,17 @@
 /// Returns the bearer token when the header is in the `Bearer <token>` format.
 #[must_use]
 pub fn bearer_token(header_value: &str) -> Option<&str> {
-    header_value.strip_prefix("Bearer ").filter(|token| !token.is_empty())
+    let (scheme, token_part) = header_value.split_once(|c: char| c.is_ascii_whitespace())?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+
+    let token = token_part.trim_start_matches(|c: char| c.is_ascii_whitespace());
+    if token.is_empty() || token.contains(|c: char| c.is_ascii_whitespace()) {
+        return None;
+    }
+
+    Some(token)
 }
 
 /// Strips a `Bearer ` prefix when present, otherwise returns the original value.
@@ -22,6 +32,18 @@ mod tests {
     }
 
     #[test]
+    fn bearer_token_is_case_insensitive() {
+        assert_eq!(bearer_token("bearer abc123"), Some("abc123"));
+        assert_eq!(bearer_token("BEARER abc123"), Some("abc123"));
+    }
+
+    #[test]
+    fn bearer_token_accepts_extra_whitespace_between_scheme_and_token() {
+        assert_eq!(bearer_token("Bearer    abc123"), Some("abc123"));
+        assert_eq!(bearer_token("Bearer\tabc123"), Some("abc123"));
+    }
+
+    #[test]
     fn bearer_token_rejects_other_schemes() {
         assert_eq!(bearer_token("Token abc123"), None);
     }
@@ -29,6 +51,11 @@ mod tests {
     #[test]
     fn bearer_token_rejects_empty_token() {
         assert_eq!(bearer_token("Bearer "), None);
+    }
+
+    #[test]
+    fn bearer_token_rejects_tokens_with_whitespace() {
+        assert_eq!(bearer_token("Bearer abc 123"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Authorization scheme names are case-insensitive and real-world `Authorization` headers may include extra horizontal whitespace, so parsing should accept `bearer`/`BEARER` and tolerate extra spaces while rejecting malformed tokens.

### Description
- Replaced naive `strip_prefix("Bearer ")` with a robust parser that `split_once` on ASCII whitespace, uses `eq_ignore_ascii_case("bearer")` to accept scheme case-insensitively, trims extra leading whitespace from the token, and rejects empty tokens or tokens containing internal whitespace.
- Preserved `strip_bearer_prefix` behavior by delegating to the improved `bearer_token` function.
- Added unit tests covering case-insensitive schemes, extra whitespace between scheme and token, and rejection of tokens containing whitespace in `crates/bitnet-http-auth-core/src/lib.rs`.

### Testing
- Ran `cargo test -p bitnet-http-auth-core` and the crate tests passed (`7 passed; 0 failed`).
- Ran `cargo test -p bitnet-api-key-auth-core --quiet` and those tests also passed (`5 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894eeca0083339155d8a31104873f)