### PR TITLE
Fix startup-contract-guard to use component-resolved profile snapshots

### DIFF
--- a/crates/bitnet-startup-contract-guard/src/lib.rs
+++ b/crates/bitnet-startup-contract-guard/src/lib.rs
@@ -7,8 +7,7 @@ use anyhow::Result;
 use tracing::{info, warn};
 
 pub use bitnet_runtime_bootstrap::{
-    ContractPolicy, RuntimeComponent, active_profile_summary, active_profile_violation_labels,
-    feature_line,
+    ContractPolicy, RuntimeComponent, feature_line,
 };
 pub use bitnet_startup_contract_diagnostics::StartupContractReport;
 
@@ -33,12 +32,24 @@ impl StartupContractGuard {
     /// Evaluate the startup contract and return a reusable snapshot.
     pub fn evaluate(component: RuntimeComponent, policy: ContractPolicy) -> Result<Self> {
         let report = StartupContractReport::evaluate(component, policy)?;
+        let profile_summary = report.profile_summary();
+        let profile_violations = if report.contract.required_features().is_empty()
+            && report.contract.optional_features().is_empty()
+            && report.contract.forbidden_features().is_empty()
+        {
+            None
+        } else {
+            Some((
+                report.contract.missing_required().to_vec(),
+                report.contract.forbidden_active().to_vec(),
+            ))
+        };
         Ok(Self {
             component,
             policy,
             feature_line: feature_line(),
-            profile_summary: active_profile_summary(),
-            profile_violations: active_profile_violation_labels(),
+            profile_summary,
+            profile_violations,
             report,
         })
     }

--- a/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
+++ b/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
@@ -78,6 +78,13 @@ fn guard_profile_summary_not_empty() {
     assert!(!guard.profile_summary.is_empty());
 }
 
+#[test]
+fn guard_profile_summary_matches_report_context() {
+    let guard =
+        StartupContractGuard::evaluate(RuntimeComponent::Test, ContractPolicy::Observe).unwrap();
+    assert_eq!(guard.profile_summary, guard.report.profile_summary());
+}
+
 // ---------------------------------------------------------------------------
 // StartupContractGuard: is_compatible
 // ---------------------------------------------------------------------------
@@ -145,6 +152,24 @@ fn guard_profile_violations_is_option() {
         }
         None => {}
     }
+}
+
+#[test]
+fn guard_profile_violations_match_contract() {
+    let guard =
+        StartupContractGuard::evaluate(RuntimeComponent::Cli, ContractPolicy::Observe).unwrap();
+    let expected = if guard.report.contract.required_features().is_empty()
+        && guard.report.contract.optional_features().is_empty()
+        && guard.report.contract.forbidden_features().is_empty()
+    {
+        None
+    } else {
+        Some((
+            guard.report.contract.missing_required().to_vec(),
+            guard.report.contract.forbidden_active().to_vec(),
+        ))
+    };
+    assert_eq!(guard.profile_violations, expected);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- The guard previously mixed global active-profile helpers with component-resolved evaluation, producing potentially inconsistent diagnostics for non-default components. 
- Diagnostics must reflect the same BDD/profile context used to evaluate the contract so reports and emitted summaries remain coherent. 

### Description
- `StartupContractGuard::evaluate` now sources `profile_summary` from `StartupContractReport::profile_summary()` instead of global helpers. 
- `profile_violations` is now derived from `report.contract` (using `missing_required()` and `forbidden_active()`), returning `None` when the evaluated contract has no grid-row features. 
- Removed re-exports of global `active_profile_summary`/`active_profile_violation_labels` from this crate's public surface to avoid accidental context drift. 
- Added two regression tests: `guard_profile_summary_matches_report_context` and `guard_profile_violations_match_contract` in `startup_contract_guard_edge_cases.rs` to lock the behavior. 

### Testing
- Added tests executed with `cargo test -p bitnet-startup-contract-guard --test startup_contract_guard_edge_cases`, and the suite passed (20 tests ran, 0 failed). 
- The two new regression tests (`guard_profile_summary_matches_report_context` and `guard_profile_violations_match_contract`) were included in the run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e957957db4833397d1038b451ff039)