### PR TITLE
[codex][apple-m4] Add CPU/Metal parity smoke (M4-006)

### DIFF
--- a/crates/bitnet-kernels/src/metal/smoke.rs
+++ b/crates/bitnet-kernels/src/metal/smoke.rs
@@ -2,10 +2,13 @@ use std::fmt;
 
 pub const MACHINE_ID: &str = "apple-m4-mac-mini";
 pub const ARTIFACT_KIND: &str = "smoke";
+pub const PARITY_ARTIFACT_KIND: &str = "parity";
 pub const REQUESTED_BACKEND: &str = "apple-m4-metal";
 pub const SELECTED_BACKEND: &str = "apple-m4-metal";
+pub const REFERENCE_BACKEND: &str = "apple-m4-cpu-neon";
 pub const RUNTIME_API: &str = "metal";
 pub const TINY_METAL_ADD_SMOKE_KERNEL_ID: &str = "tiny_metal_add_smoke";
+pub const TINY_METAL_ADD_PARITY_KERNEL_ID: &str = "tiny_metal_add_parity";
 pub const SMOKE_ELEMENT_COUNT: usize = 64;
 pub const SMOKE_WORKGROUP_SIZE: u32 = 64;
 
@@ -38,6 +41,49 @@ impl TinyMetalAddSmokeReceipt {
             selected_backend: SELECTED_BACKEND,
             runtime_api: RUNTIME_API,
             kernel_id: TINY_METAL_ADD_SMOKE_KERNEL_ID,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            element_count,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TinyMetalAddParityReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub reference_backend: &'static str,
+    pub target_backend: &'static str,
+    pub kernel_id: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub element_count: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
+impl TinyMetalAddParityReceipt {
+    pub fn passed(
+        artifact_path: impl Into<String>,
+        element_count: usize,
+        comparison: SmokeComparison,
+    ) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: PARITY_ARTIFACT_KIND,
+            requested_backend: REQUESTED_BACKEND,
+            selected_backend: SELECTED_BACKEND,
+            runtime_api: RUNTIME_API,
+            reference_backend: REFERENCE_BACKEND,
+            target_backend: SELECTED_BACKEND,
+            kernel_id: TINY_METAL_ADD_PARITY_KERNEL_ID,
             fallback_used: false,
             result: "pass",
             artifact_path: artifact_path.into(),
@@ -84,6 +130,10 @@ impl std::error::Error for TinyMetalSmokeError {}
 
 pub fn metal_smoke_artifact_path(date: &str) -> String {
     format!("ci/hardware/{MACHINE_ID}/{date}/metal-smoke.json")
+}
+
+pub fn metal_parity_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/metal-parity.json")
 }
 
 pub fn tiny_add_inputs() -> (Vec<f32>, Vec<f32>) {

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -1,10 +1,12 @@
 #![cfg(feature = "metal")]
 
 use bitnet_kernels::metal::smoke::{
-    ARTIFACT_KIND, MACHINE_ID, REQUESTED_BACKEND, RUNTIME_API, SELECTED_BACKEND,
-    SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_SMOKE_KERNEL_ID,
+    ARTIFACT_KIND, MACHINE_ID, PARITY_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND,
+    RUNTIME_API, SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SmokeComparison,
+    TINY_METAL_ADD_PARITY_KERNEL_ID, TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt,
     TinyMetalAddSmokeReceipt, compare_tiny_add_outputs, expected_tiny_add,
-    is_apple_m4_adapter_name, metal_smoke_artifact_path, tiny_add_inputs,
+    is_apple_m4_adapter_name, metal_parity_artifact_path, metal_smoke_artifact_path,
+    tiny_add_inputs,
 };
 
 #[test]
@@ -38,6 +40,29 @@ fn receipt_contract_records_only_tiny_m4_metal_smoke() {
 }
 
 #[test]
+fn parity_receipt_contract_records_cpu_neon_reference_and_metal_target() {
+    let receipt = TinyMetalAddParityReceipt::passed(
+        metal_parity_artifact_path("2026-05-06"),
+        64,
+        SmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, MACHINE_ID);
+    assert_eq!(receipt.artifact_kind, PARITY_ARTIFACT_KIND);
+    assert_eq!(receipt.requested_backend, REQUESTED_BACKEND);
+    assert_eq!(receipt.selected_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.runtime_api, RUNTIME_API);
+    assert_eq!(receipt.reference_backend, REFERENCE_BACKEND);
+    assert_eq!(receipt.target_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.kernel_id, TINY_METAL_ADD_PARITY_KERNEL_ID);
+    assert!(!receipt.fallback_used);
+    assert_eq!(receipt.result, "pass");
+    assert_eq!(receipt.artifact_path, "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-parity.json");
+    assert_eq!(receipt.max_abs_error, 0.0);
+    assert_eq!(receipt.mean_abs_error, 0.0);
+}
+
+#[test]
 fn comparison_fails_instead_of_falling_back_to_cpu() {
     let expected = [1.0_f32, 2.0, 3.0];
     let actual = [1.0_f32, 20.0, 3.0];
@@ -68,6 +93,9 @@ mod live_metal {
     const RUN_ENV: &str = "BITNET_RUN_M4_METAL_SMOKE";
     const RECEIPT_ENV: &str = "BITNET_M4_METAL_SMOKE_RECEIPT";
     const ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_SMOKE_ARTIFACT_PATH";
+    const RUN_PARITY_ENV: &str = "BITNET_RUN_M4_METAL_PARITY";
+    const PARITY_RECEIPT_ENV: &str = "BITNET_M4_METAL_PARITY_RECEIPT";
+    const PARITY_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_PARITY_ARTIFACT_PATH";
 
     struct MetalSmokeOutput {
         adapter_name: String,
@@ -121,6 +149,68 @@ mod live_metal {
         });
 
         if let Ok(path) = std::env::var(RECEIPT_ENV) {
+            if let Some(parent) = Path::new(&path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiny_m4_metal_add_matches_cpu_neon_reference_when_enabled() -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_PARITY_ENV).as_deref() != Ok("1") {
+            eprintln!("skipping live M4 CPU/Metal parity; set {RUN_PARITY_ENV}=1 to run it");
+            return Ok(());
+        }
+
+        let (lhs, rhs) = tiny_add_inputs();
+        let expected = expected_tiny_add(&lhs, &rhs)?;
+        let metal_output = run_tiny_add_smoke(&lhs, &rhs)?;
+
+        if !is_apple_m4_adapter_name(&metal_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-006 parity requires an Apple M4-family Metal adapter; found '{}'",
+                metal_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&expected, &metal_output.output, 1e-6)?;
+        let artifact_path = std::env::var(PARITY_ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(PARITY_RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-parity.json".to_string()
+            });
+        let receipt =
+            TinyMetalAddParityReceipt::passed(artifact_path.clone(), expected.len(), comparison);
+
+        let receipt_json = json!({
+            "machine_id": receipt.machine_id,
+            "artifact_kind": receipt.artifact_kind,
+            "requested_backend": receipt.requested_backend,
+            "selected_backend": receipt.selected_backend,
+            "runtime_api": receipt.runtime_api,
+            "resolved_device": {
+                "chip": metal_output.adapter_name,
+                "unified_memory": true
+            },
+            "parity": {
+                "reference_backend": receipt.reference_backend,
+                "target_backend": receipt.target_backend,
+                "kernel_id": receipt.kernel_id,
+                "max_abs_error": receipt.max_abs_error,
+                "mean_abs_error": receipt.mean_abs_error,
+                "token_agreement_for_greedy": null
+            },
+            "fallback_used": receipt.fallback_used,
+            "result": receipt.result,
+            "artifact_path": receipt.artifact_path,
+            "element_count": receipt.element_count
+        });
+
+        if let Ok(path) = std::env::var(PARITY_RECEIPT_ENV) {
             if let Some(parent) = Path::new(&path).parent() {
                 std::fs::create_dir_all(parent)?;
             }

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -192,7 +192,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-006"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-006-metal-cpu-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -192,7 +192,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-006"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-006-metal-cpu-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T093428Z-M4-006-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T093428Z-M4-006-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T09:34:28Z"
+campaign = "apple-m4"
+item = "M4-006"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started CPU/Metal parity work for the tiny M4 Metal add kernel.",
+  "No BitNet inference, QK256, MPSGraph, server, benchmark, or performance claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T093645Z-M4-006-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T093645Z-M4-006-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T09:36:45Z"
+campaign = "apple-m4"
+item = "M4-006"
+event = "pr_open"
+pr = 3709
+head_sha = "9ea8a6b1ab97a97ab701db58bec18330644226fa"
+actor = "codex"
+
+notes = [
+  "Opened CPU/Metal parity PR for the tiny M4 Metal add kernel.",
+  "Receipt records apple-m4-cpu-neon as reference and apple-m4-metal as target with fallback_used=false.",
+  "No BitNet inference, QK256, MPSGraph, server, dependency, benchmark, or performance claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -14,7 +14,7 @@
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
-| M4-006 | in_progress | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
+| M4-006 | pr_open | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -14,7 +14,7 @@
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
-| M4-006 | ready | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
+| M4-006 | in_progress | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-006 | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |
 | apple-m4 | M4-005 | M4-004 | merged |
-| apple-m4 | M4-006 | M4-005 | ready |
+| apple-m4 | M4-006 | M4-005 | in_progress |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |
 | apple-m4 | M4-009 | M4-008 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |
 | apple-m4 | M4-005 | M4-004 | merged |
-| apple-m4 | M4-006 | M4-005 | in_progress |
+| apple-m4 | M4-006 | M4-005 | pr_open |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |
 | apple-m4 | M4-009 | M4-008 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-006 | TBD | in_progress | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-006 | #3709 | pr_open | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-006 | TBD | ready | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-006 | TBD | in_progress | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- add an explicit M4 CPU/Metal parity receipt for the tiny Metal add kernel
- record `apple-m4-cpu-neon` as the reference backend and `apple-m4-metal` as the target backend
- add a manual live M4 parity test path that emits `metal-parity.json` with fallback_used=false
- mark M4-006 in progress and regenerate Apple campaign/global dashboards

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke
- BITNET_RUN_M4_METAL_PARITY=1 BITNET_M4_METAL_PARITY_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/metal-parity.json BITNET_M4_METAL_PARITY_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/metal-parity.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_add_matches_cpu_neon_reference_when_enabled -- --nocapture
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
No QK256, server inference, MPSGraph execution, BitNet model loading, dependency changes, benchmarks, or BitNet inference claims.