### PR TITLE
[codex][tracker-infra] Close tracker gate item (TRACKER-001)

### DIFF
--- a/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
@@ -26,7 +26,8 @@ Finish the move from global hand-edited alignment trackers to campaign-local TOM
 
 | Work item | Status | Notes |
 |---|---|---|
-| TRACKER-001 | in_progress | Add advisory campaign check/generate/doctor commands and generated dashboards. |
+| TRACKER-001 | merged | Advisory campaign check/generate/doctor commands and generated dashboards merged in #3660. |
+| TRACKER-002 | proposed | Add CI enforcement for campaign doctor and generated-dashboard freshness. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "TRACKER-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/tracker-infra/TRACKER-001-campaign-local-gates"
 stackable = false
 requires_human_merge = true
@@ -51,4 +51,35 @@ must_not_claim = [
   "Legacy global tracking has been fully removed.",
   "CI enforcement is active.",
   "Runtime behavior changed.",
+]
+
+[[work_item]]
+id = "TRACKER-002"
+status = "proposed"
+branch = "codex/tracker-infra/TRACKER-002-ci-enforcement"
+stackable = false
+requires_human_merge = true
+blocked_by = ["TRACKER-001"]
+acceptance = "Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run -p xtask --no-default-features -- campaign doctor",
+  "cargo run -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".github/workflows/**",
+  "docs/tracking/campaigns/tracker-infra/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "Campaign tracker checks are enforced in CI after merge.",
+]
+must_not_claim = [
+  "Runtime behavior changed.",
+  "Legacy global tracking has been removed.",
 ]

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T025026Z-TRACKER-001-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T025026Z-TRACKER-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T02:50:26Z"
+campaign = "tracker-infra"
+item = "TRACKER-001"
+event = "merged"
+pr = 3660
+merge_sha = "8bbff8c4fcf6637305f169827bc017fbfa36dda2"
+actor = "maintainer"
+
+notes = [
+  "Campaign-local tracker gates and generated dashboards merged.",
+  "Advisory only; CI enforcement remains a follow-up item.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -9,7 +9,8 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| TRACKER-001 | pr_open | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
+| TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
+| TRACKER-002 | proposed | TBD | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,4 +4,3 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | ci-coverage | CI-COVERAGE-001 | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
-| tracker-infra | TRACKER-001 | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -12,3 +12,4 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |
+| tracker-infra | TRACKER-002 | TRACKER-001 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -14,4 +14,4 @@
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-001 | #3660 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-002 | TBD | proposed | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -14,4 +14,4 @@
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
-| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | Tracker infrastructure | TRACKER-002 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- mark `TRACKER-001` merged with #3660 merge SHA `8bbff8c4fcf6637305f169827bc017fbfa36dda2`
- add the append-only merged event for `TRACKER-001`
- carry `TRACKER-002` as the proposed follow-up for CI enforcement of campaign doctor/generated-dashboard freshness
- regenerate campaign/global dashboards so active PRs no longer show #3660

## Scope boundaries
- Tracker bookkeeping only
- No runtime code
- No kernels
- No dependency changes
- No hardware claim changes

## Validation
- `cargo fmt --all -- --check`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `cargo run -p xtask --no-default-features -- campaign generate --check`
- Parsed campaign TOML files with `tomllib`
- `git diff --check`
- Searched touched tracker docs for conflict markers and forbidden borrowed-repo naming
