### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Truncation vulnerability in model loading

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2024-05-24 - Path Truncation in Model Loading
+**Vulnerability:** The `validate_model_request` function in `bitnet-server` checked for the `.gguf` or `.safetensors` extensions but did not explicitly reject null bytes (`\0`). This could allow Path Truncation attacks (e.g., `secret.txt\0.gguf`) to bypass validation, as underlying C/OS APIs terminate strings at the null byte.
+**Learning:** Standard string validation methods like `.ends_with()` in Rust operate on the full string length and do not account for null byte termination behavior in underlying C/OS APIs (like `llama.cpp` or basic file I/O).
+**Prevention:** Always explicitly reject null bytes (`\0`) in string validation logic for file paths or any input passed to C/OS APIs.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,12 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+
+        // Null byte truncation attempts
+        assert!(matches!(
+            validator.validate_model_request("secret.txt\0.gguf"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `validate_model_request` function checked for allowed file extensions (`.gguf`, `.safetensors`) but failed to reject null bytes (`\0`). This could allow Path Truncation attacks (e.g., `secret.txt\0.gguf`) to bypass validation, as underlying C/OS APIs terminate strings at the null byte.
🎯 Impact: An attacker could potentially load arbitrary files from the filesystem by bypassing the extension check, leading to information disclosure.
🔧 Fix: Added explicit rejection of null bytes (`\0`) in the model path validation logic.
✅ Verification: Run `cargo test -p bitnet-server security` to verify the new test case.

---
*PR created automatically by Jules for task [1793030643931854246](https://jules.google.com/task/1793030643931854246) started by @EffortlessSteven*