### PR TITLE
🛡️ Sentinel: [HIGH] Fix Null Byte Injection in Model Path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2024-05-27 - Null Byte Injection in File Validation
+**Vulnerability:** The `validate_model_request` function in `bitnet-server` checked file extensions using `.ends_with()`. This is vulnerable to Path Truncation attacks because underlying C APIs stop at the first null byte (`\0`). An attacker could supply a path like `/etc/passwd\0.gguf`, which passes the extension check but forces the OS to read the restricted file.
+**Learning:** String validation functions in high-level languages like Rust do not stop at null bytes, but they are often passed directly to C APIs that do.
+**Prevention:** Always explicitly check for and reject null bytes in user-provided file paths before validating their format or interacting with the OS.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -234,6 +234,13 @@ impl SecurityValidator {
             ));
         }
 
+        // Prevent null byte injection (Path Truncation)
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Only allow specific file extensions
         if !model_path.ends_with(".gguf") && !model_path.ends_with(".safetensors") {
             return Err(ValidationError::InvalidFieldValue(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `validate_model_request` function in `crates/bitnet-server/src/security.rs` was vulnerable to Null Byte Injection (Path Truncation) because standard string validation methods like `.ends_with()` do not stop at null bytes, while underlying C/OS APIs (like `llama.cpp` used for loading models) typically truncate strings at the first null byte.
🎯 Impact: An attacker could bypass the file extension check by appending `\0.gguf` to a forbidden file path (e.g., `/etc/passwd\0.gguf`), tricking the validator into thinking it has a valid extension, while the underlying OS/C code would truncate it and read the restricted file instead.
🔧 Fix: Explicitly rejected null bytes (`\0`) in the path validation logic within `validate_model_request`.
✅ Verification: Ran `cargo test -p bitnet-server security::tests::test_model_path_restriction -- --exact`.

---
*PR created automatically by Jules for task [1248130294456809793](https://jules.google.com/task/1248130294456809793) started by @EffortlessSteven*