### PR TITLE
docs: detail 258V platform buildout plan

### DIFF
--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -58,6 +58,79 @@ Record these before moving any 258V hardware lane beyond `scaffold`:
 | Shared memory pressure | 32GB LPDDR5X is shared by CPU/GPU/NPU. |
 | Power mode / thermal profile | Laptop results depend heavily on power policy. |
 
+
+## Machine-Readable Probe Schema
+
+The machine-readable platform probe should emit the following top-level fields before any lane claims inference:
+
+```json
+{
+  "platform": "core-ultra-7-258v",
+  "os": "linux|windows|wsl",
+  "arch": "x86_64",
+  "cpu_model": "Intel Core Ultra 7 258V",
+  "cpu_cores": 8,
+  "cpu_threads": 8,
+  "cpu_flags": ["avx2", "fma", "sse4_2"],
+  "cpu_has_avx2": true,
+  "cpu_has_avx512": false,
+
+  "opencl_arc_140v_visible": true,
+  "opencl_platform_name": "Intel(R) OpenCL Graphics",
+  "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+  "opencl_driver_version": "...",
+  "pci_device_id": "0x64A0",
+
+  "level_zero_visible": true,
+  "level_zero_devices": ["Intel(R) Arc(TM) 140V Graphics"],
+
+  "openvino_version": "...",
+  "openvino_available_devices": ["CPU", "GPU.0", "NPU"],
+  "openvino_gpu_device": "GPU.0",
+  "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V Graphics",
+  "openvino_npu_visible": true,
+  "openvino_npu_full_name": "...",
+
+  "accel_device_present": true,
+  "accel_devices": ["/dev/accel/accel0"],
+  "intel_vpu_driver_seen": true,
+  "npu_driver_version": "...",
+
+  "power_mode": "balanced|performance|powersaver|unknown",
+  "thermal_profile": "default|cool|performance|unknown",
+  "shared_memory_bytes": 34359738368,
+
+  "status": "runtime_detected|partial|unavailable",
+  "failure_reason": null
+}
+```
+
+The schema is visibility-only. It may prove that runtimes can see devices, but it must not be used as a BitNet inference, parity, or throughput receipt.
+
+## Build-Out Artifacts
+
+When the probe and validation commands are implemented, archive artifacts under a dated machine directory such as:
+
+```text
+ci/hardware/core-ultra-7-258v/YYYY-MM-DD/platform-probe.json
+ci/hardware/core-ultra-7-258v/YYYY-MM-DD/openvino-devices.json
+ci/hardware/core-ultra-7-258v/YYYY-MM-DD/arc-140v-probe.json
+ci/hardware/core-ultra-7-258v/YYYY-MM-DD/npu-probe.json
+ci/hardware/core-ultra-7-258v/YYYY-MM-DD/cpu-bitnet-validation.json
+```
+
+Required command-to-artifact mapping:
+
+| Artifact | Producing command | Claim supported |
+|---|---|---|
+| `platform-probe.json` | future platform probe CLI or xtask | Same-machine visibility only. |
+| `openvino-devices.json` | OpenVINO Python query below | OpenVINO runtime device visibility. |
+| `arc-140v-probe.json` | future Arc 140V probe | Exact iGPU identity when PCI/name checks pass. |
+| `npu-probe.json` | future NPU probe | Intel NPU identity and OpenVINO `NPU` visibility. |
+| `cpu-bitnet-validation.json` | future strict CPU validation command | CPU BitNet proof only if loader/tokenizer/kernel strictness is satisfied. |
+
+Do not move a lane out of scaffold based on a different lane's artifact.
+
 ## Claim Boundary
 
 - CPU AVX2 correctness does not count as Arc 140V or NPU execution.
@@ -114,6 +187,8 @@ for dev in core.available_devices:
         "FULL_DEVICE_NAME",
         "SUPPORTED_PROPERTIES",
         "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "DEVICE_ARCHITECTURE",
+        "DEVICE_UUID",
     ]:
         try:
             props[prop] = str(core.get_property(dev, prop))
@@ -180,6 +255,8 @@ for dev in core.available_devices:
         "FULL_DEVICE_NAME",
         "SUPPORTED_PROPERTIES",
         "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "DEVICE_ARCHITECTURE",
+        "DEVICE_UUID",
     ]:
         try:
             props[prop] = str(core.get_property(dev, prop))
@@ -189,6 +266,39 @@ for dev in core.available_devices:
 print(json.dumps(out, indent=2))
 PY
 ```
+
+
+## OpenVINO NPU Extended Property Query
+
+Run this when OpenVINO reports `NPU` or an `NPU.*` device. Missing properties should be recorded as errors rather than treated as absence of the device.
+
+```python
+import json
+import openvino as ov
+
+core = ov.Core()
+out = {"available_devices": list(core.available_devices), "npu": {}}
+
+if any(d.startswith("NPU") or d == "NPU" for d in core.available_devices):
+    for prop in [
+        "FULL_DEVICE_NAME",
+        "SUPPORTED_PROPERTIES",
+        "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "NPU_DRIVER_VERSION",
+        "NPU_COMPILER_VERSION",
+        "NPU_DEVICE_TOTAL_MEM_SIZE",
+        "NPU_DEVICE_ALLOC_MEM_SIZE",
+        "NPU_MAX_TILES",
+    ]:
+        try:
+            out["npu"][prop] = str(core.get_property("NPU", prop))
+        except Exception as e:
+            out["npu"][prop] = "ERR: " + repr(e)
+
+print(json.dumps(out, indent=2))
+```
+
+NPU properties support NPU identity and runtime visibility claims only. A tiny static-shape `compile_model(..., "NPU")` smoke is still required before any NPU execution claim.
 
 ## First Platform Receipt
 

--- a/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
+++ b/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
@@ -162,6 +162,275 @@ OpenVINO NPU static-shape smoke
 NPU subgraph parity, if proven
 ```
 
+
+## Build-Out Contracts
+
+The following contracts define the implementation surfaces needed to build the 258V validation platform without moving CPU kernel ownership away from the CPU proof lane.
+
+### LNL258V-RUN-001 - Platform Runtime Probe
+
+Goal: add a visibility-only platform probe for the Lunar Lake laptop. This probe collects CPU, Arc 140V, Level Zero, OpenVINO GPU, OpenVINO NPU, memory, power, and thermal facts. It must not claim BitNet inference, GPU parity, NPU execution, or CPU performance.
+
+Allowed implementation surface:
+
+| Area | Expected files | Notes |
+|---|---|---|
+| Device probe | `crates/bitnet-device-probe/src/lib.rs`, `crates/bitnet-device-probe/src/intel_lnl258v.rs` | Add the probe type and OS/runtime collectors. |
+| CLI or xtask | `crates/bitnet-cli/src/commands/probe_platform.rs` or `xtask/src/platform_probe.rs` | Emit JSON artifacts only. |
+| Receipts | `crates/bitnet-receipts-core/src/lib.rs` | Add platform runtime metadata only if needed by the probe artifact. |
+| Docs/artifacts | `docs/hardware/intel-258v-validation.md`, this roadmap | Keep claim boundaries visible. |
+
+Forbidden implementation surface:
+
+- QK256 scalar or AVX2 kernels.
+- Transformer hot paths.
+- GPU or NPU graph execution.
+- Any CPU, GPU, or NPU fallback that is counted as target-device proof.
+
+Required Rust shape:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lnl258vPlatformProbe {
+    pub platform: String,
+    pub os: String,
+    pub arch: String,
+
+    pub cpu_brand: String,
+    pub cpu_cores: usize,
+    pub cpu_threads: usize,
+    pub cpu_has_avx2: bool,
+    pub cpu_has_avx512: bool,
+
+    pub opencl_arc_140v_visible: bool,
+    pub opencl_platform_name: Option<String>,
+    pub opencl_device_name: Option<String>,
+    pub opencl_driver_version: Option<String>,
+    pub pci_device_id: Option<String>,
+
+    pub level_zero_visible: bool,
+    pub level_zero_devices: Vec<String>,
+
+    pub openvino_version: Option<String>,
+    pub openvino_available_devices: Vec<String>,
+    pub openvino_gpu_device: Option<String>,
+    pub openvino_gpu_full_name: Option<String>,
+    pub openvino_npu_visible: bool,
+    pub openvino_npu_full_name: Option<String>,
+
+    pub accel_device_present: bool,
+    pub accel_devices: Vec<String>,
+    pub intel_vpu_driver_seen: bool,
+    pub npu_driver_version: Option<String>,
+
+    pub power_mode: Option<String>,
+    pub thermal_profile: Option<String>,
+    pub shared_memory_bytes: Option<u64>,
+
+    pub status: String,
+    pub failure_reason: Option<String>,
+}
+
+pub fn probe_lnl258v_platform() -> Lnl258vPlatformProbe;
+```
+
+Acceptance checks:
+
+- JSON artifact contains `platform="core-ultra-7-258v"`, OS, architecture, CPU AVX2 status, and AVX-512 status.
+- Arc 140V evidence records PCI ID, OpenCL platform/device/driver, Level Zero visibility, and OpenVINO `GPU.0` full name when visible.
+- NPU evidence records `/dev/accel` or OS device hints, Intel VPU/NPU driver hints, OpenVINO `NPU` visibility, and driver/compiler properties when available.
+- `status` is visibility-oriented, for example `runtime_detected`, `partial`, or `unavailable`; it is never an inference result.
+
+### NPU-002-lite - Backend Identity Before Runtime
+
+Goal: stop `npu` from aliasing to Metal, CUDA, generic GPU, OpenCL, or CPU fallback. This is an identity PR, not an OpenVINO graph-execution PR.
+
+Required behavior:
+
+- Add explicit backend request labels such as `IntelNpu` and `OpenVinoNpu`.
+- Add explicit device config labels such as `IntelNpu(usize)` and `OpenVinoNpu`.
+- Map `npu`, `intel-npu`, and `openvino-npu` to an NPU identity, not `Device::Metal` and not `DeviceConfig::Gpu(0)`.
+- In strict mode, fail before inference when Intel NPU is requested but unavailable.
+- Receipts must be able to represent `requested_backend=intel-npu` and `selected_backend=intel-npu-openvino` without implying a successful smoke run.
+
+Acceptance checks:
+
+- `npu` never selects Metal on non-Apple hardware.
+- `npu` never counts a CPU fallback as NPU execution.
+- NPU availability reports identity/probe results and a failure reason when runtime support is missing.
+
+### ARC140V-002 - Exact Integrated GPU Probe
+
+Goal: prove that the integrated GPU visible on the laptop is Arc 140V through OpenCL, Level Zero, and OpenVINO `GPU.0` evidence. This PR must not alter CPU kernels or NPU execution.
+
+Required Rust shape:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntelArc140vProbe {
+    pub available: bool,
+    pub pci_device_id: Option<String>,
+    pub opencl_available: bool,
+    pub opencl_platform_name: Option<String>,
+    pub opencl_device_name: Option<String>,
+    pub opencl_driver_version: Option<String>,
+    pub level_zero_available: bool,
+    pub level_zero_devices: Vec<String>,
+    pub openvino_gpu_visible: bool,
+    pub openvino_gpu_device: Option<String>,
+    pub openvino_gpu_full_name: Option<String>,
+    pub shared_memory_bytes: Option<u64>,
+    pub power_mode: Option<String>,
+    pub failure_reason: Option<String>,
+}
+
+pub fn probe_intel_arc_140v() -> IntelArc140vProbe;
+```
+
+Detection rules:
+
+- Prefer exact PCI ID `0x64A0` when available.
+- Match OpenCL and OpenVINO full names against `Intel(R) Arc(TM) 140V Graphics`.
+- Record OpenCL, Level Zero, and OpenVINO independently.
+- CPU fallback cannot count as Arc 140V proof.
+
+### CPU258V-001 - CPU Validation Harness
+
+Goal: add a 258V CPU-only validation harness that records strict loader, tokenizer, kernel, backend, and benchmark evidence on Lunar Lake without taking ownership of shared CPU implementation work.
+
+Allowed implementation surface:
+
+| Area | Expected files | Notes |
+|---|---|---|
+| CLI validation | `crates/bitnet-cli/src/commands/validate_cpu_bitnet.rs` or an `eval` subcommand extension | Run strict CPU validation and emit receipts. |
+| Receipts | `crates/bitnet-receipts-core/src/lib.rs` | Add validation receipt fields when missing. |
+| Tracking/docs | CPU proof tracker and this platform doc | Cross-link to 8250U-owned CPU work. |
+
+Forbidden by default:
+
+- QK256 dispatch rewrites.
+- Scalar/AVX2 kernel rewrites.
+- Transformer hot-path rewrites.
+
+Required Rust shape:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuBitnetValidationReceipt {
+    pub machine: String,
+    pub requested_backend: String,
+    pub selected_backend: String,
+    pub runtime_api: String,
+
+    pub loader_mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+
+    pub kernel_family: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub fallback_used: bool,
+    pub fallback_reason: Option<String>,
+
+    pub cpu_features: Vec<String>,
+    pub threads: usize,
+
+    pub phase: String,
+    pub prompt_tokens: usize,
+    pub generated_tokens: usize,
+    pub tokens_per_second: Option<f64>,
+    pub first_token_latency_ms: Option<f64>,
+}
+
+pub fn run_cpu_bitnet_validation(args: &CpuBitnetValidationArgs) -> anyhow::Result<CpuBitnetValidationReceipt>;
+```
+
+Acceptance checks:
+
+- Strict receipt records `loader_mode=real_gguf`, `minimal_loader_fallback_used=false`, and `mock_tensors_used=false`.
+- Tokenizer source is explicit: override, GGUF embedded, sibling `tokenizer.json`, sibling `tokenizer.model`, or strict failure.
+- `requested_kernel` and `selected_kernel` match in strict success receipts.
+- `fallback_used=false` for strict CPU success receipts.
+- Decode and prefill phases are reported separately when benchmark data exists.
+
+## Downstream CPU Dependencies
+
+The 258V CPU lane should validate merged CPU work in this order:
+
+| Dependency | Owning lane | Required result before 258V claims |
+|---|---|---|
+| CPU-BITNET-001 loader authority | i5-8250U CPU proof | Strict GGUF loading cannot use minimal/mock fallback. |
+| CPU-BITNET-002 tokenizer authority | i5-8250U CPU proof | Tokenizer source is strict and receipt-backed. |
+| CPU-BITNET-003 QK256 layout/scalar truth | CPU proof | Packed layout and scalar output are canonical. |
+| CPU-BITNET-004 AVX2 decode/prefill | CPU proof | AVX2 is parity-checked against scalar and selected explicitly. |
+| CPU-BITNET-005 runtime cleanup | CPU proof | No hot-path thread-pool rebuilds or dequantizing fallback in strict mode. |
+| CPU-BITNET-006 receipts/benchmarks | CPU proof | Receipts include requested/selected kernel, phase, fallback, and timing fields. |
+
+258V validation may run these artifacts and report same-machine results. It should not reassign ownership of these implementation tasks.
+
+## Required Receipt Additions
+
+258V platform and CPU validation receipts need these optional sections when implemented:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BitnetExecutionMetadata {
+    pub kernel_family: String,
+    pub kernel_format: String,
+    pub layout: String,
+    pub layout_source: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub dequantizes_before_compute: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoaderMetadata {
+    pub mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformRuntimeMetadata {
+    pub machine: String,
+    pub cpu_features: Vec<String>,
+    pub opencl_device_name: Option<String>,
+    pub openvino_available_devices: Vec<String>,
+    pub runtime_device: Option<String>,
+    pub power_mode: Option<String>,
+    pub thermal_profile: Option<String>,
+}
+```
+
+Strict 258V CPU receipts are invalid for performance claims if any of these are missing: model hash, tokenizer source, loader fallback status, requested kernel, selected kernel, fallback status, benchmark phase, thread count, or machine/platform linkage.
+
+## Build and Validation Commands
+
+Initial PR checks:
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked -p bitnet-device-probe
+cargo test --locked -p bitnet-receipts-core
+git diff --check
+```
+
+CPU proof checks after the 8250U-owned implementation pieces land:
+
+```bash
+cargo test --locked -p bitnet-models --no-default-features --features cpu
+cargo test --locked -p bitnet-tokenizers --no-default-features --features cpu
+cargo test --locked -p bitnet-qk256-dispatch
+cargo test --locked -p bitnet-quantization
+cargo test --locked -p bitnet-inference
+cargo test --release -p bitnet-quantization bench_avx2_speedup -- --ignored --nocapture
+```
+
+Manual 258V probe commands are defined in `docs/hardware/intel-258v-validation.md` and should be archived alongside any generated JSON receipt.
+
 ## Related Roadmaps
 
 - `docs/specs/intel-lunar-lake-gpu-roadmap.md`

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -19,13 +19,25 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.
+- The 258V CPU validation harness records evidence only and does not take over shared CPU implementation ownership.
 
 ## Work Items
 
 | Work item | Status | Notes |
 |---|---|---|
-| LNL258V-002 | ready | Add 258V probe bundle and same-machine comparison hooks. |
+| LNL258V-002 | ready | Document and add the 258V probe bundle, artifact paths, receipt fields, and same-machine comparison hooks without runtime claims. |
 
 ## Review Policy
 
 Platform PRs document and compare lanes; they must not collapse CPU, GPU, and NPU implementation claims into one backend.
+
+
+## Build-Out Sequence
+
+1. Preserve Intel NPU identity before runtime work (`NPU-002-lite` / `NPU-002`).
+2. Add exact Arc 140V probe evidence (`ARC140V-002`).
+3. Add the visibility-only 258V platform probe (`LNL258V-RUN-001` / `LNL258V-002`).
+4. Let the CPU proof lane land strict loader/tokenizer/kernel/runtime work.
+5. Add the 258V CPU validation harness (`CPU258V-001`) to record strict receipts and benchmarks on Lunar Lake.
+
+Each item must keep CPU, Arc 140V, and NPU claims separate in generated artifacts.

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -14,6 +14,7 @@ hard_constraints = [
   "Arc 140V OpenCL proof is not NPU proof.",
   "OpenVINO GPU smoke is not packed BitNet kernel proof.",
   "WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.",
+  "The 258V CPU validation harness records evidence only and does not take over shared CPU implementation ownership.",
 ]
 
 [[work_item]]
@@ -23,7 +24,7 @@ branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"
 stackable = false
 requires_human_merge = true
 blocked_by = []
-acceptance = "Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims."
+acceptance = "Document and then add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, power context, artifact paths, and receipt fields without runtime claims."
 commands = [
   "cargo fmt --all -- --check",
   "Parse TOML tracker files",

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,10 +9,11 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
+| LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Document and then add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, power context, artifact paths, and receipt fields without runtime claims. |
 
 ## Hard Constraints
 
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.
+- The 258V CPU validation harness records evidence only and does not take over shared CPU implementation ownership.


### PR DESCRIPTION
### Motivation
- Provide a machine-readable, visibility-only platform probe and traceable build-out contracts so the Lunar Lake (Core Ultra 7 258V) work can collect same-machine facts without claiming CPU/GPU/NPU inference or taking ownership of existing CPU kernel work. 
- Prevent identity confusion by specifying NPU, Arc 140V GPU, and CPU claim boundaries so receipts and probes can represent requested vs selected backends accurately. 
- Define a safe 258V validation sequence that keeps the i5-8250U lane as the primary CPU implementation/proof owner while enabling same-machine validation and receipts on the 258V laptop. 

### Description
- Added a machine-readable probe schema and artifact/archival guidance to `docs/hardware/intel-258v-validation.md` including `platform-probe.json`, `openvino-devices.json`, `arc-140v-probe.json`, `npu-probe.json`, and `cpu-bitnet-validation.json` and an OpenVINO NPU extended property query. 
- Added build-out contracts to `docs/specs/intel-lunar-lake-258v-platform-roadmap.md` for `LNL258V-RUN-001` (platform probe), `NPU-002-lite` (NPU identity), `ARC140V-002` (Arc 140V probe), and `CPU258V-001` (CPU validation harness) including allowed/forbidden surfaces, Rust-shaped types, and acceptance checks. 
- Documented required receipt fields and `CpuBitnetValidationReceipt` / `Lnl258vPlatformProbe` / `IntelArc140vProbe` shapes and the downstream CPU dependency order so 258V validation does not reshape or claim ownership of QK256/AVX2 work. 
- Updated tracker files `docs/tracking/campaigns/intel-258v-platform/active.toml`, `docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md`, and regenerated campaign status to expand `LNL258V-002` scope to include artifact paths and receipt fields while enforcing the constraint that the 258V harness does not take over shared CPU implementation ownership. 

### Testing
- Ran `cargo fmt --all -- --check` and it succeeded. 
- Parsed all campaign `active.toml` files with Python `tomllib` in a scripted check and parsing succeeded. 
- Ran `git diff --check` to ensure no whitespace/check failures and it reported no issues. 
- Ran `cargo run -p xtask --no-default-features -- campaign generate` to regenerate campaign status and the xtask generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab5b4bfd08333b3901931b418e844)