### PR TITLE
[codex][apple-m4] Tiny Metal compute smoke (M4-005)

### DIFF
--- a/crates/bitnet-kernels/src/lib.rs
+++ b/crates/bitnet-kernels/src/lib.rs
@@ -47,6 +47,8 @@ pub mod kernel_selection;
 pub mod kernels;
 pub mod matmul_dispatch;
 #[cfg(feature = "metal")]
+pub mod metal;
+#[cfg(feature = "metal")]
 pub mod metal_compute;
 pub mod norm_ops;
 pub mod norm_registry;

--- a/crates/bitnet-kernels/src/metal/mod.rs
+++ b/crates/bitnet-kernels/src/metal/mod.rs
@@ -1,0 +1,7 @@
+//! Native Metal proof helpers.
+//!
+//! This module is intentionally limited to small hardware smoke surfaces.
+//! BitNet model loading, packed-kernel families, and benchmarks live in later
+//! Apple M4 campaign items.
+
+pub mod smoke;

--- a/crates/bitnet-kernels/src/metal/smoke.rs
+++ b/crates/bitnet-kernels/src/metal/smoke.rs
@@ -1,0 +1,149 @@
+use std::fmt;
+
+pub const MACHINE_ID: &str = "apple-m4-mac-mini";
+pub const ARTIFACT_KIND: &str = "smoke";
+pub const REQUESTED_BACKEND: &str = "apple-m4-metal";
+pub const SELECTED_BACKEND: &str = "apple-m4-metal";
+pub const RUNTIME_API: &str = "metal";
+pub const TINY_METAL_ADD_SMOKE_KERNEL_ID: &str = "tiny_metal_add_smoke";
+pub const SMOKE_ELEMENT_COUNT: usize = 64;
+pub const SMOKE_WORKGROUP_SIZE: u32 = 64;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TinyMetalAddSmokeReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub kernel_id: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub element_count: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
+impl TinyMetalAddSmokeReceipt {
+    pub fn passed(
+        artifact_path: impl Into<String>,
+        element_count: usize,
+        comparison: SmokeComparison,
+    ) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: ARTIFACT_KIND,
+            requested_backend: REQUESTED_BACKEND,
+            selected_backend: SELECTED_BACKEND,
+            runtime_api: RUNTIME_API,
+            kernel_id: TINY_METAL_ADD_SMOKE_KERNEL_ID,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            element_count,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SmokeComparison {
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TinyMetalSmokeError {
+    EmptyInput,
+    LengthMismatch { expected: usize, actual: usize },
+    NonFiniteOutput { index: usize, value: f32 },
+    OutputMismatch { index: usize, expected: f32, actual: f32, tolerance: f32 },
+}
+
+impl fmt::Display for TinyMetalSmokeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyInput => write!(f, "tiny Metal smoke input must not be empty"),
+            Self::LengthMismatch { expected, actual } => {
+                write!(f, "tiny Metal smoke length mismatch: expected {expected}, actual {actual}")
+            }
+            Self::NonFiniteOutput { index, value } => {
+                write!(f, "tiny Metal smoke output at index {index} is non-finite: {value}")
+            }
+            Self::OutputMismatch { index, expected, actual, tolerance } => write!(
+                f,
+                "tiny Metal smoke output mismatch at index {index}: expected {expected}, actual {actual}, tolerance {tolerance}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TinyMetalSmokeError {}
+
+pub fn metal_smoke_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/metal-smoke.json")
+}
+
+pub fn tiny_add_inputs() -> (Vec<f32>, Vec<f32>) {
+    let lhs = (0..SMOKE_ELEMENT_COUNT).map(|i| i as f32).collect();
+    let rhs = (0..SMOKE_ELEMENT_COUNT).map(|i| (i as f32) * 2.0).collect();
+    (lhs, rhs)
+}
+
+pub fn expected_tiny_add(lhs: &[f32], rhs: &[f32]) -> Result<Vec<f32>, TinyMetalSmokeError> {
+    if lhs.is_empty() {
+        return Err(TinyMetalSmokeError::EmptyInput);
+    }
+    if lhs.len() != rhs.len() {
+        return Err(TinyMetalSmokeError::LengthMismatch { expected: lhs.len(), actual: rhs.len() });
+    }
+
+    Ok(lhs.iter().zip(rhs.iter()).map(|(left, right)| left + right).collect())
+}
+
+pub fn compare_tiny_add_outputs(
+    expected: &[f32],
+    actual: &[f32],
+    tolerance: f32,
+) -> Result<SmokeComparison, TinyMetalSmokeError> {
+    if expected.is_empty() {
+        return Err(TinyMetalSmokeError::EmptyInput);
+    }
+    if expected.len() != actual.len() {
+        return Err(TinyMetalSmokeError::LengthMismatch {
+            expected: expected.len(),
+            actual: actual.len(),
+        });
+    }
+
+    let mut max_abs_error = 0.0_f32;
+    let mut total_abs_error = 0.0_f32;
+
+    for (index, (&expected_value, &actual_value)) in expected.iter().zip(actual.iter()).enumerate()
+    {
+        if !actual_value.is_finite() {
+            return Err(TinyMetalSmokeError::NonFiniteOutput { index, value: actual_value });
+        }
+
+        let abs_error = (actual_value - expected_value).abs();
+        if abs_error > tolerance {
+            return Err(TinyMetalSmokeError::OutputMismatch {
+                index,
+                expected: expected_value,
+                actual: actual_value,
+                tolerance,
+            });
+        }
+
+        max_abs_error = max_abs_error.max(abs_error);
+        total_abs_error += abs_error;
+    }
+
+    Ok(SmokeComparison { max_abs_error, mean_abs_error: total_abs_error / expected.len() as f32 })
+}
+
+pub fn is_apple_m4_adapter_name(adapter_name: &str) -> bool {
+    adapter_name.to_ascii_lowercase().contains("apple m4")
+}

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -1,0 +1,293 @@
+#![cfg(feature = "metal")]
+
+use bitnet_kernels::metal::smoke::{
+    ARTIFACT_KIND, MACHINE_ID, REQUESTED_BACKEND, RUNTIME_API, SELECTED_BACKEND,
+    SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_SMOKE_KERNEL_ID,
+    TinyMetalAddSmokeReceipt, compare_tiny_add_outputs, expected_tiny_add,
+    is_apple_m4_adapter_name, metal_smoke_artifact_path, tiny_add_inputs,
+};
+
+#[test]
+fn tiny_add_expected_output_matches_cpu_reference() {
+    let (lhs, rhs) = tiny_add_inputs();
+    let expected = expected_tiny_add(&lhs, &rhs).expect("valid smoke inputs");
+
+    assert_eq!(expected.len(), lhs.len());
+    for (index, value) in expected.iter().enumerate() {
+        assert_eq!(*value, lhs[index] + rhs[index]);
+    }
+}
+
+#[test]
+fn receipt_contract_records_only_tiny_m4_metal_smoke() {
+    let receipt = TinyMetalAddSmokeReceipt::passed(
+        metal_smoke_artifact_path("2026-05-06"),
+        64,
+        SmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, MACHINE_ID);
+    assert_eq!(receipt.artifact_kind, ARTIFACT_KIND);
+    assert_eq!(receipt.requested_backend, REQUESTED_BACKEND);
+    assert_eq!(receipt.selected_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.runtime_api, RUNTIME_API);
+    assert_eq!(receipt.kernel_id, TINY_METAL_ADD_SMOKE_KERNEL_ID);
+    assert!(!receipt.fallback_used);
+    assert_eq!(receipt.result, "pass");
+    assert_eq!(receipt.artifact_path, "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-smoke.json");
+}
+
+#[test]
+fn comparison_fails_instead_of_falling_back_to_cpu() {
+    let expected = [1.0_f32, 2.0, 3.0];
+    let actual = [1.0_f32, 20.0, 3.0];
+
+    let error = compare_tiny_add_outputs(&expected, &actual, 1e-6)
+        .expect_err("mismatch should fail the smoke contract");
+
+    assert!(error.to_string().contains("output mismatch"), "unexpected error: {error}");
+}
+
+#[test]
+fn apple_m4_adapter_name_detection_is_specific() {
+    assert!(is_apple_m4_adapter_name("Apple M4"));
+    assert!(is_apple_m4_adapter_name("Apple M4 Pro"));
+    assert!(!is_apple_m4_adapter_name("Apple M3"));
+    assert!(!is_apple_m4_adapter_name("AMD Radeon Pro"));
+}
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+mod live_metal {
+    use super::*;
+    use serde_json::json;
+    use std::error::Error;
+    use std::io;
+    use std::path::Path;
+    use wgpu::util::DeviceExt;
+
+    const RUN_ENV: &str = "BITNET_RUN_M4_METAL_SMOKE";
+    const RECEIPT_ENV: &str = "BITNET_M4_METAL_SMOKE_RECEIPT";
+    const ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_SMOKE_ARTIFACT_PATH";
+
+    struct MetalSmokeOutput {
+        adapter_name: String,
+        output: Vec<f32>,
+    }
+
+    #[test]
+    fn tiny_m4_metal_add_smoke_runs_when_enabled() -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_ENV).as_deref() != Ok("1") {
+            eprintln!("skipping live M4 Metal smoke; set {RUN_ENV}=1 to run it");
+            return Ok(());
+        }
+
+        let (lhs, rhs) = tiny_add_inputs();
+        let expected = expected_tiny_add(&lhs, &rhs)?;
+        let smoke_output = run_tiny_add_smoke(&lhs, &rhs)?;
+
+        if !is_apple_m4_adapter_name(&smoke_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-005 proof requires an Apple M4-family Metal adapter; found '{}'",
+                smoke_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&expected, &smoke_output.output, 1e-6)?;
+        let artifact_path = std::env::var(ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-smoke.json".to_string()
+            });
+        let receipt =
+            TinyMetalAddSmokeReceipt::passed(artifact_path.clone(), expected.len(), comparison);
+
+        let receipt_json = json!({
+            "machine_id": receipt.machine_id,
+            "artifact_kind": receipt.artifact_kind,
+            "requested_backend": receipt.requested_backend,
+            "selected_backend": receipt.selected_backend,
+            "runtime_api": receipt.runtime_api,
+            "resolved_device": {
+                "chip": smoke_output.adapter_name,
+                "unified_memory": true
+            },
+            "kernel_id": receipt.kernel_id,
+            "fallback_used": receipt.fallback_used,
+            "result": receipt.result,
+            "artifact_path": receipt.artifact_path,
+            "element_count": receipt.element_count,
+            "max_abs_error": receipt.max_abs_error,
+            "mean_abs_error": receipt.mean_abs_error
+        });
+
+        if let Ok(path) = std::env::var(RECEIPT_ENV) {
+            if let Some(parent) = Path::new(&path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    fn run_tiny_add_smoke(lhs: &[f32], rhs: &[f32]) -> Result<MetalSmokeOutput, Box<dyn Error>> {
+        pollster::block_on(async move {
+            let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::METAL,
+                ..Default::default()
+            });
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .ok_or_else(|| io_error("no Metal adapter found for M4-005 smoke"))?;
+
+            let adapter_info = adapter.get_info();
+            if adapter_info.backend != wgpu::Backend::Metal {
+                return Err(io_error(format!(
+                    "M4-005 smoke requires Metal backend, found {:?}",
+                    adapter_info.backend
+                )));
+            }
+
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .map_err(|error| io_error(format!("failed to create Metal device: {error}")))?;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(TINY_METAL_ADD_SMOKE_KERNEL_ID),
+                source: wgpu::ShaderSource::Wgsl(TINY_ADD_SHADER.into()),
+            });
+
+            let lhs_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_add_lhs"),
+                contents: bytemuck::cast_slice(lhs),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let rhs_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_add_rhs"),
+                contents: bytemuck::cast_slice(rhs),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let byte_len = std::mem::size_of_val(lhs) as u64;
+            let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_add_output"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_add_staging"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("tiny_metal_add_layout"),
+                    entries: &[
+                        storage_buffer_entry(0, true),
+                        storage_buffer_entry(1, true),
+                        storage_buffer_entry(2, false),
+                    ],
+                });
+
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("tiny_metal_add_bind_group"),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry { binding: 0, resource: lhs_buffer.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 1, resource: rhs_buffer.as_entire_binding() },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: output_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("tiny_metal_add_pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tiny_metal_add_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tiny_metal_add_encoder"),
+            });
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("tiny_metal_add_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.dispatch_workgroups((lhs.len() as u32).div_ceil(SMOKE_WORKGROUP_SIZE), 1, 1);
+            }
+
+            encoder.copy_buffer_to_buffer(&output_buffer, 0, &staging_buffer, 0, byte_len);
+            queue.submit(std::iter::once(encoder.finish()));
+
+            let slice = staging_buffer.slice(..);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |result| {
+                tx.send(result).unwrap();
+            });
+            device.poll(wgpu::Maintain::Wait);
+            rx.recv()
+                .map_err(|error| io_error(format!("failed to receive Metal map result: {error}")))?
+                .map_err(|error| io_error(format!("failed to map Metal smoke output: {error}")))?;
+
+            let data = slice.get_mapped_range();
+            let output = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+            drop(data);
+            staging_buffer.unmap();
+
+            Ok(MetalSmokeOutput { adapter_name: adapter_info.name, output })
+        })
+    }
+
+    fn storage_buffer_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+        wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        }
+    }
+
+    fn io_error(message: impl Into<String>) -> Box<dyn Error> {
+        Box::new(io::Error::other(message.into()))
+    }
+
+    const TINY_ADD_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read> lhs: array<f32>;
+@group(0) @binding(1) var<storage, read> rhs: array<f32>;
+@group(0) @binding(2) var<storage, read_write> output: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let index = global_id.x;
+    if index < arrayLength(&lhs) {
+        output[index] = lhs[index] + rhs[index];
+    }
+}
+"#;
+}

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -160,7 +160,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-005"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-005-metal-smoke"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -160,7 +160,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-005"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-005-metal-smoke"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T080041Z-M4-005-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T080041Z-M4-005-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T08:00:41Z"
+campaign = "apple-m4"
+item = "M4-005"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started tiny native Metal compute smoke after M4-004 merged.",
+  "Scope remains limited to bitnet-kernels Metal smoke helpers/tests and Apple campaign tracking.",
+  "No QK256, server inference, BitNet model loading, MPSGraph execution, benchmarks, or performance claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T080946Z-M4-005-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T080946Z-M4-005-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T08:09:46Z"
+campaign = "apple-m4"
+item = "M4-005"
+event = "pr_open"
+pr = 3699
+head_sha = "dac694eae804af239753e700f991932f81f981c7"
+actor = "codex"
+
+notes = [
+  "Opened tiny native Metal compute smoke PR.",
+  "The live smoke dispatch compiles and runs only when BITNET_RUN_M4_METAL_SMOKE=1 is set.",
+  "No BitNet model loading, QK256, MPSGraph execution, server inference, benchmarks, Neural Engine claims, or performance claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -13,7 +13,7 @@
 | M4-002 | merged | #3627 | `codex/apple-m4/M4-002-profile-probe-bundle` | Add the Apple M4 Mac mini machine profile and probe bundle without runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts. |
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
-| M4-005 | in_progress | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
+| M4-005 | pr_open | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | proposed | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -13,7 +13,7 @@
 | M4-002 | merged | #3627 | `codex/apple-m4/M4-002-profile-probe-bundle` | Add the Apple M4 Mac mini machine profile and probe bundle without runtime code, kernels, QK256, server inference, dependencies, or bulky artifacts. |
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
-| M4-005 | ready | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
+| M4-005 | in_progress | TBD | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | proposed | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-005 | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -6,7 +6,7 @@
 | apple-m4 | M4-002 | M4-001 | merged |
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |
-| apple-m4 | M4-005 | M4-004 | ready |
+| apple-m4 | M4-005 | M4-004 | in_progress |
 | apple-m4 | M4-006 | M4-005 | proposed |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -6,7 +6,7 @@
 | apple-m4 | M4-002 | M4-001 | merged |
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |
-| apple-m4 | M4-005 | M4-004 | in_progress |
+| apple-m4 | M4-005 | M4-004 | pr_open |
 | apple-m4 | M4-006 | M4-005 | proposed |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-005 | TBD | in_progress | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-005 | #3699 | pr_open | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-005 | TBD | ready | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-005 | TBD | in_progress | M4-006 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-005

## Summary
- Add a narrow `bitnet_kernels::metal::smoke` contract for `tiny_metal_add_smoke`.
- Add an opt-in live Metal/wgpu test that compiles a tiny add shader, dispatches it on Apple M4 Metal, reads results back, compares against CPU expected output, and emits a smoke receipt.
- Move M4-005 to in_progress and regenerate campaign/global dashboards.

## Claim boundary
This proves only a tiny native Metal compute smoke when the live M4 receipt command passes. It does not claim BitNet inference, QK256 on Metal, MPSGraph execution, Neural Engine execution, benchmarks, or general performance.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke`
- `BITNET_RUN_M4_METAL_SMOKE=1 BITNET_M4_METAL_SMOKE_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/metal-smoke.json BITNET_M4_METAL_SMOKE_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/metal-smoke.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Known unrelated failure
- `cargo test --locked -p bitnet-kernels --no-default-features --features metal` currently reaches the new smoke tests, then fails existing `tests/build_script_validation.rs` checks that expect `crates/bitnet-kernels/build.rs` under a hard-coded `/home/steven/...` path. This PR does not touch that tracker/runtime surface.