### PR TITLE
Add minimal Codecov upload and baseline config for Rust coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,16 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Enable Codecov reporting for the existing Rust coverage workflow by producing an `lcov.info` report and uploading it to Codecov while preserving the current PR label gate and the 70% `main` threshold.

### Description
- Generate `lcov.info` in the coverage job by running `cargo llvm-cov report --lcov --output-path lcov.info` alongside the existing JSON/text reports.
- Upload `lcov.info` to Codecov with a guarded step `if: ${{ always() && hashFiles('lcov.info') != '' }}` using `codecov/codecov-action` pinned to the resolved `v5` tag SHA `75cd11691c0faa626561e295848008c8a7dddffe` and `flags: rust-cpu` and `fail_ci_if_error: true`.
- Include `lcov.info` in the `coverage-report` artifact upload and keep the existing `cargo llvm-cov nextest` invocation and PR label gating unchanged.
- Add a conservative root `codecov.yml` that sets `precision: 2`, `project.target: auto` (informational), `patch.target: 70%` (informational), scopes rules to the `rust-cpu` flag, configures comment layout, and disables GitHub inline annotations.

### Testing
- Validated `.github/workflows/coverage.yml` parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/coverage.yml')"` which returned OK.
- Validated `codecov.yml` parses with `ruby -e "require 'yaml'; YAML.load_file('codecov.yml')"` which returned OK.
- Resolved the `codecov/codecov-action` `v5` tag SHA with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5` and pinned the action to `75cd11691c0faa626561e295848008c8a7dddffe`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da92571c8333b90296a04350bb3c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code coverage reporting pipeline to generate LCOV format reports for improved integration with coverage tracking services.
  * Configured coverage validation thresholds and quality gates across project and patch scopes to strengthen code quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->