### PR TITLE
[codex][apple-m4] Preserve backend identity (M4-003)

### DIFF
--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 pub struct CliConfig {
     /// Default model path
     pub default_model: Option<PathBuf>,
-    /// Default device (cpu, cuda, auto)
+    /// Default device/backend identity (cpu, cuda, auto, apple-m4-metal, etc.)
     pub default_device: String,
     /// Default quantization type
     pub default_quantization: Option<String>,
@@ -133,12 +133,11 @@ impl CliConfig {
 
     /// Validate configuration
     pub fn validate(&self) -> Result<()> {
-        match self.default_device.as_str() {
-            "cpu" | "cuda" | "gpu" | "vulkan" | "opencl" | "ocl" | "npu" | "auto" => {}
-            _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, auto",
+        if !is_supported_device_label(&self.default_device) {
+            anyhow::bail!(
+                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
                 self.default_device
-            ),
+            );
         }
 
         match self.logging.level.as_str() {
@@ -163,6 +162,25 @@ impl CliConfig {
 
         Ok(())
     }
+}
+
+fn is_supported_device_label(label: &str) -> bool {
+    matches!(
+        label,
+        "cpu"
+            | "cuda"
+            | "gpu"
+            | "vulkan"
+            | "opencl"
+            | "ocl"
+            | "npu"
+            | "metal"
+            | "mpsgraph"
+            | "apple-m4-metal"
+            | "apple-m4-mpsgraph"
+            | "apple-m4-cpu-neon"
+            | "auto"
+    )
 }
 
 /// Configuration builder for command-line usage

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -116,7 +116,7 @@ struct Cli {
     #[arg(short, long, value_name = "PATH", global = true)]
     config: Option<std::path::PathBuf>,
 
-    /// Device to use (cpu, cuda, oneapi, gpu, npu, auto)
+    /// Device/backend to use (cpu, cuda, oneapi, gpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, npu, auto)
     #[arg(short, long, value_name = "DEVICE", global = true)]
     device: Option<String>,
 
@@ -492,16 +492,17 @@ async fn main() -> Result<()> {
         use bitnet_kernels::device_features::current_kernel_capabilities;
 
         let caps = current_kernel_capabilities();
-        let request = match cli.device.as_deref() {
-            Some("cuda") => BackendRequest::Cuda,
-            Some("gpu") => BackendRequest::Gpu,
-            Some("oneapi") => BackendRequest::OneApi,
-            Some("cpu") => BackendRequest::Cpu,
-            Some("npu") => BackendRequest::Auto,
-            _ => BackendRequest::Auto,
-        };
+        let request = cli
+            .device
+            .as_deref()
+            .and_then(BackendRequest::from_label)
+            .unwrap_or(BackendRequest::Auto);
+        let strict_mode = std::env::var("BITNET_STRICT_MODE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
         match select_backend(request, &caps) {
-            Ok(result) => info!(backend_selection = %result.summary(), "backend selected"),
+            Ok(result) => info!(backend_selection = %result.identity_summary(), "backend selected"),
+            Err(e) if strict_mode => return Err(e.into()),
             Err(e) => warn!(error = %e, "backend selection warning"),
         }
     }

--- a/crates/bitnet-cli/tests/cli_config_edge_cases.rs
+++ b/crates/bitnet-cli/tests/cli_config_edge_cases.rs
@@ -46,7 +46,21 @@ fn validate_default_config() {
 
 #[test]
 fn validate_all_valid_devices() {
-    for device in &["cpu", "cuda", "gpu", "vulkan", "opencl", "ocl", "npu", "auto"] {
+    for device in &[
+        "cpu",
+        "cuda",
+        "gpu",
+        "vulkan",
+        "opencl",
+        "ocl",
+        "npu",
+        "metal",
+        "mpsgraph",
+        "apple-m4-metal",
+        "apple-m4-mpsgraph",
+        "apple-m4-cpu-neon",
+        "auto",
+    ] {
         let mut cfg = CliConfig::default();
         cfg.default_device = device.to_string();
         assert!(cfg.validate().is_ok(), "device '{}' should be valid", device);

--- a/crates/bitnet-cli/tests/cli_extended_tests.rs
+++ b/crates/bitnet-cli/tests/cli_extended_tests.rs
@@ -421,7 +421,20 @@ mod cli_config_validation {
     /// Valid device strings all pass.
     #[test]
     fn test_cli_config_all_valid_devices() {
-        for device in &["cpu", "cuda", "gpu", "vulkan", "opencl", "ocl", "auto"] {
+        for device in &[
+            "cpu",
+            "cuda",
+            "gpu",
+            "vulkan",
+            "opencl",
+            "ocl",
+            "metal",
+            "mpsgraph",
+            "apple-m4-metal",
+            "apple-m4-mpsgraph",
+            "apple-m4-cpu-neon",
+            "auto",
+        ] {
             let cfg = CliConfig { default_device: device.to_string(), ..Default::default() };
             assert!(cfg.validate().is_ok(), "device={device} must be valid");
         }

--- a/crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
+++ b/crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
@@ -2,4 +2,4 @@
 source: crates/bitnet-cli/tests/snapshot_wave10.rs
 expression: err.to_string()
 ---
-Invalid device: quantum. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, auto
+Invalid device: quantum. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto

--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -54,6 +54,36 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require native Metal compute without assuming a specific Apple machine.
+    Metal,
+    /// Require MPSGraph graph execution without treating it as native Metal kernels.
+    MpsGraph,
+    /// Require the Apple M4 native Metal lane.
+    AppleM4Metal,
+    /// Require the Apple M4 MPSGraph graph/reference lane.
+    AppleM4MpsGraph,
+    /// Require the Apple M4 CPU/NEON fallback/parity lane.
+    AppleM4CpuNeon,
+}
+
+impl BackendRequest {
+    /// Parse a CLI/config backend label without collapsing Apple proof lanes.
+    pub fn from_label(label: &str) -> Option<Self> {
+        match label.trim().to_ascii_lowercase().as_str() {
+            "auto" => Some(BackendRequest::Auto),
+            "cpu" => Some(BackendRequest::Cpu),
+            "gpu" => Some(BackendRequest::Gpu),
+            "cuda" => Some(BackendRequest::Cuda),
+            "hip" | "rocm" => Some(BackendRequest::Hip),
+            "oneapi" => Some(BackendRequest::OneApi),
+            "metal" => Some(BackendRequest::Metal),
+            "mpsgraph" => Some(BackendRequest::MpsGraph),
+            "apple-m4-metal" => Some(BackendRequest::AppleM4Metal),
+            "apple-m4-mpsgraph" => Some(BackendRequest::AppleM4MpsGraph),
+            "apple-m4-cpu-neon" => Some(BackendRequest::AppleM4CpuNeon),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for BackendRequest {
@@ -65,6 +95,11 @@ impl fmt::Display for BackendRequest {
             BackendRequest::Cuda => write!(f, "cuda"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::Metal => write!(f, "metal"),
+            BackendRequest::MpsGraph => write!(f, "mpsgraph"),
+            BackendRequest::AppleM4Metal => write!(f, "apple-m4-metal"),
+            BackendRequest::AppleM4MpsGraph => write!(f, "apple-m4-mpsgraph"),
+            BackendRequest::AppleM4CpuNeon => write!(f, "apple-m4-cpu-neon"),
         }
     }
 }
@@ -93,6 +128,72 @@ impl BackendSelectionResult {
             self.requested,
             detected.join(","),
             self.selected,
+        )
+    }
+
+    /// Requested backend label for receipt/log fields.
+    pub fn requested_backend(&self) -> String {
+        self.requested.to_string()
+    }
+
+    /// Selected backend label for receipt/log fields.
+    pub fn selected_backend(&self) -> String {
+        match (self.requested, self.selected) {
+            (BackendRequest::AppleM4CpuNeon, KernelBackend::CpuRust) => {
+                "apple-m4-cpu-neon".to_string()
+            }
+            _ => self.selected.to_string(),
+        }
+    }
+
+    /// Runtime API implied by the selected backend label.
+    pub fn runtime_api(&self) -> &'static str {
+        match self.selected_backend().as_str() {
+            "cuda" => "cuda",
+            "hip" => "hip",
+            "oneapi" => "oneapi",
+            "opencl" => "opencl",
+            "apple-m4-metal" | "metal" => "metal",
+            "apple-m4-mpsgraph" | "mpsgraph" => "mpsgraph",
+            _ => "cpu",
+        }
+    }
+
+    /// Whether backend selection changed the requested backend identity.
+    pub fn fallback_used(&self) -> bool {
+        match self.requested {
+            BackendRequest::Auto => false,
+            BackendRequest::Cpu => self.selected != KernelBackend::CpuRust,
+            BackendRequest::Gpu => !self.selected.requires_gpu(),
+            BackendRequest::Cuda => self.selected != KernelBackend::Cuda,
+            BackendRequest::Hip => self.selected != KernelBackend::Hip,
+            BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
+            BackendRequest::Metal
+            | BackendRequest::MpsGraph
+            | BackendRequest::AppleM4Metal
+            | BackendRequest::AppleM4MpsGraph
+            | BackendRequest::AppleM4CpuNeon => self.requested_backend() != self.selected_backend(),
+        }
+    }
+
+    /// Human-readable fallback reason, when fallback happened.
+    pub fn fallback_reason(&self) -> Option<&str> {
+        self.fallback_used().then_some(self.rationale.as_str())
+    }
+
+    /// Receipt-oriented one-line identity summary for logs.
+    pub fn identity_summary(&self) -> String {
+        let fallback_reason = self
+            .fallback_reason()
+            .map(|reason| format!(" fallback_reason={reason}"))
+            .unwrap_or_default();
+        format!(
+            "requested_backend={} selected_backend={} runtime_api={} fallback_used={}{}",
+            self.requested_backend(),
+            self.selected_backend(),
+            self.runtime_api(),
+            self.fallback_used(),
+            fallback_reason,
         )
     }
 }
@@ -172,6 +273,31 @@ pub fn select_backend(
         BackendRequest::OneApi => {
             if caps.oneapi_compiled && caps.oneapi_runtime {
                 (KernelBackend::OneApi, "Intel oneAPI GPU available and requested".to_string())
+            } else {
+                return Err(BackendSelectionError::RequestedUnavailable {
+                    requested: request,
+                    available: detected.clone(),
+                });
+            }
+        }
+        BackendRequest::Metal | BackendRequest::AppleM4Metal => {
+            return Err(BackendSelectionError::RequestedUnavailable {
+                requested: request,
+                available: detected.clone(),
+            });
+        }
+        BackendRequest::MpsGraph | BackendRequest::AppleM4MpsGraph => {
+            return Err(BackendSelectionError::RequestedUnavailable {
+                requested: request,
+                available: detected.clone(),
+            });
+        }
+        BackendRequest::AppleM4CpuNeon => {
+            if caps.cpu_rust
+                && matches!(caps.simd_level, crate::kernel_registry::SimdLevel::Neon)
+                && cfg!(all(target_os = "macos", target_arch = "aarch64"))
+            {
+                (KernelBackend::CpuRust, "Apple M4 CPU/NEON lane requested".to_string())
             } else {
                 return Err(BackendSelectionError::RequestedUnavailable {
                     requested: request,
@@ -322,6 +448,41 @@ mod tests {
         let summary = result.summary();
         assert!(summary.contains("requested=auto"), "got: {summary}");
         assert!(summary.contains("selected=cpu-rust"), "got: {summary}");
+    }
+
+    #[test]
+    fn apple_backend_labels_parse_without_aliasing() {
+        assert_eq!(BackendRequest::from_label("metal"), Some(BackendRequest::Metal));
+        assert_eq!(
+            BackendRequest::from_label("apple-m4-metal"),
+            Some(BackendRequest::AppleM4Metal)
+        );
+        assert_eq!(BackendRequest::from_label("mpsgraph"), Some(BackendRequest::MpsGraph));
+        assert_eq!(
+            BackendRequest::from_label("apple-m4-mpsgraph"),
+            Some(BackendRequest::AppleM4MpsGraph)
+        );
+        assert_eq!(
+            BackendRequest::from_label("apple-m4-cpu-neon"),
+            Some(BackendRequest::AppleM4CpuNeon)
+        );
+    }
+
+    #[test]
+    fn apple_m4_metal_request_is_strict_until_probe_work_lands() {
+        let err = select_backend(BackendRequest::AppleM4Metal, &cpu_only_caps()).unwrap_err();
+        assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+        assert!(err.to_string().contains("apple-m4-metal"));
+    }
+
+    #[test]
+    fn identity_summary_records_fallback_status() {
+        let result = select_backend(BackendRequest::Gpu, &cuda_no_runtime_caps()).unwrap();
+        let summary = result.identity_summary();
+        assert!(summary.contains("requested_backend=gpu"), "got: {summary}");
+        assert!(summary.contains("selected_backend=cpu-rust"), "got: {summary}");
+        assert!(summary.contains("runtime_api=cpu"), "got: {summary}");
+        assert!(summary.contains("fallback_used=true"), "got: {summary}");
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -1,7 +1,7 @@
 //! Core device configuration parsing and runtime resolution.
 
 use anyhow::Result;
-use bitnet_common::Device;
+use bitnet_common::{BackendRequest, Device};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
@@ -15,6 +15,16 @@ pub enum DeviceConfig {
     Cpu,
     /// Force GPU execution on specific device ID.
     Gpu(usize),
+    /// Preserve a native Metal backend identity.
+    Metal,
+    /// Preserve an MPSGraph graph/reference backend identity.
+    MpsGraph,
+    /// Preserve the Apple M4 native Metal backend identity.
+    AppleM4Metal,
+    /// Preserve the Apple M4 MPSGraph graph/reference backend identity.
+    AppleM4MpsGraph,
+    /// Preserve the Apple M4 CPU/NEON fallback/parity backend identity.
+    AppleM4CpuNeon,
 }
 
 impl FromStr for DeviceConfig {
@@ -25,6 +35,11 @@ impl FromStr for DeviceConfig {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
             "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            "metal" => Ok(DeviceConfig::Metal),
+            "mpsgraph" => Ok(DeviceConfig::MpsGraph),
+            "apple-m4-metal" => Ok(DeviceConfig::AppleM4Metal),
+            "apple-m4-mpsgraph" => Ok(DeviceConfig::AppleM4MpsGraph),
+            "apple-m4-cpu-neon" => Ok(DeviceConfig::AppleM4CpuNeon),
             s if s.starts_with("gpu:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
             s if s.starts_with("cuda:") => Ok(DeviceConfig::Gpu(s[5..].parse::<usize>()?)),
             s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
@@ -53,7 +68,32 @@ impl DeviceConfig {
             }
             DeviceConfig::Cpu => Device::Cpu,
             DeviceConfig::Gpu(id) => Device::Cuda(*id),
+            DeviceConfig::Metal | DeviceConfig::AppleM4Metal => Device::Metal,
+            // MPSGraph is a separate proof label; runtime execution is introduced in a later item.
+            DeviceConfig::MpsGraph | DeviceConfig::AppleM4MpsGraph => Device::Cpu,
+            DeviceConfig::AppleM4CpuNeon => Device::Cpu,
         }
+    }
+
+    /// Return the backend request identity represented by this config.
+    #[must_use]
+    pub fn backend_request(&self) -> BackendRequest {
+        match self {
+            DeviceConfig::Auto => BackendRequest::Auto,
+            DeviceConfig::Cpu => BackendRequest::Cpu,
+            DeviceConfig::Gpu(_) => BackendRequest::Gpu,
+            DeviceConfig::Metal => BackendRequest::Metal,
+            DeviceConfig::MpsGraph => BackendRequest::MpsGraph,
+            DeviceConfig::AppleM4Metal => BackendRequest::AppleM4Metal,
+            DeviceConfig::AppleM4MpsGraph => BackendRequest::AppleM4MpsGraph,
+            DeviceConfig::AppleM4CpuNeon => BackendRequest::AppleM4CpuNeon,
+        }
+    }
+
+    /// Stable label for logs and planned receipt fields.
+    #[must_use]
+    pub fn backend_label(&self) -> String {
+        self.backend_request().to_string()
     }
 }
 
@@ -68,6 +108,17 @@ mod tests {
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
         assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+        assert_eq!("metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::Metal);
+        assert_eq!("mpsgraph".parse::<DeviceConfig>().unwrap(), DeviceConfig::MpsGraph);
+        assert_eq!("apple-m4-metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::AppleM4Metal);
+        assert_eq!(
+            "apple-m4-mpsgraph".parse::<DeviceConfig>().unwrap(),
+            DeviceConfig::AppleM4MpsGraph
+        );
+        assert_eq!(
+            "apple-m4-cpu-neon".parse::<DeviceConfig>().unwrap(),
+            DeviceConfig::AppleM4CpuNeon
+        );
     }
 
     #[test]
@@ -75,5 +126,20 @@ mod tests {
         assert!("unknown".parse::<DeviceConfig>().is_err());
         assert!("gpu:".parse::<DeviceConfig>().is_err());
         assert!("gpu:abc".parse::<DeviceConfig>().is_err());
+    }
+
+    #[test]
+    fn apple_backend_labels_do_not_alias() {
+        let metal = "metal".parse::<DeviceConfig>().unwrap();
+        let apple_metal = "apple-m4-metal".parse::<DeviceConfig>().unwrap();
+        let mpsgraph = "mpsgraph".parse::<DeviceConfig>().unwrap();
+        let apple_mpsgraph = "apple-m4-mpsgraph".parse::<DeviceConfig>().unwrap();
+        let apple_cpu = "apple-m4-cpu-neon".parse::<DeviceConfig>().unwrap();
+
+        assert_eq!(metal.backend_label(), "metal");
+        assert_eq!(apple_metal.backend_label(), "apple-m4-metal");
+        assert_eq!(mpsgraph.backend_label(), "mpsgraph");
+        assert_eq!(apple_mpsgraph.backend_label(), "apple-m4-mpsgraph");
+        assert_eq!(apple_cpu.backend_label(), "apple-m4-cpu-neon");
     }
 }

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -23,7 +23,7 @@ Real BitNet CPU path sequencing after the #3625 hardware and BitNet contract mer
 | NPU-002 | TBD | ready | Preserve Intel NPU backend identity before runtime probing |
 | A770-003 | TBD | ready | Preserve Intel Arc A770 selected-device identity |
 | KBL8250U-003 | TBD | ready | Prove i5-8250U scalar and AVX2 dispatch |
-| M4-003 | TBD | ready | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity before runtime work |
+| M4-003 | TBD | in_progress | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity before runtime work |
 | RTX5070TI-003 | TBD | ready | Preserve RTX 5070 Ti CUDA selected-device identity |
 | AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
 | AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -23,7 +23,7 @@ Real BitNet CPU path sequencing after the #3625 hardware and BitNet contract mer
 | NPU-002 | TBD | ready | Preserve Intel NPU backend identity before runtime probing |
 | A770-003 | TBD | ready | Preserve Intel Arc A770 selected-device identity |
 | KBL8250U-003 | TBD | ready | Prove i5-8250U scalar and AVX2 dispatch |
-| M4-003 | TBD | in_progress | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity before runtime work |
+| M4-003 | #3652 | pr_open | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity before runtime work |
 | RTX5070TI-003 | TBD | ready | Preserve RTX 5070 Ti CUDA selected-device identity |
 | AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
 | AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1883,7 +1883,7 @@ items:
 
   - id: M4-003
     title: Preserve Apple backend identity
-    state: in_progress
+    state: pr_open
     priority: P1
     workstream: apple_silicon
     depends_on:

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1883,18 +1883,21 @@ items:
 
   - id: M4-003
     title: Preserve Apple backend identity
-    state: ready
+    state: in_progress
     priority: P1
     workstream: apple_silicon
     depends_on:
       - M4-002
     scope:
       allowed_paths:
-        - crates/bitnet-common/src/types.rs
+        - crates/bitnet-common/src/backend_selection.rs
         - crates/bitnet-device-config-core/src/lib.rs
-        - crates/bitnet-inference/src/backends.rs
         - crates/bitnet-cli-config-core/src/lib.rs
         - crates/bitnet-cli/src/main.rs
+        - crates/bitnet-cli/tests/cli_config_edge_cases.rs
+        - crates/bitnet-cli/tests/cli_extended_tests.rs
+        - crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
+        - docs/tracking/campaigns/apple-m4/**
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
@@ -1907,7 +1910,9 @@ items:
       - Strict mode fails if Apple M4 Metal is requested but unavailable.
     verification:
       - cargo fmt --all -- --check
-      - cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu
+      - cargo test --locked -p bitnet-common --no-default-features --features cpu backend_selection
+      - cargo test --locked -p bitnet-device-config-core --no-default-features
+      - cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cli_config
 
   - id: M4-004
     title: Add Apple M4 Metal device probe

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -23,7 +23,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "M4-003"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-003-backend-identity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -23,7 +23,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "M4-003"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-003-backend-identity"
 stackable = false
 requires_human_merge = true
@@ -31,15 +31,21 @@ blocked_by = []
 acceptance = "Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels."
 commands = [
   "cargo fmt --all -- --check",
-  "cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-common --no-default-features --features cpu backend_selection",
+  "cargo test --locked -p bitnet-device-config-core --no-default-features",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cli_config",
 ]
 allowed_paths = [
-  "crates/bitnet-common/src/types.rs",
+  "crates/bitnet-common/src/backend_selection.rs",
   "crates/bitnet-device-config-core/src/lib.rs",
-  "crates/bitnet-inference/src/backends.rs",
   "crates/bitnet-cli-config-core/src/lib.rs",
   "crates/bitnet-cli/src/main.rs",
+  "crates/bitnet-cli/tests/cli_config_edge_cases.rs",
+  "crates/bitnet-cli/tests/cli_extended_tests.rs",
+  "crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap",
   "docs/tracking/campaigns/apple-m4/**",
+  "docs/tracking/bitnet-alignment/status.md",
+  "docs/tracking/bitnet-alignment/workstream-ledger.yaml",
 ]
 forbidden_paths = [
   "crates/bitnet-quantization/src/qk256/**",

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T010853Z-M4-003-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T010853Z-M4-003-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T01:08:53Z"
+campaign = "apple-m4"
+item = "M4-003"
+event = "in_progress"
+branch = "codex/apple-m4/M4-003-backend-identity"
+actor = "codex"
+
+notes = [
+  "Started Apple backend identity preservation only.",
+  "No Metal kernels, MPSGraph execution, QK256, server inference, dependencies, or runtime probe work.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T011032Z-M4-003-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T011032Z-M4-003-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T01:10:32Z"
+campaign = "apple-m4"
+item = "M4-003"
+event = "pr_open"
+pr = 3652
+head_sha = "c4ad9edf"
+actor = "codex"
+
+notes = [
+  "Opened Apple backend identity PR.",
+  "No Metal kernels, MPSGraph execution, QK256, server inference, dependencies, runtime probes, or hardware artifacts touched.",
+]


### PR DESCRIPTION
## Summary
- Add distinct backend request labels for `metal`, `mpsgraph`, `apple-m4-metal`, `apple-m4-mpsgraph`, and `apple-m4-cpu-neon` without aliasing them into generic GPU/accelerator values.
- Add receipt-oriented backend identity helpers for requested backend, selected backend, runtime API, fallback status, and fallback reason.
- Update CLI startup logging and config validation so Apple M4 Metal, MPSGraph, and CPU/NEON identities stay separate before runtime/probe work begins.
- Mark M4-003 in progress in the campaign and legacy trackers.

## Claim boundary
- No Metal kernels or Metal execution are added.
- No MPSGraph execution is added.
- No QK256, server inference, dependencies, or hardware artifacts are touched.
- `apple-m4-metal` is strict and remains unavailable until a later probe/runtime item proves it.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-common --no-default-features --features cpu backend_selection`
- `cargo test --locked -p bitnet-device-config-core --no-default-features`
- `cargo test --locked -p bitnet-cli-config-core --no-default-features`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cli_config`
- Parsed campaign TOML and event TOML files
- Parsed `docs/tracking/bitnet-alignment/workstream-ledger.yaml`
- `git diff --check`

Note: the original tracker command for `bitnet-device-config-core --features cpu` was corrected because that crate does not define a `cpu` feature.
