### PR TITLE
Add Codecov lcov upload and baseline config

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,16 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Wire Codecov reporting into the existing coverage workflow so LCOV uploads are available for dashboard and PR reporting. 
- Keep the current CI shape and cost controls by not changing the `coverage` label gate or the 70% `main` threshold. 

### Description
- Generate `lcov.info` from the existing `cargo llvm-cov` reports and include it alongside `coverage.json` and `coverage.txt` in the coverage artifact. 
- Upload `lcov.info` to Codecov using `codecov/codecov-action@v5` pinned to the `v5` tag commit SHA and guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}`. 
- Add a conservative root `codecov.yml` that marks project/patch statuses as informational, sets `rust-cpu` as a flag, and disables GitHub inline annotations. 
- Modified files: `.github/workflows/coverage.yml` and `codecov.yml`. 

### Testing
- Resolved the `v5` tag SHA with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5` and the lookup succeeded. 
- Validated YAML parsing for both `.github/workflows/coverage.yml` and `codecov.yml` with `ruby -e "require 'yaml'; YAML.load_file(...)"` and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da92571c8333b90296a04350bb3c)