### PR TITLE
feat(models): record real GGUF loader authority

### DIFF
--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -298,8 +298,8 @@ pub struct InferenceCommand {
     #[arg(long)]
     pub qa: bool,
 
-    /// Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1)
-    /// Preferred for CI/parity testing. Unset to allow minimal loader fallback (reduced features).
+    /// Strict loader mode: fail-fast with authoritative real_gguf loading.
+    /// Preferred for CI/parity testing; compatibility loaders are rejected.
     #[arg(long)]
     pub strict_loader: bool,
 }
@@ -514,7 +514,7 @@ impl InferenceCommand {
 
     /// Setup environment for deterministic execution
     pub(super) fn setup_environment(&self) -> Result<()> {
-        // Enable strict loader mode if requested (AC1: fail-fast with enhanced loader + strict tolerance)
+        // Enable strict loader mode if requested (AC1: fail-fast with real_gguf loader authority)
         if self.strict_loader {
             unsafe {
                 std::env::set_var("BITNET_DISABLE_MINIMAL_LOADER", "1");

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -945,6 +945,18 @@ fn check_and_warn_qk256_performance(model_path: &std::path::Path, max_tokens: us
     Ok(())
 }
 
+fn detect_loader_mode_for_path(path: &std::path::Path, is_hf_directory: bool) -> &'static str {
+    if is_hf_directory {
+        return "huggingface";
+    }
+
+    match path.extension().and_then(|ext| ext.to_str()).map(str::to_ascii_lowercase) {
+        Some(ext) if ext == "gguf" => bitnet_models::GgufLoaderMode::RealGguf.as_str(),
+        Some(ext) if ext == "safetensors" => "safetensors",
+        _ => "unknown",
+    }
+}
+
 /// Run text generation with sampling
 #[allow(clippy::too_many_arguments)]
 async fn run_simple_generation(
@@ -1064,13 +1076,14 @@ async fn run_simple_generation(
     let loader = ModelLoader::new(Device::Cpu);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
-    let mut loader_mode = bitnet_models::GgufLoaderMode::RealGguf.as_str();
+    let loader_mode;
 
     let (model, config): (Arc<dyn Model>, _) = match loader
         .load_with_config(&model_path, &load_config)
     {
         Ok(m) => {
             let cfg = m.config().clone();
+            loader_mode = detect_loader_mode_for_path(&model_path, is_hf_directory);
             (Arc::from(m) as Arc<dyn Model>, cfg)
         }
         Err(e) => {

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1064,7 +1064,7 @@ async fn run_simple_generation(
     let loader = ModelLoader::new(Device::Cpu);
     let load_config =
         LoadConfig { use_mmap: true, validate_checksums: false, progress_callback: None };
-    let mut loader_mode = "enhanced";
+    let mut loader_mode = bitnet_models::GgufLoaderMode::RealGguf.as_str();
 
     let (model, config): (Arc<dyn Model>, _) = match loader
         .load_with_config(&model_path, &load_config)
@@ -1097,7 +1097,7 @@ async fn run_simple_generation(
                 bitnet_models::GGUFLoaderConfig::default(),
             )
             .context("Mock loader also failed")?;
-            loader_mode = "compatibility_fallback";
+            loader_mode = load_result.loader_mode.as_str();
             warn!("GGUF loader mode: {}", loader_mode);
             let mut raw_tensors = std::collections::HashMap::new();
             for (name, qk256) in load_result.i2s_qk256 {

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -842,6 +842,9 @@ impl FormatLoader for GgufLoader {
 
         // Extract model configuration
         let model_config = self.extract_config(&reader)?;
+        if Self::env_truthy("BITNET_STRICT_MODE") {
+            self.validate_strict_tensor_authority(&reader, &model_config)?;
+        }
 
         if let Some(callback) = &config.progress_callback {
             callback(0.5, "Loading tensors...");
@@ -862,6 +865,74 @@ impl FormatLoader for GgufLoader {
 }
 
 impl GgufLoader {
+    fn validate_strict_tensor_authority(
+        &self,
+        reader: &GgufReader,
+        config: &BitNetConfig,
+    ) -> Result<()> {
+        let tensor_names = reader.tensor_names();
+        let has_any = |candidates: &[String]| -> bool {
+            candidates.iter().any(|candidate| tensor_names.iter().any(|name| name == candidate))
+        };
+
+        let mut missing = Vec::new();
+
+        if !has_any(&[
+            "token_embd.weight".to_string(),
+            "tok_embeddings.weight".to_string(),
+            "embed_tokens.weight".to_string(),
+            "model.embed_tokens.weight".to_string(),
+        ]) {
+            missing.push("token embedding weight".to_string());
+        }
+
+        if !has_any(&[
+            "output.weight".to_string(),
+            "lm_head.weight".to_string(),
+            "model.lm_head.weight".to_string(),
+        ]) {
+            missing.push("output/lm head weight".to_string());
+        }
+
+        let layer_prefixes = ["blk", "layers", "model.layers"];
+        let required_suffix_groups: &[&[&str]] = &[
+            &["attn_q.weight", "attention.q_proj.weight", "self_attn.q_proj.weight"],
+            &["attn_k.weight", "attention.k_proj.weight", "self_attn.k_proj.weight"],
+            &["attn_v.weight", "attention.v_proj.weight", "self_attn.v_proj.weight"],
+            &["attn_output.weight", "attention.o_proj.weight", "self_attn.o_proj.weight"],
+            &["ffn_gate.weight", "feed_forward.gate_proj.weight", "mlp.gate_proj.weight"],
+            &["ffn_up.weight", "feed_forward.up_proj.weight", "mlp.up_proj.weight"],
+            &["ffn_down.weight", "feed_forward.down_proj.weight", "mlp.down_proj.weight"],
+            &["attn_norm.weight", "attention_norm.weight", "input_layernorm.weight"],
+            &["ffn_norm.weight", "ffn_norm.weight", "post_attention_layernorm.weight"],
+        ];
+
+        for layer_idx in 0..config.model.num_layers {
+            for suffix_group in required_suffix_groups {
+                let candidates: Vec<String> = layer_prefixes
+                    .iter()
+                    .flat_map(|prefix| {
+                        suffix_group
+                            .iter()
+                            .map(move |suffix| format!("{}.{}.{}", prefix, layer_idx, suffix))
+                    })
+                    .collect();
+                if !has_any(&candidates) {
+                    missing.push(format!("layer {} tensor group {:?}", layer_idx, suffix_group));
+                }
+            }
+        }
+
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        Err(BitNetError::Validation(format!(
+            "Strict real_gguf load rejected unsupported/incomplete tensor layout: missing {}",
+            missing.join(", ")
+        )))
+    }
+
     /// Check if a tensor name indicates it's an embedding tensor
     fn is_embedding_tensor(name: &str) -> bool {
         matches!(

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -882,6 +882,7 @@ impl GgufLoader {
             "tok_embeddings.weight".to_string(),
             "embed_tokens.weight".to_string(),
             "model.embed_tokens.weight".to_string(),
+            "transformer.wte.weight".to_string(),
         ]) {
             missing.push("token embedding weight".to_string());
         }
@@ -894,7 +895,7 @@ impl GgufLoader {
             missing.push("output/lm head weight".to_string());
         }
 
-        let layer_prefixes = ["blk", "layers", "model.layers"];
+        let layer_prefixes = ["blk", "layers", "model.layers", "transformer.h"];
         let required_suffix_groups: &[&[&str]] = &[
             &["attn_q.weight", "attention.q_proj.weight", "self_attn.q_proj.weight"],
             &["attn_k.weight", "attention.k_proj.weight", "self_attn.k_proj.weight"],
@@ -904,7 +905,7 @@ impl GgufLoader {
             &["ffn_up.weight", "feed_forward.up_proj.weight", "mlp.up_proj.weight"],
             &["ffn_down.weight", "feed_forward.down_proj.weight", "mlp.down_proj.weight"],
             &["attn_norm.weight", "attention_norm.weight", "input_layernorm.weight"],
-            &["ffn_norm.weight", "ffn_norm.weight", "post_attention_layernorm.weight"],
+            &["ffn_norm.weight", "post_attention_layernorm.weight"],
         ];
 
         for layer_idx in 0..config.model.num_layers {

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -235,6 +235,9 @@ fn load_gguf_enhanced(
     device: Device,
     loader_config: &GGUFLoaderConfig,
 ) -> Result<GgufLoadResult> {
+    let strict_mode =
+        loader_config.strict_mode || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1");
+
     let cdevice = match device {
         Device::Cpu => CDevice::Cpu,
         Device::Cuda(id) => match CDevice::new_cuda(id) {
@@ -272,7 +275,7 @@ fn load_gguf_enhanced(
     }
 
     // Strict proof paths must fail before compatibility defaults can synthesize tensors.
-    if loader_config.strict_mode || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1") {
+    if strict_mode {
         validate_tensor_completeness(&tensor_infos, &config)?;
     }
 
@@ -481,7 +484,7 @@ fn load_gguf_enhanced(
     normalize_embed_and_lm_head(&mut tensor_map, &config, &cdevice)?;
 
     // AC9: Maintain backward compatibility only outside strict proof paths.
-    if loader_config.strict_mode || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1") {
+    if strict_mode {
         tracing::debug!("Strict GGUF load: compatibility tensor synthesis disabled");
     } else {
         ensure_backward_compatibility(&mut tensor_map, &config, &cdevice)?;
@@ -876,7 +879,6 @@ fn parse_usize_prefix(bytes: &[u8]) -> Option<usize> {
 }
 
 /// AC3: Validate that all required transformer tensors are present
-#[allow(dead_code)]
 fn validate_tensor_completeness(
     tensor_infos: &HashMap<String, crate::formats::gguf::TensorInfo>,
     config: &bitnet_common::BitNetConfig,
@@ -884,42 +886,47 @@ fn validate_tensor_completeness(
     let mut missing_tensors = Vec::new();
 
     // Check for essential embedding tensors
-    if !tensor_infos.contains_key("token_embd.weight")
-        && !tensor_infos.contains_key("model.embed_tokens.weight")
-    {
+    if !has_any_tensor(
+        tensor_infos,
+        &[
+            "token_embd.weight",
+            "tok_embeddings.weight",
+            "embed_tokens.weight",
+            "model.embed_tokens.weight",
+            "transformer.wte.weight",
+        ],
+    ) {
         missing_tensors.push("token_embd.weight".to_string());
     }
 
-    if !tensor_infos.contains_key("output.weight") && !tensor_infos.contains_key("lm_head.weight") {
+    if !has_any_tensor(tensor_infos, &["output.weight", "lm_head.weight", "model.lm_head.weight"]) {
         missing_tensors.push("output.weight".to_string());
     }
 
+    let layer_prefixes = ["blk", "layers", "model.layers", "transformer.h"];
+    let required_suffix_groups: &[&[&str]] = &[
+        &["attn_q.weight", "attention.q_proj.weight", "self_attn.q_proj.weight"],
+        &["attn_k.weight", "attention.k_proj.weight", "self_attn.k_proj.weight"],
+        &["attn_v.weight", "attention.v_proj.weight", "self_attn.v_proj.weight"],
+        &["attn_output.weight", "attention.o_proj.weight", "self_attn.o_proj.weight"],
+        &["ffn_gate.weight", "feed_forward.gate_proj.weight", "mlp.gate_proj.weight"],
+        &["ffn_up.weight", "feed_forward.up_proj.weight", "mlp.up_proj.weight"],
+        &["ffn_down.weight", "feed_forward.down_proj.weight", "mlp.down_proj.weight"],
+        &["attn_norm.weight", "attention_norm.weight", "input_layernorm.weight"],
+        &["ffn_norm.weight", "post_attention_layernorm.weight"],
+    ];
+
     // Check transformer layers
     for layer_idx in 0..config.model.num_layers {
-        let layer_prefix = format!("blk.{}", layer_idx);
-
-        // Attention tensors
-        for suffix in &[".attn_q.weight", ".attn_k.weight", ".attn_v.weight", ".attn_output.weight"]
-        {
-            let tensor_name = format!("{}{}", layer_prefix, suffix);
-            if !tensor_infos.contains_key(&tensor_name) {
-                missing_tensors.push(tensor_name);
-            }
-        }
-
-        // Feed-forward tensors
-        for suffix in &[".ffn_gate.weight", ".ffn_up.weight", ".ffn_down.weight"] {
-            let tensor_name = format!("{}{}", layer_prefix, suffix);
-            if !tensor_infos.contains_key(&tensor_name) {
-                missing_tensors.push(tensor_name);
-            }
-        }
-
-        // Normalization tensors
-        for suffix in &[".attn_norm.weight", ".ffn_norm.weight"] {
-            let tensor_name = format!("{}{}", layer_prefix, suffix);
-            if !tensor_infos.contains_key(&tensor_name) {
-                missing_tensors.push(tensor_name);
+        for suffix_group in required_suffix_groups {
+            let found = layer_prefixes.iter().any(|prefix| {
+                suffix_group.iter().any(|suffix| {
+                    tensor_infos.contains_key(&format!("{}.{}.{}", prefix, layer_idx, suffix))
+                })
+            });
+            if !found {
+                missing_tensors
+                    .push(format!("layer {} tensor group {:?}", layer_idx, suffix_group));
             }
         }
     }
@@ -932,6 +939,13 @@ fn validate_tensor_completeness(
     }
 
     Ok(())
+}
+
+fn has_any_tensor(
+    tensor_infos: &HashMap<String, crate::formats::gguf::TensorInfo>,
+    names: &[&str],
+) -> bool {
+    names.iter().any(|name| tensor_infos.contains_key(*name))
 }
 
 /// Find a sibling scale tensor for I2_S quantized data

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -49,9 +49,28 @@ impl Default for GGUFLoaderConfig {
 
 /// Result of GGUF loading with both regular tensors and QK256 quantized weights
 pub struct GgufLoadResult {
+    pub loader_mode: GgufLoaderMode,
     pub config: bitnet_common::BitNetConfig,
     pub tensors: HashMap<String, CandleTensor>,
     pub i2s_qk256: HashMap<String, I2SQk256NoScale>,
+}
+
+/// Machine-readable GGUF loader mode for receipts and proof paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GgufLoaderMode {
+    /// Authoritative GGUF parser loaded the model from real GGUF metadata and tensors.
+    RealGguf,
+    /// Explicit opt-in compatibility path that may synthesize missing tensors.
+    MinimalCompatibility,
+}
+
+impl GgufLoaderMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RealGguf => "real_gguf",
+            Self::MinimalCompatibility => "minimal_compatibility",
+        }
+    }
 }
 
 fn minimal_loader_disabled() -> bool {
@@ -252,10 +271,10 @@ fn load_gguf_enhanced(
         tensor_infos.insert(info.name.clone(), info.clone());
     }
 
-    // AC3: Validate tensor metadata completeness
-    // NOTE: Validation moved to later stage (build_transformer) for better error messages
-    // and to avoid false positives with different tensor naming conventions
-    // validate_tensor_completeness(&tensor_infos, &config)?;
+    // Strict proof paths must fail before compatibility defaults can synthesize tensors.
+    if loader_config.strict_mode || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1") {
+        validate_tensor_completeness(&tensor_infos, &config)?;
+    }
 
     let mut tensor_map = HashMap::with_capacity(tensor_count);
     let mut i2s_qk256_map = HashMap::new();
@@ -461,8 +480,12 @@ fn load_gguf_enhanced(
     // This must happen HERE in the enhanced loader to prevent double transposition downstream
     normalize_embed_and_lm_head(&mut tensor_map, &config, &cdevice)?;
 
-    // AC9: Maintain backward compatibility - ensure all expected tensors exist
-    ensure_backward_compatibility(&mut tensor_map, &config, &cdevice)?;
+    // AC9: Maintain backward compatibility only outside strict proof paths.
+    if loader_config.strict_mode || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1") {
+        tracing::debug!("Strict GGUF load: compatibility tensor synthesis disabled");
+    } else {
+        ensure_backward_compatibility(&mut tensor_map, &config, &cdevice)?;
+    }
 
     tracing::debug!(
         "Enhanced loader complete: hidden={}, n_heads={}, n_kv_heads={}, vocab={}, layers={}",
@@ -473,7 +496,12 @@ fn load_gguf_enhanced(
         config.model.num_layers
     );
 
-    Ok(GgufLoadResult { config, tensors: tensor_map, i2s_qk256: i2s_qk256_map })
+    Ok(GgufLoadResult {
+        loader_mode: GgufLoaderMode::RealGguf,
+        config,
+        tensors: tensor_map,
+        i2s_qk256: i2s_qk256_map,
+    })
 }
 
 /// Minimal GGUF loading for backward compatibility with existing mock infrastructure
@@ -653,7 +681,12 @@ fn load_gguf_minimal(path: &Path, device: Device) -> Result<GgufLoadResult> {
     );
 
     tracing::info!("Loaded model using minimal GGUF parser with {} tensors", tensor_map.len());
-    Ok(GgufLoadResult { config, tensors: tensor_map, i2s_qk256: HashMap::new() })
+    Ok(GgufLoadResult {
+        loader_mode: GgufLoaderMode::MinimalCompatibility,
+        config,
+        tensors: tensor_map,
+        i2s_qk256: HashMap::new(),
+    })
 }
 
 /// Extract BitNet configuration from GGUF metadata
@@ -1810,7 +1843,12 @@ fn create_mock_tensor_layout(device: Device) -> Result<GgufLoadResult> {
         "Created mock tensor layout with {} tensors for test compatibility",
         tensor_map.len()
     );
-    Ok(GgufLoadResult { config, tensors: tensor_map, i2s_qk256: HashMap::new() })
+    Ok(GgufLoadResult {
+        loader_mode: GgufLoaderMode::MinimalCompatibility,
+        config,
+        tensors: tensor_map,
+        i2s_qk256: HashMap::new(),
+    })
 }
 
 #[cfg(test)]
@@ -1866,5 +1904,12 @@ mod tests {
                 assert!(result.is_err(), "strict mode must fail before compatibility fallback");
             });
         });
+    }
+
+    #[test]
+    #[serial]
+    fn loader_mode_names_are_receipt_stable() {
+        assert_eq!(super::GgufLoaderMode::RealGguf.as_str(), "real_gguf");
+        assert_eq!(super::GgufLoaderMode::MinimalCompatibility.as_str(), "minimal_compatibility");
     }
 }

--- a/crates/bitnet-models/src/lib.rs
+++ b/crates/bitnet-models/src/lib.rs
@@ -66,10 +66,10 @@ pub mod weight_stats;
 mod transformer_tests;
 
 pub use bitnet::*;
-pub use gguf_simple::GGUFLoaderConfig; // AC1: Export loader config for strict mode
 #[allow(deprecated)]
 pub use gguf_simple::load_gguf;
 pub use gguf_simple::load_gguf_full;
+pub use gguf_simple::{GGUFLoaderConfig, GgufLoaderMode}; // AC1: Export loader config/mode
 pub use loader::*;
 pub use production_loader::*;
 

--- a/crates/bitnet-models/tests/qk256_dual_flavor_tests.rs
+++ b/crates/bitnet-models/tests/qk256_dual_flavor_tests.rs
@@ -288,8 +288,14 @@ fn test_gguf_load_result_structure() {
     let tensors = HashMap::new();
     let i2s_qk256 = HashMap::new();
 
-    let result = GgufLoadResult { config: config.clone(), tensors, i2s_qk256 };
+    let result = GgufLoadResult {
+        loader_mode: bitnet_models::GgufLoaderMode::RealGguf,
+        config: config.clone(),
+        tensors,
+        i2s_qk256,
+    };
 
+    assert_eq!(result.loader_mode, bitnet_models::GgufLoaderMode::RealGguf);
     assert_eq!(result.config.model.vocab_size, config.model.vocab_size);
     assert_eq!(result.tensors.len(), 0);
     assert_eq!(result.i2s_qk256.len(), 0);


### PR DESCRIPTION
## Summary
- add `GgufLoaderMode` with stable `real_gguf` and `minimal_compatibility` strings for receipts/proof output
- report CLI loader JSON as `real_gguf` on the authoritative path and use the compatibility loader's recorded mode when mock compatibility is explicitly requested
- reject incomplete/unsupported GGUF tensor layouts early when `BITNET_STRICT_MODE=1`, before tensor loading can proceed
- disable compatibility tensor synthesis in strict `gguf_simple` loads and preserve explicit minimal compatibility mode for opt-in fallback paths

## Validation
- `cargo check -p bitnet-models -p bitnet-cli`
- `cargo test -p bitnet-models gguf_simple::tests:: --lib`
- `cargo test -p bitnet-models --test qk256_dual_flavor_tests test_gguf_load_result_structure`
- `git diff --check`

## Notes
This keeps the Kaby Lake AVX2 path sequenced behind loader/layout/scalar authority. It does not add AVX2 kernels yet; it makes strict model loading auditable so later scalar and AVX2 parity cannot hide behind compatibility fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added strict-mode validation for GGUF file integrity, rejecting incomplete models early.
  * Enhanced GGUF loader with improved mode handling and quantized tensor support.
  * Introduced new configuration API for GGUF loading behavior.
  * Improved support for quantized tensor formats in model imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->