### PR TITLE
Add Codecov LCOV upload and conservative codecov.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,8 +90,19 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
 
       - name: Disk usage after coverage
         if: always()
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Provide a reliable LCOV artifact for Codecov ingestion without changing existing CI shape or thresholds. 
- Ensure Codecov receives Rust coverage data and can report on the workspace while keeping PR coverage gated by the existing `coverage` label. 
- Add a conservative, informational `codecov.yml` so Codecov feedback is non-blocking while a baseline is established.

### Description
- Updated `.github/workflows/coverage.yml` to generate `lcov.info` via `cargo llvm-cov report --lcov --output-path lcov.info` alongside the existing `coverage.json` and `coverage.txt` reports. 
- Added a Codecov upload step guarded by `if: ${{ always() && hashFiles('lcov.info') != '' }}`, using `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` (current `v5` tag commit), with `token: ${{ secrets.CODECOV_TOKEN }}`, `files: lcov.info`, `flags: rust-cpu`, `name: bitnet-rs-rust-cpu`, and `fail_ci_if_error: true`. 
- Included `lcov.info` in the existing coverage artifact upload so CI artifacts contain the LCOV report. 
- Added a root `codecov.yml` that sets informational project and patch status rules (`project.target: auto`, `patch.target: 70%`), uses the `rust-cpu` flag, configures comment layout, and disables GitHub inline annotations via `github_checks.annotations: false`. 
- Preserved existing behavior: the PR label gate and the 70% `main` threshold enforcement remain unchanged.

### Testing
- Validated YAML parsing for both modified files with `python - <<'PY' ... yaml.safe_load(...) ... PY` and both files loaded successfully. (succeeded)
- Resolved and pinned the `v5` action SHA with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5` and used that commit (`75cd11691c0faa626561e295848008c8a7dddffe`) in the workflow. (succeeded)
- Committed the changes (`git commit -m "Add minimal Codecov upload and reporting config"`) and verified the working tree shows the intended changes. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da92571c8333b90296a04350bb3c)