### PR TITLE
docs(cuda): sync RTX5070TI-004 merge

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -26,7 +26,8 @@ Validate RTX 5070 Ti as a CUDA-first BitNet acceleration lane with selected-devi
 | Work item | Status | Notes |
 |---|---|---|
 | RTX5070TI-003 | merged | Preserved selected-device CUDA identity in #3679. |
-| RTX5070TI-004 | pr_open | Add CUDA and NVML runtime probe in #3691. |
+| RTX5070TI-004 | merged | Added CUDA and NVML runtime probe in #3691. |
+| RTX5070TI-005 | ready | Run tiny CUDA kernel smoke after #3691. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -63,7 +63,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "RTX5070TI-004"
-status = "pr_open"
+status = "merged"
 branch = "codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe"
 stackable = false
 requires_human_merge = true
@@ -87,4 +87,39 @@ may_claim = [
 must_not_claim = [
   "CUDA kernel execution works.",
   "BitNet inference works on RTX 5070 Ti.",
+]
+
+[[work_item]]
+id = "RTX5070TI-005"
+status = "ready"
+branch = "codex/nvidia-5070ti/RTX5070TI-005-cuda-kernel-smoke"
+stackable = false
+requires_human_merge = true
+blocked_by = ["RTX5070TI-004"]
+acceptance = "Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim."
+commands = [
+  "cargo fmt --all -- --check",
+  "Manual RTX 5070 Ti CUDA smoke command with receipt artifact.",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/cuda/**",
+  "crates/bitnet-kernels/tests/**",
+  "crates/bitnet-cli/src/main.rs",
+  "ci/hardware/_templates/cuda-smoke-receipt.json",
+  "docs/tracking/campaigns/nvidia-5070ti/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/cuda/qk256_gemv.rs",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "RTX 5070 Ti CUDA executes a tiny smoke kernel fallback-free after a smoke receipt exists.",
+]
+must_not_claim = [
+  "BitNet inference works on RTX 5070 Ti.",
+  "CUDA is faster than CPU.",
+  "QK256 CUDA works.",
 ]

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T083111Z-RTX5070TI-004-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T083111Z-RTX5070TI-004-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T08:31:11Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-004"
+event = "merged"
+pr = 3691
+merge_sha = "43023bd2aecb1a77f4e6027b10501b0c1948f8b1"
+actor = "maintainer"
+
+notes = [
+  "Merged RTX 5070 Ti CUDA/NVML runtime probe.",
+  "No CUDA kernel execution, QK256, transformer routing, server inference, WGPU proof, dense CUDA work, or hardware artifacts were claimed.",
+  "RTX5070TI-005 is ready for tiny CUDA kernel smoke.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -10,7 +10,8 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | RTX5070TI-003 | merged | #3679 | `codex/rtx5070ti-003-backend-identity` | Preserve RTX 5070 Ti requested and selected CUDA backend identity without adding kernels or inference claims. |
-| RTX5070TI-004 | pr_open | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
+| RTX5070TI-004 | merged | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |
+| RTX5070TI-005 | ready | TBD | `codex/nvidia-5070ti/RTX5070TI-005-cuda-kernel-smoke` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -5,4 +5,3 @@
 |---|---|---:|---|---|
 | apple-m4 | M4-006 | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
-| nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -22,5 +22,6 @@
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | pr_open |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
-| nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | pr_open |
+| nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
+| nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | ready |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
-| nvidia-5070ti | RTX5070TI-004 | #3691 | pr_open | none | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | RTX5070TI-005 | TBD | ready | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-004 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-001 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- record #3691 / RTX5070TI-004 as merged with merge SHA 43023bd2aecb1a77f4e6027b10501b0c1948f8b1
- advance the NVIDIA campaign current item to RTX5070TI-005
- regenerate campaign dashboards

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

## Notes
- No runtime, CUDA kernel, QK256, transformer, server, dense CUDA, or hardware artifact changes.