### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation via Null Bytes in model_path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+## 2025-06-03 - Path Truncation via Null Bytes
+**Vulnerability:** The server allowed null bytes in `model_path` fields. When passed to underlying C/OS APIs, the string is truncated, bypassing subsequent validation like file extension checks.
+**Learning:** Standard string validation methods like `.ends_with()` are insufficient when the data eventually crosses the FFI boundary as a C string.
+**Prevention:** Always explicitly reject null bytes (`\0`) in string validation logic for paths derived from user input.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -234,6 +234,13 @@ impl SecurityValidator {
             ));
         }
 
+        // Prevent path truncation vulnerabilities
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Only allow specific file extensions
         if !model_path.ends_with(".gguf") && !model_path.ends_with(".safetensors") {
             return Err(ValidationError::InvalidFieldValue(


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `model_path` validation in `validate_model_request` failed to check for null bytes (`\0`). An attacker could provide a path like `secret.txt\0.gguf`. Rust's `ends_with(".gguf")` would return true, bypassing the extension check. However, when passed to underlying C libraries (e.g., `llama.cpp`), the path would truncate at the null byte, resulting in the server loading `secret.txt`.
🎯 Impact: This could allow attackers to bypass file extension restrictions and potentially load arbitrary files from allowed directories.
🔧 Fix: Added explicit rejection of null bytes in `validate_model_request`.
✅ Verification: Run `cargo test -p bitnet-server --lib security::tests::test_model_path_restriction`

---
*PR created automatically by Jules for task [7433762617228925392](https://jules.google.com/task/7433762617228925392) started by @EffortlessSteven*