### PR TITLE
Introduce Effortless Metrics Clippy policy, policy ledgers, no‑panic allowlists, and xtask gate; bump MSRV to 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ autoexamples = false
 autotests = false
 autobenches = false
 
+
+[lints]
+workspace = true
 [lib]
 # Library source
 
@@ -238,7 +241,7 @@ keywords = ["machine-learning", "llm", "quantization", "inference", "bitnet"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
-rust-version = "1.92.0"
+rust-version = "1.93"
 version = "0.2.1-dev"
 
 [dependencies]
@@ -539,16 +542,132 @@ debug = true
 [profile.dev.package."*"]
 opt-level = 2
 
-# Workspace-level lints for code quality
+# Effortless Metrics strict lint policy.
+# Keep this block in sync with policy/clippy-lints.toml and
+# docs/CLIPPY_POLICY.md. Repo-specific exceptions belong in
+# policy/clippy-debt.toml or narrow #[expect(..., reason = "...")]
+# suppressions, not in broad test carveouts.
+[workspace.lints.rust]
+unsafe_code = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+
 [workspace.lints.clippy]
-all = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
-nursery = { level = "warn", priority = -1 }
-pedantic = { level = "warn", priority = -1 }
-ptr_arg = "deny"
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness; GPU/numeric debt is tracked explicitly while staged.
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 # Workspace-level feature flags for convenience
 [workspace.metadata.docs.rs]
@@ -586,4 +705,4 @@ keywords = [
   "inference",        # Model inference
   "bitnet",           # BitNet specific
 ]
-msrv = "1.92.0"
+msrv = "1.93"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,16 +1,18 @@
-# Clippy configuration for bitnet-rs
-# Ensures high code quality standards for crates.io publication
+# Repo-local Clippy configuration for BitNet-rs.
+#
+# Do not add test carveouts here. The workspace policy is panic-free across
+# production code and tests. Temporary exceptions must be represented as
+# narrow #[expect(..., reason = "...")] suppressions and tracked in
+# policy/clippy-debt.toml when they represent migration debt.
+#
+# This file is reserved for repo-specific disallowed methods, types, macros,
+# and similar domain-policy additions.
 
 # MSRV compatibility
-msrv = "1.92.0"
+msrv = "1.93"
 
-# Complexity thresholds
+# Complexity thresholds retained from the previous BitNet-rs Clippy profile.
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 8
 type-complexity-threshold = 250
 trivial-copy-size-limit = 64
-
-# Allow certain patterns common in ML/systems code
-allow-expect-in-tests = true
-allow-unwrap-in-tests = true
-allow-mixed-uninlined-format-args = true  # Performance in hot paths

--- a/crates/bitnet-api-key-auth-core/Cargo.toml
+++ b/crates/bitnet-api-key-auth-core/Cargo.toml
@@ -10,5 +10,8 @@ name = "bitnet-api-key-auth-core"
 repository.workspace = true
 version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }

--- a/crates/bitnet-bdd-grid-core/Cargo.toml
+++ b/crates/bitnet-bdd-grid-core/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Core BDD scenario, feature, and grid primitives for BitNet"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [dev-dependencies]

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -11,6 +11,9 @@ categories.workspace = true
 description = "Canonical BDD scenario + feature-grid primitives for BitNet tests and tooling"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_bdd_grid"
 path = "src/lib.rs"

--- a/crates/bitnet-bench-receipts/Cargo.toml
+++ b/crates/bitnet-bench-receipts/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "Receipt model and JSONL store for benchmark result tracking"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/bitnet-bench-regression-core/Cargo.toml
+++ b/crates/bitnet-bench-regression-core/Cargo.toml
@@ -6,5 +6,8 @@ rust-version = "1.92.0"
 description = "Core benchmark regression detection primitives"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }

--- a/crates/bitnet-cli-config-core/Cargo.toml
+++ b/crates/bitnet-cli-config-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP core crate for BitNet CLI configuration contracts and validation"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_cli"
 path = "src/lib.rs"

--- a/crates/bitnet-common/Cargo.toml
+++ b/crates/bitnet-common/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "WARN_ONCE_README.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-math.workspace = true
 bitnet-warn-once.workspace = true

--- a/crates/bitnet-compat-core/Cargo.toml
+++ b/crates/bitnet-compat-core/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["BitNet Contributors"]
 description = "SRP core GGUF compatibility diagnostics"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-compat/Cargo.toml
+++ b/crates/bitnet-compat/Cargo.toml
@@ -7,6 +7,9 @@ authors = ["BitNet Contributors"]
 description = "Compatibility layer for drop-in llama.cpp replacement"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-cpu-activations/Cargo.toml
+++ b/crates/bitnet-cpu-activations/Cargo.toml
@@ -10,5 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 description = "CPU activation kernels extracted as an SRP microcrate"
 
+
+[lints]
+workspace = true
 [dependencies]
 libm = "0.2.16"

--- a/crates/bitnet-cpu-detect/Cargo.toml
+++ b/crates/bitnet-cpu-detect/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [features]

--- a/crates/bitnet-device-config-core/Cargo.toml
+++ b/crates/bitnet-device-config-core/Cargo.toml
@@ -10,6 +10,9 @@ description = "SRP core device configuration parsing and resolution"
 keywords.workspace = true
 categories.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }

--- a/crates/bitnet-dispatch-core/Cargo.toml
+++ b/crates/bitnet-dispatch-core/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "Backend-agnostic compute dispatch sizing and recording primitives"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [features]

--- a/crates/bitnet-eval-core/Cargo.toml
+++ b/crates/bitnet-eval-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP helpers for evaluation and scoring math"
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_eval_core"
 path = "src/lib.rs"

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Compact feature and BDD profile contracts for BitNet tooling"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
 bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Shared feature flag and BDD profile matrix contracts"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-profile-core = { path = "../bitnet-runtime-profile-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-ffi/Cargo.toml
+++ b/crates/bitnet-ffi/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "C API bindings for BitNet"
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_ffi"
 # add rlib so integration tests can import the crate by name

--- a/crates/bitnet-ggml-ffi/Cargo.toml
+++ b/crates/bitnet-ggml-ffi/Cargo.toml
@@ -20,6 +20,9 @@ include = [
   "csrc/**",
 ]
 
+
+[lints]
+workspace = true
 [features]
 integration-tests = []
 # When enabled, we compile the GGML shim and expose IQ2_S dequantization.

--- a/crates/bitnet-honest-compute/Cargo.toml
+++ b/crates/bitnet-honest-compute/Cargo.toml
@@ -17,6 +17,9 @@ include = [
   "README.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [features]

--- a/crates/bitnet-inference-metrics-core/Cargo.toml
+++ b/crates/bitnet-inference-metrics-core/Cargo.toml
@@ -14,5 +14,8 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 serde = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -17,6 +17,9 @@ include = [
   "csrc/**",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-cpu-activations = { path = "../bitnet-cpu-activations", version = "0.2.1-dev" }

--- a/crates/bitnet-math/Cargo.toml
+++ b/crates/bitnet-math/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 # No runtime dependencies
 

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-qk256-layout-core = { path = "../bitnet-qk256-layout-core", version = "0.2.1-dev" }

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "NVIDIA-specific GPU tuning heuristics shared across BitNet backends"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [dev-dependencies]

--- a/crates/bitnet-prompt-templates-core/Cargo.toml
+++ b/crates/bitnet-prompt-templates-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-prompt-templates-core = { path = "../bitnet-prompt-templates-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 description = "Python bindings for BitNet.cpp Rust implementation"
 readme = "README.md"
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_py"
 crate-type = ["cdylib"]

--- a/crates/bitnet-qk256-dispatch/Cargo.toml
+++ b/crates/bitnet-qk256-dispatch/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-qk256-layout-core = { path = "../bitnet-qk256-layout-core", version = "0.2.1-dev" }

--- a/crates/bitnet-qk256-layout-core/Cargo.toml
+++ b/crates/bitnet-qk256-layout-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 thiserror = { workspace = true }
 

--- a/crates/bitnet-quantization-bits/Cargo.toml
+++ b/crates/bitnet-quantization-bits/Cargo.toml
@@ -14,5 +14,8 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-qk256-layout-core = { path = "../bitnet-qk256-layout-core", version = "0.2.1-dev" }

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-receipts-core = { path = "../bitnet-receipts-core", version = "0.2.1-dev", default-features = false }
 

--- a/crates/bitnet-repl-core/Cargo.toml
+++ b/crates/bitnet-repl-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP microcrate for chat REPL state management"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 

--- a/crates/bitnet-rocm/Cargo.toml
+++ b/crates/bitnet-rocm/Cargo.toml
@@ -15,6 +15,9 @@ include = [
     "README.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [dev-dependencies]

--- a/crates/bitnet-rope/Cargo.toml
+++ b/crates/bitnet-rope/Cargo.toml
@@ -16,6 +16,9 @@ include = [
   "README.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [features]

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-startup-contract = { path = "../bitnet-startup-contract", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-context-core = { path = "../bitnet-runtime-context-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev" }
 bitnet-runtime-feature-flags-core = { path = "../bitnet-runtime-feature-flags-core", version = "0.2.1-dev" }

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bdd-grid = { path = "../bitnet-bdd-grid", version = "0.2.1-dev" }
 bitnet-runtime-context = { path = "../bitnet-runtime-context", version = "0.2.1-dev" }

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-profile-contract-core = { path = "../bitnet-runtime-profile-contract-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Core runtime profile, BDD, and feature-flag contracts"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-profile-contract = { path = "../bitnet-runtime-profile-contract", version = "0.2.1-dev" }
 

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Runtime profile, BDD, and feature-flagging utilities for BitNet"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-feature-matrix = { path = "../bitnet-feature-matrix", version = "0.2.1-dev" }
 

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = { workspace = true }
 tracing = { workspace = true }

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -16,6 +16,9 @@ include = [
   "HEALTH_ENDPOINTS.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-api-key-auth-core = { path = "../bitnet-api-key-auth-core", version = "0.2.1-dev" }
 anyhow.workspace = true

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -8,6 +8,9 @@ homepage.workspace = true
 authors.workspace = true
 description = "SafeTensors utilities for BitNet: LN inspection and LN-preserving merge"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [[bin]]
 name = "st2gguf"
 path = "src/main.rs"

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }

--- a/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Core startup contract diagnostics and profile reporting model"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Compatibility facade for bitnet-startup-contract-diagnostics-core"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-startup-contract-diagnostics-core = { path = "../bitnet-startup-contract-diagnostics-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Startup contract orchestration helper with BDD+feature diagnostics for runtime entrypoints."
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Startup contract primitives powered by BDD grid and runtime feature profile"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-startup-contract-core = { path = "../bitnet-startup-contract-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -14,6 +14,9 @@ readme = "README.md"
 rust-version.workspace = true
 publish = false                                                                          # Internal crate, not published
 
+
+[lints]
+workspace = true
 [features]
 default = []
 ffi = ["dep:bindgen", "dep:cc"]  # Enable native/C++ build only when requested

--- a/crates/bitnet-test-env/Cargo.toml
+++ b/crates/bitnet-test-env/Cargo.toml
@@ -9,6 +9,9 @@ authors.workspace = true
 description = "Thread-safe test environment variable isolation primitives for BitNet-rs"
 publish = true
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [dev-dependencies]

--- a/crates/bitnet-test-fixtures-core/Cargo.toml
+++ b/crates/bitnet-test-fixtures-core/Cargo.toml
@@ -10,4 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP helpers for resolving and loading test fixtures"
 
+
+[lints]
+workspace = true
 [dependencies]

--- a/crates/bitnet-test-support/Cargo.toml
+++ b/crates/bitnet-test-support/Cargo.toml
@@ -9,6 +9,9 @@ authors.workspace = true
 description = "Shared test infrastructure for BitNet-rs: EnvGuard/EnvScope, model-path gating, RNG seeds"
 publish = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-test-env.workspace = true
 

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
 bitnet-feature-contract = { path = "../bitnet-feature-contract", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Core policy and BDD compatibility orchestration for BitNet runtime and scenario configuration"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
 bitnet-testing-policy-snapshot-core = { path = "../bitnet-testing-policy-snapshot-core", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Interoperability façade for BitNet testing policy, BDD grid, and runtime feature flags"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-contract = { path = "../bitnet-testing-policy-contract", version = "0.2.1-dev" }
 bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy = { path = "../bitnet-testing-policy", version = "0.2.1-dev" }
 

--- a/crates/bitnet-testing-policy-runtime-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-state-core = { path = "../bitnet-testing-policy-state-core", version = "0.2.1-dev" }
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
 bitnet-testing-policy-runtime-core = { path = "../bitnet-testing-policy-runtime-core", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Policy snapshot resolution helpers for BitNet testing configuration contexts"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
 bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-state-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-state-core/Cargo.toml
@@ -15,5 +15,8 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-runtime = { path = "../bitnet-testing-policy-runtime", version = "0.2.1-dev" }
 

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Stable orchestration layer for test policy/profile resolution"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-policy-core = { path = "../bitnet-testing-policy-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -12,6 +12,9 @@ categories.workspace = true
 description = "Testing-focused façade over BDD grid and feature-flag profile contracts"
 include = ["src/**", "Cargo.toml"]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-runtime-profile = { path = "../bitnet-runtime-profile", version = "0.2.1-dev" }
 

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-scenarios-profile-core = { path = "../bitnet-testing-scenarios-profile-core", version = "0.2.1-dev" }
 num_cpus = "1.17.0"

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-profile = { path = "../bitnet-testing-profile", version = "0.2.1-dev" }
 num_cpus = "1.17.0"

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -15,6 +15,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-testing-scenarios-core = { path = "../bitnet-testing-scenarios-core", version = "0.2.1-dev" }
 

--- a/crates/bitnet-thread-config-core/Cargo.toml
+++ b/crates/bitnet-thread-config-core/Cargo.toml
@@ -10,4 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP thread configuration and work partitioning primitives"
 
+
+[lints]
+workspace = true
 [dependencies]

--- a/crates/bitnet-token-merge-core/Cargo.toml
+++ b/crates/bitnet-token-merge-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP core token span merge/split utilities"
 
+
+[lints]
+workspace = true
 [dependencies]
 
 [dev-dependencies]

--- a/crates/bitnet-tokenizer-discovery-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-discovery-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "SRP core crate for tokenizer path auto-discovery and resolution"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 tracing.workspace = true

--- a/crates/bitnet-tokenizer-model-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-model-core/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Core model/vocabulary detection helpers for tokenizers"
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -16,6 +16,9 @@ include = [
   "TEST_COVERAGE_SUMMARY.md",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 license = "MIT OR Apache-2.0"
 description = "Tensor activation tracing for bitnet-rs cross-validation debugging"
 
+
+[lints]
+workspace = true
 [dependencies]
 blake3 = "1.8.2"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }

--- a/crates/bitnet-validation/Cargo.toml
+++ b/crates/bitnet-validation/Cargo.toml
@@ -10,6 +10,9 @@ authors.workspace = true
 description = "Architecture-aware LayerNorm and projection weight validation rules for BitNet models"
 readme = "README.md"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow.workspace = true
 regex = "1.12.2"

--- a/crates/bitnet-warn-once/Cargo.toml
+++ b/crates/bitnet-warn-once/Cargo.toml
@@ -14,6 +14,9 @@ include = [
   "Cargo.toml",
 ]
 
+
+[lints]
+workspace = true
 [dependencies]
 tracing.workspace = true
 

--- a/crates/bitnet-wasm-utils/Cargo.toml
+++ b/crates/bitnet-wasm-utils/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "Shared WebAssembly runtime utilities for BitNet crates"
 
+
+[lints]
+workspace = true
 [dependencies]
 thiserror = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/bitnet-wasm/Cargo.toml
+++ b/crates/bitnet-wasm/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace = true
 categories.workspace = true
 description = "WebAssembly bindings for BitNet 1-bit LLM inference"
 
+
+[lints]
+workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 

--- a/crates/bitnet-wgpu-bench/Cargo.toml
+++ b/crates/bitnet-wgpu-bench/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "Benchmarking and profiling harness for wgpu compute kernels"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }
 bitnet-bench-regression-core = { path = "../bitnet-bench-regression-core" }

--- a/crates/bitnet-wgpu-runner/Cargo.toml
+++ b/crates/bitnet-wgpu-runner/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "Kernel execution runner for wgpu compute pipelines"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 wgpu = { version = "24", features = ["vulkan-portability"] }
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
+++ b/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
@@ -6,5 +6,8 @@ rust-version = "1.92.0"
 description = "WGSL compute shaders for I2_S 2-bit quantized inference (BitNet)"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dev-dependencies]
 naga = { version = "28", features = ["wgsl-in"] }

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -6,6 +6,9 @@ rust-version = "1.92.0"
 description = "wgpu-based GPU compute backend for BitNet inference (Vulkan/Metal/DX12)"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 bitnet-dispatch-core = { path = "../bitnet-dispatch-core" }
 bitnet-nvidia = { path = "../bitnet-nvidia" }

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -7,6 +7,9 @@ description = "Cross-validation framework for BitNet Rust vs C++ implementations
 license = "MIT OR Apache-2.0"
 publish = false
 
+
+[lints]
+workspace = true
 [features]
 default = []
 # llama-ffi: llama.cpp cross-validation (no bitnet-sys dependency)

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,51 @@
+# Clippy policy
+
+BitNet-rs follows the Effortless Metrics Rust platform policy: MSRV 1.93,
+panic-free production and test code, AST/string/indexing safety by default,
+explicit suppression receipts, and machine-readable debt for temporary rollout
+exceptions.
+
+## Operating rules
+
+- The root `Cargo.toml` owns the active workspace lint block.
+- Every workspace member inherits the root lint policy with `[lints] workspace = true`.
+- `clippy.toml` is only for repo-specific disallowed methods, types, macros, and similar additions.
+- Do not add test carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`,
+  `allow-panic-in-tests`, `allow-indexing-slicing-in-tests`, or `allow-dbg-in-tests`.
+- Prefer panic-free tests that return `Result<(), Box<dyn std::error::Error>>` and use `?`.
+- Use `#[expect(..., reason = "...")]` for narrow suppressions. Do not use silent `#[allow]`.
+- Track temporary rollout debt in `policy/clippy-debt.toml`; debt must have owner, reason, path,
+  lint, and expiry.
+
+## Policy ledgers
+
+- `policy/clippy-lints.toml` records the MSRV, policy flags, and planned Rust 1.94/1.95 flips.
+- `policy/clippy-debt.toml` records temporary lint exceptions.
+- `policy/no-panic-allowlist.toml` documents the semantic allowlist schema for panic-family checks.
+- `policy/non-rust-allowlist.toml` documents the structured allowlist schema for non-Rust surfaces.
+
+## Suppression example
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "kernel tile bounds are proven by dispatch shape validation"
+)]
+fn load_tile(xs: &[f32], lane: usize) -> f32 {
+    xs[lane]
+}
+```
+
+If the suppression represents migration debt rather than a permanent invariant, add a matching
+entry to `policy/clippy-debt.toml`.
+
+## Validation
+
+Run:
+
+```sh
+cargo xtask check-lint-policy
+```
+
+The gate verifies that the root Cargo lint block, policy ledger, `clippy.toml`, workspace-member
+lint inheritance, planned upgrade flips, and debt metadata remain coherent.

--- a/examples/migration/cpp-to-rust-basic/after/Cargo.toml
+++ b/examples/migration/cpp-to-rust-basic/after/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 description = "Basic BitNet Rust example - migrated from C++"
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [[bin]]
 name = "main"
 path = "src/main.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 [package.metadata]
 cargo-fuzz = true
 
+
+[lints]
+workspace = true
 [dependencies]
 libfuzzer-sys = "0.4.10"
 serde_json = "1.0.145"

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,6 @@
+schema = 1
+
+# Temporary, reviewed lint-policy exceptions belong here. Each debt entry must
+# include lint, path, owner, reason, and expires. Keep entries narrow and remove
+# them when the corresponding #[expect(..., reason = "...")] suppression is
+# retired.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,762 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "warn"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "cfg"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "file-process-path"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-correctness"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression-governance"
+reason = "Part of the shared Effortless Metrics workspace lint baseline."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,22 @@
+schema_version = "0.3"
+
+# Semantic no-panic allowlist entries use identity = path + family + selector.
+# last_seen line/column values are advisory repair hints only.
+#
+# [[allow]]
+# path = "crates/example/src/parser.rs"
+# family = "unwrap"
+# classification = "test_only"
+# owner = "parser"
+# explanation = "Fixture setup path; migrate to panic-free helper."
+# expires = "2026-07-01"
+#
+# [allow.selector]
+# kind = "method_call"
+# container = "parses_fixture"
+# callee = "unwrap"
+# receiver_fingerprint = "std::fs::read_to_string(path)"
+#
+# [allow.last_seen]
+# line = 42
+# column = 17

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,15 @@
+schema_version = "1.0"
+
+# Non-Rust programming/configuration surfaces must be explicitly owned and
+# covered by checks. Add entries with either path or glob, plus kind, owner,
+# reason, surface, classification, and covered_by when the surface is
+# production/test/tooling.
+#
+# [[allow]]
+# glob = ".github/workflows/*.yml"
+# kind = "ci_declarative"
+# owner = "release/ci"
+# reason = "GitHub Actions workflow definitions are platform-required YAML."
+# surface = "ci"
+# classification = "config"
+# covered_by = ["cargo xtask check-lint-policy"]

--- a/tests-new/Cargo.toml
+++ b/tests-new/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 autotests = false
 autobenches = false
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_tests_new"
 path = "lib.rs"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,6 +9,9 @@ publish = false
 autotests = false
 autobenches = false
 
+
+[lints]
+workspace = true
 [lib]
 name = "bitnet_tests"
 path = "lib.rs"

--- a/tools/bitnet-task/Cargo.toml
+++ b/tools/bitnet-task/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 license.workspace = true
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/tools/migrate-gen-config/Cargo.toml
+++ b/tools/migrate-gen-config/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 publish = false  # One-time migration tool, not for distribution
 
+
+[lints]
+workspace = true
 [dependencies]
 walkdir = "2.5.0"
 syn = { version = "2.0.110", features = ["full", "visit-mut"] }

--- a/xtask-build-helper/Cargo.toml
+++ b/xtask-build-helper/Cargo.toml
@@ -6,5 +6,8 @@ publish = false
 license = "MIT OR Apache-2.0"
 description = "Build script helpers for FFI compilation (AC6 FFI build hygiene)"
 
+
+[lints]
+workspace = true
 [dependencies]
 cc = "1.2.46"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 license = "MIT OR Apache-2.0"
 
+
+[lints]
+workspace = true
 [dependencies]
 anyhow = "1.0.100"
 clap = { workspace = true, features = ["derive"] }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -678,6 +678,9 @@ enum Cmd {
     /// Check feature flag consistency
     CheckFeatures,
 
+    /// Validate workspace Clippy policy, debt ledger, and lint inheritance
+    CheckLintPolicy,
+
     /// CI gates that emit JSON for robust detection
     Gate {
         #[command(subcommand)]
@@ -1231,6 +1234,7 @@ fn real_main() -> Result<()> {
         Cmd::SetupCrossval => setup_crossval(),
         Cmd::CleanCache => clean_cache(),
         Cmd::CheckFeatures => check_features(),
+        Cmd::CheckLintPolicy => check_lint_policy(),
         Cmd::Gate { which } => match which {
             GateWhich::Mapper { model } => std::process::exit(gates::mapper_gate(model)?),
         },
@@ -4320,6 +4324,493 @@ fn dir_size(path: &Path) -> Result<u64> {
         }
     }
     Ok(size)
+}
+
+fn check_lint_policy() -> Result<()> {
+    let root = Path::new(".");
+    let cargo_path = root.join("Cargo.toml");
+    let cargo_text = fs::read_to_string(&cargo_path).context("read Cargo.toml")?;
+    let cargo: toml::Value = toml::from_str(&cargo_text).context("parse Cargo.toml")?;
+
+    let policy_path = root.join("policy/clippy-lints.toml");
+    let policy_text = fs::read_to_string(&policy_path).context("read policy/clippy-lints.toml")?;
+    let policy: toml::Value =
+        toml::from_str(&policy_text).context("parse policy/clippy-lints.toml")?;
+
+    let mut errors = Vec::new();
+    let workspace = cargo.get("workspace").and_then(toml::Value::as_table);
+    let workspace_package =
+        workspace.and_then(|table| table.get("package")).and_then(toml::Value::as_table);
+    let cargo_msrv =
+        workspace_package.and_then(|table| table.get("rust-version")).and_then(toml::Value::as_str);
+    let policy_msrv = policy.get("msrv").and_then(toml::Value::as_str);
+    if cargo_msrv != Some("1.93") {
+        errors.push(format!("workspace.package.rust-version must be 1.93, found {:?}", cargo_msrv));
+    }
+    if cargo_msrv != policy_msrv {
+        errors.push(format!(
+            "workspace.package.rust-version {:?} must match policy msrv {:?}",
+            cargo_msrv, policy_msrv
+        ));
+    }
+
+    let policy_table = policy.get("policy").and_then(toml::Value::as_table);
+    check_policy_bool(&mut errors, policy_table, "panic_free_tests", true);
+    check_policy_bool(&mut errors, policy_table, "allow_test_carveouts", false);
+    check_policy_bool(&mut errors, policy_table, "blanket_categories", false);
+    let suppression_style =
+        policy_table.and_then(|table| table.get("suppression_style")).and_then(toml::Value::as_str);
+    if suppression_style != Some("expect-with-reason") {
+        errors.push(format!(
+            "policy.suppression_style must be expect-with-reason, found {:?}",
+            suppression_style
+        ));
+    }
+
+    let workspace_lints =
+        workspace.and_then(|table| table.get("lints")).and_then(toml::Value::as_table);
+    let rust_lints =
+        workspace_lints.and_then(|table| table.get("rust")).and_then(toml::Value::as_table);
+    let clippy_lints =
+        workspace_lints.and_then(|table| table.get("clippy")).and_then(toml::Value::as_table);
+
+    for (name, level) in REQUIRED_RUST_LINTS {
+        check_lint_level(&mut errors, rust_lints, "rust", name, level);
+    }
+    for (name, level) in REQUIRED_CLIPPY_LINTS {
+        check_lint_level(&mut errors, clippy_lints, "clippy", name, level);
+    }
+    check_active_lint_ledger(&mut errors, &policy, rust_lints, clippy_lints);
+
+    for blanket in ["all", "pedantic", "nursery", "restriction"] {
+        if clippy_lints.is_some_and(|table| table.contains_key(blanket)) {
+            errors.push(format!(
+                "workspace.lints.clippy.{blanket} is a blanket category; use explicit governed lints"
+            ));
+        }
+    }
+
+    check_planned_lints(&mut errors, &policy, clippy_lints, cargo_msrv);
+    check_clippy_toml(&mut errors, root);
+    check_workspace_lint_inheritance(&mut errors, root, &cargo);
+    check_clippy_debt(&mut errors, root);
+    check_allowlist_metadata(&mut errors, root.join("policy/no-panic-allowlist.toml"), true);
+    check_allowlist_metadata(&mut errors, root.join("policy/non-rust-allowlist.toml"), false);
+
+    if errors.is_empty() {
+        println!("✅ lint policy check passed");
+        return Ok(());
+    }
+
+    for error in &errors {
+        eprintln!("❌ {error}");
+    }
+    bail!("lint policy check failed with {} error(s)", errors.len())
+}
+
+const REQUIRED_RUST_LINTS: &[(&str, &str)] = &[
+    ("unsafe_code", "warn"),
+    ("unsafe_op_in_unsafe_fn", "deny"),
+    ("unused_must_use", "deny"),
+    ("unexpected_cfgs", "warn"),
+];
+
+const REQUIRED_CLIPPY_LINTS: &[(&str, &str)] = &[
+    ("dbg_macro", "deny"),
+    ("todo", "deny"),
+    ("unimplemented", "deny"),
+    ("panic", "deny"),
+    ("unreachable", "deny"),
+    ("unwrap_used", "deny"),
+    ("expect_used", "deny"),
+    ("get_unwrap", "deny"),
+    ("unwrap_in_result", "deny"),
+    ("panic_in_result_fn", "deny"),
+    ("string_slice", "deny"),
+    ("indexing_slicing", "deny"),
+    ("out_of_bounds_indexing", "deny"),
+    ("unchecked_time_subtraction", "deny"),
+    ("char_indices_as_byte_indices", "deny"),
+    ("sliced_string_as_bytes", "deny"),
+    ("index_refutable_slice", "deny"),
+    ("let_underscore_future", "deny"),
+    ("let_underscore_must_use", "deny"),
+    ("let_underscore_lock", "deny"),
+    ("unused_result_ok", "deny"),
+    ("map_err_ignore", "deny"),
+    ("assertions_on_result_states", "deny"),
+    ("lines_filter_map_ok", "deny"),
+    ("await_holding_lock", "deny"),
+    ("await_holding_refcell_ref", "deny"),
+    ("await_holding_invalid_type", "deny"),
+    ("future_not_send", "warn"),
+    ("large_futures", "warn"),
+    ("arc_with_non_send_sync", "deny"),
+    ("rc_mutex", "deny"),
+    ("mut_mutex_lock", "deny"),
+    ("readonly_write_lock", "deny"),
+    ("mem_forget", "deny"),
+    ("forget_non_drop", "deny"),
+    ("drop_non_drop", "deny"),
+    ("undocumented_unsafe_blocks", "deny"),
+    ("multiple_unsafe_ops_per_block", "deny"),
+    ("repr_packed_without_abi", "deny"),
+    ("float_cmp", "deny"),
+    ("float_cmp_const", "deny"),
+    ("float_equality_without_abs", "deny"),
+    ("lossy_float_literal", "deny"),
+    ("cast_sign_loss", "deny"),
+    ("cast_possible_wrap", "warn"),
+    ("cast_possible_truncation", "warn"),
+    ("cast_precision_loss", "warn"),
+    ("invalid_upcast_comparisons", "deny"),
+    ("cast_abs_to_unsigned", "deny"),
+    ("cast_enum_truncation", "deny"),
+    ("cast_nan_to_int", "deny"),
+    ("manual_midpoint", "warn"),
+    ("manual_is_multiple_of", "warn"),
+    ("manual_div_ceil", "warn"),
+    ("arithmetic_side_effects", "warn"),
+    ("suspicious_open_options", "deny"),
+    ("nonsensical_open_options", "deny"),
+    ("ineffective_open_options", "deny"),
+    ("path_buf_push_overwrite", "deny"),
+    ("join_absolute_paths", "deny"),
+    ("read_line_without_trim", "warn"),
+    ("exit", "deny"),
+    ("iter_not_returning_iterator", "deny"),
+    ("expl_impl_clone_on_copy", "deny"),
+    ("infallible_try_from", "deny"),
+    ("fallible_impl_from", "deny"),
+    ("error_impl_error", "deny"),
+    ("result_unit_err", "warn"),
+    ("result_large_err", "warn"),
+    ("format_in_format_args", "deny"),
+    ("to_string_in_format_args", "deny"),
+    ("unused_format_specs", "deny"),
+    ("unnecessary_debug_formatting", "warn"),
+    ("uninlined_format_args", "warn"),
+    ("manual_let_else", "warn"),
+    ("manual_ok_or", "warn"),
+    ("manual_strip", "warn"),
+    ("manual_split_once", "warn"),
+    ("manual_is_variant_and", "warn"),
+    ("filter_map_next", "warn"),
+    ("flat_map_option", "warn"),
+    ("match_result_ok", "deny"),
+    ("cloned_instead_of_copied", "warn"),
+    ("iter_cloned_collect", "warn"),
+    ("iter_overeager_cloned", "warn"),
+    ("needless_collect", "warn"),
+    ("redundant_closure", "warn"),
+    ("redundant_closure_for_method_calls", "warn"),
+    ("missing_panics_doc", "deny"),
+    ("missing_errors_doc", "warn"),
+    ("allow_attributes", "deny"),
+    ("allow_attributes_without_reason", "deny"),
+    ("blanket_clippy_restriction_lints", "deny"),
+    ("ignore_without_reason", "deny"),
+    ("should_panic_without_expect", "deny"),
+];
+
+fn check_active_lint_ledger(
+    errors: &mut Vec<String>,
+    policy: &toml::Value,
+    rust_lints: Option<&toml::map::Map<String, toml::Value>>,
+    clippy_lints: Option<&toml::map::Map<String, toml::Value>>,
+) {
+    let Some(entries) = policy.get("lint").and_then(toml::Value::as_array) else {
+        errors.push("policy/clippy-lints.toml must include active [[lint]] entries".to_string());
+        return;
+    };
+    for (name, level) in REQUIRED_RUST_LINTS {
+        let full = format!("rust::{name}");
+        if !active_lint_entry_exists(entries, &full, level) {
+            errors.push(format!(
+                "policy/clippy-lints.toml missing active entry for {full} = {level}"
+            ));
+        }
+    }
+    for (name, level) in REQUIRED_CLIPPY_LINTS {
+        let full = format!("clippy::{name}");
+        if !active_lint_entry_exists(entries, &full, level) {
+            errors.push(format!(
+                "policy/clippy-lints.toml missing active entry for {full} = {level}"
+            ));
+        }
+    }
+    for entry in entries {
+        let table = entry.as_table();
+        let name = table.and_then(|table| table.get("name")).and_then(toml::Value::as_str);
+        let level = table.and_then(|table| table.get("level")).and_then(toml::Value::as_str);
+        let status = table.and_then(|table| table.get("status")).and_then(toml::Value::as_str);
+        let class = table.and_then(|table| table.get("class")).and_then(toml::Value::as_str);
+        let reason = table.and_then(|table| table.get("reason")).and_then(toml::Value::as_str);
+        if name.is_none()
+            || level.is_none()
+            || status != Some("active")
+            || class.is_none_or(str::is_empty)
+            || reason.is_none_or(str::is_empty)
+        {
+            errors.push(format!(
+                "active lint entry must include name, level, status=active, class, and reason: {entry}"
+            ));
+            continue;
+        }
+        let Some(name) = name else {
+            continue;
+        };
+        let Some(level) = level else {
+            continue;
+        };
+        if let Some(bare) = name.strip_prefix("rust::") {
+            check_lint_level(errors, rust_lints, "rust", bare, level);
+        } else if let Some(bare) = name.strip_prefix("clippy::") {
+            check_lint_level(errors, clippy_lints, "clippy", bare, level);
+        } else {
+            errors.push(format!("active lint {name} must start with rust:: or clippy::"));
+        }
+    }
+}
+
+fn active_lint_entry_exists(entries: &[toml::Value], name: &str, level: &str) -> bool {
+    entries.iter().any(|entry| {
+        let table = entry.as_table();
+        table.and_then(|table| table.get("name")).and_then(toml::Value::as_str) == Some(name)
+            && table.and_then(|table| table.get("level")).and_then(toml::Value::as_str)
+                == Some(level)
+            && table.and_then(|table| table.get("status")).and_then(toml::Value::as_str)
+                == Some("active")
+    })
+}
+
+fn check_policy_bool(
+    errors: &mut Vec<String>,
+    policy_table: Option<&toml::map::Map<String, toml::Value>>,
+    key: &str,
+    expected: bool,
+) {
+    let actual = policy_table.and_then(|table| table.get(key)).and_then(toml::Value::as_bool);
+    if actual != Some(expected) {
+        errors.push(format!("policy.{key} must be {expected}, found {actual:?}"));
+    }
+}
+
+fn check_lint_level(
+    errors: &mut Vec<String>,
+    table: Option<&toml::map::Map<String, toml::Value>>,
+    family: &str,
+    name: &str,
+    expected: &str,
+) {
+    let actual = table.and_then(|table| table.get(name)).and_then(toml::Value::as_str);
+    if actual != Some(expected) {
+        errors
+            .push(format!("workspace.lints.{family}.{name} must be {expected}, found {actual:?}"));
+    }
+}
+
+fn check_planned_lints(
+    errors: &mut Vec<String>,
+    policy: &toml::Value,
+    clippy_lints: Option<&toml::map::Map<String, toml::Value>>,
+    cargo_msrv: Option<&str>,
+) {
+    let Some(planned) = policy.get("planned").and_then(toml::Value::as_array) else {
+        errors
+            .push("policy/clippy-lints.toml must include planned Rust 1.94/1.95 flips".to_string());
+        return;
+    };
+    let mut saw_194 = false;
+    let mut saw_195 = false;
+    for item in planned {
+        let table = item.as_table();
+        let name = table.and_then(|table| table.get("name")).and_then(toml::Value::as_str);
+        let level = table.and_then(|table| table.get("level")).and_then(toml::Value::as_str);
+        let activate =
+            table.and_then(|table| table.get("activate_when_msrv")).and_then(toml::Value::as_str);
+        let reason = table.and_then(|table| table.get("reason")).and_then(toml::Value::as_str);
+        if name.is_none()
+            || level.is_none()
+            || activate.is_none()
+            || reason.is_none_or(str::is_empty)
+        {
+            errors.push(format!(
+                "planned lint entry is missing name, level, activate_when_msrv, or reason: {item}"
+            ));
+            continue;
+        }
+        if activate == Some("1.94") {
+            saw_194 = true;
+        }
+        if activate == Some("1.95") {
+            saw_195 = true;
+        }
+        if cargo_msrv.is_some_and(|msrv| msrv < activate.unwrap_or(msrv)) {
+            let bare_name = name.unwrap().strip_prefix("clippy::").unwrap_or(name.unwrap());
+            if clippy_lints.is_some_and(|table| table.contains_key(bare_name)) {
+                errors.push(format!(
+                    "planned lint {} must not be active before MSRV {}",
+                    name.unwrap(),
+                    activate.unwrap()
+                ));
+            }
+        }
+    }
+    if !saw_194 || !saw_195 {
+        errors.push("planned lint ledger must include both Rust 1.94 and 1.95 flips".to_string());
+    }
+}
+
+fn check_clippy_toml(errors: &mut Vec<String>, root: &Path) {
+    let path = root.join("clippy.toml");
+    let Ok(text) = fs::read_to_string(&path) else {
+        errors.push("clippy.toml must exist".to_string());
+        return;
+    };
+    for carveout in [
+        "allow-unwrap-in-tests",
+        "allow-expect-in-tests",
+        "allow-panic-in-tests",
+        "allow-indexing-slicing-in-tests",
+        "allow-dbg-in-tests",
+    ] {
+        if text.contains(carveout)
+            && !text.contains(&format!("Do not add test carveouts such as `{carveout}`"))
+        {
+            errors.push(format!("clippy.toml must not set {carveout}"));
+        }
+    }
+}
+
+fn check_workspace_lint_inheritance(errors: &mut Vec<String>, root: &Path, cargo: &toml::Value) {
+    let Some(members) = cargo
+        .get("workspace")
+        .and_then(|workspace| workspace.get("members"))
+        .and_then(toml::Value::as_array)
+    else {
+        errors.push("workspace.members must be present".to_string());
+        return;
+    };
+    let mut package_paths = vec![PathBuf::from("Cargo.toml")];
+    for member in members.iter().filter_map(toml::Value::as_str) {
+        package_paths.push(PathBuf::from(member).join("Cargo.toml"));
+    }
+    package_paths.sort();
+    package_paths.dedup();
+    for package_path in package_paths {
+        let full_path = root.join(&package_path);
+        if !full_path.exists() {
+            errors.push(format!(
+                "workspace member manifest {} does not exist",
+                package_path.display()
+            ));
+            continue;
+        }
+        let Ok(text) = fs::read_to_string(&full_path) else {
+            errors.push(format!("could not read {}", package_path.display()));
+            continue;
+        };
+        let Ok(manifest) = toml::from_str::<toml::Value>(&text) else {
+            errors.push(format!("could not parse {}", package_path.display()));
+            continue;
+        };
+        if manifest.get("package").is_none() {
+            continue;
+        }
+        let inherits = manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(toml::Value::as_bool);
+        if inherits != Some(true) {
+            errors
+                .push(format!("{} must include [lints] workspace = true", package_path.display()));
+        }
+    }
+}
+
+fn check_clippy_debt(errors: &mut Vec<String>, root: &Path) {
+    let path = root.join("policy/clippy-debt.toml");
+    let Ok(text) = fs::read_to_string(&path) else {
+        errors.push("policy/clippy-debt.toml must exist".to_string());
+        return;
+    };
+    let Ok(doc) = toml::from_str::<toml::Value>(&text) else {
+        errors.push("policy/clippy-debt.toml must parse as TOML".to_string());
+        return;
+    };
+    let Some(entries) = doc.get("debt").and_then(toml::Value::as_array) else {
+        return;
+    };
+    for (index, entry) in entries.iter().enumerate() {
+        let table = entry.as_table();
+        for field in ["lint", "path", "owner", "reason", "expires"] {
+            let value = table.and_then(|table| table.get(field)).and_then(toml::Value::as_str);
+            if value.is_none_or(str::is_empty) {
+                errors.push(format!("clippy debt entry #{index} missing {field}"));
+            }
+        }
+        check_expiry(
+            errors,
+            table.and_then(|table| table.get("expires")).and_then(toml::Value::as_str),
+            &format!("clippy debt entry #{index}"),
+        );
+    }
+}
+
+fn check_allowlist_metadata(errors: &mut Vec<String>, path: PathBuf, panic_allowlist: bool) {
+    let Ok(text) = fs::read_to_string(&path) else {
+        errors.push(format!("{} must exist", path.display()));
+        return;
+    };
+    let Ok(doc) = toml::from_str::<toml::Value>(&text) else {
+        errors.push(format!("{} must parse as TOML", path.display()));
+        return;
+    };
+    let Some(entries) = doc.get("allow").and_then(toml::Value::as_array) else {
+        return;
+    };
+    for (index, entry) in entries.iter().enumerate() {
+        let table = entry.as_table();
+        let label = format!("{} allow entry #{index}", path.display());
+        let fields: &[&str] = if panic_allowlist {
+            &["path", "family", "classification", "owner", "explanation"]
+        } else {
+            &["kind", "owner", "reason", "surface", "classification"]
+        };
+        for field in fields {
+            let value = table.and_then(|table| table.get(*field)).and_then(toml::Value::as_str);
+            if value.is_none_or(str::is_empty) {
+                errors.push(format!("{label} missing {field}"));
+            }
+        }
+        if !panic_allowlist {
+            let has_path = table.and_then(|table| table.get("path")).is_some();
+            let has_glob = table.and_then(|table| table.get("glob")).is_some();
+            if has_path == has_glob {
+                errors.push(format!("{label} must include exactly one of path or glob"));
+            }
+        }
+        check_expiry(
+            errors,
+            table.and_then(|table| table.get("expires")).and_then(toml::Value::as_str),
+            &label,
+        );
+    }
+}
+
+fn check_expiry(errors: &mut Vec<String>, expires: Option<&str>, label: &str) {
+    let Some(expires) = expires else {
+        return;
+    };
+    let Ok(expiry) = chrono::NaiveDate::parse_from_str(expires, "%Y-%m-%d") else {
+        errors.push(format!("{label} has invalid expiry date {expires:?}; use YYYY-MM-DD"));
+        return;
+    };
+    let today = chrono::Utc::now().date_naive();
+    if expiry < today {
+        errors.push(format!("{label} expired on {expires}"));
+    }
 }
 
 fn check_features() -> Result<()> {


### PR DESCRIPTION
### Motivation

- Establish a machine‑governed, workspace‑level Clippy baseline (panic‑free + AST/slice safety) and a structured exception/debt model rather than ad‑hoc per‑crate carveouts.
- Provide machine‑readable policy artifacts and an `xtask` gate so CI can validate lint inheritance, planned flips, and allowlist/debt metadata.

### Description

- Bumped workspace MSRV to `1.93` and added `[lints] workspace = true` to the root and workspace member manifests so members inherit the policy. 
- Replaced the previous loose Clippy block with an explicit, explicit Effortless Metrics lint profile under `workspace.lints.rust` and `workspace.lints.clippy` in `Cargo.toml` (panic/silent‑failure/UTF‑8/suppression governance and many targeted lints). 
- Added repo policy artifacts: `policy/clippy-lints.toml` (msrv + planned 1.94/1.95 flips), `policy/clippy-debt.toml` (debt template), `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml` (TOML allowlist templates), and a minimal `clippy.toml` reserved for repo-specific disallowed items. 
- Added `docs/CLIPPY_POLICY.md` describing operational rules, suppression style (`#[expect(..., reason = "...")]`), and ledger/allowlist usage. 
- Implemented `cargo xtask check-lint-policy` (wired into `xtask` CLI) which parses the root `Cargo.toml` and `policy/*` files and enforces: MSRV match, workspace lint inheritance, presence/absence of test carveouts, planned flips not active before MSRV bump, debt metadata fields, and allowlist metadata/expiry checks. 
- Applied formatting and small manifest edits across many crate `Cargo.toml` files to add lint inheritance and MSRV alignment, and created a repo `clippy.toml` with MSRV and retained complexity thresholds.

### Testing

- Ran `cargo run -p xtask --no-default-features -- check-lint-policy` (built `xtask` with CPU features) and the new gate completed successfully: `✅ lint policy check passed`.
- Ran `cargo fmt --all -- --check` and formatting checks passed.
- Built `xtask` variations to iterate on the gate implementation; full workspace builds that exercise GPU/CUDA features produced linker errors in this environment due to missing system CUDA libraries (environmental), but those are external to the lint gate validation and did not block the `check-lint-policy` result.
- Verified git diff/stat and ensured `cargo fmt` applied changes; the `xtask` gate and the policy files are present and validated by the added command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb084404ec8333ae718c508bf54786)