### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path truncation vulnerability via null byte injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-06-03 - [Path Truncation via Null Bytes in File Path Validation]
+**Vulnerability:** The server's `validate_model_request` function checked for path traversal but failed to reject paths containing null bytes (`\0`). An attacker could supply a path like `/etc/passwd\0.gguf`. While Rust's standard string operations evaluate this successfully as ending in `.gguf`, underlying C/OS file system APIs (like `llama.cpp`) truncate the string at the null byte, resulting in access to `/etc/passwd` instead.
+**Learning:** Standard string validation methods (like `.ends_with()`) are insufficient when dealing with paths derived from user input that will eventually be processed by underlying C APIs or the OS.
+**Prevention:** Always explicitly check for and reject null bytes (`\0`) in user-provided file paths during validation to prevent path truncation attacks.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -600,6 +600,17 @@ mod tests {
 
         let config = SecurityConfig { trust_forwarded_headers: true, ..Default::default() };
         assert_eq!(extract_client_ip(&request, &config), Some(IpAddr::from([203, 0, 113, 1])));
+    }
+
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("/etc/passwd\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function in the `bitnet-server` crate did not check for null bytes (`\0`) in the `model_path`.
🎯 Impact: Attackers could inject a null byte into the model path (e.g., `/etc/passwd\0.gguf`). Rust's standard string functions like `.ends_with(".gguf")` would evaluate this as valid, but underlying C/OS file system functions would truncate the string at the null byte, potentially leading to unauthorized access to arbitrary files.
🔧 Fix: Explicitly check for and reject any model path containing a null byte.
✅ Verification: Run `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection`

---
*PR created automatically by Jules for task [6084834646987446200](https://jules.google.com/task/6084834646987446200) started by @EffortlessSteven*