### PR TITLE
Add minimal Codecov integration to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,16 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Add a reliable Codecov upload path for Rust coverage by producing `lcov.info` and sending it to Codecov without changing the existing coverage gating or thresholds. 
- Keep the repository's cost-control policy intact by leaving the PR `coverage` label gate and the `70%` `main` threshold unchanged. 

### Description
- Generate LCOV output by adding `cargo llvm-cov report --lcov --output-path lcov.info` to the existing coverage step in `.github/workflows/coverage.yml`.
- Upload `lcov.info` to Codecov using `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` (current `v5` tag SHA) with `files: lcov.info`, `flags: rust-cpu`, `name: bitnet-rs-rust-cpu`, and `fail_ci_if_error: true` behind the guard `if: ${{ always() && hashFiles('lcov.info') != '' }}`.
- Include `lcov.info` in the artifacts uploaded by the existing `actions/upload-artifact` step in `.github/workflows/coverage.yml`.
- Add a conservative root `codecov.yml` that sets informational project/patch status defaults, scopes to the `rust-cpu` flag, and disables GitHub annotations.

### Testing
- Parsed both ` .github/workflows/coverage.yml` and `codecov.yml` with `yaml.safe_load` in Python and the parse check passed (`ok`).
- Resolved the `v5` tag SHA for `codecov/codecov-action` via `git ls-remote` and recorded `75cd11691c0faa626561e295848008c8a7dddffe` for pinning, which succeeded.
- Changes were committed locally; no CI workflow dispatch was executed as part of this change so no runtime coverage uploads were tested in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9b80d2c148333b5ae7bded1571dbc)