### PR TITLE
fix(warn-once): avoid holding registry lock while emitting tracing events

### DIFF
--- a/crates/bitnet-warn-once/src/lib.rs
+++ b/crates/bitnet-warn-once/src/lib.rs
@@ -24,6 +24,8 @@
 
 use std::collections::HashSet;
 use std::sync::{Mutex, OnceLock};
+#[cfg(test)]
+use std::sync::TryLockError;
 
 /// Global registry of seen warning keys.
 ///
@@ -63,18 +65,30 @@ fn get_registry() -> &'static Mutex<HashSet<String>> {
 pub fn warn_once_fn(key: &str, message: &str) {
     let registry = get_registry();
     // Recover from poisoned lock - we don't care if a thread panicked while holding it
-    let mut seen = match registry.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
+    let is_first_occurrence = {
+        let mut seen = match registry.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        seen.insert(key.to_string())
     };
 
-    if seen.insert(key.to_string()) {
+    if is_first_occurrence {
         // First occurrence - log at WARN level
         tracing::warn!(key = %key, "{}", message);
     } else {
         // Subsequent occurrence - log at DEBUG level
         tracing::debug!(key = %key, "(rate-limited) {}", message);
     }
+}
+
+#[cfg(test)]
+fn registry_lock_is_available_for_test() -> bool {
+    let registry = get_registry();
+    matches!(
+        registry.try_lock(),
+        Ok(_) | Err(TryLockError::Poisoned(_))
+    )
 }
 
 /// Macro for convenient warn-once logging.
@@ -119,7 +133,10 @@ pub fn clear_registry_for_test() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use serial_test::serial;
+    use tracing::Subscriber;
+    use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -286,5 +303,40 @@ mod tests {
         assert!(seen.contains("key_a"));
         assert!(seen.contains("key_b"));
         assert!(seen.contains("key_c"));
+    }
+
+    struct RegistryLockProbeLayer {
+        lock_available_during_event: &'static AtomicBool,
+    }
+
+    impl<S> Layer<S> for RegistryLockProbeLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, _event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            self.lock_available_during_event
+                .store(registry_lock_is_available_for_test(), Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_warn_once_does_not_hold_registry_lock_while_logging() {
+        static LOCK_AVAILABLE_DURING_EVENT: AtomicBool = AtomicBool::new(false);
+        LOCK_AVAILABLE_DURING_EVENT.store(false, Ordering::SeqCst);
+        clear_registry_for_test();
+
+        let subscriber = tracing_subscriber::registry().with(RegistryLockProbeLayer {
+            lock_available_during_event: &LOCK_AVAILABLE_DURING_EVENT,
+        });
+
+        tracing::subscriber::with_default(subscriber, || {
+            warn_once_fn("lock_probe_key", "probe message");
+        });
+
+        assert!(
+            LOCK_AVAILABLE_DURING_EVENT.load(Ordering::SeqCst),
+            "registry lock should not be held while emitting tracing events"
+        );
     }
 }

--- a/crates/bitnet-warn-once/src/lib.rs
+++ b/crates/bitnet-warn-once/src/lib.rs
@@ -23,9 +23,9 @@
 //! ```
 
 use std::collections::HashSet;
-use std::sync::{Mutex, OnceLock};
 #[cfg(test)]
 use std::sync::TryLockError;
+use std::sync::{Mutex, OnceLock};
 
 /// Global registry of seen warning keys.
 ///
@@ -63,15 +63,7 @@ fn get_registry() -> &'static Mutex<HashSet<String>> {
 /// warn_once_fn("model_fallback", "Falling back to CPU for unsupported operation"); // DEBUG level
 /// ```
 pub fn warn_once_fn(key: &str, message: &str) {
-    let registry = get_registry();
-    // Recover from poisoned lock - we don't care if a thread panicked while holding it
-    let is_first_occurrence = {
-        let mut seen = match registry.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        seen.insert(key.to_string())
-    };
+    let is_first_occurrence = record_warning_occurrence(key);
 
     if is_first_occurrence {
         // First occurrence - log at WARN level
@@ -82,13 +74,20 @@ pub fn warn_once_fn(key: &str, message: &str) {
     }
 }
 
+fn record_warning_occurrence(key: &str) -> bool {
+    let registry = get_registry();
+    // Recover from poisoned lock - we don't care if a thread panicked while holding it
+    let mut seen = match registry.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    seen.insert(key.to_string())
+}
+
 #[cfg(test)]
 fn registry_lock_is_available_for_test() -> bool {
     let registry = get_registry();
-    matches!(
-        registry.try_lock(),
-        Ok(_) | Err(TryLockError::Poisoned(_))
-    )
+    matches!(registry.try_lock(), Ok(_) | Err(TryLockError::Poisoned(_)))
 }
 
 /// Macro for convenient warn-once logging.
@@ -133,12 +132,12 @@ pub fn clear_registry_for_test() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicBool, Ordering};
     use serial_test::serial;
+    use std::sync::atomic::{AtomicBool, Ordering};
     use tracing::Subscriber;
-    use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::layer::{Context, Layer};
     use tracing_subscriber::util::SubscriberInitExt;
 
     /// Test helper to capture tracing output
@@ -303,6 +302,16 @@ mod tests {
         assert!(seen.contains("key_a"));
         assert!(seen.contains("key_b"));
         assert!(seen.contains("key_c"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_record_warning_occurrence_reports_first_insert_only() {
+        clear_registry_for_test();
+
+        assert!(record_warning_occurrence("record_once"));
+        assert!(!record_warning_occurrence("record_once"));
+        assert!(record_warning_occurrence("record_other"));
     }
 
     struct RegistryLockProbeLayer {


### PR DESCRIPTION
### Motivation
- Prevent potential deadlocks or re-entrancy when a tracing subscriber invokes warn-once (or otherwise touches the registry) while the registry mutex is still held.

### Description
- Changed `warn_once_fn` to determine first-occurrence state while holding the mutex and then drop the lock before calling `tracing::warn!`/`tracing::debug!`, avoiding holding the mutex during event emission in `crates/bitnet-warn-once/src/lib.rs`.
- Added a test-only helper `registry_lock_is_available_for_test()` that probes lock availability via `try_lock()` (under `#[cfg(test)]`).
- Added a regression test using a custom `tracing::Layer` (`RegistryLockProbeLayer`) that asserts the registry lock is not held during `on_event` callbacks.

### Testing
- Ran `cargo test -p bitnet-warn-once` and `cargo test -p bitnet-warn-once --lib`; all tests passed.
- New focused test `test_warn_once_does_not_hold_registry_lock_while_logging` verifies the lock-release behavior and passed with the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95797f6488333b3c6daf4dd318e55)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture of the warning system for better maintainability.

* **Tests**
  * Expanded test coverage with additional validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->