### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation Vulnerability via Null Byte Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-06-03 - Path Truncation Vulnerability via Null Byte Injection
+**Vulnerability:** The `validate_model_request` function validated file extensions (e.g., `.gguf`) but did not check for null bytes (`\0`). An attacker could supply a path like `secret.txt\0.gguf` which passes the extension check in Rust, but when passed to underlying C/OS APIs, the path is truncated at the null byte, leading to unauthorized access to `secret.txt`.
+**Learning:** Standard string validation methods in memory-safe languages like Rust's `.ends_with()` are insufficient to prevent Path Truncation vulnerabilities when the string is eventually passed to C-style APIs (like `llama.cpp`) that terminate strings at null bytes.
+**Prevention:** Always explicitly reject null bytes (`\0`) in the validation logic when handling file paths derived from user input, especially when interoperating with C/FFI layers.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,12 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+
+        // Null byte injection attempts
+        assert!(matches!(
+            validator.validate_model_request("/models/secret.txt\0.gguf"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `validate_model_request` function in `bitnet-server` checked file extensions but failed to reject null bytes (`\0`). This allowed an attacker to bypass extension validation by appending a null byte and a valid extension (e.g., `secret.txt\0.gguf`), leading to path truncation in underlying C APIs (like `llama.cpp`) and unauthorized access to arbitrary files.
🎯 Impact: Attackers could read arbitrary files on the system that they wouldn't normally have access to, potentially exposing sensitive data, credentials, or configuration files.
🔧 Fix: Explicitly reject any model paths containing null bytes (`\0`) during validation.
✅ Verification: Run `cargo test -p bitnet-server security::tests::test_model_path_restriction -- --exact` to verify the fix.

---
*PR created automatically by Jules for task [1180419436593787752](https://jules.google.com/task/1180419436593787752) started by @EffortlessSteven*