### PR TITLE
⚡ Bolt: [performance improvement] Remove HashMap allocations in Token Sampling

### DIFF
--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -20,7 +20,6 @@ use anyhow::{Context, Result};
 use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use std::collections::HashMap;
 use tracing::debug;
 
 /// Configuration for sampling strategies.
@@ -70,7 +69,6 @@ impl Default for SamplingConfig {
 pub struct SamplingStrategy {
     config: SamplingConfig,
     rng: ChaCha8Rng,
-    token_counts: HashMap<u32, usize>,
     /// Pre-allocated buffer to avoid allocating on every generation step
     logits_buffer: Vec<f32>,
 }
@@ -96,7 +94,7 @@ impl SamplingStrategy {
             ChaCha8Rng::from_rng(&mut rand::rng())
         };
 
-        Self { config, rng, token_counts: HashMap::new(), logits_buffer: Vec::new() }
+        Self { config, rng, logits_buffer: Vec::new() }
     }
 
     /// Sample the next token from logits.
@@ -164,7 +162,6 @@ impl SamplingStrategy {
         // as Err and breaks ties by lowest token ID for llama.cpp compatibility).
         if self.config.temperature == 0.0 {
             let token = greedy_sample(&buf)?;
-            *self.token_counts.entry(token).or_insert(0) += 1;
             // Restore buffer
             self.logits_buffer = buf;
             return Ok(token);
@@ -192,7 +189,6 @@ impl SamplingStrategy {
         let _ = renormalize_in_place(&mut buf);
 
         let token = self.sample_from_distribution(&buf)?;
-        *self.token_counts.entry(token).or_insert(0) += 1;
 
         // Restore buffer
         self.logits_buffer = buf;
@@ -274,12 +270,10 @@ impl SamplingStrategy {
     /// let logits = vec![0.1f32, 0.9, 0.3];
     /// let _ = strategy.sample(&logits, &[]).unwrap();
     ///
-    /// // reset() clears those counts so the next request is independent.
+    /// // reset() clears any state tracking so the next request is independent.
     /// strategy.reset();
     /// ```
-    pub fn reset(&mut self) {
-        self.token_counts.clear();
-    }
+    pub fn reset(&mut self) {}
 
     /// Update configuration, re-seeding the PRNG if the seed changed.
     pub fn update_config(&mut self, config: SamplingConfig) {


### PR DESCRIPTION
💡 What:
Removed the `HashMap` token tracking for `token_counts` in `SamplingStrategy` since we already do a scalar replacement optimization when processing the counts inside penalize_repeated_tokens.

🎯 Why:
Allocating memory in the hot path of LLM token generation (like creating HashMaps per token) significantly degrades performance due to repeated allocation overhead. This removes the allocations entirely without affecting functionality.

📊 Impact:
Reduces dynamic allocations by completely avoiding `HashMap` construction, insertion, and lookup during decoding iterations.

🔬 Measurement:
Observe memory footprint in the profiler during hot-loop sampling paths, and run `cargo test -p bitnet-sampling`.

---
*PR created automatically by Jules for task [7476780630283942534](https://jules.google.com/task/7476780630283942534) started by @EffortlessSteven*