### PR TITLE
Harden Content-Range total parsing in bitnet-download-core

### DIFF
--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -38,12 +38,25 @@ pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
         return None;
     }
 
-    // Basic sanity check for accepted `Content-Range` formats.
-    if !range.starts_with("bytes ") && range != "bytes *" {
-        return None;
+    let range = range.strip_prefix("bytes ")?;
+    if range != "*" {
+        let (start, end) = range.split_once('-')?;
+        if end.contains('-') {
+            return None;
+        }
+
+        let start = start.parse::<u64>().ok()?;
+        let end = end.parse::<u64>().ok()?;
+        if start > end {
+            return None;
+        }
     }
 
-    total.parse::<u64>().ok()
+    let total = total.parse::<u64>().ok()?;
+    if total == 0 {
+        return None;
+    }
+    Some(total)
 }
 
 /// Ensure downloaded bytes match expected total when available.
@@ -99,6 +112,9 @@ mod tests {
         assert_eq!(parse_content_range_total("bytes 0-0/1234\r\n"), Some(1234));
         assert_eq!(parse_content_range_total("bytes 0-0/1/2"), None);
         assert_eq!(parse_content_range_total("items 0-0/1234"), None);
+        assert_eq!(parse_content_range_total("bytes nope/1234"), None);
+        assert_eq!(parse_content_range_total("bytes 5-1/1234"), None);
+        assert_eq!(parse_content_range_total("bytes 0-0/0"), None);
     }
 
     #[test]

--- a/crates/bitnet-download-core/src/lib.rs
+++ b/crates/bitnet-download-core/src/lib.rs
@@ -25,7 +25,25 @@ fn is_truthy_env_value(value: &str) -> bool {
 /// Parses `Content-Range` total bytes from values like `bytes 0-0/1234`.
 #[must_use]
 pub fn parse_content_range_total(content_range: &str) -> Option<u64> {
-    content_range.rsplit('/').next()?.parse::<u64>().ok()
+    let value = content_range.trim();
+    let (range, total) = value.split_once('/')?;
+
+    // Reject malformed inputs with multiple `/` separators (e.g. `bytes 0-0/1/2`).
+    if total.contains('/') {
+        return None;
+    }
+
+    // RFC 7233 uses `*` when the complete length is unknown.
+    if total == "*" {
+        return None;
+    }
+
+    // Basic sanity check for accepted `Content-Range` formats.
+    if !range.starts_with("bytes ") && range != "bytes *" {
+        return None;
+    }
+
+    total.parse::<u64>().ok()
 }
 
 /// Ensure downloaded bytes match expected total when available.
@@ -76,6 +94,11 @@ mod tests {
     fn parses_content_range_total() {
         assert_eq!(parse_content_range_total("bytes 0-0/1234"), Some(1234));
         assert_eq!(parse_content_range_total("invalid"), None);
+        assert_eq!(parse_content_range_total("bytes */*"), None);
+        assert_eq!(parse_content_range_total("bytes */2048"), Some(2048));
+        assert_eq!(parse_content_range_total("bytes 0-0/1234\r\n"), Some(1234));
+        assert_eq!(parse_content_range_total("bytes 0-0/1/2"), None);
+        assert_eq!(parse_content_range_total("items 0-0/1234"), None);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make `parse_content_range_total` more defensive to avoid mis-parsing malformed `Content-Range` headers (extra `/` separators, wildcard totals, trailing whitespace, and wrong units). 

### Description
- Replace naive `rsplit('/')` parsing with a trimmed `split_once('/')` and explicit validation of the `range` and `total` components. 
- Reject multi-slash values and treat RFC-7233 wildcard total (`*`) as unknown (return `None`). 
- Verify the range prefix is `bytes ` (or `bytes *`) before parsing the numeric total. 
- Expand unit tests in `parses_content_range_total` to cover wildcard forms, trailing CRLF input, malformed multi-slash inputs, and invalid units.

### Testing
- Ran `CARGO_TARGET_DIR=/tmp/bitnet-target cargo test -p bitnet-download-core`, which passed (unit tests OK). 
- Ran `cargo fmt --all` to ensure formatting changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e894eeca0083339155d8a31104873f)