### PR TITLE
docs(tracking): record M4-004 merge

### DIFF
--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -33,8 +33,8 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-001 | merged | Apple M4 lane scaffold merged in #3625; docs/contracts only. |
 | M4-002 | merged | Machine profile and probe bundle merged in #3627. |
 | M4-003 | merged | Apple Metal, MPSGraph, and CPU/NEON backend identity merged in #3652. |
-| M4-004 | ready | Add Metal device probe. |
-| M4-005 | proposed | Run tiny Metal compute smoke. |
+| M4-004 | merged | Add Metal device probe. |
+| M4-005 | ready | Run tiny Metal compute smoke. |
 | M4-006 | proposed | Add CPU/Metal parity. |
 | M4-007 | proposed | Run MPSGraph tiny graph smoke. |
 | M4-008 | proposed | Record Apple backend identity in receipts. |

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -126,7 +126,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-004"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-004-metal-probe"
 stackable = false
 requires_human_merge = true
@@ -160,7 +160,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-005"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-005-metal-smoke"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T072437Z-M4-004-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T072437Z-M4-004-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T07:24:37Z"
+campaign = "apple-m4"
+item = "M4-004"
+event = "merged"
+pr = 3692
+merge_sha = "740eacd6daa972f27bc80eaf1b18edadd3f62e24"
+actor = "maintainer"
+
+notes = [
+  "Merged Apple M4 Metal device/runtime visibility probe.",
+  "No Metal execution, MPSGraph execution, Neural Engine execution, QK256, server inference, or BitNet inference was claimed.",
+  "M4-005 is ready for tiny native Metal compute smoke.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -12,8 +12,8 @@
 | M4-001 | merged | #3625 | `codex/hardware-scaffold/M4-001-apple-lane` | Add the Apple M4 Mac mini lane scaffold without runtime execution claims. |
 | M4-002 | merged | #3627 | `codex/apple-m4/M4-002-profile-probe-bundle` | Add the Apple M4 Mac mini machine profile and probe bundle without runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts. |
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
-| M4-004 | pr_open | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
-| M4-005 | proposed | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
+| M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
+| M4-005 | ready | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | proposed | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-004 | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -5,8 +5,8 @@
 |---|---|---|---|
 | apple-m4 | M4-002 | M4-001 | merged |
 | apple-m4 | M4-003 | M4-002 | merged |
-| apple-m4 | M4-004 | M4-003 | pr_open |
-| apple-m4 | M4-005 | M4-004 | proposed |
+| apple-m4 | M4-004 | M4-003 | merged |
+| apple-m4 | M4-005 | M4-004 | ready |
 | apple-m4 | M4-006 | M4-005 | proposed |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-004 | #3692 | pr_open | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-005 | TBD | ready | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-000 | #3642 | merged | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-004 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-000 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- mark M4-004 merged with PR #3692 merge SHA 740eacd6daa972f27bc80eaf1b18edadd3f62e24
- promote M4-005 to ready for the next Apple Silicon lane item
- regenerate campaign/global dashboards while preserving other device lanes

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
Tracker-only closeout; no runtime, kernel, QK256, server, dependency, Metal execution, MPSGraph, Neural Engine, or BitNet inference changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Apple M4 campaign tracking to reflect latest work item statuses and progress
  * Transitioned work items through development stages and documented merge events
  * Added new work items to the campaign roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->