### PR TITLE
docs(tracking): mark queue dedupe merged

### DIFF
--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -10,7 +10,6 @@ P0 truth boundary, then crate consolidation inventory.
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| QUEUE-001 | #3623 | pr_open | Deduplicate generated PR clusters without code changes |
 | TRUTH-002 | TBD | ready | Make GGUF fallback explicit |
 | TRUTH-003 | TBD | ready | Null-byte model path validation |
 | INV-001 | TBD | ready | Crate consolidation map |
@@ -29,6 +28,7 @@ P0 truth boundary, then crate consolidation inventory.
 | Item | PR | Merge SHA | Notes |
 |---|---:|---|---|
 | TRUTH-001 | #3621 | 10ea2b409a1d4095205722da77a600d31bb57d04 | Fence server simulated inference merged. |
+| QUEUE-001 | #3623 | 678a3ba1592ab10e9a7b473db077ec93b1d867fb | Codecov duplicate cluster normalized; #3620 retained as deferred canonical candidate. |
 
 ## Blocked
 

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -206,7 +206,7 @@ items:
 
   - id: QUEUE-001
     title: Deduplicate generated PR clusters
-    state: pr_open
+    state: merged
     priority: P0
     workstream: truth
     depends_on: []


### PR DESCRIPTION
## Work item

- `QUEUE-001`

## Summary

- Move QUEUE-001 from `pr_open` to `merged` after #3623 merged.
- Record #3623 merge SHA `678a3ba1592ab10e9a7b473db077ec93b1d867fb` in the status dashboard.

## Scope

Allowed paths:
- `docs/tracking/bitnet-alignment/status.md`
- `docs/tracking/bitnet-alignment/workstream-ledger.yaml`

Forbidden paths respected:
- yes

## Verification

Passed:
- `python` YAML parse for `docs/tracking/bitnet-alignment/workstream-ledger.yaml`
- `git diff --check`

Failed:
- none

Blocked locally:
- `cargo fmt --all -- --check` failed before formatting with Windows `os error 206`

Not run:
- runtime tests, docs-only tracker sync