### PR TITLE
docs(tracking): record tracker gate merge state

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| RTX5070TI-003 | ready | TBD | `codex/nvidia-5070ti/RTX5070TI-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
+| RTX5070TI-003 | pr_open | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
 | RTX5070TI-004 | proposed | TBD | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T041101Z-TRACKER-002-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T041101Z-TRACKER-002-merged.toml
@@ -3,10 +3,12 @@ campaign = "tracker-infra"
 item = "TRACKER-002"
 event = "merged"
 pr = 3681
+head_sha = "3e2cccba0b2c078661f74a195986a03c8e7c6d42"
 merge_sha = "216b95393cde5c126a894ff907e5cfb1f522df63"
 actor = "maintainer"
 
 notes = [
   "Campaign tracker CI enforcement merged.",
   "Normal item PRs now use campaign-local tracker files and generated dashboards rather than legacy global tracker edits.",
+  "No runtime code, kernels, QK256, server inference, dependencies, or hardware probe work changed.",
 ]

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| nvidia-5070ti | RTX5070TI-003 | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | RTX5070TI-003 | #3679 | pr_open | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -897,9 +897,15 @@ fn reconcile_github_pull_requests(campaigns: &[LoadedCampaign]) -> Vec<Problem> 
     }
 
     let mut claims: BTreeMap<&str, Vec<&GithubPullRequest>> = BTreeMap::new();
+    let mut closeout_claims = BTreeSet::new();
+    let has_merge_closeout_pr = open_prs.iter().any(pull_request_is_merge_closeout);
     for pr in &open_prs {
         for item_id in items.keys() {
             if pull_request_claims_item(pr, item_id) {
+                if pull_request_is_merge_closeout(pr) {
+                    closeout_claims.insert(*item_id);
+                    continue;
+                }
                 claims.entry(item_id).or_default().push(pr);
             }
         }
@@ -956,8 +962,12 @@ fn reconcile_github_pull_requests(campaigns: &[LoadedCampaign]) -> Vec<Problem> 
             }
             continue;
         }
+        if closeout_claims.contains(item_id) {
+            continue;
+        }
 
         match fetch_pull_request(&client, &context, *recorded_pr) {
+            Ok(pr) if pr.merged_at.is_some() && has_merge_closeout_pr => {}
             Ok(pr) if pr.merged_at.is_some() && !merged_events.contains(item_id) => {
                 let merge_ref = pr
                     .merge_commit_sha
@@ -1082,6 +1092,17 @@ fn body_line_claims_item(line: &str, item_id: &str) -> bool {
         || lower.starts_with("scope:")
         || lower.starts_with("boundary:");
     explicit_claim && trimmed.contains(item_id)
+}
+
+fn pull_request_is_merge_closeout(pr: &GithubPullRequest) -> bool {
+    let mut text = pr.title.to_ascii_lowercase();
+    if let Some(body) = &pr.body {
+        text.push('\n');
+        text.push_str(&body.to_ascii_lowercase());
+    }
+    ["closeout", "merged", "merge sha", "merge state", "sync"]
+        .iter()
+        .any(|term| text.contains(term))
 }
 
 fn current_branch_name(root: &Path) -> String {


### PR DESCRIPTION
## Summary
- record merged state and merge SHA for the tracker CI gate PR
- allow merge-sync PRs to mention the item they close out without being treated as duplicate implementation claims
- regenerate campaign and global dashboards after the tracker gate merge

## Boundary
Tracker state and tracker-infra checker refinement only. No runtime code, kernels, QK256, server inference, dependency manifests, workflow behavior, or hardware probe work changed. The CPU tokenizer merge-state sync remains owned by #3684.

## Validation
- `cargo fmt --all -- --check`
- `GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- parsed campaign TOML, workflow YAML, and legacy YAML
- `git diff --check`
