### PR TITLE
Add workspace Clippy policy, policy ledger, no-panic/non-rust allowlists, and `xtask` check; target MSRV 1.93

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ keywords = ["machine-learning", "llm", "quantization", "inference", "bitnet"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
-rust-version = "1.92.0"
+rust-version = "1.93"
 version = "0.2.1-dev"
 
 [dependencies]
@@ -540,14 +540,136 @@ debug = true
 opt-level = 2
 
 # Workspace-level lints for code quality
+[lints]
+workspace = true
+
+[workspace.lints.rust]
+unsafe_code = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
 nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
+
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 ptr_arg = "deny"
 
 # Workspace-level feature flags for convenience
@@ -586,4 +708,4 @@ keywords = [
   "inference",        # Model inference
   "bitnet",           # BitNet specific
 ]
-msrv = "1.92.0"
+msrv = "1.93"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,16 +1,15 @@
-# Clippy configuration for bitnet-rs
-# Ensures high code quality standards for crates.io publication
+# Clippy configuration for bitnet-rs.
+# Policy lives in Cargo.toml and policy/clippy-lints.toml; this file is only
+# for repo-local configuration knobs and disallowed-method/type policy.
 
-# MSRV compatibility
-msrv = "1.92.0"
+msrv = "1.93"
 
-# Complexity thresholds
+# Complexity thresholds.
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 8
 type-complexity-threshold = 250
 trivial-copy-size-limit = 64
 
-# Allow certain patterns common in ML/systems code
-allow-expect-in-tests = true
-allow-unwrap-in-tests = true
-allow-mixed-uninlined-format-args = true  # Performance in hot paths
+# Keep mixed format args available in hot numeric paths while the lint stays
+# visible through the workspace policy.
+allow-mixed-uninlined-format-args = true

--- a/crates/bitnet-api-key-auth-core/Cargo.toml
+++ b/crates/bitnet-api-key-auth-core/Cargo.toml
@@ -12,3 +12,6 @@ version.workspace = true
 
 [dependencies]
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-bdd-grid-core/Cargo.toml
+++ b/crates/bitnet-bdd-grid-core/Cargo.toml
@@ -19,3 +19,6 @@ proptest.workspace = true
 insta = { workspace = true, features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -22,3 +22,6 @@ bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev"
 bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-bench-receipts/Cargo.toml
+++ b/crates/bitnet-bench-receipts/Cargo.toml
@@ -13,3 +13,6 @@ thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/bitnet-bench-regression-core/Cargo.toml
+++ b/crates/bitnet-bench-regression-core/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-cli-config-core/Cargo.toml
+++ b/crates/bitnet-cli-config-core/Cargo.toml
@@ -16,3 +16,6 @@ serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 dirs.workspace = true
 tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -120,3 +120,6 @@ trace = ["bitnet-inference/trace", "bitnet-runtime-bootstrap/runtime-profile-tra
 # This prevents production CLI builds with test mocks
 # DO NOT enable this feature - it will fail to compile by design
 mock = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-common/Cargo.toml
+++ b/crates/bitnet-common/Cargo.toml
@@ -61,3 +61,6 @@ test-util = []  # Exposes test-only APIs for integration tests
 # ONLY on macOS, so Linux builds won't try to compile objc/Metal frameworks.
 workspace = true
 features = ["metal"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-compat-core/Cargo.toml
+++ b/crates/bitnet-compat-core/Cargo.toml
@@ -14,3 +14,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-compat/Cargo.toml
+++ b/crates/bitnet-compat/Cargo.toml
@@ -28,3 +28,6 @@ proptest.workspace = true
 [features]
 integration-tests = []
 tokenizer-probe = ["bitnet-tokenizers"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-cpu-activations/Cargo.toml
+++ b/crates/bitnet-cpu-activations/Cargo.toml
@@ -12,3 +12,6 @@ description = "CPU activation kernels extracted as an SRP microcrate"
 
 [dependencies]
 libm = "0.2.16"
+
+[lints]
+workspace = true

--- a/crates/bitnet-cpu-detect/Cargo.toml
+++ b/crates/bitnet-cpu-detect/Cargo.toml
@@ -22,3 +22,6 @@ default = []
 avx2 = []
 avx512 = []
 neon = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-device-config-core/Cargo.toml
+++ b/crates/bitnet-device-config-core/Cargo.toml
@@ -21,3 +21,6 @@ default = []
 cpu = ["bitnet-common/cpu"]
 cuda = ["dep:bitnet-kernels", "bitnet-kernels/cuda"]
 gpu = ["cuda", "bitnet-kernels/gpu"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-dispatch-core/Cargo.toml
+++ b/crates/bitnet-dispatch-core/Cargo.toml
@@ -10,3 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-eval-core/Cargo.toml
+++ b/crates/bitnet-eval-core/Cargo.toml
@@ -13,3 +13,6 @@ description = "SRP helpers for evaluation and scoring math"
 [lib]
 name = "bitnet_eval_core"
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -62,3 +62,6 @@ runtime-profile-fixtures = ["bitnet-feature-matrix/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-feature-matrix/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-feature-matrix/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-feature-matrix/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -61,3 +61,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-profile-core/runtime-profil
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-ffi/Cargo.toml
+++ b/crates/bitnet-ffi/Cargo.toml
@@ -48,3 +48,6 @@ cpu = []
 cuda = ["cudarc", "bitnet-inference/cuda"]
 gpu = ["cuda"]  # GPU umbrella — CUDA is the current implementation
 ffi-tests = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-ggml-ffi/Cargo.toml
+++ b/crates/bitnet-ggml-ffi/Cargo.toml
@@ -30,3 +30,6 @@ cc = "1.2.38"
 
 [dependencies]
 libc = { version = "0.2.175", optional = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-honest-compute/Cargo.toml
+++ b/crates/bitnet-honest-compute/Cargo.toml
@@ -25,3 +25,6 @@ default = []
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-inference-metrics-core/Cargo.toml
+++ b/crates/bitnet-inference-metrics-core/Cargo.toml
@@ -16,3 +16,6 @@ include = [
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -105,3 +105,6 @@ trace = ["bitnet-models/trace"]  # Enable tensor activation tracing
 name = "comprehensive_tests"
 path = "tests/comprehensive_tests.rs"
 required-features = ["full-engine"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -175,3 +175,6 @@ name = "gpu_validation"
 path = "examples/gpu_validation.rs"
 required-features = ["gpu"]
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-math/Cargo.toml
+++ b/crates/bitnet-math/Cargo.toml
@@ -19,3 +19,6 @@ include = [
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -81,3 +81,6 @@ tl2 = []  # TL2 quantization for test scaffolding
 test-fixtures = []  # Enable tests that require real GGUF fixtures
 fixtures = []  # Enable GGUF fixture generation for QK256 dual-flavor tests (PR1)
 trace = ["dep:bitnet-trace"]  # Enable tensor activation tracing for cross-validation
+
+[lints]
+workspace = true

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -10,3 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-prompt-templates-core/Cargo.toml
+++ b/crates/bitnet-prompt-templates-core/Cargo.toml
@@ -27,3 +27,6 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 [[bench]]
 name = "template_ops"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -21,3 +21,6 @@ tracing-test.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -54,3 +54,6 @@ gpu = ["cuda"]  # GPU umbrella — CUDA is the current implementation
 name = "streaming_comprehensive"
 path = "tests/integration/streaming_comprehensive.rs"
 required-features = ["integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-qk256-dispatch/Cargo.toml
+++ b/crates/bitnet-qk256-dispatch/Cargo.toml
@@ -26,3 +26,6 @@ cpu = ["bitnet-quantization/cpu"]
 cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda"]
 metal = ["bitnet-common/metal"]
 gpu = ["cuda", "metal"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-qk256-layout-core/Cargo.toml
+++ b/crates/bitnet-qk256-layout-core/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = { workspace = true }
 [features]
 default = []
 cpu = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-quantization-bits/Cargo.toml
+++ b/crates/bitnet-quantization-bits/Cargo.toml
@@ -16,3 +16,6 @@ include = [
 
 [dependencies]
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -54,3 +54,6 @@ inference = []
 [[bench]]
 name = "quantization"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -30,3 +30,6 @@ proptest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -24,3 +24,6 @@ insta = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-repl-core/Cargo.toml
+++ b/crates/bitnet-repl-core/Cargo.toml
@@ -15,3 +15,6 @@ anyhow.workspace = true
 
 [dev-dependencies]
 tempfile = "3.23.0"
+
+[lints]
+workspace = true

--- a/crates/bitnet-rocm/Cargo.toml
+++ b/crates/bitnet-rocm/Cargo.toml
@@ -22,3 +22,6 @@ insta.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-rope/Cargo.toml
+++ b/crates/bitnet-rope/Cargo.toml
@@ -24,3 +24,6 @@ default = []
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-startup-contract/runtime-profile-in
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -26,3 +26,6 @@ insta.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -25,3 +25,6 @@ default = []
 proptest.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -25,3 +25,6 @@ serde_json.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -67,3 +67,6 @@ runtime-profile-integration-tests = ["integration-tests"]
 proptest.workspace = true
 insta.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -68,3 +68,6 @@ insta.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 temp-env = "0.3.6"
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-fixtures = ["bitnet-runtime-profile-contract-core/runtime-profil
 runtime-profile-reporting = ["bitnet-runtime-profile-contract-core/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile-contract-core/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile-contract-core/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -57,3 +57,6 @@ runtime-profile-fixtures = ["bitnet-runtime-profile-contract/runtime-profile-fix
 runtime-profile-reporting = ["bitnet-runtime-profile-contract/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile-contract/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile-contract/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -57,3 +57,6 @@ runtime-profile-fixtures = ["bitnet-feature-matrix/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-feature-matrix/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-feature-matrix/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-feature-matrix/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -22,3 +22,6 @@ bitnet-probability = { path = "../bitnet-probability", version = "0.2.1-dev" }
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -125,3 +125,6 @@ request_batching = []                                                           
 connection_pool = []                                                                                                                                                              # Gate connection pool module (PR-1 scope)
 tuning = []                                                                                                                                                                       # Gate performance tuning module (PR-1 scope)
 receipts = []                                                                                                                                                                     # Enable KV cache eviction receipts (Phase 2)
+
+[lints]
+workspace = true

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -25,3 +25,6 @@ tempfile = "3.23.0"
 [[bin]]
 name = "st-ln-inspect"
 path = "src/bin/st-ln-inspect.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -47,3 +47,6 @@ tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -67,3 +67,6 @@ serial_test.workspace = true
 temp-env = "0.3.6"
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
@@ -15,3 +15,6 @@ include = ["src/**", "Cargo.toml"]
 [dependencies]
 anyhow.workspace = true
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -19,3 +19,6 @@ bitnet-startup-contract-diagnostics-core = { path = "../bitnet-startup-contract-
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-integration-tests = ["bitnet-startup-contract-core/runtime-profi
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -44,3 +44,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lib]
 name = "bitnet_sys"
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-env/Cargo.toml
+++ b/crates/bitnet-test-env/Cargo.toml
@@ -13,3 +13,6 @@ publish = true
 
 [dev-dependencies]
 serial_test.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-fixtures-core/Cargo.toml
+++ b/crates/bitnet-test-fixtures-core/Cargo.toml
@@ -11,3 +11,6 @@ categories.workspace = true
 description = "SRP helpers for resolving and loading test fixtures"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-support/Cargo.toml
+++ b/crates/bitnet-test-support/Cargo.toml
@@ -19,3 +19,6 @@ serial_test.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -66,3 +66,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profi
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-testing-profile/runtime-profile-int
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -62,3 +62,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profi
 
 [dev-dependencies]
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy/runtime-profile-inte
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-runtime-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime-core/Cargo.toml
@@ -18,3 +18,6 @@ include = [
 [dependencies]
 bitnet-testing-policy-state-core = { path = "../bitnet-testing-policy-state-core", version = "0.2.1-dev" }
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -65,3 +65,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-interop/runtime-prof
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
@@ -58,3 +58,6 @@ runtime-profile-fixtures = ["bitnet-testing-profile/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-testing-profile/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-testing-profile/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-testing-profile/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-state-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-state-core/Cargo.toml
@@ -17,3 +17,6 @@ include = [
 
 [dependencies]
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -64,3 +64,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-runtime/runtime-prof
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-core/runtime-profile
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -61,3 +61,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-profile/runtime-profile-int
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -26,3 +26,6 @@ insta.workspace = true
 [features]
 default = []
 fixtures = ["bitnet-testing-scenarios-profile-core/fixtures"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -26,3 +26,6 @@ fixtures = []
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -24,3 +24,6 @@ fixtures = ["bitnet-testing-scenarios-core/fixtures"]
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-thread-config-core/Cargo.toml
+++ b/crates/bitnet-thread-config-core/Cargo.toml
@@ -11,3 +11,6 @@ categories.workspace = true
 description = "SRP thread configuration and work partitioning primitives"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-token-merge-core/Cargo.toml
+++ b/crates/bitnet-token-merge-core/Cargo.toml
@@ -14,3 +14,6 @@ description = "SRP core token span merge/split utilities"
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizer-discovery-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-discovery-core/Cargo.toml
@@ -16,3 +16,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizer-model-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-model-core/Cargo.toml
@@ -13,3 +13,6 @@ description = "Core model/vocabulary detection helpers for tokenizers"
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -68,3 +68,6 @@ bitnet-test-support.workspace = true
 bitnet-test-fixtures-core = { path = "../bitnet-test-fixtures-core", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -22,3 +22,6 @@ temp-env = "0.3.6"
 insta = { workspace = true, features = ["json"] }
 proptest.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -35,3 +35,6 @@ cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda", "b
 metal = ["bitnet-common/metal", "bitnet-qk256-dispatch/metal"]
 gpu = ["cuda", "metal"]
 trace = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-validation/Cargo.toml
+++ b/crates/bitnet-validation/Cargo.toml
@@ -20,3 +20,6 @@ serde_yaml.workspace = true
 tempfile = "3"
 proptest.workspace = true
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-warn-once/Cargo.toml
+++ b/crates/bitnet-warn-once/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-wasm-utils/Cargo.toml
+++ b/crates/bitnet-wasm-utils/Cargo.toml
@@ -17,3 +17,6 @@ web-sys = { workspace = true, features = ["Window", "Navigator", "Performance"] 
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.53"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wasm/Cargo.toml
+++ b/crates/bitnet-wasm/Cargo.toml
@@ -81,3 +81,6 @@ wasm-kernels = ["dep:bitnet-kernels"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.53"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-bench/Cargo.toml
+++ b/crates/bitnet-wgpu-bench/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-runner/Cargo.toml
+++ b/crates/bitnet-wgpu-runner/Cargo.toml
@@ -15,3 +15,6 @@ tracing = "0.1"
 [dev-dependencies]
 pollster = "0.4"
 tokio = { version = "1", features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
+++ b/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 naga = { version = "28", features = ["wgsl-in"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -21,3 +21,6 @@ proptest = "1"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -80,3 +80,6 @@ cc = { version = "1.2.46", optional = true }
 
 [package.metadata.docs.rs]
 features = ["crossval"]
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,69 @@
+# Effortless Metrics Clippy policy
+
+BitNet-rs uses the Effortless Metrics Rust lint policy as a governed engineering surface, not as an ad hoc list of local preferences. The policy is intentionally workspace-wide: production code, tests, examples, build helpers, and `xtask` all inherit the same baseline.
+
+## Policy goals
+
+The active baseline enforces four workspace promises. For this first BitNet-rs rollout, `unsafe_code` is deliberately staged as `warn` because the repository contains reviewed FFI/GPU boundaries that need a follow-up unsafe-boundary cleanup before a forbid-level ratchet:
+
+1. **Panic-free Rust by default.** `unwrap`, `expect`, `panic!`, `todo!`, `unimplemented!`, `unreachable!`, unchecked indexing, and unchecked string slicing are denied for production and tests.
+2. **No silent failure.** Futures, must-use values, locks, `Result::ok`, ignored `map_err` values, suspicious result assertions, and `lines().filter_map(Result::ok)` are denied.
+3. **Explicit suppression governance.** New suppressions should use narrow `#[expect(..., reason = "...")]` receipts. Silent `#[allow]` attributes and blanket Clippy restriction enables are denied.
+4. **Reviewable numeric/GPU code.** BitNet-rs keeps GPU/numeric footguns visible while staging churn-heavy arithmetic and numeric-cast checks as warnings where global denies would obscure product work.
+
+## Source of truth
+
+The policy has three layers:
+
+- `Cargo.toml` contains the active workspace lint levels under `[workspace.lints.rust]` and `[workspace.lints.clippy]`.
+- `policy/clippy-lints.toml` is the machine-readable ledger for active lints, policy posture, and planned Rust 1.94/1.95 flips.
+- `policy/clippy-debt.toml` records temporary, reviewed exceptions with owner, reason, affected path, lint, and expiry.
+
+`clippy.toml` is reserved for repo-local Clippy knobs such as thresholds and future `disallowed-methods` or `disallowed-types` policy. It must not contain test carveouts such as `allow-unwrap-in-tests`, `allow-expect-in-tests`, `allow-panic-in-tests`, `allow-indexing-slicing-in-tests`, or `allow-dbg-in-tests`.
+
+## Suppression style
+
+Prefer fixing the lint. When a local exception is truly needed, use an expectation with a reason:
+
+```rust
+#[expect(
+    clippy::arithmetic_side_effects,
+    reason = "Kernel loop uses reviewed wrapping arithmetic; tracked in policy/clippy-debt.toml."
+)]
+fn kernel_lane_index(base: usize, lane: usize) -> usize {
+    base + lane
+}
+```
+
+Do not add broad module-level `#[allow(...)]` blocks or test-only carveouts. If a suppression represents known debt rather than a permanent invariant, add an expiring entry to `policy/clippy-debt.toml`.
+
+## Panic-free tests
+
+Tests should return `Result` and use `?` for setup/fixture failures rather than `unwrap`, `expect`, or panic-driven setup:
+
+```rust
+#[test]
+fn parses_fixture() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = std::fs::read_to_string("tests/fixtures/input.gguf")?;
+    let parsed = parse_fixture(&fixture)?;
+
+    ensure_fixture_shape(&parsed)?;
+    Ok(())
+}
+```
+
+This keeps test failures contextual without weakening the workspace panic policy.
+
+## Upgrade tracking
+
+Rust 1.94 and 1.95 lints are tracked in `policy/clippy-lints.toml` before the MSRV bump. `cargo xtask check-lint-policy` fails if planned lints become active early or if the ledger and workspace manifest drift.
+
+## Required check
+
+Run this before opening policy or linting changes:
+
+```sh
+cargo xtask check-lint-policy
+```
+
+The check validates MSRV alignment, workspace lint inheritance, active lint consistency, planned-lint staging, no test carveouts, and debt-entry shape.

--- a/examples/migration/cpp-to-rust-basic/after/Cargo.toml
+++ b/examples/migration/cpp-to-rust-basic/after/Cargo.toml
@@ -36,3 +36,6 @@ strip = true
 
 [profile.bench]
 debug = true
+
+[lints]
+workspace = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -641,3 +641,6 @@ name = "fuzz_tensor_layout"
 path = "fuzz_targets/fuzz_tensor_layout.rs"
 test = false
 doc = false
+
+[lints]
+workspace = true

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,4 @@
+schema = 1
+
+# Repo-specific lint exceptions are added here as expiring, reviewed debt.
+# Each [[debt]] entry must include lint, path, owner, reason, and expires.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,786 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "warn"
+status = "active"
+class = "unsafe-memory"
+reason = "Existing FFI/GPU boundaries remain visible while the workspace migrates toward a forbid-level unsafe policy."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Unsafe operations in unsafe functions must remain explicitly scoped."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Must-use values cannot be silently dropped."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "configuration"
+reason = "Unexpected cfg names should be reviewed without blocking early rollout."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid shared mutable const footguns."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid function pointer/integer conversion footguns."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "async-concurrency"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "filesystem-process"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api-traits"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Part of the Effortless Metrics strict Clippy baseline for panic-free, AST-safe, reviewable Rust."
+
+[[planned]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[planned]]
+name = "clippy::manual_ilog2"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Prefer the standard integer log helper."
+
+[[planned]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[planned]]
+name = "clippy::needless_type_cast"
+level = "warn"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+[[planned]]
+name = "clippy::disallowed_fields"
+level = "deny"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[planned]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[planned]]
+name = "clippy::manual_take"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "ownership"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[planned]]
+name = "clippy::manual_pop_if"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "collections"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[planned]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "time"
+reason = "Make durations legible without mental unit conversion."
+
+[[planned]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."
+

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "0.3"
+
+# No panic-family exceptions are approved by default. Add [[allow]] entries only
+# with semantic path + family + selector identity, owner, explanation,
+# classification, advisory last_seen, and optional expires.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,6 @@
+schema_version = "1.0"
+
+# Non-Rust source exceptions should be represented as structured policy data.
+# Add [[allow]] entries with path or glob, kind, owner, reason, surface,
+# classification, covered_by, and optional expires when file-policy checking is
+# enabled for this workspace.

--- a/tests-new/Cargo.toml
+++ b/tests-new/Cargo.toml
@@ -25,3 +25,6 @@ bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, features = ["cpu", "rt-tokio"] }
 bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -286,3 +286,6 @@ filetime = "0.2.26"
 html-escape = "0.2.13"
 serde = { version = "1.0.228", features = ["derive"] }
 libc = "0.2.177"
+
+[lints]
+workspace = true

--- a/tools/bitnet-task/Cargo.toml
+++ b/tools/bitnet-task/Cargo.toml
@@ -13,3 +13,6 @@ sha2 = "0.10.9"
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/tools/migrate-gen-config/Cargo.toml
+++ b/tools/migrate-gen-config/Cargo.toml
@@ -10,3 +10,6 @@ syn = { version = "2.0.110", features = ["full", "visit-mut"] }
 quote = "1.0.42"
 prettyplease = "0.2.37"
 proc-macro2 = "1.0.103"
+
+[lints]
+workspace = true

--- a/xtask-build-helper/Cargo.toml
+++ b/xtask-build-helper/Cargo.toml
@@ -8,3 +8,6 @@ description = "Build script helpers for FFI compilation (AC6 FFI build hygiene)"
 
 [dependencies]
 cc = "1.2.46"
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -57,3 +57,6 @@ predicates = "3.1.3"
 serial_test = "3.2.0"
 temp-env = "0.3.6"
 bitnet-test-support.workspace = true
+
+[lints]
+workspace = true

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -1,0 +1,398 @@
+use anyhow::{Context, Result, bail};
+use chrono::{NaiveDate, Utc};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+use toml::Value;
+use walkdir::WalkDir;
+
+const REQUIRED_POLICY_FILES: &[&str] = &[
+    "policy/clippy-lints.toml",
+    "policy/clippy-debt.toml",
+    "policy/no-panic-allowlist.toml",
+    "policy/non-rust-allowlist.toml",
+    "docs/CLIPPY_POLICY.md",
+    "clippy.toml",
+];
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+pub fn run() -> Result<()> {
+    let root = repo_root()?;
+    let mut failures = Vec::new();
+
+    check_required_files(&root, &mut failures);
+
+    let cargo_path = root.join("Cargo.toml");
+    let cargo = fs::read_to_string(&cargo_path)
+        .with_context(|| format!("failed to read {}", cargo_path.display()))?;
+    let policy = read_toml(&root.join("policy/clippy-lints.toml"), &mut failures)?;
+    let debt = read_toml(&root.join("policy/clippy-debt.toml"), &mut failures)?;
+    let clippy = read_toml(&root.join("clippy.toml"), &mut failures)?;
+
+    check_msrv(&cargo, &policy, &clippy, &mut failures);
+    check_clippy_carveouts(&clippy, &mut failures);
+    check_policy_posture(&policy, &mut failures);
+    check_active_lints(&cargo, &policy, &mut failures);
+    check_planned_lints(&cargo, &policy, &mut failures);
+    check_lint_inheritance(&root, &mut failures);
+    check_debt(&debt, &mut failures);
+
+    if !failures.is_empty() {
+        failures.sort();
+        failures.dedup();
+        for failure in &failures {
+            eprintln!("lint policy violation: {failure}");
+        }
+        bail!("lint policy check failed with {} violation(s)", failures.len());
+    }
+
+    println!("✅ lint policy check passed");
+    Ok(())
+}
+
+fn repo_root() -> Result<PathBuf> {
+    let mut dir = std::env::current_dir().context("failed to read current directory")?;
+    loop {
+        if dir.join("Cargo.toml").is_file() && dir.join("xtask").is_dir() {
+            return Ok(dir);
+        }
+        if !dir.pop() {
+            bail!("could not find repository root containing Cargo.toml and xtask/");
+        }
+    }
+}
+
+fn read_toml(path: &Path, failures: &mut Vec<String>) -> Result<Value> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            failures.push(format!("{} must be readable: {err}", path.display()));
+            String::new()
+        }
+    };
+    raw.parse::<toml::Table>()
+        .map(Value::Table)
+        .with_context(|| format!("failed to parse {} as TOML", path.display()))
+}
+
+fn check_required_files(root: &Path, failures: &mut Vec<String>) {
+    for file in REQUIRED_POLICY_FILES {
+        if !root.join(file).is_file() {
+            failures.push(format!("required policy file {file} is missing"));
+        }
+    }
+}
+
+fn check_msrv(cargo: &str, policy: &Value, clippy: &Value, failures: &mut Vec<String>) {
+    let workspace_msrv = cargo_workspace_msrv(cargo);
+    let policy_msrv = policy.get("msrv").and_then(Value::as_str);
+    let clippy_msrv = clippy.get("msrv").and_then(Value::as_str);
+
+    if workspace_msrv != Some("1.93") {
+        failures.push(format!(
+            "workspace.package.rust-version must be 1.93, found {:?}",
+            workspace_msrv
+        ));
+    }
+    if policy_msrv != workspace_msrv {
+        failures.push(format!(
+            "policy/clippy-lints.toml msrv {:?} must match workspace MSRV {:?}",
+            policy_msrv, workspace_msrv
+        ));
+    }
+    if clippy_msrv != workspace_msrv {
+        failures.push(format!(
+            "clippy.toml msrv {:?} must match workspace MSRV {:?}",
+            clippy_msrv, workspace_msrv
+        ));
+    }
+}
+
+fn check_clippy_carveouts(clippy: &Value, failures: &mut Vec<String>) {
+    for carveout in TEST_CARVEOUTS {
+        if clippy.get(*carveout).is_some() {
+            failures.push(format!("clippy.toml must not configure test carveout {carveout}"));
+        }
+    }
+}
+
+fn check_policy_posture(policy: &Value, failures: &mut Vec<String>) {
+    let posture = policy.get("policy");
+    require_bool(posture, "panic_free_tests", true, failures);
+    require_bool(posture, "allow_test_carveouts", false, failures);
+    require_bool(posture, "blanket_categories", false, failures);
+    let suppression =
+        posture.and_then(|value| value.get("suppression_style")).and_then(Value::as_str);
+    if suppression != Some("expect-with-reason") {
+        failures.push(format!(
+            "policy.suppression_style must be expect-with-reason, found {:?}",
+            suppression
+        ));
+    }
+}
+
+fn require_bool(posture: Option<&Value>, key: &str, expected: bool, failures: &mut Vec<String>) {
+    let actual = posture.and_then(|value| value.get(key)).and_then(Value::as_bool);
+    if actual != Some(expected) {
+        failures.push(format!("policy.{key} must be {expected}, found {actual:?}"));
+    }
+}
+
+fn check_active_lints(cargo: &str, policy: &Value, failures: &mut Vec<String>) {
+    let active = policy.get("lint").and_then(Value::as_array).cloned().unwrap_or_default();
+    if active.is_empty() {
+        failures.push("policy/clippy-lints.toml must define active [[lint]] entries".to_string());
+    }
+
+    let rust_lints = workspace_lint_table(cargo, "rust");
+    let clippy_lints = workspace_lint_table(cargo, "clippy");
+
+    for lint in active {
+        let Some(name) = lint.get("name").and_then(Value::as_str) else {
+            failures.push("active lint entry missing name".to_string());
+            continue;
+        };
+        let Some(level) = lint.get("level").and_then(Value::as_str) else {
+            failures.push(format!("active lint {name} missing level"));
+            continue;
+        };
+        if lint.get("status").and_then(Value::as_str) != Some("active") {
+            failures.push(format!("active lint {name} must have status = active"));
+        }
+        if lint.get("reason").and_then(Value::as_str).is_none_or(str::is_empty) {
+            failures.push(format!("active lint {name} missing reason"));
+        }
+        if lint.get("class").and_then(Value::as_str).is_none_or(str::is_empty) {
+            failures.push(format!("active lint {name} missing class"));
+        }
+
+        let (table, local_name) = if let Some(local) = name.strip_prefix("rust::") {
+            (&rust_lints, local)
+        } else if let Some(local) = name.strip_prefix("clippy::") {
+            (&clippy_lints, local)
+        } else {
+            failures.push(format!("active lint {name} must start with rust:: or clippy::"));
+            continue;
+        };
+        match table.get(local_name) {
+            Some(actual) if actual == level => {}
+            Some(actual) => {
+                failures.push(format!("active lint {name} level is {actual}, expected {level}"))
+            }
+            None => failures.push(format!("active lint {name} is missing from Cargo.toml")),
+        }
+    }
+}
+
+fn check_planned_lints(cargo: &str, policy: &Value, failures: &mut Vec<String>) {
+    let planned = policy.get("planned").and_then(Value::as_array).cloned().unwrap_or_default();
+    let clippy_lints = workspace_lint_table(cargo, "clippy");
+    let msrv = cargo_workspace_msrv(cargo).unwrap_or_default();
+
+    for lint in planned {
+        let Some(name) = lint.get("name").and_then(Value::as_str) else {
+            failures.push("planned lint entry missing name".to_string());
+            continue;
+        };
+        let Some(activate) = lint.get("activate_when_msrv").and_then(Value::as_str) else {
+            failures.push(format!("planned lint {name} missing activate_when_msrv"));
+            continue;
+        };
+        if lint.get("level").and_then(Value::as_str).is_none() {
+            failures.push(format!("planned lint {name} missing level"));
+        }
+        if lint.get("reason").and_then(Value::as_str).is_none_or(str::is_empty) {
+            failures.push(format!("planned lint {name} missing reason"));
+        }
+        if lint.get("class").and_then(Value::as_str).is_none_or(str::is_empty) {
+            failures.push(format!("planned lint {name} missing class"));
+        }
+        if version_lt(msrv, activate) {
+            if let Some(local) = name.strip_prefix("clippy::") {
+                if clippy_lints.contains_key(local) {
+                    failures.push(format!(
+                        "planned lint {name} must not be active before MSRV {activate}"
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn workspace_lint_table(cargo: &str, tool: &str) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    let header = format!("[workspace.lints.{tool}]");
+    let mut in_table = false;
+    for line in cargo.lines() {
+        let trimmed = line.trim();
+        if trimmed == header {
+            in_table = true;
+            continue;
+        }
+        if in_table && trimmed.starts_with('[') {
+            break;
+        }
+        if !in_table || trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, rest)) = trimmed.split_once('=') else {
+            continue;
+        };
+        let key = key.trim().to_string();
+        let rest = rest.split('#').next().unwrap_or(rest).trim();
+        let level = if rest.starts_with('{') {
+            rest.split("level").nth(1).and_then(|tail| tail.split('"').nth(1)).map(str::to_string)
+        } else {
+            rest.trim_matches('"').split('"').next().map(str::to_string)
+        };
+        if let Some(level) = level.filter(|level| !level.is_empty()) {
+            out.insert(key, level);
+        }
+    }
+    out
+}
+
+fn cargo_workspace_msrv(cargo: &str) -> Option<&str> {
+    let mut in_table = false;
+    for line in cargo.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[workspace.package]" {
+            in_table = true;
+            continue;
+        }
+        if in_table && trimmed.starts_with('[') {
+            return None;
+        }
+        if in_table {
+            let Some((key, value)) = trimmed.split_once('=') else {
+                continue;
+            };
+            if key.trim() == "rust-version" {
+                return value.trim().trim_matches('"').split('"').next();
+            }
+        }
+    }
+    None
+}
+
+fn check_lint_inheritance(root: &Path, failures: &mut Vec<String>) {
+    for entry in WalkDir::new(root)
+        .into_iter()
+        .filter_entry(|entry| !is_ignored_dir(entry.path()))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file() && entry.file_name() == "Cargo.toml")
+    {
+        let path = entry.path();
+        let Ok(raw) = fs::read_to_string(path) else {
+            failures.push(format!("{} must be readable", relative(root, path)));
+            continue;
+        };
+        if !raw.contains("[package]") || path == root.join("Cargo.toml") {
+            continue;
+        }
+        if !has_lints_workspace_true(&raw) {
+            failures
+                .push(format!("{} must include [lints] workspace = true", relative(root, path)));
+        }
+    }
+}
+
+fn has_lints_workspace_true(raw: &str) -> bool {
+    let mut in_table = false;
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[lints]" {
+            in_table = true;
+            continue;
+        }
+        if in_table && trimmed.starts_with('[') {
+            return false;
+        }
+        if in_table {
+            let Some((key, value)) = trimmed.split_once('=') else {
+                continue;
+            };
+            if key.trim() == "workspace" && value.trim() == "true" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn check_debt(debt: &Value, failures: &mut Vec<String>) {
+    if debt.get("schema").and_then(Value::as_integer) != Some(1) {
+        failures.push("policy/clippy-debt.toml must declare schema = 1".to_string());
+    }
+    let Some(entries) = debt.get("debt").and_then(Value::as_array) else {
+        return;
+    };
+    let today = Utc::now().date_naive();
+    let mut seen = BTreeSet::new();
+    for entry in entries {
+        let lint = required_str(entry, "lint", failures, "debt entry");
+        let path = required_str(entry, "path", failures, "debt entry");
+        required_str(entry, "owner", failures, "debt entry");
+        required_str(entry, "reason", failures, "debt entry");
+        let expires = required_str(entry, "expires", failures, "debt entry");
+        if let Some(expires) = expires {
+            match NaiveDate::parse_from_str(expires, "%Y-%m-%d") {
+                Ok(date) if date < today => failures.push(format!(
+                    "debt entry for {} at {} expired on {expires}",
+                    lint.unwrap_or("<missing lint>"),
+                    path.unwrap_or("<missing path>")
+                )),
+                Ok(_) => {}
+                Err(err) => failures.push(format!(
+                    "debt entry for {} at {} has invalid expires date {expires}: {err}",
+                    lint.unwrap_or("<missing lint>"),
+                    path.unwrap_or("<missing path>")
+                )),
+            }
+        }
+        if let (Some(lint), Some(path)) = (lint, path) {
+            let key = format!("{lint}|{path}");
+            if !seen.insert(key.clone()) {
+                failures.push(format!("duplicate debt entry {key}"));
+            }
+        }
+    }
+}
+
+fn required_str<'a>(
+    entry: &'a Value,
+    key: &str,
+    failures: &mut Vec<String>,
+    context: &str,
+) -> Option<&'a str> {
+    let value = entry.get(key).and_then(Value::as_str);
+    if value.is_none_or(str::is_empty) {
+        failures.push(format!("{context} missing {key}"));
+    }
+    value
+}
+
+fn is_ignored_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, ".git" | "target" | ".cargo"))
+}
+
+fn relative(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root).unwrap_or(path).display().to_string()
+}
+
+fn version_lt(left: &str, right: &str) -> bool {
+    parse_version(left) < parse_version(right)
+}
+
+fn parse_version(version: &str) -> Vec<u32> {
+    version.split('.').map(|part| part.parse::<u32>().unwrap_or(0)).collect()
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -44,6 +44,7 @@ mod gates;
 mod grid_check;
 #[allow(dead_code)]
 mod health_check;
+mod lint_policy;
 #[allow(dead_code)]
 mod model_info;
 mod model_registry;
@@ -998,6 +999,10 @@ enum Cmd {
         dry_run: bool,
     },
 
+    /// Validate workspace lint policy files and inheritance.
+    #[command(name = "check-lint-policy")]
+    CheckLintPolicy,
+
     /// Manage campaign-local alignment trackers.
     Campaign {
         #[command(subcommand)]
@@ -1328,6 +1333,7 @@ fn real_main() -> Result<()> {
         Cmd::GridCheck { cpu_only, verbose, dry_run } => {
             grid_check::run(cpu_only, verbose, dry_run)
         }
+        Cmd::CheckLintPolicy => lint_policy::run(),
         Cmd::Campaign { command } => campaign::run(command),
     }
 }


### PR DESCRIPTION
### Motivation

- Establish a governed, machine-readable Clippy policy baseline (panic-free, suppression governance, planned Rust 1.94/1.95 flips) and make exceptions explicit as expiring debt rather than silent carveouts.  
- Provide repo-local policy artifacts and an `xtask` gate so CI can validate MSRV, lint inheritance, no-test-carveouts, and debt/allowlist correctness.  
- Stage `unsafe_code` to `warn` for BitNet-rs initially to avoid breaking FFI/GPU boundaries while enforcing the broader lint posture.

### Description

- Added a workspace lint profile in `Cargo.toml` (migrated/expanded `[workspace.lints.rust]` and `[workspace.lints.clippy]`) and bumped workspace MSRV to `1.93`.  
- Added repo policy and tracking files under `policy/`: `clippy-lints.toml` (machine-readable ledger with active + planned lints), `clippy-debt.toml` (debt ledger template), `no-panic-allowlist.toml`, and `non-rust-allowlist.toml` plus `docs/CLIPPY_POLICY.md`.  
- Created `clippy.toml` for repo-local Clippy knobs (thresholds, msrv) and removed test carveouts such as `allow-unwrap-in-tests` / `allow-expect-in-tests`.  
- Implemented `xtask/src/lint_policy.rs` to validate policy files, MSRV alignment, workspace lint inheritance, planned-lint staging, suppression style, and debt entries, and wired a `CheckLintPolicy` command into `xtask/src/main.rs`.  
- Propagated `[lints] workspace = true` to workspace member manifests (added to ~97 crate manifests and the example), and added `policy/clippy-debt.toml` placeholder and other policy scaffolding.  
- Kept `unsafe` policy staged as `warn` for this rollout and updated documentation to explain the staged approach to unsafe/FFI GPU boundaries.

### Testing

- Ran `cargo fmt` to format changes (succeeded).  
- Installed Rust 1.93 toolchain and ran the new check gate via `cargo +1.93.0 run -p xtask --no-default-features -- check-lint-policy` to validate policy wiring and workspace inheritance; the check completed after fixes and reported warnings about existing `unsafe` usage and other lint/output warnings but no policy failures after the staged adjustments (succeeded with warnings).  
- Attempted to build `xtask` with default features but linking failed on this host due to missing CUDA libs; reran the lint check with `--no-default-features` to avoid platform GPU linking and complete the policy verification (build failure expected for full-feature build; lint check succeeded under no-default-features).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb084404ec8333ae718c508bf54786)