### PR TITLE
Enforce strict CPU receipt authority and deterministic tokenizer discovery

### DIFF
--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -150,9 +150,13 @@ pub struct InferenceCommand {
     #[arg(short, long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 
-    /// Device to use for inference (cpu, cuda, auto)
-    #[arg(short, long, value_name = "DEVICE")]
+    /// Device/backend to use for inference (cpu, cuda, auto)
+    #[arg(short, long, visible_alias = "backend", value_name = "DEVICE")]
     pub device: Option<String>,
+
+    /// Requested CPU kernel for strict receipt proof (for example: qk256-avx2-gemv)
+    #[arg(long, value_name = "KERNEL")]
+    pub kernel: Option<String>,
 
     /// Quantization type (i2s, tl1, tl2, auto)
     #[arg(short, long, value_name = "TYPE")]
@@ -290,7 +294,7 @@ pub struct InferenceCommand {
     pub emit_receipt_dir: Option<PathBuf>,
 
     /// Path for the primary inference receipt (default: ci/inference.json)
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, visible_alias = "receipt-out", value_name = "PATH")]
     pub receipt_path: Option<PathBuf>,
 
     /// Q&A mode: bundle Q&A-friendly defaults (auto template, temp=0.7, top-p=0.95, top-k=50)
@@ -300,7 +304,7 @@ pub struct InferenceCommand {
 
     /// Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1)
     /// Preferred for CI/parity testing. Unset to allow minimal loader fallback (reduced features).
-    #[arg(long)]
+    #[arg(long = "strict-loader", visible_alias = "strict")]
     pub strict_loader: bool,
 }
 
@@ -608,6 +612,13 @@ impl InferenceCommand {
             .or(config.default_model.as_ref())
             .context("No model specified. Use --model or set default_model in config")?;
 
+        if self.strict_loader && model_path.extension().and_then(|s| s.to_str()) != Some("gguf") {
+            anyhow::bail!(
+                "strict CPU inference requires a real GGUF model path; got {}",
+                model_path.display()
+            );
+        }
+
         info!("Loading model from: {}", model_path.display());
 
         // Show loading progress
@@ -782,23 +793,46 @@ impl InferenceCommand {
         model_path: &Path,
         reader: Option<&bitnet_models::GgufReader<'_>>,
     ) -> Result<Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>> {
-        // Try RustGgufTokenizer from GGUF metadata (pure Rust, preferred)
+        // Strict tokenizer authority order:
+        // 1. explicit tokenizer override;
+        // 2. tokenizer embedded in GGUF;
+        // 3. sibling/parent tokenizer.json discovery;
+        // 4. fail (no compatibility tokenizer fallback).
+        if let Some(explicit_tokenizer) = self.tokenizer.clone() {
+            let resolved = crate::tokenizer_discovery::resolve_tokenizer_with_receipt_source(
+                model_path,
+                Some(explicit_tokenizer),
+            )?;
+            debug!("Loading explicit tokenizer from: {}", resolved.path.display());
+            let tokenizer = bitnet_tokenizers::loader::load_tokenizer(&resolved.path)?;
+            unsafe {
+                std::env::set_var("BITNET_TOKENIZER_SOURCE", resolved.source.as_receipt_str());
+            }
+            return Ok(tokenizer);
+        }
+
         if let Some(reader) = reader {
             if let Ok(tokenizer) = bitnet_tokenizers::RustGgufTokenizer::from_gguf(reader) {
                 debug!("Successfully loaded pure-Rust tokenizer from GGUF metadata");
+                unsafe {
+                    std::env::set_var("BITNET_TOKENIZER_SOURCE", "gguf_embedded");
+                }
                 return Ok(Arc::new(tokenizer));
             }
-            warn!("Failed to load pure-Rust tokenizer from GGUF, falling back to auto-detection");
+            debug!(
+                "GGUF tokenizer metadata was unavailable or unsupported; checking sibling files"
+            );
         }
 
-        // Resolve tokenizer path using discovery logic
-        let tokenizer_path =
-            crate::tokenizer_discovery::resolve_tokenizer(model_path, self.tokenizer.clone())?;
+        let resolved =
+            crate::tokenizer_discovery::resolve_tokenizer_with_receipt_source(model_path, None)?;
 
-        debug!("Loading tokenizer from: {}", tokenizer_path.display());
+        debug!("Loading tokenizer from: {}", resolved.path.display());
 
-        // Load tokenizer from resolved path (returns Arc directly)
-        let tokenizer = bitnet_tokenizers::loader::load_tokenizer(&tokenizer_path)?;
+        let tokenizer = bitnet_tokenizers::loader::load_tokenizer(&resolved.path)?;
+        unsafe {
+            std::env::set_var("BITNET_TOKENIZER_SOURCE", resolved.source.as_receipt_str());
+        }
         Ok(tokenizer)
     }
 
@@ -976,6 +1010,7 @@ impl InferenceCommand {
 
         // Determine backend from device
         let backend = self.device.as_deref().unwrap_or("cpu");
+        let requested_kernel = self.kernel.as_deref().unwrap_or("auto");
 
         // Capture runtime environment (similar to xtask benchmark)
         let rust_version = std::process::Command::new("rustc")
@@ -990,8 +1025,10 @@ impl InferenceCommand {
         // Capture actual kernel IDs from engine telemetry
         let mut kernels = if let Some(recorder) = engine.kernel_recorder() {
             recorder.snapshot()
+        } else if self.strict_loader {
+            anyhow::bail!("strict receipt requires an attached kernel recorder");
         } else {
-            // Fallback to placeholder kernels if no recorder attached
+            // Non-strict compatibility receipt for older engine paths that predate kernel telemetry.
             vec![
                 "embedding_lookup".to_string(),
                 "prefill_forward".to_string(),
@@ -1013,11 +1050,56 @@ impl InferenceCommand {
             kernels.truncate(MAX_KERNEL_CLASSES);
         }
 
+        if self.strict_loader && kernels.is_empty() {
+            anyhow::bail!("strict receipt requires at least one recorded real kernel");
+        }
+
+        let selected_kernel = if requested_kernel == "auto" {
+            kernels.first().cloned().unwrap_or_else(|| "none".to_string())
+        } else if kernels.iter().any(|kernel| kernel == requested_kernel) {
+            requested_kernel.to_string()
+        } else if self.strict_loader {
+            anyhow::bail!(
+                "strict receipt requested kernel '{}' but recorded kernels were {:?}",
+                requested_kernel,
+                kernels
+            );
+        } else {
+            kernels.first().cloned().unwrap_or_else(|| "none".to_string())
+        };
+        let fallback_used = selected_kernel != requested_kernel && requested_kernel != "auto";
+        let fallback_reason = if fallback_used {
+            Some(format!(
+                "requested kernel '{}' was not recorded; selected '{}'",
+                requested_kernel, selected_kernel
+            ))
+        } else {
+            None
+        };
+        let tokenizer_source =
+            std::env::var("BITNET_TOKENIZER_SOURCE").unwrap_or_else(|_| "unresolved".to_string());
+        if self.strict_loader && tokenizer_source == "unresolved" {
+            anyhow::bail!("strict receipt requires a deterministic tokenizer source");
+        }
+        let loader_mode = if self.strict_loader { "real_gguf" } else { "auto" };
+
         let receipt = serde_json::json!({
             "schema_version": "1.0.0",
             "timestamp": Utc::now().to_rfc3339(),
             "compute_path": "real",
             "backend": backend,
+            "requested_backend": backend,
+            "selected_backend": backend,
+            "requested_kernel": requested_kernel,
+            "selected_kernel": selected_kernel,
+            "fallback_used": fallback_used,
+            "fallback_reason": fallback_reason,
+            "loader": {
+                "mode": loader_mode
+            },
+            "tokenizer": {
+                "source": tokenizer_source
+            },
             "deterministic": self.deterministic || self.greedy,
             "tokens_generated": tokens_generated,
             "kernels": kernels,
@@ -1849,6 +1931,7 @@ mod tests {
             input_file: None,
             output: None,
             device: None,
+            kernel: None,
             quantization: None,
             max_tokens: 16,
             temperature: 0.7,

--- a/crates/bitnet-cli/src/tokenizer_discovery.rs
+++ b/crates/bitnet-cli/src/tokenizer_discovery.rs
@@ -1,7 +1,7 @@
 //! Tokenizer auto-discovery for BitNet-rs CLI.
 
 use anyhow::Result;
-use bitnet_tokenizer_discovery_core::resolve_tokenizer_with;
+use bitnet_tokenizer_discovery_core::{ResolvedTokenizer, resolve_tokenizer_with_source};
 use std::path::{Path, PathBuf};
 
 /// Resolve tokenizer path with auto-discovery.
@@ -11,7 +11,18 @@ use std::path::{Path, PathBuf};
 /// 2. Sibling tokenizer.json.
 /// 3. Parent tokenizer.json.
 pub fn resolve_tokenizer(model_path: &Path, explicit_path: Option<PathBuf>) -> Result<PathBuf> {
-    resolve_tokenizer_with(model_path, explicit_path, |candidate| {
+    resolve_tokenizer_with_source(model_path, explicit_path, |candidate| {
+        Ok(bitnet_tokenizers::loader::load_tokenizer(candidate).is_ok())
+    })
+    .map(|resolved| resolved.path)
+}
+
+/// Resolve tokenizer path with its strict receipt source.
+pub fn resolve_tokenizer_with_receipt_source(
+    model_path: &Path,
+    explicit_path: Option<PathBuf>,
+) -> Result<ResolvedTokenizer> {
+    resolve_tokenizer_with_source(model_path, explicit_path, |candidate| {
         Ok(bitnet_tokenizers::loader::load_tokenizer(candidate).is_ok())
     })
 }
@@ -19,6 +30,7 @@ pub fn resolve_tokenizer(model_path: &Path, explicit_path: Option<PathBuf>) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitnet_tokenizer_discovery_core::TokenizerSource;
     use std::fs;
     use tempfile::TempDir;
 
@@ -51,6 +63,21 @@ mod tests {
 
         let result = resolve_tokenizer(&model_path, Some(explicit_tokenizer.clone()))?;
         assert_eq!(result.canonicalize()?, explicit_tokenizer.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn receipt_source_reports_sibling_discovery() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling_tokenizer = temp_dir.path().join("tokenizer.json");
+
+        fs::write(&model_path, create_mock_gguf())?;
+        fs::write(&sibling_tokenizer, create_mock_tokenizer())?;
+
+        let result = resolve_tokenizer_with_receipt_source(&model_path, None)?;
+        assert_eq!(result.path.canonicalize()?, sibling_tokenizer.canonicalize()?);
+        assert_eq!(result.source, TokenizerSource::SiblingFile);
         Ok(())
     }
 }

--- a/crates/bitnet-cli/tests/cli_args_aliases.rs
+++ b/crates/bitnet-cli/tests/cli_args_aliases.rs
@@ -241,3 +241,44 @@ mod backward_compatibility {
         Ok(())
     }
 }
+
+#[cfg(feature = "full-cli")]
+mod strict_cpu_receipt_aliases {
+    use bitnet_cli::commands::InferenceCommand;
+    use clap::Parser;
+    use std::path::PathBuf;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        cmd: InferenceCommand,
+    }
+
+    fn parse(args: &[&str]) -> InferenceCommand {
+        TestCli::try_parse_from(args).expect("strict CPU aliases must parse").cmd
+    }
+
+    #[test]
+    fn backend_alias_sets_device() {
+        let cmd = parse(&["test", "--backend", "cpu"]);
+        assert_eq!(cmd.device.as_deref(), Some("cpu"));
+    }
+
+    #[test]
+    fn strict_alias_sets_strict_loader() {
+        let cmd = parse(&["test", "--strict"]);
+        assert!(cmd.strict_loader);
+    }
+
+    #[test]
+    fn receipt_out_alias_sets_receipt_path() {
+        let cmd = parse(&["test", "--receipt-out", "ci/receipts/cpu.json"]);
+        assert_eq!(cmd.receipt_path, Some(PathBuf::from("ci/receipts/cpu.json")));
+    }
+
+    #[test]
+    fn kernel_argument_sets_requested_kernel() {
+        let cmd = parse(&["test", "--kernel", "qk256-avx2-gemv"]);
+        assert_eq!(cmd.kernel.as_deref(), Some("qk256-avx2-gemv"));
+    }
+}

--- a/crates/bitnet-tokenizer-discovery-core/src/lib.rs
+++ b/crates/bitnet-tokenizer-discovery-core/src/lib.rs
@@ -2,6 +2,28 @@ use anyhow::{Context, Result, anyhow};
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
+/// Deterministic tokenizer authority selected for an inference run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerSource {
+    /// User supplied an explicit tokenizer path.
+    ExplicitOverride,
+    /// Tokenizer discovered next to the model file.
+    SiblingFile,
+    /// Tokenizer discovered in the parent directory of the model directory.
+    ParentFile,
+}
+
+impl TokenizerSource {
+    #[must_use]
+    pub const fn as_receipt_str(self) -> &'static str {
+        match self {
+            Self::ExplicitOverride => "explicit_override",
+            Self::SiblingFile => "sibling_file",
+            Self::ParentFile => "parent_file",
+        }
+    }
+}
+
 /// Resolve tokenizer path with deterministic fallback ordering.
 ///
 /// Priority:
@@ -11,18 +33,45 @@ use tracing::debug;
 pub fn resolve_tokenizer_with<F>(
     model_path: &Path,
     explicit_path: Option<PathBuf>,
-    mut verifier: F,
+    verifier: F,
 ) -> Result<PathBuf>
+where
+    F: FnMut(&Path) -> Result<bool>,
+{
+    resolve_tokenizer_with_source(model_path, explicit_path, verifier).map(|resolved| resolved.path)
+}
+
+/// Resolve tokenizer path and return the receipt source selected by the deterministic policy.
+///
+/// Priority:
+/// 1. Explicit path (if provided).
+/// 2. Sibling `tokenizer.json` next to model.
+/// 3. Parent-directory `tokenizer.json`.
+pub fn resolve_tokenizer_with_source<F>(
+    model_path: &Path,
+    explicit_path: Option<PathBuf>,
+    mut verifier: F,
+) -> Result<ResolvedTokenizer>
 where
     F: FnMut(&Path) -> Result<bool>,
 {
     if let Some(path) = explicit_path {
         debug!("Using explicit tokenizer path: {}", path.display());
-        return validate_explicit_path(path);
+        return Ok(ResolvedTokenizer {
+            path: validate_explicit_path(path)?,
+            source: TokenizerSource::ExplicitOverride,
+        });
     }
 
     let discovery = TokenizerDiscovery::new(model_path.to_path_buf());
     discovery.discover_with(&mut verifier)
+}
+
+/// Tokenizer path plus the source label that must be written into strict receipts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTokenizer {
+    pub path: PathBuf,
+    pub source: TokenizerSource,
 }
 
 #[derive(Debug, Clone)]
@@ -36,7 +85,7 @@ impl TokenizerDiscovery {
         Self { model_path }
     }
 
-    pub fn discover_with<F>(&self, verifier: &mut F) -> Result<PathBuf>
+    pub fn discover_with<F>(&self, verifier: &mut F) -> Result<ResolvedTokenizer>
     where
         F: FnMut(&Path) -> Result<bool>,
     {
@@ -44,12 +93,12 @@ impl TokenizerDiscovery {
 
         if let Some(path) = self.check_sibling_tokenizer(verifier)? {
             debug!("Discovered sibling tokenizer: {}", path.display());
-            return Ok(path);
+            return Ok(ResolvedTokenizer { path, source: TokenizerSource::SiblingFile });
         }
 
         if let Some(path) = self.check_parent_tokenizer(verifier)? {
             debug!("Discovered parent tokenizer: {}", path.display());
-            return Ok(path);
+            return Ok(ResolvedTokenizer { path, source: TokenizerSource::ParentFile });
         }
 
         Err(self.discovery_failed_error())
@@ -153,9 +202,13 @@ mod tests {
         fs::write(&model_path, b"GGUF")?;
         fs::write(&explicit_tokenizer, b"{}")?;
 
-        let resolved =
-            resolve_tokenizer_with(&model_path, Some(explicit_tokenizer.clone()), always_valid)?;
-        assert_eq!(resolved, explicit_tokenizer.canonicalize()?);
+        let resolved = resolve_tokenizer_with_source(
+            &model_path,
+            Some(explicit_tokenizer.clone()),
+            always_valid,
+        )?;
+        assert_eq!(resolved.path, explicit_tokenizer.canonicalize()?);
+        assert_eq!(resolved.source, TokenizerSource::ExplicitOverride);
         Ok(())
     }
 
@@ -172,8 +225,9 @@ mod tests {
         fs::write(&sibling, b"{}")?;
         fs::write(&parent, b"{}")?;
 
-        let resolved = resolve_tokenizer_with(&model_path, None, always_valid)?;
-        assert_eq!(resolved, sibling.canonicalize()?);
+        let resolved = resolve_tokenizer_with_source(&model_path, None, always_valid)?;
+        assert_eq!(resolved.path, sibling.canonicalize()?);
+        assert_eq!(resolved.source, TokenizerSource::SiblingFile);
         Ok(())
     }
 
@@ -188,8 +242,9 @@ mod tests {
         fs::write(&model_path, b"GGUF")?;
         fs::write(&parent, b"{}")?;
 
-        let resolved = resolve_tokenizer_with(&model_path, None, always_valid)?;
-        assert_eq!(resolved, parent.canonicalize()?);
+        let resolved = resolve_tokenizer_with_source(&model_path, None, always_valid)?;
+        assert_eq!(resolved.path, parent.canonicalize()?);
+        assert_eq!(resolved.source, TokenizerSource::ParentFile);
         Ok(())
     }
 


### PR DESCRIPTION
### Motivation
- Provide a single authoritative path for strict CPU proofs by making GGUF/tokenizer selection deterministic and visible in receipts.
- Prevent hidden fallbacks by requiring kernel telemetry and a deterministic tokenizer source for strict-mode runs.
- Surface requested vs selected kernel/backend and loader/tokenizer meta so CI can assert a real packed CPU decode lane was used.

### Description
- Add deterministic tokenizer authority types and resolved info (`TokenizerSource`, `ResolvedTokenizer`) and a `resolve_tokenizer_with_source` API to report the selected tokenizer source for receipts. 
- Make CLI tokenizer loading follow the strict authority order: explicit override → GGUF-embedded tokenizer → sibling/parent `tokenizer.json`, and set `BITNET_TOKENIZER_SOURCE` for later receipt emission.  
- Add CPU proof-oriented CLI flags and aliases: `--kernel`, `--backend` (alias for `--device`), `--receipt-out` (alias for `--receipt_path`), and `--strict` (alias for `--strict-loader`).
- Enforce GGUF model requirement in strict loader mode and fail fast when strict preconditions are not met (missing kernel telemetry or unresolved tokenizer source). 
- Extend inference receipt JSON with `requested_backend`, `selected_backend`, `requested_kernel`, `selected_kernel`, `fallback_used`, `fallback_reason`, `loader.mode`, and `tokenizer.source`, plus strict validation logic selecting/validating the recorded kernel.
- Add unit tests and CLI parsing tests for tokenizer discovery and the new CLI aliases/flags, and update tokenizer discovery tests to assert the reported `TokenizerSource`.

### Testing
- Ran `cargo test -p bitnet-cli --lib --features full-cli` and all unit tests passed.
- Ran `cargo test -p bitnet-cli --test cli_args_aliases --features full-cli` and the new CLI alias tests passed.
- Ran `cargo test -p bitnet-tokenizer-discovery-core` and tokenizer-discovery unit tests passed.
- Ran `cargo test -p bitnet-cli tokenizer_discovery --features full-cli` and the end-to-end tokenizer discovery tests passed. All executed tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9239cb9c83338157af6e9d493fb5)