### PR TITLE
⚡ Bolt: Remove unused token_counts HashMap from SamplingStrategy

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-05 - Hot Loop Allocations in Token Sampling
 **Learning:** Allocating memory in the hot path of LLM token generation (e.g., `logits.to_vec()` or creating `HashMap`s per token) significantly degrades performance due to repeated allocation overhead of vocabulary-sized vectors (often 128K+ elements). Additionally, mathematically equivalent iterative multiplication (`logit *= inv_penalty`) can replace `HashMap` counting and `.powi(count)`, completely eliminating O(N) memory allocations per token.
 **Action:** When working on generation loops, use buffer pooling (e.g. storing a `Vec` in the generator state and using `std::mem::take` to bypass borrow checker limitations) and avoid `HashMap` allocations for simple counting if an iterative scalar approach is mathematically equivalent.
+
+## 2024-05-03 - Unused HashMap Allocation in Hot Loop
+**Learning:** Found a `HashMap` (`token_counts`) in `SamplingStrategy` that was allocated, updated in the hot generation loop, and cleared on reset, but *never actually read*. The repetition penalty correctly used the `context_tokens` slice instead. This incurred unnecessary allocation and per-token hashing overhead for absolutely no benefit.
+**Action:** Always audit structs that maintain collection state in hot loops (like `HashMap`s for token counting) to ensure they are actually read from, not just blindly written to.

--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -20,7 +20,6 @@ use anyhow::{Context, Result};
 use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use std::collections::HashMap;
 use tracing::debug;
 
 /// Configuration for sampling strategies.
@@ -70,7 +69,6 @@ impl Default for SamplingConfig {
 pub struct SamplingStrategy {
     config: SamplingConfig,
     rng: ChaCha8Rng,
-    token_counts: HashMap<u32, usize>,
     /// Pre-allocated buffer to avoid allocating on every generation step
     logits_buffer: Vec<f32>,
 }
@@ -96,7 +94,7 @@ impl SamplingStrategy {
             ChaCha8Rng::from_rng(&mut rand::rng())
         };
 
-        Self { config, rng, token_counts: HashMap::new(), logits_buffer: Vec::new() }
+        Self { config, rng, logits_buffer: Vec::new() }
     }
 
     /// Sample the next token from logits.
@@ -164,7 +162,6 @@ impl SamplingStrategy {
         // as Err and breaks ties by lowest token ID for llama.cpp compatibility).
         if self.config.temperature == 0.0 {
             let token = greedy_sample(&buf)?;
-            *self.token_counts.entry(token).or_insert(0) += 1;
             // Restore buffer
             self.logits_buffer = buf;
             return Ok(token);
@@ -192,7 +189,6 @@ impl SamplingStrategy {
         let _ = renormalize_in_place(&mut buf);
 
         let token = self.sample_from_distribution(&buf)?;
-        *self.token_counts.entry(token).or_insert(0) += 1;
 
         // Restore buffer
         self.logits_buffer = buf;
@@ -278,7 +274,7 @@ impl SamplingStrategy {
     /// strategy.reset();
     /// ```
     pub fn reset(&mut self) {
-        self.token_counts.clear();
+        // No per-sequence state to clear since token_counts was removed
     }
 
     /// Update configuration, re-seeding the PRNG if the seed changed.


### PR DESCRIPTION
💡 What: Removed the unused `token_counts` `HashMap` from `SamplingStrategy`.
🎯 Why: The `HashMap` was being allocated, updated on every generated token, and cleared, but its contents were never read. Repetition penalties are correctly calculated using `context_tokens` directly. Removing this eliminates per-token hashing and map insertion overhead in the hot generation loop.
📊 Impact: Completely eliminates O(1) allocation and hashing overhead per generated token for the token tracker, slightly improving generation throughput.
🔬 Measurement: Verify by running `cargo test -p bitnet-sampling`. All tests should pass and performance in the hot loop is cleanly improved.

---
*PR created automatically by Jules for task [17363282850506600787](https://jules.google.com/task/17363282850506600787) started by @EffortlessSteven*