### PR TITLE
Normalize BDD grid token parsing for trimmed/underscored inputs

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -7,6 +7,10 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
+fn normalize_symbol(input: &str) -> String {
+    input.trim().to_ascii_lowercase().replace('_', "-")
+}
+
 /// Logical test scenario axis for BDD planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TestingScenario {
@@ -41,7 +45,8 @@ impl FromStr for TestingScenario {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_symbol(s);
+        match normalized.as_str() {
             "unit" => Ok(Self::Unit),
             "integration" => Ok(Self::Integration),
             "e2e" | "end-to-end" | "endtoend" => Ok(Self::EndToEnd),
@@ -80,7 +85,8 @@ impl FromStr for ExecutionEnvironment {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_symbol(s);
+        match normalized.as_str() {
             "local" | "dev" | "development" => Ok(Self::Local),
             "ci" | "ci/cd" | "cicd" => Ok(Self::Ci),
             "pre-prod" | "preprod" | "pre-production" | "preproduction" | "staging" => {
@@ -154,7 +160,8 @@ impl FromStr for BitnetFeature {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_symbol(s);
+        match normalized.as_str() {
             "cpu" => Ok(Self::Cpu),
             "gpu" => Ok(Self::Gpu),
             "cuda" => Ok(Self::Cuda),

--- a/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
+++ b/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
@@ -62,6 +62,15 @@ fn scenario_case_insensitive() {
 }
 
 #[test]
+fn scenario_accepts_trimmed_and_underscored_values() {
+    assert_eq!(TestingScenario::from_str(" end_to_end "), Ok(TestingScenario::EndToEnd));
+    assert_eq!(
+        TestingScenario::from_str(" cross_validation "),
+        Ok(TestingScenario::CrossValidation)
+    );
+}
+
+#[test]
 fn scenario_display_roundtrip() {
     let scenarios = [
         TestingScenario::Unit,
@@ -164,6 +173,14 @@ fn env_case_insensitive() {
 }
 
 #[test]
+fn env_accepts_trimmed_and_underscored_values() {
+    assert_eq!(
+        ExecutionEnvironment::from_str(" pre_production "),
+        Ok(ExecutionEnvironment::PreProduction)
+    );
+}
+
+#[test]
 fn env_display_roundtrip() {
     let envs = [
         ExecutionEnvironment::Local,
@@ -245,6 +262,15 @@ fn feature_unknown_errors() {
 fn feature_case_insensitive() {
     assert_eq!(BitnetFeature::from_str("CPU"), Ok(BitnetFeature::Cpu));
     assert_eq!(BitnetFeature::from_str("Gpu"), Ok(BitnetFeature::Gpu));
+}
+
+#[test]
+fn feature_accepts_trimmed_and_underscored_values() {
+    assert_eq!(
+        BitnetFeature::from_str(" integration_tests "),
+        Ok(BitnetFeature::IntegrationTests)
+    );
+    assert_eq!(BitnetFeature::from_str(" cpp_ffi "), Ok(BitnetFeature::CppFfi));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Parsing of BDD grid tokens should be tolerant of common env/config styles (e.g. surrounding whitespace and snake_case) that previously produced "unknown" errors.
- Make scenario, environment, and feature name parsing resilient when values flow through pipelines or environment variables.
- Keep canonical `Display` output unchanged while improving acceptance of real-world input formats.

### Description
- Added a shared helper `normalize_symbol` that trims, lowercases, and converts underscores to dashes before matching input tokens in `bitnet-bdd-grid-core`.
- Updated `FromStr` parsing for `TestingScenario`, `ExecutionEnvironment`, and `BitnetFeature` to call `normalize_symbol` prior to matching.
- Added edge-case tests that assert acceptance of trimmed and underscored inputs for the three enums in `crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs`.
- Changes are limited to `crates/bitnet-bdd-grid-core/src/lib.rs` and the corresponding tests file so behavior elsewhere remains unaffected.

### Testing
- Ran `cargo test -p bitnet-bdd-grid-core`, which completed successfully with all unit and integration tests passing.
- New tests validating trimmed/underscored inputs were executed as part of the suite and passed.
- No other crates were modified or re-tested as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95797f6488333b3c6daf4dd318e55)