### PR TITLE
fix(wasm): consolidate output region accessibility

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -92,7 +92,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .container-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -296,10 +296,10 @@
 
             <div class="input-group">
                 <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
-                    <label style="margin-bottom: 0;">Output:</label>
+                    <div id="output-label" class="container-label" style="margin-bottom: 0;">Output:</div>
                     <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard">Copy</button>
                 </div>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label" aria-live="polite">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -321,8 +321,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" class="container-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label" aria-live="polite">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -364,8 +364,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" class="container-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label" aria-live="polite">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -387,8 +387,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" class="container-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label" aria-live="polite">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -82,7 +82,7 @@
             margin: 15px 0;
         }
 
-        label {
+        label, .container-label {
             display: block;
             margin-bottom: 5px;
             font-weight: 500;
@@ -274,8 +274,8 @@
             </div>
 
             <div class="input-group">
-                <label>Output:</label>
-                <div id="output" class="output">Generated text will appear here...</div>
+                <div id="output-label" class="container-label">Output:</div>
+                <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label" aria-live="polite">Generated text will appear here...</div>
             </div>
         </div>
     </div>
@@ -297,8 +297,8 @@
             </div>
 
             <div class="input-group">
-                <label>Streaming Output:</label>
-                <div id="streaming-output" class="streaming-output">Streaming output will appear here...</div>
+                <div id="streaming-output-label" class="container-label">Streaming Output:</div>
+                <div id="streaming-output" class="streaming-output" tabindex="0" role="region" aria-labelledby="streaming-output-label" aria-live="polite">Streaming output will appear here...</div>
             </div>
 
             <div class="stats">
@@ -340,8 +340,8 @@
             </div>
 
             <div class="input-group">
-                <label>Worker Output:</label>
-                <div id="worker-output" class="output">Worker output will appear here...</div>
+                <div id="worker-output-label" class="container-label">Worker Output:</div>
+                <div id="worker-output" class="output" tabindex="0" role="region" aria-labelledby="worker-output-label" aria-live="polite">Worker output will appear here...</div>
             </div>
         </div>
     </div>
@@ -363,8 +363,8 @@
             </div>
 
             <div class="input-group">
-                <label>Benchmark Results:</label>
-                <div id="benchmark-output" class="output">Run benchmarks to see performance metrics...</div>
+                <div id="benchmark-output-label" class="container-label">Benchmark Results:</div>
+                <div id="benchmark-output" class="output" tabindex="0" role="region" aria-labelledby="benchmark-output-label" aria-live="polite">Run benchmarks to see performance metrics...</div>
             </div>
 
             <div class="stats">


### PR DESCRIPTION
## Summary
- replace invalid output-region `<label>` elements in both WASM browser examples with visible label containers linked by `aria-labelledby`
- make generated, streaming, worker, and benchmark output regions keyboard focusable screen-reader regions
- add `aria-live="polite"` to dynamic output regions without carrying unrelated CI workflow edits from draft Palette variants

## Validation
- `git diff --check`
- `cargo check -p bitnet-wasm --no-default-features`
- `cargo test -p bitnet-wasm --no-default-features`

Supersedes the overlapping Palette output-region accessibility drafts.