### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Truncation in Model Path Validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The `try_consume` method in `RateLimitBucket` was vulnerable to a Time-of-Check to Time-of-Use (TOCTOU) bug because it used a separate `load` and `fetch_sub` when verifying and decrementing available tokens. Concurrently running tasks could observe a positive number of tokens, pass the conditional check, and subtract tokens simultaneously, leading to integer underflow and a bypass of the rate limiter. Additionally, the `refill` method was subject to a data race that could overwrite consumed tokens with a stale calculation.
 **Learning:** Separate read-then-write operations on atomics are inherently susceptible to race conditions under heavy concurrency.
 **Prevention:** Use atomic `fetch_update` operations to guarantee atomic Read-Modify-Write functionality when an atomic value change is conditional on its current value.
+## 2025-06-03 - Path Truncation Vulnerability
+**Vulnerability:** Model path validation was vulnerable to path truncation via null bytes.
+**Learning:** Standard string validation like `.ends_with()` can be bypassed if the underlying system API stops reading at the first null byte.
+**Prevention:** Always explicitly check for and reject null bytes in user-provided file paths.

--- a/crates/bitnet-server/src/security.rs
+++ b/crates/bitnet-server/src/security.rs
@@ -234,6 +234,13 @@ impl SecurityValidator {
             ));
         }
 
+        // Prevent path truncation vulnerabilities
+        if model_path.contains('\0') {
+            return Err(ValidationError::InvalidFieldValue(
+                "Null bytes are not allowed in model path".to_string(),
+            ));
+        }
+
         // Only allow specific file extensions
         if !model_path.ends_with(".gguf") && !model_path.ends_with(".safetensors") {
             return Err(ValidationError::InvalidFieldValue(
@@ -641,6 +648,12 @@ mod tests {
         assert!(matches!(
             validator.validate_model_request("/models/../secret.gguf"),
             Err(ValidationError::InvalidFieldValue(msg)) if msg == "Invalid characters in model path"
+        ));
+
+        // Path truncation attempts
+        assert!(matches!(
+            validator.validate_model_request("/models/llama.gguf\0.txt"),
+            Err(ValidationError::InvalidFieldValue(msg)) if msg == "Null bytes are not allowed in model path"
         ));
     }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Model path validation lacked null byte checks, allowing path truncation.
🎯 Impact: Attackers could bypass path restrictions by injecting null bytes, potentially loading unauthorized files if the underlying OS API stopped at the null byte.
🔧 Fix: Explicitly rejected null bytes in `validate_model_request`.
✅ Verification: Run `cargo test -p bitnet-server security::tests::test_model_path_restriction -- --exact` to ensure null bytes are correctly rejected.

---
*PR created automatically by Jules for task [10205966742055258282](https://jules.google.com/task/10205966742055258282) started by @EffortlessSteven*