### PR TITLE
docs: add 258V CPU validation runtime enablement buildout

### DIFF
--- a/docs/bitnet/BITNET_RECEIPT_FIELDS.md
+++ b/docs/bitnet/BITNET_RECEIPT_FIELDS.md
@@ -148,3 +148,40 @@ Parity receipts must record:
 - `docs/bitnet/BITNET_QUANTIZATION_CONTRACT.md`
 - `docs/bitnet/BITNET_RUNTIME_PHASES.md`
 - `docs/bitnet/BITNET_CPU_PATH_PLAN.md`
+
+## 258V CPU Validation Extensions
+
+The Core Ultra 7 258V validation lane requires strict CPU receipts to include loader, tokenizer, kernel, and platform linkage fields before making real-model or performance claims. The implementation plan is tracked in `docs/specs/intel-258v-cpu-validation-runtime-enablement.md`.
+
+Required 258V CPU receipt surfaces:
+
+```json
+{
+  "loader": {
+    "mode": "real_gguf",
+    "minimal_loader_fallback_used": false,
+    "tokenizer_source": "gguf|override|tokenizer.json|tokenizer.model",
+    "mock_tensors_used": false
+  },
+  "bitnet": {
+    "kernel_family": "qk256|i2_s|tl2",
+    "kernel_format": "i2_s|tl2|qk256",
+    "layout": "qk256-row-major-out-in",
+    "layout_source": "gguf|converted|repo_internal",
+    "requested_kernel": "qk256-avx2-gemv",
+    "selected_kernel": "qk256-avx2-gemv",
+    "dequantizes_before_compute": false
+  },
+  "platform_runtime": {
+    "machine": "core-ultra-7-258v",
+    "cpu_features": ["avx2", "fma", "sse4_2"],
+    "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+    "openvino_available_devices": ["CPU", "GPU.0", "NPU"],
+    "runtime_device": "CPU",
+    "power_mode": "balanced",
+    "thermal_profile": "default"
+  }
+}
+```
+
+A strict 258V CPU receipt is invalid if it uses minimal GGUF fallback, mock tensors, hidden tokenizer fallback, dequantizing fallback for a claimed packed kernel, or a selected kernel different from the requested kernel without reporting a strict failure.

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -220,3 +220,21 @@ Proof lanes:
 - Intel AI Boost NPU and OpenVINO NPU are owned by the Intel NPU workstream.
 
 The platform profile ties the lanes together for comparison, but it does not merge their claims.
+
+## Buildout Linkage
+
+The implementation-facing requirements for turning this validation profile into runtime probes, strict receipts, and CPU validation harnesses are captured in:
+
+```text
+docs/specs/intel-258v-cpu-validation-runtime-enablement.md
+```
+
+Use that spec when adding:
+
+- `Lnl258vPlatformProbe` visibility-only JSON output;
+- exact Arc 140V probe fields;
+- Intel NPU identity-preserving backend/device mappings;
+- strict CPU validation receipts for loader, tokenizer, requested kernel, selected kernel, and fallback status;
+- benchmark gates for 258V scalar-vs-AVX2 validation.
+
+This validation profile remains the manual machine-fact bundle. The buildout spec defines the code-facing APIs and acceptance criteria.

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -390,3 +390,7 @@ Technical specification for implementing manual KV cache position tracking in th
 - `bitnet-cpp-ffi-sockets.md` - Socket 1/Socket 3 architecture
 - `dual-backend-crossval.md` - Cross-validation patterns
 - `cpp-setup.md` - C++ reference setup guide
+
+## Hardware and Runtime Enablement Specs
+
+- `intel-258v-cpu-validation-runtime-enablement.md` - Lunar Lake 258V CPU validation and runtime-probe buildout requirements.

--- a/docs/specs/intel-258v-cpu-validation-runtime-enablement.md
+++ b/docs/specs/intel-258v-cpu-validation-runtime-enablement.md
@@ -1,0 +1,381 @@
+# Intel Core Ultra 7 258V CPU Validation and Runtime Enablement Buildout
+
+## Purpose
+
+This document turns the Lunar Lake 258V validation report into repo-facing buildout requirements. It keeps three facts separate:
+
+1. the i5-8250U lane owns the active CPU BitNet implementation sequence;
+2. the Core Ultra 7 258V CPU lane validates that CPU path on modern Lunar Lake AVX2 silicon;
+3. the same laptop also provides Arc 140V and Intel NPU comparison lanes, but those lanes must not be conflated with CPU proof.
+
+The 258V laptop is therefore a same-machine validation platform, not the owner of shared CPU QK256 dispatch, loader, tokenizer, or transformer hot-path implementation unless a tracker item explicitly says otherwise.
+
+## Highest-confidence conclusion
+
+Do not use the Core Ultra 7 258V laptop to take over CPU BitNet implementation. Use it to produce visibility receipts first, then strict CPU validation receipts after the i5-8250U CPU proof lane lands the authoritative loader and tokenizer work.
+
+The expected sequence is:
+
+1. preserve backend identity and runtime probes for Lunar Lake devices;
+2. let `CPU-BITNET-001` and `CPU-BITNET-002` settle loader and tokenizer authority under the CPU proof lane;
+3. validate scalar versus AVX2 CPU behavior on the 258V with strict receipts;
+4. only then compare CPU AVX2, Arc 140V, and OpenVINO NPU artifacts on the same thermally constrained shared-memory laptop.
+
+## Claim boundaries
+
+| Area | Allowed 258V claim before strict receipts | Forbidden claim |
+|---|---|---|
+| Platform probe | CPU/GPU/NPU runtimes are visible or not visible. | BitNet inference works on any device. |
+| 258V CPU lane | The merged CPU path validates or fails on Lunar Lake AVX2. | The 258V lane owns shared CPU implementation by default. |
+| Arc 140V lane | OpenCL, Level Zero, and OpenVINO GPU identity are visible. | CPU fallback counts as Arc 140V proof. |
+| Intel NPU lane | OpenVINO can enumerate or compile to `NPU` when proven. | NPU maps to Metal, generic GPU, OpenCL, or CPU fallback. |
+| Performance | A benchmark receipt records requested/selected kernels and fallback status. | Reasonable-speed claims without strict real-model receipts. |
+
+## Blocking gaps to document and build out
+
+### Loader authority
+
+Strict CPU proof requires one authoritative real GGUF loader path. Compatibility loaders may exist, but they must be opt-in and invalid for strict proof if they use minimal parsing, synthesized tensors, or mock transformer weights.
+
+Required buildout:
+
+- strict mode rejects minimal-loader fallback;
+- receipts record `loader.mode`, `loader.minimal_loader_fallback_used`, and `loader.mock_tensors_used`;
+- QK256 matrix orientation is normalized to canonical `[out_dim, in_dim]` metadata;
+- compatibility fallback remains explicit and cannot silently support proof claims.
+
+### Tokenizer authority
+
+Tokenizer precedence must be deterministic and receipt-backed:
+
+1. explicit override;
+2. GGUF-embedded tokenizer;
+3. sibling `tokenizer.json`;
+4. sibling `tokenizer.model`;
+5. strict failure.
+
+Required buildout:
+
+- tokenizer loading returns both the tokenizer and a typed tokenizer-source report;
+- receipts record the tokenizer source used by the actual CLI/inference path;
+- no hidden basic-tokenizer fallback is allowed in strict proof mode.
+
+### QK256 CPU kernels and dispatch
+
+The scalar and AVX2 QK256 kernels are valid 258V CPU targets, but the validation lane must distinguish raw kernel work from end-to-end runtime speed.
+
+Required buildout:
+
+- scalar QK256 remains the correctness floor;
+- AVX2 QK256 is parity-checked against scalar output;
+- dispatch records requested kernel, selected kernel, and fallback status;
+- decode and prefill interfaces are both represented;
+- hot paths avoid repeated tensor materialization, flattening, and allocation where possible.
+
+### Runtime identity
+
+The 258V platform cannot support trustworthy receipts while `npu` can alias to Metal or generic GPU surfaces.
+
+Required buildout:
+
+- explicit backend/device variants exist for Intel NPU, OpenVINO NPU, Arc 140V OpenCL, and OpenVINO GPU;
+- strict Intel NPU requests fail before inference when unavailable;
+- Arc 140V probes prove exact identity through PCI ID, OpenCL device name, Level Zero visibility, or OpenVINO `GPU.0` full name;
+- CPU fallback never satisfies GPU or NPU proof.
+
+## PR buildout sequence
+
+| PR | Purpose | May touch | Must not touch |
+|---|---|---|---|
+| `NPU-002-lite` / `NPU-002` | Preserve Intel NPU backend identity before runtime work. | device config, backend selection, NPU mapping, strict failure behavior, receipt identity | OpenVINO graph execution, CPU kernels |
+| `ARC140V-002` | Prove Arc 140V runtime identity through OpenCL, Level Zero, and OpenVINO GPU evidence. | device probe, GPU roadmap docs, receipts | CPU kernels, NPU runtime |
+| `LNL258V-RUN-001` | Add 258V visibility-only platform probe and platform receipt. | `bitnet-device-probe`, CLI/xtask probe command, receipts, hardware docs | QK256 CPU kernels, transformer hot path |
+| `CPU-BITNET-001` | Strict GGUF loader authority. | model loader, CLI strict-mode wiring, receipts | GPU/NPU runtime claims |
+| `CPU-BITNET-002` | Strict tokenizer authority. | tokenizer crates, CLI tokenizer discovery, receipts | CPU kernel performance claims |
+| `CPU-BITNET-003` | QK256 layout and scalar dispatch truth. | layout core, dispatch, scalar tests | 258V-specific platform probe ownership |
+| `CPU-BITNET-004` | AVX2 decode/prefill path and parity. | quantization kernels, dispatch tests | GPU/NPU claims |
+| `CPU-BITNET-005` | Transformer/runtime cleanup for real BitNet execution. | inference layers, CPU backend, generation path | backend identity shortcuts |
+| `CPU-BITNET-006` | Receipt and benchmark fields. | receipts, benchmark docs, CLI emission | unsupported performance claims |
+| `CPU258V-001` | 258V CPU validation harness and same-machine receipts. | validation command, receipt generation, hardware/tracking docs | shared CPU implementation unless stacked on CPU proof work |
+
+## Required 258V platform probe API
+
+The visibility-only platform probe should produce a single machine-readable artifact without claiming inference.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Lnl258vPlatformProbe {
+    pub platform: String,
+    pub os: String,
+    pub arch: String,
+
+    pub cpu_brand: String,
+    pub cpu_cores: usize,
+    pub cpu_threads: usize,
+    pub cpu_has_avx2: bool,
+    pub cpu_has_avx512: bool,
+
+    pub opencl_arc_140v_visible: bool,
+    pub opencl_platform_name: Option<String>,
+    pub opencl_device_name: Option<String>,
+    pub opencl_driver_version: Option<String>,
+    pub pci_device_id: Option<String>,
+
+    pub level_zero_visible: bool,
+    pub level_zero_devices: Vec<String>,
+
+    pub openvino_version: Option<String>,
+    pub openvino_available_devices: Vec<String>,
+    pub openvino_gpu_device: Option<String>,
+    pub openvino_gpu_full_name: Option<String>,
+    pub openvino_npu_visible: bool,
+    pub openvino_npu_full_name: Option<String>,
+
+    pub accel_device_present: bool,
+    pub accel_devices: Vec<String>,
+    pub intel_vpu_driver_seen: bool,
+    pub npu_driver_version: Option<String>,
+
+    pub power_mode: Option<String>,
+    pub thermal_profile: Option<String>,
+    pub shared_memory_bytes: Option<u64>,
+
+    pub status: String,
+    pub failure_reason: Option<String>,
+}
+
+pub fn probe_lnl258v_platform() -> Lnl258vPlatformProbe;
+```
+
+The initial status values should distinguish at least:
+
+- `not_lunar_lake_258v`;
+- `runtime_not_detected`;
+- `partial_runtime_detected`;
+- `runtime_detected`.
+
+## Required Arc 140V probe API
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IntelArc140vProbe {
+    pub available: bool,
+    pub pci_device_id: Option<String>,
+    pub opencl_available: bool,
+    pub opencl_platform_name: Option<String>,
+    pub opencl_device_name: Option<String>,
+    pub opencl_driver_version: Option<String>,
+    pub level_zero_available: bool,
+    pub level_zero_devices: Vec<String>,
+    pub openvino_gpu_visible: bool,
+    pub openvino_gpu_device: Option<String>,
+    pub openvino_gpu_full_name: Option<String>,
+    pub shared_memory_bytes: Option<u64>,
+    pub power_mode: Option<String>,
+    pub failure_reason: Option<String>,
+}
+
+pub fn probe_intel_arc_140v() -> IntelArc140vProbe;
+```
+
+Detection rules:
+
+- prefer exact PCI ID `0x64A0`;
+- match OpenCL/OpenVINO full device name to `Intel(R) Arc(TM) 140V Graphics` when available;
+- record Level Zero separately from OpenCL and OpenVINO;
+- never treat CPU fallback as Arc 140V proof.
+
+## Required 258V CPU validation receipt API
+
+The 258V CPU validation harness should measure the merged CPU path without taking ownership of that implementation.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuBitnetValidationReceipt {
+    pub machine: String,
+    pub requested_backend: String,
+    pub selected_backend: String,
+    pub runtime_api: String,
+
+    pub loader_mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+
+    pub kernel_family: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub fallback_used: bool,
+    pub fallback_reason: Option<String>,
+
+    pub cpu_features: Vec<String>,
+    pub threads: usize,
+
+    pub phase: String,
+    pub prompt_tokens: usize,
+    pub generated_tokens: usize,
+    pub tokens_per_second: Option<f64>,
+    pub first_token_latency_ms: Option<f64>,
+}
+
+pub fn run_cpu_bitnet_validation(args: &CpuBitnetValidationArgs) -> anyhow::Result<CpuBitnetValidationReceipt>;
+```
+
+Strict CPU validation receipts are invalid if:
+
+- `minimal_loader_fallback_used` is `true`;
+- `mock_tensors_used` is `true`;
+- tokenizer source is missing or ambiguous;
+- `requested_kernel != selected_kernel` without a failed strict result;
+- `fallback_used` is `true` for a strict proof pass.
+
+## Receipt schema additions
+
+`InferenceReceipt` should be able to carry these optional BitNet-specific surfaces:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BitnetExecutionMetadata {
+    pub kernel_family: String,
+    pub kernel_format: String,
+    pub layout: String,
+    pub layout_source: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub dequantizes_before_compute: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoaderMetadata {
+    pub mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlatformRuntimeMetadata {
+    pub machine: String,
+    pub cpu_features: Vec<String>,
+    pub opencl_device_name: Option<String>,
+    pub openvino_available_devices: Vec<String>,
+    pub runtime_device: Option<String>,
+    pub power_mode: Option<String>,
+    pub thermal_profile: Option<String>,
+}
+```
+
+## Manual probe bundle fields
+
+The 258V validation bundle must continue to collect the human/manual commands in `docs/hardware/intel-258v-validation.md`. Machine-readable probe output should normalize those facts into fields equivalent to:
+
+```json
+{
+  "platform": "core-ultra-7-258v",
+  "os": "linux|windows",
+  "arch": "x86_64",
+  "cpu_model": "Intel Core Ultra 7 258V",
+  "cpu_cores": 8,
+  "cpu_threads": 8,
+  "cpu_flags": ["avx2", "fma", "sse4_2"],
+  "cpu_has_avx2": true,
+  "cpu_has_avx512": false,
+  "opencl_arc_140v_visible": true,
+  "opencl_platform_name": "Intel(R) OpenCL Graphics",
+  "opencl_device_name": "Intel(R) Arc(TM) 140V Graphics",
+  "opencl_driver_version": "...",
+  "pci_device_id": "0x64A0",
+  "level_zero_visible": true,
+  "level_zero_devices": ["Intel(R) Arc(TM) 140V Graphics"],
+  "openvino_version": "...",
+  "openvino_available_devices": ["CPU", "GPU.0", "NPU"],
+  "openvino_gpu_device": "GPU.0",
+  "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V Graphics",
+  "openvino_npu_visible": true,
+  "openvino_npu_full_name": "...",
+  "accel_device_present": true,
+  "accel_devices": ["/dev/accel/accel0"],
+  "intel_vpu_driver_seen": true,
+  "npu_driver_version": "...",
+  "status": "runtime_detected"
+}
+```
+
+## Test and check plan
+
+### Platform and identity checks
+
+```bash
+cargo fmt --all -- --check
+cargo test --locked -p bitnet-device-config-core
+cargo test --locked -p bitnet-device-probe
+cargo test --locked -p bitnet-receipts-core
+```
+
+Acceptance:
+
+- `npu` does not alias to Metal, CUDA, OpenCL, generic GPU, or CPU;
+- strict Intel NPU request fails cleanly when unavailable;
+- Arc 140V probe cannot report CPU fallback as GPU proof;
+- 258V platform probe emits visibility facts only.
+
+### Loader and tokenizer checks
+
+```bash
+cargo test --locked -p bitnet-models --no-default-features --features cpu
+cargo test --locked -p bitnet-tokenizers --no-default-features --features cpu
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli
+```
+
+Acceptance:
+
+- strict mode rejects minimal GGUF fallback;
+- strict receipts record `minimal_loader_fallback_used=false`;
+- explicit tokenizer override wins;
+- GGUF tokenizer wins over siblings when no override exists;
+- sibling `tokenizer.json` wins over `tokenizer.model` when both exist;
+- missing tokenizer fails in strict mode.
+
+### QK256 CPU checks
+
+```bash
+cargo test --locked -p bitnet-quantization qk256_lut_basic -- --exact
+cargo test --locked -p bitnet-quantization qk256_block_decode_golden -- --exact
+cargo test --locked -p bitnet-quantization qk256_tiny_gemv_e2e -- --exact
+cargo test --locked -p bitnet-quantization test_qk256_size_tolerance -- --exact
+cargo test --locked -p bitnet-quantization test_gemv_qk256_avx2_smoke -- --exact
+cargo test --release -p bitnet-quantization bench_avx2_speedup -- --ignored --nocapture
+```
+
+Acceptance:
+
+- lookup-table mapping remains `0 -> -2`, `1 -> -1`, `2 -> +1`, `3 -> +2`;
+- tail handling matches scalar reference within the documented tolerance;
+- size tolerance accepts up to `+128` bytes and rejects `+129` bytes;
+- AVX2 output matches scalar output within mixed absolute/relative tolerance;
+- benchmark output records requested kernel, selected kernel, and fallback status.
+
+## First-pass 258V performance gates
+
+These are acceptance gates, not guarantees:
+
+| Benchmark | Initial gate | Reason |
+|---|---:|---|
+| QK256 AVX2 GEMV versus scalar | `>= 2.0x`, target `>= 3.0x` | AVX2 should be worth selecting. |
+| Prefill AVX2 path versus scalar | `>= 1.5x` for `T >= 128` | Prefill is heavier and memory-sensitive. |
+| End-to-end strict decode | `>= 1.5x` over scalar-only build | Kernel wins must survive runtime overhead. |
+| Loader/tokenizer overhead after first run | `< 5%` of total time | Scaffolding must not hide kernel speed. |
+| Strict fallback rate | `0` | Correctness requirement. |
+
+If these gates fail, prioritize runtime plumbing before rewriting only the AVX2 inner kernel: tensor extraction, allocation, dispatch, prefill batching, thread-pool setup, and dequantizing fallback paths are all likely culprits.
+
+## Documentation update requirements for implementation PRs
+
+Every PR in this sequence must update documentation before claiming support:
+
+- update `docs/hardware/intel-258v-validation.md` when probe fields or manual commands change;
+- update `docs/specs/intel-lunar-lake-258v-platform-roadmap.md` when the platform claim boundary changes;
+- update `docs/specs/intel-lunar-lake-gpu-roadmap.md` when Arc 140V identity requirements change;
+- update `docs/specs/intel-lunar-lake-npu-roadmap.md` when NPU identity, runtime smoke, or OpenVINO properties change;
+- update `docs/bitnet/BITNET_RECEIPT_FIELDS.md` when receipt fields change;
+- update `docs/tracking/campaigns/*/active.toml` when lane ownership, allowed paths, or acceptance criteria change.

--- a/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
+++ b/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
@@ -169,3 +169,21 @@ NPU subgraph parity, if proven
 - `docs/hardware/intel-258v-validation.md`
 
 Keep implementation work item ownership separate even when the same laptop produces the receipts.
+
+## CPU Validation and Runtime Enablement Buildout
+
+The detailed CPU validation/runtime buildout is defined in:
+
+```text
+docs/specs/intel-258v-cpu-validation-runtime-enablement.md
+```
+
+That buildout is normative for sequencing 258V work:
+
+1. preserve backend identity first (`NPU-002`/`NPU-002-lite`);
+2. prove Arc 140V identity separately (`ARC140V-002`);
+3. add a visibility-only 258V platform probe (`LNL258V-RUN-001`);
+4. let the CPU proof lane own strict loader and tokenizer authority;
+5. add a 258V CPU validation harness only after strict CPU receipts can record loader, tokenizer, requested kernel, selected kernel, and fallback status.
+
+The 258V platform lane must not rewrite shared QK256 dispatch, CPU kernels, or transformer hot paths unless a tracker item explicitly scopes that overlap with the CPU proof campaign.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -118,3 +118,38 @@ must_not_claim = [
   "Transformer decode is complete.",
   "CPU performance is proven.",
 ]
+
+
+[[work_item]]
+id = "CPU258V-001"
+status = "planned"
+branch = "codex/cpu-proof/CPU258V-001-lunar-lake-validation"
+stackable = true
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-002"]
+acceptance = "Add a Core Ultra 7 258V CPU-only validation harness that records strict loader, tokenizer, requested kernel, selected kernel, fallback, phase, and benchmark metrics for the merged CPU path without taking ownership of shared CPU implementation work."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-receipts-core",
+  "cargo test --locked -p bitnet-cli",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-receipts-core/**",
+  "docs/bitnet/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-258v-cpu-validation-runtime-enablement.md",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/i2s_qk256*.rs",
+  "crates/bitnet-inference/src/layers/**",
+]
+may_claim = [
+  "258V CPU validation receipts are generated after merge.",
+]
+must_not_claim = [
+  "258V owns the shared CPU implementation lane.",
+  "CPU performance is proven without receipt artifacts.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -48,3 +48,39 @@ must_not_claim = [
   "Intel NPU execution works.",
   "BitNet inference works on 258V.",
 ]
+
+
+[[work_item]]
+id = "LNL258V-RUN-001"
+status = "planned"
+branch = "codex/intel-258v-platform/LNL258V-RUN-001-platform-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = ["NPU-002", "ARC140V-002"]
+acceptance = "Add a visibility-only Core Ultra 7 258V platform probe and receipt that records CPU AVX2 facts, Arc 140V visibility, Level Zero, OpenVINO GPU.0, OpenVINO NPU, /dev/accel, driver, memory, power, and thermal context without inference claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-device-probe",
+  "cargo test --locked -p bitnet-receipts-core",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/**",
+  "crates/bitnet-receipts-core/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-platform-roadmap.md",
+  "docs/specs/intel-258v-cpu-validation-runtime-enablement.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+]
+forbidden_paths = [
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-inference/src/layers/**",
+]
+may_claim = [
+  "258V platform visibility is recorded after merge.",
+]
+must_not_claim = [
+  "BitNet inference works on 258V.",
+  "Arc 140V executes BitNet kernels.",
+  "Intel NPU executes BitNet graphs.",
+]


### PR DESCRIPTION
### Motivation

- Provide a clear, repo-facing buildout spec to turn the Lunar Lake 258V validation report into implementation-ready requirements that preserve lane ownership and claim boundaries. 
- Surface concrete probe/receipt APIs and acceptance gates so platform, Arc 140V, and Intel NPU work can proceed without conflating CPU implementation ownership. 
- Make explicit the expected PR sequencing, required receipt fields, and the checks needed before any 258V inference or performance claims.

### Description

- Added a new buildout spec `docs/specs/intel-258v-cpu-validation-runtime-enablement.md` that documents claim boundaries, blocking gaps (loader, tokenizer, QK256 dispatch, runtime identity), PR sequencing, probe APIs, receipt schema additions, and test/benchmark gates.
- Linked the new spec into platform/hardware docs and the specs index by updating `docs/specs/intel-lunar-lake-258v-platform-roadmap.md`, `docs/hardware/intel-258v-validation.md`, and `docs/specs/INDEX.md` so the buildout is discoverable from existing guidance.
- Extended receipt documentation in `docs/bitnet/BITNET_RECEIPT_FIELDS.md` with 258V-specific strict CPU receipt fields and invariant rules for strict-mode validity.
- Added planned tracker work items and acceptance metadata for visibility-only platform probe (`LNL258V-RUN-001`) and the 258V CPU validation harness (`CPU258V-001`) by updating `docs/tracking/campaigns/intel-258v-platform/active.toml` and `docs/tracking/campaigns/cpu-proof/active.toml`.

Files added or modified:
- Added: `docs/specs/intel-258v-cpu-validation-runtime-enablement.md`.
- Modified: `docs/bitnet/BITNET_RECEIPT_FIELDS.md`, `docs/hardware/intel-258v-validation.md`, `docs/specs/INDEX.md`, `docs/specs/intel-lunar-lake-258v-platform-roadmap.md`, `docs/tracking/campaigns/intel-258v-platform/active.toml`, `docs/tracking/campaigns/cpu-proof/active.toml`.

### Testing

- Ran `cargo fmt --all -- --check` to validate formatting, and it succeeded.
- Parsed all tracker `active.toml` files with Python `tomllib` to validate TOML structure, and parsing succeeded.
- Ran `git diff --check` / whitespace checks to ensure no obvious doc lint issues, and no problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab5b4bfd08333b3901931b418e844)