### PR TITLE
docs: add strict CPU proof command (CPU-001)

### DIFF
--- a/docs/howto/validate-models.md
+++ b/docs/howto/validate-models.md
@@ -68,6 +68,33 @@ The validation system uses a **3-stage pipeline**:
   models/tokenizer.json
 ```
 
+### Strict CPU Proof Smoke
+
+After the model and tokenizer are present locally, use the strict CPU proof
+command to check the user-facing CLI path without mock or minimal-loader
+ambiguity:
+
+```bash
+BITNET_DISABLE_MINIMAL_LOADER=1 \
+BITNET_STRICT_MODE=1 \
+RUST_LOG=warn \
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- run \
+  --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
+  --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
+  --strict-loader \
+  --strict-tokenizer \
+  --prompt "Answer with a single digit: 2+2=" \
+  --max-tokens 1 \
+  --temperature 0.0 \
+  --greedy \
+  --json-out target/cpu-proof.json
+```
+
+This is a strict smoke/proof command, not a model-quality or performance claim.
+The JSON artifact must distinguish the enhanced loader from compatibility
+fallback. Receipt validation, kernel IDs, and throughput claims are handled by
+follow-up CPU proof items.
+
 ---
 
 ## The 3-Stage Validation Pipeline

--- a/docs/reference/inference-cli-reference.md
+++ b/docs/reference/inference-cli-reference.md
@@ -15,6 +15,34 @@ RUST_LOG=warn cargo run --locked -p bitnet-cli --no-default-features --features 
   --prompt "What is 2+2?" --max-tokens 8
 ```
 
+### strict CPU proof command
+
+Use this command when checking the CPU proof path. It requires a real model path,
+an explicit tokenizer path, strict loader behavior, minimal fallback disabled,
+greedy decoding, and JSON proof output.
+
+```bash
+BITNET_DISABLE_MINIMAL_LOADER=1 \
+BITNET_STRICT_MODE=1 \
+RUST_LOG=warn \
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- run \
+  --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
+  --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
+  --strict-loader \
+  --strict-tokenizer \
+  --prompt "Answer with a single digit: 2+2=" \
+  --max-tokens 1 \
+  --temperature 0.0 \
+  --greedy \
+  --json-out target/cpu-proof.json
+```
+
+Passing this command is a strict smoke/proof signal for the local CPU CLI path.
+It is not a model-quality claim, a sustained performance claim, or receipt
+validation by itself. Treat `target/cpu-proof.json` as a receipt-adjacent proof
+artifact: it must show the enhanced loader path and must not show compatibility
+fallback before follow-up CPU receipt work can promote the claim.
+
 ### chat
 
 Interactive chat with REPL and auto-template detection.

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -10,7 +10,7 @@ P0 truth boundary, crate consolidation inventory, and docs-only hardware-lane sc
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| CPU-001 | TBD | in_progress | Strict CPU proof command |
+| CPU-001 | #3635 | pr_open | Strict CPU proof command |
 | HW-001 | TBD | pr_open | Add shared hardware validation matrix and proof-stage contract |
 | BITNET-001 | TBD | pr_open | Add BitNet model/kernel/receipt proof contract |
 | NPU-001 | TBD | pr_open | Add Intel NPU backend lane without runtime execution |

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -10,7 +10,7 @@ P0 truth boundary, crate consolidation inventory, and docs-only hardware-lane sc
 
 | Item | PR | State | Notes |
 |---|---:|---|---|
-| CPU-001 | TBD | ready | Strict CPU proof command |
+| CPU-001 | TBD | in_progress | Strict CPU proof command |
 | HW-001 | TBD | pr_open | Add shared hardware validation matrix and proof-stage contract |
 | BITNET-001 | TBD | pr_open | Add BitNet model/kernel/receipt proof contract |
 | NPU-001 | TBD | pr_open | Add Intel NPU backend lane without runtime execution |

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -391,7 +391,7 @@ items:
 
   - id: CPU-001
     title: Add strict CPU inference proof command
-    state: in_progress
+    state: pr_open
     priority: P0
     workstream: runtime_cpu
     depends_on:

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -391,7 +391,7 @@ items:
 
   - id: CPU-001
     title: Add strict CPU inference proof command
-    state: ready
+    state: in_progress
     priority: P0
     workstream: runtime_cpu
     depends_on:


### PR DESCRIPTION
## Summary

- document the strict CPU proof command in the inference CLI reference
- add the same strict CPU proof smoke command to model validation docs
- require explicit model and tokenizer paths, strict loader/tokenizer mode, disabled minimal fallback, greedy one-token generation, and JSON proof output
- describe the output as a smoke/proof artifact, not a model-quality, performance, or receipt-validation claim

## Work item

- CPU-001

## Scope

Allowed paths:
- docs/reference/inference-cli-reference.md
- docs/howto/validate-models.md
- docs/tracking/bitnet-alignment/status.md
- docs/tracking/bitnet-alignment/workstream-ledger.yaml

Out of scope:
- runtime code
- receipt schema/validation
- kernel work
- crate movement

## Acceptance

- [x] Strict CPU proof command is documented.
- [x] Command disables minimal fallback and enables strict mode.
- [x] Command uses explicit model and tokenizer paths.
- [x] Command enables JSON output as a receipt-adjacent proof artifact.
- [x] Output expectations are documented as smoke/proof, not model-quality claims.

## Verification

Verification result:
- passed:
  - python YAML parse check for workstream-ledger.yaml and crate-consolidation-map.yaml
  - git diff --check
- failed:
  - none
- blocked locally:
  - cargo fmt --all -- --check failed before formatting with Windows os error 206
- not run:
  - code tests; docs-only CPU proof command

## Notes

- No behavior change.
- Follow-up item CPU-002 covers receipt validation.