### PR TITLE
ci: upload lcov to Codecov and add conservative codecov.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,6 +90,7 @@ jobs:
               cargo llvm-cov nextest --workspace --locked --no-default-features --features cpu --no-report --profile ci \
                 --ignore-run-fail
               cargo llvm-cov report --json --output-path coverage.json
+              cargo llvm-cov report --lcov --output-path lcov.info
               cargo llvm-cov report --text | tee coverage.txt
             '
 
@@ -120,6 +121,16 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Upload coverage reports to Codecov
+        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: true
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +139,5 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
           retention-days: 7

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
### Motivation
- Add minimal Codecov reporting to the existing coverage workflow by uploading an `lcov.info` artifact so Codecov can ingest Rust coverage reliably. 
- Preserve the current CI gating and the local 70% `main` threshold while enabling Codecov dashboards and informational PR reports when the coverage job runs. 

### Description
- Generate `lcov.info` alongside the existing `coverage.json` and `coverage.txt` in `.github/workflows/coverage.yml` using `cargo llvm-cov report --lcov --output-path lcov.info`. 
- Upload `lcov.info` to Codecov with a new `Upload coverage reports to Codecov` step using `codecov/codecov-action@v5` (pinned to the v5 tag commit SHA) and guard the step with `if: ${{ always() && hashFiles('lcov.info') != '' }}`. 
- Include `lcov.info` in the `actions/upload-artifact` coverage artifact set so CI artifacts contain the LCOV output. 
- Add a conservative root-level `codecov.yml` that sets informational project/patch status thresholds and disables GitHub annotations, scoped to the `rust-cpu` flag. 

### Testing
- Validated the Codecov action tag source with `git ls-remote https://github.com/codecov/codecov-action refs/tags/v5`, which succeeded. 
- Verified YAML syntax for both ` .github/workflows/coverage.yml` and `codecov.yml` using `python` + `yaml.safe_load`, which parsed successfully. 
- Confirmed the modified files are present and ready for PR: ` .github/workflows/coverage.yml` and `codecov.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9da92571c8333b90296a04350bb3c)