### PR TITLE
feat(cuda): add RTX 5070 Ti tiny kernel smoke

### DIFF
--- a/ci/hardware/_templates/cuda-smoke-receipt.json
+++ b/ci/hardware/_templates/cuda-smoke-receipt.json
@@ -31,6 +31,9 @@
       "kernel_time_ms": null
     }
   ],
+  "input_len": 1024,
+  "max_abs_error": 0.0,
+  "mean_abs_error": 0.0,
   "result": "TBD",
   "claim": "kernel_smoke_tested",
   "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/<date>/cuda-smoke.json"

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -393,6 +393,17 @@ enum Commands {
         json_out: Option<std::path::PathBuf>,
     },
 
+    /// Compile and launch a tiny CUDA vector-add kernel
+    CudaSmoke {
+        /// CUDA device index to probe and launch on
+        #[arg(long, default_value_t = 0)]
+        device_index: usize,
+
+        /// Output JSON smoke receipt to file
+        #[arg(long)]
+        json_out: Option<std::path::PathBuf>,
+    },
+
     #[cfg(feature = "full-cli")]
     /// Inspect model metadata and diagnostics
     Inspect(InspectCommand),
@@ -597,6 +608,9 @@ async fn main() -> Result<()> {
         Some(Commands::Info) => show_system_info().await,
         Some(Commands::DeviceSmoke { json_out }) => {
             handle_device_smoke_command(&requested_backend_label, json_out).await
+        }
+        Some(Commands::CudaSmoke { device_index, json_out }) => {
+            handle_cuda_smoke_command(&requested_backend_label, device_index, json_out).await
         }
         #[cfg(feature = "full-cli")]
         Some(Commands::Inspect(cmd)) => cmd.execute().await,
@@ -908,6 +922,208 @@ async fn handle_device_smoke_command(
         "cuda": cuda_probe,
         "claim": "cuda_runtime_probe_recorded",
         "kernel_execution": false,
+        "artifact_path": artifact_path,
+        "error": error,
+    });
+
+    write_json_output(json_out.as_ref(), &receipt)?;
+
+    if let Some(error) = receipt.get("error").and_then(serde_json::Value::as_str) {
+        anyhow::bail!("{error}");
+    }
+
+    Ok(())
+}
+
+struct CudaSmokeReceiptFields {
+    result: &'static str,
+    input_len: serde_json::Value,
+    max_abs_error: serde_json::Value,
+    mean_abs_error: serde_json::Value,
+    host_to_device_bytes: serde_json::Value,
+    device_to_host_bytes: serde_json::Value,
+    invocations: u64,
+    kernel_launches: u64,
+}
+
+impl Default for CudaSmokeReceiptFields {
+    fn default() -> Self {
+        Self {
+            result: "fail",
+            input_len: serde_json::Value::Null,
+            max_abs_error: serde_json::Value::Null,
+            mean_abs_error: serde_json::Value::Null,
+            host_to_device_bytes: serde_json::Value::Null,
+            device_to_host_bytes: serde_json::Value::Null,
+            invocations: 0,
+            kernel_launches: 0,
+        }
+    }
+}
+
+fn run_cuda_smoke_kernel_receipt_fields(
+    cuda_probe: &mut bitnet_device_probe::NvidiaCudaProbe,
+    device_index: usize,
+    error: &mut Option<String>,
+) -> CudaSmokeReceiptFields {
+    #[cfg(feature = "cuda")]
+    {
+        match bitnet_kernels::gpu::run_cuda_tiny_vector_add_smoke(device_index) {
+            Ok(smoke) => {
+                cuda_probe.selected_device_index = Some(smoke.device_info.device_id);
+                cuda_probe.selected_device_name = Some(smoke.device_info.name);
+                cuda_probe.compute_capability = Some(format!(
+                    "{}.{}",
+                    smoke.device_info.compute_capability.0, smoke.device_info.compute_capability.1
+                ));
+                cuda_probe.vram_bytes = Some(smoke.device_info.total_memory as u64);
+
+                if !smoke.passed {
+                    *error = Some(format!(
+                        "tiny CUDA vector add mismatch: max_abs_error={}, mean_abs_error={}",
+                        smoke.max_abs_error, smoke.mean_abs_error
+                    ));
+                }
+
+                CudaSmokeReceiptFields {
+                    result: if smoke.passed { "pass" } else { "fail" },
+                    input_len: serde_json::json!(smoke.input_len),
+                    max_abs_error: serde_json::json!(smoke.max_abs_error),
+                    mean_abs_error: serde_json::json!(smoke.mean_abs_error),
+                    host_to_device_bytes: serde_json::json!(smoke.host_to_device_bytes),
+                    device_to_host_bytes: serde_json::json!(smoke.device_to_host_bytes),
+                    invocations: 1,
+                    kernel_launches: smoke.kernel_launches,
+                }
+            }
+            Err(err) => {
+                *error = Some(format!("tiny CUDA vector add smoke failed: {err}"));
+                CudaSmokeReceiptFields::default()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        let _ = cuda_probe;
+        let _ = device_index;
+        *error = Some("compiled without the cuda feature".to_string());
+        CudaSmokeReceiptFields::default()
+    }
+}
+
+async fn handle_cuda_smoke_command(
+    requested_backend_label: &str,
+    device_index: usize,
+    json_out: Option<std::path::PathBuf>,
+) -> Result<()> {
+    use bitnet_common::BackendRequest;
+
+    const MACHINE_ID: &str = "windows-9950x3d-rtx5070ti";
+    const RTX_5070_TI_CUDA: &str = "nvidia-rtx-5070-ti-cuda";
+    const REFERENCE_BACKEND: &str = "amd-9950x3d-cpu-avx512";
+    const KERNEL_ID: &str = "cuda_tiny_vector_add";
+
+    let request = BackendRequest::from_label(requested_backend_label)
+        .with_context(|| format!("unsupported cuda-smoke backend: {requested_backend_label}"))?;
+    let requested_backend = request.to_string();
+
+    if !matches!(request, BackendRequest::NvidiaRtx5070TiCuda) {
+        anyhow::bail!(
+            "cuda-smoke currently supports nvidia-rtx-5070-ti-cuda only, got {requested_backend}"
+        );
+    }
+
+    let mut cuda_probe = bitnet_device_probe::probe_nvidia_cuda(Some(device_index));
+    let identity_error =
+        if matches!(request, BackendRequest::NvidiaRtx5070TiCuda) && cuda_probe.available {
+            validate_rtx_5070_ti_identity(&cuda_probe)
+        } else {
+            None
+        };
+
+    if let Some(error) = &identity_error {
+        cuda_probe.available = false;
+        cuda_probe.failure_reason = Some(error.clone());
+    }
+
+    let mut error = if !cuda_probe.available {
+        cuda_probe
+            .failure_reason
+            .clone()
+            .or_else(|| Some("requested CUDA smoke device is unavailable".to_string()))
+    } else {
+        None
+    };
+
+    let selected_backend = if cuda_probe.available {
+        Some(if matches!(request, BackendRequest::NvidiaRtx5070TiCuda) {
+            RTX_5070_TI_CUDA
+        } else {
+            "cuda"
+        })
+    } else {
+        None
+    };
+
+    let outcome = if error.is_none() {
+        run_cuda_smoke_kernel_receipt_fields(&mut cuda_probe, device_index, &mut error)
+    } else {
+        CudaSmokeReceiptFields::default()
+    };
+
+    let timestamp_utc = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let artifact_path = json_out.as_ref().map(|path| path.display().to_string());
+    let claim = if error.is_none() && outcome.result == "pass" {
+        "kernel_smoke_tested"
+    } else {
+        "cuda_kernel_smoke_attempted"
+    };
+    let receipt = serde_json::json!({
+        "schema": 1,
+        "artifact_kind": "cuda_smoke",
+        "machine_id": MACHINE_ID,
+        "hardware_lane": RTX_5070_TI_CUDA,
+        "timestamp_utc": timestamp_utc,
+        "requested_backend": requested_backend,
+        "selected_backend": selected_backend,
+        "runtime_api": "cuda",
+        "reference_backend": REFERENCE_BACKEND,
+        "fallback_used": false,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "cuda": {
+            "available": cuda_probe.available,
+            "device_count": cuda_probe.device_count,
+            "device_index": cuda_probe.selected_device_index,
+            "device_name": cuda_probe.selected_device_name,
+            "compute_capability": cuda_probe.compute_capability,
+            "driver_version": cuda_probe.driver_version,
+            "cuda_runtime_version": cuda_probe.cuda_runtime_version,
+            "cuda_toolkit_version": cuda_probe.cuda_toolkit_version,
+            "nvrtc_version": cuda_probe.nvrtc_version,
+            "nvml_available": cuda_probe.nvml_available,
+            "vram_bytes": cuda_probe.vram_bytes,
+            "power_limit_watts": cuda_probe.power_limit_watts,
+            "power_draw_watts": cuda_probe.power_draw_watts,
+            "temperature_c": cuda_probe.temperature_c,
+        },
+        "kernel_stats": [
+            {
+                "kernel_id": KERNEL_ID,
+                "invocations": outcome.invocations,
+                "fallback_invocations": 0,
+                "host_to_device_bytes": outcome.host_to_device_bytes,
+                "device_to_host_bytes": outcome.device_to_host_bytes,
+                "kernel_launches": outcome.kernel_launches,
+                "kernel_time_ms": null
+            }
+        ],
+        "input_len": outcome.input_len,
+        "max_abs_error": outcome.max_abs_error,
+        "mean_abs_error": outcome.mean_abs_error,
+        "result": outcome.result,
+        "claim": claim,
         "artifact_path": artifact_path,
         "error": error,
     });

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -28,7 +28,7 @@ thiserror.workspace = true
 bytemuck.workspace = true
 rayon.workspace = true
 log.workspace = true
-cudarc = { version = "0.17.8", optional = true, features = ["cuda-12000"] }
+cudarc = { version = "0.17.8", optional = true, default-features = false, features = ["std", "driver", "nvrtc", "dynamic-loading", "cuda-12000"] }
 opencl3 = { version = "0.12", optional = true }
 cc = { version = "1.2.46", optional = true }
 bindgen = { version = "0.72.1", optional = true }
@@ -174,4 +174,3 @@ required-features = ["cpu"]
 name = "gpu_validation"
 path = "examples/gpu_validation.rs"
 required-features = ["gpu"]
-

--- a/crates/bitnet-kernels/build.rs
+++ b/crates/bitnet-kernels/build.rs
@@ -28,6 +28,7 @@ fn main() {
 
     // Always allow re-run if this file changes
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=BITNET_CUDA_LINK_LIBS");
 
     // Unified GPU detection: honor both "gpu" and legacy "cuda" features for back-compat.
     // This ensures the build script recognizes GPU builds regardless of which feature is enabled.
@@ -60,12 +61,26 @@ fn main() {
             println!("cargo:rustc-link-search=/usr/local/cuda/targets/x86_64-linux/lib");
             println!("cargo:rustc-link-search=/usr/local/cuda/targets/x86_64-linux/lib/stubs");
 
-            // Link CUDA libraries
-            println!("cargo:rustc-link-lib=cuda");
-            println!("cargo:rustc-link-lib=nvrtc");
-            println!("cargo:rustc-link-lib=curand");
-            println!("cargo:rustc-link-lib=cublas");
-            println!("cargo:rustc-link-lib=cublasLt");
+            // CUDA uses cudarc dynamic loading by default, so driver-visible
+            // systems do not need CUDA import libraries at build time. Set
+            // BITNET_CUDA_LINK_LIBS=1 or a comma-separated library list to
+            // force explicit linker inputs for a toolkit-installed build.
+            if let Some(link_libs) = env_var("BITNET_CUDA_LINK_LIBS") {
+                let libs: Vec<String> =
+                    if link_libs.trim().is_empty() || link_libs == "1" || link_libs == "true" {
+                        vec!["cuda".to_string(), "nvrtc".to_string()]
+                    } else {
+                        link_libs
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|lib| !lib.is_empty())
+                            .map(str::to_string)
+                            .collect()
+                    };
+                for lib in libs {
+                    println!("cargo:rustc-link-lib={lib}");
+                }
+            }
         }
 
         if env::var_os("CARGO_FEATURE_HIP").is_some() {

--- a/crates/bitnet-kernels/src/gpu/cuda.rs
+++ b/crates/bitnet-kernels/src/gpu/cuda.rs
@@ -7,11 +7,30 @@ use cudarc::driver::{
     CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
     result::device as cu_device, sys::CUdevice_attribute,
 };
-use cudarc::nvrtc::compile_ptx;
-use std::sync::Arc;
+use cudarc::nvrtc::{Ptx, compile_ptx};
+use std::{
+    any::Any,
+    mem::size_of,
+    sync::{Arc, Mutex},
+};
 
 /// Type alias for batch matrix multiplication operation
 type BatchOperation<'a> = (&'a [i8], &'a [u8], &'a mut [f32], usize, usize, usize);
+
+/// Kernel ID used by RTX5070TI-005 tiny CUDA smoke receipts.
+pub const CUDA_TINY_VECTOR_ADD_KERNEL_ID: &str = "cuda_tiny_vector_add";
+
+const CUDA_TINY_VECTOR_ADD_SRC: &str = r#"
+extern "C" __global__
+void cuda_tiny_vector_add(const float* a, const float* b, float* c, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        c[idx] = a[idx] + b[idx];
+    }
+}
+"#;
+
+static NVRTC_COMPILE_HOOK_LOCK: Mutex<()> = Mutex::new(());
 
 /// CUDA kernel provider with memory management and stream handling
 pub struct CudaKernel {
@@ -52,6 +71,139 @@ pub struct PerformanceStats {
     pub cache_misses: u64,
 }
 
+/// Result of the RTX5070TI-005 tiny CUDA vector-add smoke.
+#[derive(Debug, Clone)]
+pub struct CudaTinyVectorAddSmoke {
+    pub kernel_id: &'static str,
+    pub device_info: CudaDeviceInfo,
+    pub input_len: usize,
+    pub passed: bool,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+    pub host_to_device_bytes: u64,
+    pub device_to_host_bytes: u64,
+    pub kernel_launches: u64,
+}
+
+fn compile_cuda_ptx(source: &str, label: &str) -> Result<Ptx> {
+    // cudarc 0.17 can panic while dynamically loading NVRTC when nvrtc.dll is
+    // absent. Convert that into a normal error so smoke commands can still
+    // write negative receipts instead of aborting before receipt emission.
+    let _hook_guard = NVRTC_COMPILE_HOOK_LOCK.lock().ok();
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let compile_result = std::panic::catch_unwind(|| compile_ptx(source));
+    std::panic::set_hook(previous_hook);
+
+    match compile_result {
+        Ok(Ok(ptx)) => Ok(ptx),
+        Ok(Err(err)) => {
+            Err(KernelError::GpuError { reason: format!("Failed to compile {label} PTX: {err:?}") }
+                .into())
+        }
+        Err(payload) => Err(KernelError::GpuError {
+            reason: format!(
+                "Failed to compile {label} PTX because NVRTC was unavailable: {}",
+                panic_payload_message(&*payload)
+            ),
+        }
+        .into()),
+    }
+}
+
+fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
+}
+
+/// Compile and launch a tiny CUDA vector-add kernel on the selected device.
+///
+/// This is intentionally not a BitNet kernel or inference proof. It only proves
+/// NVRTC compilation, CUDA launch, synchronization, and device-to-host copy for
+/// a deterministic vector-add fixture.
+pub fn run_cuda_tiny_vector_add_smoke(device_id: usize) -> Result<CudaTinyVectorAddSmoke> {
+    const LEN: usize = 1024;
+    const THREADS_PER_BLOCK: u32 = 256;
+
+    let ctx = CudaContext::new(device_id).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to create CUDA context for device {device_id}: {e:?}"),
+    })?;
+    let stream = ctx.default_stream();
+
+    let ptx = compile_cuda_ptx(CUDA_TINY_VECTOR_ADD_SRC, "tiny CUDA smoke")?;
+    let module = ctx.load_module(ptx).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to load tiny CUDA smoke module: {e:?}"),
+    })?;
+    let function = module.load_function(CUDA_TINY_VECTOR_ADD_KERNEL_ID).map_err(|e| {
+        KernelError::GpuError { reason: format!("Failed to load tiny CUDA smoke kernel: {e:?}") }
+    })?;
+
+    let a: Vec<f32> = (0..LEN).map(|i| (i as f32 * 0.25) - 17.0).collect();
+    let b: Vec<f32> = (0..LEN).map(|i| ((i % 31) as f32) - 15.0).collect();
+    let expected: Vec<f32> = a.iter().zip(&b).map(|(a, b)| a + b).collect();
+
+    let a_dev = stream.memcpy_stod(&a).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to transfer tiny smoke input A to device: {e:?}"),
+    })?;
+    let b_dev = stream.memcpy_stod(&b).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to transfer tiny smoke input B to device: {e:?}"),
+    })?;
+    let mut c_dev: CudaSlice<f32> = stream.alloc_zeros(LEN).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to allocate tiny smoke output: {e:?}"),
+    })?;
+
+    let grid = (LEN as u32).div_ceil(THREADS_PER_BLOCK);
+    let cfg = LaunchConfig {
+        grid_dim: (grid, 1, 1),
+        block_dim: (THREADS_PER_BLOCK, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    let mut builder = stream.launch_builder(&function);
+    builder.arg(&a_dev);
+    builder.arg(&b_dev);
+    builder.arg(&mut c_dev);
+    let n_arg = LEN as i32;
+    builder.arg(&n_arg);
+
+    unsafe { builder.launch(cfg) }.map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to launch tiny CUDA smoke kernel: {e:?}"),
+    })?;
+    stream.synchronize().map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to synchronize tiny CUDA smoke kernel: {e:?}"),
+    })?;
+
+    let actual: Vec<f32> = stream.memcpy_dtov(&c_dev).map_err(|e| KernelError::GpuError {
+        reason: format!("Failed to transfer tiny smoke output back to host: {e:?}"),
+    })?;
+
+    let mut max_abs_error = 0.0f32;
+    let mut total_abs_error = 0.0f32;
+    for (actual, expected) in actual.iter().zip(&expected) {
+        let abs_error = (actual - expected).abs();
+        max_abs_error = max_abs_error.max(abs_error);
+        total_abs_error += abs_error;
+    }
+    let mean_abs_error = total_abs_error / LEN as f32;
+
+    Ok(CudaTinyVectorAddSmoke {
+        kernel_id: CUDA_TINY_VECTOR_ADD_KERNEL_ID,
+        device_info: CudaKernel::get_device_info(device_id)?,
+        input_len: LEN,
+        passed: max_abs_error <= f32::EPSILON,
+        max_abs_error,
+        mean_abs_error,
+        host_to_device_bytes: (2 * LEN * size_of::<f32>()) as u64,
+        device_to_host_bytes: (LEN * size_of::<f32>()) as u64,
+        kernel_launches: 1,
+    })
+}
+
 impl CudaKernel {
     /// Create a new CUDA kernel provider
     pub fn new() -> Result<Self> {
@@ -71,9 +223,7 @@ impl CudaKernel {
         let stream = ctx.default_stream();
 
         // Compile PTX kernel
-        let ptx = compile_ptx(include_str!("kernels/bitnet_kernels.cu")).map_err(|e| {
-            KernelError::GpuError { reason: format!("Failed to compile PTX: {:?}", e) }
-        })?;
+        let ptx = compile_cuda_ptx(include_str!("kernels/bitnet_kernels.cu"), "BitNet CUDA")?;
 
         // Load module
         let module = ctx.load_module(ptx).map_err(|e| KernelError::GpuError {


### PR DESCRIPTION
## Summary
- add `cuda-smoke` to compile and launch `cuda_tiny_vector_add` through NVRTC/cudarc on the selected RTX 5070 Ti CUDA backend
- write normalized smoke receipts with requested/selected backend, runtime API, fallback status, CUDA identity, kernel stats, and error fields
- reject generic `cuda` for this lane-specific receipt command so generic CUDA runs cannot be archived as RTX 5070 Ti proof
- add `--device-index` for probing and launching on the selected CUDA device
- stop unconditional CUDA import-library linking in bitnet-kernels; keep explicit toolkit linking opt-in with `BITNET_CUDA_LINK_LIBS`

## Validation
- rustfmt --edition 2024 --check crates\bitnet-kernels\src\gpu\cuda.rs crates\bitnet-cli\src\main.rs crates\bitnet-kernels\build.rs
- cargo check --locked -p bitnet-kernels --no-default-features --features cuda
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
- git diff --check
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- --device nvidia-rtx-5070-ti-cuda cuda-smoke --device-index 0 --json-out target/bitnet/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke-nvrtc-negative.json (expected failure receipt on this machine until NVRTC is installed/visible)
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- --device cuda cuda-smoke --json-out target/bitnet/hardware/generic-cuda-negative.json (expected rejection; no RTX receipt written)

## Notes
- This does not touch QK256, transformer routing, server inference, dense CUDA, WGPU/D3D12/Vulkan proof, or benchmarks.
- This does not claim BitNet inference or speedup.
- The local Windows bench selects the RTX 5070 Ti CUDA backend with `fallback_used=false`, but the tiny kernel cannot pass until NVRTC (`nvrtc.dll`) is installed or visible on PATH.

Refs #3664