### PR TITLE
Preserve Intel NPU backend identity

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -54,6 +54,14 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require an Intel NPU without aliasing it to Metal or a generic GPU.
+    IntelNpu,
+    /// Require OpenVINO NPU execution.
+    OpenVinoNpu,
+    /// Require the Lunar Lake Intel Arc 140V GPU identity.
+    IntelArc140v,
+    /// Require Arc 140V through OpenVINO GPU.0 identity.
+    IntelArc140vOpenVinoGpu,
     /// Require native Metal compute without assuming a specific Apple machine.
     Metal,
     /// Require MPSGraph graph execution without treating it as native Metal kernels.
@@ -76,6 +84,12 @@ impl BackendRequest {
             "cuda" => Some(BackendRequest::Cuda),
             "hip" | "rocm" => Some(BackendRequest::Hip),
             "oneapi" => Some(BackendRequest::OneApi),
+            "npu" | "intel-npu" => Some(BackendRequest::IntelNpu),
+            "openvino-npu" => Some(BackendRequest::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Some(BackendRequest::IntelArc140v),
+            "intel-arc-140v-openvino-gpu" | "arc-140v-openvino-gpu" => {
+                Some(BackendRequest::IntelArc140vOpenVinoGpu)
+            }
             "metal" => Some(BackendRequest::Metal),
             "mpsgraph" => Some(BackendRequest::MpsGraph),
             "apple-m4-metal" => Some(BackendRequest::AppleM4Metal),
@@ -95,6 +109,10 @@ impl fmt::Display for BackendRequest {
             BackendRequest::Cuda => write!(f, "cuda"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::IntelNpu => write!(f, "intel-npu"),
+            BackendRequest::OpenVinoNpu => write!(f, "openvino-npu"),
+            BackendRequest::IntelArc140v => write!(f, "intel-arc-140v"),
+            BackendRequest::IntelArc140vOpenVinoGpu => write!(f, "intel-arc-140v-openvino-gpu"),
             BackendRequest::Metal => write!(f, "metal"),
             BackendRequest::MpsGraph => write!(f, "mpsgraph"),
             BackendRequest::AppleM4Metal => write!(f, "apple-m4-metal"),
@@ -153,6 +171,9 @@ impl BackendSelectionResult {
             "hip" => "hip",
             "oneapi" => "oneapi",
             "opencl" => "opencl",
+            "intel-npu" | "openvino-npu" => "openvino-npu",
+            "intel-arc-140v-openvino-gpu" => "openvino-gpu",
+            "intel-arc-140v" => "opencl",
             "apple-m4-metal" | "metal" => "metal",
             "apple-m4-mpsgraph" | "mpsgraph" => "mpsgraph",
             _ => "cpu",
@@ -168,7 +189,11 @@ impl BackendSelectionResult {
             BackendRequest::Cuda => self.selected != KernelBackend::Cuda,
             BackendRequest::Hip => self.selected != KernelBackend::Hip,
             BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
-            BackendRequest::Metal
+            BackendRequest::IntelArc140v => self.selected != KernelBackend::OpenCL,
+            BackendRequest::IntelNpu
+            | BackendRequest::OpenVinoNpu
+            | BackendRequest::IntelArc140vOpenVinoGpu
+            | BackendRequest::Metal
             | BackendRequest::MpsGraph
             | BackendRequest::AppleM4Metal
             | BackendRequest::AppleM4MpsGraph
@@ -279,6 +304,24 @@ pub fn select_backend(
                     available: detected.clone(),
                 });
             }
+        }
+        BackendRequest::IntelArc140v => {
+            if caps.opencl_compiled && caps.opencl_runtime {
+                (KernelBackend::OpenCL, "Intel Arc 140V OpenCL GPU requested".to_string())
+            } else {
+                return Err(BackendSelectionError::RequestedUnavailable {
+                    requested: request,
+                    available: detected.clone(),
+                });
+            }
+        }
+        BackendRequest::IntelNpu
+        | BackendRequest::OpenVinoNpu
+        | BackendRequest::IntelArc140vOpenVinoGpu => {
+            return Err(BackendSelectionError::RequestedUnavailable {
+                requested: request,
+                available: detected.clone(),
+            });
         }
         BackendRequest::Metal | BackendRequest::AppleM4Metal => {
             return Err(BackendSelectionError::RequestedUnavailable {
@@ -448,6 +491,39 @@ mod tests {
         let summary = result.summary();
         assert!(summary.contains("requested=auto"), "got: {summary}");
         assert!(summary.contains("selected=cpu-rust"), "got: {summary}");
+    }
+
+    #[test]
+    fn intel_backend_labels_parse_without_aliasing() {
+        assert_eq!(BackendRequest::from_label("npu"), Some(BackendRequest::IntelNpu));
+        assert_eq!(BackendRequest::from_label("openvino-npu"), Some(BackendRequest::OpenVinoNpu));
+        assert_eq!(
+            BackendRequest::from_label("intel-arc-140v"),
+            Some(BackendRequest::IntelArc140v)
+        );
+        assert_eq!(
+            BackendRequest::from_label("intel-arc-140v-openvino-gpu"),
+            Some(BackendRequest::IntelArc140vOpenVinoGpu)
+        );
+    }
+
+    #[test]
+    fn intel_npu_request_is_strict_until_openvino_runtime_lands() {
+        let err = select_backend(BackendRequest::IntelNpu, &cpu_only_caps()).unwrap_err();
+        assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+        assert!(err.to_string().contains("intel-npu"));
+    }
+
+    #[test]
+    fn arc_140v_selects_opencl_only_when_opencl_runtime_available() {
+        let mut caps = cpu_only_caps();
+        caps.opencl_compiled = true;
+        caps.opencl_runtime = true;
+
+        let result = select_backend(BackendRequest::IntelArc140v, &caps).unwrap();
+        assert_eq!(result.selected, KernelBackend::OpenCL);
+        assert_eq!(result.runtime_api(), "opencl");
+        assert!(!result.fallback_used());
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -15,6 +15,14 @@ pub enum DeviceConfig {
     Cpu,
     /// Force GPU execution on specific device ID.
     Gpu(usize),
+    /// Preserve Intel NPU device identity.
+    IntelNpu(usize),
+    /// Preserve OpenVINO NPU backend identity.
+    OpenVinoNpu,
+    /// Preserve Intel Arc 140V GPU identity.
+    IntelArc140v(usize),
+    /// Preserve OpenVINO GPU device identity.
+    OpenVinoGpu(usize),
     /// Preserve a native Metal backend identity.
     Metal,
     /// Preserve an MPSGraph graph/reference backend identity.
@@ -34,7 +42,15 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" => Ok(DeviceConfig::Gpu(0)),
+            "opencl" | "ocl" | "intel-gpu" => Ok(DeviceConfig::OpenVinoGpu(0)),
+            "npu" | "intel-npu" => Ok(DeviceConfig::IntelNpu(0)),
+            "openvino-npu" => Ok(DeviceConfig::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Ok(DeviceConfig::IntelArc140v(0)),
+            "openvino-gpu" | "gpu.0" => Ok(DeviceConfig::OpenVinoGpu(0)),
+            "intel-arc-140v-openvino-gpu" | "arc-140v-openvino-gpu" => {
+                Ok(DeviceConfig::OpenVinoGpu(0))
+            }
             "metal" => Ok(DeviceConfig::Metal),
             "mpsgraph" => Ok(DeviceConfig::MpsGraph),
             "apple-m4-metal" => Ok(DeviceConfig::AppleM4Metal),
@@ -43,8 +59,24 @@ impl FromStr for DeviceConfig {
             s if s.starts_with("gpu:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
             s if s.starts_with("cuda:") => Ok(DeviceConfig::Gpu(s[5..].parse::<usize>()?)),
             s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
-            s if s.starts_with("opencl:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
-            s if s.starts_with("ocl:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("opencl:") => {
+                Ok(DeviceConfig::OpenVinoGpu(s[7..].parse::<usize>()?))
+            }
+            s if s.starts_with("ocl:") => Ok(DeviceConfig::OpenVinoGpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("intel-gpu:") => {
+                Ok(DeviceConfig::OpenVinoGpu(s[10..].parse::<usize>()?))
+            }
+            s if s.starts_with("npu:") => Ok(DeviceConfig::IntelNpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("intel-npu:") => {
+                Ok(DeviceConfig::IntelNpu(s[10..].parse::<usize>()?))
+            }
+            s if s.starts_with("intel-arc-140v:") => {
+                Ok(DeviceConfig::IntelArc140v(s[15..].parse::<usize>()?))
+            }
+            s if s.starts_with("openvino-gpu:") => {
+                Ok(DeviceConfig::OpenVinoGpu(s[13..].parse::<usize>()?))
+            }
+            s if s.starts_with("gpu.") => Ok(DeviceConfig::OpenVinoGpu(s[4..].parse::<usize>()?)),
             _ => anyhow::bail!("Unknown device config: {}", s),
         }
     }
@@ -68,6 +100,8 @@ impl DeviceConfig {
             }
             DeviceConfig::Cpu => Device::Cpu,
             DeviceConfig::Gpu(id) => Device::Cuda(*id),
+            DeviceConfig::IntelNpu(_) | DeviceConfig::OpenVinoNpu => Device::Npu,
+            DeviceConfig::IntelArc140v(id) | DeviceConfig::OpenVinoGpu(id) => Device::OpenCL(*id),
             DeviceConfig::Metal | DeviceConfig::AppleM4Metal => Device::Metal,
             // MPSGraph is a separate proof label; runtime execution is introduced in a later item.
             DeviceConfig::MpsGraph | DeviceConfig::AppleM4MpsGraph => Device::Cpu,
@@ -82,6 +116,10 @@ impl DeviceConfig {
             DeviceConfig::Auto => BackendRequest::Auto,
             DeviceConfig::Cpu => BackendRequest::Cpu,
             DeviceConfig::Gpu(_) => BackendRequest::Gpu,
+            DeviceConfig::IntelNpu(_) => BackendRequest::IntelNpu,
+            DeviceConfig::OpenVinoNpu => BackendRequest::OpenVinoNpu,
+            DeviceConfig::IntelArc140v(_) => BackendRequest::IntelArc140v,
+            DeviceConfig::OpenVinoGpu(_) => BackendRequest::IntelArc140vOpenVinoGpu,
             DeviceConfig::Metal => BackendRequest::Metal,
             DeviceConfig::MpsGraph => BackendRequest::MpsGraph,
             DeviceConfig::AppleM4Metal => BackendRequest::AppleM4Metal,
@@ -108,6 +146,13 @@ mod tests {
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
         assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+        assert_eq!("opencl".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoGpu(0));
+        assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(0));
+        assert_eq!("openvino-npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoNpu);
+        assert_eq!(
+            "intel-arc-140v".parse::<DeviceConfig>().unwrap(),
+            DeviceConfig::IntelArc140v(0)
+        );
         assert_eq!("metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::Metal);
         assert_eq!("mpsgraph".parse::<DeviceConfig>().unwrap(), DeviceConfig::MpsGraph);
         assert_eq!("apple-m4-metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::AppleM4Metal);

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -146,9 +146,9 @@ pub struct GpuBackend {
 
 /// NPU backend implementation.
 ///
-/// The current implementation routes execution through the model's Metal path and
-/// provides an explicit backend surface for NPU-oriented deployment policy,
-/// warm-up behavior, and capability reporting.
+/// This is an identity-preserving Intel NPU surface. It intentionally does not
+/// alias NPU requests to Metal, CUDA, OpenCL, or CPU fallback. Real OpenVINO NPU
+/// graph execution is introduced behind explicit runtime probes in later work.
 pub struct NpuBackend {
     model: Arc<dyn Model>,
     device: Device,
@@ -160,17 +160,20 @@ impl NpuBackend {
     pub fn new(model: Arc<dyn Model>, device: Device) -> Result<Self> {
         if !Self::is_available() {
             return Err(anyhow::anyhow!(
-                "NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and compile with metal support on macOS"
+                "Intel NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and build with the npu-backend feature once OpenVINO NPU runtime support is wired"
             ));
         }
 
-        if !matches!(device, Device::Metal) {
-            return Err(anyhow::anyhow!("NPU backend currently requires Device::Metal"));
+        if !matches!(device, Device::Npu) {
+            return Err(anyhow::anyhow!(
+                "Intel NPU backend requires Device::Npu; refusing to alias {:?} to NPU",
+                device
+            ));
         }
 
         let allow_cpu_fallback = std::env::var(NPU_FALLBACK_ENV)
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+            .unwrap_or(false);
 
         info!(
             "Created NPU backend (device={:?}, allow_cpu_fallback={})",
@@ -186,7 +189,7 @@ impl NpuBackend {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        enabled && cfg!(target_os = "macos")
+        enabled && cfg!(feature = "npu-backend")
     }
 
     fn ensure_npu_tensor(&self, input: &ConcreteTensor) -> Result<ConcreteTensor> {
@@ -194,8 +197,8 @@ impl NpuBackend {
             return Ok(input.clone());
         }
 
-        // Best-effort transfer placeholder: until dedicated NPU kernels are wired,
-        // we keep shape fidelity and allow runtime fallback.
+        // Best-effort transfer placeholder for explicitly opted-in development only.
+        // Production strict paths must leave BITNET_NPU_ALLOW_FALLBACK unset/false.
         if self.allow_cpu_fallback {
             debug!(
                 "NPU tensor transfer unavailable, using shape-preserving tensor fallback from {:?} to {:?}",
@@ -254,7 +257,7 @@ impl GpuBackend {
 #[async_trait]
 impl Backend for NpuBackend {
     fn backend_type(&self) -> String {
-        "npu_ane".to_string()
+        "intel-npu-openvino".to_string()
     }
 
     fn clone_backend(&self) -> Box<dyn Backend> {
@@ -384,14 +387,11 @@ pub fn select_backend(
             Ok(Box::new(CpuBackend::new(model)?))
         }
         Device::Metal => {
-            if NpuBackend::is_available() {
-                info!("Selected NPU backend");
-                Ok(Box::new(NpuBackend::new(model, device)?))
-            } else if GpuBackend::is_available() {
+            if GpuBackend::is_available() {
                 info!("Selected GPU backend for Metal device");
                 Ok(Box::new(GpuBackend::new(model, device)?))
             } else {
-                warn!("Metal/NPU requested but unavailable, falling back to CPU");
+                warn!("Metal requested but unavailable, falling back to CPU");
                 Ok(Box::new(CpuBackend::new(model)?))
             }
         }
@@ -415,11 +415,12 @@ pub fn select_backend(
         }
         Device::Npu => {
             if NpuBackend::is_available() {
-                info!("Selected NPU backend");
+                info!("Selected Intel NPU backend");
                 Ok(Box::new(NpuBackend::new(model, device)?))
             } else {
-                warn!("NPU requested but not available, falling back to CPU");
-                Ok(Box::new(CpuBackend::new(model)?))
+                Err(anyhow::anyhow!(
+                    "Intel NPU requested but unavailable; refusing CPU/GPU fallback for strict backend identity"
+                ))
             }
         }
         Device::OpenCL(_) => {
@@ -537,16 +538,31 @@ mod tests {
     }
 
     #[test]
-    fn test_metal_request_falls_back_without_npu() {
+    fn test_metal_request_falls_back_without_npu_aliasing() {
         let model = Arc::new(MockModel::new());
 
         let backend = select_backend(model, Some(Device::Metal)).expect("backend selection");
         let backend_type = backend.backend_type();
         assert!(
             backend_type == "cpu" || backend_type.contains("gpu"),
-            "expected CPU/GPU fallback when NPU disabled, got {}",
+            "expected CPU/GPU fallback for Metal when NPU disabled, got {}",
             backend_type
         );
+    }
+
+    #[test]
+    fn test_npu_request_fails_without_fallback_when_unavailable() {
+        let model = Arc::new(MockModel::new());
+        let backend = select_backend(model, Some(Device::Npu));
+        if NpuBackend::is_available() {
+            assert!(backend.is_ok());
+        } else {
+            let err = match backend {
+                Ok(_) => panic!("NPU request must not fall back to CPU"),
+                Err(err) => err.to_string(),
+            };
+            assert!(err.contains("Intel NPU requested but unavailable"), "got: {err}");
+        }
     }
 
     #[test]

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -2,7 +2,7 @@
 //!
 //! This module centralizes environment-driven controls for the NPU path so the
 //! engine and CLI can expose a stable "npu" target while backend wiring to
-//! Qualcomm QNN/SNPE matures.
+//! Intel OpenVINO NPU runtime integration matures.
 
 use bitnet_common::Device;
 
@@ -18,11 +18,30 @@ pub fn npu_requested() -> bool {
 
 /// Map an external `--device` style token to an internal device preference.
 pub fn map_device_token(token: &str) -> Option<Device> {
-    match token {
+    match token.trim().to_ascii_lowercase().as_str() {
         "cpu" => Some(Device::Cpu),
         "cuda" | "gpu" => Some(Device::Cuda(0)),
-        "metal" | "npu" => Some(Device::Metal),
-        "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
+        "opencl" | "intel-gpu" | "intel-arc-140v" | "arc-140v" => Some(Device::OpenCL(0)),
+        "npu" | "intel-npu" | "openvino-npu" => Some(Device::Npu),
+        "metal" => Some(Device::Metal),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npu_tokens_preserve_npu_identity() {
+        assert_eq!(map_device_token("npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("intel-npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("openvino-npu"), Some(Device::Npu));
+    }
+
+    #[test]
+    fn metal_token_remains_distinct_from_npu() {
+        assert_eq!(map_device_token("metal"), Some(Device::Metal));
+        assert_ne!(map_device_token("npu"), Some(Device::Metal));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent aliasing `npu` to Metal/generic GPU and ensure Intel NPU / Arc 140V identities are explicit and strict for platform probing and receipts.
- Avoid silent CPU/GPU fallback for requested NPU backends so strict validation can detect missing OpenVINO NPU runtime rather than masking it.

### Description
- Add new backend request variants and labels: `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `IntelArc140vOpenVinoGpu` in `crates/bitnet-common/src/backend_selection.rs` and wire parsing/display/selection logic accordingly.
- Extend device config parsing in `crates/bitnet-device-config-core/src/lib.rs` with `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `OpenVinoGpu` variants and preserve requested identities when resolving to `Device`.
- Change token-to-device mapping in `crates/bitnet-inference/src/npu.rs` so `npu|intel-npu|openvino-npu` map to `Device::Npu`, and treat `intel-arc-140v` / Arc aliases as `OpenCL` devices.
- Rework NPU backend in `crates/bitnet-inference/src/backends.rs` to be an identity-preserving Intel/OpenVINO NPU surface: require `Device::Npu`, disable default fallback unless explicitly opted-in, set `backend_type` to `intel-npu-openvino`, and make unavailable NPU requests fail rather than silently falling back.
- Add unit tests covering Intel backend label parsing, Arc 140V OpenCL selection behavior, device token mapping for NPU, and strict NPU unavailable behavior.

### Testing
- Ran formatter check: `cargo fmt --all -- --check` (passed).
- Ran targeted unit tests and package tests: `cargo test --locked -p bitnet-device-config-core` (passed), `cargo test --locked -p bitnet-inference npu -- --nocapture` (passed), and `cargo test --locked -p bitnet-common intel_` / `arc_140v` (passed specific new tests).
- Note: an earlier multi-package test run hit a disk-space error (`No space left on device`) during broad compilation; after `cargo clean` the targeted tests listed above were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab59f65848333b28a58f6df6fd41c)