### PR TITLE
docs: capture 258V runtime build-out plan

### DIFF
--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -68,6 +68,154 @@ Record these before moving any 258V hardware lane beyond `scaffold`:
 - CPU or GPU fallback cannot count as NPU execution.
 - 258V CPU validation must record artifacts without reshaping shared CPU implementation unless explicitly scoped by a ledger item.
 
+
+## Build-Out Gates
+
+Use this profile as a gate checklist before making any 258V runtime claim.
+
+| Gate | Required evidence | Claim allowed |
+|---|---|---|
+| Platform visibility | `Lnl258vPlatformProbe` JSON with CPU, Arc 140V, OpenVINO GPU, OpenVINO NPU, memory, power, and OS fields. | The 258V platform is detected. |
+| Intel NPU identity | `npu`, `intel-npu`, and `openvino-npu` preserve NPU identity and fail strictly when unavailable. | NPU request routing is identity-safe. |
+| Arc 140V identity | PCI ID `0x64A0` or exact Arc 140V full device name through OpenCL/Level Zero/OpenVINO. | Arc 140V runtime is visible. |
+| Strict CPU validation | Real GGUF loader, strict tokenizer source, selected CPU AVX2 kernel, no mock tensors, no fallback. | 258V CPU validates the CPU BitNet path. |
+| Same-machine comparison | CPU, GPU, and NPU receipts link to the same platform probe artifact. | The lanes can be compared on one laptop. |
+
+The first three gates are visibility and identity work. They do not prove BitNet inference. Strict CPU validation starts only after the CPU-proof lane lands loader and tokenizer authority.
+
+## Manual Probe Additions
+
+The platform bundle above captures the broad machine state. Add these OpenVINO property probes when OpenVINO is installed so the eventual machine-readable probe has exact source fields to mirror.
+
+### OpenVINO device inventory
+
+```python
+import json
+import openvino as ov
+
+core = ov.Core()
+out = {
+    "openvino_version": ov.__version__,
+    "available_devices": list(core.available_devices),
+    "devices": {}
+}
+for dev in core.available_devices:
+    props = {}
+    for prop in [
+        "FULL_DEVICE_NAME",
+        "SUPPORTED_PROPERTIES",
+        "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "DEVICE_ARCHITECTURE",
+        "DEVICE_UUID",
+    ]:
+        try:
+            props[prop] = str(core.get_property(dev, prop))
+        except Exception as e:
+            props[prop] = "ERR: " + repr(e)
+    out["devices"][dev] = props
+print(json.dumps(out, indent=2))
+```
+
+### OpenVINO NPU property inventory
+
+```python
+import json
+import openvino as ov
+
+core = ov.Core()
+out = {"available_devices": list(core.available_devices), "npu": {}}
+if any(d == "NPU" or d.startswith("NPU.") for d in core.available_devices):
+    for prop in [
+        "FULL_DEVICE_NAME",
+        "SUPPORTED_PROPERTIES",
+        "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "NPU_DRIVER_VERSION",
+        "NPU_COMPILER_VERSION",
+        "NPU_DEVICE_TOTAL_MEM_SIZE",
+        "NPU_DEVICE_ALLOC_MEM_SIZE",
+        "NPU_MAX_TILES",
+    ]:
+        try:
+            out["npu"][prop] = str(core.get_property("NPU", prop))
+        except Exception as e:
+            out["npu"][prop] = "ERR: " + repr(e)
+print(json.dumps(out, indent=2))
+```
+
+## Machine-Readable Artifact Targets
+
+Store raw manual logs and normalized JSON separately:
+
+```text
+ci/receipts/258v/platform/raw/<date>-<os>-probe.txt
+ci/receipts/258v/platform/lnl258v-platform.json
+ci/receipts/258v/cpu/cpu-bitnet-validation.json
+ci/receipts/258v/gpu/arc140v-runtime-probe.json
+ci/receipts/258v/npu/intel-npu-runtime-probe.json
+```
+
+The normalized platform artifact must include at least these exact identity fields:
+
+```json
+{
+  "platform": "core-ultra-7-258v",
+  "os": "linux|windows|wsl",
+  "arch": "x86_64",
+  "cpu_model": "Intel Core Ultra 7 258V",
+  "cpu_cores": 8,
+  "cpu_threads": 8,
+  "cpu_flags": ["avx2", "fma", "sse4_2"],
+  "cpu_has_avx2": true,
+  "cpu_has_avx512": false,
+  "opencl_arc_140v_visible": true,
+  "opencl_platform_name": "Intel(R) OpenCL Graphics",
+  "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+  "opencl_driver_version": "...",
+  "pci_device_id": "0x64A0",
+  "level_zero_visible": true,
+  "level_zero_devices": ["Intel(R) Arc(TM) 140V Graphics"],
+  "openvino_version": "...",
+  "openvino_available_devices": ["CPU", "GPU.0", "NPU"],
+  "openvino_gpu_device": "GPU.0",
+  "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V Graphics",
+  "openvino_npu_visible": true,
+  "openvino_npu_full_name": "...",
+  "accel_device_present": true,
+  "accel_devices": ["/dev/accel/accel0"],
+  "intel_vpu_driver_seen": true,
+  "npu_driver_version": "...",
+  "power_mode": "...",
+  "thermal_profile": "...",
+  "shared_memory_bytes": 0,
+  "status": "runtime_detected"
+}
+```
+
+For strict 258V CPU validation, the CPU artifact must include loader, tokenizer, kernel, backend, and phase fields in addition to benchmark metrics:
+
+```json
+{
+  "machine": "core-ultra-7-258v",
+  "requested_backend": "intel-258v-cpu-avx2",
+  "selected_backend": "intel-258v-cpu-avx2",
+  "runtime_api": "cpu",
+  "loader_mode": "real_gguf",
+  "minimal_loader_fallback_used": false,
+  "tokenizer_source": "gguf|override|sibling-tokenizer-json|sibling-tokenizer-model",
+  "mock_tensors_used": false,
+  "kernel_family": "qk256|i2_s|tl2",
+  "requested_kernel": "qk256-avx2-gemv",
+  "selected_kernel": "qk256-avx2-gemv",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "phase": "prefill|decode_steady_state",
+  "prompt_tokens": 0,
+  "generated_tokens": 0,
+  "tokens_per_second": null,
+  "first_token_latency_ms": null
+}
+```
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
+++ b/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
@@ -128,6 +128,145 @@ The first platform receipt is detection-only:
 
 This receipt does not prove BitNet inference, GPU kernel parity, or NPU subgraph parity.
 
+
+## Runtime Enablement Build-Out Plan
+
+The 258V laptop is the platform validation lane, not the owner of the shared CPU BitNet implementation. The build-out sequence must preserve that separation:
+
+| PR / lane | Purpose | May touch | Must not touch |
+|---|---|---|---|
+| `LNL258V-RUN-001` | Add visibility-only 258V platform probe and receipt schema. | `bitnet-device-probe`, CLI or `xtask` probe entry point, receipt types, this hardware/spec documentation. | QK256 CPU kernels, transformer hot path, model loader behavior. |
+| `NPU-002-lite` | Preserve Intel NPU identity before OpenVINO execution work. | Backend request parsing, device config mapping, strict NPU failure behavior, receipt identity fields. | OpenVINO graph execution, CPU kernels. |
+| `ARC140V-002` | Prove Arc 140V runtime identity separately from CPU and NPU. | Arc probe code, OpenCL/Level Zero/OpenVINO GPU visibility receipts, Arc docs. | CPU kernels, NPU runtime. |
+| `CPU258V-001` | Add 258V CPU-only validation harness after strict CPU loader/tokenizer work lands. | Receipt emission, validation commands, hardware artifacts, campaign docs. | Shared QK256 dispatch, quantized transformer internals unless stacked on CPU-proof work. |
+
+The dependency order is identity first, strict CPU proof second, 258V CPU validation third:
+
+```text
+NPU-002-lite -> ARC140V-002 -> LNL258V-RUN-001
+CPU-BITNET-001/002 remain owned by cpu-proof/i5-8250U
+CPU258V-001 validates the merged strict CPU path on Lunar Lake
+```
+
+### LNL258V-RUN-001 acceptance contract
+
+`LNL258V-RUN-001` should produce one platform-level detection artifact. It records what the laptop can see; it does not run inference and must not claim BitNet correctness or speed.
+
+Required probe shape:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lnl258vPlatformProbe {
+    pub platform: String,
+    pub os: String,
+    pub arch: String,
+    pub cpu_brand: String,
+    pub cpu_cores: usize,
+    pub cpu_threads: usize,
+    pub cpu_has_avx2: bool,
+    pub cpu_has_avx512: bool,
+    pub opencl_arc_140v_visible: bool,
+    pub opencl_platform_name: Option<String>,
+    pub opencl_device_name: Option<String>,
+    pub opencl_driver_version: Option<String>,
+    pub pci_device_id: Option<String>,
+    pub level_zero_visible: bool,
+    pub level_zero_devices: Vec<String>,
+    pub openvino_version: Option<String>,
+    pub openvino_available_devices: Vec<String>,
+    pub openvino_gpu_device: Option<String>,
+    pub openvino_gpu_full_name: Option<String>,
+    pub openvino_npu_visible: bool,
+    pub openvino_npu_full_name: Option<String>,
+    pub accel_device_present: bool,
+    pub accel_devices: Vec<String>,
+    pub intel_vpu_driver_seen: bool,
+    pub npu_driver_version: Option<String>,
+    pub power_mode: Option<String>,
+    pub thermal_profile: Option<String>,
+    pub shared_memory_bytes: Option<u64>,
+    pub status: String,
+    pub failure_reason: Option<String>,
+}
+
+pub fn probe_lnl258v_platform() -> Lnl258vPlatformProbe;
+```
+
+Minimum JSON fields:
+
+```json
+{
+  "platform": "core-ultra-7-258v",
+  "os": "linux|windows|wsl",
+  "arch": "x86_64",
+  "cpu_brand": "Intel Core Ultra 7 258V",
+  "cpu_cores": 8,
+  "cpu_threads": 8,
+  "cpu_has_avx2": true,
+  "cpu_has_avx512": false,
+  "opencl_arc_140v_visible": true,
+  "opencl_platform_name": "Intel(R) OpenCL Graphics",
+  "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+  "opencl_driver_version": "...",
+  "pci_device_id": "0x64A0",
+  "level_zero_visible": true,
+  "level_zero_devices": ["Intel(R) Arc(TM) 140V Graphics"],
+  "openvino_version": "...",
+  "openvino_available_devices": ["CPU", "GPU.0", "NPU"],
+  "openvino_gpu_device": "GPU.0",
+  "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V Graphics",
+  "openvino_npu_visible": true,
+  "openvino_npu_full_name": "...",
+  "accel_device_present": true,
+  "accel_devices": ["/dev/accel/accel0"],
+  "intel_vpu_driver_seen": true,
+  "npu_driver_version": "...",
+  "status": "runtime_detected"
+}
+```
+
+### CPU258V-001 acceptance contract
+
+`CPU258V-001` starts only after strict loader/tokenizer authority is available from the CPU-proof lane. It records strict CPU behavior on the 258V and must not take over shared CPU implementation work.
+
+Required receipt shape:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuBitnetValidationReceipt {
+    pub machine: String,
+    pub requested_backend: String,
+    pub selected_backend: String,
+    pub runtime_api: String,
+    pub loader_mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+    pub kernel_family: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub fallback_used: bool,
+    pub fallback_reason: Option<String>,
+    pub cpu_features: Vec<String>,
+    pub threads: usize,
+    pub phase: String,
+    pub prompt_tokens: usize,
+    pub generated_tokens: usize,
+    pub tokens_per_second: Option<f64>,
+    pub first_token_latency_ms: Option<f64>,
+}
+```
+
+Strict 258V CPU validation must assert:
+
+- `loader_mode = "real_gguf"`.
+- `minimal_loader_fallback_used = false`.
+- `mock_tensors_used = false`.
+- `requested_backend` and `selected_backend` both identify the CPU AVX2 lane.
+- `requested_kernel` equals `selected_kernel` unless the receipt explicitly records a non-strict fallback failure.
+- `fallback_used = false` for strict proof receipts.
+- Decode and prefill phases are reported separately.
+
 ## Work Plan
 
 ### LNL258V-001 - Add Platform Profile

--- a/docs/specs/intel-lunar-lake-gpu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-gpu-roadmap.md
@@ -111,6 +111,7 @@ pub struct IntelArc140vProbe {
     pub opencl_device_name: Option<String>,
     pub opencl_driver_version: Option<String>,
     pub level_zero_available: bool,
+    pub level_zero_devices: Vec<String>,
     pub openvino_gpu_visible: bool,
     pub openvino_gpu_device: Option<String>,
     pub openvino_gpu_full_name: Option<String>,
@@ -119,6 +120,42 @@ pub struct IntelArc140vProbe {
     pub failure_reason: Option<String>,
 }
 ```
+
+
+## ARC140V-002 Runtime Probe Contract
+
+The Arc 140V probe must prove exact integrated-GPU identity. Generic Intel GPU visibility is not enough.
+
+Detection priority:
+
+1. Prefer PCI device ID `0x64A0` when the OS exposes it.
+2. Match OpenCL device name or OpenVINO `FULL_DEVICE_NAME` against `Intel(R) Arc(TM) 140V Graphics`.
+3. Record Level Zero device names separately from OpenCL devices.
+4. Record OpenVINO `GPU.0` separately from native OpenCL.
+5. Never let CPU fallback satisfy `available = true`.
+
+`ARC140V-002` should emit a visibility-only receipt before any kernel smoke work:
+
+```json
+{
+  "available": true,
+  "pci_device_id": "0x64A0",
+  "opencl_available": true,
+  "opencl_platform_name": "Intel(R) OpenCL Graphics",
+  "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+  "opencl_driver_version": "...",
+  "level_zero_available": true,
+  "level_zero_devices": ["Intel(R) Arc(TM) 140V Graphics"],
+  "openvino_gpu_visible": true,
+  "openvino_gpu_device": "GPU.0",
+  "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V Graphics",
+  "shared_memory_bytes": 0,
+  "power_mode": "...",
+  "failure_reason": null
+}
+```
+
+The visibility receipt may claim only `runtime_detected`. Kernel smoke, parity, and benchmark claims require later receipts with selected backend, executed kernel or graph, output comparison, and fallback status.
 
 ## Receipt Fields
 

--- a/docs/specs/intel-lunar-lake-npu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-npu-roadmap.md
@@ -207,6 +207,34 @@ Auto mode rules:
 - CPU fallback may be allowed.
 - Receipts and smoke artifacts must record requested backend, selected backend, fallback backend, and fallback reason.
 
+
+### NPU-002-lite implementation contract
+
+Before adding real OpenVINO graph execution, land an identity-only PR that removes ambiguous `npu` routing. The required behavior is:
+
+- Backend selection has explicit `IntelNpu` and `OpenVinoNpu` request variants.
+- Device configuration has explicit `IntelNpu(usize)` and `OpenVinoNpu` variants.
+- `npu`, `intel-npu`, and `openvino-npu` never map to Metal, CUDA, OpenCL, or generic `Gpu(0)`.
+- Strict mode fails before inference when Intel NPU is requested but unavailable.
+- Receipts can represent `requested_backend = "intel-npu"` and `selected_backend = "intel-npu-openvino"` without inventing a GPU or Metal route.
+
+Suggested mapping contract:
+
+```rust
+pub fn map_device_token(token: &str) -> Option<Device> {
+    match token {
+        "cpu" => Some(Device::Cpu),
+        "cuda" | "gpu" => Some(Device::Cuda(0)),
+        "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
+        "npu" | "intel-npu" | "openvino-npu" => Some(Device::Npu),
+        "metal" => Some(Device::Metal),
+        _ => None,
+    }
+}
+```
+
+`NpuBackend::is_available()` must be an Intel-NPU identity surface. It may consult feature-gated OpenVINO or OS probes, but it must not imply macOS Metal availability or generic GPU availability.
+
 ## Detection Layers
 
 Detection should be layered and conservative.

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -20,6 +20,18 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.
 
+
+## Needed Build-Out Parts
+
+| Part | Status to unblock | Acceptance boundary |
+|---|---|---|
+| `LNL258V-RUN-001` platform probe | Ready after docs merge. | Visibility-only JSON records CPU, Arc 140V, Level Zero, OpenVINO GPU, OpenVINO NPU, `/dev/accel`, power, thermal, memory, and OS context. |
+| `NPU-002-lite` backend identity | Must precede NPU runtime smoke. | `npu` preserves Intel NPU/OpenVINO NPU identity and never aliases to Metal or generic GPU. |
+| `ARC140V-002` Arc runtime probe | Must precede Arc kernel smoke. | PCI ID `0x64A0` or exact Arc 140V full name is recorded through OpenCL/Level Zero/OpenVINO GPU without CPU fallback. |
+| `CPU258V-001` CPU validation harness | Starts only after CPU-proof strict loader/tokenizer authority. | Strict CPU receipt records loader, tokenizer, requested/selected kernel, requested/selected backend, phase metrics, and zero fallback. |
+
+The campaign can collect same-machine artifacts, but CPU loader, tokenizer, QK256 layout, AVX2 dispatch, and transformer hot-path implementation remain owned by the CPU-proof campaign unless a future work item explicitly changes that scope.
+
 ## Work Items
 
 | Work item | Status | Notes |


### PR DESCRIPTION
### Motivation
- Establish a conservative, identity-first enablement sequence so the Core Ultra 7 258V laptop is a validation lane and does not assume ownership of shared CPU BitNet implementation work. 
- Prevent ambiguous backend routing and accidental CPU/GPU/NPU conflation by requiring explicit identity probes and strict receipt fields before any runtime claims. 
- Provide a clear, machine-readable contract for platform probes and strict CPU validation receipts so downstream PRs can emit verifiable artifacts and benchmarks. 

### Description
- Added a runtime build-out plan and gate checklist to `docs/hardware/intel-258v-validation.md` and `docs/specs/intel-lunar-lake-258v-platform-roadmap.md` that documents `LNL258V-RUN-001`, `NPU-002-lite`, `ARC140V-002`, and `CPU258V-001` lane boundaries and dependency order. 
- Introduced the `Lnl258vPlatformProbe` acceptance contract and minimum normalized JSON fields (CPU, Arc 140V OpenCL/Level Zero, OpenVINO GPU/NPU, `/dev/accel`, power/thermal/memory) plus example probe scripts for OpenVINO property extraction. 
- Added strict CPU validation receipt shape `CpuBitnetValidationReceipt` and acceptance assertions (real GGUF loader, tokenizer source, requested/selected backend & kernel parity, no mock tensors, decode/prefill phase metrics) and example JSON artifact targets under `ci/receipts/258v/*`. 
- Hardened identity contracts for NPU and Arc 140V by documenting `NPU-002-lite` mapping rules (avoid aliasing `npu` to Metal/generic GPU) and `ARC140V-002` probe contract (PCI ID/full-name matching, separate Level Zero/OpenCL/OpenVINO reporting). 
- Updated the `intel-258v-platform` campaign tracker to list the needed build-out parts and acceptance boundaries for platform, NPU, Arc, and CPU validation work. 

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded to verify formatting. 
- Parsed all tracker TOML files via a Python `tomllib` script (`python3` snippet) to ensure tracker files remain valid TOML and the campaign changes are syntactically correct. 
- Ran `git diff --check` to validate there are no whitespace/indexing issues in the diffs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab5b4bfd08333b3901931b418e844)