### PR TITLE
[PR #3610 follow-up] Guard Codecov upload when CODECOV_TOKEN is missing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -122,7 +122,7 @@ jobs:
           echo "Coverage OK"
 
       - name: Upload coverage reports to Codecov
-        if: ${{ always() && hashFiles('lcov.info') != '' }}
+        if: ${{ always() && hashFiles('lcov.info') != '' && secrets.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent false-negative CI failures on fork-originated pull requests by skipping the Codecov upload when the repository secret `CODECOV_TOKEN` is not available.

### Description
- Update `.github/workflows/coverage.yml` to change the Codecov upload guard from `if: ${{ always() && hashFiles('lcov.info') != '' }}` to `if: ${{ always() && hashFiles('lcov.info') != '' && secrets.CODECOV_TOKEN != '' }}` so the upload step is skipped when the token is missing.

### Testing
- Parsed `.github/workflows/coverage.yml` with `python -c 'import yaml; yaml.safe_load(open(".github/workflows/coverage.yml"))'` which returned `OK`, verified the `git diff` shows only the intended conditional change, and committed the update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c43cae1883339b9a8c46e9764d49)