### PR TITLE
Fix checkpoint inventory path alias deduplication

### DIFF
--- a/crates/bitnet-models/src/checkpoint.rs
+++ b/crates/bitnet-models/src/checkpoint.rs
@@ -159,12 +159,29 @@ fn model_name_from_path(path: &Path) -> String {
     path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown").to_string()
 }
 
+/// Build a stable inventory key for a path.
+///
+/// We prefer canonicalized paths to deduplicate relative/absolute aliases that
+/// point to the same file, but fall back to an absolute best-effort key when
+/// canonicalization is unavailable (e.g. path does not currently exist).
+fn inventory_key(path: &Path) -> String {
+    let normalized = std::fs::canonicalize(path).unwrap_or_else(|_| {
+        if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir().map(|cwd| cwd.join(path)).unwrap_or_else(|_| path.to_path_buf())
+        }
+    });
+    normalized.to_string_lossy().to_string()
+}
+
 /// Build [`CheckpointMetadata`] by inspecting a file on disk.
 pub fn extract_metadata(path: &Path) -> Result<CheckpointMetadata, CheckpointError> {
     let meta = std::fs::metadata(path)?;
     let hash = compute_sha256(path)?;
     let format = CheckpointFormat::detect(path);
     let modified_at = meta.modified().ok();
+    let canonical_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
 
     Ok(CheckpointMetadata {
         format,
@@ -173,7 +190,7 @@ pub fn extract_metadata(path: &Path) -> Result<CheckpointMetadata, CheckpointErr
         created_at: SystemTime::now(),
         file_size: meta.len(),
         hash,
-        path: path.to_path_buf(),
+        path: canonical_path,
         modified_at,
     })
 }
@@ -211,7 +228,7 @@ impl CheckpointManager {
     /// stores it in the inventory. Returns an error if the path is already
     /// registered.
     pub fn add(&self, path: &Path) -> Result<CheckpointMetadata, CheckpointError> {
-        let key = path.to_string_lossy().to_string();
+        let key = inventory_key(path);
         let meta = extract_metadata(path)?;
 
         let mut inv = self.inventory.write().expect("lock poisoned");
@@ -224,7 +241,7 @@ impl CheckpointManager {
 
     /// Remove a checkpoint from the inventory (does **not** delete the file).
     pub fn remove(&self, path: &Path) -> Result<CheckpointMetadata, CheckpointError> {
-        let key = path.to_string_lossy().to_string();
+        let key = inventory_key(path);
         let mut inv = self.inventory.write().expect("lock poisoned");
         inv.remove(&key).ok_or(CheckpointError::NotFound(key))
     }
@@ -243,7 +260,7 @@ impl CheckpointManager {
 
     /// Retrieve metadata for a specific path.
     pub fn get(&self, path: &Path) -> Option<CheckpointMetadata> {
-        let key = path.to_string_lossy().to_string();
+        let key = inventory_key(path);
         self.inventory.read().expect("lock poisoned").get(&key).cloned()
     }
 
@@ -504,6 +521,26 @@ mod tests {
     }
 
     #[test]
+    fn inventory_rejects_duplicate_absolute_vs_relative_aliases() {
+        let dir = TempDir::new().unwrap();
+        let p = temp_file(&dir, "m.gguf", b"data");
+        let relative = PathBuf::from("m.gguf");
+        struct CwdGuard(PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
+
+        let _guard = CwdGuard(std::env::current_dir().unwrap());
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let mgr = CheckpointManager::new();
+        mgr.add(&relative).unwrap();
+        assert!(matches!(mgr.add(&p), Err(CheckpointError::Duplicate(_))));
+    }
+
+    #[test]
     fn inventory_remove() {
         let dir = TempDir::new().unwrap();
         let p = temp_file(&dir, "m.gguf", b"data");
@@ -702,5 +739,13 @@ mod tests {
         let p = temp_file(&dir, "ts.gguf", b"timestamp_test");
         let meta = extract_metadata(&p).unwrap();
         assert!(meta.modified_at.is_some());
+    }
+
+    #[test]
+    fn metadata_path_is_canonicalized() {
+        let dir = TempDir::new().unwrap();
+        let p = temp_file(&dir, "canon.gguf", b"canonical_test");
+        let meta = extract_metadata(&p).unwrap();
+        assert_eq!(meta.path, p.canonicalize().unwrap());
     }
 }


### PR DESCRIPTION
### Motivation
- Inventory keyed entries by the raw input path string, allowing the same file to be registered multiple times when one caller used a relative path and another used an absolute path.
- Metadata returned `path` as the input path instead of a canonicalized path, which is surprising for consumers that expect a stable canonical path.

### Description
- Add `inventory_key(path: &Path) -> String` which prefers `std::fs::canonicalize` and falls back to an absolute best-effort join for relative paths, and use it for inventory lookups.
- Update `extract_metadata` to store a canonicalized file path in `CheckpointMetadata.path` (falling back when canonicalization fails).
- Wire `add`, `get`, and `remove` to use the normalized inventory key so relative/absolute aliases deduplicate correctly.
- Add regression tests `inventory_rejects_duplicate_absolute_vs_relative_aliases` and `metadata_path_is_canonicalized` to cover the new behavior and ensure the metadata path is canonicalized.

### Testing
- Ran formatting and fixed issues with `cargo fmt --all` which completed successfully.
- Ran targeted unit tests with `cargo test -p bitnet-models inventory_rejects_duplicate_absolute_vs_relative_aliases` and the test passed.
- Ran targeted unit tests with `cargo test -p bitnet-models metadata_path_is_canonicalized` and the test passed.
- Ran `cargo test -p bitnet-models` as part of verification; compilation completed and the targeted tests passed (other tests were filtered out in the targeted runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957957db4833397d1038b451ff039)