### PR TITLE
fix(xtask): satisfy campaign clippy

### DIFF
--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -618,7 +618,7 @@ fn current_item(manifest: &CampaignManifest) -> Option<&WorkItem> {
 }
 
 fn latest_pr(events: &[Event], item_id: &str) -> Option<u64> {
-    events.iter().filter(|event| event.item == item_id).filter_map(|event| event.pr).last()
+    events.iter().filter(|event| event.item == item_id).filter_map(|event| event.pr).next_back()
 }
 
 fn render_campaign_status(campaign: &LoadedCampaign) -> String {


### PR DESCRIPTION
## Summary
- replace `.last()` on a double-ended iterator with `.next_back()` in the campaign PR lookup

## Validation
- `git diff --check`
- `cargo clippy --locked -p xtask --no-default-features -- -D warnings`

This unblocks backlog PR validation that is currently failing on mainline clippy.