### PR TITLE
bdd-grid: validate curated feature labels strictly

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -257,6 +257,27 @@ impl FeatureSet {
     }
 }
 
+/// Error returned when one or more feature names are unknown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownFeatureNames {
+    names: Vec<String>,
+}
+
+impl UnknownFeatureNames {
+    /// Unknown feature labels in deterministic input order.
+    pub fn names(&self) -> &[String] {
+        &self.names
+    }
+}
+
+impl fmt::Display for UnknownFeatureNames {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown features: {}", self.names.join(", "))
+    }
+}
+
+impl std::error::Error for UnknownFeatureNames {}
+
 impl From<&[BitnetFeature]> for FeatureSet {
     fn from(value: &[BitnetFeature]) -> Self {
         Self(value.iter().copied().collect())
@@ -354,6 +375,27 @@ pub fn feature_set_from_names(features: &[&str]) -> FeatureSet {
     set
 }
 
+/// Strict variant of [`feature_set_from_names`] that errors on unknown values.
+pub fn feature_set_from_names_strict(features: &[&str]) -> Result<FeatureSet, UnknownFeatureNames> {
+    let mut set = FeatureSet::new();
+    let mut unknown = Vec::new();
+
+    for feature in features {
+        match feature.parse() {
+            Ok(parsed) => {
+                set.insert(parsed);
+            }
+            Err(_) => unknown.push((*feature).to_string()),
+        }
+    }
+
+    if unknown.is_empty() {
+        Ok(set)
+    } else {
+        Err(UnknownFeatureNames { names: unknown })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,5 +431,20 @@ mod tests {
         let grid = BddGrid::from_rows(rows);
         let found = grid.find(TestingScenario::Unit, ExecutionEnvironment::Local);
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn test_feature_set_from_names_strict_reports_unknowns() {
+        let err = feature_set_from_names_strict(&["inference", "wat", "also-wat"])
+            .expect_err("expected strict parser to reject unknown features");
+        assert_eq!(err.names(), &["wat".to_string(), "also-wat".to_string()]);
+    }
+
+    #[test]
+    fn test_feature_set_from_names_strict_accepts_knowns() {
+        let set = feature_set_from_names_strict(&["inference", "kernels"])
+            .expect("known feature names should parse");
+        assert!(set.contains(BitnetFeature::Inference));
+        assert!(set.contains(BitnetFeature::Kernels));
     }
 }

--- a/crates/bitnet-bdd-grid/src/lib.rs
+++ b/crates/bitnet-bdd-grid/src/lib.rs
@@ -8,70 +8,75 @@ use std::sync::LazyLock;
 
 pub use bitnet_bdd_grid_core::{
     BddCell, BddGrid, BitnetFeature, ExecutionEnvironment, FeatureSet, TestingScenario,
-    feature_set_from_names,
+    feature_set_from_names, feature_set_from_names_strict,
 };
 
 static CURATED_ROWS: LazyLock<Box<[BddCell]>> = LazyLock::new(build_curated_rows);
 
 fn build_curated_rows() -> Box<[BddCell]> {
+    fn curated_features(features: &[&str]) -> FeatureSet {
+        feature_set_from_names_strict(features)
+            .unwrap_or_else(|e| panic!("curated grid has unknown feature labels: {e}"))
+    }
+
     vec![
         BddCell {
             scenario: TestingScenario::Unit,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["reporting", "fixtures"]),
-            forbidden_features: feature_set_from_names(&["cpp-ffi"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["reporting", "fixtures"]),
+            forbidden_features: curated_features(&["cpp-ffi"]),
             intent: "Fast, isolated unit execution with core inference path",
         },
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["crossval", "reporting", "fixtures"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["crossval", "reporting", "fixtures"]),
             forbidden_features: FeatureSet::new(),
             intent: "Component and module interaction in local build",
         },
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "crossval",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting", "trend"]),
+            optional_features: curated_features(&["fixtures", "reporting", "trend"]),
             forbidden_features: FeatureSet::new(),
             intent: "Reference parity / regression surface with controlled fixtures",
         },
         BddCell {
             scenario: TestingScenario::Performance,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["gpu", "cuda", "reporting", "trend"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["gpu", "cuda", "reporting", "trend"]),
             forbidden_features: FeatureSet::new(),
             intent: "Throughput and latency-sensitive checks",
         },
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["tokenizers", "kernels", "crossval"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["tokenizers", "kernels", "crossval"]),
             forbidden_features: FeatureSet::new(),
             intent: "Minimum viable run for deployment safety",
         },
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["trace", "reporting"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["trace", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Detailed behavior introspection and diagnostics",
         },
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference"]),
+            required_features: curated_features(&["inference"]),
             optional_features: FeatureSet::new(),
             forbidden_features: FeatureSet::new(),
             intent: "Fastest-path execution with hard constraints",
@@ -79,14 +84,14 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "reporting",
                 "crossval",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "trend", "server"]),
+            optional_features: curated_features(&["fixtures", "trend", "server"]),
             forbidden_features: FeatureSet::new(),
             intent: "Full stack workflow checks spanning startup through response path",
         },
@@ -95,8 +100,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Unit,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["cpu", "inference", "kernels"]),
-            optional_features: feature_set_from_names(&["tokenizers", "reporting"]),
+            required_features: curated_features(&["cpu", "inference", "kernels"]),
+            optional_features: curated_features(&["tokenizers", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Deterministic CPU-only unit path with explicit kernel feature",
         },
@@ -105,13 +110,13 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "quantization",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting"]),
+            optional_features: curated_features(&["fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "GGUF model loading and quantization format integration (I2_S, QK256, TL1/TL2)",
         },
@@ -120,8 +125,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Performance,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["cpu", "gpu", "cuda", "reporting"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["cpu", "gpu", "cuda", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Local backend selection and kernel dispatch benchmarks",
         },
@@ -130,8 +135,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["reporting", "trace"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["reporting", "trace"]),
             forbidden_features: FeatureSet::new(),
             intent: "Sampling strategy development and greedy/top-p/top-k path exercising",
         },
@@ -140,8 +145,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Smoke path for receipt generation and schema v1.0.0 validation",
         },
@@ -152,8 +157,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference", "server", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "server", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Server health-check path (/health endpoint returns 200)",
         },
@@ -163,8 +168,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "tokenizers", "cli"]),
-            optional_features: feature_set_from_names(&["kernels", "reporting"]),
+            required_features: curated_features(&["inference", "tokenizers", "cli"]),
+            optional_features: curated_features(&["kernels", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Prompt-template auto-detection selects instruct for base models",
         },
@@ -174,8 +179,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "tokenizers"]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting"]),
+            required_features: curated_features(&["inference", "tokenizers"]),
+            optional_features: curated_features(&["fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Tokenizer encode/decode round-trip preserves original token sequence",
         },
@@ -185,8 +190,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Receipt JSON validates against schema v1.0.0 with all required gates",
         },
@@ -197,7 +202,7 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
+            required_features: curated_features(&["inference", "kernels"]),
             optional_features: FeatureSet::new(),
             forbidden_features: FeatureSet::new(),
             intent: "Deterministic seed produces identical output across repeated runs",
@@ -209,9 +214,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["cpu", "inference"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["gpu", "cuda"]),
+            required_features: curated_features(&["cpu", "inference"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["gpu", "cuda"]),
             intent: "Device probe detects CPU features and reports available SIMD capabilities",
         },
         // Feature: logits — Scenario: "pure logits transforms pass numerical precision checks"
@@ -221,8 +226,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "inference", "kernels"]),
-            optional_features: feature_set_from_names(&["reporting"]),
+            required_features: curated_features(&["cpu", "inference", "kernels"]),
+            optional_features: curated_features(&["reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Pure logits transforms (temperature, top-k, top-p) pass numerical precision checks",
         },
@@ -233,8 +238,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["trace", "reporting"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["trace", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Generation stopping criteria (max-tokens, stop-id, stop-string) fire deterministically",
         },
@@ -246,8 +251,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["crossval", "fixtures", "reporting"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["crossval", "fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Engine-core session contracts match C++ reference for all decode-step invariants",
         },
@@ -258,9 +263,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["cpu", "metal"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "metal"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Metal backend feature gate compiles without errors (compile-only check)",
         },
         // Feature: vulkan — Scenario: "Vulkan backend compiles and probes availability"
@@ -269,9 +274,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "vulkan"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "vulkan"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Vulkan backend feature gate compiles and probe reports compiled=true",
         },
         // Feature: oneapi — Scenario: "Intel oneAPI backend compiles without errors"
@@ -280,9 +285,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "oneapi"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "oneapi"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Intel oneAPI backend feature gate compiles without errors (compile-only check)",
         },
     ]


### PR DESCRIPTION
### Motivation
- The curated BDD grid is policy-critical and previously relied on a lenient parser that silently ignored unknown feature labels, risking accidental weakening of scenario constraints. 
- We want curated metadata and configuration paths to fail fast on typos so issues are caught during initialization or CI.

### Description
- Added a new error type `UnknownFeatureNames` and a strict parser `feature_set_from_names_strict(...) -> Result<FeatureSet, UnknownFeatureNames>` to `crates/bitnet-bdd-grid-core/src/lib.rs`.
- Kept the existing lenient `feature_set_from_names` for runtime/CLI compatibility and exported the strict API where appropriate.
- Updated `crates/bitnet-bdd-grid/src/lib.rs` to construct curated rows using a local `curated_features(...)` helper that calls the strict parser and `panic!`s with a clear message on unknown labels, ensuring fail-fast behavior for curated policy data.
- Added unit tests for the strict parser to verify successful parsing of known labels and deterministic reporting of unknown labels.

### Testing
- Ran `cargo test -p bitnet-bdd-grid-core -p bitnet-bdd-grid` and all tests in both crates completed successfully.
- New unit tests in `bitnet-bdd-grid-core` passed and existing curated-grid tests remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9579953f483338bc082e34bfa6980)