### PR TITLE
feat(quantization): add CPU-BITNET-004 scalar QK256 truth kernels

### DIFF
--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -44,6 +44,12 @@ pub const QK256_BLOCK: usize = QK256_BLOCK_COLS;
 /// Packed bytes per block (2 bits/elem * 256 elem / 8 bits/byte)
 pub const QK256_PACKED_BYTES: usize = QK256_PACKED_BYTES_PER_BLOCK;
 
+/// Stable receipt/proof kernel ID for the canonical scalar QK256 decode GEMV.
+pub const QK256_SCALAR_GEMV_KERNEL_ID: &str = "qk256-scalar-gemv";
+
+/// Stable receipt/proof kernel ID for the canonical scalar QK256 prefill GEMM.
+pub const QK256_SCALAR_GEMM_KERNEL_ID: &str = "qk256-scalar-gemm";
+
 /// Storage for GGML I2_S (QK=256) quantized weights without per-block scales
 ///
 /// This structure holds raw packed 2-bit codes for a weight tensor in the
@@ -293,7 +299,7 @@ pub fn gemv_qk256_row(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
 /// # Errors
 ///
 /// Returns error if dimensions don't match or data is insufficient.
-fn gemv_qk256_scalar(
+fn gemv_qk256_scalar_checked(
     qs_data: &[u8],
     x: &[f32],
     y_out: &mut [f32],
@@ -318,6 +324,68 @@ fn gemv_qk256_scalar(
         let end = start + row_stride_bytes;
         let row_bytes = &qs_data[start..end];
         *output = gemv_qk256_row(row_bytes, x, cols);
+    }
+
+    Ok(())
+}
+
+/// Canonical scalar QK256 GEMV oracle for decode: `y = A x`.
+///
+/// This path uses the GGML I2_S no-scale mapping from [`code_to_f32`] and the
+/// canonical QK256 packed layout. It never dispatches to SIMD.
+pub fn qk256_gemv_scalar(
+    qs_data: &[u8],
+    x: &[f32],
+    y_out: &mut [f32],
+    rows: usize,
+    cols: usize,
+) -> Result<()> {
+    let layout = Qk256Layout::from_rows_cols(rows, cols)?;
+    layout.validate_packed_len(qs_data.len())?;
+    gemv_qk256_scalar_checked(qs_data, x, y_out, rows, cols, layout.row_stride_bytes)
+}
+
+/// Canonical scalar QK256 GEMM oracle for prefill: `Y = X A^T`.
+///
+/// `x` is row-major with shape `tokens × cols`; `y_out` is row-major with shape
+/// `tokens × rows`. The packed matrix `A` is row-major QK256 with shape
+/// `rows × cols`.
+pub fn qk256_gemm_scalar(
+    qs_data: &[u8],
+    x: &[f32],
+    y_out: &mut [f32],
+    tokens: usize,
+    rows: usize,
+    cols: usize,
+) -> Result<()> {
+    let layout = Qk256Layout::from_rows_cols(rows, cols)?;
+    layout.validate_packed_len(qs_data.len())?;
+
+    let expected_x_len = tokens.checked_mul(cols).ok_or_else(|| {
+        anyhow::anyhow!("I2S_QK256: x length overflow for tokens={tokens}, cols={cols}")
+    })?;
+    if x.len() != expected_x_len {
+        bail!("I2S_QK256: x length {} != tokens*cols {}", x.len(), expected_x_len);
+    }
+
+    let expected_y_len = tokens.checked_mul(rows).ok_or_else(|| {
+        anyhow::anyhow!("I2S_QK256: y_out length overflow for tokens={tokens}, rows={rows}")
+    })?;
+    if y_out.len() != expected_y_len {
+        bail!("I2S_QK256: y_out length {} != tokens*rows {}", y_out.len(), expected_y_len);
+    }
+
+    for token in 0..tokens {
+        let x_start = token * cols;
+        let y_start = token * rows;
+        gemv_qk256_scalar_checked(
+            qs_data,
+            &x[x_start..x_start + cols],
+            &mut y_out[y_start..y_start + rows],
+            rows,
+            cols,
+            layout.row_stride_bytes,
+        )?;
     }
 
     Ok(())
@@ -381,12 +449,32 @@ pub fn gemv_qk256(
     }
 
     // Fallback to scalar implementation
-    gemv_qk256_scalar(qs_data, x, y_out, rows, cols, row_stride_bytes)
+    gemv_qk256_scalar_checked(qs_data, x, y_out, rows, cols, row_stride_bytes)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pack_codes_for_cols(codes: &[u8], cols: usize) -> Vec<u8> {
+        let layout = Qk256Layout::from_rows_cols(1, cols).expect("layout");
+        let mut packed = vec![0u8; layout.row_stride_bytes];
+        for (i, &code) in codes.iter().enumerate().take(cols) {
+            assert!(code < 4, "test code must be 0..=3");
+            packed[i / 4] |= code << ((i % 4) * 2);
+        }
+        packed
+    }
+
+    fn reference_dot(codes: &[u8], x: &[f32], cols: usize) -> f32 {
+        codes
+            .iter()
+            .copied()
+            .zip(x.iter().copied())
+            .take(cols)
+            .map(|(code, x)| code_to_f32(code) * x)
+            .sum()
+    }
 
     #[test]
     fn unpack_block_smoke() {
@@ -484,6 +572,70 @@ mod tests {
         assert_eq!(code_to_f32(1), -1.0);
         assert_eq!(code_to_f32(2), 1.0);
         assert_eq!(code_to_f32(3), 2.0);
+    }
+
+    #[test]
+    fn qk256_scalar_kernel_ids_are_stable() {
+        assert_eq!(QK256_SCALAR_GEMV_KERNEL_ID, "qk256-scalar-gemv");
+        assert_eq!(QK256_SCALAR_GEMM_KERNEL_ID, "qk256-scalar-gemm");
+    }
+
+    #[test]
+    fn qk256_gemv_scalar_matches_reference_fixture() -> Result<()> {
+        let rows = 2usize;
+        let cols = 300usize;
+        let x: Vec<f32> = (0..cols).map(|i| ((i % 11) as f32 - 5.0) * 0.25).collect();
+        let row0_codes: Vec<u8> = (0..cols).map(|i| (i % 4) as u8).collect();
+        let row1_codes: Vec<u8> = (0..cols).map(|i| ((i + 1) % 4) as u8).collect();
+
+        let mut qs_data = Vec::new();
+        qs_data.extend_from_slice(&pack_codes_for_cols(&row0_codes, cols));
+        qs_data.extend_from_slice(&pack_codes_for_cols(&row1_codes, cols));
+
+        let mut y_out = vec![0.0f32; rows];
+        qk256_gemv_scalar(&qs_data, &x, &mut y_out, rows, cols)?;
+
+        let expected = [reference_dot(&row0_codes, &x, cols), reference_dot(&row1_codes, &x, cols)];
+        for (got, expected) in y_out.iter().zip(expected) {
+            assert!((got - expected).abs() < 1e-5, "got {got}, expected {expected}");
+        }
+
+        let mut y_out_repeat = vec![0.0f32; rows];
+        qk256_gemv_scalar(&qs_data, &x, &mut y_out_repeat, rows, cols)?;
+        assert_eq!(y_out, y_out_repeat, "scalar GEMV must be deterministic");
+
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_gemm_scalar_matches_batched_gemv_fixture() -> Result<()> {
+        let tokens = 3usize;
+        let rows = 2usize;
+        let cols = 256usize;
+        let row0_codes: Vec<u8> = (0..cols).map(|i| (i % 4) as u8).collect();
+        let row1_codes: Vec<u8> = (0..cols).map(|i| ((i + 2) % 4) as u8).collect();
+
+        let mut qs_data = Vec::new();
+        qs_data.extend_from_slice(&pack_codes_for_cols(&row0_codes, cols));
+        qs_data.extend_from_slice(&pack_codes_for_cols(&row1_codes, cols));
+
+        let x: Vec<f32> = (0..tokens * cols).map(|i| ((i % 17) as f32 - 8.0) / 8.0).collect();
+        let mut y_out = vec![0.0f32; tokens * rows];
+        qk256_gemm_scalar(&qs_data, &x, &mut y_out, tokens, rows, cols)?;
+
+        for token in 0..tokens {
+            let x_token = &x[token * cols..(token + 1) * cols];
+            let expected0 = reference_dot(&row0_codes, x_token, cols);
+            let expected1 = reference_dot(&row1_codes, x_token, cols);
+            assert!((y_out[token * rows] - expected0).abs() < 1e-5);
+            assert!((y_out[token * rows + 1] - expected1).abs() < 1e-5);
+        }
+
+        let mut y_out_repeat = vec![0.0f32; tokens * rows];
+        qk256_gemm_scalar(&qs_data, &x, &mut y_out_repeat, tokens, rows, cols)?;
+        assert_eq!(y_out, y_out_repeat, "scalar GEMM must be deterministic");
+
+        Ok(())
     }
 
     #[test]

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -154,3 +154,34 @@ must_not_claim = [
   "Scalar truth kernels are complete.",
   "AVX2 dispatch is complete.",
 ]
+
+[[work_item]]
+id = "CPU-BITNET-004"
+status = "pr_open"
+branch = "codex/cpu-bitnet-004-scalar-packed-truth"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-003"]
+acceptance = "Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu i2s_qk256 --lib",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/src/i2s_qk256.rs",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "Scalar packed QK256 GEMV/GEMM correctness oracles exist after merge.",
+]
+must_not_claim = [
+  "Optimized kernel performance is proven.",
+  "AVX2 dispatch is complete.",
+  "Transformer decode is complete.",
+]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T072555Z-CPU-BITNET-004-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T072555Z-CPU-BITNET-004-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T07:25:55Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-004"
+event = "pr_open"
+pr = 3696
+head_sha = "e926b22ffdb2c4ec805bfbcd8f99cf17d86e232a"
+actor = "codex"
+
+notes = [
+  "Started scalar packed QK256 truth kernels after CPU-BITNET-003 merged.",
+  "This item is scalar correctness only; AVX2 dispatch, transformer decode, receipts, and benchmarks remain follow-up work.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -13,6 +13,7 @@
 | CPU-BITNET-001 | merged | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
 | CPU-BITNET-002 | merged | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
+| CPU-BITNET-004 | pr_open | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -19,6 +19,7 @@
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
+| cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | pr_open |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-005 | TBD | ready | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-000 | #3642 | merged | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-005 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-000 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-004 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- CPU-BITNET-004: expose canonical no-scale scalar QK256 GEMV and GEMM oracle APIs
- add stable scalar kernel IDs: qk256-scalar-gemv and qk256-scalar-gemm
- add deterministic packed fixture tests against explicit reference dots

## Scope
- scalar correctness only
- no AVX2 dispatch changes
- no transformer decode, receipts, benchmarks, server, GPU, or crate collapse

## Validation
- rustfmt --edition 2024 --check crates/bitnet-quantization/src/i2s_qk256.rs
- cargo test --locked -p bitnet-quantization --no-default-features --features cpu i2s_qk256 --lib
- cargo check --locked -p bitnet-quantization --no-default-features --features cpu