### PR TITLE
perf(ci): gate GPU Docker builds and duplicate CPU tests to main/labels

### DIFF
--- a/.github/workflows/gpu-ci-matrix.yml
+++ b/.github/workflows/gpu-ci-matrix.yml
@@ -33,10 +33,20 @@ env:
 
 jobs:
   # ── Docker-based compile checks for each GPU backend ───────────
+  # Docker image builds are expensive (45-min timeout, multi-GB layers).
+  # Run on main, manual dispatch, or when explicitly requested via labels.
+  # Native compile checks below still run on PRs and catch most feature
+  # regressions without building Docker images.
   docker-compile:
     name: "docker-compile (${{ matrix.label }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'gpu-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'docker') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     strategy:
       fail-fast: false
       matrix:
@@ -111,11 +121,19 @@ jobs:
         run: cargo check --workspace --locked ${{ matrix.flags }}
 
   # ── CPU test run ───────────────────────────────────────────────
+  # CI (Core)'s build-test-linux job already runs the CPU test suite on every PR.
+  # This job duplicates that signal. Keep it on main and manual/labeled runs as a
+  # second-source check for the GPU matrix workflow.
   cpu-tests:
     name: CPU Tests
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     needs: [native-compile]
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'gpu-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
       - name: Checkout
@@ -141,6 +159,12 @@ jobs:
     name: Intel GPU Docker Build
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'gpu-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'docker') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
       - name: Checkout
@@ -164,6 +188,12 @@ jobs:
     name: NVIDIA GPU Docker Build
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'gpu-ci') ||
+      contains(github.event.pull_request.labels.*.name, 'docker') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Gates four jobs in `gpu-ci-matrix.yml` so they no longer run on every PR:

| Job | Reason |
|---|---|
| `docker-compile` (3-entry matrix) | 45-min timeout per entry; builds multi-GB Docker layers |
| `intel-gpu-docker` | 45-min Docker build |
| `nvidia-gpu-docker` | 45-min Docker build |
| `cpu-tests` | Duplicates `CI (Core) → build-test-linux` |

Trigger conditions for each:
- `github.ref == 'refs/heads/main'`, or
- `workflow_dispatch`, or
- the relevant opt-in label (`gpu-ci`, `docker`), or
- the umbrella `full-ci` label

`native-compile` (lightweight `cargo check` matrix for each GPU backend) continues to run on every PR. That gives the actual feature-wiring signal that GPU CI is supposed to provide, without the Docker build overhead.

## Why

GPU CI Matrix triggers on `crates/**`, `Cargo.toml`, `Cargo.lock`, `docker/**`. Today, a one-line change to a non-GPU crate spends ~6 long-running jobs to confirm GPU Docker images still build. That confirmation is more useful on main and on PRs that actually touch GPU code (or that explicitly opt in via label).

## Test plan

- [ ] CI run on this PR shows `docker-compile (cpu/gpu/oneapi)`, `intel-gpu-docker`, `nvidia-gpu-docker`, and `CPU Tests` as **skipped**
- [ ] `native-check (cpu/gpu/cpu+gpu/oneapi/cpu+oneapi)` still runs
- [ ] On merge to main, all gated jobs run on the next push to main
- [ ] Apply the `gpu-ci` label to a test PR and verify the gated jobs do run

## Risk / rollback

- Risk: a Dockerfile or backend-specific compile regression that would have been caught by the gated jobs slips into a PR. Mitigation: native-compile still runs the actual `cargo check` for each backend, which is where most regressions surface; Docker-only regressions are caught on the merge-to-main run.
- Rollback: revert this commit.

https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx)_