### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation via Null Byte

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,8 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+
+## 2025-06-03 - [Path Truncation via Null Bytes in Model Paths]
+**Vulnerability:** The model path validation logic in `validate_model_request` only checked the file extension using `.ends_with()`. This allowed paths containing null bytes (e.g., `model.gguf\0.gguf`) to bypass the check. Underlying C libraries (like those used in `llama.cpp`) would truncate the string at the null byte, potentially loading unintended or sensitive files.
+**Learning:** String validation in higher-level languages (like Rust) might not align with how lower-level APIs interpret strings, particularly regarding null terminators.
+**Prevention:** Explicitly reject paths containing null bytes (`\0`) alongside existing path traversal and extension checks.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -228,7 +228,7 @@ impl SecurityValidator {
         }
 
         // Prevent path traversal attacks
-        if model_path.contains("..") || model_path.contains("~") {
+        if model_path.contains("..") || model_path.contains("~") || model_path.contains('\0') {
             return Err(ValidationError::InvalidFieldValue(
                 "Invalid characters in model path".to_string(),
             ));
@@ -640,6 +640,12 @@ mod tests {
         // Path traversal attempts (already blocked, but verifying combined behavior)
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+
+        // Null byte injection attempt
+        assert!(matches!(
+            validator.validate_model_request("/models/secret.txt\0.gguf"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
         ));
     }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The model path validation in `validate_model_request` checked for file extensions but did not reject null bytes. This allowed attackers to provide paths like `/path/to/secret.txt\0.gguf`, bypassing the `.ends_with()` extension check while causing underlying C APIs (like `llama.cpp`) to truncate the path at the null byte and read the unintended file.
🎯 Impact: Attackers could bypass file extension restrictions and potentially load or interact with unintended files on the filesystem.
🔧 Fix: Added explicit rejection of null bytes (`\0`) in the model path validation logic alongside existing path traversal protections.
✅ Verification: Run `cargo test -p bitnet-server security::tests::test_model_path_restriction -- --exact` to verify null byte paths are blocked.

---
*PR created automatically by Jules for task [16652673756747245334](https://jules.google.com/task/16652673756747245334) started by @EffortlessSteven*