### PR TITLE
[codex] Add M4 machine profile and probe bundle

### DIFF
--- a/ci/hardware/README.md
+++ b/ci/hardware/README.md
@@ -41,6 +41,8 @@ ci/hardware/intel-258v/2026-05-05/arc-140v-opencl-smoke.json
 ci/hardware/intel-258v/2026-05-05/npu-openvino-smoke.json
 
 ci/hardware/apple-m4-mac-mini/2026-05-05/metal-probe.json
+ci/hardware/apple-m4-mac-mini/2026-05-05/cpu-neon-probe.json
+ci/hardware/apple-m4-mac-mini/2026-05-05/mpsgraph-probe.json
 ci/hardware/apple-m4-mac-mini/2026-05-05/metal-smoke.json
 ci/hardware/apple-m4-mac-mini/2026-05-05/mpsgraph-smoke.json
 
@@ -87,6 +89,8 @@ opencl-probe.json
 openvino-gpu-smoke.json
 npu-openvino-smoke.json
 metal-probe.json
+cpu-neon-probe.json
+mpsgraph-probe.json
 metal-smoke.json
 mpsgraph-smoke.json
 cuda-probe.json

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-This file defines the hardware data bundle for the Apple M4 Mac mini validation lane. It is a Metal-first profile with MPSGraph as a reference lane and CPU/NEON as fallback/parity.
+This file defines the machine profile and probe bundle for the Apple M4 Mac mini validation lane. It is a Metal-first profile with MPSGraph as a graph/reference lane and CPU/NEON as fallback/parity.
+
+M4-002 is docs and artifact prep only. It records stable machine facts and planned probe artifact paths before any Metal kernels, MPSGraph graph execution, CPU/Metal parity, receipts, or benchmarks.
 
 Roadmap:
 
@@ -12,27 +14,39 @@ docs/specs/apple-m4-mac-mini-roadmap.md
 
 ## Hardware Baseline
 
-Base M4 Mac mini:
+Known public configuration classes:
 
-- Chip: Apple M4.
-- CPU: 10-core CPU.
-- GPU: 10-core GPU.
-- Neural Engine: 16-core Neural Engine.
-- Unified memory: 16GB configurable to 24GB or 32GB.
-- Memory bandwidth: 120 GB/s.
-- GPU features: Dynamic Caching, hardware ray tracing, mesh shading.
+| Machine class | Chip | CPU | GPU | Unified memory | Memory bandwidth class |
+|---|---|---:|---:|---|---:|
+| Base M4 Mac mini | Apple M4 | 10-core CPU | 10-core GPU | 16GB, configurable to 24GB or 32GB | 120 GB/s |
+| M4 Pro Mac mini | Apple M4 Pro | 12-core or configurable 14-core CPU | 16-core or configurable 20-core GPU | up to 64GB | 273 GB/s |
 
-M4 Pro Mac mini:
+The probe bundle must record the actual machine configuration. Do not infer base M4 values for an M4 Pro machine, and do not infer GPU core count or memory size from the lane name.
 
-- CPU: 12-core or configurable 14-core CPU.
-- GPU: 16-core or configurable 20-core GPU.
-- Neural Engine: 16-core Neural Engine.
-- Unified memory: up to 64GB.
-- Memory bandwidth: 273 GB/s.
+Required recorded facts:
 
-Record the actual machine configuration in every receipt.
+- macOS version and kernel/build.
+- Native macOS vs virtualized execution.
+- Chip name: Apple M4 or Apple M4 Pro.
+- CPU core count.
+- GPU core count when visible from system tools or confirmed machine spec.
+- Unified memory size.
+- Memory bandwidth class when known from confirmed Apple machine docs/specs.
+- Metal device visibility.
+- MPSGraph lane availability notes.
+- CPU/NEON visibility.
+- Rust toolchain versions.
 
 ## Claim Boundary
+
+| Lane | Meaning | Must not claim |
+|---|---|---|
+| `apple-m4-cpu-neon` | ARM64 CPU/NEON fallback and parity | Metal acceleration |
+| `apple-m4-metal` | Native Metal compute path | MPSGraph or Neural Engine proof |
+| `apple-m4-mpsgraph` | Graph/reference lane | Native Metal packed-kernel proof |
+| Neural Engine | Only if resolved and receipt-backed | Never infer from MPSGraph alone |
+
+Additional boundaries:
 
 - Metal visibility is not Metal execution.
 - Metal smoke is not CPU/Metal parity.
@@ -40,6 +54,7 @@ Record the actual machine configuration in every receipt.
 - MPSGraph smoke cannot count as native handwritten Metal kernel proof.
 - MPSGraph smoke cannot count as Neural Engine execution unless the resolved target is receipt-backed.
 - Apple CPU/NEON is not AVX2 or AVX-512.
+- Hardware probe artifacts are not BitNet proof artifacts.
 
 ## macOS Probe Bundle
 
@@ -60,50 +75,117 @@ system_profiler SPMetalDataType || true
 echo "=== Memory ==="
 vm_stat
 sysctl hw.memsize
+
+echo "=== CPU / NEON ==="
 sysctl machdep.cpu.brand_string || true
+sysctl hw.physicalcpu hw.logicalcpu || true
+sysctl hw.perflevel0.physicalcpu hw.perflevel1.physicalcpu || true
 sysctl hw.optional.neon || true
 
-echo "=== Rust / toolchain ==="
+echo "=== Virtualization ==="
+sysctl kern.hv_vmm_present || true
+
+echo "=== Rust toolchain ==="
 rustc --version
 cargo --version
 ```
 
-## First Metal Receipt
+Record command output into the machine profile bundle without committing bulky machine-specific output in docs-only PRs.
 
-The first useful receipt is a Metal smoke proof:
+## Expected Artifact Paths
+
+Use the shared hardware artifact convention:
+
+```text
+ci/hardware/apple-m4-mac-mini/<date>/metal-probe.json
+ci/hardware/apple-m4-mac-mini/<date>/cpu-neon-probe.json
+ci/hardware/apple-m4-mac-mini/<date>/mpsgraph-probe.json
+```
+
+Use ISO dates such as `2026-05-05`. These are planned probe artifact paths only; do not add large artifacts for M4-002.
+
+## Probe Receipt Shape
+
+Metal probe artifacts record visibility only:
 
 ```json
 {
-  "hardware": "apple-m4-mac-mini",
-  "requested_backend": "apple-m4",
+  "requested_backend": "apple-m4-metal",
   "selected_backend": "apple-m4-metal",
   "runtime_api": "metal",
-  "chip": "Apple M4",
-  "gpu_cores": 10,
-  "unified_memory": true,
-  "memory_bandwidth_gbps": 120,
+  "resolved_device": {
+    "chip": "Apple M4",
+    "cpu_cores": 10,
+    "gpu_cores": 10,
+    "unified_memory": true,
+    "unified_memory_bytes": 17179869184,
+    "memory_bandwidth_gbps": 120,
+    "native_or_virtualized": "native-macos",
+    "metal_visible": true
+  },
   "fallback_used": false,
-  "status": "kernel_smoke_tested"
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/metal-probe.json"
 }
 ```
 
-For M4 Pro, this must record the actual core and memory configuration.
-
-## Optional MPSGraph Receipt
+CPU/NEON probe artifacts remain separate from Metal:
 
 ```json
 {
-  "hardware": "apple-m4-mac-mini",
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "resolved_device": {
+    "chip": "Apple M4",
+    "cpu_cores": 10,
+    "neon_visible": true,
+    "unified_memory": true,
+    "native_or_virtualized": "native-macos"
+  },
+  "fallback_used": false,
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/cpu-neon-probe.json"
+}
+```
+
+MPSGraph probe artifacts remain graph/reference lane evidence only:
+
+```json
+{
   "requested_backend": "apple-m4-mpsgraph",
   "selected_backend": "apple-m4-mpsgraph",
   "runtime_api": "mpsgraph",
-  "resolved_target": "unknown",
+  "resolved_device": {
+    "chip": "Apple M4",
+    "mpsgraph_visible": true,
+    "resolved_target": "unknown"
+  },
   "fallback_used": false,
-  "status": "kernel_smoke_tested"
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/mpsgraph-probe.json"
 }
 ```
 
-This is graph/reference proof only, not native Metal kernel proof.
+The concrete values above are example base-M4 values. Generated artifacts must replace them with recorded machine facts, including M4 Pro values when applicable.
+
+When a later artifact claims BitNet progress, it must also include the BitNet contract fields:
+
+```json
+{
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "tokenizer": "llama3"
+  },
+  "bitnet": {
+    "kernel_family": "i2_s|tl1|qk256|openvino_graph",
+    "execution_phase": "probe|smoke|parity|prefill|decode"
+  }
+}
+```
+
+M4-002 probe artifacts do not claim BitNet inference, Metal kernel execution, MPSGraph graph execution, or Neural Engine execution.
 
 ## Benchmark Notes
 

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -12,7 +12,7 @@ apple-m4-mpsgraph
 apple-m4-cpu-neon
 ```
 
-The first useful milestone is tiny Metal compute smoke with a receipt proving `selected_backend=apple-m4-metal` and `fallback_used=false`.
+The first work after the lane scaffold is M4-002 machine profiling. It records stable machine facts and planned probe artifact paths before any Metal kernels, MPSGraph graph execution, CPU/Metal parity, receipts, or benchmarks.
 
 ## Hardware Baseline
 
@@ -38,7 +38,7 @@ M4 Pro variants:
 | Memory | Up to 64GB unified memory |
 | Memory bandwidth | 273 GB/s |
 
-Receipts must record the actual chip, CPU/GPU core counts, unified memory size, and memory bandwidth. Do not assume base M4 when validating M4 Pro.
+Receipts and probe artifacts must record the actual chip, CPU/GPU core counts, unified memory size, and memory bandwidth class when known from confirmed docs/specs. Do not assume base M4 when validating M4 Pro.
 
 ## Claim Boundary
 
@@ -51,6 +51,32 @@ Receipts must record the actual chip, CPU/GPU core counts, unified memory size, 
 - Apple CPU/NEON fallback is not AVX2 or AVX-512.
 
 ## Runtime Paths
+
+### Machine Profile Path
+
+M4-002 owns docs/artifact prep only. It must collect and document:
+
+- macOS version and kernel/build.
+- Native macOS vs virtualized execution.
+- Apple chip name: M4 or M4 Pro.
+- CPU core count.
+- GPU core count when visible from system tools or confirmed machine spec.
+- Unified memory size.
+- Memory bandwidth class when known.
+- Metal visibility.
+- MPSGraph lane notes.
+- CPU/NEON lane notes.
+- Rust toolchain versions.
+
+Expected probe artifact paths:
+
+```text
+ci/hardware/apple-m4-mac-mini/<date>/metal-probe.json
+ci/hardware/apple-m4-mac-mini/<date>/cpu-neon-probe.json
+ci/hardware/apple-m4-mac-mini/<date>/mpsgraph-probe.json
+```
+
+These paths are probe placeholders until a machine run produces receipts. Do not commit large machine-specific outputs as part of M4-002.
 
 ### Native Metal Path
 
@@ -93,15 +119,17 @@ Minimum Metal receipt:
 
 ```json
 {
-  "requested_backend": "apple-m4",
+  "requested_backend": "apple-m4-metal",
   "selected_backend": "apple-m4-metal",
   "runtime_api": "metal",
-  "chip": "Apple M4",
-  "gpu_cores": 10,
-  "unified_memory": true,
-  "memory_bandwidth_gbps": 120,
-  "fallback_backend": null,
-  "fallback_used": false
+  "resolved_device": {
+    "chip": "Apple M4",
+    "gpu_cores": 10,
+    "unified_memory": true
+  },
+  "fallback_used": false,
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/metal-probe.json"
 }
 ```
 
@@ -112,11 +140,50 @@ Minimum MPSGraph receipt:
   "requested_backend": "apple-m4-mpsgraph",
   "selected_backend": "apple-m4-mpsgraph",
   "runtime_api": "mpsgraph",
-  "resolved_target": "gpu|cpu|neural-engine|unknown",
+  "resolved_device": {
+    "chip": "Apple M4",
+    "resolved_target": "gpu|cpu|neural-engine|unknown"
+  },
   "fallback_used": false,
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/mpsgraph-probe.json",
   "graph": {
     "name": "tiny_matmul",
     "shape_mode": "static"
+  }
+}
+```
+
+Minimum CPU/NEON receipt:
+
+```json
+{
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "resolved_device": {
+    "chip": "Apple M4",
+    "cpu_cores": 10,
+    "unified_memory": true
+  },
+  "fallback_used": false,
+  "proof_stage": "runtime_detected",
+  "artifact_path": "ci/hardware/apple-m4-mac-mini/2026-05-05/cpu-neon-probe.json"
+}
+```
+
+BitNet-specific artifacts must add:
+
+```json
+{
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "tokenizer": "llama3"
+  },
+  "bitnet": {
+    "kernel_family": "i2_s|tl1|qk256|openvino_graph",
+    "execution_phase": "probe|smoke|parity|prefill|decode"
   }
 }
 ```
@@ -138,6 +205,7 @@ It must collect:
 - Unified memory size and bandwidth target.
 - Metal device visibility.
 - MPSGraph availability notes.
+- CPU/NEON availability notes.
 - Rust toolchain.
 
 ## Work Plan
@@ -148,7 +216,7 @@ Docs/tracking only. Add M4 Metal, MPSGraph, and CPU/NEON lanes.
 
 ### M4-002 - Machine Profile
 
-Collect macOS, Apple chip, GPU cores, unified memory, Metal visibility, and Rust toolchain data.
+Collect macOS, native-vs-virtualized status, Apple chip, CPU/GPU cores, unified memory, memory bandwidth class when known, Metal visibility, MPSGraph lane notes, CPU/NEON lane notes, Rust toolchain data, and expected probe artifact paths.
 
 ### M4-003 - Backend Identity
 

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -4,21 +4,29 @@ Updated: 2026-05-05
 
 ## Current Focus
 
-P0 truth boundary, crate consolidation inventory, and first implementation prep after the hardware and BitNet validation contracts merged.
+Apple Silicon M4-002 machine profile and probe bundle, after the #3625 hardware and BitNet contract merge. Earlier truth, crate inventory, and strict CPU proof documentation items are merged.
 
-## Active PR queue
+## Active / Coordination Queue
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| BITNET-002 | #3628 | pr_open | Add canonical BitNet fixture manifest and receipt templates |
+| HW-001 | #3625 | merged | Shared hardware validation matrix and proof-stage contract; docs/contracts only, no runtime execution |
+| BITNET-001 | #3625 | merged | BitNet model, kernel, and receipt proof contract; docs/contracts only |
+| NPU-001 | #3625 | merged | Intel NPU backend lane scaffold; no runtime execution |
+| A770-001 | #3625 | merged | Intel Arc A770 OpenCL-first lane scaffold; no runtime execution |
+| LNL258V-001 | #3625 | merged | Core Ultra 7 258V platform scaffold; no runtime execution |
+| KBL8250U-001 | #3625 | merged | i5-8250U AVX2 CPU lane scaffold; no runtime execution |
+| M4-001 | #3625 | merged | Apple M4 Mac mini lane scaffold; no runtime execution |
+| RTX5070TI-001 | #3625 | merged | RTX 5070 Ti CUDA lane scaffold; no runtime execution |
+| AMD9950X3D-001 | #3625 | merged | AMD 9950X3D CPU lane scaffold; no runtime execution |
+| AMD5700X-001 | #3625 | merged | AMD 5700X CPU lane scaffold; no runtime execution |
 | CPU-002 | TBD | ready | Validate CPU inference receipt for CLI proof |
-| NPU-002 | TBD | ready | Preserve Intel NPU backend identity before runtime probing |
-| A770-003 | TBD | ready | Preserve Intel Arc A770 selected-device identity |
-| KBL8250U-003 | TBD | ready | Prove i5-8250U scalar and AVX2 dispatch |
-| M4-003 | TBD | ready | Preserve Apple Metal backend identity |
-| RTX5070TI-003 | TBD | ready | Preserve RTX 5070 Ti CUDA selected-device identity |
-| AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
-| AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |
+| M4-002 | #3627 | pr_open | Add Apple M4 Mac mini machine profile and probe bundle without runtime work |
+
+These rows are coordination markers, not implementation proof. Merged scaffold
+rows stay visible so the A770, NPU, 258V, 8250U, AMD, NVIDIA, and Mac lanes can
+coordinate follow-up work without implying that runtime execution has been built
+or tested.
 
 ## Hardware Lanes
 
@@ -93,9 +101,15 @@ The 5700X and 9950X3D lanes are CPU proof lanes, not accelerator lanes. The 5700
 
 The M4 Mac mini lane is Metal-first, with MPSGraph as a graph/reference lane and CPU/NEON as fallback/parity. CPU fallback cannot count as Metal execution, MPSGraph smoke cannot count as native Metal kernel proof, and Neural Engine execution must not be claimed unless the resolved target is receipt-backed.
 
+The Apple Silicon implementation order is M4-002 machine profile, M4-003 backend identity, M4-004 Metal probe, M4-005 Metal compute smoke, M4-006 CPU/Metal parity, M4-007 MPSGraph smoke, M4-008 receipt identity fields, and M4-009 benchmark baseline. The current M4-002 work is docs/artifact prep only and must not touch runtime code, kernels, QK256, server inference, or dependencies.
+
 ## NVIDIA CUDA Boundary
 
 The RTX 5070 Ti lane is CUDA-first, with wgpu/Vulkan/D3D12 as a cross-platform reference lane. CUDA visibility is not kernel execution, WGPU smoke is not CUDA proof, CPU fallback cannot count as CUDA execution, and performance claims require driver, CUDA version, compute capability, VRAM, power, and thermal context.
+
+## Tracker Notes
+
+HW-002 remains proposed. #3625 added `ci/hardware/README.md` with artifact naming guidance, but maintainers should confirm whether that fully satisfies HW-002 before marking it merged.
 
 ## Queue hygiene
 
@@ -117,25 +131,15 @@ The RTX 5070 Ti lane is CUDA-first, with wgpu/Vulkan/D3D12 as a cross-platform r
 | INV-001 | #3632 | 457b36630906f2044e406e0dcf27ecb539e8a7a5 | Crate consolidation inventory completed for all workspace members. |
 | CPU-001 | #3635 | d90f70f4410155077ffc9741e018e5d747d40a9f | Strict CPU proof command documented. |
 | HW-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Shared hardware validation matrix and proof-stage contract merged. |
-| HW-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Hardware artifact naming policy merged. |
-| BITNET-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | BitNet model/kernel/receipt proof contract merged. |
-| BITNET-003 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Initial BitNet parity tolerance policy merged. |
-| NPU-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel NPU backend lane merged. |
-| A770-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel Arc A770 backend lane merged. |
-| A770-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel Arc A770 machine profile merged. |
-| ARC140V-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel Arc 140V integrated GPU lane merged. |
-| LNL258V-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core Ultra 7 258V platform profile merged. |
-| CPU258V-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core Ultra 7 258V CPU AVX2 validation lane merged. |
-| KBL8250U-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core i5-8250U CPU validation lane merged. |
-| KBL8250U-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core i5-8250U machine profile and probe bundle merged. |
-| M4-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Apple M4 Mac mini backend lane merged. |
-| M4-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Apple M4 machine profile and probe bundle merged. |
-| RTX5070TI-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | NVIDIA RTX 5070 Ti CUDA backend lane merged. |
-| RTX5070TI-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | NVIDIA RTX 5070 Ti machine profile and probe bundle merged. |
-| AMD9950X3D-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 9 9950X3D CPU validation lane merged. |
-| AMD9950X3D-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 9 9950X3D machine profile and probe bundle merged. |
-| AMD5700X-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 7 5700X CPU validation lane merged. |
-| AMD5700X-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 7 5700X machine profile and probe bundle merged. |
+| BITNET-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | BitNet model, kernel, and receipt proof contract merged. |
+| NPU-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel NPU backend lane scaffold merged without runtime execution. |
+| A770-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel Arc A770 backend lane scaffold merged without runtime execution. |
+| LNL258V-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core Ultra 7 258V platform profile merged without runtime execution. |
+| KBL8250U-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Intel Core i5-8250U CPU validation lane merged without runtime execution. |
+| M4-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Apple M4 Mac mini Metal, MPSGraph, and CPU/NEON lane scaffold merged without runtime execution. |
+| RTX5070TI-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | NVIDIA RTX 5070 Ti CUDA backend lane scaffold merged without runtime execution. |
+| AMD9950X3D-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 9 9950X3D CPU validation lane merged without runtime execution. |
+| AMD5700X-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 7 5700X CPU validation lane merged without runtime execution. |
 
 ## Blocked
 

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -293,7 +293,7 @@ items:
 
   - id: HW-002
     title: Add hardware artifact naming policy
-    state: merged
+    state: proposed
     priority: P1
     workstream: inventory
     depends_on:
@@ -313,6 +313,9 @@ items:
       - No binary or large artifacts are added.
     verification:
       - cargo fmt --all -- --check
+    notes:
+      - "#3625 added ci/hardware/README.md with hardware artifact naming guidance, but this item remains proposed until maintainers confirm HW-002 should be marked merged."
+    followups: []
 
   - id: BITNET-001
     title: Add BitNet model and kernel proof contract
@@ -1418,7 +1421,7 @@ items:
 
   - id: M4-002
     title: Add M4 machine profile and probe bundle
-    state: merged
+    state: pr_open
     priority: P1
     workstream: apple_silicon
     depends_on:
@@ -1427,6 +1430,7 @@ items:
       allowed_paths:
         - docs/hardware/apple-m4-mac-mini-validation.md
         - docs/specs/apple-m4-mac-mini-roadmap.md
+        - ci/hardware/README.md
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
@@ -1435,17 +1439,31 @@ items:
     acceptance:
       - Probe bundle captures macOS version, Apple chip, CPU/GPU core counts, unified memory, Metal visibility, and Rust toolchain.
       - M4 and M4 Pro configurations are recorded rather than assumed.
+      - Metal, MPSGraph, and CPU/NEON probe artifact paths are documented as separate proof labels.
+      - Probe artifacts do not claim Metal execution, MPSGraph execution, Neural Engine execution, or BitNet inference.
       - No runtime code is touched.
     verification:
       - cargo fmt --all -- --check
+      - Parse YAML tracker files.
+      - git diff --check
+    notes:
+      - Docs/artifact-prep only; do not touch kernels, QK256, server inference, or dependency manifests.
+    followups:
+      - M4-003
+      - M4-004
+      - M4-005
+      - M4-006
+      - M4-007
+      - M4-008
+      - M4-009
 
   - id: M4-003
-    title: Preserve Apple Metal backend identity
-    state: ready
+    title: Preserve Apple backend identity
+    state: proposed
     priority: P1
     workstream: apple_silicon
     depends_on:
-      - M4-001
+      - M4-002
     scope:
       allowed_paths:
         - crates/bitnet-common/src/types.rs
@@ -1548,7 +1566,7 @@ items:
     priority: P1
     workstream: apple_silicon
     depends_on:
-      - M4-004
+      - M4-006
     scope:
       allowed_paths:
         - crates/bitnet-device-probe/**
@@ -1575,7 +1593,7 @@ items:
     priority: P1
     workstream: apple_silicon
     depends_on:
-      - M4-005
+      - M4-007
     scope:
       allowed_paths:
         - crates/bitnet-receipts/**


### PR DESCRIPTION
## Summary

- Sync #3625 docs/tracking scaffold items from `pr_open` to merged with merge SHA `bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3`.
- Start `M4-002` as docs/artifact prep only, documenting the Apple M4 Mac mini machine profile fields, probe commands, and separate Metal, CPU/NEON, and MPSGraph probe artifact paths.
- Preserve the strict lane boundaries: probe artifacts do not claim Metal execution, MPSGraph execution, Neural Engine execution, or BitNet inference.

## Scope

No runtime code, kernels, QK256, server inference, dependencies, or machine-specific bulky artifacts are touched.

## Validation

- `cargo fmt --all -- --check`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "parsed #{p}" }' docs/tracking/bitnet-alignment/workstream-ledger.yaml docs/tracking/bitnet-alignment/backend-status.yaml docs/hardware/machine-profile.schema.yaml`
- `git diff --check`