### PR TITLE
docs(tracking): record CPU-BITNET-004 merge

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -157,7 +157,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-004"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-bitnet-004-scalar-packed-truth"
 stackable = false
 requires_human_merge = true
@@ -184,4 +184,39 @@ must_not_claim = [
   "Optimized kernel performance is proven.",
   "AVX2 dispatch is complete.",
   "Transformer decode is complete.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-005"
+status = "ready"
+branch = "codex/cpu-bitnet-005-avx2-gemv"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-004"]
+acceptance = "CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/src/i2s_qk256.rs",
+  "crates/bitnet-quantization/src/i2s_qk256_avx2.rs",
+  "crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-receipts/**",
+]
+may_claim = [
+  "AVX2/FMA GEMV dispatch parity against the scalar QK256 oracle exists after merge.",
+]
+must_not_claim = [
+  "Transformer decode is complete.",
+  "Strict receipts are complete.",
+  "Benchmark or throughput performance is proven.",
+  "GPU or NPU execution is involved.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T081811Z-CPU-BITNET-004-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T081811Z-CPU-BITNET-004-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T08:18:11Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-004"
+event = "merged"
+pr = 3696
+merge_sha = "85a2a8ee723fffa089196de991544bbba2a97d4e"
+actor = "maintainer"
+
+notes = [
+  "Scalar packed QK256 truth kernels merged.",
+  "AVX2 dispatch, transformer decode, strict receipts, and benchmarks remain follow-up work.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -13,7 +13,8 @@
 | CPU-BITNET-001 | merged | #3651 | `codex/cpu-proof/CPU-BITNET-001-loader-authority` | Strict CPU inference has one authoritative real GGUF loader path for BitNet models, and minimal fallback is impossible in strict proof mode. |
 | CPU-BITNET-002 | merged | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
-| CPU-BITNET-004 | pr_open | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
+| CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
+| CPU-BITNET-005 | ready | TBD | `codex/cpu-bitnet-005-avx2-gemv` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -91,8 +91,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "RTX5070TI-005"
-status = "ready"
-branch = "codex/nvidia-5070ti/RTX5070TI-005-cuda-kernel-smoke"
+status = "pr_open"
+branch = "codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt"
 stackable = false
 requires_human_merge = true
 blocked_by = ["RTX5070TI-004"]

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T113500Z-RTX5070TI-005-pr-open.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T113500Z-RTX5070TI-005-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:35:00Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-005"
+event = "pr_open"
+pr = 3723
+head_sha = "425bc737ac6170e2b6865bb359d84f01d067c469"
+actor = "codex"
+
+notes = [
+  "Recorded live GitHub state for the RTX 5070 Ti smoke receipt PR so campaign doctor can reconcile open PR claims.",
+  "No CPU-BITNET runtime behavior changed in this tracker sync.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | RTX5070TI-003 | merged | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
 | RTX5070TI-004 | merged | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
-| RTX5070TI-005 | ready | TBD | `codex/nvidia-5070ti/RTX5070TI-005-cuda-kernel-smoke` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
+| RTX5070TI-005 | pr_open | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -19,10 +19,11 @@
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
-| cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | pr_open |
+| cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
+| cpu-proof | CPU-BITNET-005 | CPU-BITNET-004 | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
-| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | ready |
+| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | pr_open |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
 | tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,12 +6,12 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-009 | TBD | ready | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-005 | TBD | ready | none | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | RTX5070TI-005 | #3723 | pr_open | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-004 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- mark CPU-BITNET-004 as merged after #3696 (`85a2a8ee723fffa089196de991544bbba2a97d4e`)
- add the CPU-BITNET-004 merge event
- advance CPU-BITNET-005 to the next ready CPU proof item in generated dashboards

## Validation
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

No runtime files changed.