### PR TITLE
Improve BDD grid label normalization and parser consistency

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -7,6 +7,10 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
+fn normalize_label(input: &str) -> String {
+    input.trim().to_ascii_lowercase().replace(['_', ' '], "-")
+}
+
 /// Logical test scenario axis for BDD planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TestingScenario {
@@ -41,7 +45,8 @@ impl FromStr for TestingScenario {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_label(s);
+        match normalized.as_str() {
             "unit" => Ok(Self::Unit),
             "integration" => Ok(Self::Integration),
             "e2e" | "end-to-end" | "endtoend" => Ok(Self::EndToEnd),
@@ -80,7 +85,8 @@ impl FromStr for ExecutionEnvironment {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_label(s);
+        match normalized.as_str() {
             "local" | "dev" | "development" => Ok(Self::Local),
             "ci" | "ci/cd" | "cicd" => Ok(Self::Ci),
             "pre-prod" | "preprod" | "pre-production" | "preproduction" | "staging" => {
@@ -154,7 +160,8 @@ impl FromStr for BitnetFeature {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        let normalized = normalize_label(s);
+        match normalized.as_str() {
             "cpu" => Ok(Self::Cpu),
             "gpu" => Ok(Self::Gpu),
             "cuda" => Ok(Self::Cuda),
@@ -345,13 +352,7 @@ impl BddGrid {
 
 /// Canonical, reusable helper for mapping runtime feature selections to `FeatureSet`.
 pub fn feature_set_from_names(features: &[&str]) -> FeatureSet {
-    let mut set = FeatureSet::new();
-    for feature in features {
-        if let Ok(feature) = feature.parse() {
-            set.insert(feature);
-        }
-    }
-    set
+    FeatureSet::from_names(features.iter().copied())
 }
 
 #[cfg(test)]
@@ -361,6 +362,7 @@ mod tests {
     #[test]
     fn test_scenario_parsing() {
         assert_eq!(TestingScenario::from_str("unit"), Ok(TestingScenario::Unit));
+        assert_eq!(TestingScenario::from_str(" END_TO_END "), Ok(TestingScenario::EndToEnd));
         assert_eq!(
             TestingScenario::from_str("perf").map_err(|e| e.to_string()),
             Ok(TestingScenario::Performance)
@@ -389,5 +391,21 @@ mod tests {
         let grid = BddGrid::from_rows(rows);
         let found = grid.find(TestingScenario::Unit, ExecutionEnvironment::Local);
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn test_feature_and_environment_normalization() {
+        assert_eq!(
+            ExecutionEnvironment::from_str(" pre_production "),
+            Ok(ExecutionEnvironment::PreProduction)
+        );
+        assert_eq!(
+            BitnetFeature::from_str(" integration_tests "),
+            Ok(BitnetFeature::IntegrationTests)
+        );
+        assert_eq!(
+            BitnetFeature::from_str(" CROSS_VALIDATION "),
+            Ok(BitnetFeature::CrossValidation)
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Parsing of scenario, environment, and feature labels was brittle when fed from environment variables or CLI strings containing extra whitespace, underscores, or mixed case.  
- Normalizing input in one place reduces duplicate parsing logic and avoids silent drops of unknown feature names.

### Description
- Added a shared `normalize_label` helper to trim, lowercase, and map underscores/spaces to hyphens before parsing.  
- Updated `FromStr` implementations for `TestingScenario`, `ExecutionEnvironment`, and `BitnetFeature` to use the normalized input.  
- Refactored `feature_set_from_names` to delegate to `FeatureSet::from_names` to centralize parsing logic.  
- Added unit tests to verify normalization behavior for variants like `END_TO_END`, `pre_production`, `integration_tests`, and `CROSS_VALIDATION` in `crates/bitnet-bdd-grid-core/src/lib.rs`.

### Testing
- Ran formatting with `cargo fmt --all` (succeeded).  
- Ran unit tests for the crate with `cargo test -p bitnet-bdd-grid-core` and all tests passed (multiple test binaries, total tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95793ebc883339fa0f9353c206c12)