### PR TITLE
perf(ci): reduce default PR feature matrix from 20 jobs to 3

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -24,12 +24,59 @@ permissions:
   contents: read
 
 jobs:
-  # Compile-only checks for each significant feature combination.
-  # These are fast (no linking of tests) and catch feature-wiring regressions early.
+  # Reduced PR-time matrix: just the canonical CPU paths. Catches the most common
+  # feature-wiring regressions cheaply. The full matrix below runs on main and
+  # opt-in PRs (via `feature-matrix` or `full-ci` label) and on workflow_dispatch.
+  pr-compile-check:
+    name: "pr-check (${{ matrix.label }})"
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.ref != 'refs/heads/main' &&
+      !contains(github.event.pull_request.labels.*.name, 'feature-matrix') &&
+      !contains(github.event.pull_request.labels.*.name, 'full-ci')
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - label: "no-features"
+            flags: "--no-default-features"
+          - label: "cpu"
+            flags: "--no-default-features --features cpu"
+          - label: "cpu+full-cli"
+            flags: "--no-default-features --features cpu,full-cli"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
+        with:
+          toolchain: "1.92.0"
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: feature-matrix-pr
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: cargo check ${{ matrix.label }}
+        run: cargo check --workspace --locked ${{ matrix.flags }}
+
+  # Full feature matrix. Runs on main pushes, manual dispatch, and PRs that opt in
+  # via the `feature-matrix` or `full-ci` label. The PR-time matrix above already
+  # covers the canonical CPU paths.
   compile-check:
     name: "check (${{ matrix.label }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 15
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'feature-matrix') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     strategy:
       fail-fast: false
       matrix:
@@ -97,11 +144,18 @@ jobs:
           RUSTFLAGS: ${{ matrix.env.RUSTFLAGS || '' }}
         run: cargo check --workspace --locked ${{ matrix.flags }}
 
-  # Targeted compile checks for key crates that are most likely to diverge
+  # Targeted compile checks for key crates that are most likely to diverge.
+  # Gated to main/dispatch/full-ci same as the full matrix above; the PR-time
+  # canonical CPU checks already exercise these crates as part of the workspace.
   crate-feature-check:
     name: "crate-check (${{ matrix.crate }}/${{ matrix.label }})"
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'feature-matrix') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Reduces the default PR feature matrix from 20 jobs to 3.

**Before (every PR):**
- `compile-check` matrix: 12 entries (`no-features`, `cpu`, `cpu+avx2`, `cpu-no-avx2`, `cpu+full-cli`, `gpu`, `cpu+gpu`, `cpu+ffi`, `cpu+fixtures`, `cpu+crossval`, `oneapi`, `cpu+oneapi`)
- `crate-feature-check` matrix: 8 entries (per-crate variants of the above)

**After:**
- New `pr-compile-check` matrix on PR: 3 canonical entries (`no-features`, `cpu`, `cpu+full-cli`), `fail-fast: true`
- Existing 12+8 matrix gated to: main pushes, `workflow_dispatch`, or PRs labeled `feature-matrix` / `full-ci`

The bulk of the original matrix was either `allow_failure: true` (informational only — exotic backends without local toolchain) or already covered by GPU CI Matrix's native-compile job and CI (Core)'s build-test-linux.

## ⚠ Branch protection note

Branch protection rules that require specific check names from the existing matrix — e.g. `check (cpu)`, `check (no-features)` — will need to be updated:

- Either require the new PR-time names: `pr-check (no-features)`, `pr-check (cpu)`, `pr-check (cpu+full-cli)`
- Or require the workflow itself rather than individual matrix entries

If branch protection isn't updated, PRs will block on missing required checks. **I recommend reviewing branch protection settings before merging this PR.**

## Test plan

- [ ] Confirm CI on this PR shows 3 `pr-check (...)` jobs and the original `check (...)` / `crate-check (...)` jobs as **skipped**
- [ ] Verify branch protection settings; update required-check names if needed
- [ ] Apply the `feature-matrix` label to a test PR and confirm the full matrix runs
- [ ] On merge to main, the next push to main runs the full matrix

## Risk / rollback

- Risk: a feature combination that would have been caught by an exotic-backend matrix entry slips into a PR. Mitigation: full matrix still runs on main; exotic entries are mostly `allow_failure` so they weren't blocking anyway.
- Risk: branch protection breaks if not updated alongside this PR.
- Rollback: revert this commit.

https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDciTSV3dv41doc9C8agdx)_