### PR TITLE
Add minimal Codecov LCOV upload wiring for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,17 @@ jobs:
           fi
           echo "Coverage OK"
 
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +140,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Enable Codecov uploads and reporting for BitNet-rs by producing a reliable `lcov.info` coverage artifact that Codecov can ingest. 
- Preserve the existing coverage workflow shape, keep the PR `coverage` label gate, and retain the existing 70% main-branch threshold to avoid increasing CI cost or changing enforcement behavior.

### Description
- Generate `lcov.info` alongside the existing JSON/text reports by running `cargo llvm-cov report --lcov --output-path lcov.info` in `.github/workflows/coverage.yml`.
- Upload `lcov.info` to Codecov using `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` (v5) with `token: ${{ secrets.CODECOV_TOKEN }}`, `files: lcov.info`, `flags: rust-cpu`, `name: bitnet-rs-rust-cpu`, `fail_ci_if_error: true`, and guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}`.
- Add `lcov.info` to the existing `actions/upload-artifact` step so the artifact bundle includes `coverage.json`, `coverage.txt`, and `lcov.info`.
- Add a conservative root `codecov.yml` that sets informational `project`/`patch` status entries, uses the `rust-cpu` flag, configures the comment layout, and disables GitHub inline annotations.

### Testing
- Parsed both modified YAML files with Python using `yaml.safe_load` and the parse succeeded.
- Resolved the `v5` tag for `codecov/codecov-action` using `git ls-remote` and confirmed the v5 tag maps to commit SHA `75cd11691c0faa626561e295848008c8a7dddffe`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b80d2c148333b5ae7bded1571dbc)