### PR TITLE
fix(models): make GGUF minimal fallback explicit (TRUTH-002)

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1063,6 +1063,7 @@ async fn run_simple_generation(
     let loader = ModelLoader::new(Device::Cpu);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
+    let mut loader_mode = "enhanced";
 
     let (model, config): (Arc<dyn Model>, _) = match loader
         .load_with_config(&model_path, &load_config)
@@ -1080,6 +1081,14 @@ async fn run_simple_generation(
                 );
             }
             tracing::warn!("Real loader failed: {e}. Falling back to MOCK loader (by request).");
+            if !strict_loader {
+                unsafe {
+                    std::env::set_var("BITNET_ALLOW_MINIMAL_LOADER", "1");
+                }
+                warn!(
+                    "BITNET_ALLOW_MINIMAL_LOADER=1 enabled by --allow-mock for compatibility fallback"
+                );
+            }
             // Mock fallback
             let load_result = bitnet_models::gguf_simple::load_gguf_full(
                 &model_path,
@@ -1087,6 +1096,8 @@ async fn run_simple_generation(
                 bitnet_models::GGUFLoaderConfig::default(),
             )
             .context("Mock loader also failed")?;
+            loader_mode = "compatibility_fallback";
+            warn!("GGUF loader mode: {}", loader_mode);
             let mut raw_tensors = std::collections::HashMap::new();
             for (name, qk256) in load_result.i2s_qk256 {
                 let expected_bytes = qk256.rows * qk256.row_stride_bytes;
@@ -1599,6 +1610,12 @@ async fn run_simple_generation(
             "greedy": greedy,
             "deterministic": deterministic,
         });
+        let loader_info = serde_json::json!({
+            "mode": loader_mode,
+            "minimal_fallback_allowed": std::env::var("BITNET_ALLOW_MINIMAL_LOADER").as_deref() == Ok("1"),
+            "minimal_fallback_disabled": std::env::var("BITNET_DISABLE_MINIMAL_LOADER").as_deref() == Ok("1")
+                || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1"),
+        });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
         let output = serde_json::json!({
@@ -1621,6 +1638,7 @@ async fn run_simple_generation(
             },
             "counts": counts,
             "tokenizer": tokenizer_info,
+            "loader": loader_info,
             "gen_policy": gen_policy,
             "logits_dump": if !logits_dump.is_empty() {
                 Some(logits_dump.iter().map(|step| {

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -54,6 +54,20 @@ pub struct GgufLoadResult {
     pub i2s_qk256: HashMap<String, I2SQk256NoScale>,
 }
 
+fn minimal_loader_disabled() -> bool {
+    std::env::var("BITNET_DISABLE_MINIMAL_LOADER").as_deref() == Ok("1")
+        || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1")
+}
+
+fn minimal_loader_allowed() -> bool {
+    std::env::var("BITNET_ALLOW_MINIMAL_LOADER").as_deref() == Ok("1")
+}
+
+fn minimal_loader_hint() -> &'static str {
+    "Set BITNET_ALLOW_MINIMAL_LOADER=1 to opt into the reduced-feature minimal loader. \
+     Set BITNET_DISABLE_MINIMAL_LOADER=1 or BITNET_STRICT_MODE=1 to fail fast for proof/CI paths."
+}
+
 /// Load a GGUF model file - backward compatibility shim (returns tuple)
 ///
 /// This function provides backward compatibility with existing tests that expect
@@ -124,31 +138,23 @@ pub fn load_gguf_full(
                 }
             }
 
-            // For other errors, fall back to minimal parser
+            // For other errors, fall back to minimal parser only when explicitly requested.
             match result {
                 Ok(x) => Ok(x),
                 Err(e) => {
-                    let hint = "Set BITNET_DISABLE_MINIMAL_LOADER=1 to fail-fast with the enhanced loader \
-                                (preferred for CI/parity). Unset to allow minimal loader fallback (reduced features).";
+                    let hint = minimal_loader_hint();
 
-                    let fail_fast =
-                        std::env::var("BITNET_DISABLE_MINIMAL_LOADER").as_deref() == Ok("1");
-
-                    if fail_fast {
+                    if minimal_loader_disabled() || !minimal_loader_allowed() {
                         tracing::error!("Enhanced loader failed: {}. {}", e, hint);
-                        tracing::error!(
-                            "BITNET_DISABLE_MINIMAL_LOADER=1: stopping here (no minimal fallback)."
-                        );
-                        return Err(BitNetError::Validation(format!(
-                            "{}\nHint: unset BITNET_DISABLE_MINIMAL_LOADER to try the minimal loader (reduced features).",
-                            e
-                        )));
-                    } else {
-                        tracing::warn!("Enhanced loader failed: {}. {}", e, hint);
-                        tracing::warn!(
-                            "Falling back to minimal parser (may use 32/0 default dims)"
-                        );
+                        tracing::error!("Stopping here without minimal compatibility fallback.");
+                        return Err(BitNetError::Validation(format!("{}\nHint: {}", e, hint)));
                     }
+
+                    tracing::warn!("Enhanced loader failed: {}. {}", e, hint);
+                    tracing::warn!(
+                        "BITNET_ALLOW_MINIMAL_LOADER=1: using minimal parser \
+                        (reduced features; may use default/mock transformer tensors)"
+                    );
 
                     // AC9: Fallback to minimal GGUF parser for backward compatibility
                     // This happens when:
@@ -164,9 +170,17 @@ pub fn load_gguf_full(
             }
         }
         Err(e) => {
-            // GgufReader construction failed - fall back to minimal
-            tracing::info!(
-                "GGUF reader construction failed ({}), falling back to minimal parser",
+            // GgufReader construction failed - fall back to minimal only when explicitly requested.
+            if minimal_loader_disabled() || !minimal_loader_allowed() {
+                return Err(BitNetError::Validation(format!(
+                    "GGUF reader construction failed: {}\nHint: {}",
+                    e,
+                    minimal_loader_hint()
+                )));
+            }
+            tracing::warn!(
+                "GGUF reader construction failed ({}); BITNET_ALLOW_MINIMAL_LOADER=1: \
+                using minimal compatibility parser",
                 e
             );
             load_gguf_minimal(path, device)
@@ -1797,4 +1811,60 @@ fn create_mock_tensor_layout(device: Device) -> Result<GgufLoadResult> {
         tensor_map.len()
     );
     Ok(GgufLoadResult { config, tensors: tensor_map, i2s_qk256: HashMap::new() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GGUFLoaderConfig, load_gguf_full};
+    use bitnet_common::Device;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    #[test]
+    #[serial]
+    fn mock_compatibility_loader_requires_explicit_opt_in() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("mock.gguf");
+        std::fs::write(&path, b"mock_gguf_content").expect("write mock fixture");
+
+        temp_env::with_var_unset("BITNET_ALLOW_MINIMAL_LOADER", || {
+            temp_env::with_var_unset("BITNET_DISABLE_MINIMAL_LOADER", || {
+                temp_env::with_var_unset("BITNET_STRICT_MODE", || {
+                    let result = load_gguf_full(&path, Device::Cpu, GGUFLoaderConfig::default());
+                    assert!(result.is_err(), "minimal/mock fallback must be opt-in");
+                    let err = result.err().expect("error").to_string();
+                    assert!(
+                        err.contains("BITNET_ALLOW_MINIMAL_LOADER=1"),
+                        "error should explain explicit opt-in: {err}"
+                    );
+                });
+            });
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn minimal_loader_opt_in_env_is_explicit() {
+        temp_env::with_var_unset("BITNET_ALLOW_MINIMAL_LOADER", || {
+            assert!(!super::minimal_loader_allowed());
+        });
+        temp_env::with_var("BITNET_ALLOW_MINIMAL_LOADER", Some("1"), || {
+            assert!(super::minimal_loader_allowed());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn strict_mode_blocks_minimal_loader_even_when_allowed() {
+        let dir = TempDir::new().expect("tempdir");
+        let path = dir.path().join("mock.gguf");
+        std::fs::write(&path, b"mock_gguf_content").expect("write mock fixture");
+
+        temp_env::with_var("BITNET_ALLOW_MINIMAL_LOADER", Some("1"), || {
+            temp_env::with_var("BITNET_STRICT_MODE", Some("1"), || {
+                let result = load_gguf_full(&path, Device::Cpu, GGUFLoaderConfig::default());
+                assert!(result.is_err(), "strict mode must fail before compatibility fallback");
+            });
+        });
+    }
 }

--- a/docs/reference/quantization-support.md
+++ b/docs/reference/quantization-support.md
@@ -17,6 +17,16 @@ BitNet-rs supports multiple quantization formats with advanced device-aware acce
 - **Real Computation**: Native quantized GEMV kernel eliminates FP32 dequantization staging (Issue #261 - AC3)
 - **QuantizedLinear Integration**: Replaces standard Linear layers in transformer architecture (Issue #261 - AC5)
 
+## GGUF Loader Fallback Boundary
+
+User-facing runtime and proof paths must not silently use the reduced-feature GGUF minimal loader. The enhanced GGUF loader is the default expectation for real inference claims.
+
+- `BITNET_STRICT_MODE=1` or `BITNET_DISABLE_MINIMAL_LOADER=1` fails fast when the enhanced loader cannot parse or validate the model.
+- `BITNET_ALLOW_MINIMAL_LOADER=1` is the explicit compatibility opt-in for the minimal loader. It may initialize missing transformer tensors with compatibility defaults and cannot support correctness or performance claims.
+- `bitnet run --strict-loader` sets strict loader mode for CLI proof paths.
+- `bitnet run --allow-mock` is a smoke/UX-test escape hatch and enables compatibility fallback only by request.
+- JSON output from `bitnet run --json-out` records the loader mode so receipts or adjacent proof artifacts can distinguish `enhanced` from explicitly requested `compatibility_fallback`.
+
 ### TL1 - Table Lookup Quantization (ARM Optimized - Issue #261)
 
 - Table lookup quantization optimized for ARM NEON architecture (4-bit, 2 elements per byte with nibble packing)

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -10,7 +10,7 @@ P0 truth boundary, crate consolidation inventory, and docs-only hardware-lane sc
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| TRUTH-002 | TBD | ready | Make GGUF fallback explicit |
+| TRUTH-002 | TBD | in_progress | Make GGUF fallback explicit |
 | INV-001 | TBD | ready | Crate consolidation map |
 | HW-001 | TBD | pr_open | Add shared hardware validation matrix and proof-stage contract |
 | BITNET-001 | TBD | pr_open | Add BitNet model/kernel/receipt proof contract |

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -10,7 +10,7 @@ P0 truth boundary, crate consolidation inventory, and docs-only hardware-lane sc
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| TRUTH-002 | TBD | in_progress | Make GGUF fallback explicit |
+| TRUTH-002 | #3630 | pr_open | Make GGUF fallback explicit |
 | INV-001 | TBD | ready | Crate consolidation map |
 | HW-001 | TBD | pr_open | Add shared hardware validation matrix and proof-stage contract |
 | BITNET-001 | TBD | pr_open | Add BitNet model/kernel/receipt proof contract |

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -147,7 +147,7 @@ items:
 
   - id: TRUTH-002
     title: Make GGUF minimal fallback explicit
-    state: ready
+    state: in_progress
     priority: P0
     workstream: truth
     depends_on:

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -147,7 +147,7 @@ items:
 
   - id: TRUTH-002
     title: Make GGUF minimal fallback explicit
-    state: in_progress
+    state: pr_open
     priority: P0
     workstream: truth
     depends_on:


### PR DESCRIPTION
## Work item

- `TRUTH-002`

## Summary

- Require explicit `BITNET_ALLOW_MINIMAL_LOADER=1` before the reduced-feature GGUF minimal/mock compatibility fallback can run.
- Keep strict/proof paths fail-fast with `BITNET_STRICT_MODE=1` or `BITNET_DISABLE_MINIMAL_LOADER=1`.
- Record loader mode in `bitnet run --json-out` as `enhanced` or `compatibility_fallback`, and document the fallback boundary.

## Scope

Allowed paths:
- `crates/bitnet-models/src/gguf_simple.rs`
- `crates/bitnet-cli/src/main.rs`
- `docs/reference/quantization-support.md`
- `docs/tracking/bitnet-alignment/status.md`
- `docs/tracking/bitnet-alignment/workstream-ledger.yaml` via tracker exception

Forbidden paths respected:
- yes

## Acceptance

- [x] CLI/server/bench paths do not silently use minimal loader fallback.
- [x] Explicit opt-in exists for compatibility/test fallback.
- [x] JSON output records loader mode.

## Verification

Passed:
- `cargo check --locked -p bitnet-models --no-default-features --features cpu --lib`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet`
- `cargo test --locked -p bitnet-models --no-default-features --features cpu --lib loader -- --nocapture`
- YAML parse check for `docs/tracking/bitnet-alignment/workstream-ledger.yaml`
- `git diff --check`

Failed:
- `cargo test --locked -p bitnet-models --no-default-features --features cpu` failed in `fixture_integrity_tests` because local fixture files are missing under `ci/fixtures/qk256/`.
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli` failed in `cli_snapshot_tests` on existing Windows snapshot differences (`bitnet.exe` usage text and device help text). Generated `.snap.new` files were removed.
- `cargo fmt -p bitnet-models -p bitnet-cli -- --check` failed on pre-existing newline-style issues in `bitnet-cli` and `bitnet-models/src/weight_mapper.rs`.

Blocked locally:
- `cargo fmt --all -- --check` failed before formatting with Windows `os error 206` path-length behavior.

Not run:
- Full workspace tests; not required for `TRUTH-002`.

## Follow-ups

- New ledger items: none.