### PR TITLE
Improve BDD grid pair validation semantics

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -327,6 +327,22 @@ impl BddGrid {
         self.rows.iter().find(|cell| cell.scenario == scenario && cell.environment == environment)
     }
 
+    /// Find all rows for a scenario/environment pair.
+    ///
+    /// This is useful when curated policy intentionally contains multiple rows
+    /// for the same pair (for example, when one scenario/environment has
+    /// multiple focused intents with different feature contracts).
+    pub fn rows_for_pair(
+        &self,
+        scenario: TestingScenario,
+        environment: ExecutionEnvironment,
+    ) -> Vec<&'static BddCell> {
+        self.rows
+            .iter()
+            .filter(|cell| cell.scenario == scenario && cell.environment == environment)
+            .collect()
+    }
+
     /// Find all rows for a scenario.
     pub fn rows_for_scenario(&self, scenario: TestingScenario) -> Vec<&'static BddCell> {
         self.rows.iter().filter(|cell| cell.scenario == scenario).collect()
@@ -339,7 +355,25 @@ impl BddGrid {
         environment: ExecutionEnvironment,
         features: &FeatureSet,
     ) -> Option<(FeatureSet, FeatureSet)> {
-        self.find(scenario, environment).map(|cell| cell.violations(features))
+        let matches = self.rows_for_pair(scenario, environment);
+        if matches.is_empty() {
+            return None;
+        }
+
+        if matches.iter().any(|cell| cell.supports(features)) {
+            return Some((FeatureSet::new(), FeatureSet::new()));
+        }
+
+        // If no row fully supports the features, return diagnostics from the
+        // "closest" row to aid remediation. Prefer fewer missing requirements,
+        // then fewer forbidden-feature conflicts.
+        matches.into_iter().map(|cell| cell.violations(features)).min_by(|a, b| {
+            let a_missing = a.0.iter().count();
+            let b_missing = b.0.iter().count();
+            let a_forbidden = a.1.iter().count();
+            let b_forbidden = b.1.iter().count();
+            (a_missing, a_forbidden).cmp(&(b_missing, b_forbidden))
+        })
     }
 }
 
@@ -370,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_grid_lookup_and_validation() {
-        let cell = BddCell {
+        let row_a = BddCell {
             scenario: TestingScenario::Unit,
             environment: ExecutionEnvironment::Local,
             required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
@@ -378,16 +412,63 @@ mod tests {
             forbidden_features: FeatureSet::new(),
             intent: "Unit test row",
         };
+        let row_b = BddCell {
+            scenario: TestingScenario::Unit,
+            environment: ExecutionEnvironment::Local,
+            required_features: feature_set_from_names(&["inference"]),
+            optional_features: FeatureSet::new(),
+            forbidden_features: feature_set_from_names(&["gpu"]),
+            intent: "Alternative unit row",
+        };
 
         let active = feature_set_from_names(&["inference", "kernels", "tokenizers"]);
-        assert!(cell.supports(&active));
-        assert!(cell.violations(&active).0.is_empty());
-        assert!(cell.violations(&active).1.is_empty());
+        assert!(row_a.supports(&active));
+        assert!(row_a.violations(&active).0.is_empty());
+        assert!(row_a.violations(&active).1.is_empty());
 
         // Verify grid lookup with a leaked static slice (test-only).
-        let rows: &'static [BddCell] = Box::leak(Box::new([cell]));
+        let rows: &'static [BddCell] = Box::leak(Box::new([row_a, row_b]));
         let grid = BddGrid::from_rows(rows);
         let found = grid.find(TestingScenario::Unit, ExecutionEnvironment::Local);
         assert!(found.is_some());
+        assert_eq!(
+            grid.rows_for_pair(TestingScenario::Unit, ExecutionEnvironment::Local).len(),
+            2
+        );
+        assert_eq!(
+            grid.validate(TestingScenario::Unit, ExecutionEnvironment::Local, &active),
+            Some((FeatureSet::new(), FeatureSet::new()))
+        );
+    }
+
+    #[test]
+    fn validate_uses_best_match_when_no_row_supports_features() {
+        let strict = BddCell {
+            scenario: TestingScenario::Integration,
+            environment: ExecutionEnvironment::Ci,
+            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
+            optional_features: FeatureSet::new(),
+            forbidden_features: FeatureSet::new(),
+            intent: "Strict row",
+        };
+        let lenient = BddCell {
+            scenario: TestingScenario::Integration,
+            environment: ExecutionEnvironment::Ci,
+            required_features: feature_set_from_names(&["inference"]),
+            optional_features: FeatureSet::new(),
+            forbidden_features: feature_set_from_names(&["gpu"]),
+            intent: "Lenient row",
+        };
+        let rows: &'static [BddCell] = Box::leak(Box::new([strict, lenient]));
+        let grid = BddGrid::from_rows(rows);
+
+        // Missing "inference", but avoids forbidden overlap and is therefore
+        // closer to the lenient row than to the strict row.
+        let active = feature_set_from_names(&["gpu"]);
+        let (missing, forbidden) = grid
+            .validate(TestingScenario::Integration, ExecutionEnvironment::Ci, &active)
+            .expect("matching rows should exist");
+        assert_eq!(missing.labels(), vec!["inference".to_string()]);
+        assert_eq!(forbidden.labels(), vec!["gpu".to_string()]);
     }
 }

--- a/crates/bitnet-bdd-grid/tests/grid_tests.rs
+++ b/crates/bitnet-bdd-grid/tests/grid_tests.rs
@@ -119,6 +119,20 @@ fn cell_lookup_nonexistent_returns_none() {
     assert!(cell.is_none(), "Unit/Production cell should NOT exist in the curated grid");
 }
 
+#[test]
+fn rows_for_pair_matches_find_for_existing_cell() {
+    let grid = curated();
+    let rows = grid.rows_for_pair(TestingScenario::Unit, ExecutionEnvironment::Local);
+    assert!(
+        !rows.is_empty(),
+        "rows_for_pair() should return at least one row for existing Unit/Local cell"
+    );
+    let found = grid
+        .find(TestingScenario::Unit, ExecutionEnvironment::Local)
+        .expect("Unit/Local should exist");
+    assert_eq!(rows[0].intent, found.intent, "find() should return first pair row");
+}
+
 // ── 3. Required-feature spot-checks ─────────────────────────────────────────
 
 #[test]
@@ -257,6 +271,19 @@ fn violations_detects_missing_required_features() {
         "EndToEnd/Ci must report missing required features for an empty active set"
     );
     assert!(violated.is_empty(), "An empty active set cannot trigger forbidden violations");
+}
+
+#[test]
+fn validate_accepts_any_matching_row_for_same_pair() {
+    let grid = curated();
+    // This set satisfies the Smoke/Local contract and should produce no
+    // missing/forbidden diagnostics from validate().
+    let active = feature_set_from_names(&["cpu", "inference"]);
+    let (missing, forbidden) = grid
+        .validate(TestingScenario::Smoke, ExecutionEnvironment::Local, &active)
+        .expect("Smoke/Local rows must exist");
+    assert!(missing.is_empty(), "at least one Smoke/Local row should be satisfied");
+    assert!(forbidden.is_empty(), "matching row should not report forbidden overlap");
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- The existing validation logic considered only a single row for a scenario/environment pair which made pair-level validation brittle when multiple curated rows exist for the same pair. 
- Make pair-level semantics explicit so tooling can enumerate and validate all curated intents for the same scenario/environment.

### Description
- Add `rows_for_pair(scenario, environment)` on `BddGrid` to return all `BddCell` entries for a given scenario/environment pair in `crates/bitnet-bdd-grid-core/src/lib.rs`.
- Update `BddGrid::validate` to evaluate all matching pair rows, returning `None` when no rows exist, empty diagnostics when any matching row supports the active feature set, or diagnostics from the best-matching row otherwise (preferring fewer missing required features then fewer forbidden conflicts).
- Preserve `find` semantics (first-match) while exposing pair enumeration and deterministic best-match fallback behavior.
- Expand/adjust tests in `crates/bitnet-bdd-grid-core/src/lib.rs` and `crates/bitnet-bdd-grid/tests/grid_tests.rs` to cover multi-row pair behavior, `rows_for_pair` consistency with `find`, successful pair validation, and best-match diagnostic selection.

### Testing
- Ran `cargo test -p bitnet-bdd-grid-core -p bitnet-bdd-grid` and all tests completed successfully.
- Ran `cargo test -p bitnet-bdd-grid --test grid_tests` and the updated integration tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95793ebc883339fa0f9353c206c12)