### PR TITLE
🎨 Palette: Make output containers accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Semantic Labeling for Generic Output Areas
+**Learning:** Using `<label>` tags to describe generic scrollable `<div>` output areas violates HTML semantics and accessibility rules, as `<label>` elements are strictly for form controls. This causes confusion for screen reader users.
+**Action:** When creating text descriptions for non-interactive output regions, use styled `<div>` elements with IDs, and link them to the output container using `aria-labelledby`. Ensure the container has `role="region"` and `tabindex="0"` for keyboard scrolling and proper screen reader announcement.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" style="font-weight: 500; margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" style="font-weight: 500; margin-bottom: 5px;">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" style="font-weight: 500; margin-bottom: 5px;">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" style="font-weight: 500; margin-bottom: 5px;">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
💡 What: Converted incorrect `<label>` elements for scrollable, non-interactive generic output containers to styled `<div>` elements and linked them using `aria-labelledby`. Added `tabindex="0"` and `role="region"` to the scrollable `<div>` elements.
🎯 Why: Non-interactive scrollable generic containers must be keyboard accessible and properly announced by screen readers. Using `<label>` tags on non-form elements violates HTML standards and ARIA rules. Adding a keyboard focusable region solves this.
📸 Before/After: Verified locally via Playwright screenshot in basic output tab.
♿ Accessibility: Ensures that keyboard users can tab into and scroll the output container areas, and screen reader users hear the context of the container properly.

---
*PR created automatically by Jules for task [1894530799316568967](https://jules.google.com/task/1894530799316568967) started by @EffortlessSteven*