### PR TITLE
[codex][tracker-infra] Add campaign tracker gates (TRACKER-001)

### DIFF
--- a/.codex/bitnet-alignment.md
+++ b/.codex/bitnet-alignment.md
@@ -6,17 +6,31 @@ Campaign goals:
 
 - `apple-m4`: `.codex/campaigns/apple-m4/goal.md`
 - `cpu-proof`: `.codex/campaigns/cpu-proof/goal.md`
+- `cpu-qk256-performance`: `.codex/campaigns/cpu-qk256-performance/goal.md`
 - `intel-a770`: `.codex/campaigns/intel-a770/goal.md`
 - `intel-npu`: `.codex/campaigns/intel-npu/goal.md`
+- `intel-258v-platform`: `.codex/campaigns/intel-258v-platform/goal.md`
+- `nvidia-5070ti`: `.codex/campaigns/nvidia-5070ti/goal.md`
+- `amd-cpu-baselines`: `.codex/campaigns/amd-cpu-baselines/goal.md`
 - `crate-collapse`: `.codex/campaigns/crate-collapse/goal.md`
+- `server-real-inference`: `.codex/campaigns/server-real-inference/goal.md`
+- `ci-coverage`: `.codex/campaigns/ci-coverage/goal.md`
+- `tracker-infra`: `.codex/campaigns/tracker-infra/goal.md`
 
 Campaign manifests:
 
 - `apple-m4`: `docs/tracking/campaigns/apple-m4/active.toml`
 - `cpu-proof`: `docs/tracking/campaigns/cpu-proof/active.toml`
+- `cpu-qk256-performance`: `docs/tracking/campaigns/cpu-qk256-performance/active.toml`
 - `intel-a770`: `docs/tracking/campaigns/intel-a770/active.toml`
 - `intel-npu`: `docs/tracking/campaigns/intel-npu/active.toml`
+- `intel-258v-platform`: `docs/tracking/campaigns/intel-258v-platform/active.toml`
+- `nvidia-5070ti`: `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+- `amd-cpu-baselines`: `docs/tracking/campaigns/amd-cpu-baselines/active.toml`
 - `crate-collapse`: `docs/tracking/campaigns/crate-collapse/active.toml`
+- `server-real-inference`: `docs/tracking/campaigns/server-real-inference/active.toml`
+- `ci-coverage`: `docs/tracking/campaigns/ci-coverage/active.toml`
+- `tracker-infra`: `docs/tracking/campaigns/tracker-infra/active.toml`
 
 Rules:
 
@@ -27,7 +41,9 @@ Rules:
 - Do not edit global dashboards by hand.
 - Do not delete hardware lane visibility.
 - Add follow-up items instead of broadening a PR.
+- Use `cargo run -p xtask --no-default-features -- campaign check <campaign>` before opening a tracker PR.
+- Use `cargo run -p xtask --no-default-features -- campaign generate` to refresh dashboards; do not hand-edit generated files.
 
 Transition note:
 
-`docs/tracking/bitnet-alignment/workstream-ledger.yaml` and `docs/tracking/bitnet-alignment/status.md` remain transition trackers until generator/checker tooling makes campaign manifests authoritative. New planning work should prefer `docs/tracking/campaigns/**` and generated dashboards.
+`docs/tracking/bitnet-alignment/workstream-ledger.yaml` and `docs/tracking/bitnet-alignment/status.md` are transition surfaces. Normal item PRs should use campaign-local manifests and events once generated dashboards are available.

--- a/.codex/campaigns/amd-cpu-baselines/goal.md
+++ b/.codex/campaigns/amd-cpu-baselines/goal.md
@@ -1,0 +1,1 @@
+Use the AMD CPU baselines campaign to validate 5700X and 9950X3D CPU behavior with scalar, AVX2, AVX-512, cache, memory, and sustained-power context. Keep 5700X and 9950X3D claims separate, never claim AVX-512 on 5700X, and do not make performance claims before receipt-backed proof artifacts exist.

--- a/.codex/campaigns/ci-coverage/goal.md
+++ b/.codex/campaigns/ci-coverage/goal.md
@@ -1,0 +1,1 @@
+Use the CI coverage campaign to make coverage upload and reporting reliable in trusted and forked PR contexts. Keep this work CI-only, make skipped coverage reasons visible, and do not let optional coverage upload failures block unrelated runtime or tracker work.

--- a/.codex/campaigns/cpu-qk256-performance/goal.md
+++ b/.codex/campaigns/cpu-qk256-performance/goal.md
@@ -1,0 +1,1 @@
+Use the CPU QK256 performance campaign to move from strict proof surfaces into scalar, packed-layout, AVX2, and sustained benchmark evidence. Keep scalar truth before SIMD claims, keep receipts explicit about selected CPU paths and fallback status, and do not claim performance until proof artifacts and hardware context support it.

--- a/.codex/campaigns/intel-258v-platform/goal.md
+++ b/.codex/campaigns/intel-258v-platform/goal.md
@@ -1,0 +1,1 @@
+Use the Intel 258V platform campaign to coordinate same-machine CPU, Arc 140V GPU, and Intel NPU validation without merging their proof labels. Record OS, driver, memory, power, thermal, OpenVINO, OpenCL, Level Zero, native, and WSL visibility context before any implementation claim.

--- a/.codex/campaigns/nvidia-5070ti/goal.md
+++ b/.codex/campaigns/nvidia-5070ti/goal.md
@@ -1,0 +1,1 @@
+Use the NVIDIA 5070 Ti campaign to make RTX 5070 Ti a CUDA-first, receipt-backed BitNet target. Keep CUDA, WGPU, CPU fallback, and generic GPU labels separate, and do not claim kernel execution, inference, or performance from visibility alone.

--- a/.codex/campaigns/server-real-inference/goal.md
+++ b/.codex/campaigns/server-real-inference/goal.md
@@ -1,0 +1,1 @@
+Use the server real inference campaign to replace server-side simulated output with real engine execution or explicit unavailable responses. Keep loader, tokenizer, backend, fallback, and receipt truth shared with the CLI, and do not mix server runtime work with hardware acceleration claims.

--- a/.codex/campaigns/tracker-infra/goal.md
+++ b/.codex/campaigns/tracker-infra/goal.md
@@ -1,0 +1,1 @@
+Use the tracker infrastructure campaign to finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates. Preserve hardware lane visibility, treat legacy global status files as transition surfaces, and do not touch runtime code or kernels.

--- a/docs/tracking/TRACKER_MODEL.md
+++ b/docs/tracking/TRACKER_MODEL.md
@@ -2,7 +2,7 @@
 
 The alignment tracker is moving from one high-churn global ledger toward campaign-local control cards plus generated dashboards.
 
-The existing files under `docs/tracking/bitnet-alignment/` remain the transition source of truth until generator/checker tooling lands. New work should prefer campaign-local tracker files for planning and should avoid hand-editing global dashboard rows except for transition compatibility.
+Campaign-local TOML manifests and append-only events are the intended source of truth for active campaign work. The existing files under `docs/tracking/bitnet-alignment/` remain transition surfaces for compatibility and historical context; normal item PRs should stop editing those global files once generated dashboards are available.
 
 ## Model
 
@@ -11,9 +11,20 @@ Each campaign has:
 - `CAMPAIGN.md` for narrative context, constraints, sequencing, non-goals, and review policy.
 - `active.toml` for compact machine-readable work items.
 - `events/` for append-only lifecycle records in later PRs.
-- `generated/` for derived dashboards in later PRs.
+- `generated/` for derived dashboards.
 
-Global dashboards should be generated from campaign manifests and events. Agents should not solve global dashboard conflicts by deleting hardware lanes.
+Global dashboards are generated from campaign manifests and events. Agents should not solve global dashboard conflicts by deleting hardware lanes.
+
+Use:
+
+```bash
+cargo run -p xtask --no-default-features -- campaign list
+cargo run -p xtask --no-default-features -- campaign status apple-m4
+cargo run -p xtask --no-default-features -- campaign next apple-m4
+cargo run -p xtask --no-default-features -- campaign check apple-m4
+cargo run -p xtask --no-default-features -- campaign generate
+cargo run -p xtask --no-default-features -- campaign doctor
+```
 
 ## Work Item Contract
 
@@ -28,7 +39,16 @@ Each `[[work_item]]` in `active.toml` should include:
 - `acceptance`
 - `commands`
 
-Items may also include `allowed_paths`, `forbidden_paths`, `may_claim`, and `must_not_claim` when the scope needs hard boundaries.
+Items should also include `allowed_paths`, `forbidden_paths`, `may_claim`, and `must_not_claim` for implementation or runtime work. Documentation-only items may keep these short, but they should still make their boundaries explicit.
+
+Normal item PRs should edit only their campaign files and their scoped implementation paths. They should not hand-edit:
+
+- `docs/tracking/bitnet-alignment/status.md`
+- `docs/tracking/bitnet-alignment/workstream-ledger.yaml`
+- `docs/tracking/generated/*.md`
+- `docs/tracking/campaigns/*/generated/*.md`
+
+Tracker infrastructure PRs may touch transition docs and generated dashboards.
 
 ## State Rules
 
@@ -42,7 +62,18 @@ Use boring states:
 - `merged`
 - `superseded`
 
-Do not mark a PR as `merged` until the merge SHA exists. Use GitHub PRs as live locks and append-only events as audit records in later PRs.
+Do not mark a PR as `merged` until the merge SHA exists. Use GitHub PRs as live locks and append-only events as audit records.
+
+Lifecycle events are TOML files under `events/` with these event types:
+
+- `in_progress`
+- `pr_open`
+- `blocked`
+- `superseded`
+- `merged`
+- `closeout`
+
+Merged events must include `merge_sha`. `pr_open` events should include the PR number and head SHA when available.
 
 ## Stackability
 
@@ -62,3 +93,4 @@ Docs-only scaffolding can be stackable when it does not change a lane contract o
 - Do not edit generated dashboards by hand once generator tooling exists.
 - If generated files conflict during rebase, regenerate them instead of resolving tables manually.
 - If two branches touch the same item manifest, stop and resolve ownership before continuing.
+- Treat `docs/tracking/bitnet-alignment/status.md` and `docs/tracking/bitnet-alignment/workstream-ledger.yaml` as transition surfaces. Freeze or generate them in a later PR instead of keeping them as another hand-edited source of truth.

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -4,7 +4,9 @@ Updated: 2026-05-06
 
 ## Current Focus
 
-Real BitNet CPU path sequencing remains active, and the NVIDIA CUDA proof bench is now documented as a separate staged lane. The next NVIDIA item is `RTX5070TI-003` backend identity, before CUDA/NVML probing, kernel smoke, parity, receipts, benchmarks, or BitNet CUDA inference work.
+Real BitNet CPU path sequencing remains active, Apple Silicon M4-003 backend identity is merged, and the NVIDIA CUDA proof bench is documented as a separate staged lane. The next Apple Silicon item is M4-004 Metal probe, before Metal execution smoke, kernels, MPSGraph execution, parity, receipts, or benchmarks. The next NVIDIA item is `RTX5070TI-003` backend identity, before CUDA/NVML probing, kernel smoke, parity, receipts, benchmarks, or BitNet CUDA inference work.
+
+Transition note: campaign-local `active.toml` files and append-only `events/*.toml` files are now the active tracker model. This legacy global status file remains a transition view; normal item PRs should use campaign-local tracking plus generated dashboards instead of hand-editing this table.
 
 ## Active / Coordination Queue
 
@@ -23,7 +25,7 @@ Real BitNet CPU path sequencing remains active, and the NVIDIA CUDA proof bench 
 | NPU-002 | TBD | ready | Preserve Intel NPU backend identity before runtime probing |
 | A770-003 | TBD | ready | Preserve Intel Arc A770 selected-device identity |
 | KBL8250U-003 | TBD | ready | Prove i5-8250U scalar and AVX2 dispatch |
-| M4-003 | #3652 | pr_open | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity before runtime work |
+| M4-004 | TBD | ready | Add Apple M4 Metal device probe before execution smoke or inference claims |
 | RTX5070TI-003 | TBD | ready | Preserve RTX 5070 Ti CUDA selected-device identity |
 | AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
 | AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |
@@ -107,7 +109,7 @@ The 5700X and 9950X3D lanes are CPU proof lanes, not accelerator lanes. The 5700
 
 The M4 Mac mini lane is Metal-first, with MPSGraph as a graph/reference lane and CPU/NEON as fallback/parity. CPU fallback cannot count as Metal execution, MPSGraph smoke cannot count as native Metal kernel proof, and Neural Engine execution must not be claimed unless the resolved target is receipt-backed.
 
-The Apple Silicon implementation order is M4-002 machine profile, M4-003 backend identity, M4-004 Metal probe, M4-005 Metal compute smoke, M4-006 CPU/Metal parity, M4-007 MPSGraph smoke, M4-008 receipt identity fields, and M4-009 benchmark baseline. M4-002 was docs/artifact prep only; M4-003 is the next Apple Silicon item and must not touch Metal kernels, MPSGraph execution, QK256, server inference, or dependencies.
+The Apple Silicon implementation order is M4-002 machine profile, M4-003 backend identity, M4-004 Metal probe, M4-005 Metal compute smoke, M4-006 CPU/Metal parity, M4-007 MPSGraph smoke, M4-008 receipt identity fields, and M4-009 benchmark baseline. M4-002 was docs/artifact prep only, and M4-003 preserved backend identity only. M4-004 is the next Apple Silicon item and must not touch Metal kernels, MPSGraph execution, QK256, server inference, or dependencies.
 
 ## NVIDIA CUDA Boundary
 
@@ -159,6 +161,7 @@ HW-002 remains proposed. #3625 added `ci/hardware/README.md` with artifact namin
 | KBL8250U-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Core i5-8250U machine profile and probe bundle merged. |
 | M4-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | Apple M4 Mac mini backend lane merged. |
 | M4-002 | #3627 | 6362101c3249a0758100d22c31e084eba37c387b | Apple M4 Mac mini machine profile and probe bundle merged; docs/artifact prep only, no runtime execution. |
+| M4-003 | #3652 | 849c3db73b786483bb7955371b95f733235119bb | Apple M4 backend identity merged; no Metal kernels, MPSGraph execution, QK256, server inference, dependencies, runtime probes, or hardware artifacts. |
 | RTX5070TI-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | NVIDIA RTX 5070 Ti CUDA backend lane merged. |
 | RTX5070TI-002 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | NVIDIA RTX 5070 Ti machine profile and probe bundle merged. |
 | AMD9950X3D-001 | #3625 | bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3 | AMD Ryzen 9 9950X3D CPU validation lane merged. |

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1883,7 +1883,7 @@ items:
 
   - id: M4-003
     title: Preserve Apple backend identity
-    state: pr_open
+    state: merged
     priority: P1
     workstream: apple_silicon
     depends_on:
@@ -1898,8 +1898,6 @@ items:
         - crates/bitnet-cli/tests/cli_extended_tests.rs
         - crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
         - docs/tracking/campaigns/apple-m4/**
-        - docs/tracking/bitnet-alignment/status.md
-        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
       forbidden_paths:
         - crates/bitnet-quantization/src/qk256/**
         - crates/bitnet-qk256-dispatch/**
@@ -1913,10 +1911,13 @@ items:
       - cargo test --locked -p bitnet-common --no-default-features --features cpu backend_selection
       - cargo test --locked -p bitnet-device-config-core --no-default-features
       - cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cli_config
+    notes:
+      - Merged in #3652 with SHA 849c3db73b786483bb7955371b95f733235119bb.
+      - Identity only; no Metal kernels, MPSGraph execution, QK256, server inference, dependencies, runtime probes, or hardware artifacts.
 
   - id: M4-004
     title: Add Apple M4 Metal device probe
-    state: proposed
+    state: ready
     priority: P1
     workstream: apple_silicon
     depends_on:
@@ -1924,11 +1925,14 @@ items:
     scope:
       allowed_paths:
         - crates/bitnet-device-probe/**
-        - docs/tracking/bitnet-alignment/backend-status.yaml
-        - docs/tracking/bitnet-alignment/status.md
-        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+        - docs/hardware/apple-m4-mac-mini-validation.md
+        - docs/specs/apple-m4-mac-mini-roadmap.md
+        - docs/tracking/campaigns/apple-m4/**
       forbidden_paths:
+        - crates/bitnet-quantization/src/qk256/**
+        - crates/bitnet-qk256-dispatch/**
         - crates/bitnet-server/**
+        - crates/bitnet-kernels/src/metal/**
     acceptance:
       - Probe reports Metal device visibility, Apple chip name, GPU family when available, unified memory, and macOS version.
       - Probe distinguishes Metal visibility from MPSGraph visibility.

--- a/docs/tracking/campaigns/README.md
+++ b/docs/tracking/campaigns/README.md
@@ -1,0 +1,14 @@
+# Campaign Trackers
+
+Campaign-local trackers are the control cards for parallel BitNet work.
+
+Each campaign directory contains:
+
+- `CAMPAIGN.md`: human-readable objective, end state, constraints, work items, and review policy.
+- `active.toml`: machine-readable current work items, commands, allowed paths, forbidden paths, and claim boundaries.
+- `events/`: append-only lifecycle events such as `in_progress`, `pr_open`, `merged`, and `closeout`.
+- `generated/`: generated dashboards. Do not edit these files by hand.
+
+Use `cargo run -p xtask --no-default-features -- campaign check <campaign>` before opening a tracker PR, and `cargo run -p xtask --no-default-features -- campaign generate` to refresh dashboards.
+
+Normal item PRs should not hand-edit legacy global tracker files under `docs/tracking/bitnet-alignment/`. Those files remain transition surfaces until they are frozen or generated.

--- a/docs/tracking/campaigns/amd-cpu-baselines/CAMPAIGN.md
+++ b/docs/tracking/campaigns/amd-cpu-baselines/CAMPAIGN.md
@@ -1,0 +1,32 @@
+# AMD CPU Baselines Campaign
+
+Campaign ID: `amd-cpu-baselines`
+
+Status: active
+
+## Objective
+
+Validate AMD 5700X and 9950X3D as CPU proof and benchmark lanes while preserving scalar, AVX2, AVX-512, cache, memory, and sustained-power context.
+
+## End State
+
+- 5700X proves mainstream Zen 3 AVX2 behavior and never claims AVX-512.
+- 9950X3D proves Zen 5 AVX2 and AVX-512 behavior with cache-domain context.
+- Benchmark artifacts separate correctness proof from performance claims.
+
+## Hard Constraints
+
+- These lanes are CPU proof lanes, not accelerator lanes.
+- The 5700X lane must not claim AVX-512.
+- 9950X3D receipts must record scheduler/core placement and cache-domain context before performance claims.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| AMD5700X-003 | ready | Prove 5700X scalar and AVX2 dispatch. |
+| AMD9950X3D-003 | ready | Prove 9950X3D scalar, AVX2, and AVX-512 dispatch. |
+
+## Review Policy
+
+AMD CPU baseline PRs should keep 5700X and 9950X3D claims separate unless an item explicitly owns a shared comparison artifact.

--- a/docs/tracking/campaigns/amd-cpu-baselines/active.toml
+++ b/docs/tracking/campaigns/amd-cpu-baselines/active.toml
@@ -1,0 +1,82 @@
+id = "amd-cpu-baselines"
+title = "AMD CPU baselines"
+status = "active"
+
+objective = "Validate AMD 5700X and 9950X3D as CPU proof and benchmark lanes while preserving scalar, AVX2, AVX-512, cache, memory, and sustained-power context."
+
+end_state = [
+  "5700X proves mainstream Zen 3 AVX2 behavior and never claims AVX-512.",
+  "9950X3D proves Zen 5 AVX2 and AVX-512 behavior with cache-domain context.",
+  "Benchmark artifacts separate correctness proof from performance claims.",
+]
+
+hard_constraints = [
+  "These lanes are CPU proof lanes, not accelerator lanes.",
+  "The 5700X lane must not claim AVX-512.",
+  "9950X3D receipts must record scheduler/core placement and cache-domain context before performance claims.",
+]
+
+[[work_item]]
+id = "AMD5700X-003"
+status = "ready"
+branch = "codex/amd-cpu-baselines/AMD5700X-003-scalar-avx2-dispatch"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Prove 5700X scalar and AVX2 dispatch with selected CPU kernel receipts and no GPU/NPU fallback."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu,avx2",
+]
+allowed_paths = [
+  "crates/bitnet-cpu-detect/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-receipts/**",
+  "docs/tracking/campaigns/amd-cpu-baselines/**",
+]
+forbidden_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "5700X scalar and AVX2 dispatch can be selected after receipt-backed validation.",
+]
+must_not_claim = [
+  "5700X AVX-512 works.",
+  "CPU performance is proven.",
+  "GPU or NPU acceleration is involved.",
+]
+
+[[work_item]]
+id = "AMD9950X3D-003"
+status = "ready"
+branch = "codex/amd-cpu-baselines/AMD9950X3D-003-scalar-avx2-avx512-dispatch"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Prove 9950X3D scalar, AVX2, and AVX-512 dispatch with selected CPU kernel receipts and no GPU/NPU fallback."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu,avx2",
+]
+allowed_paths = [
+  "crates/bitnet-cpu-detect/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-receipts/**",
+  "docs/tracking/campaigns/amd-cpu-baselines/**",
+]
+forbidden_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "9950X3D scalar, AVX2, and AVX-512 dispatch can be selected after receipt-backed validation.",
+]
+must_not_claim = [
+  "CPU performance is proven.",
+  "GPU or NPU acceleration is involved.",
+]

--- a/docs/tracking/campaigns/amd-cpu-baselines/generated/status.md
+++ b/docs/tracking/campaigns/amd-cpu-baselines/generated/status.md
@@ -1,0 +1,19 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# AMD CPU baselines Campaign Status
+
+- Campaign: `amd-cpu-baselines`
+- State: `active`
+- Objective: Validate AMD 5700X and 9950X3D as CPU proof and benchmark lanes while preserving scalar, AVX2, AVX-512, cache, memory, and sustained-power context.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| AMD5700X-003 | ready | TBD | `codex/amd-cpu-baselines/AMD5700X-003-scalar-avx2-dispatch` | Prove 5700X scalar and AVX2 dispatch with selected CPU kernel receipts and no GPU/NPU fallback. |
+| AMD9950X3D-003 | ready | TBD | `codex/amd-cpu-baselines/AMD9950X3D-003-scalar-avx2-avx512-dispatch` | Prove 9950X3D scalar, AVX2, and AVX-512 dispatch with selected CPU kernel receipts and no GPU/NPU fallback. |
+
+## Hard Constraints
+
+- These lanes are CPU proof lanes, not accelerator lanes.
+- The 5700X lane must not claim AVX-512.
+- 9950X3D receipts must record scheduler/core placement and cache-domain context before performance claims.

--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -30,9 +30,10 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 
 | Work item | Status | Notes |
 |---|---|---|
+| M4-001 | merged | Apple M4 lane scaffold merged in #3625; docs/contracts only. |
 | M4-002 | merged | Machine profile and probe bundle merged in #3627. |
-| M4-003 | ready | Preserve Apple Metal, MPSGraph, and CPU/NEON backend identity. |
-| M4-004 | proposed | Add Metal device probe. |
+| M4-003 | merged | Apple Metal, MPSGraph, and CPU/NEON backend identity merged in #3652. |
+| M4-004 | ready | Add Metal device probe. |
 | M4-005 | proposed | Run tiny Metal compute smoke. |
 | M4-006 | proposed | Add CPU/Metal parity. |
 | M4-007 | proposed | Run MPSGraph tiny graph smoke. |

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -22,12 +22,76 @@ hard_constraints = [
 ]
 
 [[work_item]]
-id = "M4-003"
-status = "pr_open"
-branch = "codex/apple-m4/M4-003-backend-identity"
+id = "M4-001"
+status = "merged"
+branch = "codex/hardware-scaffold/M4-001-apple-lane"
 stackable = false
 requires_human_merge = true
 blocked_by = []
+acceptance = "Add the Apple M4 Mac mini lane scaffold without runtime execution claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "Parse YAML tracker files",
+]
+allowed_paths = [
+  "docs/hardware/**",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+  "docs/tracking/campaigns/apple-m4/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Apple M4 lane scaffold exists.",
+]
+must_not_claim = [
+  "Metal execution works.",
+  "MPSGraph execution works.",
+  "BitNet inference works on M4.",
+]
+
+[[work_item]]
+id = "M4-002"
+status = "merged"
+branch = "codex/apple-m4/M4-002-profile-probe-bundle"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-001"]
+acceptance = "Add the Apple M4 Mac mini machine profile and probe bundle without runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts."
+commands = [
+  "cargo fmt --all -- --check",
+  "Parse TOML tracker files",
+  "Parse YAML tracker files",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+  "ci/hardware/README.md",
+  "docs/tracking/campaigns/apple-m4/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Apple M4 machine profile and probe bundle docs exist.",
+]
+must_not_claim = [
+  "Metal execution works.",
+  "MPSGraph execution works.",
+  "Neural Engine execution works.",
+  "BitNet inference works on M4.",
+]
+
+[[work_item]]
+id = "M4-003"
+status = "merged"
+branch = "codex/apple-m4/M4-003-backend-identity"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-002"]
 acceptance = "Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels."
 commands = [
   "cargo fmt --all -- --check",
@@ -44,8 +108,6 @@ allowed_paths = [
   "crates/bitnet-cli/tests/cli_extended_tests.rs",
   "crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap",
   "docs/tracking/campaigns/apple-m4/**",
-  "docs/tracking/bitnet-alignment/status.md",
-  "docs/tracking/bitnet-alignment/workstream-ledger.yaml",
 ]
 forbidden_paths = [
   "crates/bitnet-quantization/src/qk256/**",
@@ -64,7 +126,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-004"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-004-metal-probe"
 stackable = false
 requires_human_merge = true
@@ -73,6 +135,27 @@ acceptance = "Add Apple M4 Metal device probe without claiming Metal execution o
 commands = [
   "cargo fmt --all -- --check",
   "cargo test --locked -p bitnet-device-probe --no-default-features --features metal",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/**",
+  "docs/tracking/campaigns/apple-m4/**",
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+]
+may_claim = [
+  "Apple M4 Metal runtime visibility is recorded after merge.",
+]
+must_not_claim = [
+  "Metal execution works.",
+  "MPSGraph execution works.",
+  "Neural Engine execution works.",
+  "BitNet inference works on M4.",
 ]
 
 [[work_item]]
@@ -86,4 +169,23 @@ acceptance = "Run a tiny native Metal compute smoke on M4 with fallback_used=fal
 commands = [
   "cargo fmt --all -- --check",
   "Manual M4 Metal smoke command with receipt artifact",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-kernels/tests/**",
+  "docs/tracking/campaigns/apple-m4/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Tiny Metal compute dispatch works on the tested M4 machine after receipt-backed smoke passes.",
+]
+must_not_claim = [
+  "BitNet Metal inference works.",
+  "QK256 works on Metal.",
+  "MPSGraph works.",
+  "Neural Engine execution works.",
 ]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-05T231000Z-M4-001-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-05T231000Z-M4-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-05T23:10:00Z"
+campaign = "apple-m4"
+item = "M4-001"
+event = "merged"
+pr = 3625
+merge_sha = "bbc5d563ce22c4a81e517992120c4ad5d8a6d0d3"
+actor = "maintainer"
+
+notes = [
+  "Apple M4 Mac mini lane scaffold merged as docs/contracts only.",
+  "No runtime execution, kernels, MPSGraph execution, Neural Engine execution, or BitNet inference proof was claimed.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T000420Z-M4-002-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T000420Z-M4-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T00:04:20Z"
+campaign = "apple-m4"
+item = "M4-002"
+event = "merged"
+pr = 3627
+merge_sha = "6362101c3249a0758100d22c31e084eba37c387b"
+actor = "maintainer"
+
+notes = [
+  "Apple M4 Mac mini machine profile and probe bundle merged.",
+  "Docs and artifact-prep only; no runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts were added.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T011826Z-M4-003-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T011826Z-M4-003-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T01:18:26Z"
+campaign = "apple-m4"
+item = "M4-003"
+event = "merged"
+pr = 3652
+head_sha = "ddf0602c84121795fcc5b85ed2d8393910f9b437"
+merge_sha = "849c3db73b786483bb7955371b95f733235119bb"
+actor = "maintainer"
+
+notes = [
+  "Apple backend identity PR merged.",
+  "Preserves Apple M4 Metal, MPSGraph, and CPU/NEON backend labels without adding Metal kernels, MPSGraph execution, QK256, server inference, dependencies, runtime probes, or hardware artifacts.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -1,0 +1,24 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 Mac mini validation Campaign Status
+
+- Campaign: `apple-m4`
+- State: `active`
+- Objective: Make Apple Silicon a receipt-backed BitNet target through Metal, MPSGraph, and CPU/NEON proof lanes without conflating detection, execution, parity, inference, or performance.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| M4-001 | merged | #3625 | `codex/hardware-scaffold/M4-001-apple-lane` | Add the Apple M4 Mac mini lane scaffold without runtime execution claims. |
+| M4-002 | merged | #3627 | `codex/apple-m4/M4-002-profile-probe-bundle` | Add the Apple M4 Mac mini machine profile and probe bundle without runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts. |
+| M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
+| M4-004 | ready | TBD | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
+| M4-005 | proposed | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
+
+## Hard Constraints
+
+- Do not touch QK256 before a BitNet-specific Apple item explicitly allows it.
+- Do not touch server inference.
+- Do not claim Neural Engine execution from MPSGraph.
+- Do not claim Metal execution from a Metal probe.
+- Do not benchmark before parity exists.

--- a/docs/tracking/campaigns/ci-coverage/CAMPAIGN.md
+++ b/docs/tracking/campaigns/ci-coverage/CAMPAIGN.md
@@ -1,0 +1,31 @@
+# CI Coverage Campaign
+
+Campaign ID: `ci-coverage`
+
+Status: active
+
+## Objective
+
+Make coverage upload and reporting reliable without turning forked PRs or missing secrets into failing unrelated work.
+
+## End State
+
+- Coverage upload handles trusted and forked PR contexts explicitly.
+- Duplicate Codecov PRs are normalized behind one canonical path.
+- CI reports make skipped coverage reasons visible.
+
+## Hard Constraints
+
+- Do not block unrelated runtime or tracker work on optional coverage uploads.
+- Do not leak or assume Codecov secrets in forked PRs.
+- Do not conflate coverage wiring with test quality claims.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| CI-COVERAGE-001 | pr_open | Canonical Codecov upload guard is open in #3620. |
+
+## Review Policy
+
+Coverage PRs should remain CI-only and avoid touching runtime, kernels, loaders, or tracker campaign semantics.

--- a/docs/tracking/campaigns/ci-coverage/active.toml
+++ b/docs/tracking/campaigns/ci-coverage/active.toml
@@ -1,0 +1,46 @@
+id = "ci-coverage"
+title = "CI coverage"
+status = "active"
+
+objective = "Make coverage upload and reporting reliable without turning forked PRs or missing secrets into failing unrelated work."
+
+end_state = [
+  "Coverage upload handles trusted and forked PR contexts explicitly.",
+  "Duplicate Codecov PRs are normalized behind one canonical path.",
+  "CI reports make skipped coverage reasons visible.",
+]
+
+hard_constraints = [
+  "Do not block unrelated runtime or tracker work on optional coverage uploads.",
+  "Do not leak or assume Codecov secrets in forked PRs.",
+  "Do not conflate coverage wiring with test quality claims.",
+]
+
+[[work_item]]
+id = "CI-COVERAGE-001"
+status = "pr_open"
+branch = "codex/implement-minimal-codecov-integration-vm5aks"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI."
+commands = [
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".github/workflows/**",
+  "codecov.yml",
+  "docs/tracking/campaigns/ci-coverage/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Coverage upload handling is safer after merge.",
+]
+must_not_claim = [
+  "Coverage thresholds are complete.",
+  "Runtime behavior changed.",
+]

--- a/docs/tracking/campaigns/ci-coverage/events/2026-05-04T030000Z-CI-COVERAGE-001-pr-open.toml
+++ b/docs/tracking/campaigns/ci-coverage/events/2026-05-04T030000Z-CI-COVERAGE-001-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-04T03:00:00Z"
+campaign = "ci-coverage"
+item = "CI-COVERAGE-001"
+event = "pr_open"
+pr = 3620
+head_sha = "2bce180b35265f17278db10e9c235220659b07d1"
+actor = "codex"
+
+notes = [
+  "Canonical Codecov upload guard PR is open.",
+  "Coverage work remains CI-only and does not touch runtime or kernel code.",
+]

--- a/docs/tracking/campaigns/ci-coverage/generated/status.md
+++ b/docs/tracking/campaigns/ci-coverage/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# CI coverage Campaign Status
+
+- Campaign: `ci-coverage`
+- State: `active`
+- Objective: Make coverage upload and reporting reliable without turning forked PRs or missing secrets into failing unrelated work.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| CI-COVERAGE-001 | pr_open | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
+
+## Hard Constraints
+
+- Do not block unrelated runtime or tracker work on optional coverage uploads.
+- Do not leak or assume Codecov secrets in forked PRs.
+- Do not conflate coverage wiring with test quality claims.

--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -29,8 +29,8 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 
 | Work item | Status | Notes |
 |---|---|---|
-| CPU-BITNET-000 | pr_open | Real BitNet CPU path plan. |
-| CPU-BITNET-001 | proposed | Strict GGUF loader authority. |
+| CPU-BITNET-000 | merged | Real BitNet CPU path plan merged in #3642. |
+| CPU-BITNET-001 | pr_open | Strict GGUF loader authority is open in #3651. |
 | CPU-BITNET-002 | proposed | Strict tokenizer authority. |
 | CPU-BITNET-003 | proposed | Canonical packed layout. |
 | CPU-BITNET-004 | proposed | Scalar truth kernels. |

--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -30,8 +30,8 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 | Work item | Status | Notes |
 |---|---|---|
 | CPU-BITNET-000 | merged | Real BitNet CPU path plan merged in #3642. |
-| CPU-BITNET-001 | pr_open | Strict GGUF loader authority is open in #3651. |
-| CPU-BITNET-002 | proposed | Strict tokenizer authority. |
+| CPU-BITNET-001 | merged | Strict GGUF loader authority merged in #3651. |
+| CPU-BITNET-002 | ready | Strict tokenizer authority. |
 | CPU-BITNET-003 | proposed | Canonical packed layout. |
 | CPU-BITNET-004 | proposed | Scalar truth kernels. |
 | CPU-BITNET-005 | proposed | AVX2 decode GEMV. |

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -21,8 +21,38 @@ hard_constraints = [
 ]
 
 [[work_item]]
+id = "CPU-BITNET-000"
+status = "merged"
+branch = "codex/cpu-proof/CPU-BITNET-000-path-plan"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Document the real BitNet CPU path implementation plan and sequence strict loader, tokenizer, layout, scalar, AVX2, receipts, and benchmarks."
+commands = [
+  "cargo fmt --all -- --check",
+  "Parse TOML tracker files",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "The real BitNet CPU path plan is documented.",
+]
+must_not_claim = [
+  "Strict loader authority is implemented.",
+  "Tokenizer authority is complete.",
+  "CPU performance is proven.",
+]
+
+[[work_item]]
 id = "CPU-BITNET-001"
-status = "proposed"
+status = "pr_open"
 branch = "codex/cpu-proof/CPU-BITNET-001-loader-authority"
 stackable = false
 requires_human_merge = true
@@ -68,4 +98,23 @@ acceptance = "Strict tokenizer resolution uses explicit override, GGUF metadata,
 commands = [
   "cargo fmt --all -- --check",
   "cargo test --locked -p bitnet-tokenizers --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-cli/**",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "Strict tokenizer authority exists after merge.",
+]
+must_not_claim = [
+  "Packed kernels are complete.",
+  "Transformer decode is complete.",
+  "CPU performance is proven.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -52,7 +52,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-proof/CPU-BITNET-001-loader-authority"
 stackable = false
 requires_human_merge = true
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-002"
-status = "proposed"
+status = "ready"
 branch = "codex/cpu-proof/CPU-BITNET-002-tokenizer-authority"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T001203Z-CPU-BITNET-000-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T001203Z-CPU-BITNET-000-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T00:12:03Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-000"
+event = "merged"
+pr = 3642
+merge_sha = "c5f3480ac90cccfd1aec9766ae4628fd7e9fd3c3"
+actor = "maintainer"
+
+notes = [
+  "Real BitNet CPU path implementation plan merged.",
+  "Plan only; strict loader, tokenizer, layout, scalar, AVX2, receipt, and benchmark implementation remains sequenced follow-up work.",
+]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T014803Z-CPU-BITNET-001-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T014803Z-CPU-BITNET-001-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T01:48:03Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-001"
+event = "pr_open"
+pr = 3651
+head_sha = "4f076aa1660e388280af13dbf19bcae4a94162db"
+actor = "codex"
+
+notes = [
+  "Strict GGUF loader authority PR is open.",
+  "No AVX2 kernels or performance claims are included in the campaign tracker state.",
+]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T015900Z-CPU-BITNET-001-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T015900Z-CPU-BITNET-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T01:59:00Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-001"
+event = "merged"
+pr = 3651
+merge_sha = "5bf32dc335a52aeab5a790d3811a57dc06ed0d3d"
+actor = "maintainer"
+
+notes = [
+  "Strict real GGUF loader authority merged.",
+  "Tokenizer authority, packed layout, transformer decode, and performance remain follow-up work.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -10,8 +10,8 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | CPU-BITNET-000 | merged | #3642 | `codex/cpu-proof/CPU-BITNET-000-path-plan` | Document the real BitNet CPU path implementation plan and sequence strict loader, tokenizer, layout, scalar, AVX2, receipts, and benchmarks. |
-| CPU-BITNET-001 | pr_open | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
-| CPU-BITNET-002 | proposed | TBD | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+| CPU-BITNET-001 | merged | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
+| CPU-BITNET-002 | ready | TBD | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -1,0 +1,21 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# BitNet CPU proof Campaign Status
+
+- Campaign: `cpu-proof`
+- State: `active`
+- Objective: Make real BitNet CPU inference strict, receipt-backed, and measurable without routing around model, tokenizer, layout, or fallback truth.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| CPU-BITNET-000 | merged | #3642 | `codex/cpu-proof/CPU-BITNET-000-path-plan` | Document the real BitNet CPU path implementation plan and sequence strict loader, tokenizer, layout, scalar, AVX2, receipts, and benchmarks. |
+| CPU-BITNET-001 | pr_open | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
+| CPU-BITNET-002 | proposed | TBD | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+
+## Hard Constraints
+
+- No GPU or NPU claims.
+- No silent GGUF fallback.
+- No performance claim without receipt artifacts.
+- No helper-only SIMD work unless it is wired to real inference or explicitly scoped as preparation.

--- a/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
@@ -1,0 +1,34 @@
+# CPU QK256 Performance Campaign
+
+Campaign ID: `cpu-qk256-performance`
+
+Status: active
+
+## Objective
+
+Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2, and sustained benchmark evidence without hiding fallback behavior.
+
+## End State
+
+- Scalar truth kernels are available before SIMD dispatch claims.
+- QK256 and related packed layouts are receipt-backed.
+- AVX2 paths can be forced and compared against scalar references.
+- Mobile and desktop baselines record thermal, power, memory, and sustained-load context.
+
+## Hard Constraints
+
+- Do not claim performance before strict proof receipts exist.
+- Do not mix GPU, NPU, CUDA, OpenCL, or Metal execution into CPU proof.
+- Do not treat helper-only AVX2 code as real inference.
+- Do not report short turbo behavior as sustained performance.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| KBL8250U-003 | ready | Prove i5-8250U scalar and AVX2 dispatch. |
+| KBL8250U-004 | proposed | Add strict CPU proof run on the i5-8250U lane. |
+
+## Review Policy
+
+CPU QK256 and performance PRs are non-stackable when they touch dispatch, packed layouts, receipts, or benchmark interpretation.

--- a/docs/tracking/campaigns/cpu-qk256-performance/active.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/active.toml
@@ -1,0 +1,79 @@
+id = "cpu-qk256-performance"
+title = "CPU QK256 performance"
+status = "active"
+
+objective = "Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2, and sustained benchmark evidence without hiding fallback behavior."
+
+end_state = [
+  "Scalar truth kernels are available before SIMD dispatch claims.",
+  "QK256 and related packed layouts are receipt-backed.",
+  "AVX2 paths can be forced and compared against scalar references.",
+  "Mobile and desktop baselines record thermal, power, memory, and sustained-load context.",
+]
+
+hard_constraints = [
+  "Do not claim performance before strict proof receipts exist.",
+  "Do not mix GPU, NPU, CUDA, OpenCL, or Metal execution into CPU proof.",
+  "Do not treat helper-only AVX2 code as real inference.",
+  "Do not report short turbo behavior as sustained performance.",
+]
+
+[[work_item]]
+id = "KBL8250U-003"
+status = "ready"
+branch = "codex/cpu-qk256-performance/KBL8250U-003-scalar-avx2-dispatch"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu,avx2",
+]
+allowed_paths = [
+  "crates/bitnet-cpu-detect/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-receipts/**",
+  "docs/tracking/campaigns/cpu-qk256-performance/**",
+]
+forbidden_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "i5-8250U scalar and AVX2 dispatch can be selected after receipt-backed validation.",
+]
+must_not_claim = [
+  "CPU performance is proven.",
+  "GPU, NPU, CUDA, OpenCL, or Metal execution works.",
+]
+
+[[work_item]]
+id = "KBL8250U-004"
+status = "proposed"
+branch = "codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run"
+stackable = false
+requires_human_merge = true
+blocked_by = ["KBL8250U-003"]
+acceptance = "Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context."
+commands = [
+  "cargo fmt --all -- --check",
+  "Manual i5-8250U strict CPU proof command with receipt artifact",
+]
+allowed_paths = [
+  "docs/hardware/intel-i5-8250u-validation.md",
+  "ci/intel-i5-8250u/**",
+  "docs/tracking/campaigns/cpu-qk256-performance/**",
+]
+forbidden_paths = [
+  "crates/**",
+]
+may_claim = [
+  "i5-8250U strict CPU proof receipt exists after the hardware run is complete.",
+]
+must_not_claim = [
+  "Sustained mobile performance is proven.",
+  "GPU or NPU acceleration is involved.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
@@ -1,0 +1,20 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# CPU QK256 performance Campaign Status
+
+- Campaign: `cpu-qk256-performance`
+- State: `active`
+- Objective: Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2, and sustained benchmark evidence without hiding fallback behavior.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| KBL8250U-003 | ready | TBD | `codex/cpu-qk256-performance/KBL8250U-003-scalar-avx2-dispatch` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
+| KBL8250U-004 | proposed | TBD | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
+
+## Hard Constraints
+
+- Do not claim performance before strict proof receipts exist.
+- Do not mix GPU, NPU, CUDA, OpenCL, or Metal execution into CPU proof.
+- Do not treat helper-only AVX2 code as real inference.
+- Do not report short turbo behavior as sustained performance.

--- a/docs/tracking/campaigns/crate-collapse/CAMPAIGN.md
+++ b/docs/tracking/campaigns/crate-collapse/CAMPAIGN.md
@@ -26,6 +26,7 @@ Collapse low-risk public microcrates into SRP modules while preserving behavior,
 
 | Work item | Status | Notes |
 |---|---|---|
+| INV-001 | merged | Crate consolidation inventory merged in #3632. |
 | LEAF-001 | proposed | Collapse warn-once into common. |
 
 ## Review Policy

--- a/docs/tracking/campaigns/crate-collapse/active.toml
+++ b/docs/tracking/campaigns/crate-collapse/active.toml
@@ -19,6 +19,35 @@ hard_constraints = [
 ]
 
 [[work_item]]
+id = "INV-001"
+status = "merged"
+branch = "codex/inventory/INV-001-crate-consolidation-map"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Add crate consolidation inventory mapping every workspace member to a final public crate or internal module without moving code."
+commands = [
+  "cargo fmt --all -- --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/tracking/bitnet-alignment/crate-consolidation-map.yaml",
+  "docs/tracking/campaigns/crate-collapse/**",
+]
+forbidden_paths = [
+  "Cargo.toml",
+  "crates/**",
+  ".github/**",
+]
+may_claim = [
+  "Crate consolidation inventory exists.",
+]
+must_not_claim = [
+  "Any crate has moved.",
+  "Runtime behavior changed.",
+]
+
+[[work_item]]
 id = "LEAF-001"
 status = "proposed"
 branch = "codex/crate-collapse/LEAF-001-warn-once"

--- a/docs/tracking/campaigns/crate-collapse/events/2026-05-05T220000Z-INV-001-merged.toml
+++ b/docs/tracking/campaigns/crate-collapse/events/2026-05-05T220000Z-INV-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-05T22:00:00Z"
+campaign = "crate-collapse"
+item = "INV-001"
+event = "merged"
+pr = 3632
+merge_sha = "457b36630906f2044e406e0dcf27ecb539e8a7a5"
+actor = "maintainer"
+
+notes = [
+  "Crate consolidation inventory merged.",
+  "Inventory only; no crate movement or runtime behavior changes.",
+]

--- a/docs/tracking/campaigns/crate-collapse/generated/status.md
+++ b/docs/tracking/campaigns/crate-collapse/generated/status.md
@@ -1,0 +1,20 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Crate collapse Campaign Status
+
+- Campaign: `crate-collapse`
+- State: `active`
+- Objective: Collapse low-risk public microcrates into SRP modules while preserving behavior, feature gates, and public API intent.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| INV-001 | merged | #3632 | `codex/inventory/INV-001-crate-consolidation-map` | Add crate consolidation inventory mapping every workspace member to a final public crate or internal module without moving code. |
+| LEAF-001 | proposed | TBD | `codex/crate-collapse/LEAF-001-warn-once` | Move warn-once code under bitnet-common, update imports and workspace membership, and preserve behavior. |
+
+## Hard Constraints
+
+- Do not combine crate movement with runtime proof.
+- Do not change hardware lane semantics.
+- Do not move domain crates before leaf dependencies are settled.
+- Do not mass-format unrelated files.

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -1,0 +1,31 @@
+# Intel 258V Platform Campaign
+
+Campaign ID: `intel-258v-platform`
+
+Status: active
+
+## Objective
+
+Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
+
+## End State
+
+- Same-machine CPU, GPU, and NPU facts are captured.
+- Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.
+- Receipts record OS, drivers, memory, power, thermal, and WSL/native visibility context.
+
+## Hard Constraints
+
+- Arc 140V OpenCL proof is not NPU proof.
+- OpenVINO GPU smoke is not packed BitNet kernel proof.
+- WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| LNL258V-002 | ready | Add 258V probe bundle and same-machine comparison hooks. |
+
+## Review Policy
+
+Platform PRs document and compare lanes; they must not collapse CPU, GPU, and NPU implementation claims into one backend.

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -1,0 +1,50 @@
+id = "intel-258v-platform"
+title = "Intel 258V platform validation"
+status = "active"
+
+objective = "Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate."
+
+end_state = [
+  "Same-machine CPU, GPU, and NPU facts are captured.",
+  "Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.",
+  "Receipts record OS, drivers, memory, power, thermal, and WSL/native visibility context.",
+]
+
+hard_constraints = [
+  "Arc 140V OpenCL proof is not NPU proof.",
+  "OpenVINO GPU smoke is not packed BitNet kernel proof.",
+  "WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.",
+]
+
+[[work_item]]
+id = "LNL258V-002"
+status = "ready"
+branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "Parse TOML tracker files",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-platform-roadmap.md",
+  "docs/specs/intel-lunar-lake-npu-roadmap.md",
+  "docs/specs/intel-lunar-lake-gpu-roadmap.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "258V platform probe fields and artifact paths are documented after merge.",
+]
+must_not_claim = [
+  "Arc 140V execution works.",
+  "Intel NPU execution works.",
+  "BitNet inference works on 258V.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Intel 258V platform validation Campaign Status
+
+- Campaign: `intel-258v-platform`
+- State: `active`
+- Objective: Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
+
+## Hard Constraints
+
+- Arc 140V OpenCL proof is not NPU proof.
+- OpenVINO GPU smoke is not packed BitNet kernel proof.
+- WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.

--- a/docs/tracking/campaigns/intel-a770/generated/status.md
+++ b/docs/tracking/campaigns/intel-a770/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Intel Arc A770 validation Campaign Status
+
+- Campaign: `intel-a770`
+- State: `active`
+- Objective: Validate Intel Arc A770 as an OpenCL-first BitNet acceleration lane with selected-device receipts and no CPU, NPU, CUDA, or OpenVINO GPU conflation.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| A770-003 | ready | TBD | `codex/intel-a770/A770-003-backend-identity` | Preserve Intel Arc A770 requested and selected backend identity without adding kernels or inference claims. |
+
+## Hard Constraints
+
+- OpenCL-first for native A770 proof.
+- OpenVINO GPU is reference only.
+- CPU fallback cannot count as A770 execution.

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -1,0 +1,19 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Intel NPU validation Campaign Status
+
+- Campaign: `intel-npu`
+- State: `active`
+- Objective: Validate Intel Lunar Lake NPU through OpenVINO static-shape detection, smoke, parity, and receipts without conflating NPU, GPU, or CPU work.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| NPU-002 | ready | TBD | `codex/intel-npu/NPU-002-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+
+## Hard Constraints
+
+- Device-node detection is not inference.
+- OpenVINO NPU smoke is not full BitNet inference.
+- CPU fallback cannot count as NPU execution.
+- Do not assume WSL can see the NPU unless OpenVINO reports NPU inside WSL.

--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -1,0 +1,33 @@
+# NVIDIA 5070 Ti Campaign
+
+Campaign ID: `nvidia-5070ti`
+
+Status: active
+
+## Objective
+
+Validate RTX 5070 Ti as a CUDA-first BitNet acceleration lane with selected-device receipts and no CPU, OpenCL, WGPU, or generic GPU conflation.
+
+## End State
+
+- RTX 5070 Ti CUDA backend identity is distinct from generic CUDA and WGPU.
+- CUDA and NVML probe facts are recorded before kernel execution claims.
+- CUDA smoke, parity, receipts, and benchmarks are sequenced after identity.
+
+## Hard Constraints
+
+- CUDA visibility is not kernel execution.
+- WGPU smoke is not CUDA proof.
+- CPU fallback cannot count as CUDA execution.
+- Performance claims require driver, CUDA, VRAM, power, and thermal context.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| RTX5070TI-003 | ready | Preserve selected-device CUDA identity. |
+| RTX5070TI-004 | proposed | Add CUDA and NVML runtime probe. |
+
+## Review Policy
+
+CUDA PRs are non-stackable when they touch backend identity, kernels, receipts, or benchmark interpretation.

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -1,0 +1,80 @@
+id = "nvidia-5070ti"
+title = "NVIDIA RTX 5070 Ti validation"
+status = "active"
+
+objective = "Validate RTX 5070 Ti as a CUDA-first BitNet acceleration lane with selected-device receipts and no CPU, OpenCL, WGPU, or generic GPU conflation."
+
+end_state = [
+  "RTX 5070 Ti CUDA backend identity is distinct from generic CUDA and WGPU.",
+  "CUDA and NVML probe facts are recorded before kernel execution claims.",
+  "CUDA smoke, parity, receipts, and benchmarks are sequenced after identity.",
+]
+
+hard_constraints = [
+  "CUDA visibility is not kernel execution.",
+  "WGPU smoke is not CUDA proof.",
+  "CPU fallback cannot count as CUDA execution.",
+  "Performance claims require driver, CUDA, VRAM, power, and thermal context.",
+]
+
+[[work_item]]
+id = "RTX5070TI-003"
+status = "ready"
+branch = "codex/nvidia-5070ti/RTX5070TI-003-backend-identity"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-device-config-core --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-common/src/types.rs",
+  "crates/bitnet-device-config-core/src/lib.rs",
+  "crates/bitnet-inference/src/backends.rs",
+  "crates/bitnet-cli-config-core/src/lib.rs",
+  "crates/bitnet-cli/src/main.rs",
+  "docs/tracking/campaigns/nvidia-5070ti/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "RTX 5070 Ti CUDA backend identity is preserved through config and logging surfaces.",
+]
+must_not_claim = [
+  "CUDA execution works.",
+  "WGPU smoke proves CUDA.",
+  "BitNet inference works on RTX 5070 Ti.",
+]
+
+[[work_item]]
+id = "RTX5070TI-004"
+status = "proposed"
+branch = "codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = ["RTX5070TI-003"]
+acceptance = "Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-device-probe --no-default-features --features cuda",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/**",
+  "docs/tracking/campaigns/nvidia-5070ti/**",
+]
+forbidden_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/cuda/**",
+]
+may_claim = [
+  "RTX 5070 Ti CUDA runtime visibility is recorded after probe receipts exist.",
+]
+must_not_claim = [
+  "CUDA kernel execution works.",
+  "BitNet inference works on RTX 5070 Ti.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -1,0 +1,20 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# NVIDIA RTX 5070 Ti validation Campaign Status
+
+- Campaign: `nvidia-5070ti`
+- State: `active`
+- Objective: Validate RTX 5070 Ti as a CUDA-first BitNet acceleration lane with selected-device receipts and no CPU, OpenCL, WGPU, or generic GPU conflation.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| RTX5070TI-003 | ready | TBD | `codex/nvidia-5070ti/RTX5070TI-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
+| RTX5070TI-004 | proposed | TBD | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
+
+## Hard Constraints
+
+- CUDA visibility is not kernel execution.
+- WGPU smoke is not CUDA proof.
+- CPU fallback cannot count as CUDA execution.
+- Performance claims require driver, CUDA, VRAM, power, and thermal context.

--- a/docs/tracking/campaigns/server-real-inference/CAMPAIGN.md
+++ b/docs/tracking/campaigns/server-real-inference/CAMPAIGN.md
@@ -1,0 +1,31 @@
+# Server Real Inference Campaign
+
+Campaign ID: `server-real-inference`
+
+Status: active
+
+## Objective
+
+Replace server-side simulated inference surfaces with real engine execution or explicit unavailable responses without weakening strict proof boundaries.
+
+## End State
+
+- Server endpoints never return fake model output in non-test builds.
+- Real inference entrypoints share loader, tokenizer, backend, receipt, and fallback truth with the CLI.
+- Unsupported server configurations fail explicitly.
+
+## Hard Constraints
+
+- Do not reintroduce simulated inference.
+- Do not bypass strict model loading, tokenizer authority, or fallback receipts.
+- Do not mix server runtime work with hardware kernel claims.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| SERVER-001 | proposed | Wire single-request server inference to real engine surfaces or explicit 501/503. |
+
+## Review Policy
+
+Server PRs should be non-stackable when they touch inference routing, runtime configuration, streaming, or receipt emission.

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -1,0 +1,47 @@
+id = "server-real-inference"
+title = "Server real inference"
+status = "active"
+
+objective = "Replace server-side simulated inference surfaces with real engine execution or explicit unavailable responses without weakening strict proof boundaries."
+
+end_state = [
+  "Server endpoints never return fake model output in non-test builds.",
+  "Real inference entrypoints share loader, tokenizer, backend, receipt, and fallback truth with the CLI.",
+  "Unsupported server configurations fail explicitly.",
+]
+
+hard_constraints = [
+  "Do not reintroduce simulated inference.",
+  "Do not bypass strict model loading, tokenizer authority, or fallback receipts.",
+  "Do not mix server runtime work with hardware kernel claims.",
+]
+
+[[work_item]]
+id = "SERVER-001"
+status = "proposed"
+branch = "codex/server-real-inference/SERVER-001-single-request-engine"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-inference/**",
+  "docs/tracking/campaigns/server-real-inference/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "Server inference routes are wired to real execution or explicit unavailable responses after merge.",
+]
+must_not_claim = [
+  "Any hardware acceleration works.",
+  "Server performance is proven.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -1,0 +1,18 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Server real inference Campaign Status
+
+- Campaign: `server-real-inference`
+- State: `active`
+- Objective: Replace server-side simulated inference surfaces with real engine execution or explicit unavailable responses without weakening strict proof boundaries.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| SERVER-001 | proposed | TBD | `codex/server-real-inference/SERVER-001-single-request-engine` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
+
+## Hard Constraints
+
+- Do not reintroduce simulated inference.
+- Do not bypass strict model loading, tokenizer authority, or fallback receipts.
+- Do not mix server runtime work with hardware kernel claims.

--- a/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
@@ -1,0 +1,33 @@
+# Tracker Infrastructure Campaign
+
+Campaign ID: `tracker-infra`
+
+Status: active
+
+## Objective
+
+Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates.
+
+## End State
+
+- Campaign manifests and events are the source of truth for active work.
+- Generated dashboards preserve global coordination visibility.
+- Legacy global status and ledger files are transition surfaces, not normal item PR targets.
+- xtask can check, generate, and doctor campaign state.
+
+## Hard Constraints
+
+- Do not touch runtime code, kernels, or dependencies for tracker infrastructure.
+- Do not remove hardware lane visibility.
+- Do not mark work merged without a merge SHA.
+- Do not name the pattern after the other repository it was borrowed from.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| TRACKER-001 | in_progress | Add advisory campaign check/generate/doctor commands and generated dashboards. |
+
+## Review Policy
+
+Tracker infrastructure PRs may touch global tracker transition docs and generated dashboards. Normal item PRs should not hand-edit legacy global tracker files once generation lands.

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "TRACKER-001"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/tracker-infra/TRACKER-001-campaign-local-gates"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -1,0 +1,54 @@
+id = "tracker-infra"
+title = "Tracker infrastructure"
+status = "active"
+
+objective = "Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates."
+
+end_state = [
+  "Campaign manifests and events are the source of truth for active work.",
+  "Generated dashboards preserve global coordination visibility.",
+  "Legacy global status and ledger files are transition surfaces, not normal item PR targets.",
+  "xtask can check, generate, and doctor campaign state.",
+]
+
+hard_constraints = [
+  "Do not touch runtime code, kernels, or dependencies for tracker infrastructure.",
+  "Do not remove hardware lane visibility.",
+  "Do not mark work merged without a merge SHA.",
+  "Do not name the pattern after the other repository it was borrowed from.",
+]
+
+[[work_item]]
+id = "TRACKER-001"
+status = "in_progress"
+branch = "codex/tracker-infra/TRACKER-001-campaign-local-gates"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run -p xtask --no-default-features -- campaign check apple-m4",
+  "cargo run -p xtask --no-default-features -- campaign doctor",
+  "cargo run -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".codex/campaigns/**",
+  "docs/tracking/TRACKER_MODEL.md",
+  "docs/tracking/campaigns/**",
+  "docs/tracking/generated/**",
+  "xtask/src/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Campaign-local tracker checks and generated dashboards are available after merge.",
+]
+must_not_claim = [
+  "Legacy global tracking has been fully removed.",
+  "CI enforcement is active.",
+  "Runtime behavior changed.",
+]

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T014803Z-TRACKER-001-in-progress.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T014803Z-TRACKER-001-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T01:48:03Z"
+campaign = "tracker-infra"
+item = "TRACKER-001"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started tracker infrastructure only.",
+  "Scope is campaign-local manifests, append-only events, generated dashboards, and advisory xtask gates; no runtime or kernel code.",
+]

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T020430Z-TRACKER-001-pr-open.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T020430Z-TRACKER-001-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T02:04:30Z"
+campaign = "tracker-infra"
+item = "TRACKER-001"
+event = "pr_open"
+pr = 3660
+head_sha = "46a2dc58599a771e459762a56fa0523875b4ee55"
+actor = "codex"
+
+notes = [
+  "Opened tracker infrastructure PR.",
+  "Adds advisory campaign-local tracker checks and generated dashboards without runtime code, kernels, QK256, server inference, or dependency changes.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -1,0 +1,19 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Tracker infrastructure Campaign Status
+
+- Campaign: `tracker-infra`
+- State: `active`
+- Objective: Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates.
+
+## Work Items
+
+| Item | State | PR | Branch | Acceptance |
+|---|---|---:|---|---|
+| TRACKER-001 | in_progress | TBD | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
+
+## Hard Constraints
+
+- Do not touch runtime code, kernels, or dependencies for tracker infrastructure.
+- Do not remove hardware lane visibility.
+- Do not mark work merged without a merge SHA.
+- Do not name the pattern after the other repository it was borrowed from.

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| TRACKER-001 | in_progress | TBD | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
+| TRACKER-001 | pr_open | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/README.md
+++ b/docs/tracking/generated/README.md
@@ -2,10 +2,23 @@
 
 This directory is reserved for generated alignment dashboards.
 
-Planned generated outputs:
+Generated outputs:
 
 - `global-dashboard.md`
 - `active-prs.md`
-- `lane-map.md`
+- `lane-dashboard.md`
+- `blocked-items.md`
 
-Do not hand-edit generated dashboard files once the generator lands. Source data should come from campaign-local `active.toml` files and append-only event files.
+Do not hand-edit generated dashboard files. Source data comes from campaign-local `active.toml` files and append-only event files.
+
+Refresh dashboards with:
+
+```bash
+cargo run -p xtask --no-default-features -- campaign generate
+```
+
+Check for stale dashboards with:
+
+```bash
+cargo run -p xtask --no-default-features -- campaign generate --check
+```

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -1,0 +1,7 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Active Campaign PRs
+
+| Campaign | Item | PR | Branch | Notes |
+|---|---|---:|---|---|
+| ci-coverage | CI-COVERAGE-001 | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
+| cpu-proof | CPU-BITNET-001 | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -5,3 +5,4 @@
 |---|---|---:|---|---|
 | ci-coverage | CI-COVERAGE-001 | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
 | cpu-proof | CPU-BITNET-001 | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
+| tracker-infra | TRACKER-001 | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,5 +4,4 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | ci-coverage | CI-COVERAGE-001 | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
-| cpu-proof | CPU-BITNET-001 | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
 | tracker-infra | TRACKER-001 | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -7,8 +7,8 @@
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | ready |
 | apple-m4 | M4-005 | M4-004 | proposed |
-| cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | pr_open |
-| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | proposed |
+| cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
+| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -1,0 +1,14 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Blocked Campaign Items
+
+| Campaign | Item | Blocked by | State |
+|---|---|---|---|
+| apple-m4 | M4-002 | M4-001 | merged |
+| apple-m4 | M4-003 | M4-002 | merged |
+| apple-m4 | M4-004 | M4-003 | ready |
+| apple-m4 | M4-005 | M4-004 | proposed |
+| cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | pr_open |
+| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | proposed |
+| cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
+| crate-collapse | LEAF-001 | INV-001 | proposed |
+| nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -1,0 +1,17 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# BitNet Campaign Dashboard
+
+| Campaign | Active item | PR | State | Next | Notes |
+|---|---|---:|---|---|---|
+| amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| apple-m4 | M4-004 | TBD | ready | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| ci-coverage | CI-COVERAGE-001 | #3620 | pr_open | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
+| cpu-proof | CPU-BITNET-001 | #3651 | pr_open | CPU-BITNET-002 | No GPU or NPU claims. |
+| cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
+| crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
+| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
+| intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
+| nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
+| server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
+| tracker-infra | TRACKER-001 | TBD | in_progress | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-004 | TBD | ready | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | pr_open | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-001 | #3651 | pr_open | CPU-BITNET-002 | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-002 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -14,4 +14,4 @@
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-001 | TBD | in_progress | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-001 | #3660 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-004 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-001 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-002 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -1,0 +1,17 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Campaign Lane Dashboard
+
+| Campaign | Title | Current item | Boundary |
+|---|---|---|---|
+| amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| apple-m4 | Apple M4 Mac mini validation | M4-004 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-001 | No GPU or NPU claims. |
+| cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
+| crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
+| intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
+| server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
+| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -1,0 +1,816 @@
+use anyhow::{Context, Result, bail};
+use clap::Subcommand;
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const CAMPAIGNS_DIR: &str = "docs/tracking/campaigns";
+const GENERATED_DIR: &str = "docs/tracking/generated";
+const GENERATED_HEADER: &str = "<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->\n";
+
+const WORK_ITEM_STATUSES: &[&str] =
+    &["proposed", "ready", "in_progress", "pr_open", "blocked", "merged", "superseded"];
+
+const CAMPAIGN_STATUSES: &[&str] = &["proposed", "active", "blocked", "complete", "archived"];
+const EVENT_TYPES: &[&str] =
+    &["in_progress", "pr_open", "blocked", "superseded", "merged", "closeout"];
+const REQUIRED_CAMPAIGNS: &[&str] = &[
+    "apple-m4",
+    "cpu-proof",
+    "cpu-qk256-performance",
+    "intel-a770",
+    "intel-npu",
+    "intel-258v-platform",
+    "nvidia-5070ti",
+    "amd-cpu-baselines",
+    "crate-collapse",
+    "server-real-inference",
+    "ci-coverage",
+    "tracker-infra",
+];
+
+#[derive(Subcommand)]
+pub enum CampaignCmd {
+    /// List campaign manifests.
+    List,
+    /// Print one campaign's status.
+    Status { campaign: String },
+    /// Print the next runnable item for a campaign.
+    Next { campaign: String },
+    /// Validate one campaign manifest and event log.
+    Check { campaign: String },
+    /// Generate campaign and global dashboards.
+    Generate {
+        /// Check that generated dashboards are current without writing files.
+        #[arg(long, default_value_t = false)]
+        check: bool,
+    },
+    /// Run cross-campaign advisory checks.
+    Doctor,
+}
+
+pub fn run(cmd: CampaignCmd) -> Result<()> {
+    let root = std::env::current_dir().context("resolve current directory")?;
+    match cmd {
+        CampaignCmd::List => cmd_list(&root),
+        CampaignCmd::Status { campaign } => cmd_status(&root, &campaign),
+        CampaignCmd::Next { campaign } => cmd_next(&root, &campaign),
+        CampaignCmd::Check { campaign } => cmd_check(&root, &campaign),
+        CampaignCmd::Generate { check } => cmd_generate(&root, check),
+        CampaignCmd::Doctor => cmd_doctor(&root),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CampaignManifest {
+    id: String,
+    title: String,
+    status: String,
+    #[serde(default)]
+    objective: String,
+    #[serde(default)]
+    end_state: Vec<String>,
+    #[serde(default)]
+    hard_constraints: Vec<String>,
+    #[serde(default, rename = "work_item")]
+    work_items: Vec<WorkItem>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct WorkItem {
+    id: String,
+    status: String,
+    branch: String,
+    #[serde(default)]
+    stackable: Option<bool>,
+    #[serde(default)]
+    requires_human_merge: Option<bool>,
+    #[serde(default)]
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    acceptance: Option<TextList>,
+    #[serde(default)]
+    commands: Vec<String>,
+    #[serde(default)]
+    allowed_paths: Vec<String>,
+    #[serde(default)]
+    forbidden_paths: Vec<String>,
+    #[serde(default)]
+    may_claim: Vec<String>,
+    #[serde(default)]
+    must_not_claim: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum TextList {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl TextList {
+    fn summary(&self) -> String {
+        match self {
+            TextList::One(value) => value.clone(),
+            TextList::Many(values) => values.join("; "),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            TextList::One(value) => value.trim().is_empty(),
+            TextList::Many(values) => values.iter().all(|value| value.trim().is_empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct Event {
+    timestamp: String,
+    campaign: String,
+    item: String,
+    event: String,
+    #[serde(default)]
+    pr: Option<u64>,
+    #[serde(default)]
+    head_sha: Option<String>,
+    #[serde(default)]
+    merge_sha: Option<String>,
+    #[serde(default)]
+    actor: Option<String>,
+    #[serde(default)]
+    notes: Vec<String>,
+}
+
+struct LoadedCampaign {
+    dir: PathBuf,
+    manifest: CampaignManifest,
+    events: Vec<Event>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Debug)]
+struct Problem {
+    severity: Severity,
+    message: String,
+}
+
+impl Problem {
+    fn error(message: impl Into<String>) -> Self {
+        Self { severity: Severity::Error, message: message.into() }
+    }
+
+    fn warning(message: impl Into<String>) -> Self {
+        Self { severity: Severity::Warning, message: message.into() }
+    }
+}
+
+fn cmd_list(root: &Path) -> Result<()> {
+    for campaign in load_all_campaigns(root)? {
+        println!(
+            "{}\t{}\t{}\t{} items",
+            campaign.manifest.id,
+            campaign.manifest.status,
+            campaign.manifest.title,
+            campaign.manifest.work_items.len()
+        );
+    }
+    Ok(())
+}
+
+fn cmd_status(root: &Path, campaign_id: &str) -> Result<()> {
+    let campaign = load_campaign(root, campaign_id)?;
+    let active = current_item(&campaign.manifest);
+    println!("campaign: {}", campaign.manifest.id);
+    println!("title: {}", campaign.manifest.title);
+    println!("status: {}", campaign.manifest.status);
+    if !campaign.manifest.objective.is_empty() {
+        println!("objective: {}", campaign.manifest.objective);
+    }
+    match active {
+        Some(item) => {
+            println!("active_item: {}", item.id);
+            println!("item_status: {}", item.status);
+            if let Some(pr) = latest_pr(&campaign.events, &item.id) {
+                println!("pr: #{pr}");
+            }
+        }
+        None => println!("active_item: none"),
+    }
+    Ok(())
+}
+
+fn cmd_next(root: &Path, campaign_id: &str) -> Result<()> {
+    let campaign = load_campaign(root, campaign_id)?;
+    let item_by_id = item_map(&campaign.manifest);
+    let next = campaign
+        .manifest
+        .work_items
+        .iter()
+        .find(|item| item.status == "ready" && deps_met(item, &item_by_id))
+        .or_else(|| {
+            campaign
+                .manifest
+                .work_items
+                .iter()
+                .find(|item| item.status == "proposed" && deps_met(item, &item_by_id))
+        });
+
+    match next {
+        Some(item) => {
+            println!("campaign: {}", campaign.manifest.id);
+            println!("next_item: {}", item.id);
+            println!("status: {}", item.status);
+            println!("branch: {}", item.branch);
+            if let Some(acceptance) = &item.acceptance {
+                println!("acceptance: {}", acceptance.summary());
+            }
+            println!("commands:");
+            for command in &item.commands {
+                println!("- {command}");
+            }
+        }
+        None => println!("campaign: {}\nnext_item: none", campaign.manifest.id),
+    }
+    Ok(())
+}
+
+fn cmd_check(root: &Path, campaign_id: &str) -> Result<()> {
+    let campaign = load_campaign(root, campaign_id)?;
+    let problems = validate_campaign(&campaign);
+    print_problems(&problems);
+    fail_on_errors(&problems)?;
+    println!("campaign check passed: {campaign_id}");
+    Ok(())
+}
+
+fn cmd_generate(root: &Path, check: bool) -> Result<()> {
+    let campaigns = load_all_campaigns(root)?;
+    let mut writes = BTreeMap::new();
+
+    for campaign in &campaigns {
+        let rel = format!("{CAMPAIGNS_DIR}/{}/generated/status.md", campaign.manifest.id);
+        writes.insert(root.join(&rel), render_campaign_status(campaign));
+    }
+
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/global-dashboard.md")),
+        render_global_dashboard(&campaigns),
+    );
+    writes
+        .insert(root.join(format!("{GENERATED_DIR}/active-prs.md")), render_active_prs(&campaigns));
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/lane-dashboard.md")),
+        render_lane_dashboard(&campaigns),
+    );
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/blocked-items.md")),
+        render_blocked_items(&campaigns),
+    );
+
+    let stale: Vec<_> = writes
+        .iter()
+        .filter_map(|(path, content)| {
+            let current = fs::read_to_string(path).ok();
+            if current.as_deref() == Some(content.as_str()) { None } else { Some(path.clone()) }
+        })
+        .collect();
+
+    if check {
+        if stale.is_empty() {
+            println!("generated dashboards are current");
+            return Ok(());
+        }
+        bail!(
+            "generated dashboards are stale:\n{}",
+            stale.iter().map(|path| format!("- {}", path.display())).collect::<Vec<_>>().join("\n")
+        );
+    }
+
+    for (path, content) in writes {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create generated directory {}", parent.display()))?;
+        }
+        fs::write(&path, content).with_context(|| format!("write {}", path.display()))?;
+    }
+    println!("generated campaign dashboards");
+    Ok(())
+}
+
+fn cmd_doctor(root: &Path) -> Result<()> {
+    let campaigns = load_all_campaigns(root)?;
+    let mut problems = Vec::new();
+    let campaign_ids: BTreeSet<_> =
+        campaigns.iter().map(|campaign| campaign.manifest.id.as_str()).collect();
+    for required in REQUIRED_CAMPAIGNS {
+        if !campaign_ids.contains(required) {
+            problems.push(Problem::error(format!("missing required campaign `{required}`")));
+        }
+    }
+
+    let mut item_ids: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut branches: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut prs: BTreeMap<u64, Vec<String>> = BTreeMap::new();
+
+    for campaign in &campaigns {
+        problems.extend(validate_campaign(campaign));
+        for item in &campaign.manifest.work_items {
+            item_ids.entry(&item.id).or_default().push(&campaign.manifest.id);
+            if !item.branch.trim().is_empty() {
+                branches.entry(&item.branch).or_default().push(&item.id);
+            }
+        }
+        for event in &campaign.events {
+            if let Some(pr) = event.pr {
+                prs.entry(pr).or_default().push(format!("{}:{}", campaign.manifest.id, event.item));
+            }
+        }
+    }
+
+    for (item_id, owners) in item_ids {
+        if owners.len() > 1 {
+            problems.push(Problem::error(format!(
+                "item `{item_id}` appears in multiple campaigns: {}",
+                owners.join(", ")
+            )));
+        }
+    }
+    for (branch, owners) in branches {
+        if owners.len() > 1 {
+            problems.push(Problem::error(format!(
+                "branch `{branch}` is claimed by multiple items: {}",
+                owners.join(", ")
+            )));
+        }
+    }
+    for (pr, owners) in prs {
+        let unique: BTreeSet<_> = owners.iter().collect();
+        if unique.len() > 1 {
+            problems.push(Problem::error(format!(
+                "PR #{pr} is claimed by multiple items: {}",
+                owners.join(", ")
+            )));
+        }
+    }
+
+    if generated_is_stale(root)? {
+        problems.push(Problem::warning(
+            "generated dashboards are stale; run `cargo run -p xtask --no-default-features -- campaign generate`",
+        ));
+    }
+
+    for path in changed_legacy_tracker_files(root)? {
+        problems.push(Problem::warning(format!(
+            "legacy tracker changed in this branch: {}; normal item PRs should use campaign files",
+            path.display()
+        )));
+    }
+
+    print_problems(&problems);
+    fail_on_errors(&problems)?;
+    println!("campaign doctor passed");
+    Ok(())
+}
+
+fn load_all_campaigns(root: &Path) -> Result<Vec<LoadedCampaign>> {
+    let campaigns_root = root.join(CAMPAIGNS_DIR);
+    let mut dirs = Vec::new();
+    for entry in fs::read_dir(&campaigns_root)
+        .with_context(|| format!("read {}", campaigns_root.display()))?
+    {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() && entry.path().join("active.toml").exists() {
+            dirs.push(entry.path());
+        }
+    }
+    dirs.sort();
+    dirs.into_iter().map(load_campaign_dir).collect()
+}
+
+fn load_campaign(root: &Path, campaign_id: &str) -> Result<LoadedCampaign> {
+    load_campaign_dir(root.join(CAMPAIGNS_DIR).join(campaign_id))
+}
+
+fn load_campaign_dir(dir: PathBuf) -> Result<LoadedCampaign> {
+    let manifest_path = dir.join("active.toml");
+    let raw = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let manifest: CampaignManifest =
+        toml::from_str(&raw).with_context(|| format!("parse {}", manifest_path.display()))?;
+    let events = load_events(&dir)?;
+    Ok(LoadedCampaign { dir, manifest, events })
+}
+
+fn load_events(campaign_dir: &Path) -> Result<Vec<Event>> {
+    let events_dir = campaign_dir.join("events");
+    if !events_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut paths = Vec::new();
+    for entry in
+        fs::read_dir(&events_dir).with_context(|| format!("read {}", events_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) == Some("toml") {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+
+    let mut events = Vec::new();
+    for path in paths {
+        let raw = fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let event: Event =
+            toml::from_str(&raw).with_context(|| format!("parse {}", path.display()))?;
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn validate_campaign(campaign: &LoadedCampaign) -> Vec<Problem> {
+    let mut problems = Vec::new();
+    let manifest = &campaign.manifest;
+    let dir_id = campaign.dir.file_name().and_then(|value| value.to_str()).unwrap_or_default();
+
+    if manifest.id != dir_id {
+        problems.push(Problem::error(format!(
+            "campaign id `{}` does not match directory `{dir_id}`",
+            manifest.id
+        )));
+    }
+    if !CAMPAIGN_STATUSES.contains(&manifest.status.as_str()) {
+        problems.push(Problem::error(format!(
+            "campaign `{}` has invalid status `{}`",
+            manifest.id, manifest.status
+        )));
+    }
+    if manifest.objective.trim().is_empty() {
+        problems.push(Problem::error(format!("campaign `{}` has empty objective", manifest.id)));
+    }
+    if manifest.end_state.is_empty() {
+        problems.push(Problem::warning(format!("campaign `{}` has no end_state", manifest.id)));
+    }
+    if manifest.hard_constraints.is_empty() {
+        problems
+            .push(Problem::warning(format!("campaign `{}` has no hard_constraints", manifest.id)));
+    }
+
+    let mut seen = BTreeSet::new();
+    let item_by_id = item_map(manifest);
+    for item in &manifest.work_items {
+        if !seen.insert(item.id.as_str()) {
+            problems.push(Problem::error(format!(
+                "campaign `{}` has duplicate item `{}`",
+                manifest.id, item.id
+            )));
+        }
+        if !WORK_ITEM_STATUSES.contains(&item.status.as_str()) {
+            problems.push(Problem::error(format!(
+                "item `{}` has invalid status `{}`",
+                item.id, item.status
+            )));
+        }
+        if item.branch.trim().is_empty() {
+            problems.push(Problem::error(format!("item `{}` has empty branch", item.id)));
+        }
+        if item.stackable.is_none() {
+            problems.push(Problem::warning(format!("item `{}` does not set stackable", item.id)));
+        }
+        if item.requires_human_merge.is_none() {
+            problems.push(Problem::warning(format!(
+                "item `{}` does not set requires_human_merge",
+                item.id
+            )));
+        }
+        for dep in &item.blocked_by {
+            if !item_by_id.contains_key(dep.as_str()) {
+                problems.push(Problem::error(format!(
+                    "item `{}` has unknown blocked_by dependency `{dep}`",
+                    item.id
+                )));
+            }
+        }
+        let acceptance_empty = match item.acceptance.as_ref() {
+            Some(acceptance) => acceptance.is_empty(),
+            None => true,
+        };
+        if acceptance_empty {
+            problems.push(Problem::error(format!("item `{}` has empty acceptance", item.id)));
+        }
+        if item.commands.is_empty() {
+            problems.push(Problem::error(format!("item `{}` has no commands", item.id)));
+        }
+        if item.allowed_paths.is_empty() {
+            problems.push(Problem::warning(format!("item `{}` has no allowed_paths", item.id)));
+        }
+        if item.forbidden_paths.is_empty() {
+            problems.push(Problem::warning(format!("item `{}` has no forbidden_paths", item.id)));
+        }
+        if item.status != "proposed" && item.may_claim.is_empty() {
+            problems.push(Problem::warning(format!("item `{}` has no may_claim", item.id)));
+        }
+        if item.status != "proposed" && item.must_not_claim.is_empty() {
+            problems.push(Problem::warning(format!("item `{}` has no must_not_claim", item.id)));
+        }
+    }
+
+    let item_ids: BTreeSet<_> = manifest.work_items.iter().map(|item| item.id.as_str()).collect();
+    let mut merged_events = BTreeSet::new();
+    for event in &campaign.events {
+        if event.timestamp.trim().is_empty() {
+            problems.push(Problem::error(format!(
+                "event for `{}` in campaign `{}` has empty timestamp",
+                event.item, manifest.id
+            )));
+        }
+        if event.campaign != manifest.id {
+            problems.push(Problem::error(format!(
+                "event `{}` points at campaign `{}` but is stored under `{}`",
+                event.item, event.campaign, manifest.id
+            )));
+        }
+        if !EVENT_TYPES.contains(&event.event.as_str()) {
+            problems.push(Problem::error(format!(
+                "event for `{}` has invalid event type `{}`",
+                event.item, event.event
+            )));
+        }
+        if !item_ids.contains(event.item.as_str()) {
+            problems.push(Problem::error(format!(
+                "event references unknown item `{}` in campaign `{}`",
+                event.item, manifest.id
+            )));
+        }
+        if event.event == "merged" {
+            if event.merge_sha.as_deref().unwrap_or("").trim().is_empty() {
+                problems.push(Problem::error(format!(
+                    "merged event for `{}` is missing merge_sha",
+                    event.item
+                )));
+            }
+            merged_events.insert(event.item.as_str());
+        }
+        if event.event == "pr_open" && event.pr.is_none() {
+            problems.push(Problem::warning(format!(
+                "pr_open event for `{}` is missing pr",
+                event.item
+            )));
+        }
+        if event.event == "pr_open" && event.head_sha.as_deref().unwrap_or("").trim().is_empty() {
+            problems.push(Problem::warning(format!(
+                "pr_open event for `{}` is missing head_sha",
+                event.item
+            )));
+        }
+        if event.actor.as_deref().unwrap_or("").trim().is_empty() {
+            problems.push(Problem::warning(format!(
+                "event `{}` for `{}` is missing actor",
+                event.event, event.item
+            )));
+        }
+        if event.notes.is_empty() {
+            problems.push(Problem::warning(format!(
+                "event `{}` for `{}` has no notes",
+                event.event, event.item
+            )));
+        }
+    }
+
+    for item in &manifest.work_items {
+        if item.status == "merged" && !merged_events.contains(item.id.as_str()) {
+            problems.push(Problem::error(format!(
+                "item `{}` is merged but has no merged event with merge_sha",
+                item.id
+            )));
+        }
+    }
+
+    problems
+}
+
+fn item_map(manifest: &CampaignManifest) -> BTreeMap<&str, &WorkItem> {
+    manifest.work_items.iter().map(|item| (item.id.as_str(), item)).collect()
+}
+
+fn deps_met<'a>(item: &WorkItem, item_by_id: &BTreeMap<&'a str, &'a WorkItem>) -> bool {
+    item.blocked_by
+        .iter()
+        .all(|dep| item_by_id.get(dep.as_str()).is_some_and(|dep_item| dep_item.status == "merged"))
+}
+
+fn current_item(manifest: &CampaignManifest) -> Option<&WorkItem> {
+    for status in ["pr_open", "in_progress", "blocked", "ready", "proposed"] {
+        if let Some(item) = manifest.work_items.iter().find(|item| item.status == status) {
+            return Some(item);
+        }
+    }
+    manifest.work_items.iter().find(|item| item.status == "merged")
+}
+
+fn latest_pr(events: &[Event], item_id: &str) -> Option<u64> {
+    events.iter().filter(|event| event.item == item_id).filter_map(|event| event.pr).last()
+}
+
+fn render_campaign_status(campaign: &LoadedCampaign) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+    out.push_str(&format!("# {} Campaign Status\n\n", campaign.manifest.title));
+    out.push_str(&format!("- Campaign: `{}`\n", campaign.manifest.id));
+    out.push_str(&format!("- State: `{}`\n", campaign.manifest.status));
+    out.push_str(&format!("- Objective: {}\n\n", campaign.manifest.objective));
+    out.push_str("## Work Items\n\n");
+    out.push_str("| Item | State | PR | Branch | Acceptance |\n");
+    out.push_str("|---|---|---:|---|---|\n");
+    for item in &campaign.manifest.work_items {
+        let pr = latest_pr(&campaign.events, &item.id)
+            .map(|pr| format!("#{pr}"))
+            .unwrap_or_else(|| "TBD".to_string());
+        let acceptance = item
+            .acceptance
+            .as_ref()
+            .map(TextList::summary)
+            .unwrap_or_else(|| "".to_string())
+            .replace('|', "\\|");
+        out.push_str(&format!(
+            "| {} | {} | {} | `{}` | {} |\n",
+            item.id, item.status, pr, item.branch, acceptance
+        ));
+    }
+    out.push('\n');
+    out.push_str("## Hard Constraints\n\n");
+    for constraint in &campaign.manifest.hard_constraints {
+        out.push_str(&format!("- {constraint}\n"));
+    }
+    out
+}
+
+fn render_global_dashboard(campaigns: &[LoadedCampaign]) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+    out.push_str("# BitNet Campaign Dashboard\n\n");
+    out.push_str("| Campaign | Active item | PR | State | Next | Notes |\n");
+    out.push_str("|---|---|---:|---|---|---|\n");
+    for campaign in campaigns {
+        let active = current_item(&campaign.manifest);
+        let active_id = active.map(|item| item.id.as_str()).unwrap_or("none");
+        let state = active.map(|item| item.status.as_str()).unwrap_or("none");
+        let pr = active
+            .and_then(|item| latest_pr(&campaign.events, &item.id))
+            .map(|pr| format!("#{pr}"))
+            .unwrap_or_else(|| "TBD".to_string());
+        let next = next_after_current(&campaign.manifest, active_id)
+            .map(|item| item.id.as_str())
+            .unwrap_or("none");
+        let note = campaign.manifest.hard_constraints.first().map(String::as_str).unwrap_or("");
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {} |\n",
+            campaign.manifest.id,
+            active_id,
+            pr,
+            state,
+            next,
+            note.replace('|', "\\|")
+        ));
+    }
+    out
+}
+
+fn next_after_current<'a>(manifest: &'a CampaignManifest, active_id: &str) -> Option<&'a WorkItem> {
+    let active_index = manifest.work_items.iter().position(|item| item.id == active_id)?;
+    manifest
+        .work_items
+        .iter()
+        .skip(active_index + 1)
+        .find(|item| !matches!(item.status.as_str(), "merged" | "superseded"))
+}
+
+fn render_active_prs(campaigns: &[LoadedCampaign]) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+    out.push_str("# Active Campaign PRs\n\n");
+    out.push_str("| Campaign | Item | PR | Branch | Notes |\n");
+    out.push_str("|---|---|---:|---|---|\n");
+    for campaign in campaigns {
+        for item in &campaign.manifest.work_items {
+            if item.status == "pr_open" {
+                let pr = latest_pr(&campaign.events, &item.id)
+                    .map(|pr| format!("#{pr}"))
+                    .unwrap_or_else(|| "TBD".to_string());
+                out.push_str(&format!(
+                    "| {} | {} | {} | `{}` | {} |\n",
+                    campaign.manifest.id,
+                    item.id,
+                    pr,
+                    item.branch,
+                    item.acceptance.as_ref().map(TextList::summary).unwrap_or_default()
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn render_lane_dashboard(campaigns: &[LoadedCampaign]) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+    out.push_str("# Campaign Lane Dashboard\n\n");
+    out.push_str("| Campaign | Title | Current item | Boundary |\n");
+    out.push_str("|---|---|---|---|\n");
+    for campaign in campaigns {
+        let current =
+            current_item(&campaign.manifest).map(|item| item.id.as_str()).unwrap_or("none");
+        let boundary = campaign
+            .manifest
+            .hard_constraints
+            .first()
+            .map(String::as_str)
+            .unwrap_or("")
+            .replace('|', "\\|");
+        out.push_str(&format!(
+            "| {} | {} | {} | {} |\n",
+            campaign.manifest.id, campaign.manifest.title, current, boundary
+        ));
+    }
+    out
+}
+
+fn render_blocked_items(campaigns: &[LoadedCampaign]) -> String {
+    let mut out = String::new();
+    out.push_str(GENERATED_HEADER);
+    out.push_str("# Blocked Campaign Items\n\n");
+    out.push_str("| Campaign | Item | Blocked by | State |\n");
+    out.push_str("|---|---|---|---|\n");
+    for campaign in campaigns {
+        for item in &campaign.manifest.work_items {
+            if item.status == "blocked" || !item.blocked_by.is_empty() {
+                out.push_str(&format!(
+                    "| {} | {} | {} | {} |\n",
+                    campaign.manifest.id,
+                    item.id,
+                    item.blocked_by.join(", "),
+                    item.status
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn generated_is_stale(root: &Path) -> Result<bool> {
+    let campaigns = load_all_campaigns(root)?;
+    let expected = root.join(format!("{GENERATED_DIR}/global-dashboard.md"));
+    let rendered = render_global_dashboard(&campaigns);
+    Ok(fs::read_to_string(expected).ok().as_deref() != Some(rendered.as_str()))
+}
+
+fn changed_legacy_tracker_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .args(["diff", "--name-only", "origin/main...HEAD"])
+        .current_dir(root)
+        .output();
+    let Ok(output) = output else {
+        return Ok(Vec::new());
+    };
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+    let paths = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|path| {
+            matches!(
+                *path,
+                "docs/tracking/bitnet-alignment/status.md"
+                    | "docs/tracking/bitnet-alignment/workstream-ledger.yaml"
+            )
+        })
+        .map(PathBuf::from)
+        .collect();
+    Ok(paths)
+}
+
+fn print_problems(problems: &[Problem]) {
+    for problem in problems {
+        match problem.severity {
+            Severity::Error => eprintln!("error: {}", problem.message),
+            Severity::Warning => eprintln!("warning: {}", problem.message),
+        }
+    }
+}
+
+fn fail_on_errors(problems: &[Problem]) -> Result<()> {
+    let errors = problems.iter().filter(|problem| problem.severity == Severity::Error).count();
+    if errors > 0 {
+        bail!("{errors} campaign tracker error(s)");
+    }
+    Ok(())
+}

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -774,6 +774,18 @@ fn generated_is_stale(root: &Path) -> Result<bool> {
 }
 
 fn changed_legacy_tracker_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let branch = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default();
+    if branch.contains("tracker-infra") || branch.contains("campaign-local") {
+        return Ok(Vec::new());
+    }
+
     let output = Command::new("git")
         .args(["diff", "--name-only", "origin/main...HEAD"])
         .current_dir(root)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -36,6 +36,7 @@ use std::{
 };
 use walkdir::WalkDir;
 
+mod campaign;
 mod cpp_setup_auto;
 mod crossval;
 pub mod ffi;
@@ -996,6 +997,12 @@ enum Cmd {
         #[arg(long, default_value_t = false)]
         dry_run: bool,
     },
+
+    /// Manage campaign-local alignment trackers.
+    Campaign {
+        #[command(subcommand)]
+        command: campaign::CampaignCmd,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1321,6 +1328,7 @@ fn real_main() -> Result<()> {
         Cmd::GridCheck { cpu_only, verbose, dry_run } => {
             grid_check::run(cpu_only, verbose, dry_run)
         }
+        Cmd::Campaign { command } => campaign::run(command),
     }
 }
 


### PR DESCRIPTION
## Summary
- add advisory `xtask campaign` commands for list/status/next/check/generate/doctor over campaign-local TOML trackers
- seed missing campaign-local goals/manifests for CPU QK256 performance, 258V platform, NVIDIA 5070 Ti, AMD CPU baselines, server real inference, CI coverage, and tracker infrastructure
- generate campaign/global dashboards from `active.toml` plus append-only event files, while marking legacy `status.md` and `workstream-ledger.yaml` as transition surfaces
- record M4-003 merged with #3652 merge SHA and move Apple M4 to M4-004 ready

## Scope boundaries
- Tracker infrastructure only
- No runtime code
- No kernels
- No QK256 implementation
- No server inference implementation
- No dependency changes
- Hardware lane visibility is preserved

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p xtask --no-default-features`
- `cargo run -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `cargo run -p xtask --no-default-features -- campaign generate --check`
- Parsed campaign TOML files with `tomllib`
- Parsed YAML tracker files with PyYAML
- `git diff --check`
- Searched touched tracker docs/xtask for conflict markers and forbidden borrowed-repo naming

## Note
`cargo run -p xtask -- campaign ...` still uses the repo's existing xtask default `gpu` feature, which links CUDA locally on this Mac. The tracker gate is feature-neutral and is documented/validated with `--no-default-features` so it works on non-CUDA machines.
