### PR TITLE
perf(ci): limit rust-cache saves to main in ci-core

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -98,6 +98,7 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: ci-core-ubuntu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -213,6 +214,7 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: ci-core-grid-check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run BDD Grid Check (CPU cells)
         run: cargo run --locked --no-default-features -p xtask -- grid-check --cpu-only --verbose
@@ -240,6 +242,7 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: ci-core-clippy
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy (core crates, libs only)
         run: |
@@ -298,6 +301,7 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: ci-core-clippy-macos-arm64
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run clippy (core crates, libs only)
         run: |
@@ -328,6 +332,7 @@ jobs:
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
           shared-key: ci-core-docs
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build documentation
         env:


### PR DESCRIPTION
## Summary

- Adds `save-if: ${{ github.ref == 'refs/heads/main' }}` to all five `Swatinem/rust-cache` invocations in `.github/workflows/ci-core.yml` (`build-test-linux`, `grid-check`, `clippy`, `clippy-macos-arm64`, `docs`).
- PR runs continue to **restore** the cache normally; they just stop **saving** it.

## Why

GitHub Actions cache scoping rules mean a cache saved on a PR ref is only available to that PR's branch — it can't be restored by other PRs or by `main`. Saving on every PR run therefore adds compaction/upload time without producing reusable cache entries. Limiting saves to `main` is the canonical pattern recommended by `Swatinem/rust-cache`.

This is the smallest piece of the broader CI efficiency review — chosen because it's low-risk and reversible. Larger items (cross-job shared cache keys, AVX2 step cost, audit of 52 workflows) are intentionally not included here.

## Test plan

- [ ] CI (Core) runs green on this PR
- [ ] Verify in the run logs that PR-side `Post Cache Rust dependencies` steps no longer upload (skipped due to `save-if: false` evaluating on PR refs)
- [ ] After merge to `main`, confirm the next `main` run uploads cache entries under each `shared-key`

https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx)_