### PR TITLE
LNL258V-RUN-001: add Lunar Lake platform visibility probe

### DIFF
--- a/ci/hardware/intel-258v/README.md
+++ b/ci/hardware/intel-258v/README.md
@@ -1,0 +1,16 @@
+# Intel 258V Hardware Artifacts
+
+This directory holds machine-local artifacts for the Core Ultra 7 258V Lunar
+Lake laptop.
+
+Expected path pattern:
+
+```text
+ci/hardware/intel-258v/<date>/platform-probe.json
+ci/hardware/intel-258v/<date>/cpu-bitnet-validation.json
+```
+
+`platform-probe.json` is visibility-only. It may record CPU AVX2 facts, Arc
+140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO
+visibility, memory, power, and OS context. It must not claim BitNet inference,
+Arc 140V execution, NPU execution, or acceleration.

--- a/crates/bitnet-device-probe/src/cpu/mod.rs
+++ b/crates/bitnet-device-probe/src/cpu/mod.rs
@@ -1,0 +1,7 @@
+//! CPU probe helpers shared by hardware-lane visibility probes.
+
+pub mod topology;
+pub mod x86;
+
+pub use topology::{CpuTopologyProbe, probe_cpu_topology};
+pub use x86::{X86CpuFeatureProbe, probe_x86_cpu_features};

--- a/crates/bitnet-device-probe/src/cpu/topology.rs
+++ b/crates/bitnet-device-probe/src/cpu/topology.rs
@@ -29,7 +29,7 @@ fn cpu_brand() -> Option<String> {
                 line.strip_prefix("model name")
                     .and_then(|rest| rest.split_once(':').map(|(_, value)| value.trim().to_owned()))
             }) {
-                return non_empty(value);
+                return non_empty(&value);
             }
         }
     }
@@ -44,14 +44,14 @@ fn cpu_brand() -> Option<String> {
                 "(Get-CimInstance Win32_Processor | Select-Object -First 1).Name",
             ],
         ) {
-            return non_empty(value);
+            return non_empty(&value);
         }
     }
 
     #[cfg(target_os = "macos")]
     {
         if let Some(value) = command_stdout("sysctl", &["-n", "machdep.cpu.brand_string"]) {
-            return non_empty(value);
+            return non_empty(&value);
         }
     }
 
@@ -67,7 +67,7 @@ fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
         .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
 }
 
-fn non_empty(value: String) -> Option<String> {
+fn non_empty(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() { None } else { Some(trimmed.to_owned()) }
 }

--- a/crates/bitnet-device-probe/src/cpu/topology.rs
+++ b/crates/bitnet-device-probe/src/cpu/topology.rs
@@ -1,5 +1,6 @@
 //! Portable CPU topology and brand probing.
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::process::Command;
 
 use serde::{Deserialize, Serialize};
@@ -24,13 +25,13 @@ pub fn probe_cpu_topology() -> CpuTopologyProbe {
 fn cpu_brand() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
-        if let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo") {
-            if let Some(value) = cpuinfo.lines().find_map(|line| {
+        if let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo")
+            && let Some(value) = cpuinfo.lines().find_map(|line| {
                 line.strip_prefix("model name")
                     .and_then(|rest| rest.split_once(':').map(|(_, value)| value.trim().to_owned()))
-            }) {
-                return non_empty(&value);
-            }
+            })
+        {
+            return non_empty(&value);
         }
     }
 
@@ -58,6 +59,7 @@ fn cpu_brand() -> Option<String> {
     None
 }
 
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
     Command::new(command)
         .args(args)

--- a/crates/bitnet-device-probe/src/cpu/topology.rs
+++ b/crates/bitnet-device-probe/src/cpu/topology.rs
@@ -1,0 +1,73 @@
+//! Portable CPU topology and brand probing.
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+/// Basic CPU topology facts available without platform-specific dependencies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CpuTopologyProbe {
+    /// Human-readable CPU brand string when available.
+    pub brand: Option<String>,
+    /// Best-effort physical core count.
+    pub cores: usize,
+    /// Logical thread count visible to the process.
+    pub threads: usize,
+}
+
+/// Probe CPU brand and topology, falling back to logical thread count.
+pub fn probe_cpu_topology() -> CpuTopologyProbe {
+    let threads = std::thread::available_parallelism().map(std::num::NonZero::get).unwrap_or(1);
+    CpuTopologyProbe { brand: cpu_brand(), cores: threads, threads }
+}
+
+fn cpu_brand() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(cpuinfo) = std::fs::read_to_string("/proc/cpuinfo") {
+            if let Some(value) = cpuinfo.lines().find_map(|line| {
+                line.strip_prefix("model name")
+                    .and_then(|rest| rest.split_once(':').map(|(_, value)| value.trim().to_owned()))
+            }) {
+                return non_empty(value);
+            }
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(value) = command_stdout(
+            "powershell",
+            &[
+                "-NoProfile",
+                "-Command",
+                "(Get-CimInstance Win32_Processor | Select-Object -First 1).Name",
+            ],
+        ) {
+            return non_empty(value);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(value) = command_stdout("sysctl", &["-n", "machdep.cpu.brand_string"]) {
+            return non_empty(value);
+        }
+    }
+
+    None
+}
+
+fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
+    Command::new(command)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_owned()) }
+}

--- a/crates/bitnet-device-probe/src/cpu/x86.rs
+++ b/crates/bitnet-device-probe/src/cpu/x86.rs
@@ -1,0 +1,34 @@
+//! x86 CPU feature probing used by validation lanes.
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime-visible x86 CPU feature facts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct X86CpuFeatureProbe {
+    /// Whether AVX2 is available to the current process.
+    pub has_avx2: bool,
+    /// Whether AVX-512F is available to the current process.
+    pub has_avx512: bool,
+    /// Whether FMA is available to the current process.
+    pub has_fma: bool,
+    /// Whether SSE4.2 is available to the current process.
+    pub has_sse42: bool,
+}
+
+/// Probe x86 SIMD features without panicking on non-x86 targets.
+pub fn probe_x86_cpu_features() -> X86CpuFeatureProbe {
+    #[cfg(target_arch = "x86_64")]
+    {
+        X86CpuFeatureProbe {
+            has_avx2: is_x86_feature_detected!("avx2"),
+            has_avx512: is_x86_feature_detected!("avx512f"),
+            has_fma: is_x86_feature_detected!("fma"),
+            has_sse42: is_x86_feature_detected!("sse4.2"),
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        X86CpuFeatureProbe { has_avx2: false, has_avx512: false, has_fma: false, has_sse42: false }
+    }
+}

--- a/crates/bitnet-device-probe/src/cpu/x86.rs
+++ b/crates/bitnet-device-probe/src/cpu/x86.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Runtime-visible x86 CPU feature facts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct X86CpuFeatureProbe {
     /// Whether AVX2 is available to the current process.
     pub has_avx2: bool,

--- a/crates/bitnet-device-probe/src/cpu/x86.rs
+++ b/crates/bitnet-device-probe/src/cpu/x86.rs
@@ -17,6 +17,7 @@ pub struct X86CpuFeatureProbe {
 }
 
 /// Probe x86 SIMD features without panicking on non-x86 targets.
+#[allow(clippy::missing_const_for_fn)]
 pub fn probe_x86_cpu_features() -> X86CpuFeatureProbe {
     #[cfg(target_arch = "x86_64")]
     {

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
@@ -1,4 +1,5 @@
 //! Intel Arc 140V visibility probe.
+#![allow(clippy::doc_markdown)]
 
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +11,7 @@ const ARC_140V_PCI_DEVICE_ID: &str = "0x64A0";
 
 /// Visibility facts for the Lunar Lake integrated Arc 140V GPU.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct IntelArc140vProbe {
     /// Whether the probe found evidence that the Arc 140V is visible.
     pub available: bool,
@@ -60,7 +62,7 @@ pub fn probe_intel_arc_140v(
         openvino_gpu_device.as_deref().and_then(|token| openvino.full_name_for(token));
     let openvino_gpu_visible = openvino_gpu_device.is_some();
     let openvino_name_matches =
-        openvino_gpu_full_name.as_deref().map(name_matches_arc_140v).unwrap_or(false);
+        openvino_gpu_full_name.as_deref().is_some_and(name_matches_arc_140v);
 
     let available =
         opencl_device.is_some() || !level_zero_devices.is_empty() || openvino_name_matches;

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
@@ -1,0 +1,94 @@
+//! Intel Arc 140V visibility probe.
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtimes::{LevelZeroProbe, OpenClRuntimeProbe, OpenVinoProbe};
+
+use super::platform::{PlatformMemoryProbe, PlatformPowerProbe};
+
+const ARC_140V_PCI_DEVICE_ID: &str = "0x64A0";
+
+/// Visibility facts for the Lunar Lake integrated Arc 140V GPU.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntelArc140vProbe {
+    /// Whether the probe found evidence that the Arc 140V is visible.
+    pub available: bool,
+    /// Expected PCI device ID when it can be resolved.
+    pub pci_device_id: Option<String>,
+    /// Whether OpenCL runtime visibility includes Arc 140V.
+    pub opencl_available: bool,
+    /// OpenCL platform name when available.
+    pub opencl_platform_name: Option<String>,
+    /// OpenCL device name when available.
+    pub opencl_device_name: Option<String>,
+    /// OpenCL driver version when available.
+    pub opencl_driver_version: Option<String>,
+    /// Whether Level Zero tooling sees a matching device.
+    pub level_zero_available: bool,
+    /// Level Zero device lines or names.
+    pub level_zero_devices: Vec<String>,
+    /// Whether OpenVINO exposes a GPU device on this platform.
+    pub openvino_gpu_visible: bool,
+    /// OpenVINO GPU token, usually `GPU.0` on an iGPU-only Lunar Lake system.
+    pub openvino_gpu_device: Option<String>,
+    /// OpenVINO GPU full device name when available.
+    pub openvino_gpu_full_name: Option<String>,
+    /// Shared-memory size context when available.
+    pub shared_memory_bytes: Option<u64>,
+    /// Power mode context when available.
+    pub power_mode: Option<String>,
+    /// Non-fatal reason explaining why exact Arc 140V identity was not found.
+    pub failure_reason: Option<String>,
+}
+
+/// Build an Arc 140V visibility result from runtime probes.
+pub fn probe_intel_arc_140v(
+    opencl: &OpenClRuntimeProbe,
+    level_zero: &LevelZeroProbe,
+    openvino: &OpenVinoProbe,
+    memory: &PlatformMemoryProbe,
+    power: &PlatformPowerProbe,
+) -> IntelArc140vProbe {
+    let opencl_device =
+        opencl.devices.iter().find(|device| name_matches_arc_140v(&device.device_name));
+
+    let level_zero_devices: Vec<String> =
+        level_zero.devices.iter().filter(|device| name_matches_arc_140v(device)).cloned().collect();
+
+    let openvino_gpu_device = openvino.gpu_device_token();
+    let openvino_gpu_full_name =
+        openvino_gpu_device.as_deref().and_then(|token| openvino.full_name_for(token));
+    let openvino_gpu_visible = openvino_gpu_device.is_some();
+    let openvino_name_matches =
+        openvino_gpu_full_name.as_deref().map(name_matches_arc_140v).unwrap_or(false);
+
+    let available =
+        opencl_device.is_some() || !level_zero_devices.is_empty() || openvino_name_matches;
+    let failure_reason = if available {
+        None
+    } else {
+        Some("Arc 140V identity was not visible through OpenCL, Level Zero, or OpenVINO".to_owned())
+    };
+
+    IntelArc140vProbe {
+        available,
+        pci_device_id: available.then_some(ARC_140V_PCI_DEVICE_ID.to_owned()),
+        opencl_available: opencl_device.is_some(),
+        opencl_platform_name: opencl_device.and_then(|device| device.platform_name.clone()),
+        opencl_device_name: opencl_device.map(|device| device.device_name.clone()),
+        opencl_driver_version: opencl_device.and_then(|device| device.driver_version.clone()),
+        level_zero_available: !level_zero_devices.is_empty(),
+        level_zero_devices,
+        openvino_gpu_visible,
+        openvino_gpu_device,
+        openvino_gpu_full_name,
+        shared_memory_bytes: memory.shared_memory_bytes,
+        power_mode: power.mode.clone(),
+        failure_reason,
+    }
+}
+
+fn name_matches_arc_140v(value: &str) -> bool {
+    let lower = value.to_ascii_lowercase();
+    (lower.contains("arc") && lower.contains("140v")) || lower.contains("64a0")
+}

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/cpu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/cpu.rs
@@ -1,4 +1,5 @@
 //! Lunar Lake CPU visibility facts.
+#![allow(clippy::doc_markdown)]
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +7,7 @@ use crate::cpu::{probe_cpu_topology, probe_x86_cpu_features};
 
 /// CPU facts for the Core Ultra 7 258V validation lane.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Lnl258vCpuProbe {
     /// CPU brand string when the OS exposes one.
     pub brand: Option<String>,
@@ -36,8 +38,7 @@ pub fn probe_lnl258v_cpu() -> Lnl258vCpuProbe {
     let is_258v = topology
         .brand
         .as_deref()
-        .map(|brand| brand.contains("258V") || brand.contains("Core Ultra 7"))
-        .unwrap_or(false);
+        .is_some_and(|brand| brand.contains("258V") || brand.contains("Core Ultra 7"));
 
     Lnl258vCpuProbe {
         brand: topology.brand,

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/cpu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/cpu.rs
@@ -1,0 +1,57 @@
+//! Lunar Lake CPU visibility facts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::cpu::{probe_cpu_topology, probe_x86_cpu_features};
+
+/// CPU facts for the Core Ultra 7 258V validation lane.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lnl258vCpuProbe {
+    /// CPU brand string when the OS exposes one.
+    pub brand: Option<String>,
+    /// Best-effort physical core count.
+    pub cores: usize,
+    /// Logical thread count visible to the process.
+    pub threads: usize,
+    /// Expected 258V P-core count when the machine identity matches Lunar Lake.
+    pub p_core_count: Option<usize>,
+    /// Expected 258V low-power E-core count when the machine identity matches Lunar Lake.
+    pub lp_e_core_count: Option<usize>,
+    /// Whether AVX2 is available at runtime.
+    pub has_avx2: bool,
+    /// Whether AVX-512F is available at runtime.
+    pub has_avx512: bool,
+    /// Whether FMA is available at runtime.
+    pub has_fma: bool,
+    /// Whether SSE4.2 is available at runtime.
+    pub has_sse42: bool,
+    /// Human-readable scheduler or topology note.
+    pub scheduler_hint: Option<String>,
+}
+
+/// Probe Lunar Lake CPU facts without making a BitNet inference claim.
+pub fn probe_lnl258v_cpu() -> Lnl258vCpuProbe {
+    let topology = probe_cpu_topology();
+    let features = probe_x86_cpu_features();
+    let is_258v = topology
+        .brand
+        .as_deref()
+        .map(|brand| brand.contains("258V") || brand.contains("Core Ultra 7"))
+        .unwrap_or(false);
+
+    Lnl258vCpuProbe {
+        brand: topology.brand,
+        cores: topology.cores,
+        threads: topology.threads,
+        p_core_count: is_258v.then_some(4),
+        lp_e_core_count: is_258v.then_some(4),
+        has_avx2: features.has_avx2,
+        has_avx512: features.has_avx512,
+        has_fma: features.has_fma,
+        has_sse42: features.has_sse42,
+        scheduler_hint: is_258v.then_some(
+            "Lunar Lake validation should record P-core / low-power E-core and power context"
+                .to_owned(),
+        ),
+    }
+}

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs
@@ -1,0 +1,15 @@
+//! Intel Core Ultra 7 258V Lunar Lake platform visibility probes.
+
+pub mod arc140v;
+pub mod cpu;
+pub mod npu;
+pub mod platform;
+
+pub use crate::runtimes::OpenVinoProbe;
+pub use arc140v::{IntelArc140vProbe, probe_intel_arc_140v};
+pub use cpu::{Lnl258vCpuProbe, probe_lnl258v_cpu};
+pub use npu::{IntelNpuProbe, probe_intel_npu};
+pub use platform::{
+    LNL258V_PROOF_STAGE_RUNTIME_DETECTED, Lnl258vPlatformProbe, PlatformMemoryProbe,
+    PlatformPowerProbe, probe_lnl258v_platform,
+};

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
@@ -1,4 +1,5 @@
 //! Intel AI Boost NPU visibility probe for Lunar Lake.
+#![allow(clippy::doc_markdown)]
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +7,7 @@ use crate::runtimes::OpenVinoProbe;
 
 /// Visibility facts for the Intel AI Boost NPU lane.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct IntelNpuProbe {
     /// Whether any OS or OpenVINO NPU evidence was visible.
     pub available: bool,
@@ -85,6 +87,7 @@ pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
     }
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn accel_devices() -> Vec<String> {
     #[cfg(target_os = "linux")]
     {
@@ -115,7 +118,7 @@ fn intel_vpu_driver_seen() -> bool {
 
     #[cfg(target_os = "windows")]
     {
-        return std::process::Command::new("powershell")
+        std::process::Command::new("powershell")
             .args([
                 "-NoProfile",
                 "-Command",
@@ -123,7 +126,7 @@ fn intel_vpu_driver_seen() -> bool {
             ])
             .output()
             .map(|output| output.status.success() && !output.stdout.is_empty())
-            .unwrap_or(false);
+            .unwrap_or(false)
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
@@ -1,0 +1,133 @@
+//! Intel AI Boost NPU visibility probe for Lunar Lake.
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtimes::OpenVinoProbe;
+
+/// Visibility facts for the Intel AI Boost NPU lane.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntelNpuProbe {
+    /// Whether any OS or OpenVINO NPU evidence was visible.
+    pub available: bool,
+    /// Whether Linux `/dev/accel` devices are present.
+    pub accel_device_present: bool,
+    /// Linux `/dev/accel/*` entries when available.
+    pub accel_devices: Vec<String>,
+    /// Whether kernel logs or OS device evidence mention Intel VPU/NPU.
+    pub intel_vpu_driver_seen: bool,
+    /// Driver hint parsed from local evidence when available.
+    pub driver_hint: Option<String>,
+    /// Whether OpenVINO runtime itself was visible.
+    pub openvino_runtime_available: bool,
+    /// OpenVINO version when available.
+    pub openvino_version: Option<String>,
+    /// Whether OpenVINO exposes an NPU device token.
+    pub openvino_npu_visible: bool,
+    /// OpenVINO NPU full name when available.
+    pub openvino_npu_full_name: Option<String>,
+    /// OpenVINO supported property names for NPU when available.
+    pub supported_properties: Vec<String>,
+    /// NPU driver version when available.
+    pub driver_version: Option<String>,
+    /// NPU compiler version when available.
+    pub compiler_version: Option<String>,
+    /// NPU total memory size when available.
+    pub total_mem_size: Option<u64>,
+    /// Non-fatal reason explaining unavailable state.
+    pub failure_reason: Option<String>,
+}
+
+/// Probe Intel NPU visibility without compiling an OpenVINO graph.
+pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
+    let accel_devices = accel_devices();
+    let accel_device_present = !accel_devices.is_empty();
+    let openvino_npu_visible = openvino.npu_visible();
+    let npu_device = openvino
+        .available_devices
+        .iter()
+        .find(|device| device.as_str() == "NPU" || device.starts_with("NPU."))
+        .cloned();
+    let openvino_npu_full_name =
+        npu_device.as_deref().and_then(|token| openvino.full_name_for(token));
+    let supported_properties = npu_device
+        .as_deref()
+        .and_then(|token| {
+            openvino
+                .devices
+                .iter()
+                .find(|device| device.device == token)
+                .map(|device| device.supported_properties.clone())
+        })
+        .unwrap_or_default();
+    let intel_vpu_driver_seen = intel_vpu_driver_seen();
+    let available = accel_device_present || openvino_npu_visible || intel_vpu_driver_seen;
+    let failure_reason = if available {
+        None
+    } else {
+        Some("Intel NPU was not visible through OS accelerator devices or OpenVINO".to_owned())
+    };
+
+    IntelNpuProbe {
+        available,
+        accel_device_present,
+        accel_devices,
+        intel_vpu_driver_seen,
+        driver_hint: intel_vpu_driver_seen.then_some("intel_vpu/ivpu evidence".to_owned()),
+        openvino_runtime_available: openvino.runtime_available,
+        openvino_version: openvino.version.clone(),
+        openvino_npu_visible,
+        openvino_npu_full_name,
+        supported_properties,
+        driver_version: None,
+        compiler_version: None,
+        total_mem_size: None,
+        failure_reason,
+    }
+}
+
+fn accel_devices() -> Vec<String> {
+    #[cfg(target_os = "linux")]
+    {
+        return std::fs::read_dir("/dev/accel")
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .map(|entry| entry.path().display().to_string())
+                    .filter(|path| path.contains("accel"))
+                    .collect()
+            })
+            .unwrap_or_default();
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Vec::new()
+    }
+}
+
+fn intel_vpu_driver_seen() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        return std::fs::read_to_string("/sys/bus/pci/drivers/intel_vpu/module/drivers")
+            .map(|content| content.to_ascii_lowercase().contains("vpu"))
+            .unwrap_or(false);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                "Get-PnpDevice | Where-Object { $_.FriendlyName -match 'NPU|AI Boost|VPU' }",
+            ])
+            .output()
+            .map(|output| output.status.success() && !output.stdout.is_empty())
+            .unwrap_or(false);
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        false
+    }
+}

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
@@ -108,6 +108,7 @@ fn accel_devices() -> Vec<String> {
     }
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn intel_vpu_driver_seen() -> bool {
     #[cfg(target_os = "linux")]
     {

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
@@ -91,7 +91,7 @@ pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
 fn accel_devices() -> Vec<String> {
     #[cfg(target_os = "linux")]
     {
-        return std::fs::read_dir("/dev/accel")
+        std::fs::read_dir("/dev/accel")
             .map(|entries| {
                 entries
                     .flatten()
@@ -99,7 +99,7 @@ fn accel_devices() -> Vec<String> {
                     .filter(|path| path.contains("accel"))
                     .collect()
             })
-            .unwrap_or_default();
+            .unwrap_or_default()
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -111,9 +111,9 @@ fn accel_devices() -> Vec<String> {
 fn intel_vpu_driver_seen() -> bool {
     #[cfg(target_os = "linux")]
     {
-        return std::fs::read_to_string("/sys/bus/pci/drivers/intel_vpu/module/drivers")
+        std::fs::read_to_string("/sys/bus/pci/drivers/intel_vpu/module/drivers")
             .map(|content| content.to_ascii_lowercase().contains("vpu"))
-            .unwrap_or(false);
+            .unwrap_or(false)
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
@@ -1,4 +1,5 @@
 //! JSON-ready Core Ultra 7 258V Lunar Lake platform probe.
+#![allow(clippy::doc_markdown)]
 
 use std::process::Command;
 
@@ -38,6 +39,7 @@ pub struct PlatformPowerProbe {
 
 /// Visibility-only Lunar Lake platform probe.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Lnl258vPlatformProbe {
     /// Stable machine identifier used by receipts.
     pub machine_id: String,
@@ -152,6 +154,7 @@ fn power_mode() -> Option<String> {
     platform_power_mode()
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn thermal_profile() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
@@ -162,6 +165,7 @@ fn thermal_profile() -> Option<String> {
     None
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn ac_power_connected() -> Option<bool> {
     #[cfg(target_os = "linux")]
     {

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
@@ -152,6 +152,7 @@ fn total_memory_bytes() -> Option<u64> {
     }
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn power_mode() -> Option<String> {
     platform_power_mode()
 }

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
@@ -118,18 +118,18 @@ pub fn probe_platform_power() -> PlatformPowerProbe {
 fn total_memory_bytes() -> Option<u64> {
     #[cfg(target_os = "linux")]
     {
-        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
-            return meminfo.lines().find_map(|line| {
+        std::fs::read_to_string("/proc/meminfo").ok().and_then(|meminfo| {
+            meminfo.lines().find_map(|line| {
                 let rest = line.strip_prefix("MemTotal:")?;
                 let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
                 Some(kb * 1024)
-            });
-        }
+            })
+        })
     }
 
     #[cfg(target_os = "windows")]
     {
-        return command_stdout(
+        command_stdout(
             "powershell",
             &[
                 "-NoProfile",
@@ -137,17 +137,19 @@ fn total_memory_bytes() -> Option<u64> {
                 "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
             ],
         )
-        .and_then(|value| value.trim().parse::<u64>().ok());
+        .and_then(|value| value.trim().parse::<u64>().ok())
     }
 
     #[cfg(target_os = "macos")]
     {
-        return command_stdout("sysctl", &["-n", "hw.memsize"])
-            .and_then(|value| value.trim().parse::<u64>().ok());
+        command_stdout("sysctl", &["-n", "hw.memsize"])
+            .and_then(|value| value.trim().parse::<u64>().ok())
     }
 
-    #[allow(unreachable_code)]
-    None
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+    {
+        None
+    }
 }
 
 fn power_mode() -> Option<String> {
@@ -159,10 +161,13 @@ fn thermal_profile() -> Option<String> {
     #[cfg(target_os = "linux")]
     {
         let zones = std::fs::read_dir("/sys/class/thermal").ok()?.flatten().count();
-        return (zones > 0).then(|| format!("{zones} thermal zones visible"));
+        (zones > 0).then(|| format!("{zones} thermal zones visible"))
     }
 
-    None
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
 }
 
 #[allow(clippy::missing_const_for_fn)]

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/platform.rs
@@ -1,0 +1,252 @@
+//! JSON-ready Core Ultra 7 258V Lunar Lake platform probe.
+
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+
+use crate::runtimes::{
+    OpenVinoProbe, level_zero::probe_level_zero, opencl::probe_opencl_runtime,
+    openvino::probe_openvino,
+};
+
+use super::{arc140v::probe_intel_arc_140v, cpu::probe_lnl258v_cpu, npu::probe_intel_npu};
+
+/// Proof stage emitted by the platform probe.
+pub const LNL258V_PROOF_STAGE_RUNTIME_DETECTED: &str = "runtime_detected";
+
+/// Memory context for the shared-memory Lunar Lake platform.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformMemoryProbe {
+    /// Total system memory in bytes when available.
+    pub total_bytes: Option<u64>,
+    /// Shared memory available to integrated devices when known.
+    pub shared_memory_bytes: Option<u64>,
+    /// Whether platform devices use shared memory.
+    pub shared_memory: bool,
+}
+
+/// Power and thermal context for platform receipts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PlatformPowerProbe {
+    /// OS power mode or governor summary when available.
+    pub mode: Option<String>,
+    /// Thermal profile when available.
+    pub thermal_profile: Option<String>,
+    /// Whether AC power is visible as connected.
+    pub ac_power: Option<bool>,
+}
+
+/// Visibility-only Lunar Lake platform probe.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Lnl258vPlatformProbe {
+    /// Stable machine identifier used by receipts.
+    pub machine_id: String,
+    /// Universal proof stage for this visibility-only probe.
+    pub proof_stage: String,
+    /// OS family.
+    pub os: String,
+    /// OS version/build when available.
+    pub os_build: Option<String>,
+    /// CPU architecture.
+    pub arch: String,
+    /// CPU lane facts.
+    pub cpu: super::cpu::Lnl258vCpuProbe,
+    /// Arc 140V lane visibility facts.
+    pub arc140v: super::arc140v::IntelArc140vProbe,
+    /// Intel NPU lane visibility facts.
+    pub npu: super::npu::IntelNpuProbe,
+    /// OpenVINO runtime visibility facts.
+    pub openvino: OpenVinoProbe,
+    /// Memory context.
+    pub memory: PlatformMemoryProbe,
+    /// Power context.
+    pub power: PlatformPowerProbe,
+    /// Always false: this probe never substitutes a fallback device.
+    pub fallback_used: bool,
+    /// Human-readable status.
+    pub status: String,
+    /// Non-fatal failure reason when platform identity is incomplete.
+    pub failure_reason: Option<String>,
+}
+
+/// Probe Lunar Lake platform visibility without running inference.
+pub fn probe_lnl258v_platform() -> Lnl258vPlatformProbe {
+    let cpu = probe_lnl258v_cpu();
+    let memory = probe_platform_memory();
+    let power = probe_platform_power();
+    let opencl = probe_opencl_runtime();
+    let level_zero = probe_level_zero();
+    let openvino = probe_openvino();
+    let arc140v = probe_intel_arc_140v(&opencl, &level_zero, &openvino, &memory, &power);
+    let npu = probe_intel_npu(&openvino);
+
+    Lnl258vPlatformProbe {
+        machine_id: "intel-258v".to_owned(),
+        proof_stage: LNL258V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        os: std::env::consts::OS.to_owned(),
+        os_build: os_build(),
+        arch: std::env::consts::ARCH.to_owned(),
+        cpu,
+        arc140v,
+        npu,
+        openvino,
+        memory,
+        power,
+        fallback_used: false,
+        status: LNL258V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        failure_reason: None,
+    }
+}
+
+/// Probe system memory context.
+pub fn probe_platform_memory() -> PlatformMemoryProbe {
+    let total_bytes = total_memory_bytes();
+    PlatformMemoryProbe { total_bytes, shared_memory_bytes: total_bytes, shared_memory: true }
+}
+
+/// Probe platform power context.
+pub fn probe_platform_power() -> PlatformPowerProbe {
+    PlatformPowerProbe {
+        mode: power_mode(),
+        thermal_profile: thermal_profile(),
+        ac_power: ac_power_connected(),
+    }
+}
+
+fn total_memory_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
+            return meminfo.lines().find_map(|line| {
+                let rest = line.strip_prefix("MemTotal:")?;
+                let kb = rest.split_whitespace().next()?.parse::<u64>().ok()?;
+                Some(kb * 1024)
+            });
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return command_stdout(
+            "powershell",
+            &[
+                "-NoProfile",
+                "-Command",
+                "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory",
+            ],
+        )
+        .and_then(|value| value.trim().parse::<u64>().ok());
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return command_stdout("sysctl", &["-n", "hw.memsize"])
+            .and_then(|value| value.trim().parse::<u64>().ok());
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
+fn power_mode() -> Option<String> {
+    platform_power_mode()
+}
+
+fn thermal_profile() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let zones = std::fs::read_dir("/sys/class/thermal").ok()?.flatten().count();
+        return (zones > 0).then(|| format!("{zones} thermal zones visible"));
+    }
+
+    None
+}
+
+fn ac_power_connected() -> Option<bool> {
+    #[cfg(target_os = "linux")]
+    {
+        let supplies = std::fs::read_dir("/sys/class/power_supply").ok()?;
+        for entry in supplies.flatten() {
+            let online_path = entry.path().join("online");
+            if let Ok(value) = std::fs::read_to_string(online_path) {
+                return Some(value.trim() == "1");
+            }
+        }
+    }
+
+    None
+}
+
+fn os_build() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        let release = std::fs::read_to_string("/etc/os-release").ok();
+        let pretty = release.as_deref().and_then(|content| {
+            content.lines().find_map(|line| {
+                let value = line.strip_prefix("PRETTY_NAME=")?;
+                Some(value.trim_matches('"').to_owned())
+            })
+        });
+        let kernel = command_stdout("uname", &["-r"]);
+        return match (pretty, kernel) {
+            (Some(pretty), Some(kernel)) => Some(format!("{pretty}; kernel {kernel}")),
+            (Some(pretty), None) => Some(pretty),
+            (None, Some(kernel)) => Some(format!("kernel {kernel}")),
+            (None, None) => None,
+        };
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return command_stdout(
+            "powershell",
+            &[
+                "-NoProfile",
+                "-Command",
+                "$ci = Get-ComputerInfo; \"$($ci.OsName) $($ci.OsVersion) $($ci.WindowsVersion)\"",
+            ],
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return command_stdout("sw_vers", &["-productVersion"]);
+    }
+
+    #[allow(unreachable_code)]
+    None
+}
+
+fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
+    Command::new(command)
+        .args(args)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(target_os = "linux")]
+fn platform_power_mode() -> Option<String> {
+    let governors = std::fs::read_dir("/sys/devices/system/cpu")
+        .ok()?
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path().join("cpufreq/scaling_governor");
+            std::fs::read_to_string(path).ok().map(|value| value.trim().to_owned())
+        })
+        .filter(|value| !value.is_empty())
+        .collect::<std::collections::BTreeSet<_>>();
+    (!governors.is_empty()).then(|| governors.into_iter().collect::<Vec<_>>().join(","))
+}
+
+#[cfg(target_os = "windows")]
+fn platform_power_mode() -> Option<String> {
+    command_stdout("powercfg", &["/GETACTIVESCHEME"])
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+const fn platform_power_mode() -> Option<String> {
+    None
+}

--- a/crates/bitnet-device-probe/src/intel/mod.rs
+++ b/crates/bitnet-device-probe/src/intel/mod.rs
@@ -1,0 +1,3 @@
+//! Intel hardware-lane probes.
+
+pub mod lunar_lake;

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -5,6 +5,10 @@
 
 pub use bitnet_common::kernel_registry::SimdLevel;
 
+pub mod cpu;
+pub mod intel;
+pub mod runtimes;
+
 #[cfg(feature = "metal")]
 pub mod apple_metal;
 #[cfg(feature = "metal")]
@@ -23,6 +27,11 @@ pub use intel_arc::{
 
 pub mod nvidia_cuda;
 pub use nvidia_cuda::{NvidiaCudaProbe, probe_nvidia_cuda};
+
+pub use intel::lunar_lake::{
+    IntelArc140vProbe, IntelNpuProbe, Lnl258vCpuProbe, Lnl258vPlatformProbe, OpenVinoProbe,
+    PlatformMemoryProbe, PlatformPowerProbe, probe_lnl258v_platform,
+};
 
 #[cfg(feature = "opencl")]
 pub mod opencl;

--- a/crates/bitnet-device-probe/src/opencl.rs
+++ b/crates/bitnet-device-probe/src/opencl.rs
@@ -3,6 +3,15 @@
 //! Loads `OpenCL.dll` (Windows) or `libOpenCL.so` (Linux) at runtime so the
 //! code compiles and runs even when no OpenCL SDK is installed.  When the
 //! library is absent every query returns an empty result instead of panicking.
+#![allow(
+    clippy::borrow_as_ptr,
+    clippy::doc_markdown,
+    clippy::if_not_else,
+    clippy::missing_const_for_fn,
+    clippy::redundant_closure_for_method_calls,
+    clippy::ref_as_ptr,
+    clippy::too_many_lines
+)]
 
 use std::fmt;
 

--- a/crates/bitnet-device-probe/src/runtimes/level_zero.rs
+++ b/crates/bitnet-device-probe/src/runtimes/level_zero.rs
@@ -1,0 +1,62 @@
+//! Level Zero runtime visibility probing through installed command-line tools.
+
+use serde::{Deserialize, Serialize};
+
+use super::command_output;
+
+/// Level Zero runtime visibility result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LevelZeroProbe {
+    /// Whether Level Zero tooling was visible.
+    pub runtime_available: bool,
+    /// Best-effort device names parsed from `ze_info` or `sycl-ls`.
+    pub devices: Vec<String>,
+    /// Non-fatal probe error when the runtime tooling was absent or unusable.
+    pub error: Option<String>,
+}
+
+impl LevelZeroProbe {
+    /// Build an unavailable Level Zero probe result.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self { runtime_available: false, devices: Vec::new(), error: Some(reason.into()) }
+    }
+}
+
+/// Probe Level Zero visibility without compiling or dispatching kernels.
+pub fn probe_level_zero() -> LevelZeroProbe {
+    match command_output("ze_info", std::iter::empty::<&str>()) {
+        Ok(stdout) => {
+            let devices = parse_ze_info_devices(&stdout);
+            LevelZeroProbe { runtime_available: true, devices, error: None }
+        }
+        Err(ze_error) => match command_output("sycl-ls", std::iter::empty::<&str>()) {
+            Ok(stdout) => {
+                let devices = parse_sycl_ls_level_zero_devices(&stdout);
+                LevelZeroProbe { runtime_available: !devices.is_empty(), devices, error: None }
+            }
+            Err(sycl_error) => LevelZeroProbe::unavailable(format!("{ze_error}; {sycl_error}")),
+        },
+    }
+}
+
+pub(crate) fn parse_ze_info_devices(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            trimmed
+                .strip_prefix("Device Name")
+                .and_then(|rest| rest.split_once(':').map(|(_, value)| value.trim().to_owned()))
+                .filter(|value| !value.is_empty())
+        })
+        .collect()
+}
+
+pub(crate) fn parse_sycl_ls_level_zero_devices(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter(|line| line.to_ascii_lowercase().contains("level_zero"))
+        .map(|line| line.trim().to_owned())
+        .filter(|line| !line.is_empty())
+        .collect()
+}

--- a/crates/bitnet-device-probe/src/runtimes/mod.rs
+++ b/crates/bitnet-device-probe/src/runtimes/mod.rs
@@ -1,0 +1,40 @@
+//! Runtime visibility probes used by lane-specific hardware probes.
+
+use std::{
+    ffi::OsStr,
+    process::{Command, Stdio},
+};
+
+pub mod level_zero;
+pub mod opencl;
+pub mod openvino;
+
+pub use level_zero::LevelZeroProbe;
+pub use opencl::{OpenClRuntimeDevice, OpenClRuntimeProbe};
+pub use openvino::{OpenVinoDeviceProbe, OpenVinoProbe};
+
+pub(crate) fn command_output<I, S>(command: &str, args: I) -> Result<String, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    Command::new(command)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|err| format!("{command} unavailable: {err}"))
+        .and_then(|output| {
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).to_string())
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+                let reason = if stderr.is_empty() {
+                    format!("{command} exited with {}", output.status)
+                } else {
+                    format!("{command} exited with {}: {stderr}", output.status)
+                };
+                Err(reason)
+            }
+        })
+}

--- a/crates/bitnet-device-probe/src/runtimes/opencl.rs
+++ b/crates/bitnet-device-probe/src/runtimes/opencl.rs
@@ -1,4 +1,5 @@
 //! OpenCL runtime visibility wrapper for platform receipts.
+#![allow(clippy::doc_markdown)]
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/bitnet-device-probe/src/runtimes/opencl.rs
+++ b/crates/bitnet-device-probe/src/runtimes/opencl.rs
@@ -1,0 +1,72 @@
+//! OpenCL runtime visibility wrapper for platform receipts.
+
+use serde::{Deserialize, Serialize};
+
+/// OpenCL device facts needed for hardware-lane identity receipts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenClRuntimeDevice {
+    /// OpenCL platform name.
+    pub platform_name: Option<String>,
+    /// Device name.
+    pub device_name: String,
+    /// Device vendor.
+    pub vendor: String,
+    /// Driver version reported by OpenCL.
+    pub driver_version: Option<String>,
+    /// Whether the device is a GPU.
+    pub is_gpu: bool,
+}
+
+/// OpenCL runtime visibility result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenClRuntimeProbe {
+    /// Whether an OpenCL runtime was visible.
+    pub runtime_available: bool,
+    /// Devices reported by the runtime.
+    pub devices: Vec<OpenClRuntimeDevice>,
+    /// Non-fatal probe error when the runtime was absent or unusable.
+    pub error: Option<String>,
+}
+
+impl OpenClRuntimeProbe {
+    /// Build an unavailable OpenCL probe result.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self { runtime_available: false, devices: Vec::new(), error: Some(reason.into()) }
+    }
+}
+
+/// Probe OpenCL visibility without making an execution claim.
+pub fn probe_opencl_runtime() -> OpenClRuntimeProbe {
+    #[cfg(feature = "opencl")]
+    {
+        let result = crate::opencl::probe_opencl();
+        let devices = result
+            .devices
+            .into_iter()
+            .map(|device| {
+                let is_gpu = device.is_gpu();
+                OpenClRuntimeDevice {
+                    platform_name: result
+                        .platforms
+                        .get(device.platform_index)
+                        .map(|platform| platform.name.clone()),
+                    device_name: device.name,
+                    vendor: device.vendor,
+                    driver_version: Some(device.driver_version),
+                    is_gpu,
+                }
+            })
+            .collect();
+
+        OpenClRuntimeProbe {
+            runtime_available: result.runtime_available,
+            devices,
+            error: result.error,
+        }
+    }
+
+    #[cfg(not(feature = "opencl"))]
+    {
+        OpenClRuntimeProbe::unavailable("compiled without opencl feature")
+    }
+}

--- a/crates/bitnet-device-probe/src/runtimes/openvino.rs
+++ b/crates/bitnet-device-probe/src/runtimes/openvino.rs
@@ -1,4 +1,5 @@
 //! OpenVINO runtime visibility probing without linking OpenVINO.
+#![allow(clippy::doc_markdown)]
 
 use serde::{Deserialize, Serialize};
 
@@ -82,9 +83,8 @@ for dev in core.available_devices:
 "#;
 
     for python in ["python3", "python"] {
-        match command_output(python, ["-c", script]) {
-            Ok(stdout) => return parse_openvino_line_output(&stdout),
-            Err(_) => continue,
+        if let Ok(stdout) = command_output(python, ["-c", script]) {
+            return parse_openvino_line_output(&stdout);
         }
     }
 
@@ -136,17 +136,17 @@ fn apply_property_line(probe: &mut OpenVinoProbe, rest: &str) {
         probe.available_devices.push(device_token.to_owned());
     }
 
-    let idx = match probe.devices.iter().position(|device| device.device == device_token) {
-        Some(idx) => idx,
-        None => {
+    let idx =
+        if let Some(idx) = probe.devices.iter().position(|device| device.device == device_token) {
+            idx
+        } else {
             probe.devices.push(OpenVinoDeviceProbe {
                 device: device_token.to_owned(),
                 full_name: None,
                 supported_properties: Vec::new(),
             });
             probe.devices.len() - 1
-        }
-    };
+        };
 
     match property {
         "FULL_DEVICE_NAME" if !value.trim().is_empty() => {

--- a/crates/bitnet-device-probe/src/runtimes/openvino.rs
+++ b/crates/bitnet-device-probe/src/runtimes/openvino.rs
@@ -1,0 +1,165 @@
+//! OpenVINO runtime visibility probing without linking OpenVINO.
+
+use serde::{Deserialize, Serialize};
+
+use super::command_output;
+
+/// OpenVINO device facts used in platform receipts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenVinoDeviceProbe {
+    /// OpenVINO device token, such as `CPU`, `GPU.0`, or `NPU`.
+    pub device: String,
+    /// `FULL_DEVICE_NAME` when OpenVINO reports it.
+    pub full_name: Option<String>,
+    /// Supported property names when collected.
+    pub supported_properties: Vec<String>,
+}
+
+/// OpenVINO runtime visibility result.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenVinoProbe {
+    /// Whether Python could import OpenVINO and instantiate `ov.Core`.
+    pub runtime_available: bool,
+    /// OpenVINO Python package version.
+    pub version: Option<String>,
+    /// Available OpenVINO device tokens.
+    pub available_devices: Vec<String>,
+    /// Per-device properties collected without compiling a model.
+    pub devices: Vec<OpenVinoDeviceProbe>,
+    /// Non-fatal probe error when OpenVINO was absent or unusable.
+    pub error: Option<String>,
+}
+
+impl OpenVinoProbe {
+    /// Build an unavailable OpenVINO probe result.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            runtime_available: false,
+            version: None,
+            available_devices: Vec::new(),
+            devices: Vec::new(),
+            error: Some(reason.into()),
+        }
+    }
+
+    /// Return the first OpenVINO GPU token, preferring `GPU.0`.
+    pub fn gpu_device_token(&self) -> Option<String> {
+        self.available_devices
+            .iter()
+            .find(|device| device.as_str() == "GPU.0")
+            .or_else(|| self.available_devices.iter().find(|device| device.starts_with("GPU")))
+            .cloned()
+    }
+
+    /// Return the full name for an OpenVINO device token.
+    pub fn full_name_for(&self, token: &str) -> Option<String> {
+        self.devices
+            .iter()
+            .find(|device| device.device == token)
+            .and_then(|device| device.full_name.clone())
+    }
+
+    /// Return whether OpenVINO exposes an `NPU` device.
+    pub fn npu_visible(&self) -> bool {
+        self.available_devices.iter().any(|device| device == "NPU" || device.starts_with("NPU."))
+    }
+}
+
+/// Probe OpenVINO runtime visibility through Python, without compiling a model.
+pub fn probe_openvino() -> OpenVinoProbe {
+    let script = r#"
+import openvino as ov
+
+core = ov.Core()
+print("OPENVINO_VERSION=" + str(ov.__version__))
+for dev in core.available_devices:
+    print("DEVICE=" + str(dev))
+    for prop in ["FULL_DEVICE_NAME", "SUPPORTED_PROPERTIES"]:
+        try:
+            print("PROP=" + str(dev) + "=" + prop + "=" + str(core.get_property(dev, prop)))
+        except Exception as exc:
+            print("PROP_ERR=" + str(dev) + "=" + prop + "=" + repr(exc))
+"#;
+
+    for python in ["python3", "python"] {
+        match command_output(python, ["-c", script]) {
+            Ok(stdout) => return parse_openvino_line_output(&stdout),
+            Err(_) => continue,
+        }
+    }
+
+    OpenVinoProbe::unavailable("python openvino import unavailable")
+}
+
+pub(crate) fn parse_openvino_line_output(output: &str) -> OpenVinoProbe {
+    let mut probe = OpenVinoProbe {
+        runtime_available: true,
+        version: None,
+        available_devices: Vec::new(),
+        devices: Vec::new(),
+        error: None,
+    };
+
+    for line in output.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        if let Some(value) = line.strip_prefix("OPENVINO_VERSION=") {
+            probe.version = Some(value.to_owned());
+        } else if let Some(value) = line.strip_prefix("DEVICE=") {
+            if !probe.available_devices.iter().any(|device| device == value) {
+                probe.available_devices.push(value.to_owned());
+                probe.devices.push(OpenVinoDeviceProbe {
+                    device: value.to_owned(),
+                    full_name: None,
+                    supported_properties: Vec::new(),
+                });
+            }
+        } else if let Some(rest) = line.strip_prefix("PROP=") {
+            apply_property_line(&mut probe, rest);
+        }
+    }
+
+    probe
+}
+
+fn apply_property_line(probe: &mut OpenVinoProbe, rest: &str) {
+    let mut parts = rest.splitn(3, '=');
+    let Some(device_token) = parts.next() else {
+        return;
+    };
+    let Some(property) = parts.next() else {
+        return;
+    };
+    let Some(value) = parts.next() else {
+        return;
+    };
+
+    if !probe.available_devices.iter().any(|device| device == device_token) {
+        probe.available_devices.push(device_token.to_owned());
+    }
+
+    let idx = match probe.devices.iter().position(|device| device.device == device_token) {
+        Some(idx) => idx,
+        None => {
+            probe.devices.push(OpenVinoDeviceProbe {
+                device: device_token.to_owned(),
+                full_name: None,
+                supported_properties: Vec::new(),
+            });
+            probe.devices.len() - 1
+        }
+    };
+
+    match property {
+        "FULL_DEVICE_NAME" if !value.trim().is_empty() => {
+            probe.devices[idx].full_name = Some(value.trim().to_owned());
+        }
+        "SUPPORTED_PROPERTIES" => {
+            probe.devices[idx].supported_properties = value
+                .trim_matches(['[', ']'])
+                .split(',')
+                .map(|entry| entry.trim().trim_matches(['\'', '"']).to_owned())
+                .filter(|entry| !entry.is_empty())
+                .collect();
+        }
+        _ => {}
+    }
+}

--- a/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
+++ b/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
@@ -1,0 +1,111 @@
+use bitnet_device_probe::intel::lunar_lake::{
+    IntelArc140vProbe, IntelNpuProbe, LNL258V_PROOF_STAGE_RUNTIME_DETECTED, Lnl258vCpuProbe,
+    Lnl258vPlatformProbe, PlatformMemoryProbe, PlatformPowerProbe,
+};
+use bitnet_device_probe::runtimes::{OpenVinoDeviceProbe, OpenVinoProbe};
+
+#[test]
+fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
+    let probe = Lnl258vPlatformProbe {
+        machine_id: "intel-258v".to_owned(),
+        proof_stage: LNL258V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        os: "linux".to_owned(),
+        os_build: Some("test-os".to_owned()),
+        arch: "x86_64".to_owned(),
+        cpu: Lnl258vCpuProbe {
+            brand: Some("Intel Core Ultra 7 258V".to_owned()),
+            cores: 8,
+            threads: 8,
+            p_core_count: Some(4),
+            lp_e_core_count: Some(4),
+            has_avx2: true,
+            has_avx512: false,
+            has_fma: true,
+            has_sse42: true,
+            scheduler_hint: Some("record topology context".to_owned()),
+        },
+        arc140v: IntelArc140vProbe {
+            available: true,
+            pci_device_id: Some("0x64A0".to_owned()),
+            opencl_available: true,
+            opencl_platform_name: Some("Intel(R) OpenCL Graphics".to_owned()),
+            opencl_device_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
+            opencl_driver_version: Some("test-driver".to_owned()),
+            level_zero_available: true,
+            level_zero_devices: vec!["Intel(R) Arc(TM) 140V Graphics".to_owned()],
+            openvino_gpu_visible: true,
+            openvino_gpu_device: Some("GPU.0".to_owned()),
+            openvino_gpu_full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
+            shared_memory_bytes: Some(32 * 1024 * 1024 * 1024),
+            power_mode: Some("balanced".to_owned()),
+            failure_reason: None,
+        },
+        npu: IntelNpuProbe {
+            available: true,
+            accel_device_present: true,
+            accel_devices: vec!["/dev/accel/accel0".to_owned()],
+            intel_vpu_driver_seen: true,
+            driver_hint: Some("intel_vpu/ivpu evidence".to_owned()),
+            openvino_runtime_available: true,
+            openvino_version: Some("2026.1".to_owned()),
+            openvino_npu_visible: true,
+            openvino_npu_full_name: Some("Intel(R) AI Boost".to_owned()),
+            supported_properties: vec!["FULL_DEVICE_NAME".to_owned()],
+            driver_version: None,
+            compiler_version: None,
+            total_mem_size: None,
+            failure_reason: None,
+        },
+        openvino: OpenVinoProbe {
+            runtime_available: true,
+            version: Some("2026.1".to_owned()),
+            available_devices: vec!["CPU".to_owned(), "GPU.0".to_owned(), "NPU".to_owned()],
+            devices: vec![
+                OpenVinoDeviceProbe {
+                    device: "GPU.0".to_owned(),
+                    full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
+                    supported_properties: Vec::new(),
+                },
+                OpenVinoDeviceProbe {
+                    device: "NPU".to_owned(),
+                    full_name: Some("Intel(R) AI Boost".to_owned()),
+                    supported_properties: vec!["FULL_DEVICE_NAME".to_owned()],
+                },
+            ],
+            error: None,
+        },
+        memory: PlatformMemoryProbe {
+            total_bytes: Some(32 * 1024 * 1024 * 1024),
+            shared_memory_bytes: Some(32 * 1024 * 1024 * 1024),
+            shared_memory: true,
+        },
+        power: PlatformPowerProbe {
+            mode: Some("balanced".to_owned()),
+            thermal_profile: Some("default".to_owned()),
+            ac_power: Some(true),
+        },
+        fallback_used: false,
+        status: LNL258V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        failure_reason: None,
+    };
+
+    let value = serde_json::to_value(&probe).expect("probe serializes");
+    assert_eq!(value["machine_id"], "intel-258v");
+    assert_eq!(value["proof_stage"], "runtime_detected");
+    assert_eq!(value["fallback_used"], false);
+    assert_eq!(value["cpu"]["has_avx2"], true);
+    assert_eq!(value["cpu"]["has_avx512"], false);
+    assert_eq!(value["arc140v"]["openvino_gpu_device"], "GPU.0");
+    assert_eq!(value["npu"]["openvino_npu_visible"], true);
+}
+
+#[test]
+fn unavailable_runtime_fields_are_false_or_null_not_claims() {
+    let openvino = OpenVinoProbe::unavailable("not installed");
+    assert!(!openvino.runtime_available);
+    assert!(openvino.available_devices.is_empty());
+    assert_eq!(openvino.version, None);
+    assert!(openvino.error.is_some());
+    assert!(!openvino.npu_visible());
+    assert_eq!(openvino.gpu_device_token(), None);
+}

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -221,6 +221,12 @@ The first 258V platform receipt should establish visibility only:
 
 This is not an inference claim. Smoke, parity, and benchmark receipts come later.
 
+The code-facing visibility probe for this first receipt lives in
+`bitnet-device-probe` as `probe_lnl258v_platform()`. It emits a JSON-ready
+`Lnl258vPlatformProbe` with nested CPU, Arc 140V, NPU, OpenVINO, memory, and
+power sections. Unsupported runtime tools must be represented as `false`,
+empty lists, or `null` fields rather than panics or fallback claims.
+
 ## Ownership
 
 Proof lanes:

--- a/docs/specs/intel-lunar-lake-258v-buildout-plan.md
+++ b/docs/specs/intel-lunar-lake-258v-buildout-plan.md
@@ -82,6 +82,26 @@ pub struct Lnl258vPlatformProbe {
 pub fn probe_lnl258v_platform() -> Lnl258vPlatformProbe;
 ```
 
+The implementation keeps runtime probes separate:
+
+```text
+crates/bitnet-device-probe/src/
+  cpu/
+  runtimes/
+    opencl.rs
+    level_zero.rs
+    openvino.rs
+  intel/lunar_lake/
+    cpu.rs
+    arc140v.rs
+    npu.rs
+    platform.rs
+```
+
+These modules collect visibility facts only. They must not compile OpenVINO
+graphs, dispatch OpenCL kernels, run BitNet inference, or route through CPU
+fallbacks as accelerator proof.
+
 Initial files:
 
 - `crates/bitnet-device-probe/src/intel_lnl258v.rs`

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "LNL258V-RUN-001"
-status = "ready"
+status = "pr_open"
 branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -17,6 +17,53 @@ hard_constraints = [
 ]
 
 [[work_item]]
+id = "LNL258V-RUN-001"
+status = "ready"
+branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = []
+acceptance = "Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims."
+commands = [
+  "cargo test --locked -p bitnet-device-probe --no-default-features",
+  "cargo test --locked -p bitnet-device-probe --no-default-features --features cpu",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/src/intel/lunar_lake/**",
+  "crates/bitnet-device-probe/src/intel/mod.rs",
+  "crates/bitnet-device-probe/src/cpu/**",
+  "crates/bitnet-device-probe/src/runtimes/**",
+  "crates/bitnet-device-probe/src/lib.rs",
+  "crates/bitnet-device-probe/tests/**",
+  "ci/hardware/intel-258v/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-buildout-plan.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Lunar Lake runtime visibility can be recorded after merge.",
+]
+must_not_claim = [
+  "BitNet inference works on 258V.",
+  "Arc 140V execution works.",
+  "Intel NPU execution works.",
+  "NPU accelerates BitNet.",
+]
+
+[[work_item]]
 id = "LNL258V-002"
 status = "ready"
 branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T100456Z-LNL258V-RUN-001-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T100456Z-LNL258V-RUN-001-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T10:04:56Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-RUN-001"
+event = "pr_open"
+pr = 3714
+head_sha = "daabc852a1cd5c84a5a1184dc2c967a2ebb5d122"
+actor = "codex"
+
+notes = [
+  "Opened the visibility-only Lunar Lake 258V platform probe PR.",
+  "The PR records CPU, Arc 140V, OpenVINO GPU, Intel NPU, memory, power, and OS visibility without inference, kernel, graph, or accelerator claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-RUN-001 | ready | TBD | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| LNL258V-RUN-001 | pr_open | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,6 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
+| LNL258V-RUN-001 | ready | TBD | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,3 +4,4 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
+| intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-RUN-001 | TBD | ready | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-005 | TBD | ready | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | TBD | ready | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-005 | TBD | ready | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-004 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- add JSON-ready Lunar Lake 258V platform probe structs for CPU, Arc 140V, NPU, OpenVINO, memory, and power context
- add runtime visibility wrappers for OpenCL, Level Zero, and OpenVINO that return false/null fields when tools are absent
- add serialization coverage plus tracker/docs wiring for LNL258V-RUN-001

## Claim boundary
- visibility only: no BitNet inference, OpenCL kernels, OpenVINO graph execution, or accelerator performance claims
- does not touch GGUF loader, tokenizer, QK256 layout/dispatch, CPU kernels, transformer inference, or server code

## Verification
- cargo test --locked -p bitnet-device-probe --no-default-features
- cargo test --locked -p bitnet-device-probe --no-default-features --features cpu
- cargo check --locked -p bitnet-device-probe --no-default-features --features opencl
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check