### PR TITLE
docs: sync CPU-BITNET-001 merge status

### DIFF
--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -137,6 +137,7 @@ HW-002 remains proposed. #3625 added `ci/hardware/README.md` with artifact namin
 | INV-001 | #3632 | 457b36630906f2044e406e0dcf27ecb539e8a7a5 | Crate consolidation inventory completed for all workspace members. |
 | CPU-001 | #3635 | d90f70f4410155077ffc9741e018e5d747d40a9f | Strict CPU proof command documented. |
 | CPU-BITNET-000 | #3642 | c5f3480ac90cccfd1aec9766ae4628fd7e9fd3c3 | Real BitNet CPU path implementation plan merged. |
+| CPU-BITNET-001 | #3651 | 5bf32dc335a52aeab5a790d3811a57dc06ed0d3d | Strict real GGUF loader authority merged. |
 | HW-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Shared hardware validation matrix and proof-stage contract merged. |
 | HW-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Hardware artifact naming policy merged. |
 | BITNET-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | BitNet model/kernel/receipt proof contract merged. |

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -488,7 +488,7 @@ items:
 
   - id: CPU-BITNET-001
     title: Establish strict BitNet GGUF loader authority
-    state: proposed
+    state: merged
     priority: P0
     workstream: runtime_cpu
     depends_on:


### PR DESCRIPTION
## Summary
- mark `CPU-BITNET-001` merged in the BitNet alignment ledger
- add the #3651 merge SHA to `docs/tracking/bitnet-alignment/status.md`

## Validation
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/tracking/bitnet-alignment/workstream-ledger.yaml').read_text()); print('workstream-ledger.yaml ok')"`
- `git diff --check`