### PR TITLE
Support snake_case aliases for BDD grid scenarios, environments, and features

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -44,9 +44,9 @@ impl FromStr for TestingScenario {
         match s.to_ascii_lowercase().as_str() {
             "unit" => Ok(Self::Unit),
             "integration" => Ok(Self::Integration),
-            "e2e" | "end-to-end" | "endtoend" => Ok(Self::EndToEnd),
+            "e2e" | "end-to-end" | "endtoend" | "end_to_end" => Ok(Self::EndToEnd),
             "performance" | "perf" => Ok(Self::Performance),
-            "crossval" | "cross-validation" => Ok(Self::CrossValidation),
+            "crossval" | "cross-validation" | "cross_validation" => Ok(Self::CrossValidation),
             "smoke" => Ok(Self::Smoke),
             "development" | "dev" => Ok(Self::Development),
             "debug" => Ok(Self::Debug),
@@ -83,7 +83,13 @@ impl FromStr for ExecutionEnvironment {
         match s.to_ascii_lowercase().as_str() {
             "local" | "dev" | "development" => Ok(Self::Local),
             "ci" | "ci/cd" | "cicd" => Ok(Self::Ci),
-            "pre-prod" | "preprod" | "pre-production" | "preproduction" | "staging" => {
+            "pre-prod"
+            | "preprod"
+            | "pre-production"
+            | "preproduction"
+            | "pre_prod"
+            | "pre_production"
+            | "staging" => {
                 Ok(Self::PreProduction)
             }
             "prod" | "production" => Ok(Self::Production),
@@ -170,14 +176,16 @@ impl FromStr for BitnetFeature {
             "ffi" => Ok(Self::Ffi),
             "python" => Ok(Self::Python),
             "wasm" => Ok(Self::Wasm),
-            "crossval" | "cross-validation" => Ok(Self::CrossValidation),
+            "crossval" | "cross-validation" | "cross_validation" => Ok(Self::CrossValidation),
             "trace" => Ok(Self::Trace),
-            "iq2s-ffi" => Ok(Self::Iq2sFfi),
-            "cpp-ffi" => Ok(Self::CppFfi),
+            "iq2s-ffi" | "iq2s_ffi" => Ok(Self::Iq2sFfi),
+            "cpp-ffi" | "cpp_ffi" => Ok(Self::CppFfi),
             "fixtures" => Ok(Self::Fixtures),
             "reporting" => Ok(Self::Reporting),
             "trend" => Ok(Self::Trend),
-            "integration-tests" => Ok(Self::IntegrationTests),
+            "integration-tests" | "integration_tests" | "integration-test" | "integration_test" => {
+                Ok(Self::IntegrationTests)
+            }
             _ => Err("unknown feature"),
         }
     }

--- a/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
+++ b/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
@@ -21,13 +21,18 @@ fn scenario_integration_parses() {
 }
 
 #[test]
-fn scenario_e2e_alias_end_to_end() {
+fn scenario_e2e_alias_end_dash_to_dash_end() {
     assert_eq!(TestingScenario::from_str("end-to-end"), Ok(TestingScenario::EndToEnd));
 }
 
 #[test]
 fn scenario_e2e_alias_endtoend() {
     assert_eq!(TestingScenario::from_str("endtoend"), Ok(TestingScenario::EndToEnd));
+}
+
+#[test]
+fn scenario_e2e_alias_end_to_end() {
+    assert_eq!(TestingScenario::from_str("end_to_end"), Ok(TestingScenario::EndToEnd));
 }
 
 #[test]
@@ -38,6 +43,11 @@ fn scenario_perf_alias() {
 #[test]
 fn scenario_crossval_alias() {
     assert_eq!(TestingScenario::from_str("cross-validation"), Ok(TestingScenario::CrossValidation));
+}
+
+#[test]
+fn scenario_crossval_alias_underscore() {
+    assert_eq!(TestingScenario::from_str("cross_validation"), Ok(TestingScenario::CrossValidation));
 }
 
 #[test]
@@ -137,7 +147,15 @@ fn env_cicd_no_slash_alias() {
 
 #[test]
 fn env_preprod_aliases() {
-    for alias in &["pre-prod", "preprod", "pre-production", "preproduction", "staging"] {
+    for alias in &[
+        "pre-prod",
+        "preprod",
+        "pre-production",
+        "preproduction",
+        "pre_prod",
+        "pre_production",
+        "staging",
+    ] {
         assert_eq!(
             ExecutionEnvironment::from_str(alias),
             Ok(ExecutionEnvironment::PreProduction),
@@ -234,6 +252,21 @@ fn feature_all_known_parse() {
 #[test]
 fn feature_crossval_alias() {
     assert_eq!(BitnetFeature::from_str("cross-validation"), Ok(BitnetFeature::CrossValidation));
+    assert_eq!(BitnetFeature::from_str("cross_validation"), Ok(BitnetFeature::CrossValidation));
+}
+
+#[test]
+fn feature_ffi_and_integration_aliases() {
+    assert_eq!(BitnetFeature::from_str("iq2s_ffi"), Ok(BitnetFeature::Iq2sFfi));
+    assert_eq!(BitnetFeature::from_str("cpp_ffi"), Ok(BitnetFeature::CppFfi));
+    assert_eq!(
+        BitnetFeature::from_str("integration_tests"),
+        Ok(BitnetFeature::IntegrationTests)
+    );
+    assert_eq!(
+        BitnetFeature::from_str("integration_test"),
+        Ok(BitnetFeature::IntegrationTests)
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Runtime flags and external config commonly use snake_case and were being ignored by the BDD grid parsers, causing fragile feature-set lookups and mismatch diagnostics.
- The BDD grid contract should be forgiving for common alias formats so cross-crate integrations and environment-derived settings map cleanly to canonical enums.

### Description
- Extended `TestingScenario::from_str` to accept underscore aliases such as `end_to_end` and `cross_validation` in `crates/bitnet-bdd-grid-core/src/lib.rs`.
- Extended `ExecutionEnvironment::from_str` to accept `pre_prod` and `pre_production` (and other previously supported pre-prod aliases) in `crates/bitnet-bdd-grid-core/src/lib.rs`.
- Extended `BitnetFeature::from_str` to accept underscore aliases `iq2s_ffi`, `cpp_ffi`, `integration_tests`, and `integration_test` in `crates/bitnet-bdd-grid-core/src/lib.rs`.
- Added focused edge-case tests to `crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs` to lock these aliases into the public contract.

### Testing
- Ran `cargo test -p bitnet-bdd-grid-core` and all tests in the crate completed successfully, with the test run passing (136 tests total across unit, edge-case, property and snapshot suites).
- The new and existing tests in `bdd_grid_core_edge_cases.rs` passed and validate the added aliases at parse-time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957957db4833397d1038b451ff039)