### PR TITLE
Normalize BDD grid token parsing and accept underscore/whitespace aliases

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -7,6 +7,12 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
+fn normalize_name_token(raw: &str) -> String {
+    raw.trim()
+        .to_ascii_lowercase()
+        .replace(['_', ' '], "-")
+}
+
 /// Logical test scenario axis for BDD planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TestingScenario {
@@ -41,7 +47,7 @@ impl FromStr for TestingScenario {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_name_token(s).as_str() {
             "unit" => Ok(Self::Unit),
             "integration" => Ok(Self::Integration),
             "e2e" | "end-to-end" | "endtoend" => Ok(Self::EndToEnd),
@@ -80,7 +86,7 @@ impl FromStr for ExecutionEnvironment {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_name_token(s).as_str() {
             "local" | "dev" | "development" => Ok(Self::Local),
             "ci" | "ci/cd" | "cicd" => Ok(Self::Ci),
             "pre-prod" | "preprod" | "pre-production" | "preproduction" | "staging" => {
@@ -154,7 +160,7 @@ impl FromStr for BitnetFeature {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_name_token(s).as_str() {
             "cpu" => Ok(Self::Cpu),
             "gpu" => Ok(Self::Gpu),
             "cuda" => Ok(Self::Cuda),
@@ -177,7 +183,9 @@ impl FromStr for BitnetFeature {
             "fixtures" => Ok(Self::Fixtures),
             "reporting" => Ok(Self::Reporting),
             "trend" => Ok(Self::Trend),
-            "integration-tests" => Ok(Self::IntegrationTests),
+            "integration-tests" | "integrationtest" | "integrationtests" => {
+                Ok(Self::IntegrationTests)
+            }
             _ => Err("unknown feature"),
         }
     }

--- a/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
+++ b/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
@@ -62,6 +62,18 @@ fn scenario_case_insensitive() {
 }
 
 #[test]
+fn scenario_parsing_accepts_whitespace_and_underscore_aliases() {
+    assert_eq!(
+        TestingScenario::from_str("  end_to_end "),
+        Ok(TestingScenario::EndToEnd)
+    );
+    assert_eq!(
+        TestingScenario::from_str("cross_validation"),
+        Ok(TestingScenario::CrossValidation)
+    );
+}
+
+#[test]
 fn scenario_display_roundtrip() {
     let scenarios = [
         TestingScenario::Unit,
@@ -164,6 +176,14 @@ fn env_case_insensitive() {
 }
 
 #[test]
+fn env_parsing_accepts_whitespace_and_underscore_aliases() {
+    assert_eq!(
+        ExecutionEnvironment::from_str("  pre_production "),
+        Ok(ExecutionEnvironment::PreProduction)
+    );
+}
+
+#[test]
 fn env_display_roundtrip() {
     let envs = [
         ExecutionEnvironment::Local,
@@ -234,6 +254,15 @@ fn feature_all_known_parse() {
 #[test]
 fn feature_crossval_alias() {
     assert_eq!(BitnetFeature::from_str("cross-validation"), Ok(BitnetFeature::CrossValidation));
+}
+
+#[test]
+fn feature_parsing_accepts_whitespace_and_underscore_aliases() {
+    assert_eq!(
+        BitnetFeature::from_str("  integration_tests "),
+        Ok(BitnetFeature::IntegrationTests)
+    );
+    assert_eq!(BitnetFeature::from_str("cpp_ffi"), Ok(BitnetFeature::CppFfi));
 }
 
 #[test]
@@ -310,6 +339,14 @@ fn feature_set_from_names_skips_unknown() {
     assert!(set.contains(BitnetFeature::Cpu));
     assert!(set.contains(BitnetFeature::Gpu));
     assert!(!set.contains(BitnetFeature::Cuda));
+}
+
+#[test]
+fn feature_set_from_names_trims_and_normalizes_labels() {
+    let set = FeatureSet::from_names([" cpu ", "integration_tests", "cross_validation"]);
+    assert!(set.contains(BitnetFeature::Cpu));
+    assert!(set.contains(BitnetFeature::IntegrationTests));
+    assert!(set.contains(BitnetFeature::CrossValidation));
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Parsing of scenario, environment and feature names was strict and could silently ignore common real-world inputs (extra whitespace or underscore separators) coming from CLI/env values, reducing reliability of grid matching.

### Description
- Add a shared `normalize_name_token` helper that trims input, lowercases it, and normalizes underscores/spaces to `-`, and route all `FromStr` parsing through it for `TestingScenario`, `ExecutionEnvironment`, and `BitnetFeature`.
- Extend `BitnetFeature` aliases to accept additional integration-test naming variants (`integration_tests`, `integrationtests`, `integrationtest`) for more robust matching.
- Add focused edge-case tests in `crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs` that verify whitespace/underscore acceptance for scenarios, environments, and features and that `FeatureSet::from_names` normalizes inputs.
- Modified files: `crates/bitnet-bdd-grid-core/src/lib.rs` and `crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs`.

### Testing
- Ran `cargo test -p bitnet-bdd-grid-core` and all unit and edge-case tests in the package passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95797f6488333b3c6daf4dd318e55)