### PR TITLE
docs(tracking): sync campaign merge events

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -31,8 +31,8 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 |---|---|---|
 | CPU-BITNET-000 | merged | Real BitNet CPU path plan merged in #3642. |
 | CPU-BITNET-001 | merged | Strict GGUF loader authority merged in #3651. |
-| CPU-BITNET-002 | ready | Strict tokenizer authority. |
-| CPU-BITNET-003 | proposed | Canonical packed layout. |
+| CPU-BITNET-002 | merged | Strict tokenizer authority merged in #3680. |
+| CPU-BITNET-003 | ready | Canonical packed layout. |
 | CPU-BITNET-004 | proposed | Scalar truth kernels. |
 | CPU-BITNET-005 | proposed | AVX2 decode GEMV. |
 | CPU-BITNET-006 | proposed | CPU transformer decode ops. |

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -89,7 +89,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-proof/CPU-BITNET-002-tokenizer-authority"
 stackable = false
 requires_human_merge = true
@@ -117,4 +117,40 @@ must_not_claim = [
   "Packed kernels are complete.",
   "Transformer decode is complete.",
   "CPU performance is proven.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-003"
+status = "ready"
+branch = "codex/cpu-proof/CPU-BITNET-003-canonical-packed-layout"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-002"]
+acceptance = "Canonical block geometry, alignment, stride, and row/block iteration API are defined."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-qk256-layout-core --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-models --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-quantization/src/i2s_qk256.rs",
+  "crates/bitnet-quantization/src/qk256_dispatch.rs",
+  "crates/bitnet-models/src/quant/**",
+  "crates/bitnet-models/src/qk256_utils.rs",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Canonical packed layout exists after merge.",
+]
+must_not_claim = [
+  "Optimized kernel performance is proven.",
+  "Scalar truth kernels are complete.",
+  "AVX2 dispatch is complete.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T040647Z-CPU-BITNET-002-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T040647Z-CPU-BITNET-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T04:06:47Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-002"
+event = "merged"
+pr = 3680
+merge_sha = "5a42ba619fcc89a4d4c72131f70512b19754e3db"
+actor = "maintainer"
+
+notes = [
+  "Strict tokenizer authority merged.",
+  "Canonical packed layout, scalar truth kernels, AVX2 dispatch, transformer decode, strict receipts, and benchmarks remain follow-up work.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -11,7 +11,8 @@
 |---|---|---:|---|---|
 | CPU-BITNET-000 | merged | #3642 | `codex/cpu-proof/CPU-BITNET-000-path-plan` | Document the real BitNet CPU path implementation plan and sequence strict loader, tokenizer, layout, scalar, AVX2, receipts, and benchmarks. |
 | CPU-BITNET-001 | merged | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
-| CPU-BITNET-002 | pr_open | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+| CPU-BITNET-002 | merged | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
+| CPU-BITNET-003 | ready | TBD | `codex/cpu-proof/CPU-BITNET-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
@@ -27,7 +27,7 @@ Finish the move from global hand-edited alignment trackers to campaign-local TOM
 | Work item | Status | Notes |
 |---|---|---|
 | TRACKER-001 | merged | Advisory campaign check/generate/doctor commands and generated dashboards merged in #3660. |
-| TRACKER-002 | proposed | Add CI enforcement for campaign doctor and generated-dashboard freshness. |
+| TRACKER-002 | merged | CI enforcement for campaign doctor and generated-dashboard freshness merged in #3681. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -55,7 +55,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/tracker-infra/TRACKER-002-ci-enforcement"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-06T041101Z-TRACKER-002-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-06T041101Z-TRACKER-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T04:11:01Z"
+campaign = "tracker-infra"
+item = "TRACKER-002"
+event = "merged"
+pr = 3681
+merge_sha = "216b95393cde5c126a894ff907e5cfb1f522df63"
+actor = "maintainer"
+
+notes = [
+  "Campaign tracker CI enforcement merged.",
+  "Normal item PRs now use campaign-local tracker files and generated dashboards rather than legacy global tracker edits.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
-| TRACKER-002 | pr_open | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
+| TRACKER-002 | merged | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-proof | CPU-BITNET-002 | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
-| tracker-infra | TRACKER-002 | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -8,8 +8,9 @@
 | apple-m4 | M4-004 | M4-003 | ready |
 | apple-m4 | M4-005 | M4-004 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
-| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | pr_open |
+| cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
+| cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | proposed |
-| tracker-infra | TRACKER-002 | TRACKER-001 | pr_open |
+| tracker-infra | TRACKER-002 | TRACKER-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-004 | TBD | ready | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-002 | #3680 | pr_open | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-003 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
@@ -14,4 +14,4 @@
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | TBD | ready | RTX5070TI-004 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
-| tracker-infra | TRACKER-002 | #3681 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-004 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-002 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-003 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
@@ -14,4 +14,4 @@
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
-| tracker-infra | Tracker infrastructure | TRACKER-002 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- record the tokenizer-authority merge in the CPU proof campaign tracker
- record the tracker enforcement merge required by the new campaign doctor gate
- regenerate campaign dashboards so the CPU proof lane points at canonical packed layout next

## Validation
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

## Boundary
Docs/tracking sync only. No runtime, layout, scalar kernel, AVX2, receipt schema, server, GPU, or crate-collapse work.
