### PR TITLE
feat(tokenizers): establish deterministic tokenizer authority

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1147,140 +1147,77 @@ async fn run_simple_generation(
         }
     };
 
-    // Load tokenizer with auto-discovery
-    // Priority: explicit path ΓåÆ sibling tokenizer.json ΓåÆ parent tokenizer.json ΓåÆ GGUF embedded ΓåÆ mock
+    // Load tokenizer with deterministic CPU-BITNET authority.
+    // Priority: explicit path -> GGUF metadata -> sibling tokenizer asset.
 
     // Track GGUF metadata for JSON output
     let mut gguf_metadata: Option<(usize, usize)> = None;
-    let mut external_tokenizer = false;
+    let effective_strict_tokenizer = strict_tokenizer || strict_loader;
 
-    let tokenizer: std::sync::Arc<dyn Tokenizer + Send + Sync> = {
-        // Try auto-discovery first (handles explicit, sibling, parent)
-        let discovered_path = if tokenizer_path.is_some() {
-            // Explicit path provided
-            crate::tokenizer_discovery::resolve_tokenizer(&model_path, tokenizer_path)
-        } else {
-            // Try sibling/parent discovery
-            crate::tokenizer_discovery::resolve_tokenizer(&model_path, None)
-        };
-
-        match discovered_path {
-            Ok(path) => {
-                // Found tokenizer via discovery
-                external_tokenizer = true;
-                println!("Loading tokenizer from: {}", path.display());
-
-                match bitnet_tokenizers::load_tokenizer(&path) {
-                    Ok(tok) => tok,
-                    Err(e) => {
-                        if strict_tokenizer {
-                            eprintln!("Strict tokenizer failed: Failed to load tokenizer: {e}");
-                            std::process::exit(EXIT_STRICT_TOKENIZER);
-                        }
-                        if !allow_mock {
-                            anyhow::bail!(
-                                "Failed to load tokenizer from {}: {e}. Use --allow-mock to use mock tokenizer.",
-                                path.display()
-                            );
-                        }
-                        println!("Warning: Using mock tokenizer due to: {e}");
-                        std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
+    let tokenizer_resolution = match bitnet_tokenizers::auto::resolve_tokenizer(
+        &model_path,
+        tokenizer_path.as_deref(),
+        effective_strict_tokenizer,
+    ) {
+        Ok(resolution) => {
+            match resolution.source {
+                bitnet_tokenizers::auto::TokenizerSource::Explicit
+                | bitnet_tokenizers::auto::TokenizerSource::Sibling => {
+                    if let Some(path) = &resolution.path {
+                        println!("Loading tokenizer from: {}", path.display());
                     }
                 }
+                bitnet_tokenizers::auto::TokenizerSource::GgufMetadata => {
+                    println!("Successfully loaded tokenizer from GGUF metadata");
+                }
+                bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback => {}
             }
-            Err(_discovery_err) => {
-                if is_hf_directory {
-                    // For HF directories, check for tokenizer.json inside the model dir
-                    let hf_tok_path = model_path.join("tokenizer.json");
-                    if hf_tok_path.exists() {
-                        println!("Loading tokenizer from HuggingFace directory...");
-                        external_tokenizer = true;
-                        match bitnet_tokenizers::load_tokenizer(&hf_tok_path) {
-                            Ok(tok) => tok,
-                            Err(e) => {
-                                if strict_tokenizer {
-                                    eprintln!("Strict tokenizer failed: {e}");
-                                    std::process::exit(EXIT_STRICT_TOKENIZER);
-                                }
-                                if !allow_mock {
-                                    anyhow::bail!(
-                                        "Failed to load tokenizer from {}: {e}",
-                                        hf_tok_path.display()
-                                    );
-                                }
-                                println!("Warning: Using mock tokenizer due to: {e}");
-                                std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
-                            }
-                        }
-                    } else if strict_tokenizer {
-                        eprintln!(
-                            "Strict tokenizer failed: no tokenizer.json in {}",
-                            model_path.display()
-                        );
-                        std::process::exit(EXIT_STRICT_TOKENIZER);
-                    } else if !allow_mock {
-                        anyhow::bail!(
-                            "No tokenizer.json found in HuggingFace model directory: {}\n\
-                             Provide --tokenizer or use --allow-mock",
-                            model_path.display()
-                        );
-                    } else {
-                        println!("Warning: Using mock tokenizer (no tokenizer.json in HF dir)");
-                        std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
-                    }
+            resolution
+        }
+        Err(e) => {
+            if effective_strict_tokenizer {
+                eprintln!("Strict tokenizer failed: {e}");
+                std::process::exit(EXIT_STRICT_TOKENIZER);
+            }
+            if !allow_mock {
+                let model_dir = if is_hf_directory {
+                    model_path.as_path()
                 } else {
-                    // Discovery failed, try GGUF embedded as fallback
-                    println!("No external tokenizer found, attempting to load from GGUF model...");
-
-                    // Read the GGUF file to get tokenizer metadata
-                    let gguf_data = std::fs::read(&model_path)
-                        .context("Failed to read GGUF file for tokenizer extraction")?;
-                    let reader = bitnet_models::GgufReader::new(&gguf_data)
-                        .context("Failed to parse GGUF for tokenizer extraction")?;
-
-                    // Capture metadata counts
-                    let n_tensors = reader.tensor_count() as usize;
-                    let n_kv = reader.metadata_keys().len();
-                    gguf_metadata = Some((n_kv, n_tensors));
-
-                    match bitnet_tokenizers::loader::load_tokenizer_from_gguf_reader(&reader) {
-                        Ok(tok) => {
-                            println!("Successfully loaded SentencePiece tokenizer from GGUF");
-                            tok
-                        }
-                        Err(e) => {
-                            if strict_tokenizer {
-                                eprintln!(
-                                    "Strict tokenizer failed: Failed to load tokenizer from GGUF: {e}"
-                                );
-                                std::process::exit(EXIT_STRICT_TOKENIZER);
-                            }
-                            if !allow_mock {
-                                // Provide actionable error message
-                                let model_dir = model_path
-                                    .parent()
-                                    .unwrap_or_else(|| std::path::Path::new("."));
-                                anyhow::bail!(
-                                    "Failed to load tokenizer from GGUF: {e}\n\
-                                 \n\
-                                 No tokenizer found. Solutions:\n\
-                                 1. Download tokenizer:\n\
-                                    cargo run -p xtask -- tokenizer --into {}\n\
-                                 2. Provide explicit tokenizer path:\n\
-                                    --tokenizer /path/to/tokenizer.json\n\
-                                 3. Use mock tokenizer for testing:\n\
-                                    --allow-mock",
-                                    model_dir.display()
-                                );
-                            }
-                            println!("Warning: Using mock tokenizer due to: {e}");
-                            std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new())
-                        }
-                    }
-                } // end GGUF else branch
+                    model_path.parent().unwrap_or_else(|| std::path::Path::new("."))
+                };
+                anyhow::bail!(
+                    "{e}\n\
+                     \n\
+                     No tokenizer found. Solutions:\n\
+                     1. Download tokenizer:\n\
+                        cargo run -p xtask -- tokenizer --into {}\n\
+                     2. Provide explicit tokenizer path:\n\
+                        --tokenizer /path/to/tokenizer.json\n\
+                     3. Use mock tokenizer for testing only:\n\
+                        --allow-mock",
+                    model_dir.display()
+                );
+            }
+            println!("Warning: Using mock tokenizer due to: {e}");
+            bitnet_tokenizers::auto::TokenizerResolution {
+                tokenizer: std::sync::Arc::new(bitnet_tokenizers::MockTokenizer::new()),
+                source: bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback,
+                strict: false,
+                path: None,
             }
         }
     };
+    let tokenizer_source = tokenizer_resolution.source;
+    let tokenizer_strict = tokenizer_resolution.strict;
+    let tokenizer: std::sync::Arc<dyn Tokenizer + Send + Sync> = tokenizer_resolution.tokenizer;
+
+    if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
+        let gguf_data = std::fs::read(&model_path)
+            .context("Failed to read GGUF file for tokenizer metadata")?;
+        let reader = bitnet_models::GgufReader::new(&gguf_data)
+            .context("Failed to parse GGUF for tokenizer metadata")?;
+        gguf_metadata = Some((reader.metadata_keys().len(), reader.tensor_count() as usize));
+    }
 
     // Auto-detect template if needed
     let template_type = if prompt_template == "auto" {
@@ -1602,9 +1539,16 @@ async fn run_simple_generation(
         let generated_text = tokenizer.decode(&generated_tokens)?;
 
         // Get tokenizer info
+        let tokenizer_source_str = tokenizer_source.as_str();
         let tokenizer_info = serde_json::json!({
             "type": "sentencepiece",
-            "origin": if external_tokenizer { "external" } else { "embedded" },
+            "origin": if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
+                "embedded"
+            } else {
+                "external"
+            },
+            "source": tokenizer_source_str,
+            "strict": tokenizer_strict,
             "bos": tokenizer.bos_token_id().unwrap_or(1),
             "eos": tokenizer.eos_token_id().unwrap_or(2),
         });

--- a/crates/bitnet-tokenizers/src/auto.rs
+++ b/crates/bitnet-tokenizers/src/auto.rs
@@ -1,23 +1,96 @@
 use crate::Tokenizer;
-use anyhow::{Result, bail};
-use std::path::Path;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+/// Stable tokenizer source names for proof and receipt surfaces.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TokenizerSource {
+    Explicit,
+    GgufMetadata,
+    Sibling,
+    CompatibilityFallback,
+}
+
+impl TokenizerSource {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::GgufMetadata => "gguf_metadata",
+            Self::Sibling => "sibling",
+            Self::CompatibilityFallback => "compatibility_fallback",
+        }
+    }
+}
+
+/// Result of deterministic tokenizer resolution.
+#[derive(Clone)]
+pub struct TokenizerResolution {
+    pub tokenizer: Arc<dyn Tokenizer + Send + Sync>,
+    pub source: TokenizerSource,
+    pub strict: bool,
+    pub path: Option<PathBuf>,
+}
 
 pub fn load_auto(
     model_path: &Path,
     explicit: Option<&Path>,
 ) -> Result<Arc<dyn Tokenizer + Send + Sync>> {
+    Ok(resolve_tokenizer(model_path, explicit, false)?.tokenizer)
+}
+
+/// Resolve a tokenizer using the strict CPU-BITNET precedence.
+///
+/// Precedence:
+/// 1. Explicit tokenizer path.
+/// 2. Tokenizer embedded in GGUF metadata.
+/// 3. Sibling tokenizer assets next to the model.
+/// 4. Error. Compatibility fallbacks must be handled by callers explicitly.
+pub fn resolve_tokenizer(
+    model_path: &Path,
+    explicit: Option<&Path>,
+    strict: bool,
+) -> Result<TokenizerResolution> {
+    resolve_tokenizer_with(model_path, explicit, strict, crate::load_tokenizer, load_gguf_tokenizer)
+}
+
+fn resolve_tokenizer_with<LoadPath, LoadGguf>(
+    model_path: &Path,
+    explicit: Option<&Path>,
+    strict: bool,
+    mut load_path: LoadPath,
+    mut load_gguf: LoadGguf,
+) -> Result<TokenizerResolution>
+where
+    LoadPath: FnMut(&Path) -> Result<Arc<dyn Tokenizer + Send + Sync>>,
+    LoadGguf: FnMut(&Path) -> Result<Arc<dyn Tokenizer + Send + Sync>>,
+{
     if let Some(p) = explicit {
         tracing::info!("Using tokenizer: {}", p.display());
-        return crate::load_tokenizer(p);
+        let tokenizer = load_path(p)
+            .with_context(|| format!("Failed to load explicit tokenizer {}", p.display()))?;
+        return Ok(TokenizerResolution {
+            tokenizer,
+            source: TokenizerSource::Explicit,
+            strict,
+            path: Some(p.to_path_buf()),
+        });
     }
 
     // Try tokenizer embedded in GGUF (using proper BPE/SPM implementation)
     if model_path.extension().and_then(|s| s.to_str()) == Some("gguf") {
-        match load_gguf_tokenizer(model_path) {
+        match load_gguf(model_path) {
             Ok(tok) => {
                 tracing::info!("Using tokenizer: embedded in GGUF (BPE/SPM)");
-                return Ok(tok);
+                return Ok(TokenizerResolution {
+                    tokenizer: tok,
+                    source: TokenizerSource::GgufMetadata,
+                    strict,
+                    path: Some(model_path.to_path_buf()),
+                });
             }
             Err(e) => {
                 tracing::warn!(
@@ -29,16 +102,23 @@ pub fn load_auto(
     }
 
     // Try tokenizer.json / tokenizer.model in the model directory
-    if let Some(dir) = model_path.parent() {
-        let json = dir.join("tokenizer.json");
-        if json.exists() {
-            tracing::info!("Using tokenizer: {} (auto-detected)", json.display());
-            return crate::load_tokenizer(&json);
-        }
-        let spm = dir.join("tokenizer.model");
-        if spm.exists() {
-            tracing::info!("Using tokenizer: {} (auto-detected)", spm.display());
-            return crate::load_tokenizer(&spm);
+    let tokenizer_dir = if model_path.is_dir() { Some(model_path) } else { model_path.parent() };
+
+    if let Some(dir) = tokenizer_dir {
+        for file_name in ["tokenizer.json", "tokenizer.model"] {
+            let candidate = dir.join(file_name);
+            if candidate.exists() {
+                tracing::info!("Using tokenizer: {} (auto-detected)", candidate.display());
+                let tokenizer = load_path(&candidate).with_context(|| {
+                    format!("Failed to load sibling tokenizer {}", candidate.display())
+                })?;
+                return Ok(TokenizerResolution {
+                    tokenizer,
+                    source: TokenizerSource::Sibling,
+                    strict,
+                    path: Some(candidate),
+                });
+            }
         }
     }
 
@@ -57,7 +137,7 @@ pub fn load_auto(
 }
 
 /// Load tokenizer from GGUF file using pure-Rust BPE/SPM implementation
-fn load_gguf_tokenizer(model_path: &Path) -> Result<Arc<dyn Tokenizer + Send + Sync>> {
+pub fn load_gguf_tokenizer(model_path: &Path) -> Result<Arc<dyn Tokenizer + Send + Sync>> {
     use bitnet_models::formats::gguf::GgufReader;
     use bitnet_models::loader::MmapFile;
 
@@ -71,4 +151,109 @@ fn load_gguf_tokenizer(model_path: &Path) -> Result<Arc<dyn Tokenizer + Send + S
     let tokenizer = crate::gguf_loader::RustTokenizer::from_gguf(&reader)?;
 
     Ok(Arc::new(tokenizer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::MockTokenizer;
+    use anyhow::anyhow;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn mock_tokenizer() -> Arc<dyn Tokenizer + Send + Sync> {
+        Arc::new(MockTokenizer::new())
+    }
+
+    #[test]
+    fn explicit_path_takes_precedence() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let explicit = temp_dir.path().join("explicit.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&explicit, b"{}")?;
+
+        let result = resolve_tokenizer_with(
+            &model_path,
+            Some(&explicit),
+            true,
+            |_| Ok(mock_tokenizer()),
+            |_| Err(anyhow!("gguf should not be used")),
+        )?;
+
+        assert_eq!(result.source, TokenizerSource::Explicit);
+        assert!(result.strict);
+        assert_eq!(result.path.as_deref(), Some(explicit.as_path()));
+        Ok(())
+    }
+
+    #[test]
+    fn gguf_metadata_wins_before_sibling() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+
+        let result = resolve_tokenizer_with(
+            &model_path,
+            None,
+            true,
+            |_| Err(anyhow!("sibling should not be used")),
+            |_| Ok(mock_tokenizer()),
+        )?;
+
+        assert_eq!(result.source, TokenizerSource::GgufMetadata);
+        assert!(result.strict);
+        assert_eq!(result.path.as_deref(), Some(model_path.as_path()));
+        Ok(())
+    }
+
+    #[test]
+    fn sibling_selected_after_missing_gguf_tokenizer() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        let sibling = temp_dir.path().join("tokenizer.json");
+        fs::write(&model_path, b"GGUF")?;
+        fs::write(&sibling, b"{}")?;
+
+        let result = resolve_tokenizer_with(
+            &model_path,
+            None,
+            false,
+            |_| Ok(mock_tokenizer()),
+            |_| Err(anyhow!("no embedded tokenizer")),
+        )?;
+
+        assert_eq!(result.source, TokenizerSource::Sibling);
+        assert!(!result.strict);
+        assert_eq!(result.path.as_deref(), Some(sibling.as_path()));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_tokenizer_fails_in_strict_mode() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let model_path = temp_dir.path().join("model.gguf");
+        fs::write(&model_path, b"GGUF")?;
+
+        let result = resolve_tokenizer_with(
+            &model_path,
+            None,
+            true,
+            |_| Ok(mock_tokenizer()),
+            |_| Err(anyhow!("no embedded tokenizer")),
+        );
+
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn source_strings_are_stable() {
+        assert_eq!(TokenizerSource::Explicit.as_str(), "explicit");
+        assert_eq!(TokenizerSource::GgufMetadata.as_str(), "gguf_metadata");
+        assert_eq!(TokenizerSource::Sibling.as_str(), "sibling");
+        assert_eq!(TokenizerSource::CompatibilityFallback.as_str(), "compatibility_fallback");
+    }
 }

--- a/crates/bitnet-tokenizers/src/universal.rs
+++ b/crates/bitnet-tokenizers/src/universal.rs
@@ -50,8 +50,12 @@ impl UniversalTokenizer {
         let mmap = MmapFile::open(path)?;
         let reader = GgufReader::new(mmap.as_slice())?;
 
-        let model_type =
-            reader.get_string_metadata("tokenizer.ggml.model").unwrap_or_else(|| "gpt2".into());
+        let model_type = reader.get_string_metadata("tokenizer.ggml.model").ok_or_else(|| {
+            BitNetError::Inference(InferenceError::TokenizationFailed {
+                reason: "GGUF missing tokenizer.ggml.model; refusing GPT-2 compatibility guess"
+                    .to_string(),
+            })
+        })?;
 
         let tokens = reader.get_string_array_metadata("tokenizer.ggml.tokens").unwrap_or_default();
         let vocab_size = tokens.len();


### PR DESCRIPTION
## Summary
- add an authoritative tokenizer resolver that reports stable source and strictness metadata
- enforce CPU-BITNET tokenizer precedence: explicit path, GGUF metadata, sibling tokenizer asset, then failure
- wire the CLI run path to the resolver and mark mock fallback as explicit compatibility fallback only
- stop UniversalTokenizer::from_gguf from guessing GPT-2 when GGUF tokenizer metadata is missing

## Validation
- cargo check -p bitnet-tokenizers -p bitnet-cli
- cargo test -p bitnet-tokenizers auto::tests --lib
- git diff --check

## Boundary
CPU-BITNET-002 only. No packed layout, scalar kernels, AVX2, receipts schema, server inference, GPU, or crate collapse work.