### PR TITLE
docs: plan RTX 5070 Ti CUDA proof bench

### DIFF
--- a/ci/hardware/README.md
+++ b/ci/hardware/README.md
@@ -49,6 +49,14 @@ ci/hardware/apple-m4-mac-mini/2026-05-05/mpsgraph-smoke.json
 ci/hardware/nvidia-rtx-5070-ti/2026-05-05/cuda-probe.json
 ci/hardware/nvidia-rtx-5070-ti/2026-05-05/cuda-smoke.json
 ci/hardware/nvidia-rtx-5070-ti/2026-05-05/cuda-parity.json
+
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/machine-profile.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-probe.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/nvml-probe.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-parity.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-benchmark.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-proof.json
 ```
 
 ## Artifact Kinds
@@ -77,6 +85,10 @@ smoke.json
 parity.json
 benchmark.json
 strict-bitnet-proof.json
+cuda-probe-receipt.json
+cuda-smoke-receipt.json
+cuda-parity-receipt.json
+strict-bitnet-cuda-proof.json
 ```
 
 Templates are schema starters, not evidence. Replace every `TBD` field and write the completed receipt under `ci/hardware/<machine-id>/<date>/`.
@@ -96,14 +108,17 @@ mpsgraph-smoke.json
 cuda-probe.json
 cuda-smoke.json
 cuda-parity.json
+cuda-benchmark.json
 matmul-i2s-parity.json
 strict-cpu-proof.json
+strict-bitnet-cuda-proof.json
 sustained-cpu-benchmark.json
 ```
 
 ## Rules
 
 - Do not add binary or large artifacts to normal docs PRs.
+- Do not add raw command transcripts when a normalized JSON receipt is enough.
 - Probe artifacts cannot support execution claims.
 - Smoke artifacts cannot support parity claims.
 - Parity artifacts cannot support full inference claims.

--- a/ci/hardware/_templates/cuda-parity-receipt.json
+++ b/ci/hardware/_templates/cuda-parity-receipt.json
@@ -1,0 +1,45 @@
+{
+  "schema": 1,
+  "artifact_kind": "cuda_parity",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "TBD",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "fallback_used": false,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "cuda": {
+    "device_index": null,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "TBD",
+    "cuda_runtime_version": "TBD",
+    "cuda_toolkit_version": "TBD",
+    "vram_bytes": null
+  },
+  "parity": {
+    "reference_backend": "amd-9950x3d-cpu-avx512",
+    "target_backend": "nvidia-rtx-5070-ti-cuda",
+    "kernel_id": "TBD",
+    "fixture_id": "TBD",
+    "max_abs_error": null,
+    "mean_abs_error": null,
+    "tolerance_source": "docs/bitnet/BITNET_PARITY_TOLERANCES.md",
+    "debug_artifact_path": null
+  },
+  "kernel_stats": [
+    {
+      "kernel_id": "TBD",
+      "invocations": null,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": null,
+      "device_to_host_bytes": null,
+      "kernel_launches": null,
+      "kernel_time_ms": null
+    }
+  ],
+  "claim": "cuda_cpu_parity_tested",
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-parity.json"
+}

--- a/ci/hardware/_templates/cuda-probe-receipt.json
+++ b/ci/hardware/_templates/cuda-probe-receipt.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "artifact_kind": "cuda_probe",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "TBD",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "TBD",
+  "runtime_api": "cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "fallback_used": false,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "cuda": {
+    "available": null,
+    "device_count": null,
+    "selected_device_index": null,
+    "selected_device_name": null,
+    "compute_capability": null,
+    "driver_version": null,
+    "cuda_runtime_version": null,
+    "cuda_toolkit_version": null,
+    "nvrtc_version": null,
+    "nvml_available": null,
+    "vram_bytes": null,
+    "power_limit_watts": null,
+    "power_draw_watts": null,
+    "temperature_c": null,
+    "failure_reason": null
+  },
+  "claim": "cuda_runtime_probe_recorded",
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-probe.json"
+}

--- a/ci/hardware/_templates/cuda-smoke-receipt.json
+++ b/ci/hardware/_templates/cuda-smoke-receipt.json
@@ -1,0 +1,37 @@
+{
+  "schema": 1,
+  "artifact_kind": "cuda_smoke",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "TBD",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "fallback_used": false,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "cuda": {
+    "device_index": null,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "TBD",
+    "cuda_runtime_version": "TBD",
+    "cuda_toolkit_version": "TBD",
+    "nvrtc_version": "TBD",
+    "vram_bytes": null
+  },
+  "kernel_stats": [
+    {
+      "kernel_id": "cuda_tiny_vector_add",
+      "invocations": 1,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": null,
+      "device_to_host_bytes": null,
+      "kernel_launches": 1,
+      "kernel_time_ms": null
+    }
+  ],
+  "result": "TBD",
+  "claim": "kernel_smoke_tested",
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-smoke.json"
+}

--- a/ci/hardware/_templates/strict-bitnet-cuda-proof.json
+++ b/ci/hardware/_templates/strict-bitnet-cuda-proof.json
@@ -1,0 +1,68 @@
+{
+  "schema": 1,
+  "artifact_kind": "strict_bitnet_cuda_proof",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "TBD",
+  "claim": "strict_bitnet_cuda_inference",
+  "speedup_claim": false,
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "fallback_used": false,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "cuda": {
+    "device_index": null,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "TBD",
+    "cuda_runtime_version": "TBD",
+    "cuda_toolkit_version": "TBD",
+    "nvrtc_version": "TBD",
+    "vram_bytes": null,
+    "cuda_kernel_invocations": null
+  },
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "sha256": "TBD",
+    "format": "gguf",
+    "loader_mode": "strict",
+    "fallback_loader_used": false,
+    "tokenizer_source": "gguf|sibling-tokenizer-json|explicit"
+  },
+  "bitnet": {
+    "quantization": "W1.58A8",
+    "kernel_family": "i2_s|qk256",
+    "layout": "packed",
+    "weights_uploaded_once": true,
+    "per_token_weight_upload": false
+  },
+  "execution_coverage": {
+    "linear_layers_total": null,
+    "linear_layers_on_cuda": null,
+    "linear_layers_cpu_fallback": 0,
+    "unsupported_ops": []
+  },
+  "reference": {
+    "greedy_token_agreement": null,
+    "top1_agreement": null,
+    "max_abs_error": null,
+    "mean_abs_error": null
+  },
+  "kernel_stats": [
+    {
+      "kernel_id": "TBD",
+      "invocations": null,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": null,
+      "device_to_host_bytes": null,
+      "kernel_launches": null,
+      "kernel_time_ms": null
+    }
+  ],
+  "cpu_fallback_ops": [],
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/<date>/strict-bitnet-cuda-proof.json"
+}

--- a/docs/hardware/nvidia-rtx-5070-ti-validation.md
+++ b/docs/hardware/nvidia-rtx-5070-ti-validation.md
@@ -10,6 +10,12 @@ Roadmap:
 docs/specs/nvidia-rtx-5070-ti-roadmap.md
 ```
 
+Windows proof bench:
+
+```text
+docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+```
+
 ## Hardware Baseline
 
 - GPU: NVIDIA GeForce RTX 5070 Ti.
@@ -69,6 +75,17 @@ cargo --version
 ```powershell
 $ErrorActionPreference = "Continue"
 
+Write-Host "=== Windows ==="
+Get-ComputerInfo | Select-Object OsName, OsVersion, WindowsVersion, OsBuildNumber, CsSystemType
+
+Write-Host "=== CPU ==="
+Get-CimInstance Win32_Processor |
+  Format-List Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed
+
+Write-Host "=== Memory ==="
+Get-CimInstance Win32_PhysicalMemory |
+  Format-Table Manufacturer,Capacity,Speed,ConfiguredClockSpeed,PartNumber
+
 Write-Host "=== GPU devices ==="
 Get-PnpDevice | Where-Object {
   $_.FriendlyName -match "NVIDIA|5070|GeForce"
@@ -78,9 +95,17 @@ Write-Host "=== NVIDIA SMI ==="
 nvidia-smi
 nvidia-smi --query-gpu=name,driver_version,cuda_version,memory.total,power.limit,power.draw,temperature.gpu,compute_cap --format=csv
 
-Write-Host "=== CUDA ==="
+Write-Host "=== CUDA toolkit ==="
 where nvcc
 nvcc --version
+
+Write-Host "=== Rust ==="
+rustc --version
+cargo --version
+
+Write-Host "=== Optional WGPU / Vulkan / D3D12 ==="
+where vulkaninfo
+vulkaninfo --summary
 ```
 
 ## First CUDA Receipt
@@ -90,13 +115,16 @@ The first useful receipt is a CUDA smoke proof:
 ```json
 {
   "hardware": "nvidia-rtx-5070-ti",
-  "requested_backend": "nvidia-rtx-5070-ti",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
   "selected_backend": "nvidia-rtx-5070-ti-cuda",
   "runtime_api": "cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
   "compute_capability": "12.0",
   "vram_bytes": 17179869184,
   "driver_version": "...",
-  "cuda_version": "...",
+  "cuda_runtime_version": "...",
+  "cuda_toolkit_version": "...",
   "fallback_used": false,
   "status": "kernel_smoke_tested"
 }

--- a/docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+++ b/docs/hardware/windows-9950x3d-rtx5070ti-validation.md
@@ -1,0 +1,217 @@
+# Windows 9950X3D RTX 5070 Ti Validation Profile
+
+## Purpose
+
+This file defines the Windows proof bench that combines the AMD Ryzen 9
+9950X3D CPU reference path with the NVIDIA GeForce RTX 5070 Ti CUDA target. It
+is a machine profile and validation plan, not proof that CUDA inference works.
+
+Machine ID:
+
+```text
+windows-9950x3d-rtx5070ti
+```
+
+Related lane docs:
+
+```text
+docs/hardware/amd-9950x3d-validation.md
+docs/hardware/nvidia-rtx-5070-ti-validation.md
+docs/specs/nvidia-rtx-5070-ti-roadmap.md
+```
+
+## Role
+
+| Component | Role |
+|---|---|
+| AMD Ryzen 9 9950X3D | CPU reference path for scalar, AVX2, AVX-512, and strict model proof. |
+| NVIDIA GeForce RTX 5070 Ti 16GB | CUDA target for probe, smoke, parity, BitNet kernels, and benchmarks. |
+| Windows | Primary validation OS for this proof bench. |
+| WGPU / D3D12 / Vulkan | Optional comparison lane only; never CUDA proof. |
+
+## Backend Labels
+
+Use narrow labels in requests, selected backend summaries, and receipts:
+
+```text
+amd-9950x3d-cpu-scalar
+amd-9950x3d-cpu-avx2
+amd-9950x3d-cpu-avx512
+nvidia-rtx-5070-ti-cuda
+nvidia-rtx-5070-ti-wgpu
+```
+
+Do not collapse this machine into `gpu`, `cuda`, `nvidia`, `accelerated`, or
+`blackwell` labels. Generic `cuda` may remain available, but it is not the
+same request as `nvidia-rtx-5070-ti-cuda`.
+
+## Required Machine Facts
+
+| Field | Why it matters |
+|---|---|
+| Windows version / build | CUDA, driver, and toolchain behavior differs by Windows version. |
+| CPU model | Confirms the 9950X3D CPU reference path. |
+| CPU features | Confirms AVX2 / AVX-512 proof and fallback references. |
+| RAM amount / speed | Affects load, prefill, CPU baseline, and parity context. |
+| GPU name | Must resolve to NVIDIA GeForce RTX 5070 Ti. |
+| GPU VRAM | Expected 16GB, but receipts must record the runtime value. |
+| NVIDIA driver version | Required for CUDA reproducibility. |
+| CUDA runtime version | Required for CUDA proof. |
+| CUDA toolkit / `nvcc` version | Required for NVRTC and build debugging. |
+| Compute capability | Expected 12.0 for RTX 5070 Ti; receipts must record actual. |
+| Power limit / thermals | Required before performance claims. |
+| WGPU/D3D12/Vulkan visibility | Optional comparison lane; not CUDA proof. |
+| Rust toolchain | Needed for reproducible Codex builds. |
+
+## Windows Probe Bundle
+
+Capture this output locally when opening a machine-profile or probe work item.
+Commit only small normalized JSON receipts when the work item explicitly calls
+for them.
+
+```powershell
+$ErrorActionPreference = "Continue"
+
+Write-Host "=== Windows ==="
+Get-ComputerInfo | Select-Object OsName, OsVersion, WindowsVersion, OsBuildNumber, CsSystemType
+
+Write-Host "=== CPU ==="
+Get-CimInstance Win32_Processor |
+  Format-List Name,NumberOfCores,NumberOfLogicalProcessors,MaxClockSpeed
+
+Write-Host "=== Memory ==="
+Get-CimInstance Win32_PhysicalMemory |
+  Format-Table Manufacturer,Capacity,Speed,ConfiguredClockSpeed,PartNumber
+
+Write-Host "=== GPU devices ==="
+Get-PnpDevice | Where-Object {
+  $_.FriendlyName -match "NVIDIA|5070|GeForce"
+} | Format-List *
+
+Write-Host "=== NVIDIA SMI ==="
+nvidia-smi
+nvidia-smi --query-gpu=name,driver_version,cuda_version,memory.total,power.limit,power.draw,temperature.gpu,compute_cap --format=csv
+
+Write-Host "=== CUDA toolkit ==="
+where nvcc
+nvcc --version
+
+Write-Host "=== Rust ==="
+rustc --version
+cargo --version
+
+Write-Host "=== Optional WGPU / Vulkan / D3D12 ==="
+where vulkaninfo
+vulkaninfo --summary
+```
+
+## Artifact Paths
+
+Use ISO dates under the combined machine ID:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/machine-profile.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-probe.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/nvml-probe.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-smoke.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-parity.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-benchmark.json
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/strict-bitnet-cuda-proof.json
+```
+
+Do not commit bulky local logs, raw command transcripts, GGUFs, model files, or
+binary traces in normal docs or implementation PRs.
+
+## Claim Boundary
+
+- `nvidia-smi` visibility is not CUDA kernel execution.
+- Creating a CUDA context is not CPU/CUDA parity.
+- WGPU/D3D12/Vulkan smoke is not CUDA proof.
+- Tiny CUDA smoke is not full BitNet inference.
+- I2S matmul parity is not QK256 packed-kernel inference.
+- Dense FP16/BF16 regular-LLM CUDA kernels are not BitNet packed-kernel proof.
+- CPU fallback cannot count as CUDA execution under strict CUDA requests.
+- Full BitNet CUDA inference cannot be claimed while QK256 CUDA remains scaffold-only.
+
+## Practical Order
+
+1. Run environment sanity: `nvidia-smi`, `nvcc --version`, `rustc --version`,
+   and `cargo --version`.
+2. Implement `RTX5070TI-003` to preserve selected-device identity before probe
+   or kernel work.
+3. Implement `RTX5070TI-004` to emit a normalized CUDA/NVML probe.
+4. Implement `RTX5070TI-005` to prove a tiny CUDA kernel runs fallback-free.
+5. Implement `RTX5070TI-006` to compare an existing CUDA kernel against the
+   9950X3D CPU reference path.
+6. Implement receipt counters and benchmark baselines only after parity.
+7. Start the `CUDA-BITNET-*` wave only after CUDA receipts are hard to fake.
+
+If CUDA compilation fails during sanity checks, capture driver version, CUDA
+toolkit version, cudarc/NVRTC errors, `PATH`, `CUDA_PATH`, and the Rust target
+triple before changing CUDA kernels.
+
+## First CUDA Probe Receipt
+
+```json
+{
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "fallback_used": false,
+  "cuda": {
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "TBD",
+    "cuda_runtime_version": "TBD",
+    "cuda_toolkit_version": "TBD",
+    "vram_bytes": 17179869184
+  },
+  "claim": "cuda_runtime_probe_recorded"
+}
+```
+
+This receipt is runtime identity only. It must not claim kernel execution.
+
+## First Kernel Smoke Receipt
+
+```json
+{
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "kernel_id": "cuda_tiny_vector_add",
+  "fallback_used": false,
+  "result": "pass",
+  "claim": "kernel_smoke_tested"
+}
+```
+
+This receipt proves a tiny CUDA kernel only. It must not claim BitNet inference
+or speedup.
+
+## Strict BitNet CUDA Proof Target
+
+Later BitNet CUDA receipts must add model, tokenizer, quantization, kernel
+family, execution phase, fallback, and coverage fields:
+
+```json
+{
+  "claim": "strict_bitnet_cuda_inference",
+  "model": "microsoft/bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf",
+  "tokenizer_source": "gguf|sibling-tokenizer-json|explicit",
+  "quantization": "W1.58A8",
+  "kernel_family": "i2_s|qk256",
+  "execution_phase": "end_to_end_inference",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "fallback_used": false,
+  "cuda_kernel_invocations": 1,
+  "cpu_fallback_ops": []
+}
+```
+
+The first strict BitNet CUDA proof should set `speedup_claim=false`.

--- a/docs/specs/nvidia-rtx-5070-ti-roadmap.md
+++ b/docs/specs/nvidia-rtx-5070-ti-roadmap.md
@@ -13,6 +13,23 @@ nvidia-rtx-5070-ti-wgpu
 
 The first useful milestone is CUDA kernel smoke with a receipt proving `selected_backend=nvidia-rtx-5070-ti-cuda` and `fallback_used=false`.
 
+## Current Implementation Boundary
+
+The CUDA lane is scaffolded infrastructure, not a working CUDA inference path.
+The existing CUDA provider can create a cudarc context, compile CUDA source
+with NVRTC, and load kernel-provider-level functions such as I2S matmul and
+quantization helpers. That is not proof that the transformer forward path
+routes BitNet inference through CUDA.
+
+QK256 CUDA is explicitly scaffold-only until the packed kernel path is
+implemented and wired. Any `launch_qk256_gemv` path that returns an explicit
+"scaffold only" or "not yet compiled" error must block full 1-bit BitNet CUDA
+claims.
+
+The first CUDA lane can progress through device probe, tiny kernel smoke, and
+I2S/matmul parity before full BitNet inference. Full inference requires the
+later `CUDA-BITNET-*` work items.
+
 ## Hardware Baseline
 
 Expected RTX 5070 Ti facts:
@@ -33,6 +50,29 @@ Expected RTX 5070 Ti facts:
 
 Board partner cards may vary in clocks, cooling, and power limits. Receipts must record the actual board and runtime-reported values.
 
+## Windows Proof Bench
+
+The primary Windows CUDA proof bench combines:
+
+| Component | Role |
+|---|---|
+| AMD Ryzen 9 9950X3D | CPU reference path for scalar, AVX2, AVX-512, and strict model proof. |
+| NVIDIA GeForce RTX 5070 Ti 16GB | CUDA target for probe, smoke, parity, BitNet kernels, and benchmark receipts. |
+| Windows | Primary validation OS for this box. |
+| WGPU / D3D12 / Vulkan | Optional comparison lane only; never CUDA proof. |
+
+Machine profile:
+
+```text
+docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+```
+
+Receipt machine ID:
+
+```text
+windows-9950x3d-rtx5070ti
+```
+
 ## Claim Boundary
 
 - PCI detection is not CUDA runtime proof.
@@ -42,6 +82,9 @@ Board partner cards may vary in clocks, cooling, and power limits. Receipts must
 - CUDA proof is not wgpu/Vulkan proof.
 - wgpu/Vulkan smoke is not CUDA kernel proof.
 - CPU fallback cannot count as CUDA execution.
+- Dense FP16/BF16 regular-LLM CUDA kernels are not BitNet packed-kernel proof.
+- I2S CUDA parity is not QK256 CUDA inference.
+- Full BitNet CUDA inference cannot be claimed while QK256 CUDA is scaffold-only.
 
 ## Runtime Paths
 
@@ -76,15 +119,23 @@ Minimum CUDA receipt:
 
 ```json
 {
-  "requested_backend": "nvidia-rtx-5070-ti",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
   "selected_backend": "nvidia-rtx-5070-ti-cuda",
   "runtime_api": "cuda",
-  "compute_capability": "12.0",
-  "vram_bytes": 17179869184,
-  "driver_version": "...",
-  "cuda_version": "...",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
   "fallback_backend": null,
-  "fallback_used": false
+  "fallback_used": false,
+  "cuda": {
+    "device_index": 0,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "...",
+    "cuda_runtime_version": "...",
+    "cuda_toolkit_version": "...",
+    "nvrtc_version": "...",
+    "vram_bytes": 17179869184
+  }
 }
 ```
 
@@ -98,6 +149,51 @@ Minimum wgpu receipt:
   "backend_api": "vulkan|d3d12",
   "adapter_name": "NVIDIA GeForce RTX 5070 Ti",
   "fallback_used": false
+}
+```
+
+Minimum CUDA kernel stats:
+
+```json
+{
+  "kernel_stats": [
+    {
+      "kernel_id": "cuda_tiny_vector_add",
+      "invocations": 1,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": 4096,
+      "device_to_host_bytes": 4096,
+      "kernel_launches": 1,
+      "kernel_time_ms": null
+    }
+  ]
+}
+```
+
+Strict BitNet CUDA proof receipts must also preserve:
+
+```json
+{
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "loader_mode": "strict",
+    "fallback_loader_used": false
+  },
+  "bitnet": {
+    "quantization": "W1.58A8",
+    "kernel_family": "i2_s|qk256",
+    "layout": "packed",
+    "weights_uploaded_once": true,
+    "per_token_weight_upload": false
+  },
+  "execution_coverage": {
+    "linear_layers_total": 0,
+    "linear_layers_on_cuda": 0,
+    "linear_layers_cpu_fallback": 0,
+    "unsupported_ops": []
+  },
+  "speedup_claim": false
 }
 ```
 
@@ -159,12 +255,86 @@ Compare CPU against RTX 5070 Ti CUDA for the validated kernel/subgraph.
 
 Run a tiny wgpu/Vulkan/D3D12 shader smoke as a cross-platform reference path.
 
+## BitNet CUDA Implementation Wave
+
+Start these only after `RTX5070TI-003` through `RTX5070TI-008` make CUDA
+identity, probe, smoke, parity, receipts, and benchmark baselines durable.
+
+### CUDA-BITNET-001 - Persistent Context and Weight Handles
+
+Create a CUDA BitNet context with persistent device, stream, weight handles,
+activation workspace, and stats. Weights must be uploadable once, and receipts
+must record `per_token_weight_upload=false`.
+
+### CUDA-BITNET-002 - Reusable CUDA I2S Linear Primitive
+
+Turn existing I2S CUDA matmul into a reusable backend primitive for real layer
+shapes. It must handle tails and padding, match CPU reference, and record
+kernel IDs and invocation stats.
+
+### CUDA-BITNET-003 - CUDA QK256 Fused Dequant GEMV
+
+Replace the scaffold-only QK256 launch path with a real fused packed-weight
+dequant plus GEMV kernel. It must support official BitNet GGUF shapes and pass
+CPU QK256 scalar parity before any full inference claim.
+
+### CUDA-BITNET-004 - Prepack and Upload BitNet Weights Once
+
+At strict GGUF load time, validate BitNet layout, pack or normalize weights for
+CUDA, upload them once, and store per-layer CUDA weight handles. Decode must not
+repack or upload weights per token.
+
+### CUDA-BITNET-005 - Route BitNetLinear Through CUDA
+
+Wire the actual transformer forward path so `BitNetLinear` dispatches through
+the selected CUDA backend. Strict CUDA mode must fail on unsupported CPU
+fallback and coverage counters must record total, CUDA-routed, and fallback
+linear layers.
+
+### CUDA-BITNET-006 - One-Token Strict BitNet CUDA Proof
+
+Run the official GGUF in strict mode for one greedy token. The proof must record
+CUDA kernel invocation count greater than zero, CPU fallback count zero,
+CPU/CUDA greedy or top-1 parity, and `speedup_claim=false`.
+
+### CUDA-BITNET-007 - Short Decode BitNet CUDA Proof
+
+Extend the one-token proof to a short greedy decode and record prefill,
+first-token, steady-state decode timing, CUDA memory high-water mark, kernel
+invocations, and CPU fallback operations.
+
+### CUDA-BITNET-008 - BitNet CUDA Benchmark Baseline
+
+Benchmark only after correctness. Compare 9950X3D CPU scalar, AVX2, AVX-512,
+and RTX 5070 Ti CUDA on the same model, tokenizer, prompt profile, strict
+loader mode, and fallback-free receipt.
+
+## Dense CUDA Reference Lane
+
+Regular LLM CUDA support is useful, but it is separate from BitNet packed-kernel
+proof. A future dense lane may share device selection, probes, context lifetime,
+allocator, workspace, stats, parity harness, and benchmark protocol, but FP16,
+BF16, or INT8 dense kernels must be labeled as `dense_regular_llm`, not BitNet
+packed inference.
+
+## GitHub Issue Tracking
+
+After this roadmap lands, create or link GitHub issues with titles that begin
+with the work item ID, for example
+`RTX5070TI-003: Preserve RTX 5070 Ti CUDA backend identity`. Each issue should link back to
+`docs/tracking/bitnet-alignment/workstream-ledger.yaml`, copy the acceptance
+criteria for that item, and record the PR that advances it. Do not combine
+distinct proof stages into one implementation PR.
+
 ## Do Not
 
 - Do not make CUDA a generic GPU claim.
 - Do not count CPU fallback as CUDA execution.
 - Do not count wgpu/Vulkan smoke as CUDA kernel proof.
 - Do not omit compute capability from receipts.
+- Do not leave QK256 CUDA scaffold-only while claiming full 1-bit inference.
+- Do not upload weights every token and call it real inference.
+- Do not use dense regular-LLM CUDA kernels as BitNet packed-kernel proof.
 - Do not make benchmark claims without driver, CUDA, VRAM, power, and temperature context.
 
 ## Related Contract Docs
@@ -173,3 +343,8 @@ Run a tiny wgpu/Vulkan/D3D12 shader smoke as a cross-platform reference path.
 - `docs/hardware/PROOF_STAGES.md`
 - `docs/hardware/LANE_OWNERSHIP.md`
 - `docs/hardware/BENCHMARK_PROTOCOL.md`
+- `docs/hardware/windows-9950x3d-rtx5070ti-validation.md`
+- `ci/hardware/_templates/cuda-probe-receipt.json`
+- `ci/hardware/_templates/cuda-smoke-receipt.json`
+- `ci/hardware/_templates/cuda-parity-receipt.json`
+- `ci/hardware/_templates/strict-bitnet-cuda-proof.json`

--- a/docs/tracking/bitnet-alignment/backend-status.yaml
+++ b/docs/tracking/bitnet-alignment/backend-status.yaml
@@ -285,15 +285,20 @@ backends:
       - Native path is CUDA first.
       - CUDA compute capability is 12.0.
       - Expected memory is 16 GB GDDR7 on a 256-bit bus.
+      - Primary proof bench is windows-9950x3d-rtx5070ti with AMD Ryzen 9 9950X3D as the CPU reference path.
+      - Existing CUDA code is kernel-provider-level infrastructure, not proof that the real transformer inference path routes through CUDA.
+      - QK256 CUDA remains scaffold-only until a real packed fused dequant GEMV kernel is implemented and wired.
       - CPU fallback cannot count as CUDA execution.
     blockers:
-      - Add 5070 Ti machine profile.
+      - Collect normalized Windows 9950X3D plus RTX 5070 Ti machine profile receipt.
       - Add CUDA runtime and NVML probe.
       - Add strict selected-device identity.
       - Add CUDA kernel smoke.
       - Add CPU/CUDA parity.
-      - Add receipt fields for CUDA runtime, driver, compute capability, VRAM, power, and fallback.
+      - Add receipt fields for CUDA runtime, driver, compute capability, VRAM, power, fallback, and kernel invocation counts.
       - Add benchmark baseline.
+      - Add persistent CUDA BitNet context and upload-once weight handles.
+      - Replace scaffold-only QK256 CUDA with a real packed-kernel path before full BitNet inference claims.
 
   nvidia_rtx_5070_ti_wgpu:
     status: scaffold
@@ -301,11 +306,23 @@ backends:
       - Cross-platform reference path through wgpu/Vulkan/D3D12.
       - WGPU smoke is not CUDA kernel proof.
       - Useful for shader portability and non-CUDA comparison.
+      - This lane must preserve selected backend identity as nvidia-rtx-5070-ti-wgpu and must not satisfy CUDA proof items.
     blockers:
       - Add wgpu adapter probe.
       - Add tiny shader smoke.
       - Add CPU/wgpu parity.
       - Record backend API, adapter name, driver, and fallback status.
+
+  cuda_dense_regular_llm:
+    status: not_present
+    notes:
+      - Future CUDA reference lane for regular FP16/BF16/INT8 dense LLM kernels.
+      - Can share CUDA probe, context, allocator, workspace, stats, parity, receipts, and benchmark protocol.
+      - Dense regular-LLM kernels cannot count as BitNet packed I2S or QK256 proof.
+    blockers:
+      - Complete RTX 5070 Ti CUDA receipt and kernel counter work first.
+      - Add dense FP16/BF16 or cuBLAS-backed matmul parity.
+      - Label receipts as dense_regular_llm rather than BitNet packed-kernel proof.
 
   rocm:
     status: scaffold

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -1,10 +1,10 @@
 # bitnet-rs Alignment Status
 
-Updated: 2026-05-05
+Updated: 2026-05-06
 
 ## Current Focus
 
-Real BitNet CPU path sequencing after the #3625 hardware and BitNet contract merge. Apple Silicon M4-002 is merged; the next Apple Silicon item is M4-003 backend identity, before Metal probes, kernels, MPSGraph execution, parity, receipts, or benchmarks.
+Real BitNet CPU path sequencing remains active, and the NVIDIA CUDA proof bench is now documented as a separate staged lane. The next NVIDIA item is `RTX5070TI-003` backend identity, before CUDA/NVML probing, kernel smoke, parity, receipts, benchmarks, or BitNet CUDA inference work.
 
 ## Active / Coordination Queue
 
@@ -112,6 +112,12 @@ The Apple Silicon implementation order is M4-002 machine profile, M4-003 backend
 ## NVIDIA CUDA Boundary
 
 The RTX 5070 Ti lane is CUDA-first, with wgpu/Vulkan/D3D12 as a cross-platform reference lane. CUDA visibility is not kernel execution, WGPU smoke is not CUDA proof, CPU fallback cannot count as CUDA execution, and performance claims require driver, CUDA version, compute capability, VRAM, power, and thermal context.
+
+The Windows CUDA proof bench is `windows-9950x3d-rtx5070ti`: AMD Ryzen 9 9950X3D is the CPU reference path and NVIDIA GeForce RTX 5070 Ti is the CUDA target. Receipts should use narrow backend labels such as `amd-9950x3d-cpu-avx512`, `nvidia-rtx-5070-ti-cuda`, and `nvidia-rtx-5070-ti-wgpu`; generic `gpu`, `cuda`, `nvidia`, `accelerated`, or `blackwell` labels are not enough for strict proof.
+
+The current CUDA code is scaffolded kernel-provider infrastructure, not end-to-end CUDA inference. QK256 CUDA is scaffold-only until the packed fused dequant GEMV path is implemented and wired. The staged order is `RTX5070TI-003` backend identity, `RTX5070TI-004` CUDA/NVML probe, `RTX5070TI-005` tiny CUDA kernel smoke, `RTX5070TI-006` CPU/CUDA parity, `RTX5070TI-007` receipt/kernel counters, and `RTX5070TI-008` benchmark baseline. Only after those land should the `CUDA-BITNET-001` through `CUDA-BITNET-008` wave start persistent CUDA BitNet context, upload-once weights, reusable I2S linear, real QK256 CUDA, BitNetLinear routing, one-token strict proof, short decode proof, and full benchmark baselines.
+
+Dense regular-LLM CUDA work is useful as a future `CUDA-DENSE-001` reference lane, but it must be labeled as dense regular LLM execution and cannot claim BitNet packed I2S/QK256 inference.
 
 ## Tracker Notes
 

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1,6 +1,6 @@
 schema: 1
 project: bitnet-rs-alignment
-updated: 2026-05-05
+updated: 2026-05-06
 
 states:
   - proposed
@@ -2124,23 +2124,31 @@ items:
       - RTX5070TI-001
     scope:
       allowed_paths:
-        - crates/bitnet-common/src/types.rs
+        - crates/bitnet-common/src/backend_selection.rs
+        - crates/bitnet-common/src/kernel_registry.rs
         - crates/bitnet-device-config-core/src/lib.rs
-        - crates/bitnet-inference/src/backends.rs
         - crates/bitnet-cli-config-core/src/lib.rs
         - crates/bitnet-cli/src/main.rs
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
+        - crates/bitnet-kernels/src/gpu/kernels/**
+        - crates/bitnet-kernels/src/cuda/qk256_gemv.rs
+        - crates/bitnet-quantization/**
         - crates/bitnet-quantization/src/qk256/**
         - crates/bitnet-qk256-dispatch/**
+        - crates/bitnet-transformer/**
         - crates/bitnet-server/**
     acceptance:
-      - Requested backend can distinguish generic CUDA from RTX 5070 Ti when selected by explicit flag or device probe.
-      - Logs and receipts preserve requested backend and selected backend separately.
+      - nvidia-rtx-5070-ti-cuda parses as a distinct backend request.
+      - nvidia-rtx-5070-ti-wgpu parses as a distinct reference backend request.
+      - Generic cuda can still exist and remains distinguishable from nvidia-rtx-5070-ti-cuda.
+      - Logs and planned receipts preserve requested backend, selected backend, runtime API, fallback status, and fallback reason.
       - Strict mode fails if RTX 5070 Ti CUDA is requested but unavailable.
+      - No CUDA kernel execution is claimed.
     verification:
       - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-common --no-default-features --features cpu
       - cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu
 
   - id: RTX5070TI-004
@@ -2153,14 +2161,22 @@ items:
     scope:
       allowed_paths:
         - crates/bitnet-device-probe/**
+        - crates/bitnet-cli/src/main.rs
+        - xtask/**
+        - ci/hardware/_templates/cuda-probe-receipt.json
         - docs/tracking/bitnet-alignment/backend-status.yaml
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
         - crates/bitnet-server/**
     acceptance:
+      - Probe can create a CUDA context for the selected device.
       - Probe reports CUDA runtime visibility, NVIDIA driver, CUDA version, compute capability, device name, VRAM, power limit, and temperature when available.
       - Probe reports NVML visibility when available.
+      - Probe records CUDA toolkit and NVRTC version where available.
+      - Probe verifies selected CUDA device identity against NVIDIA GeForce RTX 5070 Ti when requested.
+      - CPU fallback is not counted as probe success.
+      - Probe does not claim kernel execution.
       - Fake detection is ignored in strict mode.
     verification:
       - cargo fmt --all -- --check
@@ -2177,6 +2193,7 @@ items:
       allowed_paths:
         - crates/bitnet-kernels/src/cuda/**
         - crates/bitnet-kernels/tests/**
+        - ci/hardware/_templates/cuda-smoke-receipt.json
         - docs/tracking/bitnet-alignment/backend-status.yaml
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -2185,9 +2202,12 @@ items:
         - crates/bitnet-qk256-dispatch/**
         - crates/bitnet-server/**
     acceptance:
-      - Tiny CUDA kernel compiles and executes on RTX 5070 Ti.
+      - Tiny CUDA kernel compiles with NVRTC and executes on RTX 5070 Ti.
+      - Output matches CPU expected result.
+      - Receipt records kernel_id and fallback_used=false.
       - Strict mode fails if CPU fallback is used.
       - Smoke output records selected device name, compute capability 12.0, CUDA version, driver version, VRAM, and fallback status.
+      - No BitNet inference claim or speedup claim is made.
     verification:
       - cargo fmt --all -- --check
       - Manual RTX 5070 Ti CUDA smoke command with receipt artifact.
@@ -2204,6 +2224,7 @@ items:
         - crates/bitnet-kernels/**
         - crates/bitnet-inference/**
         - tests/**
+        - ci/hardware/_templates/cuda-parity-receipt.json
         - docs/tracking/bitnet-alignment/backend-status.yaml
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -2211,8 +2232,10 @@ items:
         - crates/bitnet-server/**
     acceptance:
       - One isolated kernel or subgraph runs on RTX 5070 Ti through CUDA.
+      - Same input fixture goes through 9950X3D CPU reference and RTX 5070 Ti CUDA target.
       - CPU reference parity records max_abs_error and mean_abs_error.
-      - Receipt records selected CUDA backend and fallback status.
+      - Receipt records kernel ID, selected CUDA device, selected CUDA backend, and fallback status.
+      - Mismatch produces a debug artifact.
       - No full CUDA inference claim is made from isolated parity.
     verification:
       - cargo fmt --all -- --check
@@ -2231,12 +2254,18 @@ items:
         - crates/bitnet-receipts-core/**
         - crates/bitnet-bench-receipts/**
         - crates/bitnet-kernels/**
+        - ci/hardware/_templates/cuda-smoke-receipt.json
+        - ci/hardware/_templates/cuda-parity-receipt.json
         - docs/tracking/bitnet-alignment/status.md
         - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
         - crates/bitnet-server/**
     acceptance:
       - Receipts record requested backend, selected backend, CUDA runtime, driver, CUDA version, compute capability, VRAM, power, fallback status, and kernel IDs.
+      - CUDA smoke and parity receipts validate.
+      - Kernel invocation count is greater than zero for CUDA proof.
+      - fallback_invocations equals zero for strict CUDA proof.
+      - Host-to-device bytes, device-to-host bytes, kernel launches, and optional kernel time are recorded.
       - Strict RTX 5070 Ti CUDA validation fails if fallback was used.
       - CPU fallback remains visible when allowed in auto mode.
     verification:
@@ -2262,6 +2291,8 @@ items:
         - crates/bitnet-server/**
     acceptance:
       - Benchmark compares CPU against RTX 5070 Ti CUDA for the validated kernel or subgraph.
+      - Benchmark profiles include cuda_tiny_smoke, cuda_fp32_matmul_small, cuda_i2s_matmul_small, cuda_i2s_matmul_medium, and cuda_transfer_h2d_d2h.
+      - Benchmark separates CPU reference time, CUDA total time, CUDA kernel time, host-to-device time, and device-to-host time.
       - Receipt records driver, CUDA version, compute capability, VRAM, power, temperature, selected backend, and fallback status.
       - Performance claim only appears if benchmark artifact exists.
     verification:
@@ -2294,6 +2325,301 @@ items:
     verification:
       - cargo fmt --all -- --check
       - Manual RTX 5070 Ti wgpu smoke command with receipt artifact.
+
+  - id: CUDA-BITNET-001
+    title: Add persistent CUDA BitNet context and weight handles
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - RTX5070TI-007
+    scope:
+      allowed_paths:
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-kernels/src/lib.rs
+        - crates/bitnet-inference/**
+        - crates/bitnet-common/src/backend_selection.rs
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - CUDA context and stream persist across inference.
+      - Weights can be uploaded once and referenced by CUDA weight handles.
+      - Reusable activation workspace exists for decode-time buffers.
+      - Receipts can record weights_uploaded_once=true and per_token_weight_upload=false.
+      - CPU-only builds still compile.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-kernels --no-default-features --features cpu
+      - cargo test --locked -p bitnet-kernels --no-default-features --features cuda
+    notes:
+      - This creates CUDA lifetime infrastructure only; it must not claim full BitNet inference.
+    followups:
+      - CUDA-BITNET-002
+      - CUDA-BITNET-003
+
+  - id: CUDA-BITNET-002
+    title: Add reusable CUDA I2S linear primitive
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-001
+    scope:
+      allowed_paths:
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-kernels/tests/**
+        - crates/bitnet-quantization/**
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Real layer shapes are supported.
+      - Tails and padding are handled.
+      - CPU/CUDA parity passes for the I2S primitive.
+      - Kernel invocation stats are recorded.
+      - Weights are not allocated or uploaded per token.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-kernels --no-default-features --features cuda
+      - Manual RTX 5070 Ti I2S parity command with receipt artifact.
+    notes:
+      - I2S primitive parity is not QK256 proof and is not full inference proof.
+    followups:
+      - CUDA-BITNET-004
+
+  - id: CUDA-BITNET-003
+    title: Implement CUDA QK256 fused dequant GEMV
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-001
+    scope:
+      allowed_paths:
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-kernels/tests/**
+        - crates/bitnet-quantization/**
+        - crates/bitnet-qk256-dispatch/**
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Scaffold-only QK256 launch path is replaced with a real compiled CUDA kernel.
+      - Packed QK256 weights and scale blocks are consumed without materializing full FP32 weights.
+      - Official BitNet GGUF layer shapes are supported.
+      - CPU QK256 scalar parity passes.
+      - Receipt records qk256_cuda kernel ID and fallback_used=false.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-kernels --no-default-features --features cuda
+      - Manual RTX 5070 Ti QK256 parity command with receipt artifact.
+    notes:
+      - This is the packed-kernel blocker for strict BitNet CUDA inference claims.
+    followups:
+      - CUDA-BITNET-004
+
+  - id: CUDA-BITNET-004
+    title: Prepack and upload BitNet weights once for CUDA
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-002
+      - CUDA-BITNET-003
+    scope:
+      allowed_paths:
+        - crates/bitnet-models/**
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-inference/**
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Strict GGUF load validates BitNet layout before CUDA upload.
+      - Per-layer CUDA weight handles exist.
+      - Decode path does not repack or upload weights per token.
+      - Receipt records packed_at_load=true and uploaded_once=true.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-models --no-default-features --features cpu
+      - cargo test --locked -p bitnet-inference --no-default-features --features cpu,cuda
+    notes:
+      - This does not claim full CUDA inference until BitNetLinear dispatch is routed through CUDA.
+    followups:
+      - CUDA-BITNET-005
+
+  - id: CUDA-BITNET-005
+    title: Route BitNetLinear through CUDA backend
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-004
+    scope:
+      allowed_paths:
+        - crates/bitnet-transformer/**
+        - crates/bitnet-inference/**
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-common/src/backend_selection.rs
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Actual transformer forward path invokes CUDA for BitNetLinear.
+      - Strict CUDA mode fails on unsupported CPU fallback.
+      - Coverage counters record total, CUDA-routed, and CPU-fallback BitNet linear layers.
+      - If only some layers route to CUDA, receipts label it as CUDA inference contribution, not full CUDA inference.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-transformer --no-default-features --features cpu,cuda
+      - cargo test --locked -p bitnet-inference --no-default-features --features cpu,cuda
+    notes:
+      - This is the real integration point for CUDA inference routing.
+    followups:
+      - CUDA-BITNET-006
+
+  - id: CUDA-BITNET-006
+    title: Add strict one-token BitNet CUDA proof
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-005
+    scope:
+      allowed_paths:
+        - crates/bitnet-cli/**
+        - crates/bitnet-inference/**
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - ci/hardware/**
+        - docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Official GGUF loads in strict mode.
+      - One token is generated greedily.
+      - CUDA kernel invocation count is greater than zero.
+      - CPU fallback count is zero.
+      - CPU/CUDA greedy or top-1 parity is recorded.
+      - Receipt records fallback_used=false and speedup_claim=false.
+    verification:
+      - cargo fmt --all -- --check
+      - Manual RTX 5070 Ti strict one-token BitNet CUDA proof with receipt artifact.
+    notes:
+      - The first proof must not claim speedup.
+    followups:
+      - CUDA-BITNET-007
+
+  - id: CUDA-BITNET-007
+    title: Add short decode BitNet CUDA proof
+    state: proposed
+    priority: P1
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-006
+    scope:
+      allowed_paths:
+        - crates/bitnet-cli/**
+        - crates/bitnet-inference/**
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - ci/hardware/**
+        - docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Short greedy decode succeeds.
+      - Prefill, first-token, and decode timing are recorded.
+      - CUDA kernel invocations, CPU fallback operations, and CUDA memory high-water mark are recorded.
+      - fallback_used=false.
+    verification:
+      - cargo fmt --all -- --check
+      - Manual RTX 5070 Ti short decode BitNet CUDA proof with receipt artifact.
+    notes:
+      - Short decode proof is correctness and instrumentation first, not a speedup claim.
+    followups:
+      - CUDA-BITNET-008
+
+  - id: CUDA-BITNET-008
+    title: Add RTX 5070 Ti BitNet CUDA benchmark baseline
+    state: proposed
+    priority: P2
+    workstream: nvidia_cuda
+    depends_on:
+      - CUDA-BITNET-007
+    scope:
+      allowed_paths:
+        - crates/bitnet-kernels/benches/**
+        - crates/bitnet-bench-receipts/**
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - ci/hardware/**
+        - docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - Benchmarks compare 9950X3D CPU scalar, AVX2, AVX-512, and RTX 5070 Ti CUDA.
+      - Same model, tokenizer, prompt profile, generated token count, and strict loader mode are used.
+      - Driver, CUDA, VRAM, power, and thermal context are recorded.
+      - Speedup claim appears only if the same-model fallback-free receipt proves it.
+    verification:
+      - cargo fmt --all -- --check
+      - Manual RTX 5070 Ti BitNet CUDA benchmark with receipt artifact.
+    notes:
+      - This is the first work item allowed to make performance claims, and only with matching receipts.
+    followups: []
+
+  - id: CUDA-DENSE-001
+    title: Add regular LLM CUDA dense-kernel reference lane
+    state: proposed
+    priority: P2
+    workstream: nvidia_cuda
+    depends_on:
+      - RTX5070TI-007
+    scope:
+      allowed_paths:
+        - crates/bitnet-kernels/src/cuda/**
+        - crates/bitnet-inference/**
+        - crates/bitnet-receipts/**
+        - crates/bitnet-receipts-core/**
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-server/**
+    acceptance:
+      - FP16/BF16 dense matmul or cuBLAS-backed path has CPU parity.
+      - RMSNorm, RoPE, and KV-cache CUDA helpers are shared where useful.
+      - Receipts label the path as dense_regular_llm, not BitNet packed-kernel proof.
+      - Dense-lane receipts cannot satisfy CUDA-BITNET packed I2S/QK256 acceptance criteria.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-kernels --no-default-features --features cuda
+    notes:
+      - This lane is separate from strict BitNet CUDA inference.
+    followups: []
 
   - id: AMD9950X3D-001
     title: Add AMD Ryzen 9 9950X3D CPU validation lane


### PR DESCRIPTION
## Summary
- add the Windows 9950X3D + RTX 5070 Ti proof-bench profile
- add CUDA-specific probe, smoke, parity, and strict BitNet proof receipt templates
- extend the NVIDIA CUDA roadmap/status/ledger with RTX5070TI-003 through benchmark sequencing, CUDA-BITNET-001 through CUDA-BITNET-008, and CUDA-DENSE-001

## Validation
- JSON templates parsed with PowerShell ConvertFrom-Json
- YAML trackers parsed with Python yaml.safe_load
- git diff --cached --check

## Notes
- cargo fmt --all -- --check is blocked on Windows by os error 206 before formatting runs
- targeted cargo fmt for the touched planning packages is blocked by pre-existing newline style in crates/bitnet-cli/src/commands/serve.rs, which this docs PR does not touch