### PR TITLE
feat(governance): Clippy lint policy scaffolding (PR 1 of stack)

### DIFF
--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,133 @@
+# Clippy and Lint Policy
+
+> Status: **PR 1 of a stacked rollout — governance scaffolding only.**
+> The strict baseline lint block has not yet been applied to `[workspace.lints]`.
+> See "Rollout plan" below for the schedule.
+
+## What this is
+
+This document describes the lint governance model for the `bitnet-rs`
+workspace. Lints are treated as **infrastructure**, not as personal taste:
+
+- The list of lints we intend to enforce lives in
+  [`policy/clippy-lints.toml`](../policy/clippy-lints.toml) — a
+  machine-readable ledger covering both currently-active lints and lints
+  planned to flip on a future Rust MSRV.
+- Temporary exceptions live in
+  [`policy/clippy-debt.toml`](../policy/clippy-debt.toml). Every entry has an
+  owner, a reason, and an expiry; CI fails on expired or undeclared debt.
+- Per-call-site panic exceptions live in
+  [`policy/no-panic-allowlist.toml`](../policy/no-panic-allowlist.toml) using
+  semantic identifiers (`path + family + selector`), not line numbers.
+- Non-Rust source files live behind
+  [`policy/non-rust-allowlist.toml`](../policy/non-rust-allowlist.toml),
+  which migrates the prior pipe-delimited convention to TOML.
+- `cargo run -p xtask -- check-lint-policy` verifies that the policy ledger,
+  `Cargo.toml`, `clippy.toml`, and `rust-toolchain.toml` agree.
+
+## Posture
+
+Three rules drive the policy:
+
+1. **Global deny by default. Local exception by structured receipt.**
+   No silent `#[allow]`. Every suppression must use
+   `#[expect(..., reason = "...")]`, or appear as a tracked entry in
+   `policy/clippy-debt.toml` or `policy/no-panic-allowlist.toml`.
+2. **Identity is semantic, not positional.**
+   The no-panic allowlist keys on `path + family + selector`; line/column are
+   advisory hints used only for diagnostics. This survives normal refactors.
+3. **Future flips are tracked, not surprises.**
+   Lints planned to flip when MSRV rises (Rust 1.94 / 1.95 cohorts) are
+   declared in `policy/clippy-lints.toml` so we can adopt them on the same
+   cycle as the toolchain bump.
+
+## Suppression style
+
+All suppressions must use `#[expect]` with a `reason` string:
+
+```rust
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Tensor sizes are bounded by GGUF spec; truncation is impossible.",
+)]
+let len = vector.len() as u32;
+```
+
+Bare `#[allow(...)]` will be denied workspace-wide once PR 2 lands. Do not
+add a `#[allow]` even temporarily — use `policy/clippy-debt.toml` instead so
+the exception is reviewable, has an owner, and has an expiry.
+
+## BitNet-rs overlay
+
+bitnet-rs is a high-churn numeric / GPU / FFI workspace. The strict baseline
+applies, but with an explicit overlay:
+
+| Lint class                 | Workspace level | BitNet-rs overlay |
+|----------------------------|-----------------|-------------------|
+| Panic family               | `deny`          | `deny`            |
+| Silent failure             | `deny`          | `deny`            |
+| Suppression governance     | `deny`          | `deny`            |
+| Numeric correctness        | `warn` → `deny` | `warn` (ratchet per crate) |
+| `arithmetic_side_effects`  | `warn`          | `warn` (no estate-wide deny without kernel triage) |
+| `unsafe_code`              | `forbid`        | `forbid` *except* in GPU backend crates (`bitnet-kernels`, `bitnet-rocm`, `bitnet-cuda*`, `bitnet-metal`, `bitnet-vulkan`, `bitnet-opencl`, `bitnet-wgpu`) where it is `deny` with documented `unsafe { }` blocks |
+| Test carveouts             | none            | currently `allow-unwrap-in-tests = true` / `allow-expect-in-tests = true` in `clippy.toml`; **scheduled for removal in PR 2** |
+
+The overlay is encoded in `policy/clippy-lints.toml` as `class` and
+`overlay_exception` fields per planned lint.
+
+## Rollout plan
+
+This is a stacked rollout. Each PR is independently reviewable.
+
+### PR 1 — Governance scaffolding (this PR)
+
+- Add `policy/clippy-lints.toml`, `policy/clippy-debt.toml`,
+  `policy/no-panic-allowlist.toml`, `policy/non-rust-allowlist.toml`.
+- Add this document.
+- Add `cargo xtask check-lint-policy` (advisory). No lint behavior changes.
+
+### PR 2 — Strict baseline
+
+- Replace the `all`/`pedantic`/`nursery` warn block in root `Cargo.toml` with
+  the explicit lint set declared as `activate_when_msrv = "1.92"` in
+  `policy/clippy-lints.toml`.
+- Remove `allow-unwrap-in-tests` and `allow-expect-in-tests` from
+  `clippy.toml`.
+- Seed `policy/clippy-debt.toml` with the resulting violations, each with a
+  named owner and an expiry no further than +90 days.
+- Promote `cargo xtask check-lint-policy` to a CI gate.
+
+### PR 3 — MSRV ratchet 1.92 → 1.93
+
+- Bump `rust-toolchain.toml` and `workspace.package.rust-version`.
+- Bump `policy/clippy-lints.toml` `msrv = "1.93"`.
+- Promote `warn`-level numeric lints to `deny` per crate as kernel debt is
+  cleared.
+
+### PR 4+ — Rust 1.94 / 1.95 flip cohorts
+
+- When MSRV reaches 1.94, activate the lints declared with
+  `activate_when_msrv = "1.94"` (same for 1.95).
+- The xtask check verifies the cohort matches the planned ledger.
+
+## Estate-wide context
+
+This policy is part of a platform-wide rollout across the Effortless Metrics
+Rust estate (`ripr`, `perl-lsp`, `perfgate`, `tokmd`, `shiplog`, `uselesskey`,
+`hl7v2-rs`, `lintdiff`, `BitNet-rs`, …). The shared baseline is identical
+across repos; per-repo overlays are restricted to *adding* strictness or
+*tracking* domain-specific debt. The same `policy/` directory layout and
+TOML schemas are used everywhere so that one tooling pass produces a
+consistent estate report.
+
+## Related tooling
+
+- `ripr` — second-stage evidence layer. Clippy says "the code shape is
+  acceptable"; ripr says "the behavior seams have test grip." The two
+  together form the org-wide Rust quality floor.
+- `cargo xtask check-lint-policy` (this repo) — verifies repo-local policy
+  consistency.
+- `cargo xtask check-no-panic-family` (planned) — AST-aware enforcement of
+  `policy/no-panic-allowlist.toml`.
+- `cargo xtask check-file-policy` (planned) — enforcement of
+  `policy/non-rust-allowlist.toml`.

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,40 @@
+# Tracked Clippy / lint debt for bitnet-rs.
+#
+# Every entry here is a *temporary, reviewed* exception to the workspace lint
+# baseline. Silent debt (a bare #[allow] or a config carveout in clippy.toml)
+# is not allowed; if you need an exception, add it here with an owner, a
+# reason, and an expiry date. `cargo xtask check-lint-policy` fails on:
+#   - missing required fields
+#   - debt past its expiry
+#   - debt referring to lints not declared as active or planned
+#
+# Schema:
+#   schema     : integer, increments on breaking schema change
+#   [[debt]]
+#     lint    : "clippy::name" or "rust::name" (matches policy/clippy-lints.toml)
+#     path    : exact file path, or glob (use trailing /** for directories)
+#     owner   : team or crate-owner identifier (free text, but must be set)
+#     reason  : 1-3 sentences explaining why the global rule cannot apply yet
+#     expires : ISO-8601 date; once past, CI will fail until removed or extended
+#
+# This file is intentionally empty in PR 1 (governance scaffolding only).
+# PR 2 (strict baseline rollout) will seed it with the violations the new
+# lint block exposes; each entry must be reviewed before merge.
+
+schema = 1
+
+# Examples of the expected shape (commented out — these are not active debt):
+#
+# [[debt]]
+# lint    = "clippy::indexing_slicing"
+# path    = "crates/bitnet-kernels/src/i2s/qk256/scalar.rs"
+# owner   = "kernels"
+# reason  = "Bounds-checked at the kernel-launcher boundary; promoting to .get() requires a benchmark sweep."
+# expires = "2026-09-01"
+#
+# [[debt]]
+# lint    = "clippy::arithmetic_side_effects"
+# path    = "crates/bitnet-kernels/src/**"
+# owner   = "kernels"
+# reason  = "Kernel arithmetic needs a reviewed checked/wrapping/saturating policy before global promotion."
+# expires = "2026-09-01"

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,371 @@
+# Clippy / rustc lint policy ledger for bitnet-rs.
+#
+# This file is the source of truth for which lints are *intended* to be active
+# at the workspace level, and which are *planned* to flip when a future MSRV is
+# adopted. The block in `Cargo.toml` `[workspace.lints]` is what the compiler
+# actually enforces; `cargo xtask check-lint-policy` verifies the two stay in
+# sync and that planned lints are not activated before their target MSRV.
+#
+# Schema:
+#   schema           : integer, increments on breaking schema change
+#   msrv             : current workspace MSRV (must match workspace.package.rust-version)
+#   policy           : repo-wide policy posture
+#   [[active]]       : lint expected to be enforced today
+#   [[planned]]      : lint expected to flip on a specific future MSRV
+#
+# See docs/CLIPPY_POLICY.md for the rationale and rollout plan.
+
+schema = 1
+msrv = "1.92.0"
+
+[policy]
+# Workspace-wide posture flags, asserted by `cargo xtask check-lint-policy`.
+panic_free_tests       = false  # ratchet target; flips to true when test carveouts are removed
+allow_test_carveouts   = true   # current state: clippy.toml still allows unwrap/expect in tests
+suppression_style      = "expect-with-reason"
+blanket_categories     = true   # current state: workspace warns on all/pedantic/nursery
+target_panic_free_tests = true  # docs/CLIPPY_POLICY.md commits to flipping this
+target_msrv            = "1.93" # platform-wide ratchet target
+
+# ---------------------------------------------------------------------------
+# Active lints (enforced today). Each entry should match an entry in the root
+# Cargo.toml [workspace.lints.*] block. The xtask checker treats this list as
+# advisory until the strict baseline lands (see PR 2 of the rollout).
+# ---------------------------------------------------------------------------
+
+[[active]]
+name = "clippy::ptr_arg"
+level = "deny"
+class = "api"
+reason = "Prefer slice references over &Vec/&String in public APIs."
+
+[[active]]
+name = "clippy::all"
+level = "warn"
+class = "category"
+reason = "Workspace baseline; tracked for promotion to explicit lints in PR 2."
+
+[[active]]
+name = "clippy::pedantic"
+level = "warn"
+class = "category"
+reason = "Workspace baseline; will be replaced with explicit selections in PR 2."
+
+[[active]]
+name = "clippy::nursery"
+level = "warn"
+class = "category"
+reason = "Workspace baseline; will be replaced with explicit selections in PR 2."
+
+# ---------------------------------------------------------------------------
+# Planned lints (PR 2 — strict baseline). These are the lints we intend to add
+# to [workspace.lints] in the next stacked PR. They are listed here so the
+# governance check can verify the next PR matches the plan.
+# ---------------------------------------------------------------------------
+
+[[planned]]
+name = "rust::unsafe_code"
+level = "forbid"
+activate_when_msrv = "1.92"
+class = "unsafe-memory"
+reason = "BitNet-rs already does not use unsafe Rust outside FFI shims; lock that in."
+overlay_exception = ["bitnet-kernels", "bitnet-rocm", "bitnet-cuda*", "bitnet-metal", "bitnet-vulkan", "bitnet-opencl", "bitnet-wgpu"]
+
+[[planned]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "unsafe-memory"
+reason = "Force explicit unsafe blocks even inside unsafe fn."
+
+[[planned]]
+name = "rust::unused_must_use"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Catch ignored Result/Future returns at compile time."
+
+[[planned]]
+name = "clippy::dbg_macro"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "diagnostic-debt"
+reason = "dbg!() must not ship; pre-commit already greps for it."
+
+[[planned]]
+name = "clippy::todo"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "diagnostic-debt"
+reason = "TDD scaffolds use #[ignore] tests with panic!(); never todo!() in shipping code."
+
+[[planned]]
+name = "clippy::unimplemented"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "diagnostic-debt"
+reason = "Same posture as todo!()."
+
+[[planned]]
+name = "clippy::panic"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Production code must propagate errors; tests use Result-returning helpers."
+
+[[planned]]
+name = "clippy::unreachable"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Use exhaustive matches or explicit error returns."
+
+[[planned]]
+name = "clippy::unwrap_used"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[planned]]
+name = "clippy::expect_used"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Same posture as unwrap_used; .expect() is just a labelled panic."
+
+[[planned]]
+name = "clippy::get_unwrap"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Slice access must be bounds-checked or use checked accessors."
+
+[[planned]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "A Result-returning function should propagate, not panic on failure."
+
+[[planned]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Same posture as unwrap_in_result."
+
+[[planned]]
+name = "clippy::indexing_slicing"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Numeric kernels must use checked_*, get(), or window iterators."
+
+[[planned]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Compile-time bounds violations are always bugs."
+
+[[planned]]
+name = "clippy::string_slice"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "String slicing on byte indices is a UTF-8 footgun."
+
+[[planned]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "panic"
+reason = "Use checked_duration_since to avoid panics on clock skew."
+
+[[planned]]
+name = "clippy::let_underscore_future"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Dropping a Future without awaiting cancels work silently."
+
+[[planned]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Suppressing #[must_use] with `let _ =` hides intent; use a binding with a reason."
+
+[[planned]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Dropping a lock guard immediately is almost always a bug."
+
+[[planned]]
+name = "clippy::unused_result_ok"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Use ? or explicit handling, not .ok() to discard."
+
+[[planned]]
+name = "clippy::map_err_ignore"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Ignoring the original error loses diagnostic information."
+
+[[planned]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "assert!(result.is_ok()) hides the actual error; unwrap or match instead."
+
+[[planned]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "silent-failure"
+reason = "Silently skipping IO errors is not a substitute for handling them."
+
+[[planned]]
+name = "clippy::allow_attributes"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "suppression-governance"
+reason = "Migrate every #[allow] to #[expect(..., reason = \"...\")]."
+
+[[planned]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "suppression-governance"
+reason = "Suppressions must justify themselves."
+
+[[planned]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+activate_when_msrv = "1.92"
+class = "suppression-governance"
+reason = "Restriction lints must be opted-in individually."
+
+# Numeric / GPU / kernel lane — staged carefully per the rollout plan.
+# These are kept at warn during PR 2 and only promoted in a later PR after
+# kernel debt is triaged.
+
+[[planned]]
+name = "clippy::float_cmp"
+level = "warn"
+activate_when_msrv = "1.92"
+class = "numeric"
+reason = "Bit-for-bit float comparison is rarely what kernels want; verify per call site."
+
+[[planned]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+activate_when_msrv = "1.92"
+class = "numeric"
+reason = "Track u64-as-usize and i32-as-isize sites; promote to deny per crate."
+
+[[planned]]
+name = "clippy::cast_sign_loss"
+level = "warn"
+activate_when_msrv = "1.92"
+class = "numeric"
+reason = "Audit signed-to-unsigned casts in tensor sizing paths."
+
+[[planned]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+activate_when_msrv = "1.92"
+class = "numeric"
+reason = "Audit usize-as-f32/f64 in metric and logging paths."
+
+[[planned]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+activate_when_msrv = "1.92"
+class = "numeric"
+reason = "Stays at warn for BitNet-rs; do not promote without kernel-debt triage."
+
+# ---------------------------------------------------------------------------
+# Rust 1.94 flip cohort (target activate_when_msrv = "1.94").
+# ---------------------------------------------------------------------------
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "good-taste"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+# ---------------------------------------------------------------------------
+# Rust 1.95 flip cohort (target activate_when_msrv = "1.95").
+# ---------------------------------------------------------------------------
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "good-taste"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "good-taste"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "good-taste"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "good-taste"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,69 @@
+# No-panic allowlist for bitnet-rs.
+#
+# When the strict Clippy baseline is active (see policy/clippy-lints.toml,
+# planned cohort with activate_when_msrv = "1.92"), the workspace forbids:
+#
+#   .unwrap(), .expect(), panic!(), todo!(), unimplemented!(), unreachable!()
+#
+# in both production and test code. Each call site that cannot yet comply must
+# be listed here with a *semantic* identifier — not a line/column pair, since
+# locations rot during refactors.
+#
+# Identity (must be unique per [[allow]]):
+#   path     + family + selector
+#
+# Locator (advisory only, used for diagnostics; refreshed by tooling):
+#   last_seen.line, last_seen.column
+#
+# Schema fields:
+#   schema_version : "0.3" (compatible with the ripr v0.2 model + owner/expires)
+#   [[allow]]
+#     path           : repo-relative source file
+#     family         : one of unwrap | expect | panic | todo | unimplemented | unreachable
+#     classification : test_only | fixture_setup | infallible_invariant | external_api_panic
+#                      | tdd_scaffold | other
+#     owner          : crate or team identifier
+#     explanation    : 1-3 sentences; must include why the panic is safe or temporary
+#     expires        : optional ISO-8601 date; required for tdd_scaffold and other
+#   [allow.selector]
+#     kind                  : method_call | macro_call | function_call
+#     container             : enclosing fn / impl / module path
+#     callee                : the panicking item (e.g. "unwrap", "panic")
+#     receiver_fingerprint  : optional; helps disambiguate multiple sites in one fn
+#   [allow.last_seen]
+#     line   : advisory
+#     column : advisory
+#
+# `cargo xtask check-no-panic-family` (added in a follow-up PR) will:
+#   - parse Rust with syn / rust-analyzer
+#   - reject panic-family calls outside this allowlist
+#   - reject stale entries (selector no longer present)
+#   - require owner + reason
+#   - fail expired entries
+#
+# This file is intentionally empty in PR 1 (governance scaffolding only).
+# It will be populated when the strict baseline is enabled, by walking the
+# existing tree and converting genuine carveouts (TDD scaffolds, fixture
+# setup, infallible invariants) into structured entries.
+
+schema_version = "0.3"
+
+# Example of the expected shape (commented out — not an active entry):
+#
+# [[allow]]
+# path           = "crates/bitnet-quantization/src/i2s/qk256/tests/golden.rs"
+# family         = "expect"
+# classification = "fixture_setup"
+# owner          = "quantization"
+# explanation    = "Loading checked-in golden fixture; missing fixture means a build-system bug, not a runtime path."
+# expires        = "2026-09-01"
+#
+# [allow.selector]
+# kind                 = "method_call"
+# container            = "load_qk256_golden"
+# callee               = "expect"
+# receiver_fingerprint = "std::fs::read(&fixture_path)"
+#
+# [allow.last_seen]
+# line   = 42
+# column = 17

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,218 @@
+# Non-Rust file policy allowlist for bitnet-rs.
+#
+# bitnet-rs is a Rust workspace. New non-Rust *programming* files (shell, Python,
+# C++, TypeScript, ...) require an explicit reviewed entry here that explains
+# why xtask / Rust is not the right home for that surface.
+#
+# Files always excluded from this policy (no entry needed):
+#   - Markdown / docs: *.md, docs/**, ROADMAP.md, CHANGELOG.md
+#   - Configuration: *.toml, *.yaml, *.yml, *.json (in conventional locations)
+#   - Build artefacts: target/**, Cargo.lock
+#   - License / repo metadata: LICENSE, .gitignore, .gitattributes, CODEOWNERS
+#   - Fixture inputs: fixtures/**, models/**, tests/**/fixtures/**
+#
+# For any other non-Rust source file, add an entry here.
+#
+# Schema fields:
+#   schema_version : "1.0"
+#   [[allow]]
+#     glob | path  : exactly one — repo-relative
+#     kind         : editor_extension | ci_declarative | ci_script | build_script
+#                    | fixture_input | reference_impl | binding_glue | tooling_script
+#                    | benchmark_harness | nix_module | container_artifact | other
+#     owner        : crate / team / surface identifier
+#     reason       : 1-3 sentences explaining why this is not a Rust/xtask surface
+#     surface      : ci | release | tooling | reference | editor | benchmarks
+#                    | infra | other
+#     classification : production | test | tooling | config | reference | example
+#     covered_by   : list of CI/test commands or workflows that exercise this file
+#     expires      : optional ISO-8601 date for known-temporary entries
+#
+# `cargo xtask check-file-policy` (added in a follow-up PR) will:
+#   - reject programming files not covered by an entry here
+#   - require owner + reason + surface + classification
+#   - require covered_by for production/test/tooling surfaces
+#   - fail expired entries
+#   - report unused / stale entries
+#
+# This file is the TOML migration of the prior pipe-delimited convention used
+# in `ripr`. It is seeded with the most common bitnet-rs non-Rust surfaces;
+# enforcement is wired up in a later PR (after `cargo xtask check-file-policy`
+# lands and the false-positive rate is tuned).
+
+schema_version = "1.0"
+
+# ---------- CI / release ----------
+
+[[allow]]
+glob           = ".github/workflows/*.yml"
+kind           = "ci_declarative"
+owner          = "release/ci"
+reason         = "GitHub Actions workflow definitions are platform-required YAML."
+surface        = "ci"
+classification = "config"
+covered_by     = ["cargo xtask check-workflows"]
+
+[[allow]]
+glob           = ".github/actions/**/*.yml"
+kind           = "ci_declarative"
+owner          = "release/ci"
+reason         = "Composite GitHub Actions definitions."
+surface        = "ci"
+classification = "config"
+covered_by     = ["cargo xtask check-workflows"]
+
+[[allow]]
+glob           = ".github/scripts/**/*.sh"
+kind           = "ci_script"
+owner          = "release/ci"
+reason         = "Workflow helpers invoked from GitHub Actions runners."
+surface        = "ci"
+classification = "tooling"
+covered_by     = ["shellcheck (via pre-commit)", "GitHub Actions runs"]
+
+[[allow]]
+glob           = ".githooks/**"
+kind           = "ci_script"
+owner          = "release/ci"
+reason         = "Pre-commit hook implementations."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = [".pre-commit-config.yaml"]
+
+# ---------- Build / packaging ----------
+
+[[allow]]
+path           = "Dockerfile"
+kind           = "container_artifact"
+owner          = "release/packaging"
+reason         = "Container image definition for reproducible builds."
+surface        = "release"
+classification = "config"
+covered_by     = ["GitHub Actions docker build job"]
+
+[[allow]]
+path           = "Makefile"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "Convenience entry points for common CI workflows; thin wrapper around xtask."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["make guards", "make CI matrix"]
+
+[[allow]]
+path           = "Makefile.ci"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "CI-only Make targets; same posture as Makefile."
+surface        = "ci"
+classification = "tooling"
+covered_by     = ["GitHub Actions"]
+
+[[allow]]
+path           = "Makefile.minimal"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "Minimal Make targets for constrained environments."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["docs/quickstart.md"]
+
+[[allow]]
+path           = "Justfile"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "Just task runner; mirror of Makefile entry points for contributors."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["docs/development/build-commands.md"]
+
+# ---------- Reference / cross-validation ----------
+
+[[allow]]
+glob           = "crates/*/src/**/*.cu"
+kind           = "reference_impl"
+owner          = "kernels/cuda"
+reason         = "CUDA kernel sources compiled by build.rs; required to be C++/CUDA, cannot be Rust."
+surface        = "reference"
+classification = "production"
+covered_by     = ["cargo build --features gpu", "GPU CI lane"]
+
+[[allow]]
+glob           = "crates/*/src/**/*.cpp"
+kind           = "binding_glue"
+owner          = "ffi"
+reason         = "C++ FFI shims for cross-validation against bitnet.cpp."
+surface        = "reference"
+classification = "production"
+covered_by     = ["cargo build --features ffi", "cargo run -p xtask -- fetch-cpp"]
+
+[[allow]]
+glob           = "crates/*/src/**/*.h"
+kind           = "binding_glue"
+owner          = "ffi"
+reason         = "C/C++ headers for FFI bindings."
+surface        = "reference"
+classification = "production"
+covered_by     = ["cargo build --features ffi"]
+
+[[allow]]
+glob           = "crates/*/build.rs"
+kind           = "build_script"
+owner          = "release/build"
+reason         = "Cargo build scripts; required to be Rust but excluded from no-panic policy until reviewed."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["cargo build"]
+
+# ---------- Nix ----------
+
+[[allow]]
+path           = "flake.nix"
+kind           = "nix_module"
+owner          = "release/nix"
+reason         = "Nix flake entry point for reproducible builds."
+surface        = "release"
+classification = "config"
+covered_by     = ["nix flake check", "nix build .#bitnet-cli"]
+
+[[allow]]
+glob           = "nix/**/*.nix"
+kind           = "nix_module"
+owner          = "release/nix"
+reason         = "Nix flake modules; required to be Nix, not Rust."
+surface        = "release"
+classification = "config"
+covered_by     = ["nix flake check"]
+
+# ---------- Documentation tooling ----------
+
+[[allow]]
+glob           = "docs/**/*.py"
+kind           = "tooling_script"
+owner          = "docs"
+reason         = "Documentation generators; pending migration to xtask."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["docs build job"]
+expires        = "2026-12-01"
+
+[[allow]]
+glob           = "scripts/**/*.sh"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "Operator scripts; pending audit and migration to xtask."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["shellcheck", "operator runbooks"]
+expires        = "2026-12-01"
+
+[[allow]]
+glob           = "scripts/**/*.py"
+kind           = "tooling_script"
+owner          = "release/ci"
+reason         = "Python operator scripts; pending audit and migration to xtask."
+surface        = "tooling"
+classification = "tooling"
+covered_by     = ["operator runbooks"]
+expires        = "2026-12-01"

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,574 @@
+//! `cargo xtask check-lint-policy` — verify the workspace lint governance
+//! ledger (`policy/clippy-lints.toml`), the lint debt ledger
+//! (`policy/clippy-debt.toml`), and the no-panic / non-Rust allowlists are
+//! self-consistent and consistent with `Cargo.toml` and
+//! `rust-toolchain.toml`.
+//!
+//! This is the PR 1 (governance scaffolding) implementation. It performs the
+//! checks that make sense before the strict lint baseline lands:
+//!
+//! 1. `policy/clippy-lints.toml` parses and has the expected schema version.
+//! 2. `policy.msrv` matches `workspace.package.rust-version` in `Cargo.toml`
+//!    and the channel pinned by `rust-toolchain.toml`.
+//! 3. Every `[[planned]]` entry has a sane `activate_when_msrv` — either the
+//!    current MSRV (already-active baseline) or a future Rust release.
+//! 4. Every `[[active]]` entry references a real lint name shape
+//!    (`<root>::<lint>`) and a recognised level.
+//! 5. `policy/clippy-debt.toml` parses; every entry has owner / reason / lint /
+//!    expiry; expired debt fails (warn-only in PR 1, gate in PR 2).
+//! 6. `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml`
+//!    parse and have the expected schema versions.
+//!
+//! It does *not* yet:
+//!   - Walk the AST to enforce the no-panic allowlist (planned: `xtask
+//!     check-no-panic-family`).
+//!   - Walk the file tree to enforce the non-Rust allowlist (planned: `xtask
+//!     check-file-policy`).
+//!   - Diff `policy/clippy-lints.toml` against `[workspace.lints]` in
+//!     `Cargo.toml` (added in PR 2 when the strict block lands).
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+const POLICY_DIR: &str = "policy";
+const LINTS_TOML: &str = "clippy-lints.toml";
+const DEBT_TOML: &str = "clippy-debt.toml";
+const NO_PANIC_TOML: &str = "no-panic-allowlist.toml";
+const NON_RUST_TOML: &str = "non-rust-allowlist.toml";
+
+const LINTS_SCHEMA: u32 = 1;
+const DEBT_SCHEMA: u32 = 1;
+const NO_PANIC_SCHEMA: &str = "0.3";
+const NON_RUST_SCHEMA: &str = "1.0";
+
+/// Mode in which the checker runs. `Advisory` reports findings but never
+/// returns a non-zero exit code; `Strict` fails on any finding. PR 1 wires
+/// this up as advisory; PR 2 promotes it to strict.
+#[derive(Clone, Copy, Debug)]
+pub enum Mode {
+    Advisory,
+    Strict,
+}
+
+#[derive(Debug, Deserialize)]
+struct LintsLedger {
+    schema: u32,
+    msrv: String,
+    #[serde(default)]
+    policy: Policy,
+    #[serde(default)]
+    active: Vec<ActiveLint>,
+    #[serde(default)]
+    planned: Vec<PlannedLint>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[allow(dead_code)] // fields are documented in policy/clippy-lints.toml; checker only reads a subset today
+struct Policy {
+    #[serde(default)]
+    panic_free_tests: bool,
+    #[serde(default)]
+    allow_test_carveouts: bool,
+    #[serde(default)]
+    suppression_style: Option<String>,
+    #[serde(default)]
+    blanket_categories: bool,
+    #[serde(default)]
+    target_panic_free_tests: bool,
+    #[serde(default)]
+    target_msrv: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActiveLint {
+    name: String,
+    level: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    class: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlannedLint {
+    name: String,
+    level: String,
+    activate_when_msrv: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    class: Option<String>,
+    reason: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    overlay_exception: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtLedger {
+    schema: u32,
+    #[serde(default)]
+    debt: Vec<DebtEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DebtEntry {
+    lint: String,
+    path: String,
+    owner: String,
+    reason: String,
+    expires: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct NoPanicLedger {
+    schema_version: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    allow: Vec<toml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NonRustLedger {
+    schema_version: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    allow: Vec<toml::Value>,
+}
+
+const VALID_LEVELS: &[&str] = &["allow", "warn", "deny", "forbid"];
+const VALID_LINT_PREFIXES: &[&str] = &["clippy::", "rust::", "rustc::", "rustdoc::"];
+
+pub fn run(mode: Mode) -> Result<()> {
+    let repo_root = repo_root()?;
+    let policy_dir = repo_root.join(POLICY_DIR);
+    if !policy_dir.is_dir() {
+        bail!(
+            "policy directory not found at {} — run from the workspace root or check that PR 1 has landed",
+            policy_dir.display()
+        );
+    }
+
+    let mut findings = Findings::default();
+
+    let lints = load_lints(&policy_dir, &mut findings);
+    load_debt(&policy_dir, lints.as_ref(), &mut findings);
+    load_no_panic(&policy_dir, &mut findings);
+    load_non_rust(&policy_dir, &mut findings);
+
+    if let Some(lints) = lints.as_ref() {
+        check_msrv_consistency(&repo_root, lints, &mut findings);
+    }
+
+    findings.report(mode)
+}
+
+#[derive(Default)]
+struct Findings {
+    info: Vec<String>,
+    warnings: Vec<String>,
+    errors: Vec<String>,
+}
+
+impl Findings {
+    fn info(&mut self, s: impl Into<String>) {
+        self.info.push(s.into());
+    }
+    fn warn(&mut self, s: impl Into<String>) {
+        self.warnings.push(s.into());
+    }
+    fn error(&mut self, s: impl Into<String>) {
+        self.errors.push(s.into());
+    }
+
+    fn report(self, mode: Mode) -> Result<()> {
+        for line in &self.info {
+            println!("info: {line}");
+        }
+        for line in &self.warnings {
+            println!("warn: {line}");
+        }
+        for line in &self.errors {
+            println!("error: {line}");
+        }
+
+        let summary = format!(
+            "lint policy: {} info, {} warnings, {} errors",
+            self.info.len(),
+            self.warnings.len(),
+            self.errors.len()
+        );
+
+        match mode {
+            Mode::Advisory => {
+                println!("{summary} (advisory mode — not failing build)");
+                Ok(())
+            }
+            Mode::Strict => {
+                println!("{summary}");
+                if self.errors.is_empty() {
+                    Ok(())
+                } else {
+                    bail!("lint policy check failed: {} error(s)", self.errors.len())
+                }
+            }
+        }
+    }
+}
+
+fn repo_root() -> Result<PathBuf> {
+    // The xtask binary is always invoked from the workspace root in CI and in
+    // the standard developer workflow, but be defensive: walk upward looking
+    // for a Cargo.toml that has [workspace].
+    let cwd = std::env::current_dir().context("getting current directory")?;
+    for ancestor in cwd.ancestors() {
+        let cargo = ancestor.join("Cargo.toml");
+        if cargo.is_file()
+            && fs::read_to_string(&cargo).map(|s| s.contains("[workspace]")).unwrap_or(false)
+        {
+            return Ok(ancestor.to_path_buf());
+        }
+    }
+    Ok(cwd)
+}
+
+fn load_lints(policy_dir: &Path, findings: &mut Findings) -> Option<LintsLedger> {
+    let path = policy_dir.join(LINTS_TOML);
+    let text = match fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            findings.error(format!("cannot read {}: {e}", path.display()));
+            return None;
+        }
+    };
+    let ledger: LintsLedger = match toml::from_str(&text) {
+        Ok(l) => l,
+        Err(e) => {
+            findings.error(format!("parsing {}: {e}", path.display()));
+            return None;
+        }
+    };
+
+    if ledger.schema != LINTS_SCHEMA {
+        findings.error(format!(
+            "{}: schema = {}, expected {LINTS_SCHEMA}",
+            path.display(),
+            ledger.schema
+        ));
+    }
+
+    let mut seen: BTreeSet<String> = BTreeSet::new();
+    for lint in &ledger.active {
+        check_lint_name(&lint.name, &path, "active", findings);
+        check_level(&lint.level, &lint.name, &path, findings);
+        if !seen.insert(format!("active:{}", lint.name)) {
+            findings.error(format!(
+                "{}: duplicate [[active]] entry for {}",
+                path.display(),
+                lint.name
+            ));
+        }
+    }
+    for lint in &ledger.planned {
+        check_lint_name(&lint.name, &path, "planned", findings);
+        check_level(&lint.level, &lint.name, &path, findings);
+        check_planned_msrv(&lint.activate_when_msrv, &lint.name, &ledger.msrv, &path, findings);
+        if lint.reason.as_deref().unwrap_or("").trim().is_empty() {
+            findings.error(format!(
+                "{}: planned lint {} is missing `reason`",
+                path.display(),
+                lint.name
+            ));
+        }
+        if !seen.insert(format!("planned:{}:{}", lint.name, lint.activate_when_msrv)) {
+            findings.error(format!(
+                "{}: duplicate [[planned]] entry for {} @ {}",
+                path.display(),
+                lint.name,
+                lint.activate_when_msrv
+            ));
+        }
+    }
+
+    if ledger.policy.target_panic_free_tests && ledger.policy.allow_test_carveouts {
+        findings.info(
+            "policy.target_panic_free_tests=true with allow_test_carveouts=true — \
+             test carveouts are scheduled for removal in a follow-up PR"
+                .to_string(),
+        );
+    }
+    if let Some(style) = &ledger.policy.suppression_style
+        && style != "expect-with-reason"
+    {
+        findings.warn(format!(
+            "policy.suppression_style = {style:?}; the workspace standard is \"expect-with-reason\""
+        ));
+    }
+
+    Some(ledger)
+}
+
+fn load_debt(policy_dir: &Path, lints: Option<&LintsLedger>, findings: &mut Findings) {
+    let path = policy_dir.join(DEBT_TOML);
+    let text = match fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            findings.error(format!("cannot read {}: {e}", path.display()));
+            return;
+        }
+    };
+    let ledger: DebtLedger = match toml::from_str(&text) {
+        Ok(l) => l,
+        Err(e) => {
+            findings.error(format!("parsing {}: {e}", path.display()));
+            return;
+        }
+    };
+    if ledger.schema != DEBT_SCHEMA {
+        findings.error(format!(
+            "{}: schema = {}, expected {DEBT_SCHEMA}",
+            path.display(),
+            ledger.schema
+        ));
+    }
+
+    let known_lints: BTreeSet<&str> = lints
+        .map(|l| {
+            l.active
+                .iter()
+                .map(|a| a.name.as_str())
+                .chain(l.planned.iter().map(|p| p.name.as_str()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let today = chrono::Utc::now().date_naive();
+    for entry in &ledger.debt {
+        for (name, value) in [
+            ("lint", &entry.lint),
+            ("path", &entry.path),
+            ("owner", &entry.owner),
+            ("reason", &entry.reason),
+            ("expires", &entry.expires),
+        ] {
+            if value.trim().is_empty() {
+                findings.error(format!(
+                    "{}: debt entry for {} has empty `{}`",
+                    path.display(),
+                    entry.lint,
+                    name
+                ));
+            }
+        }
+        if !known_lints.is_empty() && !known_lints.contains(entry.lint.as_str()) {
+            findings.error(format!(
+                "{}: debt entry references unknown lint {}",
+                path.display(),
+                entry.lint
+            ));
+        }
+        match chrono::NaiveDate::parse_from_str(&entry.expires, "%Y-%m-%d") {
+            Ok(exp) if exp < today => {
+                findings.error(format!(
+                    "{}: debt entry for {} ({}) expired on {}",
+                    path.display(),
+                    entry.lint,
+                    entry.path,
+                    entry.expires
+                ));
+            }
+            Ok(_) => {}
+            Err(_) => {
+                findings.error(format!(
+                    "{}: debt entry for {} has unparseable `expires = {:?}` (want YYYY-MM-DD)",
+                    path.display(),
+                    entry.lint,
+                    entry.expires
+                ));
+            }
+        }
+    }
+}
+
+fn load_no_panic(policy_dir: &Path, findings: &mut Findings) {
+    let path = policy_dir.join(NO_PANIC_TOML);
+    let text = match fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            findings.error(format!("cannot read {}: {e}", path.display()));
+            return;
+        }
+    };
+    let ledger: NoPanicLedger = match toml::from_str(&text) {
+        Ok(l) => l,
+        Err(e) => {
+            findings.error(format!("parsing {}: {e}", path.display()));
+            return;
+        }
+    };
+    if ledger.schema_version != NO_PANIC_SCHEMA {
+        findings.error(format!(
+            "{}: schema_version = {:?}, expected {:?}",
+            path.display(),
+            ledger.schema_version,
+            NO_PANIC_SCHEMA
+        ));
+    }
+}
+
+fn load_non_rust(policy_dir: &Path, findings: &mut Findings) {
+    let path = policy_dir.join(NON_RUST_TOML);
+    let text = match fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) => {
+            findings.error(format!("cannot read {}: {e}", path.display()));
+            return;
+        }
+    };
+    let ledger: NonRustLedger = match toml::from_str(&text) {
+        Ok(l) => l,
+        Err(e) => {
+            findings.error(format!("parsing {}: {e}", path.display()));
+            return;
+        }
+    };
+    if ledger.schema_version != NON_RUST_SCHEMA {
+        findings.error(format!(
+            "{}: schema_version = {:?}, expected {:?}",
+            path.display(),
+            ledger.schema_version,
+            NON_RUST_SCHEMA
+        ));
+    }
+}
+
+fn check_lint_name(name: &str, path: &Path, kind: &str, findings: &mut Findings) {
+    if !VALID_LINT_PREFIXES.iter().any(|p| name.starts_with(p)) {
+        findings.error(format!(
+            "{}: {kind} lint {name:?} must start with one of {VALID_LINT_PREFIXES:?}",
+            path.display()
+        ));
+    }
+}
+
+fn check_level(level: &str, lint: &str, path: &Path, findings: &mut Findings) {
+    if !VALID_LEVELS.contains(&level) {
+        findings.error(format!(
+            "{}: lint {lint} has invalid level {level:?} (want one of {VALID_LEVELS:?})",
+            path.display()
+        ));
+    }
+}
+
+fn check_planned_msrv(
+    target: &str,
+    lint: &str,
+    current: &str,
+    path: &Path,
+    findings: &mut Findings,
+) {
+    let target_v = parse_msrv(target);
+    let current_v = parse_msrv(current);
+    let (Some(target_v), Some(current_v)) = (target_v, current_v) else {
+        findings.error(format!(
+            "{}: planned lint {lint} has unparseable `activate_when_msrv = {target:?}`",
+            path.display()
+        ));
+        return;
+    };
+    if target_v < current_v {
+        findings.error(format!(
+            "{}: planned lint {lint} activates at {target} but workspace MSRV is already {current}",
+            path.display()
+        ));
+    }
+}
+
+fn parse_msrv(s: &str) -> Option<(u32, u32)> {
+    let mut parts = s.split('.').take(2);
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+fn check_msrv_consistency(repo_root: &Path, lints: &LintsLedger, findings: &mut Findings) {
+    // workspace.package.rust-version
+    let cargo_path = repo_root.join("Cargo.toml");
+    if let Ok(cargo) = fs::read_to_string(&cargo_path) {
+        match extract_rust_version(&cargo) {
+            Some(rust_version) if !msrv_matches(&rust_version, &lints.msrv) => {
+                findings.error(format!(
+                    "MSRV mismatch: Cargo.toml workspace.package.rust-version = {rust_version:?}, \
+                     policy/clippy-lints.toml msrv = {:?}",
+                    lints.msrv
+                ));
+            }
+            Some(_) => {}
+            None => findings.warn(format!(
+                "{}: could not locate workspace.package.rust-version",
+                cargo_path.display()
+            )),
+        }
+    }
+
+    // rust-toolchain.toml channel
+    let toolchain_path = repo_root.join("rust-toolchain.toml");
+    if let Ok(text) = fs::read_to_string(&toolchain_path)
+        && let Some(channel) = extract_toolchain_channel(&text)
+        && !msrv_matches(&channel, &lints.msrv)
+    {
+        findings.error(format!(
+            "MSRV mismatch: rust-toolchain.toml channel = {channel:?}, \
+             policy/clippy-lints.toml msrv = {:?}",
+            lints.msrv
+        ));
+    }
+}
+
+fn msrv_matches(left: &str, right: &str) -> bool {
+    parse_msrv(left) == parse_msrv(right)
+}
+
+fn extract_rust_version(cargo_toml: &str) -> Option<String> {
+    // Look for the workspace.package table and pull rust-version. We do this
+    // by string scanning rather than a typed parse so we don't have to model
+    // the full workspace manifest schema.
+    let value: toml::Value = toml::from_str(cargo_toml).ok()?;
+    let workspace = value.get("workspace")?.as_table()?;
+    let package = workspace.get("package")?.as_table()?;
+    let rust_version = package.get("rust-version")?.as_str()?;
+    Some(rust_version.to_string())
+}
+
+fn extract_toolchain_channel(text: &str) -> Option<String> {
+    let value: toml::Value = toml::from_str(text).ok()?;
+    let toolchain = value.get("toolchain")?.as_table()?;
+    let channel = toolchain.get("channel")?.as_str()?;
+    Some(channel.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_msrv() {
+        assert_eq!(parse_msrv("1.92"), Some((1, 92)));
+        assert_eq!(parse_msrv("1.92.0"), Some((1, 92)));
+        assert_eq!(parse_msrv("1.93"), Some((1, 93)));
+        assert!(parse_msrv("nightly").is_none());
+        assert!(parse_msrv("").is_none());
+    }
+
+    #[test]
+    fn msrv_matching_is_minor_level() {
+        assert!(msrv_matches("1.92", "1.92.0"));
+        assert!(msrv_matches("1.92.0", "1.92"));
+        assert!(!msrv_matches("1.92", "1.93"));
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,6 +44,7 @@ mod gates;
 mod grid_check;
 #[allow(dead_code)]
 mod health_check;
+mod lint_policy;
 #[allow(dead_code)]
 mod model_info;
 mod model_registry;
@@ -1003,6 +1004,20 @@ enum Cmd {
         #[command(subcommand)]
         command: campaign::CampaignCmd,
     },
+
+    /// Verify the workspace lint governance ledger (`policy/clippy-lints.toml`)
+    /// is internally consistent and matches `Cargo.toml` and
+    /// `rust-toolchain.toml`.
+    ///
+    /// Advisory by default (always exits 0). Pass `--strict` to fail on any
+    /// finding; this is what CI will use once the strict lint baseline lands
+    /// in PR 2 of the Clippy governance rollout.
+    #[command(name = "check-lint-policy")]
+    CheckLintPolicy {
+        /// Fail the command on any finding instead of just reporting them.
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1329,6 +1344,11 @@ fn real_main() -> Result<()> {
             grid_check::run(cpu_only, verbose, dry_run)
         }
         Cmd::Campaign { command } => campaign::run(command),
+        Cmd::CheckLintPolicy { strict } => lint_policy::run(if strict {
+            lint_policy::Mode::Strict
+        } else {
+            lint_policy::Mode::Advisory
+        }),
     }
 }
 


### PR DESCRIPTION
## Summary

Base of a stacked rollout that turns Clippy into a **governed engineering surface** rather than ad-hoc settings in `Cargo.toml`. **No lint behaviour changes in this PR** — only policy infrastructure.

- `policy/clippy-lints.toml` — machine-readable ledger of active lints + planned Rust 1.94/1.95 flip cohorts
- `policy/clippy-debt.toml` — seed for tracked exceptions (owner / reason / lint / `expires`)
- `policy/no-panic-allowlist.toml` — semantic schema (`path + family + selector`) ported from the `ripr` v0.2 model
- `policy/non-rust-allowlist.toml` — TOML migration of the prior pipe-delimited non-Rust file policy
- `docs/CLIPPY_POLICY.md` — policy doc, suppression style (`#[expect(..., reason = "...")]`), BitNet-rs overlay, rollout schedule
- `cargo xtask check-lint-policy` — advisory by default, `--strict` available for CI once PR 2 lands

## What the checker verifies today

1. Schema versions of all four `policy/*.toml` files.
2. MSRV agreement between `policy/clippy-lints.toml`, `workspace.package.rust-version`, and `rust-toolchain.toml` channel.
3. Every planned lint activates at the current MSRV or a future one (never past).
4. Debt entries have `owner` / `reason` / `lint` / `expires`, expiry is parseable, and not in the past.
5. Lint names use a recognised root (`clippy::`, `rust::`, `rustc::`, `rustdoc::`).

It deliberately does **not** yet:
- Walk the AST to enforce the no-panic allowlist (planned: `xtask check-no-panic-family`).
- Walk the file tree to enforce the non-Rust allowlist (planned: `xtask check-file-policy`).
- Diff `policy/clippy-lints.toml` against `[workspace.lints]` — that lands with PR 2 when the strict block is applied.

## Stack plan

| PR  | Branch (planned)                                | Scope |
|-----|--------------------------------------------------|-------|
| **1** | `claude/clippy-governance-system-HERR6` (this) | Governance scaffolding only. Zero lint behaviour change. |
| 2   | `claude/clippy-strict-baseline-...`              | Replace `all`/`pedantic`/`nursery` with explicit lint set; remove `allow-unwrap-in-tests` / `allow-expect-in-tests` from `clippy.toml`; seed `policy/clippy-debt.toml` with the resulting violations (named owner + ≤90-day expiry); promote `xtask check-lint-policy` to CI gate. |
| 3   | `claude/clippy-msrv-1.93-...`                    | Bump MSRV 1.92 → 1.93 in `rust-toolchain.toml`, `workspace.package.rust-version`, and `policy/clippy-lints.toml`. Promote `warn` numeric lints → `deny` per crate. |
| 4+  | `claude/clippy-1.94-cohort-...` etc.             | Activate planned `activate_when_msrv = "1.94"` / `"1.95"` cohorts when MSRV reaches each. |

## BitNet-rs overlay (encoded in `policy/clippy-lints.toml`)

- Panic / silent-failure / suppression-governance lints → **`deny`** at PR 2.
- `unsafe_code` → **`forbid`**, with a documented exception list for GPU backend crates (`bitnet-kernels`, `bitnet-rocm`, `bitnet-cuda*`, `bitnet-metal`, `bitnet-vulkan`, `bitnet-opencl`, `bitnet-wgpu`).
- Numeric correctness lints (`cast_*`, `float_cmp`) start at **`warn`**; `arithmetic_side_effects` stays `warn` indefinitely until kernel debt is triaged.
- Test carveouts (`allow-unwrap-in-tests` etc.) currently in `clippy.toml` → flagged as `info` today, scheduled for removal in PR 2.

## Test plan

- [x] `cargo build --locked -p xtask --no-default-features` — clean build
- [x] `cargo clippy --locked -p xtask --no-default-features --bin xtask --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --locked -p xtask --no-default-features --bin xtask lint_policy::` — 2 passed
- [x] `cargo run --locked -p xtask --no-default-features -- check-lint-policy` — `1 info, 0 warnings, 0 errors`
- [x] `cargo run --locked -p xtask --no-default-features -- check-lint-policy --strict` — exit 0
- [ ] Manual review of policy schema before PR 2 begins seeding `clippy-debt.toml`

## Why review this in isolation

PR 2 will produce a *large* set of debt entries when it removes the `pedantic`/`nursery` warn block in favour of the explicit list and drops the test carveouts. Landing the schema, doc, and checker first means PR 2's diff is "applied lint policy + reviewed debt list" rather than "lots of new files mixed with lint changes."

https://claude.ai/code/session_01B5tBepFTH4UCnpBqXGt4CC

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5tBepFTH4UCnpBqXGt4CC)_