### PR TITLE
🛡️ Sentinel: [HIGH] Fix null byte path truncation vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2024-04-25 - Null Byte Path Truncation in Model Path
+**Vulnerability:** `validate_model_request` allowed null bytes (`\0`) in the model path, which could bypass extension checks (like `.ends_with(".gguf")`) when passed to underlying C APIs (like llama.cpp), leading to arbitrary file read.
+**Learning:** Rust strings are not null-terminated, so `.ends_with()` can be bypassed if the string is later passed to C/OS APIs.
+**Prevention:** Always explicitly reject null bytes (`\0`) in file path validation logic when the path might be passed to underlying C/OS APIs.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -234,6 +234,13 @@ impl SecurityValidator {
             ));
         }
 
+        // Prevent path truncation attacks (null byte injection)
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Only allow specific file extensions
         if !model_path.ends_with(".gguf") && !model_path.ends_with(".safetensors") {
             return Err(ValidationError::InvalidFieldValue(
@@ -647,6 +654,17 @@ mod tests {
     /// An empty string in `allowed_model_directories` must NOT act as a wildcard.
     /// `Path::starts_with("")` returns `true` for every path (empty path has no
     /// components, which is trivially a prefix of anything), so we must skip empty entries.
+    #[test]
+    fn test_model_path_null_byte_rejection() {
+        let config = SecurityConfig::default();
+        let validator = SecurityValidator::new(config).unwrap();
+
+        assert!(matches!(
+            validator.validate_model_request("valid_model.gguf\0.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Null bytes are not allowed in model path"
+        ));
+    }
+
     #[test]
     fn test_empty_allowed_dir_does_not_bypass_restriction() {
         let config = SecurityConfig {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `validate_model_request` function validated file extensions (e.g., `.gguf`) using Rust's `.ends_with()`, but failed to reject null bytes (`\0`). This allowed path truncation attacks where a path like `secret.txt\0.gguf` passes the extension check but is truncated to `secret.txt` when passed to underlying C/OS APIs.
🎯 Impact: Attackers could bypass path validation to load arbitrary files or probe for file existence on the filesystem.
🔧 Fix: Explicitly check for and reject null bytes in the model path before performing extension or directory validation.
✅ Verification: Run `cargo test -p bitnet-server --lib security::tests::test_model_path_null_byte_rejection`.

---
*PR created automatically by Jules for task [5554472715702630567](https://jules.google.com/task/5554472715702630567) started by @EffortlessSteven*