### PR TITLE
ci(tracking): enforce campaign tracker gates (TRACKER-002)

### DIFF
--- a/.github/workflows/campaign-tracker.yml
+++ b/.github/workflows/campaign-tracker.yml
@@ -1,0 +1,60 @@
+name: Campaign Tracker
+
+on:
+  pull_request:
+    paths:
+      - '.codex/campaigns/**'
+      - 'docs/tracking/**'
+      - 'xtask/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/campaign-tracker.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.codex/campaigns/**'
+      - 'docs/tracking/**'
+      - 'xtask/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/campaign-tracker.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  campaign-tracker:
+    name: Doctor + Generated Dashboards
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      CARGO_TERM_COLOR: always
+      CARGO_INCREMENTAL: "0"
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: '1.92.0'
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: campaign-tracker
+
+      - name: Campaign doctor
+        run: cargo run --locked -p xtask --no-default-features -- campaign doctor
+
+      - name: Generated dashboard freshness
+        run: cargo run --locked -p xtask --no-default-features -- campaign generate --check

--- a/docs/tracking/TRACKER_MODEL.md
+++ b/docs/tracking/TRACKER_MODEL.md
@@ -26,6 +26,24 @@ cargo run -p xtask --no-default-features -- campaign generate
 cargo run -p xtask --no-default-features -- campaign doctor
 ```
 
+CI runs the strict forms with `--locked`:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign doctor
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+```
+
+`campaign doctor` treats stale generated dashboards and normal item PR edits to
+legacy global tracker files as failures. Branches whose names contain
+`tracker-infra`, `legacy-migration`, or `generated-dashboard` are the intended
+maintenance exceptions for legacy tracker edits.
+
+When `GITHUB_REPOSITORY` and `GITHUB_TOKEN` are available outside push-to-main
+checks, `campaign doctor` also reconciles campaign state against live open
+GitHub PRs. An open PR that claims an item must have that item marked `pr_open`
+with a matching `pr_open` event, and an item marked `pr_open` must still have a
+live open PR that claims the item.
+
 ## Work Item Contract
 
 Each `[[work_item]]` in `active.toml` should include:
@@ -73,7 +91,9 @@ Lifecycle events are TOML files under `events/` with these event types:
 - `merged`
 - `closeout`
 
-Merged events must include `merge_sha`. `pr_open` events should include the PR number and head SHA when available.
+Merged events must include `merge_sha`. `pr_open` events must include the PR
+number; head SHA remains recommended so humans can audit which branch state
+opened the PR.
 
 ## Stackability
 

--- a/docs/tracking/campaigns/ci-coverage/active.toml
+++ b/docs/tracking/campaigns/ci-coverage/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "CI-COVERAGE-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/implement-minimal-codecov-integration-vm5aks"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/ci-coverage/events/2026-05-06T030140Z-CI-COVERAGE-001-merged.toml
+++ b/docs/tracking/campaigns/ci-coverage/events/2026-05-06T030140Z-CI-COVERAGE-001-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T03:01:40Z"
+campaign = "ci-coverage"
+item = "CI-COVERAGE-001"
+event = "merged"
+pr = 3620
+head_sha = "f25be6d0ce883d32b67eb66691b194ca19c9a543"
+merge_sha = "650e1df17c43fef535d3ed50da75993de6eb65bc"
+actor = "maintainer"
+
+notes = [
+  "Recorded live GitHub state for #3620 before making campaign doctor enforce PR reconciliation.",
+  "No coverage workflow behavior changed in this tracker-infra PR.",
+]

--- a/docs/tracking/campaigns/ci-coverage/generated/status.md
+++ b/docs/tracking/campaigns/ci-coverage/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| CI-COVERAGE-001 | pr_open | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
+| CI-COVERAGE-001 | merged | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-002"
-status = "ready"
+status = "pr_open"
 branch = "codex/cpu-proof/CPU-BITNET-002-tokenizer-authority"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T033829Z-CPU-BITNET-002-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T033829Z-CPU-BITNET-002-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T03:38:29Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-002"
+event = "pr_open"
+pr = 3680
+head_sha = "92bce81a61f585bf5ed74c75689694fa4e018a3f"
+actor = "codex"
+
+notes = [
+  "Recorded live GitHub state for the tokenizer authority PR before making campaign doctor enforce PR reconciliation.",
+  "No CPU runtime behavior changed in this tracker-infra PR.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | CPU-BITNET-000 | merged | #3642 | `codex/cpu-proof/CPU-BITNET-000-path-plan` | Document the real BitNet CPU path implementation plan and sequence strict loader, tokenizer, layout, scalar, AVX2, receipts, and benchmarks. |
 | CPU-BITNET-001 | merged | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
-| CPU-BITNET-002 | ready | TBD | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+| CPU-BITNET-002 | pr_open | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -2,13 +2,13 @@ id = "tracker-infra"
 title = "Tracker infrastructure"
 status = "active"
 
-objective = "Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates."
+objective = "Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and enforced xtask gates."
 
 end_state = [
   "Campaign manifests and events are the source of truth for active work.",
   "Generated dashboards preserve global coordination visibility.",
   "Legacy global status and ledger files are transition surfaces, not normal item PR targets.",
-  "xtask can check, generate, and doctor campaign state.",
+  "xtask can check, generate, and doctor campaign state in mandatory CI gates.",
 ]
 
 hard_constraints = [
@@ -55,22 +55,25 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-002"
-status = "proposed"
+status = "in_progress"
 branch = "codex/tracker-infra/TRACKER-002-ci-enforcement"
 stackable = false
 requires_human_merge = true
 blocked_by = ["TRACKER-001"]
-acceptance = "Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed."
+acceptance = "Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures."
 commands = [
   "cargo fmt --all -- --check",
-  "cargo run -p xtask --no-default-features -- campaign doctor",
-  "cargo run -p xtask --no-default-features -- campaign generate --check",
+  "cargo check --locked -p xtask --no-default-features",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
   "git diff --check",
 ]
 allowed_paths = [
   ".github/workflows/**",
-  "docs/tracking/campaigns/tracker-infra/**",
+  "docs/tracking/TRACKER_MODEL.md",
+  "docs/tracking/campaigns/**",
   "docs/tracking/generated/**",
+  "xtask/src/**",
 ]
 forbidden_paths = [
   "crates/**",

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -55,7 +55,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-002"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/tracker-infra/TRACKER-002-ci-enforcement"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T032706Z-TRACKER-002-in-progress.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T032706Z-TRACKER-002-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T03:27:06Z"
+campaign = "tracker-infra"
+item = "TRACKER-002"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started CI enforcement for campaign doctor and generated-dashboard freshness.",
+  "Scope is tracker infrastructure only; no runtime code, kernels, QK256, server inference, or dependencies.",
+]

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T035245Z-TRACKER-002-pr-open.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T035245Z-TRACKER-002-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T03:52:45Z"
+campaign = "tracker-infra"
+item = "TRACKER-002"
+event = "pr_open"
+pr = 3681
+head_sha = "5ae9c5627ff086c071e29333b7f373ddb689972e"
+actor = "codex"
+
+notes = [
+  "Opened the CI enforcement PR for campaign doctor and generated-dashboard freshness.",
+  "The PR is tracker infrastructure only; no runtime code, kernels, QK256, server inference, dependencies, or hardware probe work changed.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -3,14 +3,14 @@
 
 - Campaign: `tracker-infra`
 - State: `active`
-- Objective: Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and advisory xtask gates.
+- Objective: Finish the move from global hand-edited alignment trackers to campaign-local TOML manifests, append-only events, generated dashboards, and enforced xtask gates.
 
 ## Work Items
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
-| TRACKER-002 | proposed | TBD | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed. |
+| TRACKER-002 | in_progress | TBD | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
-| TRACKER-002 | in_progress | TBD | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
+| TRACKER-002 | pr_open | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,3 +4,4 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-002 | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+| tracker-infra | TRACKER-002 | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| ci-coverage | CI-COVERAGE-001 | #3620 | `codex/implement-minimal-codecov-integration-vm5aks` | Guard Codecov upload so forked PRs and missing tokens skip coverage upload without failing unrelated CI. |
+| cpu-proof | CPU-BITNET-002 | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -8,8 +8,8 @@
 | apple-m4 | M4-004 | M4-003 | ready |
 | apple-m4 | M4-005 | M4-004 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
-| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | ready |
+| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | pr_open |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |
-| tracker-infra | TRACKER-002 | TRACKER-001 | proposed |
+| tracker-infra | TRACKER-002 | TRACKER-001 | in_progress |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -12,4 +12,4 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |
-| tracker-infra | TRACKER-002 | TRACKER-001 | in_progress |
+| tracker-infra | TRACKER-002 | TRACKER-001 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -5,8 +5,8 @@
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-004 | TBD | ready | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
-| ci-coverage | CI-COVERAGE-001 | #3620 | pr_open | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-002 | TBD | ready | none | No GPU or NPU claims. |
+| ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
+| cpu-proof | CPU-BITNET-002 | #3680 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
@@ -14,4 +14,4 @@
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-002 | TBD | proposed | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-002 | TBD | in_progress | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -14,4 +14,4 @@
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-002 | TBD | in_progress | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-002 | #3681 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -1053,13 +1053,35 @@ fn pull_request_claims_item(pr: &GithubPullRequest, item_id: &str) -> bool {
     if pr.labels.iter().any(|label| label.name.eq_ignore_ascii_case(&item_label)) {
         return true;
     }
-
-    let mut text = pr.title.clone();
-    if let Some(body) = &pr.body {
-        text.push('\n');
-        text.push_str(body);
+    if pr.title.contains(item_id) {
+        return true;
     }
-    text.contains(item_id)
+
+    pr.body
+        .as_deref()
+        .is_some_and(|body| body.lines().any(|line| body_line_claims_item(line, item_id)))
+}
+
+fn body_line_claims_item(line: &str, item_id: &str) -> bool {
+    let trimmed = line
+        .trim()
+        .trim_start_matches('-')
+        .trim_start_matches('*')
+        .trim_start_matches('>')
+        .trim()
+        .trim_matches('`')
+        .trim();
+    if trimmed.starts_with(item_id) {
+        return true;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let explicit_claim = lower.starts_with("work item")
+        || lower.starts_with("item:")
+        || lower.starts_with("item ")
+        || lower.starts_with("scope:")
+        || lower.starts_with("boundary:");
+    explicit_claim && trimmed.contains(item_id)
 }
 
 fn current_branch_name(root: &Path) -> String {

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -144,6 +144,31 @@ struct Event {
     notes: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GithubPullRequest {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    merged_at: Option<String>,
+    #[serde(default)]
+    merge_commit_sha: Option<String>,
+    #[serde(default)]
+    labels: Vec<GithubLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubLabel {
+    name: String,
+}
+
+struct GithubContext {
+    repository: String,
+    token: String,
+}
+
 struct LoadedCampaign {
     dir: PathBuf,
     manifest: CampaignManifest,
@@ -253,35 +278,8 @@ fn cmd_check(root: &Path, campaign_id: &str) -> Result<()> {
 
 fn cmd_generate(root: &Path, check: bool) -> Result<()> {
     let campaigns = load_all_campaigns(root)?;
-    let mut writes = BTreeMap::new();
-
-    for campaign in &campaigns {
-        let rel = format!("{CAMPAIGNS_DIR}/{}/generated/status.md", campaign.manifest.id);
-        writes.insert(root.join(&rel), render_campaign_status(campaign));
-    }
-
-    writes.insert(
-        root.join(format!("{GENERATED_DIR}/global-dashboard.md")),
-        render_global_dashboard(&campaigns),
-    );
-    writes
-        .insert(root.join(format!("{GENERATED_DIR}/active-prs.md")), render_active_prs(&campaigns));
-    writes.insert(
-        root.join(format!("{GENERATED_DIR}/lane-dashboard.md")),
-        render_lane_dashboard(&campaigns),
-    );
-    writes.insert(
-        root.join(format!("{GENERATED_DIR}/blocked-items.md")),
-        render_blocked_items(&campaigns),
-    );
-
-    let stale: Vec<_> = writes
-        .iter()
-        .filter_map(|(path, content)| {
-            let current = fs::read_to_string(path).ok();
-            if current.as_deref() == Some(content.as_str()) { None } else { Some(path.clone()) }
-        })
-        .collect();
+    let writes = expected_dashboard_writes(root, &campaigns);
+    let stale = stale_generated_dashboards(&writes);
 
     if check {
         if stale.is_empty() {
@@ -361,18 +359,26 @@ fn cmd_doctor(root: &Path) -> Result<()> {
         }
     }
 
-    if generated_is_stale(root)? {
-        problems.push(Problem::warning(
-            "generated dashboards are stale; run `cargo run -p xtask --no-default-features -- campaign generate`",
-        ));
+    let stale_dashboards = stale_generated_dashboards(&expected_dashboard_writes(root, &campaigns));
+    if !stale_dashboards.is_empty() {
+        problems.push(Problem::error(format!(
+            "generated dashboards are stale; run `cargo run -p xtask --no-default-features -- campaign generate`:\n{}",
+            stale_dashboards
+                .iter()
+                .map(|path| format!("- {}", path.display()))
+                .collect::<Vec<_>>()
+                .join("\n")
+        )));
     }
 
     for path in changed_legacy_tracker_files(root)? {
-        problems.push(Problem::warning(format!(
+        problems.push(Problem::error(format!(
             "legacy tracker changed in this branch: {}; normal item PRs should use campaign files",
             path.display()
         )));
     }
+
+    problems.extend(reconcile_github_pull_requests(&campaigns));
 
     print_problems(&problems);
     fail_on_errors(&problems)?;
@@ -526,6 +532,7 @@ fn validate_campaign(campaign: &LoadedCampaign) -> Vec<Problem> {
 
     let item_ids: BTreeSet<_> = manifest.work_items.iter().map(|item| item.id.as_str()).collect();
     let mut merged_events = BTreeSet::new();
+    let mut pr_open_events_with_pr = BTreeSet::new();
     for event in &campaign.events {
         if event.timestamp.trim().is_empty() {
             problems.push(Problem::error(format!(
@@ -561,10 +568,11 @@ fn validate_campaign(campaign: &LoadedCampaign) -> Vec<Problem> {
             merged_events.insert(event.item.as_str());
         }
         if event.event == "pr_open" && event.pr.is_none() {
-            problems.push(Problem::warning(format!(
-                "pr_open event for `{}` is missing pr",
-                event.item
-            )));
+            problems
+                .push(Problem::error(format!("pr_open event for `{}` is missing pr", event.item)));
+        }
+        if event.event == "pr_open" && event.pr.is_some() {
+            pr_open_events_with_pr.insert(event.item.as_str());
         }
         if event.event == "pr_open" && event.head_sha.as_deref().unwrap_or("").trim().is_empty() {
             problems.push(Problem::warning(format!(
@@ -590,6 +598,12 @@ fn validate_campaign(campaign: &LoadedCampaign) -> Vec<Problem> {
         if item.status == "merged" && !merged_events.contains(item.id.as_str()) {
             problems.push(Problem::error(format!(
                 "item `{}` is merged but has no merged event with merge_sha",
+                item.id
+            )));
+        }
+        if item.status == "pr_open" && !pr_open_events_with_pr.contains(item.id.as_str()) {
+            problems.push(Problem::error(format!(
+                "item `{}` is pr_open but has no pr_open event with a PR number",
                 item.id
             )));
         }
@@ -766,23 +780,48 @@ fn render_blocked_items(campaigns: &[LoadedCampaign]) -> String {
     out
 }
 
-fn generated_is_stale(root: &Path) -> Result<bool> {
-    let campaigns = load_all_campaigns(root)?;
-    let expected = root.join(format!("{GENERATED_DIR}/global-dashboard.md"));
-    let rendered = render_global_dashboard(&campaigns);
-    Ok(fs::read_to_string(expected).ok().as_deref() != Some(rendered.as_str()))
+fn expected_dashboard_writes(
+    root: &Path,
+    campaigns: &[LoadedCampaign],
+) -> BTreeMap<PathBuf, String> {
+    let mut writes = BTreeMap::new();
+
+    for campaign in campaigns {
+        let rel = format!("{CAMPAIGNS_DIR}/{}/generated/status.md", campaign.manifest.id);
+        writes.insert(root.join(&rel), render_campaign_status(campaign));
+    }
+
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/global-dashboard.md")),
+        render_global_dashboard(campaigns),
+    );
+    writes
+        .insert(root.join(format!("{GENERATED_DIR}/active-prs.md")), render_active_prs(campaigns));
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/lane-dashboard.md")),
+        render_lane_dashboard(campaigns),
+    );
+    writes.insert(
+        root.join(format!("{GENERATED_DIR}/blocked-items.md")),
+        render_blocked_items(campaigns),
+    );
+
+    writes
+}
+
+fn stale_generated_dashboards(writes: &BTreeMap<PathBuf, String>) -> Vec<PathBuf> {
+    writes
+        .iter()
+        .filter_map(|(path, content)| {
+            let current = fs::read_to_string(path).ok();
+            if current.as_deref() == Some(content.as_str()) { None } else { Some(path.clone()) }
+        })
+        .collect()
 }
 
 fn changed_legacy_tracker_files(root: &Path) -> Result<Vec<PathBuf>> {
-    let branch = Command::new("git")
-        .args(["branch", "--show-current"])
-        .current_dir(root)
-        .output()
-        .ok()
-        .filter(|output| output.status.success())
-        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
-        .unwrap_or_default();
-    if branch.contains("tracker-infra") || branch.contains("campaign-local") {
+    let branch = current_branch_name(root);
+    if legacy_tracker_change_exception(&branch) {
         return Ok(Vec::new());
     }
 
@@ -808,6 +847,245 @@ fn changed_legacy_tracker_files(root: &Path) -> Result<Vec<PathBuf>> {
         .map(PathBuf::from)
         .collect();
     Ok(paths)
+}
+
+fn reconcile_github_pull_requests(campaigns: &[LoadedCampaign]) -> Vec<Problem> {
+    let Some(context) = github_context() else {
+        return Vec::new();
+    };
+
+    let mut problems = Vec::new();
+    let client = match reqwest::blocking::Client::builder()
+        .user_agent("bitnet-rs-xtask-campaign-doctor")
+        .build()
+    {
+        Ok(client) => client,
+        Err(err) => {
+            problems
+                .push(github_reconciliation_problem(format!("build GitHub client failed: {err}")));
+            return problems;
+        }
+    };
+
+    let open_prs = match fetch_open_pull_requests(&client, &context) {
+        Ok(prs) => prs,
+        Err(err) => {
+            problems.push(github_reconciliation_problem(format!(
+                "fetch open GitHub PRs failed: {err}"
+            )));
+            return problems;
+        }
+    };
+
+    let mut items = BTreeMap::new();
+    let mut pr_open_event_prs = BTreeMap::new();
+    let mut merged_events = BTreeSet::new();
+    for campaign in campaigns {
+        for item in &campaign.manifest.work_items {
+            items.insert(item.id.as_str(), (&campaign.manifest.id, item));
+        }
+        for event in &campaign.events {
+            if event.event == "pr_open" {
+                if let Some(pr) = event.pr {
+                    pr_open_event_prs.insert(event.item.as_str(), pr);
+                }
+            }
+            if event.event == "merged" {
+                merged_events.insert(event.item.as_str());
+            }
+        }
+    }
+
+    let mut claims: BTreeMap<&str, Vec<&GithubPullRequest>> = BTreeMap::new();
+    for pr in &open_prs {
+        for item_id in items.keys() {
+            if pull_request_claims_item(pr, item_id) {
+                claims.entry(item_id).or_default().push(pr);
+            }
+        }
+    }
+
+    for (item_id, claimed_prs) in &claims {
+        if claimed_prs.len() > 1 {
+            problems.push(Problem::error(format!(
+                "multiple open GitHub PRs claim `{item_id}`: {}",
+                claimed_prs
+                    .iter()
+                    .map(|pr| format!("#{}", pr.number))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+
+        let Some((_campaign_id, item)) = items.get(item_id).copied() else {
+            continue;
+        };
+        let pr = claimed_prs[0];
+        if item.status != "pr_open" {
+            problems.push(Problem::error(format!(
+                "open GitHub PR #{} claims `{item_id}`, but active.toml status is `{}`",
+                pr.number, item.status
+            )));
+        }
+        match pr_open_event_prs.get(item_id) {
+            Some(recorded_pr) if *recorded_pr == pr.number => {}
+            Some(recorded_pr) => problems.push(Problem::error(format!(
+                "open GitHub PR #{} claims `{item_id}`, but the latest pr_open event records #{}",
+                pr.number, recorded_pr
+            ))),
+            None => problems.push(Problem::error(format!(
+                "open GitHub PR #{} claims `{item_id}`, but no pr_open event records a PR number",
+                pr.number
+            ))),
+        }
+    }
+
+    let open_pr_numbers: BTreeSet<_> = open_prs.iter().map(|pr| pr.number).collect();
+    for (item_id, (_campaign_id, item)) in &items {
+        if item.status != "pr_open" {
+            continue;
+        }
+        let Some(recorded_pr) = pr_open_event_prs.get(item_id) else {
+            continue;
+        };
+        if open_pr_numbers.contains(recorded_pr) {
+            if !claims.contains_key(item_id) {
+                problems.push(Problem::error(format!(
+                    "item `{item_id}` is pr_open for GitHub PR #{recorded_pr}, but that open PR does not claim the item in its title, body, or labels"
+                )));
+            }
+            continue;
+        }
+
+        match fetch_pull_request(&client, &context, *recorded_pr) {
+            Ok(pr) if pr.merged_at.is_some() && !merged_events.contains(item_id) => {
+                let merge_ref = pr
+                    .merge_commit_sha
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("<unknown merge sha>");
+                problems.push(Problem::error(format!(
+                    "item `{item_id}` is pr_open, but GitHub PR #{} merged at {}; add a merged event with merge_sha `{merge_ref}` and mark the item merged",
+                    pr.number,
+                    pr.merged_at.unwrap_or_default()
+                )));
+            }
+            Ok(pr) => {
+                problems.push(Problem::error(format!(
+                    "item `{item_id}` is pr_open for GitHub PR #{}, but the PR is not open",
+                    pr.number
+                )));
+            }
+            Err(err) => problems.push(github_reconciliation_problem(format!(
+                "fetch GitHub PR #{recorded_pr} for `{item_id}` failed: {err}"
+            ))),
+        }
+    }
+
+    problems
+}
+
+fn github_context() -> Option<GithubContext> {
+    if std::env::var("GITHUB_EVENT_NAME").ok().as_deref() == Some("push") {
+        return None;
+    }
+
+    let repository = std::env::var("GITHUB_REPOSITORY").ok();
+    let token = std::env::var("GITHUB_TOKEN").or_else(|_| std::env::var("GH_TOKEN")).ok();
+    match (repository, token) {
+        (Some(repository), Some(token))
+            if !repository.trim().is_empty() && !token.trim().is_empty() =>
+        {
+            Some(GithubContext { repository, token })
+        }
+        _ => None,
+    }
+}
+
+fn github_reconciliation_problem(message: String) -> Problem {
+    if std::env::var("GITHUB_ACTIONS").ok().as_deref() == Some("true") {
+        Problem::error(format!("GitHub PR reconciliation failed: {message}"))
+    } else {
+        Problem::warning(format!("GitHub PR reconciliation skipped: {message}"))
+    }
+}
+
+fn fetch_open_pull_requests(
+    client: &reqwest::blocking::Client,
+    context: &GithubContext,
+) -> Result<Vec<GithubPullRequest>> {
+    let url = format!(
+        "https://api.github.com/repos/{}/pulls?state=open&per_page=100",
+        context.repository
+    );
+    client
+        .get(url)
+        .bearer_auth(&context.token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .context("send GitHub open PR request")?
+        .error_for_status()
+        .context("GitHub open PR request failed")?
+        .json()
+        .context("parse GitHub open PR response")
+}
+
+fn fetch_pull_request(
+    client: &reqwest::blocking::Client,
+    context: &GithubContext,
+    pr: u64,
+) -> Result<GithubPullRequest> {
+    let url = format!("https://api.github.com/repos/{}/pulls/{pr}", context.repository);
+    client
+        .get(url)
+        .bearer_auth(&context.token)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .with_context(|| format!("send GitHub PR #{pr} request"))?
+        .error_for_status()
+        .with_context(|| format!("GitHub PR #{pr} request failed"))?
+        .json()
+        .with_context(|| format!("parse GitHub PR #{pr} response"))
+}
+
+fn pull_request_claims_item(pr: &GithubPullRequest, item_id: &str) -> bool {
+    let item_label = format!("item:{item_id}").to_ascii_lowercase();
+    if pr.labels.iter().any(|label| label.name.eq_ignore_ascii_case(&item_label)) {
+        return true;
+    }
+
+    let mut text = pr.title.clone();
+    if let Some(body) = &pr.body {
+        text.push('\n');
+        text.push_str(body);
+    }
+    text.contains(item_id)
+}
+
+fn current_branch_name(root: &Path) -> String {
+    for key in ["GITHUB_HEAD_REF", "GITHUB_REF_NAME"] {
+        if let Ok(value) = std::env::var(key) {
+            let value = value.trim().to_string();
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+
+    Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+fn legacy_tracker_change_exception(branch: &str) -> bool {
+    ["tracker-infra", "legacy-migration", "generated-dashboard"]
+        .iter()
+        .any(|marker| branch.contains(marker))
 }
 
 fn print_problems(problems: &[Problem]) {


### PR DESCRIPTION
Campaign: tracker-infra
Work item: TRACKER-002

## Summary
- add a mandatory Campaign Tracker GitHub Actions workflow for `campaign doctor` and generated-dashboard freshness
- make `campaign doctor` fail on stale generated dashboards, normal legacy global tracker edits, and malformed `pr_open` tracker state
- reconcile live open GitHub PRs against campaign `pr_open` state when a PR check has repository token access
- record current live tracker drift before enforcing it: #3620 merged for `CI-COVERAGE-001`, and #3680 is open for `CPU-BITNET-002`

## Boundary
Tracker infrastructure only. No runtime code, kernels, QK256, server inference, dependency manifests, or hardware probe/runtime work changed.

## Validation
- `cargo fmt --all -- --check`
- `cargo check --locked -p xtask --no-default-features`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `GITHUB_EVENT_NAME=push GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- parsed campaign TOML, workflow YAML, and legacy YAML
- `git diff --check`
