### PR TITLE
perf(ci): gate validation-pr, gguf-compat, audit jobs to main/labels

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -219,7 +219,15 @@ jobs:
     name: Model Validation (PR Lane)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'pull_request'
+    # Currently a no-op when no test model is committed; only run when a real
+    # model fixture exists (signaled via the `model-validation` or `full-ci` label),
+    # on main, or on manual dispatch. Avoids wasting minutes on an unconditional
+    # successful exit on every PR.
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'model-validation') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
@@ -328,6 +336,13 @@ jobs:
     name: GGUF Compatibility Check
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Downloads a multi-GB GGUF on cache miss; not worth running on every PR.
+    # Run on main, manual dispatch, or when explicitly requested via labels.
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'gguf') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
@@ -398,6 +413,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     continue-on-error: true  # Non-blocking for PRs
+    # Audit/license output is informational and duplicated by the dedicated
+    # security workflow. Run on main and manual dispatch only; PRs can opt in
+    # via the `audit` or `full-ci` label.
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'audit') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable


### PR DESCRIPTION
## Summary

Gates three jobs in `compatibility.yml` so they no longer run on every PR:

- **`validation-pr`** — currently exits successfully without doing anything when no test model is committed. Made label/main/dispatch only.
- **`gguf-compat`** — downloads a multi-GB Llama-2 Q2_K GGUF on cache miss, then runs a compat check against it. Worth running on main, but not on every PR.
- **`audit-and-deny`** — `cargo audit` + `cargo deny`. Already `continue-on-error`, and the repo already has a dedicated `security.yml` workflow. Demoted to main/dispatch.

Trigger conditions for each:
- `github.ref == 'refs/heads/main'`, or
- `workflow_dispatch`, or
- the relevant opt-in label (`model-validation`, `gguf`, `audit`), or
- the umbrella `full-ci` label

The other compat jobs (`msrv`, `msrv-workspace-informational`, `abi-stability`, `ffi-smoke-test`, `tokenizer-fixtures`, `cross-val-determinism`) keep their existing behavior.

## Why

These three jobs together account for the majority of `compatibility.yml` minutes on PRs and produce little blocking signal: one is a literal no-op, one downloads a model fixture only useful for main-branch validation, and the third duplicates a dedicated workflow.

## Test plan

- [ ] CI runs on this PR show `validation-pr`, `gguf-compat`, and `audit-and-deny` as **skipped**, not running
- [ ] `msrv`, `abi-stability`, `ffi-smoke-test`, `tokenizer-fixtures` still run normally
- [ ] Apply the `full-ci` label to a test PR and verify the gated jobs do run
- [ ] On merge to main, all three jobs run on the next push to main

## Risk / rollback

- Risk: a regression that would have been caught by `gguf-compat` or `validation-pr` slips into a PR. Mitigation: still caught on the merge-to-main run before any release; can also be opt-in tested with labels.
- Rollback: revert this commit.

https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx)_