### PR TITLE
perf(ci): narrow property-tests smoke to targeted proptest run

### DIFF
--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -36,10 +36,15 @@ env:
 
 jobs:
   # Lightweight smoke test — runs on every push and PR so the workflow never has 0 jobs.
+  # Previously ran the full workspace test suite, duplicating CI (Core)'s build-test-linux
+  # job. Narrowed to a targeted proptest run on bitnet-quantization, which is the crate
+  # most likely to surface property regressions and isn't covered by Core's --lib filter.
   cargo-tests:
     name: Cargo Tests (smoke)
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 10
+    env:
+      PROPTEST_CASES: "16"
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
 
@@ -48,23 +53,22 @@ jobs:
         with:
           toolchain: "1.92.0"
 
-      - name: Cache Rust dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      - name: Rust cache
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-smoke-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-smoke-
-            ${{ runner.os }}-cargo-
+          shared-key: property-tests-smoke
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Run workspace tests
+      - name: Run targeted proptest smoke
+        # Targets the i2s property fuzz integration test specifically; CI (Core)
+        # already runs bitnet-quantization --lib unit tests, so we don't duplicate
+        # them here. PROPTEST_CASES kept low for PR latency.
         run: |
-          cargo test --locked --workspace --no-default-features --features cpu -- --test-threads 4 2>&1 | tail -20
+          cargo test --locked \
+            -p bitnet-quantization \
+            --test i2s_property_fuzz_tests \
+            --no-default-features --features cpu \
+            -- --test-threads 4 2>&1 | tail -20
 
   property-tests:
     name: Greedy Parity Tests


### PR DESCRIPTION
## Summary

Replaces the full-workspace `cargo test` smoke in `property-tests.yml` with a narrow integration-test run.

**Before:**
```yaml
cargo test --locked --workspace --no-default-features --features cpu -- --test-threads 4
```

This duplicates CI (Core)'s `build-test-linux` job on every PR.

**After:**
```yaml
cargo test --locked \
  -p bitnet-quantization \
  --test i2s_property_fuzz_tests \
  --no-default-features --features cpu \
  -- --test-threads 4
```

Targets the dedicated `i2s_property_fuzz_tests` integration test which Core does **not** run (Core uses `--lib` for `bitnet-quantization`). `PROPTEST_CASES=16` keeps cases low for PR latency.

Also:
- Replaced the manual `actions/cache` stanza with `Swatinem/rust-cache@v2` for consistency with the rest of the repo
- Added `save-if: github.ref == 'refs/heads/main'` to avoid PR cache write churn
- Reduced `timeout-minutes` from 20 to 10
- Preserved the `Cargo Tests (smoke)` job name in case any branch protection rule depends on it

The `property-tests` (Greedy Parity) and `cross-system-parity` jobs are untouched — they were already gated to `schedule`/`workflow_dispatch`.

## Why

The PR was running two large CPU test surfaces in parallel: `Build & Test (ubuntu-latest)` in CI (Core) and `Cargo Tests (smoke)` in Property-Based Tests. The latter was the bigger of the two (`--workspace` vs Core's targeted `-p` list) and added no signal Core didn't already provide. The narrowed job retains the *property* aspect the workflow's name suggests, without re-running everything.

## Test plan

- [ ] CI runs and `Cargo Tests (smoke)` completes faster than before (target: under 5 min once cache warms on main)
- [ ] `i2s_property_fuzz_tests` test runs successfully — verify in job logs
- [ ] CI (Core) still runs unchanged
- [ ] Greedy Parity / cross-system parity remain schedule/dispatch only

## Risk / rollback

- Risk: a regression in another crate that would have been caught by the workspace-wide `cargo test` slips past PR review. Mitigation: CI (Core)'s `build-test-linux` already runs the same crate-targeted tests. Anything Core skipped that this used to catch was duplicate coverage with no second source of truth.
- Rollback: revert this commit.

https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx)_