### PR TITLE
docs(tracking): sync Apple M4 PR state

### DIFF
--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -35,7 +35,7 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-003 | merged | Apple Metal, MPSGraph, and CPU/NEON backend identity merged in #3652. |
 | M4-004 | merged | Add Metal device probe. |
 | M4-005 | ready | Run tiny Metal compute smoke. |
-| M4-006 | proposed | Add CPU/Metal parity. |
+| M4-006 | pr_open | Add CPU/Metal parity in #3709. |
 | M4-007 | proposed | Run MPSGraph tiny graph smoke. |
 | M4-008 | proposed | Record Apple backend identity in receipts. |
 | M4-009 | proposed | Add benchmark baseline after parity and receipt identity. |

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -192,7 +192,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-006"
-status = "ready"
+status = "pr_open"
 branch = "codex/apple-m4/M4-006-metal-cpu-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T094504Z-M4-006-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T094504Z-M4-006-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T09:45:04Z"
+campaign = "apple-m4"
+item = "M4-006"
+event = "pr_open"
+previous_status = "ready"
+new_status = "pr_open"
+pr = 3709
+head_sha = "20b9ba2af5b9f7058281dc80a94679e1a739527e"
+actor = "codex"
+notes = [
+  "Recorded live GitHub state for the M4-006 CPU/Metal parity PR so campaign doctor can reconcile open PR claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -14,7 +14,7 @@
 | M4-003 | merged | #3652 | `codex/apple-m4/M4-003-backend-identity` | Preserve Apple M4 Metal, MPSGraph, and CPU/NEON backend identity without adding runtime execution or kernels. |
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
-| M4-006 | ready | TBD | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
+| M4-006 | pr_open | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | proposed | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-006 | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |
 | apple-m4 | M4-005 | M4-004 | merged |
-| apple-m4 | M4-006 | M4-005 | ready |
+| apple-m4 | M4-006 | M4-005 | pr_open |
 | apple-m4 | M4-007 | M4-006 | proposed |
 | apple-m4 | M4-008 | M4-007 | proposed |
 | apple-m4 | M4-009 | M4-008 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-006 | TBD | ready | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-006 | #3709 | pr_open | M4-007 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- record the live M4-006 PR #3709 in the Apple M4 campaign tracker
- add the pr_open event with the current #3709 head SHA
- regenerate campaign dashboards so campaign doctor can reconcile open PR claims

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign generate
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

## Notes
- Tracker-only reconciliation; no Metal kernel, CUDA, QK256, inference, or benchmark code changes.