### PR TITLE
Introduce org Clippy policy, MSRV 1.93, policy ledgers, no-panic allowlists, and xtask checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -223,6 +223,9 @@ autoexamples = false
 autotests = false
 autobenches = false
 
+[lints]
+workspace = true
+
 [lib]
 # Library source
 
@@ -238,7 +241,7 @@ keywords = ["machine-learning", "llm", "quantization", "inference", "bitnet"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
-rust-version = "1.92.0"
+rust-version = "1.93"
 version = "0.2.1-dev"
 
 [dependencies]
@@ -539,16 +542,134 @@ debug = true
 [profile.dev.package."*"]
 opt-level = 2
 
-# Workspace-level lints for code quality
+# Workspace-level lint policy for panic-free, suppression-governed Rust.
+[workspace.lints.rust]
+unsafe_code = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+unused_must_use = "deny"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-module_name_repetitions = "allow"
-must_use_candidate = "allow"
 nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
-ptr_arg = "deny"
+
+# Panic-free production and tests
+dbg_macro = "deny"
+todo = "deny"
+unimplemented = "deny"
+panic = "deny"
+unreachable = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+get_unwrap = "deny"
+unwrap_in_result = "deny"
+panic_in_result_fn = "deny"
+string_slice = "deny"
+indexing_slicing = "deny"
+out_of_bounds_indexing = "deny"
+unchecked_time_subtraction = "deny"
+
+# AST / parser / UTF-8 / slice safety
+char_indices_as_byte_indices = "deny"
+sliced_string_as_bytes = "deny"
+index_refutable_slice = "deny"
+
+# Silent failure
+let_underscore_future = "deny"
+let_underscore_must_use = "deny"
+let_underscore_lock = "deny"
+unused_result_ok = "deny"
+map_err_ignore = "deny"
+assertions_on_result_states = "deny"
+lines_filter_map_ok = "deny"
+
+# Async / concurrency
+await_holding_lock = "deny"
+await_holding_refcell_ref = "deny"
+await_holding_invalid_type = "deny"
+future_not_send = "warn"
+large_futures = "warn"
+arc_with_non_send_sync = "deny"
+rc_mutex = "deny"
+mut_mutex_lock = "deny"
+readonly_write_lock = "deny"
+
+# Unsafe / memory
+mem_forget = "deny"
+forget_non_drop = "deny"
+drop_non_drop = "deny"
+undocumented_unsafe_blocks = "deny"
+multiple_unsafe_ops_per_block = "deny"
+repr_packed_without_abi = "deny"
+
+# Numeric correctness
+float_cmp = "deny"
+float_cmp_const = "deny"
+float_equality_without_abs = "deny"
+lossy_float_literal = "deny"
+cast_sign_loss = "deny"
+cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_precision_loss = "warn"
+invalid_upcast_comparisons = "deny"
+cast_abs_to_unsigned = "deny"
+cast_enum_truncation = "deny"
+cast_nan_to_int = "deny"
+manual_midpoint = "warn"
+manual_is_multiple_of = "warn"
+manual_div_ceil = "warn"
+arithmetic_side_effects = "warn"
+
+# File/process/path footguns
+suspicious_open_options = "deny"
+nonsensical_open_options = "deny"
+ineffective_open_options = "deny"
+path_buf_push_overwrite = "deny"
+join_absolute_paths = "deny"
+read_line_without_trim = "warn"
+exit = "deny"
+
+# API / trait correctness
+iter_not_returning_iterator = "deny"
+expl_impl_clone_on_copy = "deny"
+infallible_try_from = "deny"
+fallible_impl_from = "deny"
+error_impl_error = "deny"
+result_unit_err = "warn"
+result_large_err = "warn"
+
+# Good taste that pays rent
+format_in_format_args = "deny"
+to_string_in_format_args = "deny"
+unused_format_specs = "deny"
+unnecessary_debug_formatting = "warn"
+uninlined_format_args = "warn"
+manual_let_else = "warn"
+manual_ok_or = "warn"
+manual_strip = "warn"
+manual_split_once = "warn"
+manual_is_variant_and = "warn"
+filter_map_next = "warn"
+flat_map_option = "warn"
+match_result_ok = "deny"
+cloned_instead_of_copied = "warn"
+iter_cloned_collect = "warn"
+iter_overeager_cloned = "warn"
+needless_collect = "warn"
+redundant_closure = "warn"
+redundant_closure_for_method_calls = "warn"
+missing_panics_doc = "deny"
+missing_errors_doc = "warn"
+
+# Suppression governance
+allow_attributes = "deny"
+allow_attributes_without_reason = "deny"
+blanket_clippy_restriction_lints = "deny"
+ignore_without_reason = "deny"
+should_panic_without_expect = "deny"
 
 # Workspace-level feature flags for convenience
 [workspace.metadata.docs.rs]
@@ -586,4 +707,4 @@ keywords = [
   "inference",        # Model inference
   "bitnet",           # BitNet specific
 ]
-msrv = "1.92.0"
+msrv = "1.93"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,16 +1,13 @@
-# Clippy configuration for bitnet-rs
-# Ensures high code quality standards for crates.io publication
+# Clippy configuration for bitnet-rs.
+# Repo-local Clippy config is intentionally narrow: lint levels live in
+# Cargo.toml and policy/clippy-lints.toml; suppressions must be local
+# #[expect(..., reason = "...")] receipts rather than test carveouts.
 
 # MSRV compatibility
-msrv = "1.92.0"
+msrv = "1.93"
 
-# Complexity thresholds
+# Complexity thresholds tuned for ML/systems code review.
 cognitive-complexity-threshold = 30
 too-many-arguments-threshold = 8
 type-complexity-threshold = 250
 trivial-copy-size-limit = 64
-
-# Allow certain patterns common in ML/systems code
-allow-expect-in-tests = true
-allow-unwrap-in-tests = true
-allow-mixed-uninlined-format-args = true  # Performance in hot paths

--- a/crates/bitnet-api-key-auth-core/Cargo.toml
+++ b/crates/bitnet-api-key-auth-core/Cargo.toml
@@ -12,3 +12,6 @@ version.workspace = true
 
 [dependencies]
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-bdd-grid-core/Cargo.toml
+++ b/crates/bitnet-bdd-grid-core/Cargo.toml
@@ -19,3 +19,6 @@ proptest.workspace = true
 insta = { workspace = true, features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-bdd-grid/Cargo.toml
+++ b/crates/bitnet-bdd-grid/Cargo.toml
@@ -22,3 +22,6 @@ bitnet-bdd-grid-core = { path = "../bitnet-bdd-grid-core", version = "0.2.1-dev"
 bitnet-runtime-feature-flags = { path = "../bitnet-runtime-feature-flags", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-bench-receipts/Cargo.toml
+++ b/crates/bitnet-bench-receipts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-bench-receipts"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "Receipt model and JSONL store for benchmark result tracking"
 license = "MIT OR Apache-2.0"
 
@@ -13,3 +13,6 @@ thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/bitnet-bench-regression-core/Cargo.toml
+++ b/crates/bitnet-bench-regression-core/Cargo.toml
@@ -2,9 +2,12 @@
 name = "bitnet-bench-regression-core"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "Core benchmark regression detection primitives"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 bitnet-bench-receipts = { path = "../bitnet-bench-receipts" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-cli-config-core/Cargo.toml
+++ b/crates/bitnet-cli-config-core/Cargo.toml
@@ -16,3 +16,6 @@ serde = { workspace = true, features = ["derive"] }
 toml.workspace = true
 dirs.workspace = true
 tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -120,3 +120,6 @@ trace = ["bitnet-inference/trace", "bitnet-runtime-bootstrap/runtime-profile-tra
 # This prevents production CLI builds with test mocks
 # DO NOT enable this feature - it will fail to compile by design
 mock = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-common/Cargo.toml
+++ b/crates/bitnet-common/Cargo.toml
@@ -61,3 +61,6 @@ test-util = []  # Exposes test-only APIs for integration tests
 # ONLY on macOS, so Linux builds won't try to compile objc/Metal frameworks.
 workspace = true
 features = ["metal"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-compat-core/Cargo.toml
+++ b/crates/bitnet-compat-core/Cargo.toml
@@ -14,3 +14,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-compat/Cargo.toml
+++ b/crates/bitnet-compat/Cargo.toml
@@ -28,3 +28,6 @@ proptest.workspace = true
 [features]
 integration-tests = []
 tokenizer-probe = ["bitnet-tokenizers"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-cpu-activations/Cargo.toml
+++ b/crates/bitnet-cpu-activations/Cargo.toml
@@ -12,3 +12,6 @@ description = "CPU activation kernels extracted as an SRP microcrate"
 
 [dependencies]
 libm = "0.2.16"
+
+[lints]
+workspace = true

--- a/crates/bitnet-cpu-detect/Cargo.toml
+++ b/crates/bitnet-cpu-detect/Cargo.toml
@@ -22,3 +22,6 @@ default = []
 avx2 = []
 avx512 = []
 neon = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-device-config-core/Cargo.toml
+++ b/crates/bitnet-device-config-core/Cargo.toml
@@ -21,3 +21,6 @@ default = []
 cpu = ["bitnet-common/cpu"]
 cuda = ["dep:bitnet-kernels", "bitnet-kernels/cuda"]
 gpu = ["cuda", "bitnet-kernels/gpu"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-dispatch-core/Cargo.toml
+++ b/crates/bitnet-dispatch-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-dispatch-core"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "Backend-agnostic compute dispatch sizing and recording primitives"
 license = "MIT OR Apache-2.0"
 
@@ -10,3 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-eval-core/Cargo.toml
+++ b/crates/bitnet-eval-core/Cargo.toml
@@ -13,3 +13,6 @@ description = "SRP helpers for evaluation and scoring math"
 [lib]
 name = "bitnet_eval_core"
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-feature-contract/Cargo.toml
+++ b/crates/bitnet-feature-contract/Cargo.toml
@@ -62,3 +62,6 @@ runtime-profile-fixtures = ["bitnet-feature-matrix/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-feature-matrix/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-feature-matrix/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-feature-matrix/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-feature-matrix/Cargo.toml
+++ b/crates/bitnet-feature-matrix/Cargo.toml
@@ -61,3 +61,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-profile-core/runtime-profil
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-ffi/Cargo.toml
+++ b/crates/bitnet-ffi/Cargo.toml
@@ -48,3 +48,6 @@ cpu = []
 cuda = ["cudarc", "bitnet-inference/cuda"]
 gpu = ["cuda"]  # GPU umbrella — CUDA is the current implementation
 ffi-tests = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-ggml-ffi/Cargo.toml
+++ b/crates/bitnet-ggml-ffi/Cargo.toml
@@ -30,3 +30,6 @@ cc = "1.2.38"
 
 [dependencies]
 libc = { version = "0.2.175", optional = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-honest-compute/Cargo.toml
+++ b/crates/bitnet-honest-compute/Cargo.toml
@@ -25,3 +25,6 @@ default = []
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-inference-metrics-core/Cargo.toml
+++ b/crates/bitnet-inference-metrics-core/Cargo.toml
@@ -16,3 +16,6 @@ include = [
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-inference/Cargo.toml
+++ b/crates/bitnet-inference/Cargo.toml
@@ -105,3 +105,6 @@ trace = ["bitnet-models/trace"]  # Enable tensor activation tracing
 name = "comprehensive_tests"
 path = "tests/comprehensive_tests.rs"
 required-features = ["full-engine"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -175,3 +175,6 @@ name = "gpu_validation"
 path = "examples/gpu_validation.rs"
 required-features = ["gpu"]
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-math/Cargo.toml
+++ b/crates/bitnet-math/Cargo.toml
@@ -19,3 +19,6 @@ include = [
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -81,3 +81,6 @@ tl2 = []  # TL2 quantization for test scaffolding
 test-fixtures = []  # Enable tests that require real GGUF fixtures
 fixtures = []  # Enable GGUF fixture generation for QK256 dual-flavor tests (PR1)
 trace = ["dep:bitnet-trace"]  # Enable tensor activation tracing for cross-validation
+
+[lints]
+workspace = true

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-nvidia"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "NVIDIA-specific GPU tuning heuristics shared across BitNet backends"
 license = "MIT OR Apache-2.0"
 
@@ -10,3 +10,6 @@ license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-prompt-templates-core/Cargo.toml
+++ b/crates/bitnet-prompt-templates-core/Cargo.toml
@@ -27,3 +27,6 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 [[bench]]
 name = "template_ops"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/bitnet-prompt-templates/Cargo.toml
+++ b/crates/bitnet-prompt-templates/Cargo.toml
@@ -21,3 +21,6 @@ tracing-test.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-py/Cargo.toml
+++ b/crates/bitnet-py/Cargo.toml
@@ -54,3 +54,6 @@ gpu = ["cuda"]  # GPU umbrella — CUDA is the current implementation
 name = "streaming_comprehensive"
 path = "tests/integration/streaming_comprehensive.rs"
 required-features = ["integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-qk256-dispatch/Cargo.toml
+++ b/crates/bitnet-qk256-dispatch/Cargo.toml
@@ -26,3 +26,6 @@ cpu = ["bitnet-quantization/cpu"]
 cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda"]
 metal = ["bitnet-common/metal"]
 gpu = ["cuda", "metal"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-qk256-layout-core/Cargo.toml
+++ b/crates/bitnet-qk256-layout-core/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = { workspace = true }
 [features]
 default = []
 cpu = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-quantization-bits/Cargo.toml
+++ b/crates/bitnet-quantization-bits/Cargo.toml
@@ -16,3 +16,6 @@ include = [
 
 [dependencies]
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -54,3 +54,6 @@ inference = []
 [[bench]]
 name = "quantization"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/bitnet-receipts-core/Cargo.toml
+++ b/crates/bitnet-receipts-core/Cargo.toml
@@ -30,3 +30,6 @@ proptest = { workspace = true }
 insta = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-receipts/Cargo.toml
+++ b/crates/bitnet-receipts/Cargo.toml
@@ -24,3 +24,6 @@ insta = { workspace = true }
 tempfile = { workspace = true }
 serde_json = { workspace = true }
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-repl-core/Cargo.toml
+++ b/crates/bitnet-repl-core/Cargo.toml
@@ -15,3 +15,6 @@ anyhow.workspace = true
 
 [dev-dependencies]
 tempfile = "3.23.0"
+
+[lints]
+workspace = true

--- a/crates/bitnet-rocm/Cargo.toml
+++ b/crates/bitnet-rocm/Cargo.toml
@@ -22,3 +22,6 @@ insta.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-rope/Cargo.toml
+++ b/crates/bitnet-rope/Cargo.toml
@@ -24,3 +24,6 @@ default = []
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-bootstrap/Cargo.toml
+++ b/crates/bitnet-runtime-bootstrap/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-startup-contract/runtime-profile-in
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-context-core/Cargo.toml
+++ b/crates/bitnet-runtime-context-core/Cargo.toml
@@ -26,3 +26,6 @@ insta.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-context/Cargo.toml
+++ b/crates/bitnet-runtime-context/Cargo.toml
@@ -25,3 +25,6 @@ default = []
 proptest.workspace = true
 serial_test.workspace = true
 temp-env.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-feature-flags-core/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags-core/Cargo.toml
@@ -25,3 +25,6 @@ serde_json.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-feature-flags/Cargo.toml
+++ b/crates/bitnet-runtime-feature-flags/Cargo.toml
@@ -67,3 +67,6 @@ runtime-profile-integration-tests = ["integration-tests"]
 proptest.workspace = true
 insta.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-contract-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract-core/Cargo.toml
@@ -68,3 +68,6 @@ insta.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 temp-env = "0.3.6"
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-contract/Cargo.toml
+++ b/crates/bitnet-runtime-profile-contract/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-fixtures = ["bitnet-runtime-profile-contract-core/runtime-profil
 runtime-profile-reporting = ["bitnet-runtime-profile-contract-core/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile-contract-core/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile-contract-core/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile-core/Cargo.toml
+++ b/crates/bitnet-runtime-profile-core/Cargo.toml
@@ -57,3 +57,6 @@ runtime-profile-fixtures = ["bitnet-runtime-profile-contract/runtime-profile-fix
 runtime-profile-reporting = ["bitnet-runtime-profile-contract/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-runtime-profile-contract/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-runtime-profile-contract/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-runtime-profile/Cargo.toml
+++ b/crates/bitnet-runtime-profile/Cargo.toml
@@ -57,3 +57,6 @@ runtime-profile-fixtures = ["bitnet-feature-matrix/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-feature-matrix/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-feature-matrix/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-feature-matrix/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-sampling/Cargo.toml
+++ b/crates/bitnet-sampling/Cargo.toml
@@ -22,3 +22,6 @@ bitnet-probability = { path = "../bitnet-probability", version = "0.2.1-dev" }
 [dev-dependencies]
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-server/Cargo.toml
+++ b/crates/bitnet-server/Cargo.toml
@@ -125,3 +125,6 @@ request_batching = []                                                           
 connection_pool = []                                                                                                                                                              # Gate connection pool module (PR-1 scope)
 tuning = []                                                                                                                                                                       # Gate performance tuning module (PR-1 scope)
 receipts = []                                                                                                                                                                     # Enable KV cache eviction receipts (Phase 2)
+
+[lints]
+workspace = true

--- a/crates/bitnet-st-tools/Cargo.toml
+++ b/crates/bitnet-st-tools/Cargo.toml
@@ -25,3 +25,6 @@ tempfile = "3.23.0"
 [[bin]]
 name = "st-ln-inspect"
 path = "src/bin/st-ln-inspect.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-st2gguf/Cargo.toml
+++ b/crates/bitnet-st2gguf/Cargo.toml
@@ -47,3 +47,6 @@ tempfile.workspace = true
 memmap2.workspace = true
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-core/Cargo.toml
@@ -67,3 +67,6 @@ serial_test.workspace = true
 temp-env = "0.3.6"
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics-core/Cargo.toml
@@ -15,3 +15,6 @@ include = ["src/**", "Cargo.toml"]
 [dependencies]
 anyhow.workspace = true
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-diagnostics/Cargo.toml
+++ b/crates/bitnet-startup-contract-diagnostics/Cargo.toml
@@ -19,3 +19,6 @@ bitnet-startup-contract-diagnostics-core = { path = "../bitnet-startup-contract-
 bitnet-runtime-bootstrap = { path = "../bitnet-runtime-bootstrap", version = "0.2.1-dev" }
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract-guard/Cargo.toml
+++ b/crates/bitnet-startup-contract-guard/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-startup-contract/Cargo.toml
+++ b/crates/bitnet-startup-contract/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-integration-tests = ["bitnet-startup-contract-core/runtime-profi
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-sys/Cargo.toml
+++ b/crates/bitnet-sys/Cargo.toml
@@ -44,3 +44,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 [lib]
 name = "bitnet_sys"
 path = "src/lib.rs"
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-env/Cargo.toml
+++ b/crates/bitnet-test-env/Cargo.toml
@@ -13,3 +13,6 @@ publish = true
 
 [dev-dependencies]
 serial_test.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-fixtures-core/Cargo.toml
+++ b/crates/bitnet-test-fixtures-core/Cargo.toml
@@ -11,3 +11,6 @@ categories.workspace = true
 description = "SRP helpers for resolving and loading test fixtures"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-test-support/Cargo.toml
+++ b/crates/bitnet-test-support/Cargo.toml
@@ -19,3 +19,6 @@ serial_test.workspace = true
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-contract/Cargo.toml
+++ b/crates/bitnet-testing-policy-contract/Cargo.toml
@@ -66,3 +66,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profi
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-core/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-testing-profile/runtime-profile-int
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-interop/Cargo.toml
+++ b/crates/bitnet-testing-policy-interop/Cargo.toml
@@ -62,3 +62,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-feature-flags/runtime-profi
 
 [dev-dependencies]
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-kit/Cargo.toml
+++ b/crates/bitnet-testing-policy-kit/Cargo.toml
@@ -63,3 +63,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy/runtime-profile-inte
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-runtime-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime-core/Cargo.toml
@@ -18,3 +18,6 @@ include = [
 [dependencies]
 bitnet-testing-policy-state-core = { path = "../bitnet-testing-policy-state-core", version = "0.2.1-dev" }
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-runtime/Cargo.toml
+++ b/crates/bitnet-testing-policy-runtime/Cargo.toml
@@ -65,3 +65,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-interop/runtime-prof
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-snapshot-core/Cargo.toml
@@ -58,3 +58,6 @@ runtime-profile-fixtures = ["bitnet-testing-profile/runtime-profile-fixtures"]
 runtime-profile-reporting = ["bitnet-testing-profile/runtime-profile-reporting"]
 runtime-profile-trend = ["bitnet-testing-profile/runtime-profile-trend"]
 runtime-profile-integration-tests = ["bitnet-testing-profile/runtime-profile-integration-tests"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-state-core/Cargo.toml
+++ b/crates/bitnet-testing-policy-state-core/Cargo.toml
@@ -17,3 +17,6 @@ include = [
 
 [dependencies]
 bitnet-testing-policy-interop = { path = "../bitnet-testing-policy-interop", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy-tests/Cargo.toml
+++ b/crates/bitnet-testing-policy-tests/Cargo.toml
@@ -64,3 +64,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-runtime/runtime-prof
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-policy/Cargo.toml
+++ b/crates/bitnet-testing-policy/Cargo.toml
@@ -60,3 +60,6 @@ runtime-profile-integration-tests = ["bitnet-testing-policy-core/runtime-profile
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-profile/Cargo.toml
+++ b/crates/bitnet-testing-profile/Cargo.toml
@@ -61,3 +61,6 @@ runtime-profile-integration-tests = ["bitnet-runtime-profile/runtime-profile-int
 [dev-dependencies]
 proptest.workspace = true
 insta.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-core/Cargo.toml
@@ -26,3 +26,6 @@ insta.workspace = true
 [features]
 default = []
 fixtures = ["bitnet-testing-scenarios-profile-core/fixtures"]
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
+++ b/crates/bitnet-testing-scenarios-profile-core/Cargo.toml
@@ -26,3 +26,6 @@ fixtures = []
 [dev-dependencies]
 insta.workspace = true
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-testing-scenarios/Cargo.toml
+++ b/crates/bitnet-testing-scenarios/Cargo.toml
@@ -24,3 +24,6 @@ fixtures = ["bitnet-testing-scenarios-core/fixtures"]
 
 [dev-dependencies]
 proptest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-thread-config-core/Cargo.toml
+++ b/crates/bitnet-thread-config-core/Cargo.toml
@@ -11,3 +11,6 @@ categories.workspace = true
 description = "SRP thread configuration and work partitioning primitives"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-token-merge-core/Cargo.toml
+++ b/crates/bitnet-token-merge-core/Cargo.toml
@@ -14,3 +14,6 @@ description = "SRP core token span merge/split utilities"
 
 [dev-dependencies]
 proptest = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizer-discovery-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-discovery-core/Cargo.toml
@@ -16,3 +16,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizer-model-core/Cargo.toml
+++ b/crates/bitnet-tokenizer-model-core/Cargo.toml
@@ -13,3 +13,6 @@ description = "Core model/vocabulary detection helpers for tokenizers"
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 
+
+[lints]
+workspace = true

--- a/crates/bitnet-tokenizers/Cargo.toml
+++ b/crates/bitnet-tokenizers/Cargo.toml
@@ -68,3 +68,6 @@ bitnet-test-support.workspace = true
 bitnet-test-fixtures-core = { path = "../bitnet-test-fixtures-core", version = "0.2.1-dev" }
 proptest = { workspace = true }
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-trace"
 version = "0.2.1-dev"
 edition.workspace = true
-rust-version = "1.92.0"
+rust-version.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Tensor activation tracing for bitnet-rs cross-validation debugging"
 
@@ -22,3 +22,6 @@ temp-env = "0.3.6"
 insta = { workspace = true, features = ["json"] }
 proptest.workspace = true
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-transformer/Cargo.toml
+++ b/crates/bitnet-transformer/Cargo.toml
@@ -35,3 +35,6 @@ cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda", "b
 metal = ["bitnet-common/metal", "bitnet-qk256-dispatch/metal"]
 gpu = ["cuda", "metal"]
 trace = []
+
+[lints]
+workspace = true

--- a/crates/bitnet-validation/Cargo.toml
+++ b/crates/bitnet-validation/Cargo.toml
@@ -20,3 +20,6 @@ serde_yaml.workspace = true
 tempfile = "3"
 proptest.workspace = true
 insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/bitnet-warn-once/Cargo.toml
+++ b/crates/bitnet-warn-once/Cargo.toml
@@ -21,3 +21,6 @@ tracing.workspace = true
 proptest.workspace = true
 serial_test.workspace = true
 tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bitnet-wasm-utils/Cargo.toml
+++ b/crates/bitnet-wasm-utils/Cargo.toml
@@ -17,3 +17,6 @@ web-sys = { workspace = true, features = ["Window", "Navigator", "Performance"] 
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.53"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wasm/Cargo.toml
+++ b/crates/bitnet-wasm/Cargo.toml
@@ -81,3 +81,6 @@ wasm-kernels = ["dep:bitnet-kernels"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.53"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-bench/Cargo.toml
+++ b/crates/bitnet-wgpu-bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu-bench"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "Benchmarking and profiling harness for wgpu compute kernels"
 license = "MIT OR Apache-2.0"
 
@@ -16,3 +16,6 @@ thiserror = "2"
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-runner/Cargo.toml
+++ b/crates/bitnet-wgpu-runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu-runner"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "Kernel execution runner for wgpu compute pipelines"
 license = "MIT OR Apache-2.0"
 
@@ -15,3 +15,6 @@ tracing = "0.1"
 [dev-dependencies]
 pollster = "0.4"
 tokio = { version = "1", features = ["rt", "macros"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
+++ b/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
@@ -2,9 +2,12 @@
 name = "bitnet-wgpu-shaders-i2s"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "WGSL compute shaders for I2_S 2-bit quantized inference (BitNet)"
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
 naga = { version = "28", features = ["wgsl-in"] }
+
+[lints]
+workspace = true

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.92.0"
+rust-version.workspace = true
 description = "wgpu-based GPU compute backend for BitNet inference (Vulkan/Metal/DX12)"
 license = "MIT OR Apache-2.0"
 
@@ -21,3 +21,6 @@ proptest = "1"
 
 [features]
 default = []
+
+[lints]
+workspace = true

--- a/crossval/Cargo.toml
+++ b/crossval/Cargo.toml
@@ -80,3 +80,6 @@ cc = { version = "1.2.46", optional = true }
 
 [package.metadata.docs.rs]
 features = ["crossval"]
+
+[lints]
+workspace = true

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -1,0 +1,98 @@
+# Effortless Metrics Clippy Policy
+
+BitNet-rs uses the shared Effortless Metrics Rust lint policy as an engineering
+surface, not as local taste embedded in `Cargo.toml`. The policy has three
+checked artifacts:
+
+- `Cargo.toml` carries the active workspace lint levels.
+- `policy/clippy-lints.toml` is the machine-readable ledger for active lints and
+  planned Rust 1.94/1.95 flips.
+- `cargo xtask check-lint-policy` verifies that the manifest, Clippy config, and
+  policy ledgers still agree.
+
+## Baseline
+
+The active baseline is workspace-wide and applies to production code and tests.
+It surfaces unsafe code as reviewed rollout debt, denies panic-family lints,
+prevents silent failure patterns, rejects broad suppression habits, and keeps
+GPU/numeric review lints staged as warnings where a blanket deny would create
+churn before policy.
+
+There are no test carveouts. Do not add Clippy configuration such as:
+
+```toml
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-panic-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-dbg-in-tests = true
+```
+
+Tests should return `Result` and propagate setup failures instead of using
+`unwrap`, `expect`, or panic-driven fixture setup:
+
+```rust
+#[test]
+fn parses_fixture() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = std::fs::read_to_string("tests/fixtures/input.txt")?;
+    let parsed = parse_fixture(&fixture)?;
+
+    ensure_eq!(parsed.items.len(), 3, "fixture should expose three items")?;
+
+    Ok(())
+}
+```
+
+## Suppressions
+
+The suppression style is **structured receipt, not silent carveout**:
+
+```rust
+#[expect(
+    clippy::indexing_slicing,
+    reason = "Reviewed fixed-size QK256 tile indexing; bounds proven by tile constructor."
+)]
+let value = tile.values[index];
+```
+
+Use `#[expect(..., reason = "...")]` for narrow, local exceptions. Do not use
+plain `#[allow]` for Clippy policy suppressions. If an exception represents
+rollout debt rather than a permanent invariant, add it to `policy/clippy-debt.toml`
+with an owner, reason, path, lint, and expiry.
+
+## BitNet-rs overlay
+
+BitNet-rs is a GPU/numeric/performance workspace. Numeric-correctness lints are
+therefore split between immediate denies for clearly dangerous casts/comparisons
+and staged warnings for broad arithmetic/cast review:
+
+- `clippy::arithmetic_side_effects = "warn"`
+- `clippy::cast_possible_wrap = "warn"`
+- `clippy::cast_possible_truncation = "warn"`
+- `clippy::cast_precision_loss = "warn"`
+
+Backend-specific exceptions should stay narrow and documented at the call site.
+Do not weaken the workspace lint block or add test carveouts to `clippy.toml`.
+
+## Planned Rust 1.94 / 1.95 flips
+
+The ledger tracks planned lints before the MSRV bump. `cargo xtask
+check-lint-policy` rejects planned lints that become active before their recorded
+MSRV gate. When the workspace moves to a newer MSRV, update the ledger and root
+lint block in the same PR.
+
+## Required local checks
+
+Run these before policy changes are reviewed:
+
+```shell
+cargo fmt --all --check
+cargo xtask check-lint-policy
+cargo xtask policy-report
+```
+
+Full Clippy enforcement is the desired CI gate once current debt is triaged:
+
+```shell
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -641,3 +641,6 @@ name = "fuzz_tensor_layout"
 path = "fuzz_targets/fuzz_tensor_layout.rs"
 test = false
 doc = false
+
+[lints]
+workspace = true

--- a/policy/clippy-debt.toml
+++ b/policy/clippy-debt.toml
@@ -1,0 +1,6 @@
+schema = 1
+
+# Temporary lint exceptions belong here as reviewed, expiring debt. This first
+# policy PR establishes the ledger; follow-up cleanup PRs should add concrete
+# entries only when they introduce narrow #[expect(..., reason = "...")]
+# suppressions or documented rollout debt.

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,0 +1,799 @@
+schema = 1
+msrv = "1.93"
+
+[policy]
+panic_free_tests = true
+allow_test_carveouts = false
+suppression_style = "expect-with-reason"
+blanket_categories = false
+
+# Active lints must match the root Cargo.toml workspace lint block.
+
+[[lint]]
+name = "rust::unsafe_code"
+level = "warn"
+status = "active"
+class = "unsafe-memory"
+reason = "Surface unsafe code across GPU and FFI crates while follow-up debt entries narrow reviewed exceptions."
+
+[[lint]]
+name = "rust::unsafe_op_in_unsafe_fn"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Require explicit unsafe operation scopes when unsafe is introduced."
+
+[[lint]]
+name = "rust::unused_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not silently drop must-use work."
+
+[[lint]]
+name = "rust::unexpected_cfgs"
+level = "warn"
+status = "active"
+class = "cfg"
+reason = "Surface misspelled or unregistered cfg gates without blocking initial rollout."
+
+[[lint]]
+name = "rust::const_item_interior_mutations"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Reject surprising mutable const item behavior."
+
+[[lint]]
+name = "rust::function_casts_as_integer"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Reject fragile function-pointer-to-integer casts."
+
+[[lint]]
+name = "clippy::dbg_macro"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No debug macros in production or tests."
+
+[[lint]]
+name = "clippy::todo"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No checked-in TODO placeholders in executable Rust."
+
+[[lint]]
+name = "clippy::unimplemented"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No checked-in unimplemented control paths."
+
+[[lint]]
+name = "clippy::panic"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No panic-driven production or test behavior."
+
+[[lint]]
+name = "clippy::unreachable"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked unreachable control paths."
+
+[[lint]]
+name = "clippy::unwrap_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::expect_used"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No message-only unchecked Result/Option collapse in production or tests."
+
+[[lint]]
+name = "clippy::get_unwrap"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No unchecked get().unwrap() indexing collapse."
+
+[[lint]]
+name = "clippy::unwrap_in_result"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "No panic-family collapse inside Result-returning functions."
+
+[[lint]]
+name = "clippy::panic_in_result_fn"
+level = "deny"
+status = "active"
+class = "panic"
+reason = "Result-returning functions must report errors instead of panicking."
+
+[[lint]]
+name = "clippy::string_slice"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Avoid byte-indexed string slicing on UTF-8 data."
+
+[[lint]]
+name = "clippy::indexing_slicing"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Avoid unchecked indexing and slicing."
+
+[[lint]]
+name = "clippy::out_of_bounds_indexing"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Reject statically out-of-bounds indexing."
+
+[[lint]]
+name = "clippy::unchecked_time_subtraction"
+level = "deny"
+status = "active"
+class = "correctness"
+reason = "Avoid panicking or lossy time arithmetic."
+
+[[lint]]
+name = "clippy::char_indices_as_byte_indices"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Keep char offsets distinct from byte offsets."
+
+[[lint]]
+name = "clippy::sliced_string_as_bytes"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Avoid slicing strings before converting to bytes."
+
+[[lint]]
+name = "clippy::index_refutable_slice"
+level = "deny"
+status = "active"
+class = "ast-safety"
+reason = "Avoid unchecked refutable slice indexing."
+
+[[lint]]
+name = "clippy::let_underscore_future"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not drop futures silently."
+
+[[lint]]
+name = "clippy::let_underscore_must_use"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not discard must-use values with underscore bindings."
+
+[[lint]]
+name = "clippy::let_underscore_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not immediately drop synchronization locks."
+
+[[lint]]
+name = "clippy::unused_result_ok"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not erase Result failures with ok()."
+
+[[lint]]
+name = "clippy::map_err_ignore"
+level = "deny"
+status = "active"
+class = "silent-failure"
+reason = "Do not discard error details in map_err."
+
+[[lint]]
+name = "clippy::assertions_on_result_states"
+level = "deny"
+status = "active"
+class = "test-quality"
+reason = "Avoid assertion shapes that discard Result context."
+
+[[lint]]
+name = "clippy::lines_filter_map_ok"
+level = "deny"
+status = "active"
+class = "io"
+reason = "Avoid infinite iteration on repeated line-read errors."
+
+[[lint]]
+name = "clippy::await_holding_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold locks across await points."
+
+[[lint]]
+name = "clippy::await_holding_refcell_ref"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold RefCell borrows across await points."
+
+[[lint]]
+name = "clippy::await_holding_invalid_type"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Do not hold configured invalid types across await points."
+
+[[lint]]
+name = "clippy::future_not_send"
+level = "warn"
+status = "active"
+class = "concurrency"
+reason = "Surface non-Send futures for review without blocking first rollout."
+
+[[lint]]
+name = "clippy::large_futures"
+level = "warn"
+status = "active"
+class = "performance"
+reason = "Surface large async state machines for review."
+
+[[lint]]
+name = "clippy::arc_with_non_send_sync"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid Arc around non-Send/Sync payloads."
+
+[[lint]]
+name = "clippy::rc_mutex"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid single-thread reference-counted mutex footguns."
+
+[[lint]]
+name = "clippy::mut_mutex_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid locking mutexes through mutable references."
+
+[[lint]]
+name = "clippy::readonly_write_lock"
+level = "deny"
+status = "active"
+class = "concurrency"
+reason = "Avoid unnecessary write locks for read-only work."
+
+[[lint]]
+name = "clippy::mem_forget"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid intentionally leaking destructors."
+
+[[lint]]
+name = "clippy::forget_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid forgetting values that do not need Drop suppression."
+
+[[lint]]
+name = "clippy::drop_non_drop"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Avoid meaningless explicit drops."
+
+[[lint]]
+name = "clippy::undocumented_unsafe_blocks"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Unsafe blocks require safety documentation."
+
+[[lint]]
+name = "clippy::multiple_unsafe_ops_per_block"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Keep unsafe operations narrowly auditable."
+
+[[lint]]
+name = "clippy::repr_packed_without_abi"
+level = "deny"
+status = "active"
+class = "unsafe-memory"
+reason = "Require explicit ABI with packed representation."
+
+[[lint]]
+name = "clippy::float_cmp"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid exact runtime float equality."
+
+[[lint]]
+name = "clippy::float_cmp_const"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid exact float comparisons to constants."
+
+[[lint]]
+name = "clippy::float_equality_without_abs"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Require robust float comparisons."
+
+[[lint]]
+name = "clippy::lossy_float_literal"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid silently rounded float literals."
+
+[[lint]]
+name = "clippy::cast_sign_loss"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid unchecked sign-losing casts."
+
+[[lint]]
+name = "clippy::cast_possible_wrap"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Stage potentially wrapping casts for review."
+
+[[lint]]
+name = "clippy::cast_possible_truncation"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Stage potentially truncating casts for review."
+
+[[lint]]
+name = "clippy::cast_precision_loss"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Stage precision-losing casts for numeric-kernel review."
+
+[[lint]]
+name = "clippy::invalid_upcast_comparisons"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Reject comparisons made impossible by casts."
+
+[[lint]]
+name = "clippy::cast_abs_to_unsigned"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Prefer unsigned_abs-style intent."
+
+[[lint]]
+name = "clippy::cast_enum_truncation"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid truncating enum representation casts."
+
+[[lint]]
+name = "clippy::cast_nan_to_int"
+level = "deny"
+status = "active"
+class = "numeric"
+reason = "Avoid NaN-to-integer casts."
+
+[[lint]]
+name = "clippy::manual_midpoint"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer standard midpoint helper."
+
+[[lint]]
+name = "clippy::manual_is_multiple_of"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer standard divisibility helper."
+
+[[lint]]
+name = "clippy::manual_div_ceil"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Prefer standard division-ceiling helper."
+
+[[lint]]
+name = "clippy::arithmetic_side_effects"
+level = "warn"
+status = "active"
+class = "numeric"
+reason = "Surface arithmetic side effects without blanket-denying GPU/numeric kernels."
+
+[[lint]]
+name = "clippy::suspicious_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Require explicit truncate/append semantics."
+
+[[lint]]
+name = "clippy::nonsensical_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Reject impossible open option combinations."
+
+[[lint]]
+name = "clippy::ineffective_open_options"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Reject ignored open options."
+
+[[lint]]
+name = "clippy::path_buf_push_overwrite"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Avoid path push overwriting with absolute paths."
+
+[[lint]]
+name = "clippy::join_absolute_paths"
+level = "deny"
+status = "active"
+class = "filesystem"
+reason = "Avoid joins that discard the base path."
+
+[[lint]]
+name = "clippy::read_line_without_trim"
+level = "warn"
+status = "active"
+class = "cli"
+reason = "Surface newline-retaining input reads for review."
+
+[[lint]]
+name = "clippy::exit"
+level = "deny"
+status = "active"
+class = "cli"
+reason = "Keep process exits at reviewed CLI boundaries only."
+
+[[lint]]
+name = "clippy::iter_not_returning_iterator"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Avoid misleading iterator-like APIs."
+
+[[lint]]
+name = "clippy::expl_impl_clone_on_copy"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Prefer derived Copy/Clone semantics."
+
+[[lint]]
+name = "clippy::infallible_try_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Use From for infallible conversions."
+
+[[lint]]
+name = "clippy::fallible_impl_from"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Do not hide fallible conversions behind From."
+
+[[lint]]
+name = "clippy::error_impl_error"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Implement Error correctly."
+
+[[lint]]
+name = "clippy::result_unit_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Prefer meaningful error types."
+
+[[lint]]
+name = "clippy::result_large_err"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Avoid large error payloads on hot Result paths."
+
+[[lint]]
+name = "clippy::format_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Avoid nested formatting noise."
+
+[[lint]]
+name = "clippy::to_string_in_format_args"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Avoid unnecessary to_string in formatting."
+
+[[lint]]
+name = "clippy::unused_format_specs"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Reject ignored format specifiers."
+
+[[lint]]
+name = "clippy::unnecessary_debug_formatting"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer display formatting when debug is unnecessary."
+
+[[lint]]
+name = "clippy::uninlined_format_args"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer inline format args."
+
+[[lint]]
+name = "clippy::manual_let_else"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer let-else for early exits."
+
+[[lint]]
+name = "clippy::manual_ok_or"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer ok_or/ok_or_else idioms."
+
+[[lint]]
+name = "clippy::manual_strip"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer strip_prefix/suffix."
+
+[[lint]]
+name = "clippy::manual_split_once"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer split_once."
+
+[[lint]]
+name = "clippy::manual_is_variant_and"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer is_some_and/is_ok_and-style helpers."
+
+[[lint]]
+name = "clippy::filter_map_next"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Prefer find_map."
+
+[[lint]]
+name = "clippy::flat_map_option"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Avoid flat_map on Option."
+
+[[lint]]
+name = "clippy::match_result_ok"
+level = "deny"
+status = "active"
+class = "reviewability"
+reason = "Match Result directly instead of ok()."
+
+[[lint]]
+name = "clippy::cloned_instead_of_copied"
+level = "warn"
+status = "active"
+class = "allocation"
+reason = "Avoid needless clone when copy is available."
+
+[[lint]]
+name = "clippy::iter_cloned_collect"
+level = "warn"
+status = "active"
+class = "allocation"
+reason = "Prefer to_vec or clearer collection helpers."
+
+[[lint]]
+name = "clippy::iter_overeager_cloned"
+level = "warn"
+status = "active"
+class = "allocation"
+reason = "Avoid cloning before filtering."
+
+[[lint]]
+name = "clippy::needless_collect"
+level = "warn"
+status = "active"
+class = "allocation"
+reason = "Avoid collecting when iteration is enough."
+
+[[lint]]
+name = "clippy::redundant_closure"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Remove redundant closures."
+
+[[lint]]
+name = "clippy::redundant_closure_for_method_calls"
+level = "warn"
+status = "active"
+class = "reviewability"
+reason = "Use method references where clearer."
+
+[[lint]]
+name = "clippy::missing_panics_doc"
+level = "deny"
+status = "active"
+class = "api"
+reason = "Document panics in public APIs until they are removed."
+
+[[lint]]
+name = "clippy::missing_errors_doc"
+level = "warn"
+status = "active"
+class = "api"
+reason = "Document public error conditions."
+
+[[lint]]
+name = "clippy::allow_attributes"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Prefer expect attributes with reasons over silent allows."
+
+[[lint]]
+name = "clippy::allow_attributes_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Every suppression needs an explicit reason."
+
+[[lint]]
+name = "clippy::blanket_clippy_restriction_lints"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Do not blanket-enable restriction lint groups."
+
+[[lint]]
+name = "clippy::ignore_without_reason"
+level = "deny"
+status = "active"
+class = "suppression"
+reason = "Ignored tests require a reason."
+
+[[lint]]
+name = "clippy::should_panic_without_expect"
+level = "deny"
+status = "active"
+class = "test-quality"
+reason = "should_panic tests must state the expected panic."
+
+# Planned lints are tracked before the MSRV bump and must not be active early.
+
+[[lint]]
+name = "clippy::same_length_and_capacity"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "unsafe-memory"
+reason = "Catch raw-parts reconstruction mistakes."
+
+[[lint]]
+name = "clippy::manual_ilog2"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Prefer the standard integer log helper."
+
+[[lint]]
+name = "clippy::decimal_bitwise_operands"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Make bit masks visually inspectable."
+
+[[lint]]
+name = "clippy::needless_type_cast"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.94"
+class = "numeric"
+reason = "Avoid stale numeric type drift."
+
+[[lint]]
+name = "clippy::disallowed_fields"
+level = "deny"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "architecture"
+reason = "Allow architecture policy to ban direct field access across protected seams."
+
+[[lint]]
+name = "clippy::manual_checked_ops"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "numeric"
+reason = "Prefer checked arithmetic over manual divide-by-zero guards."
+
+[[lint]]
+name = "clippy::manual_take"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use standard ownership helper instead of local reimplementation."
+
+[[lint]]
+name = "clippy::manual_pop_if"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Use collection APIs that encode predicate-and-pop intent directly."
+
+[[lint]]
+name = "clippy::duration_suboptimal_units"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Make durations legible without mental unit conversion."
+
+[[lint]]
+name = "clippy::unnecessary_trailing_comma"
+level = "warn"
+status = "planned"
+activate_when_msrv = "1.95"
+class = "reviewability"
+reason = "Keep generated and hand-written format macro calls clean."

--- a/policy/no-panic-allowlist.toml
+++ b/policy/no-panic-allowlist.toml
@@ -1,0 +1,5 @@
+schema_version = "0.3"
+
+# Panic-family exceptions use semantic identity:
+# path + family + selector. last_seen line/column data is advisory only.
+# New exceptions require owner, classification, explanation, and optional expiry.

--- a/policy/non-rust-allowlist.toml
+++ b/policy/non-rust-allowlist.toml
@@ -1,0 +1,28 @@
+schema_version = "1.0"
+
+[[allow]]
+glob = ".github/workflows/*.yml"
+kind = "ci_declarative"
+owner = "release/ci"
+reason = "GitHub Actions workflow definitions are platform-required YAML."
+surface = "ci"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "docs/**"
+kind = "documentation"
+owner = "docs"
+reason = "Repository documentation is authored in Markdown and related documentation formats."
+surface = "docs"
+classification = "config"
+covered_by = ["cargo xtask check-lint-policy"]
+
+[[allow]]
+glob = "tests/fixtures/**"
+kind = "fixture_input"
+owner = "testing"
+reason = "Test fixtures intentionally contain non-Rust sample inputs and golden data."
+surface = "fixtures"
+classification = "test"
+covered_by = ["cargo test --workspace"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
-# Pinned Rust toolchain for reproducible builds
-# MSRV: 1.92.0 (using Rust 2024 edition)
+# Pinned Rust toolchain for reproducible builds.
+# MSRV: 1.93 (using Rust 2024 edition)
 [toolchain]
-channel = "1.92.0"
+channel = "1.93"
 profile = "minimal"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = []

--- a/tests-new/Cargo.toml
+++ b/tests-new/Cargo.toml
@@ -25,3 +25,6 @@ bitnet-common = { path = "../crates/bitnet-common", version = "0.2.1-dev" }
 bitnet-inference = { path = "../crates/bitnet-inference", version = "0.2.1-dev", default-features = false, features = ["cpu", "rt-tokio"] }
 bitnet-models = { path = "../crates/bitnet-models", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../crates/bitnet-kernels", version = "0.2.1-dev" }
+
+[lints]
+workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -286,3 +286,6 @@ filetime = "0.2.26"
 html-escape = "0.2.13"
 serde = { version = "1.0.228", features = ["derive"] }
 libc = "0.2.177"
+
+[lints]
+workspace = true

--- a/tools/bitnet-task/Cargo.toml
+++ b/tools/bitnet-task/Cargo.toml
@@ -13,3 +13,6 @@ sha2 = "0.10.9"
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/tools/migrate-gen-config/Cargo.toml
+++ b/tools/migrate-gen-config/Cargo.toml
@@ -10,3 +10,6 @@ syn = { version = "2.0.110", features = ["full", "visit-mut"] }
 quote = "1.0.42"
 prettyplease = "0.2.37"
 proc-macro2 = "1.0.103"
+
+[lints]
+workspace = true

--- a/xtask-build-helper/Cargo.toml
+++ b/xtask-build-helper/Cargo.toml
@@ -8,3 +8,6 @@ description = "Build script helpers for FFI compilation (AC6 FFI build hygiene)"
 
 [dependencies]
 cc = "1.2.46"
+
+[lints]
+workspace = true

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -57,3 +57,6 @@ predicates = "3.1.3"
 serial_test = "3.2.0"
 temp-env = "0.3.6"
 bitnet-test-support.workspace = true
+
+[lints]
+workspace = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -47,6 +47,7 @@ mod health_check;
 #[allow(dead_code)]
 mod model_info;
 mod model_registry;
+mod policy_checks;
 mod tokenizers;
 mod trace_diff;
 
@@ -183,6 +184,11 @@ impl PromptTemplateArg {
 
 #[derive(Subcommand)]
 enum Cmd {
+    /// Verify the workspace Clippy lint policy ledgers and manifest wiring.
+    CheckLintPolicy,
+
+    /// Print a concise policy inventory for review and CI logs.
+    PolicyReport,
     /// Download a GGUF model from Hugging Face
     ///
     /// Features:
@@ -1068,6 +1074,8 @@ fn classify_exit(e: &anyhow::Error) -> i32 {
 fn real_main() -> Result<()> {
     let cli = Cli::parse();
     match cli.cmd {
+        Cmd::CheckLintPolicy => policy_checks::check_lint_policy(Path::new(".")),
+        Cmd::PolicyReport => policy_checks::policy_report(Path::new(".")),
         Cmd::DownloadModel {
             id,
             file,

--- a/xtask/src/policy_checks.rs
+++ b/xtask/src/policy_checks.rs
@@ -1,0 +1,350 @@
+use anyhow::{Context, Result, anyhow, bail};
+use chrono::NaiveDate;
+use std::{fs, path::Path};
+use toml::Value;
+use walkdir::WalkDir;
+
+const TEST_CARVEOUTS: &[&str] = &[
+    "allow-unwrap-in-tests",
+    "allow-expect-in-tests",
+    "allow-panic-in-tests",
+    "allow-indexing-slicing-in-tests",
+    "allow-dbg-in-tests",
+];
+
+const REQUIRED_PLANNED: &[(&str, &str)] = &[
+    ("clippy::same_length_and_capacity", "1.94"),
+    ("clippy::manual_ilog2", "1.94"),
+    ("clippy::decimal_bitwise_operands", "1.94"),
+    ("clippy::needless_type_cast", "1.94"),
+    ("clippy::disallowed_fields", "1.95"),
+    ("clippy::manual_checked_ops", "1.95"),
+    ("clippy::manual_take", "1.95"),
+    ("clippy::manual_pop_if", "1.95"),
+    ("clippy::duration_suboptimal_units", "1.95"),
+    ("clippy::unnecessary_trailing_comma", "1.95"),
+];
+
+pub fn check_lint_policy(root: &Path) -> Result<()> {
+    let cargo = read_toml(&root.join("Cargo.toml"))?;
+    let policy = read_toml(&root.join("policy/clippy-lints.toml"))?;
+
+    let msrv = required_str(&policy, &["msrv"])?;
+    let workspace_msrv = required_str(&cargo, &["workspace", "package", "rust-version"])?;
+    ensure_eq("workspace.package.rust-version", workspace_msrv, "policy msrv", msrv)?;
+
+    let clippy_toml = fs::read_to_string(root.join("clippy.toml")).context("read clippy.toml")?;
+    ensure_no_test_carveouts(&clippy_toml)?;
+    let clippy_msrv = parse_scalar_assignment(&clippy_toml, "msrv")
+        .ok_or_else(|| anyhow!("clippy.toml must set msrv"))?;
+    ensure_eq("clippy.toml msrv", &clippy_msrv, "policy msrv", msrv)?;
+
+    validate_policy_flags(&policy)?;
+    validate_active_lints(&cargo, &policy, msrv)?;
+    validate_required_planned(&cargo, &policy, msrv)?;
+    validate_workspace_lint_inheritance(root)?;
+    validate_debt(root, "policy/clippy-debt.toml")?;
+    validate_no_panic_allowlist(root, "policy/no-panic-allowlist.toml")?;
+    validate_non_rust_allowlist(root, "policy/non-rust-allowlist.toml")?;
+
+    println!("lint policy OK: MSRV {msrv}, active lints and planned flips are coherent");
+    Ok(())
+}
+
+pub fn policy_report(root: &Path) -> Result<()> {
+    let policy = read_toml(&root.join("policy/clippy-lints.toml"))?;
+    let lints = required_array(&policy, &["lint"])?;
+    let mut active = 0;
+    let mut planned = 0;
+    for lint in lints {
+        let status = table_str(lint, "status")?;
+        if status == "active" {
+            active += 1;
+        } else if status == "planned" {
+            planned += 1;
+        }
+    }
+
+    let debt = optional_array(root, "policy/clippy-debt.toml", "debt")?;
+    let panic_allow = optional_array(root, "policy/no-panic-allowlist.toml", "allow")?;
+    let non_rust_allow = optional_array(root, "policy/non-rust-allowlist.toml", "allow")?;
+
+    println!("lint policy report");
+    println!("  active lints: {active}");
+    println!("  planned lints: {planned}");
+    println!("  clippy debt entries: {}", debt.len());
+    println!("  no-panic allowlist entries: {}", panic_allow.len());
+    println!("  non-rust allowlist entries: {}", non_rust_allow.len());
+    Ok(())
+}
+
+fn validate_policy_flags(policy: &Value) -> Result<()> {
+    ensure_bool(policy, &["policy", "panic_free_tests"], true)?;
+    ensure_bool(policy, &["policy", "allow_test_carveouts"], false)?;
+    ensure_bool(policy, &["policy", "blanket_categories"], false)?;
+    let suppression_style = required_str(policy, &["policy", "suppression_style"])?;
+    ensure_eq(
+        "policy.suppression_style",
+        suppression_style,
+        "required suppression style",
+        "expect-with-reason",
+    )
+}
+
+fn validate_active_lints(cargo: &Value, policy: &Value, policy_msrv: &str) -> Result<()> {
+    for lint in required_array(policy, &["lint"])? {
+        if table_str(lint, "status")? != "active" {
+            continue;
+        }
+        let name = table_str(lint, "name")?;
+        let expected_level = table_str(lint, "level")?;
+        let actual_level = cargo_lint_level(cargo, name)?;
+        ensure_eq(name, &actual_level, "policy level", expected_level)?;
+        if let Some(activate_when) = table_optional_str(lint, "activate_when_msrv")? {
+            bail!("active lint {name} must not retain activate_when_msrv={activate_when}");
+        }
+        let _ = policy_msrv;
+    }
+    Ok(())
+}
+
+fn validate_required_planned(cargo: &Value, policy: &Value, policy_msrv: &str) -> Result<()> {
+    for (name, msrv) in REQUIRED_PLANNED {
+        let lint = find_lint(policy, name, "planned")?
+            .ok_or_else(|| anyhow!("missing planned lint {name}"))?;
+        ensure_eq(
+            &format!("planned {name} activate_when_msrv"),
+            table_str(lint, "activate_when_msrv")?,
+            "required planned MSRV",
+            msrv,
+        )?;
+        if version_lt(policy_msrv, msrv) && cargo_lint_level(cargo, name).is_ok() {
+            bail!("planned lint {name} must not be active before MSRV {msrv}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_workspace_lint_inheritance(root: &Path) -> Result<()> {
+    let mut missing = Vec::new();
+    for entry in WalkDir::new(root).into_iter().filter_entry(|entry| !is_ignored(entry.path())) {
+        let entry = entry?;
+        if !entry.file_type().is_file() || entry.file_name() != "Cargo.toml" {
+            continue;
+        }
+        let path = entry.path();
+        if path.starts_with(root.join("examples")) {
+            continue;
+        }
+        let manifest = read_toml(path)?;
+        if manifest.get("package").is_none() {
+            continue;
+        }
+        let inherits = manifest
+            .get("lints")
+            .and_then(|lints| lints.get("workspace"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if !inherits {
+            missing.push(path.strip_prefix(root).unwrap_or(path).display().to_string());
+        }
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        bail!("workspace members must inherit [lints] workspace = true: {}", missing.join(", "))
+    }
+}
+
+fn validate_debt(root: &Path, relative: &str) -> Result<()> {
+    let value = read_toml(&root.join(relative))?;
+    for debt in value.get("debt").and_then(Value::as_array).into_iter().flatten() {
+        require_fields(debt, &["lint", "path", "owner", "reason", "expires"])?;
+        ensure_future_date(table_str(debt, "expires")?, relative)?;
+    }
+    Ok(())
+}
+
+fn validate_no_panic_allowlist(root: &Path, relative: &str) -> Result<()> {
+    let value = read_toml(&root.join(relative))?;
+    ensure_eq("no-panic schema", required_str(&value, &["schema_version"])?, "required", "0.3")?;
+    for allow in value.get("allow").and_then(Value::as_array).into_iter().flatten() {
+        require_fields(
+            allow,
+            &["path", "family", "classification", "owner", "explanation", "selector"],
+        )?;
+        let selector = allow
+            .get("selector")
+            .ok_or_else(|| anyhow!("no-panic allow entry missing selector"))?;
+        require_fields(selector, &["kind"])?;
+        if let Some(expires) = table_optional_str(allow, "expires")? {
+            ensure_future_date(expires, relative)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_non_rust_allowlist(root: &Path, relative: &str) -> Result<()> {
+    let value = read_toml(&root.join(relative))?;
+    ensure_eq("non-rust schema", required_str(&value, &["schema_version"])?, "required", "1.0")?;
+    for allow in value.get("allow").and_then(Value::as_array).into_iter().flatten() {
+        require_fields(allow, &["kind", "owner", "reason", "surface", "classification"])?;
+        if allow.get("path").is_none() && allow.get("glob").is_none() {
+            bail!("non-rust allow entry must set path or glob");
+        }
+        let covered_by = allow
+            .get("covered_by")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("non-rust allow entry must set covered_by"))?;
+        if covered_by.is_empty() {
+            bail!("non-rust allow entry covered_by must not be empty");
+        }
+        if let Some(expires) = table_optional_str(allow, "expires")? {
+            ensure_future_date(expires, relative)?;
+        }
+    }
+    Ok(())
+}
+
+fn cargo_lint_level(cargo: &Value, lint_name: &str) -> Result<String> {
+    let (tool, lint) = lint_name
+        .split_once("::")
+        .ok_or_else(|| anyhow!("lint name must be tool::name: {lint_name}"))?;
+    let value = required_value(cargo, &["workspace", "lints", tool, lint])?;
+    if let Some(level) = value.as_str() {
+        return Ok(level.to_owned());
+    }
+    value
+        .get("level")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow!("workspace lint {lint_name} must be a string or {{ level = ... }}"))
+}
+
+fn read_toml(path: &Path) -> Result<Value> {
+    let contents = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str::<Value>(&contents).with_context(|| format!("parse {}", path.display()))
+}
+
+fn optional_array(root: &Path, relative: &str, key: &str) -> Result<Vec<Value>> {
+    let value = read_toml(&root.join(relative))?;
+    Ok(value.get(key).and_then(Value::as_array).cloned().unwrap_or_default())
+}
+
+fn find_lint<'a>(policy: &'a Value, name: &str, status: &str) -> Result<Option<&'a Value>> {
+    for lint in required_array(policy, &["lint"])? {
+        if table_str(lint, "name")? == name && table_str(lint, "status")? == status {
+            return Ok(Some(lint));
+        }
+    }
+    Ok(None)
+}
+
+fn required_array<'a>(value: &'a Value, path: &[&str]) -> Result<&'a Vec<Value>> {
+    required_value(value, path)?
+        .as_array()
+        .ok_or_else(|| anyhow!("{} must be an array", path.join(".")))
+}
+
+fn required_str<'a>(value: &'a Value, path: &[&str]) -> Result<&'a str> {
+    required_value(value, path)?
+        .as_str()
+        .ok_or_else(|| anyhow!("{} must be a string", path.join(".")))
+}
+
+fn required_value<'a>(value: &'a Value, path: &[&str]) -> Result<&'a Value> {
+    let mut current = value;
+    for part in path {
+        current =
+            current.get(*part).ok_or_else(|| anyhow!("missing required key {}", path.join(".")))?;
+    }
+    Ok(current)
+}
+
+fn ensure_bool(value: &Value, path: &[&str], expected: bool) -> Result<()> {
+    let actual = required_value(value, path)?
+        .as_bool()
+        .ok_or_else(|| anyhow!("{} must be a boolean", path.join(".")))?;
+    if actual == expected { Ok(()) } else { bail!("{} must be {expected}", path.join(".")) }
+}
+
+fn table_str<'a>(value: &'a Value, key: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("policy table missing string field {key}"))
+}
+
+fn table_optional_str<'a>(value: &'a Value, key: &str) -> Result<Option<&'a str>> {
+    value
+        .get(key)
+        .map(|field| field.as_str().ok_or_else(|| anyhow!("field {key} must be a string")))
+        .transpose()
+}
+
+fn require_fields(value: &Value, fields: &[&str]) -> Result<()> {
+    for field in fields {
+        if value.get(*field).is_none() {
+            bail!("policy entry missing required field {field}");
+        }
+    }
+    Ok(())
+}
+
+fn ensure_eq(left_name: &str, left: &str, right_name: &str, right: &str) -> Result<()> {
+    if left == right {
+        Ok(())
+    } else {
+        bail!("{left_name} ({left}) must match {right_name} ({right})")
+    }
+}
+
+fn ensure_no_test_carveouts(clippy_toml: &str) -> Result<()> {
+    for carveout in TEST_CARVEOUTS {
+        if parse_scalar_assignment(clippy_toml, carveout).is_some() {
+            bail!("clippy.toml must not set test carveout {carveout}");
+        }
+    }
+    Ok(())
+}
+
+fn parse_scalar_assignment(contents: &str, key: &str) -> Option<String> {
+    contents.lines().find_map(|line| {
+        let trimmed = line.split('#').next()?.trim();
+        let (left, right) = trimmed.split_once('=')?;
+        if left.trim() != key {
+            return None;
+        }
+        let value = right.trim().trim_matches('"').to_owned();
+        Some(value)
+    })
+}
+
+fn ensure_future_date(date: &str, source: &str) -> Result<()> {
+    let expires = NaiveDate::parse_from_str(date, "%Y-%m-%d")
+        .with_context(|| format!("parse expiry {date} in {source}"))?;
+    let today = chrono::Utc::now().date_naive();
+    if expires < today {
+        bail!("expired policy entry in {source}: {date}");
+    }
+    Ok(())
+}
+
+fn version_lt(left: &str, right: &str) -> bool {
+    version_parts(left) < version_parts(right)
+}
+
+fn version_parts(version: &str) -> (u32, u32, u32) {
+    let mut parts = version.split('.').map(|part| part.parse::<u32>().unwrap_or(0));
+    let major = parts.next().unwrap_or(0);
+    let minor = parts.next().unwrap_or(0);
+    let patch = parts.next().unwrap_or(0);
+    (major, minor, patch)
+}
+
+fn is_ignored(path: &Path) -> bool {
+    path.components().any(|component| {
+        let name = component.as_os_str();
+        name == ".git" || name == "target" || name == "vendor"
+    })
+}


### PR DESCRIPTION
### Motivation

- Establish a shared, machine-readable Clippy/lint policy and rollout model for the workspace (panic-free baseline, suppression governance, planned 1.94/1.95 flips, and repo-local overlays). 
- Provide structured, expiring exception tracking (debt) and semantic allowlists for panic-family and non-Rust files so exceptions are reviewable and CI-enforceable. 
- Add an `xtask` gate to verify manifest ⇄ policy coherence so CI can reject accidental policy drift. 

### Description

- Bumped the workspace MSRV to `1.93` and added/updated `rust-toolchain.toml` and `clippy.toml` to align repo-local Clippy metadata with the policy. 
- Replaced the ad-hoc workspace lint block with a stricter workspace lints surface in `Cargo.toml` (panic-family denies, AST/parser-safety, silent-failure denies, numeric/async staged warnings, suppression governance). 
- Added policy artifacts under `policy/`: `clippy-lints.toml` (machine-readable ledger of active and planned lints), `clippy-debt.toml` (debt ledger placeholder), `no-panic-allowlist.toml` (semantic panic-family allowlist), and `non-rust-allowlist.toml` (structured non-Rust file allowlist). 
- Added `docs/CLIPPY_POLICY.md` explaining the model, suppression style (`#[expect(..., reason = "...")]`), no test carveouts rule, and rollout guidance. 
- Extended `xtask` by adding `xtask/src/policy_checks.rs` and wiring new CLI commands (`CheckLintPolicy`, `PolicyReport`) into `xtask/src/main.rs` to validate: manifest MSRV vs policy MSRV, workspace lint inheritance (`[lints] workspace = true`), no test carveouts in `clippy.toml`, active vs planned lint coherence, debt entry shape/expiry, and the two allowlists. 
- Updated many crate `Cargo.toml` manifests to include `[lints] workspace = true` so members inherit the workspace lint block. 
- Small robustness fixes in `xtask` policy code for TOML parsing. 

### Testing

- Installed and pinned Rust 1.93 toolchain with `rustup toolchain install 1.93` (succeeded). 
- Ran `cargo run -p xtask --no-default-features -- check-lint-policy` to compile `xtask` and validate the new policy artifacts; the `xtask` checks ran (policy validations exercised) with warnings emitted by numeric/GPU crates as expected; the policy check path completed under the non-default-features run. 
- Observed an intentional early failure when `unsafe_code = "forbid"` was enabled because several GPU/numeric crates use required `unsafe`/FFI; the policy was adjusted (surfaced as `warn` for unsafe code) and the checks were re-run successfully. 
- Note: full workspace builds with default GPU/CUDA features triggered linker failures on this environment due to missing system CUDA libraries; CI runs should exercise the full build on appropriately provisioned agents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb084404ec8333ae718c508bf54786)