### PR TITLE
feat(governance): wire strict lint policy gate, deny dbg_macro (PR 2 of stack)

### DIFF
--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -8,6 +8,8 @@ on:
       - 'scripts/**'
       - 'tools/bitnet-task/**'
       - 'crates/**'
+      - 'xtask/**'
+      - 'policy/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
@@ -47,6 +49,9 @@ jobs:
       # Ensure scripts are executable in fresh clones
       - run: chmod +x scripts/*.sh || true
       - run: chmod +x scripts/tests/*.sh || true
+
+      - name: Lint policy (strict)
+        run: cargo run --locked -p xtask --no-default-features -- check-lint-policy --strict
 
       - name: bitnet-task integration tests
         run: cargo test --locked -p bitnet-task

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,7 +539,11 @@ debug = true
 [profile.dev.package."*"]
 opt-level = 2
 
-# Workspace-level lints for code quality
+# Workspace-level lints for code quality.
+#
+# The active set must stay in sync with `policy/clippy-lints.toml`; the check
+# is enforced by `cargo xtask check-lint-policy --strict` (see
+# docs/CLIPPY_POLICY.md and the rollout plan there).
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 missing_errors_doc = "allow"
@@ -549,6 +553,13 @@ must_use_candidate = "allow"
 nursery = { level = "warn", priority = -1 }
 pedantic = { level = "warn", priority = -1 }
 ptr_arg = "deny"
+
+# PR 2 strict baseline (panic-free / suppression-governed estate floor).
+# The block grows incrementally; entries here must appear as `[[active]]` in
+# `policy/clippy-lints.toml`. Zero-hit lints land at `deny` directly; lints
+# with existing violations are seeded into `policy/clippy-debt.toml` before
+# promotion.
+dbg_macro = "deny"
 
 # Workspace-level feature flags for convenience
 [workspace.metadata.docs.rs]

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -86,25 +86,44 @@ This is a stacked rollout. Each PR is independently reviewable.
 - Add this document.
 - Add `cargo xtask check-lint-policy` (advisory). No lint behavior changes.
 
-### PR 2 — Strict baseline
+### PR 2 — Strict baseline kickoff
 
-- Replace the `all`/`pedantic`/`nursery` warn block in root `Cargo.toml` with
-  the explicit lint set declared as `activate_when_msrv = "1.92"` in
-  `policy/clippy-lints.toml`.
+- Promote `cargo xtask check-lint-policy --strict` to a CI gate (Guards
+  workflow).
+- Add `Cargo.toml` ↔ `policy/clippy-lints.toml` consistency check: every
+  `[workspace.lints.<root>]` entry must appear as `[[active]]` in the ledger
+  with the same level, and vice versa (category lints excepted until they are
+  expanded into their explicit lint set).
+- Promote `clippy::dbg_macro` to `deny` (zero-hit lint, safe to land).
+- Pedantic overrides in `Cargo.toml` (`missing_errors_doc`, `missing_panics_doc`,
+  `module_name_repetitions`, `must_use_candidate`) are recorded as
+  `[[active]] level = "allow"` in the ledger.
+
+### PR 3 — Suppression migration
+
+- Convert existing `#[allow(clippy::*)]` attributes (~447 instances) to
+  `#[expect(clippy::*, reason = "...")]` with reasons sourced from the
+  surrounding context.
+- Add `clippy::allow_attributes_without_reason = "deny"` and
+  `clippy::blanket_clippy_restriction_lints = "deny"`.
+
+### PR 4 — Panic family ratchet
+
+- Per-crate ratchet of `clippy::unwrap_used`, `clippy::expect_used`,
+  `clippy::panic`, `clippy::unimplemented`, `clippy::unreachable` from
+  `allow` → `warn` → `deny`. Each crate gets a debt entry + `#![allow]` at
+  the crate root until cleaned.
 - Remove `allow-unwrap-in-tests` and `allow-expect-in-tests` from
-  `clippy.toml`.
-- Seed `policy/clippy-debt.toml` with the resulting violations, each with a
-  named owner and an expiry no further than +90 days.
-- Promote `cargo xtask check-lint-policy` to a CI gate.
+  `clippy.toml` once test code is migrated to `Result`-returning helpers.
 
-### PR 3 — MSRV ratchet 1.92 → 1.93
+### PR 5 — MSRV ratchet 1.92 → 1.93
 
 - Bump `rust-toolchain.toml` and `workspace.package.rust-version`.
 - Bump `policy/clippy-lints.toml` `msrv = "1.93"`.
 - Promote `warn`-level numeric lints to `deny` per crate as kernel debt is
   cleared.
 
-### PR 4+ — Rust 1.94 / 1.95 flip cohorts
+### PR 6+ — Rust 1.94 / 1.95 flip cohorts
 
 - When MSRV reaches 1.94, activate the lints declared with
   `activate_when_msrv = "1.94"` (same for 1.95).

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -57,6 +57,40 @@ level = "warn"
 class = "category"
 reason = "Workspace baseline; will be replaced with explicit selections in PR 2."
 
+# Pedantic overrides — these lints come from clippy::pedantic but produce
+# noise that has not been tackled yet; explicitly silencing them is policy.
+[[active]]
+name = "clippy::missing_errors_doc"
+level = "allow"
+class = "documentation"
+reason = "API doc backfill is a separate workstream; tracked outside this ledger."
+
+[[active]]
+name = "clippy::missing_panics_doc"
+level = "allow"
+class = "documentation"
+reason = "Panic-doc tracking moves with the panic-family promotion; revisit after #[expect] migration."
+
+[[active]]
+name = "clippy::module_name_repetitions"
+level = "allow"
+class = "naming"
+reason = "Workspace prefers re-exports that intentionally repeat module names (e.g. `Foo::Foo`)."
+
+[[active]]
+name = "clippy::must_use_candidate"
+level = "allow"
+class = "api"
+reason = "#[must_use] policy is being defined separately; off until that lands."
+
+# Promoted from [[planned]] to [[active]] in PR 2 (strict baseline kickoff).
+# Empirical scan showed 0 hits in `crates/` and `xtask/`, so deny is safe.
+[[active]]
+name = "clippy::dbg_macro"
+level = "deny"
+class = "diagnostic-debt"
+reason = "dbg!() must not ship; pre-commit hook also greps for it."
+
 # ---------------------------------------------------------------------------
 # Planned lints (PR 2 — strict baseline). These are the lints we intend to add
 # to [workspace.lints] in the next stacked PR. They are listed here so the
@@ -84,13 +118,6 @@ level = "deny"
 activate_when_msrv = "1.92"
 class = "silent-failure"
 reason = "Catch ignored Result/Future returns at compile time."
-
-[[planned]]
-name = "clippy::dbg_macro"
-level = "deny"
-activate_when_msrv = "1.92"
-class = "diagnostic-debt"
-reason = "dbg!() must not ship; pre-commit already greps for it."
 
 [[planned]]
 name = "clippy::todo"

--- a/xtask/src/lint_policy.rs
+++ b/xtask/src/lint_policy.rs
@@ -19,13 +19,16 @@
 //! 6. `policy/no-panic-allowlist.toml` and `policy/non-rust-allowlist.toml`
 //!    parse and have the expected schema versions.
 //!
+//! 7. (PR 2) Every `[[active]]` entry in `policy/clippy-lints.toml` is
+//!    reflected in `Cargo.toml` `[workspace.lints.<root>]` at the same
+//!    level, and every Cargo-active lint is either in the ledger or is a
+//!    blanket category (`all`, `pedantic`, `nursery`, ...).
+//!
 //! It does *not* yet:
 //!   - Walk the AST to enforce the no-panic allowlist (planned: `xtask
 //!     check-no-panic-family`).
 //!   - Walk the file tree to enforce the non-Rust allowlist (planned: `xtask
 //!     check-file-policy`).
-//!   - Diff `policy/clippy-lints.toml` against `[workspace.lints]` in
-//!     `Cargo.toml` (added in PR 2 when the strict block lands).
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -163,6 +166,7 @@ pub fn run(mode: Mode) -> Result<()> {
 
     if let Some(lints) = lints.as_ref() {
         check_msrv_consistency(&repo_root, lints, &mut findings);
+        check_active_lints_match_cargo(&repo_root, lints, &mut findings);
     }
 
     findings.report(mode)
@@ -550,6 +554,112 @@ fn extract_toolchain_channel(text: &str) -> Option<String> {
     let toolchain = value.get("toolchain")?.as_table()?;
     let channel = toolchain.get("channel")?.as_str()?;
     Some(channel.to_string())
+}
+
+/// Verify that every `[[active]]` lint in `policy/clippy-lints.toml` is also
+/// present in `Cargo.toml` `[workspace.lints.<root>]` at the declared level.
+/// The reverse direction (lints active in Cargo.toml without a ledger entry)
+/// is also reported. We accept either bare-string levels (`level = "warn"`)
+/// or table form with `priority`.
+fn check_active_lints_match_cargo(repo_root: &Path, lints: &LintsLedger, findings: &mut Findings) {
+    let cargo_path = repo_root.join("Cargo.toml");
+    let cargo_text = match fs::read_to_string(&cargo_path) {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+    let cargo: toml::Value = match toml::from_str(&cargo_text) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let workspace_lints =
+        cargo.get("workspace").and_then(|w| w.get("lints")).and_then(|l| l.as_table());
+    let Some(workspace_lints) = workspace_lints else {
+        findings.warn(format!(
+            "{}: workspace.lints table is missing — strict baseline cannot be verified",
+            cargo_path.display()
+        ));
+        return;
+    };
+
+    // Build map: ("clippy" | "rust" | ...) -> { lint_name -> level_string }
+    let mut cargo_lints: std::collections::BTreeMap<
+        String,
+        std::collections::BTreeMap<String, String>,
+    > = std::collections::BTreeMap::new();
+    for (root, body) in workspace_lints {
+        let Some(body) = body.as_table() else { continue };
+        let bucket = cargo_lints.entry(root.clone()).or_default();
+        for (name, value) in body {
+            let level = match value {
+                toml::Value::String(s) => Some(s.clone()),
+                toml::Value::Table(t) => t.get("level").and_then(|v| v.as_str()).map(str::to_owned),
+                _ => None,
+            };
+            if let Some(level) = level {
+                bucket.insert(name.clone(), level);
+            }
+        }
+    }
+
+    // Forward direction: every [[active]] entry must be reflected in cargo.
+    for active in &lints.active {
+        let Some((root, name)) = split_lint_name(&active.name) else { continue };
+        let cargo_level = cargo_lints.get(root).and_then(|b| b.get(name));
+        match cargo_level {
+            None => findings.error(format!(
+                "policy/clippy-lints.toml declares [[active]] {} but Cargo.toml has no entry",
+                active.name
+            )),
+            Some(level) if level != &active.level => findings.error(format!(
+                "lint {} level mismatch: Cargo.toml = {level:?}, policy/clippy-lints.toml = {:?}",
+                active.name, active.level
+            )),
+            Some(_) => {}
+        }
+    }
+
+    // Reverse direction: report any cargo-active lint not in the ledger as a
+    // warning. Category lints (`all`, `pedantic`, `nursery`, `cargo`,
+    // `complexity`, `correctness`, `perf`, `style`, `restriction`,
+    // `suspicious`) are accepted without ledger entries until the explicit
+    // baseline replaces them in a later PR.
+    let known: std::collections::BTreeSet<&str> =
+        lints.active.iter().map(|a| a.name.as_str()).collect();
+    for (root, bucket) in &cargo_lints {
+        for name in bucket.keys() {
+            let qualified = format!("{root}::{name}");
+            if known.contains(qualified.as_str()) {
+                continue;
+            }
+            if root == "clippy" && is_clippy_category(name) {
+                continue;
+            }
+            findings.warn(format!(
+                "Cargo.toml declares {qualified} but policy/clippy-lints.toml has no [[active]] entry"
+            ));
+        }
+    }
+}
+
+fn split_lint_name(qualified: &str) -> Option<(&str, &str)> {
+    qualified.split_once("::")
+}
+
+fn is_clippy_category(name: &str) -> bool {
+    matches!(
+        name,
+        "all"
+            | "cargo"
+            | "complexity"
+            | "correctness"
+            | "nursery"
+            | "pedantic"
+            | "perf"
+            | "restriction"
+            | "style"
+            | "suspicious"
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Stacks on **#3710** (PR 1: governance scaffolding). PR 2 turns the policy ledger from a document into an enforced contract:

- **`clippy::dbg_macro = "deny"`** in `[workspace.lints.clippy]` — empirically zero-hit across `crates/` and `xtask/`, so safe to land at deny.
- **`Cargo.toml` ↔ `policy/clippy-lints.toml` consistency check** in `cargo xtask check-lint-policy`. Every `[[active]]` entry must appear in `[workspace.lints.<root>]` at the same level, and every Cargo-active lint must either be in the ledger or be a blanket category (`all`, `pedantic`, `nursery`, etc.).
- **CI gate**: new first step in the Guards workflow — `cargo run --locked -p xtask --no-default-features -- check-lint-policy --strict`. Trigger paths extended to `xtask/**` and `policy/**`.
- **Pedantic overrides recorded**: `missing_errors_doc`, `missing_panics_doc`, `module_name_repetitions`, `must_use_candidate` are now `[[active]] level = "allow"` in the ledger so the bidirectional consistency check is satisfied.

## Empirical sizing of the strict block (this PR's scope rationale)

Counts across `crates/` + `xtask/`:

| Lint                          | Hits   | Action this PR |
|-------------------------------|--------|----------------|
| `dbg!(`                       | 0      | **deny now**   |
| `todo!(`                      | 148    | defer to PR 4  |
| `unimplemented!(`             | 760    | defer (TDD scaffolds per CLAUDE.md) |
| `panic!(`                     | 646    | defer          |
| `unreachable!(`               | 28     | defer          |
| `.unwrap()`                   | 25 535 | defer (per-crate ratchet) |
| `.expect(`                    | 2 294  | defer          |
| `#[allow(clippy::*)]`         | 447    | migrate in PR 3 |
| `unsafe fn` / `unsafe impl`   | 2 814  | overlay-managed |

This is exactly why the rollout is staged. PR 2 lands the **gate**; debt-bearing lints land in PRs 3-5 with seeded `policy/clippy-debt.toml` entries.

## Updated rollout plan (in `docs/CLIPPY_POLICY.md`)

| PR  | Scope |
|-----|-------|
| 1 (#3710) | Governance scaffolding (policy/, doc, advisory xtask check) |
| **2 (this)** | CI gate, cargo↔ledger consistency, deny `dbg_macro` |
| 3   | Migrate ~447 `#[allow]` → `#[expect(..., reason = "...")]`; deny `allow_attributes_without_reason` and `blanket_clippy_restriction_lints` |
| 4   | Per-crate panic-family ratchet (`unwrap_used`, `expect_used`, `panic`, `unimplemented`, `unreachable`); seed `policy/clippy-debt.toml` |
| 5   | MSRV 1.92 → 1.93 ratchet |
| 6+  | Rust 1.94 / 1.95 lint cohorts |

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --locked -p xtask --no-default-features --bin xtask --all-targets -- -D warnings` — clean
- [x] `cargo test --locked -p xtask --no-default-features --bin xtask lint_policy::` — 2 passed
- [x] `cargo run --locked -p xtask --no-default-features -- check-lint-policy --strict` — `1 info, 0 warnings, 0 errors`
- [ ] CI Guards workflow runs the new step and stays green

## Reviewer note

Base branch is `claude/clippy-governance-system-HERR6` (PR 1), not `main`. Once #3710 merges, please retarget this PR to `main` (or merge in stack order).

https://claude.ai/code/session_01B5tBepFTH4UCnpBqXGt4CC

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5tBepFTH4UCnpBqXGt4CC)_