### PR TITLE
[codex][apple-m4] Add MPSGraph smoke (M4-007)

### DIFF
--- a/crates/bitnet-device-probe/src/apple_mpsgraph.rs
+++ b/crates/bitnet-device-probe/src/apple_mpsgraph.rs
@@ -1,0 +1,232 @@
+//! Apple MPSGraph reference-lane smoke helpers.
+//!
+//! This module is intentionally separate from native Metal probes and kernels.
+//! A passing MPSGraph smoke proves only that a tiny graph executed through the
+//! MPSGraph API; it is not native Metal, Neural Engine, or BitNet inference
+//! proof.
+
+use std::fmt;
+
+pub const MACHINE_ID: &str = "apple-m4-mac-mini";
+pub const ARTIFACT_KIND: &str = "smoke";
+pub const APPLE_M4_MPSGRAPH_BACKEND: &str = "apple-m4-mpsgraph";
+pub const APPLE_M4_MPSGRAPH_RUNTIME_API: &str = "mpsgraph";
+pub const APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN: &str = "unknown";
+pub const TINY_MPSGRAPH_MATMUL_GRAPH_ID: &str = "tiny_mpsgraph_matmul";
+pub const MPSGRAPH_SMOKE_ELEMENT_COUNT: usize = 4;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TinyMpsGraphSmokeReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub graph_id: &'static str,
+    pub resolved_target: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub element_count: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
+impl TinyMpsGraphSmokeReceipt {
+    pub fn passed(
+        artifact_path: impl Into<String>,
+        element_count: usize,
+        comparison: TinyMpsGraphSmokeComparison,
+    ) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: ARTIFACT_KIND,
+            requested_backend: APPLE_M4_MPSGRAPH_BACKEND,
+            selected_backend: APPLE_M4_MPSGRAPH_BACKEND,
+            runtime_api: APPLE_M4_MPSGRAPH_RUNTIME_API,
+            graph_id: TINY_MPSGRAPH_MATMUL_GRAPH_ID,
+            resolved_target: APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            element_count,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TinyMpsGraphSmokeComparison {
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TinyMpsGraphSmokeError {
+    EmptyInput,
+    LengthMismatch { expected: usize, actual: usize },
+    NonFiniteOutput { index: usize, value: f32 },
+    OutputMismatch { index: usize, expected: f32, actual: f32, tolerance: f32 },
+}
+
+impl fmt::Display for TinyMpsGraphSmokeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyInput => write!(f, "tiny MPSGraph smoke input must not be empty"),
+            Self::LengthMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "tiny MPSGraph smoke length mismatch: expected {expected}, actual {actual}"
+                )
+            }
+            Self::NonFiniteOutput { index, value } => {
+                write!(f, "tiny MPSGraph smoke output at index {index} is non-finite: {value}")
+            }
+            Self::OutputMismatch { index, expected, actual, tolerance } => write!(
+                f,
+                "tiny MPSGraph smoke output mismatch at index {index}: expected {expected}, actual {actual}, tolerance {tolerance}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TinyMpsGraphSmokeError {}
+
+#[must_use]
+pub fn apple_mpsgraph_smoke_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/mpsgraph-smoke.json")
+}
+
+#[must_use]
+pub fn tiny_mpsgraph_matmul_inputs()
+-> ([f32; MPSGRAPH_SMOKE_ELEMENT_COUNT], [f32; MPSGRAPH_SMOKE_ELEMENT_COUNT]) {
+    ([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0])
+}
+
+pub fn expected_tiny_mpsgraph_matmul(
+    lhs: &[f32],
+    rhs: &[f32],
+) -> Result<Vec<f32>, TinyMpsGraphSmokeError> {
+    if lhs.is_empty() || rhs.is_empty() {
+        return Err(TinyMpsGraphSmokeError::EmptyInput);
+    }
+    if lhs.len() != MPSGRAPH_SMOKE_ELEMENT_COUNT {
+        return Err(TinyMpsGraphSmokeError::LengthMismatch {
+            expected: MPSGRAPH_SMOKE_ELEMENT_COUNT,
+            actual: lhs.len(),
+        });
+    }
+    if rhs.len() != MPSGRAPH_SMOKE_ELEMENT_COUNT {
+        return Err(TinyMpsGraphSmokeError::LengthMismatch {
+            expected: MPSGRAPH_SMOKE_ELEMENT_COUNT,
+            actual: rhs.len(),
+        });
+    }
+
+    Ok(vec![
+        lhs[0] * rhs[0] + lhs[1] * rhs[2],
+        lhs[0] * rhs[1] + lhs[1] * rhs[3],
+        lhs[2] * rhs[0] + lhs[3] * rhs[2],
+        lhs[2] * rhs[1] + lhs[3] * rhs[3],
+    ])
+}
+
+pub fn compare_tiny_mpsgraph_matmul_outputs(
+    expected: &[f32],
+    actual: &[f32],
+    tolerance: f32,
+) -> Result<TinyMpsGraphSmokeComparison, TinyMpsGraphSmokeError> {
+    if expected.is_empty() {
+        return Err(TinyMpsGraphSmokeError::EmptyInput);
+    }
+    if expected.len() != actual.len() {
+        return Err(TinyMpsGraphSmokeError::LengthMismatch {
+            expected: expected.len(),
+            actual: actual.len(),
+        });
+    }
+
+    let mut max_abs_error = 0.0_f32;
+    let mut total_abs_error = 0.0_f32;
+
+    for (index, (&expected_value, &actual_value)) in expected.iter().zip(actual.iter()).enumerate()
+    {
+        if !actual_value.is_finite() {
+            return Err(TinyMpsGraphSmokeError::NonFiniteOutput { index, value: actual_value });
+        }
+
+        let abs_error = (actual_value - expected_value).abs();
+        if abs_error > tolerance {
+            return Err(TinyMpsGraphSmokeError::OutputMismatch {
+                index,
+                expected: expected_value,
+                actual: actual_value,
+                tolerance,
+            });
+        }
+
+        max_abs_error = max_abs_error.max(abs_error);
+        total_abs_error += abs_error;
+    }
+
+    Ok(TinyMpsGraphSmokeComparison {
+        max_abs_error,
+        mean_abs_error: total_abs_error / expected.len() as f32,
+    })
+}
+
+#[must_use]
+pub fn tiny_mpsgraph_smoke_swift_source() -> &'static str {
+    r#"
+import Foundation
+import Metal
+import MetalPerformanceShaders
+import MetalPerformanceShadersGraph
+
+let graph = MPSGraph()
+let lhs = [Float32](arrayLiteral: 1, 2, 3, 4)
+let rhs = [Float32](arrayLiteral: 5, 6, 7, 8)
+let lhsTensor = graph.constant(
+    Data(bytes: lhs, count: lhs.count * MemoryLayout<Float32>.size),
+    shape: [2, 2] as [NSNumber],
+    dataType: .float32
+)
+let rhsTensor = graph.constant(
+    Data(bytes: rhs, count: rhs.count * MemoryLayout<Float32>.size),
+    shape: [2, 2] as [NSNumber],
+    dataType: .float32
+)
+let resultTensor = graph.matrixMultiplication(
+    primary: lhsTensor,
+    secondary: rhsTensor,
+    name: "tiny_mpsgraph_matmul"
+)
+guard let metalDevice = MTLCreateSystemDefaultDevice(),
+      let commandQueue = metalDevice.makeCommandQueue() else {
+    fputs("M4-007 MPSGraph smoke requires a Metal command queue\n", stderr)
+    exit(2)
+}
+let results = graph.run(
+    with: commandQueue,
+    feeds: [:],
+    targetTensors: [resultTensor],
+    targetOperations: nil
+)
+guard let tensorData = results[resultTensor] else {
+    fputs("M4-007 MPSGraph smoke did not return target tensor data\n", stderr)
+    exit(3)
+}
+let ndarray = tensorData.mpsndarray()
+var output = [Float32](repeating: 0, count: 4)
+ndarray.readBytes(&output, strideBytes: nil)
+let payload: [String: Any] = [
+    "graph_id": "tiny_mpsgraph_matmul",
+    "device_name": metalDevice.name,
+    "resolved_target": "unknown",
+    "output": output
+]
+let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+print(String(data: data, encoding: .utf8)!)
+"#
+}

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -15,6 +15,17 @@ pub use apple_metal::{
     parse_apple_metal_probe, probe_apple_metal,
 };
 
+#[cfg(feature = "metal")]
+pub mod apple_mpsgraph;
+#[cfg(feature = "metal")]
+pub use apple_mpsgraph::{
+    APPLE_M4_MPSGRAPH_BACKEND, APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN,
+    APPLE_M4_MPSGRAPH_RUNTIME_API, TINY_MPSGRAPH_MATMUL_GRAPH_ID, TinyMpsGraphSmokeComparison,
+    TinyMpsGraphSmokeError, TinyMpsGraphSmokeReceipt, apple_mpsgraph_smoke_artifact_path,
+    compare_tiny_mpsgraph_matmul_outputs, expected_tiny_mpsgraph_matmul,
+    tiny_mpsgraph_matmul_inputs, tiny_mpsgraph_smoke_swift_source,
+};
+
 pub mod intel_arc;
 pub use intel_arc::{
     IntelArcCapabilities, IntelArcTier, detect_intel_arc, detect_intel_arc_by_pci_id,

--- a/crates/bitnet-device-probe/tests/apple_mpsgraph_smoke.rs
+++ b/crates/bitnet-device-probe/tests/apple_mpsgraph_smoke.rs
@@ -1,0 +1,188 @@
+#![cfg(feature = "metal")]
+
+use bitnet_device_probe::{
+    APPLE_M4_MPSGRAPH_BACKEND, APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN,
+    APPLE_M4_MPSGRAPH_RUNTIME_API, TINY_MPSGRAPH_MATMUL_GRAPH_ID, TinyMpsGraphSmokeComparison,
+    TinyMpsGraphSmokeReceipt, apple_mpsgraph_smoke_artifact_path,
+    compare_tiny_mpsgraph_matmul_outputs, expected_tiny_mpsgraph_matmul,
+    tiny_mpsgraph_matmul_inputs, tiny_mpsgraph_smoke_swift_source,
+};
+
+#[test]
+fn tiny_mpsgraph_matmul_expected_output_matches_cpu_reference() {
+    let (lhs, rhs) = tiny_mpsgraph_matmul_inputs();
+    let expected = expected_tiny_mpsgraph_matmul(&lhs, &rhs).expect("valid tiny matmul inputs");
+
+    assert_eq!(expected, vec![19.0, 22.0, 43.0, 50.0]);
+}
+
+#[test]
+fn mpsgraph_receipt_contract_keeps_reference_lane_separate() {
+    let receipt = TinyMpsGraphSmokeReceipt::passed(
+        apple_mpsgraph_smoke_artifact_path("2026-05-06"),
+        4,
+        TinyMpsGraphSmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, "apple-m4-mac-mini");
+    assert_eq!(receipt.artifact_kind, "smoke");
+    assert_eq!(receipt.requested_backend, APPLE_M4_MPSGRAPH_BACKEND);
+    assert_eq!(receipt.selected_backend, APPLE_M4_MPSGRAPH_BACKEND);
+    assert_eq!(receipt.runtime_api, APPLE_M4_MPSGRAPH_RUNTIME_API);
+    assert_eq!(receipt.graph_id, TINY_MPSGRAPH_MATMUL_GRAPH_ID);
+    assert_eq!(receipt.resolved_target, APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN);
+    assert!(!receipt.fallback_used);
+    assert_eq!(receipt.result, "pass");
+    assert_eq!(
+        receipt.artifact_path,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json"
+    );
+}
+
+#[test]
+fn comparison_fails_instead_of_claiming_graph_success() {
+    let expected = [19.0_f32, 22.0, 43.0, 50.0];
+    let actual = [19.0_f32, 220.0, 43.0, 50.0];
+
+    let error = compare_tiny_mpsgraph_matmul_outputs(&expected, &actual, 1e-6)
+        .expect_err("mismatch should fail the MPSGraph smoke contract");
+
+    assert!(error.to_string().contains("output mismatch"), "unexpected error: {error}");
+}
+
+#[test]
+fn swift_source_names_mpsgraph_not_native_metal_or_neural_engine() {
+    let source = tiny_mpsgraph_smoke_swift_source();
+
+    assert!(source.contains("MetalPerformanceShadersGraph"));
+    assert!(source.contains("tiny_mpsgraph_matmul"));
+    assert!(source.contains("\"resolved_target\": \"unknown\""));
+    assert!(!source.contains("NeuralEngine"));
+    assert!(!source.contains("MTLComputePipelineState"));
+}
+
+#[cfg(target_os = "macos")]
+mod live_mpsgraph {
+    use super::*;
+    use serde_json::json;
+    use std::error::Error;
+    use std::io;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    const RUN_ENV: &str = "BITNET_RUN_M4_MPSGRAPH_SMOKE";
+    const RECEIPT_ENV: &str = "BITNET_M4_MPSGRAPH_SMOKE_RECEIPT";
+    const ARTIFACT_PATH_ENV: &str = "BITNET_M4_MPSGRAPH_SMOKE_ARTIFACT_PATH";
+
+    #[test]
+    fn tiny_m4_mpsgraph_matmul_smoke_runs_when_enabled() -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_ENV).as_deref() != Ok("1") {
+            eprintln!("skipping live M4 MPSGraph smoke; set {RUN_ENV}=1 to run it");
+            return Ok(());
+        }
+
+        let swift_output = run_swift_mpsgraph_smoke()?;
+        let device_name = swift_output
+            .get("device_name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| io_error("MPSGraph smoke output missing device_name"))?;
+        if !is_apple_m4_device_name(device_name) {
+            return Err(io_error(format!(
+                "M4-007 MPSGraph smoke requires an Apple M4-family device; found '{device_name}'"
+            )));
+        }
+
+        let actual = parse_output_values(&swift_output)?;
+        let (lhs, rhs) = tiny_mpsgraph_matmul_inputs();
+        let expected = expected_tiny_mpsgraph_matmul(&lhs, &rhs)?;
+        let comparison = compare_tiny_mpsgraph_matmul_outputs(&expected, &actual, 1e-6)?;
+
+        let artifact_path = std::env::var(ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/mpsgraph-smoke.json".to_string()
+            });
+        let receipt =
+            TinyMpsGraphSmokeReceipt::passed(artifact_path.clone(), expected.len(), comparison);
+
+        let receipt_json = json!({
+            "machine_id": receipt.machine_id,
+            "artifact_kind": receipt.artifact_kind,
+            "requested_backend": receipt.requested_backend,
+            "selected_backend": receipt.selected_backend,
+            "runtime_api": receipt.runtime_api,
+            "resolved_device": {
+                "chip": device_name,
+                "unified_memory": true
+            },
+            "graph_id": receipt.graph_id,
+            "resolved_target": receipt.resolved_target,
+            "fallback_used": receipt.fallback_used,
+            "result": receipt.result,
+            "artifact_path": receipt.artifact_path,
+            "element_count": receipt.element_count,
+            "max_abs_error": receipt.max_abs_error,
+            "mean_abs_error": receipt.mean_abs_error
+        });
+
+        if let Ok(path) = std::env::var(RECEIPT_ENV) {
+            if let Some(parent) = Path::new(&path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    fn run_swift_mpsgraph_smoke() -> Result<serde_json::Value, Box<dyn Error>> {
+        let script_path = write_temp_swift_script()?;
+        let output = Command::new("xcrun").args(["swift"]).arg(&script_path).output()?;
+        let _ = std::fs::remove_file(&script_path);
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(io_error(format!("xcrun swift MPSGraph smoke failed: {stderr}")));
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        serde_json::from_str(stdout.trim())
+            .map_err(|error| io_error(format!("failed to parse MPSGraph smoke JSON: {error}")))
+    }
+
+    fn write_temp_swift_script() -> Result<PathBuf, Box<dyn Error>> {
+        let path = std::env::temp_dir().join(format!(
+            "bitnet-m4-mpsgraph-smoke-{}-{}.swift",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::write(&path, tiny_mpsgraph_smoke_swift_source())?;
+        Ok(path)
+    }
+
+    fn parse_output_values(value: &serde_json::Value) -> Result<Vec<f32>, Box<dyn Error>> {
+        let values = value
+            .get("output")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| io_error("MPSGraph smoke output missing output array"))?;
+
+        values
+            .iter()
+            .map(|value| {
+                value
+                    .as_f64()
+                    .map(|number| number as f32)
+                    .ok_or_else(|| io_error("MPSGraph smoke output array contains non-number"))
+            })
+            .collect()
+    }
+
+    fn is_apple_m4_device_name(device_name: &str) -> bool {
+        device_name.to_ascii_lowercase().contains("apple m4")
+    }
+
+    fn io_error(message: impl Into<String>) -> Box<dyn Error> {
+        Box::new(io::Error::other(message.into()))
+    }
+}

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -223,7 +223,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-007"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-007-mpsgraph-smoke"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -223,7 +223,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-007"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-007-mpsgraph-smoke"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T103810Z-M4-007-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T103810Z-M4-007-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T10:38:10Z"
+campaign = "apple-m4"
+item = "M4-007"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started MPSGraph tiny graph smoke as Apple graph/reference-lane evidence.",
+  "No native Metal kernel, Neural Engine, BitNet inference, QK256, server, or benchmark claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T104222Z-M4-007-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T104222Z-M4-007-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T10:42:22Z"
+campaign = "apple-m4"
+item = "M4-007"
+event = "pr_open"
+pr = 3719
+head_sha = "bf921f968827323c2d8afd8b6cfe1aecfa2dc6b2"
+actor = "codex"
+
+notes = [
+  "Opened MPSGraph tiny graph smoke PR.",
+  "Receipt records apple-m4-mpsgraph with runtime_api=mpsgraph, resolved_target=unknown, and fallback_used=false.",
+  "No native Metal kernel proof, Neural Engine claim, BitNet inference, QK256, server, dependency, benchmark, or performance claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -15,7 +15,7 @@
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
-| M4-007 | in_progress | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
+| M4-007 | pr_open | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -15,7 +15,7 @@
 | M4-004 | merged | #3692 | `codex/apple-m4/M4-004-metal-probe` | Add Apple M4 Metal device probe without claiming Metal execution or BitNet inference. |
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
-| M4-007 | ready | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
+| M4-007 | in_progress | TBD | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | proposed | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-007 | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | nvidia-5070ti | RTX5070TI-004 | #3691 | `codex/nvidia-5070ti/RTX5070TI-004-cuda-nvml-probe` | Add RTX 5070 Ti CUDA and NVML runtime probe without claiming kernel execution or BitNet inference. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -8,7 +8,7 @@
 | apple-m4 | M4-004 | M4-003 | merged |
 | apple-m4 | M4-005 | M4-004 | merged |
 | apple-m4 | M4-006 | M4-005 | merged |
-| apple-m4 | M4-007 | M4-006 | ready |
+| apple-m4 | M4-007 | M4-006 | in_progress |
 | apple-m4 | M4-008 | M4-007 | proposed |
 | apple-m4 | M4-009 | M4-008 | proposed |
 | apple-m4 | M4-010 | M4-009 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -8,7 +8,7 @@
 | apple-m4 | M4-004 | M4-003 | merged |
 | apple-m4 | M4-005 | M4-004 | merged |
 | apple-m4 | M4-006 | M4-005 | merged |
-| apple-m4 | M4-007 | M4-006 | in_progress |
+| apple-m4 | M4-007 | M4-006 | pr_open |
 | apple-m4 | M4-008 | M4-007 | proposed |
 | apple-m4 | M4-009 | M4-008 | proposed |
 | apple-m4 | M4-010 | M4-009 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-007 | TBD | ready | M4-008 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-007 | TBD | in_progress | M4-008 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-007 | TBD | in_progress | M4-008 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-007 | #3719 | pr_open | M4-008 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- add an Apple MPSGraph reference-lane smoke helper for a tiny 2x2 matmul graph
- add an opt-in live M4 MPSGraph smoke test that runs through Swift/MPSGraph without adding Rust dependencies
- emit a receipt shape with requested_backend=apple-m4-mpsgraph, selected_backend=apple-m4-mpsgraph, runtime_api=mpsgraph, resolved_target=unknown, and fallback_used=false
- mark M4-007 in progress and regenerate Apple campaign/global dashboards

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-device-probe --no-default-features --features metal --test apple_mpsgraph_smoke
- BITNET_RUN_M4_MPSGRAPH_SMOKE=1 BITNET_M4_MPSGRAPH_SMOKE_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json BITNET_M4_MPSGRAPH_SMOKE_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json cargo test --locked -p bitnet-device-probe --no-default-features --features metal --test apple_mpsgraph_smoke tiny_m4_mpsgraph_matmul_smoke_runs_when_enabled -- --nocapture
- cargo test --locked -p bitnet-device-probe --no-default-features --features metal
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
No native Metal kernel proof, Neural Engine claim, BitNet inference, QK256, server, dependency, benchmark, or performance changes.