### PR TITLE
ci: add Codecov upload and LCOV generation to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,16 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Provide a reliable Codecov upload path for Rust coverage by producing an `lcov.info` report that Codecov ingests well. 
- Wire Codecov reporting into the existing coverage workflow without changing the existing PR label gate or the 70% `main` threshold. 

### Description
- Generate LCOV output in the coverage job by adding `cargo llvm-cov report --lcov --output-path lcov.info` to `.github/workflows/coverage.yml`. 
- Upload `lcov.info` to Codecov using `codecov/codecov-action@v5` pinned to the `v5` tag commit SHA and guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}`. 
- Include `lcov.info` in the `coverage-report` artifact upload alongside `coverage.json` and `coverage.txt` in `.github/workflows/coverage.yml`. 
- Add a conservative repository `codecov.yml` that sets informational `project` and `patch` status (flag `rust-cpu`), configures comment layout, and disables GitHub inline annotations. 

### Testing
- Validated YAML parsing for both files with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/coverage.yml'); YAML.load_file('codecov.yml'); puts 'YAML OK'"`, which printed `YAML OK`. 
- Confirmed the `v5` tag source for the Codecov action with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5 refs/tags/v5^{}`, which returned a tag SHA. 
- Verified repository status and staged changes using `git status --short` and file diffs to ensure only the intended files (`.github/workflows/coverage.yml` and `codecov.yml`) were affected, and the checks above all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b80d2c148333b5ae7bded1571dbc)