### PR TITLE
docs(tracking): sync open campaign PR state

### DIFF
--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T053130Z-M4-004-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T053130Z-M4-004-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T05:31:30Z"
+campaign = "apple-m4"
+item = "M4-004"
+event = "pr_open"
+pr = 3692
+head_sha = "8389c4869efec58e360f89fee56a74242ec988b7"
+actor = "codex"
+
+notes = [
+  "Opened Apple M4 Metal runtime visibility probe PR.",
+  "Records requested/selected backend identity, runtime API, macOS/chip/core/memory/virtualization fields, Metal visibility, fallback status, proof stage, and planned artifact path.",
+  "No Metal kernels, MPSGraph execution, Neural Engine claims, QK256, server inference, dependencies, or BitNet inference claims.",
+]

--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -32,7 +32,7 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 | CPU-BITNET-000 | merged | Real BitNet CPU path plan merged in #3642. |
 | CPU-BITNET-001 | merged | Strict GGUF loader authority merged in #3651. |
 | CPU-BITNET-002 | merged | Strict tokenizer authority merged in #3680. |
-| CPU-BITNET-003 | ready | Canonical packed layout. |
+| CPU-BITNET-003 | pr_open | Canonical packed layout open in #3690. |
 | CPU-BITNET-004 | proposed | Scalar truth kernels. |
 | CPU-BITNET-005 | proposed | AVX2 decode GEMV. |
 | CPU-BITNET-006 | proposed | CPU transformer decode ops. |

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T053130Z-CPU-BITNET-003-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T053130Z-CPU-BITNET-003-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T05:31:30Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-003"
+event = "pr_open"
+pr = 3690
+head_sha = "ab89f51cf7aae1ffb5e34e24758c11eff6aa637e"
+actor = "maintainer"
+
+notes = [
+  "Synced live GitHub PR state for the canonical packed layout PR.",
+  "Tracker-only update so campaign doctor can reconcile the open PR live lock.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -26,7 +26,7 @@ Validate RTX 5070 Ti as a CUDA-first BitNet acceleration lane with selected-devi
 | Work item | Status | Notes |
 |---|---|---|
 | RTX5070TI-003 | pr_open | Preserve selected-device CUDA identity in #3679. |
-| RTX5070TI-004 | proposed | Add CUDA and NVML runtime probe. |
+| RTX5070TI-004 | pr_open | Add CUDA and NVML runtime probe in #3691. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T053130Z-RTX5070TI-004-pr-open.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T053130Z-RTX5070TI-004-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T05:31:30Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-004"
+event = "pr_open"
+pr = 3691
+head_sha = "6c2fa736b182570b990c326cb02b7e33b9e068fe"
+actor = "codex"
+
+notes = [
+  "Synced live GitHub PR state for the RTX 5070 Ti CUDA and NVML runtime probe PR.",
+  "Tracker-only update so campaign doctor can reconcile the open PR live lock.",
+]

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -885,10 +885,10 @@ fn reconcile_github_pull_requests(campaigns: &[LoadedCampaign]) -> Vec<Problem> 
             items.insert(item.id.as_str(), (&campaign.manifest.id, item));
         }
         for event in &campaign.events {
-            if event.event == "pr_open" {
-                if let Some(pr) = event.pr {
-                    pr_open_event_prs.insert(event.item.as_str(), pr);
-                }
+            if event.event == "pr_open"
+                && let Some(pr) = event.pr
+            {
+                pr_open_event_prs.insert(event.item.as_str(), pr);
             }
             if event.event == "merged" {
                 merged_events.insert(event.item.as_str());


### PR DESCRIPTION
## Summary
- record the currently open CPU and Apple campaign item PRs in campaign-local TOML
- regenerate campaign/global dashboards so strict live-lock reconciliation has an audited source of truth
- leave legacy global tracker files untouched

## Scope
Tracker sync only. No runtime code, kernels, QK256 implementation changes, server inference, dependencies, or hardware artifacts.

## Verification
- GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pull request event tracking records for hardware validation campaign milestones across Apple M4, CPU proof, and Nvidia RTX 5070 Ti initiatives.
  * Updated campaign status documentation to reflect new pull request submissions and synchronized tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->