### PR TITLE
fix(kernels): normalize GPU env boolean flags

### DIFF
--- a/crates/bitnet-kernels/src/gpu/debug_layer.rs
+++ b/crates/bitnet-kernels/src/gpu/debug_layer.rs
@@ -115,7 +115,10 @@ impl<P: KernelProvider> DebugLayer<P> {
 /// Check whether `BITNET_GPU_DEBUG` is set to a truthy value.
 pub fn gpu_debug_enabled() -> bool {
     std::env::var("BITNET_GPU_DEBUG")
-        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .map(|v| {
+            let normalized = v.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
         .unwrap_or(false)
 }
 
@@ -450,6 +453,12 @@ mod tests {
             assert!(gpu_debug_enabled());
         });
         temp_env::with_var("BITNET_GPU_DEBUG", Some("yes"), || {
+            assert!(gpu_debug_enabled());
+        });
+        temp_env::with_var("BITNET_GPU_DEBUG", Some(" TRUE "), || {
+            assert!(gpu_debug_enabled());
+        });
+        temp_env::with_var("BITNET_GPU_DEBUG", Some("on"), || {
             assert!(gpu_debug_enabled());
         });
     }

--- a/crates/bitnet-kernels/src/gpu_utils.rs
+++ b/crates/bitnet-kernels/src/gpu_utils.rs
@@ -12,6 +12,24 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 const PROBE_POLL_INTERVAL: Duration = Duration::from_millis(50);
 static REAL_GPU_INFO_CACHE: OnceLock<GpuInfo> = OnceLock::new();
 
+fn env_var_truthy(key: &str) -> bool {
+    env::var(key)
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
+fn env_var_falsey(key: &str) -> bool {
+    env::var(key)
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "0" | "false" | "no" | "off")
+        })
+        .unwrap_or(false)
+}
+
 /// Run a shell command with a hard-kill timeout. Returns `false` on timeout or failure.
 ///
 /// Unlike the previous `recv_timeout` approach, this actually kills the subprocess
@@ -89,7 +107,7 @@ pub fn gpu_available() -> bool {
 /// Get information about available GPU backends
 pub fn get_gpu_info() -> GpuInfo {
     if let Ok(fake) = env::var("BITNET_GPU_FAKE") {
-        if env::var("BITNET_STRICT_NO_FAKE_GPU").as_deref() == Ok("1") {
+        if env_var_truthy("BITNET_STRICT_NO_FAKE_GPU") {
             panic!(
                 "BITNET_GPU_FAKE is set but strict mode forbids fake GPU (BITNET_STRICT_NO_FAKE_GPU=1)"
             );
@@ -113,7 +131,7 @@ pub fn get_gpu_info() -> GpuInfo {
 
     // Fake GPU selection is intentionally not cached, so tests and tooling can
     // change BITNET_GPU_FAKE across calls and get deterministic responses.
-    if env::var("BITNET_GPU_CACHE").as_deref() == Ok("0") {
+    if env_var_falsey("BITNET_GPU_CACHE") {
         return detect_real_gpu_info();
     }
 
@@ -355,5 +373,31 @@ mod tests {
     fn test_parse_hipcc_version() {
         let output = "HIP version: 6.1.0\nclang version 17.0.0\n";
         assert_eq!(parse_hipcc_version(output).as_deref(), Some("6.1.0"));
+    }
+
+    #[test]
+    fn env_var_truthy_accepts_common_values() {
+        temp_env::with_var("BITNET_TEST_BOOL", Some(" true "), || {
+            assert!(env_var_truthy("BITNET_TEST_BOOL"));
+        });
+        temp_env::with_var("BITNET_TEST_BOOL", Some("YES"), || {
+            assert!(env_var_truthy("BITNET_TEST_BOOL"));
+        });
+        temp_env::with_var("BITNET_TEST_BOOL", Some("on"), || {
+            assert!(env_var_truthy("BITNET_TEST_BOOL"));
+        });
+    }
+
+    #[test]
+    fn env_var_falsey_accepts_common_values() {
+        temp_env::with_var("BITNET_TEST_BOOL", Some(" false "), || {
+            assert!(env_var_falsey("BITNET_TEST_BOOL"));
+        });
+        temp_env::with_var("BITNET_TEST_BOOL", Some("NO"), || {
+            assert!(env_var_falsey("BITNET_TEST_BOOL"));
+        });
+        temp_env::with_var("BITNET_TEST_BOOL", Some("off"), || {
+            assert!(env_var_falsey("BITNET_TEST_BOOL"));
+        });
     }
 }

--- a/crates/bitnet-kernels/tests/kernels_gpu_utils_edge_cases.rs
+++ b/crates/bitnet-kernels/tests/kernels_gpu_utils_edge_cases.rs
@@ -243,3 +243,23 @@ fn strict_mode_rejects_fake_gpu() {
         },
     );
 }
+
+#[test]
+#[serial(bitnet_env)]
+#[should_panic(expected = "strict mode forbids fake GPU")]
+fn strict_mode_rejects_fake_gpu_with_text_bool() {
+    temp_env::with_vars(
+        [("BITNET_GPU_FAKE", Some("cuda")), ("BITNET_STRICT_NO_FAKE_GPU", Some("true"))],
+        || {
+            let _ = get_gpu_info();
+        },
+    );
+}
+
+#[test]
+#[serial(bitnet_env)]
+fn gpu_cache_false_text_disables_cache() {
+    temp_env::with_vars([("BITNET_GPU_FAKE", None), ("BITNET_GPU_CACHE", Some("false"))], || {
+        let _ = get_gpu_info();
+    });
+}


### PR DESCRIPTION
### Motivation
- GPU-related environment flags were matched only by exact strings (e.g. `"1"`/`"0"`) and were sensitive to case/whitespace, which caused fragile behavior in scripts, CI, and container environments.
- Make GPU env toggles more predictable and tolerant to common boolean representations to avoid accidental misconfiguration.

### Description
- Added `env_var_truthy` and `env_var_falsey` helpers in `crates/bitnet-kernels/src/gpu_utils.rs` to trim, lowercase, and accept common boolean values (`1/true/yes/on` and `0/false/no/off`).
- Replaced the previous exact-match checks for `BITNET_STRICT_NO_FAKE_GPU` and `BITNET_GPU_CACHE` with the normalized helpers in `get_gpu_info`.
- Hardened `gpu_debug_enabled()` in `crates/bitnet-kernels/src/gpu/debug_layer.rs` to accept trimmed and case-insensitive truthy values and extended its tests.
- Added unit tests to cover the new parsing helpers and extended integration tests in `crates/bitnet-kernels/tests/kernels_gpu_utils_edge_cases.rs` to verify strict-mode and cache-bypass semantics.

### Testing
- Ran `cargo fmt --all`, which succeeded.
- Attempted to run targeted `cargo test` for the `bitnet-kernels` crate, which initiated a workspace build; the build started and dependencies compiled but full test execution was interrupted by workspace build lock/contention in this environment so tests did not fully complete.
- The changes compiled during the build attempts and new tests were added; final test execution should be re-run in CI or a development environment to validate all tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95793ebc883339fa0f9353c206c12)