### PR TITLE
Add minimal Codecov upload and reporting for Rust coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,8 +90,19 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
 
       - name: Disk usage after coverage
         if: always()
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Provide minimal Codecov integration so CI uploads a reliable `lcov.info` in addition to existing reports and surfaces coverage to Codecov without changing CI gating or thresholds. 
- Preserve the existing PR label gate and the 70% `main` threshold to avoid increasing CI cost or creating new merge blockers. 
- Keep the change conservative and informational to establish a baseline before expanding coverage scope. 

### Description
- Generate `lcov.info` from the existing Dockerized `cargo llvm-cov` report step by adding `cargo llvm-cov report --lcov --output-path lcov.info` to `.github/workflows/coverage.yml`. 
- Upload `lcov.info` to Codecov using `codecov/codecov-action@v5` pinned to tag `v5` commit SHA `75cd11691c0faa626561e295848008c8a7dddffe` and guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}` with `files: lcov.info`, `flags: rust-cpu`, `name: bitnet-rs-rust-cpu`, and `fail_ci_if_error: true`. 
- Include `lcov.info` in the coverage artifact bundle alongside `coverage.json` and `coverage.txt`. 
- Add a conservative root `codecov.yml` with informational project/patch status settings, `rust-cpu` flag scoping, comments layout, and GitHub annotation disabling. 

### Testing
- Resolved the `v5` tag SHA for `codecov/codecov-action` with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5`, which succeeded and returned `75cd11691c0faa626561e295848008c8a7dddffe`. 
- Validated both YAML files parse successfully using `python - <<'PY' ... yaml.safe_load(...) ... PY`, which reported `OK` for `.github/workflows/coverage.yml` and `codecov.yml`. 
- Confirmed the workflow contains the new `lcov.info` generation, Codecov upload step, and artifact inclusion as intended (YAML validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b80d2c148333b5ae7bded1571dbc)