### PR TITLE
[codex][apple-m4] Add Apple backend receipt fields (M4-008)

### DIFF
--- a/crates/bitnet-device-probe/src/apple_mpsgraph.rs
+++ b/crates/bitnet-device-probe/src/apple_mpsgraph.rs
@@ -1,8 +1,8 @@
-//! Apple MPSGraph reference-lane smoke helpers.
+//! Apple `MPSGraph` reference-lane smoke helpers.
 //!
 //! This module is intentionally separate from native Metal probes and kernels.
-//! A passing MPSGraph smoke proves only that a tiny graph executed through the
-//! MPSGraph API; it is not native Metal, Neural Engine, or BitNet inference
+//! A passing `MPSGraph` smoke proves only that a tiny graph executed through the
+//! `MPSGraph` API; it is not native Metal, Neural Engine, or `BitNet` inference
 //! proof.
 
 use std::fmt;
@@ -14,6 +14,7 @@ pub const APPLE_M4_MPSGRAPH_RUNTIME_API: &str = "mpsgraph";
 pub const APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN: &str = "unknown";
 pub const TINY_MPSGRAPH_MATMUL_GRAPH_ID: &str = "tiny_mpsgraph_matmul";
 pub const MPSGRAPH_SMOKE_ELEMENT_COUNT: usize = 4;
+const MPSGRAPH_SMOKE_ELEMENT_COUNT_F32: f32 = 4.0;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TinyMpsGraphSmokeReceipt {
@@ -99,7 +100,7 @@ pub fn apple_mpsgraph_smoke_artifact_path(date: &str) -> String {
 }
 
 #[must_use]
-pub fn tiny_mpsgraph_matmul_inputs()
+pub const fn tiny_mpsgraph_matmul_inputs()
 -> ([f32; MPSGRAPH_SMOKE_ELEMENT_COUNT], [f32; MPSGRAPH_SMOKE_ELEMENT_COUNT]) {
     ([1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0])
 }
@@ -125,10 +126,10 @@ pub fn expected_tiny_mpsgraph_matmul(
     }
 
     Ok(vec![
-        lhs[0] * rhs[0] + lhs[1] * rhs[2],
-        lhs[0] * rhs[1] + lhs[1] * rhs[3],
-        lhs[2] * rhs[0] + lhs[3] * rhs[2],
-        lhs[2] * rhs[1] + lhs[3] * rhs[3],
+        lhs[0].mul_add(rhs[0], lhs[1] * rhs[2]),
+        lhs[0].mul_add(rhs[1], lhs[1] * rhs[3]),
+        lhs[2].mul_add(rhs[0], lhs[3] * rhs[2]),
+        lhs[2].mul_add(rhs[1], lhs[3] * rhs[3]),
     ])
 }
 
@@ -139,6 +140,12 @@ pub fn compare_tiny_mpsgraph_matmul_outputs(
 ) -> Result<TinyMpsGraphSmokeComparison, TinyMpsGraphSmokeError> {
     if expected.is_empty() {
         return Err(TinyMpsGraphSmokeError::EmptyInput);
+    }
+    if expected.len() != MPSGRAPH_SMOKE_ELEMENT_COUNT {
+        return Err(TinyMpsGraphSmokeError::LengthMismatch {
+            expected: MPSGRAPH_SMOKE_ELEMENT_COUNT,
+            actual: expected.len(),
+        });
     }
     if expected.len() != actual.len() {
         return Err(TinyMpsGraphSmokeError::LengthMismatch {
@@ -172,12 +179,12 @@ pub fn compare_tiny_mpsgraph_matmul_outputs(
 
     Ok(TinyMpsGraphSmokeComparison {
         max_abs_error,
-        mean_abs_error: total_abs_error / expected.len() as f32,
+        mean_abs_error: total_abs_error / MPSGRAPH_SMOKE_ELEMENT_COUNT_F32,
     })
 }
 
 #[must_use]
-pub fn tiny_mpsgraph_smoke_swift_source() -> &'static str {
+pub const fn tiny_mpsgraph_smoke_swift_source() -> &'static str {
     r#"
 import Foundation
 import Metal

--- a/crates/bitnet-device-probe/src/apple_receipts.rs
+++ b/crates/bitnet-device-probe/src/apple_receipts.rs
@@ -1,0 +1,186 @@
+//! Durable Apple backend receipt fields.
+//!
+//! These types record Apple proof identity without collapsing Metal, MPSGraph,
+//! and CPU/NEON evidence. They do not prove BitNet inference on their own.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppleResolvedDevice {
+    pub chip: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_cores: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unified_memory: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_bandwidth_gbps: Option<u32>,
+}
+
+impl AppleResolvedDevice {
+    #[must_use]
+    pub fn new(chip: impl Into<String>) -> Self {
+        Self {
+            chip: chip.into(),
+            gpu_cores: None,
+            unified_memory: None,
+            memory_bandwidth_gbps: None,
+        }
+    }
+
+    #[must_use]
+    pub const fn with_gpu_cores(mut self, gpu_cores: u32) -> Self {
+        self.gpu_cores = Some(gpu_cores);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_unified_memory(mut self, unified_memory: bool) -> Self {
+        self.unified_memory = Some(unified_memory);
+        self
+    }
+
+    #[must_use]
+    pub const fn with_memory_bandwidth_gbps(mut self, memory_bandwidth_gbps: u32) -> Self {
+        self.memory_bandwidth_gbps = Some(memory_bandwidth_gbps);
+        self
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppleBackendReceipt {
+    pub machine_id: String,
+    pub artifact_kind: String,
+    pub requested_backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_backend: Option<String>,
+    pub runtime_api: String,
+    pub resolved_device: AppleResolvedDevice,
+    pub fallback_used: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback_reason: Option<String>,
+    pub artifact_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub graph_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<String>,
+}
+
+impl AppleBackendReceipt {
+    #[must_use]
+    pub fn new(
+        machine_id: impl Into<String>,
+        artifact_kind: impl Into<String>,
+        requested_backend: impl Into<String>,
+        selected_backend: Option<impl Into<String>>,
+        runtime_api: impl Into<String>,
+        resolved_device: AppleResolvedDevice,
+        fallback_used: bool,
+        artifact_path: impl Into<String>,
+    ) -> Self {
+        Self {
+            machine_id: machine_id.into(),
+            artifact_kind: artifact_kind.into(),
+            requested_backend: requested_backend.into(),
+            selected_backend: selected_backend.map(Into::into),
+            runtime_api: runtime_api.into(),
+            resolved_device,
+            fallback_used,
+            fallback_reason: None,
+            artifact_path: artifact_path.into(),
+            kernel_id: None,
+            graph_id: None,
+            resolved_target: None,
+            result: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_kernel_id(mut self, kernel_id: impl Into<String>) -> Self {
+        self.kernel_id = Some(kernel_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_graph_id(mut self, graph_id: impl Into<String>) -> Self {
+        self.graph_id = Some(graph_id.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_resolved_target(mut self, resolved_target: impl Into<String>) -> Self {
+        self.resolved_target = Some(resolved_target.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_result(mut self, result: impl Into<String>) -> Self {
+        self.result = Some(result.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_fallback_reason(mut self, fallback_reason: impl Into<String>) -> Self {
+        self.fallback_reason = Some(fallback_reason.into());
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), AppleReceiptError> {
+        require_nonempty("machine_id", &self.machine_id)?;
+        require_nonempty("artifact_kind", &self.artifact_kind)?;
+        require_nonempty("requested_backend", &self.requested_backend)?;
+        require_nonempty("runtime_api", &self.runtime_api)?;
+        require_nonempty("resolved_device.chip", &self.resolved_device.chip)?;
+        require_nonempty("artifact_path", &self.artifact_path)?;
+
+        if self.fallback_used && self.fallback_reason.as_deref().unwrap_or_default().is_empty() {
+            return Err(AppleReceiptError::MissingFallbackReason);
+        }
+        if !self.fallback_used && self.fallback_reason.is_some() {
+            return Err(AppleReceiptError::UnexpectedFallbackReason);
+        }
+        if self.kernel_id.is_some() && self.graph_id.is_some() {
+            return Err(AppleReceiptError::AmbiguousWorkId);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppleReceiptError {
+    MissingField(&'static str),
+    MissingFallbackReason,
+    UnexpectedFallbackReason,
+    AmbiguousWorkId,
+}
+
+impl fmt::Display for AppleReceiptError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingField(field) => write!(f, "Apple backend receipt missing {field}"),
+            Self::MissingFallbackReason => {
+                write!(f, "Apple backend receipt fallback_used=true requires fallback_reason")
+            }
+            Self::UnexpectedFallbackReason => {
+                write!(
+                    f,
+                    "Apple backend receipt fallback_reason must be absent when fallback_used=false"
+                )
+            }
+            Self::AmbiguousWorkId => {
+                write!(f, "Apple backend receipt must not record both kernel_id and graph_id")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AppleReceiptError {}
+
+fn require_nonempty(field: &'static str, value: &str) -> Result<(), AppleReceiptError> {
+    if value.trim().is_empty() { Err(AppleReceiptError::MissingField(field)) } else { Ok(()) }
+}

--- a/crates/bitnet-device-probe/src/apple_receipts.rs
+++ b/crates/bitnet-device-probe/src/apple_receipts.rs
@@ -1,7 +1,7 @@
 //! Durable Apple backend receipt fields.
 //!
-//! These types record Apple proof identity without collapsing Metal, MPSGraph,
-//! and CPU/NEON evidence. They do not prove BitNet inference on their own.
+//! These types record Apple proof identity without collapsing Metal, `MPSGraph`,
+//! and CPU/NEON evidence. They do not prove `BitNet` inference on their own.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/crates/bitnet-device-probe/src/lib.rs
+++ b/crates/bitnet-device-probe/src/lib.rs
@@ -5,9 +5,12 @@
 
 pub use bitnet_common::kernel_registry::SimdLevel;
 
+pub mod apple_receipts;
 pub mod cpu;
 pub mod intel;
 pub mod runtimes;
+
+pub use apple_receipts::{AppleBackendReceipt, AppleReceiptError, AppleResolvedDevice};
 
 #[cfg(feature = "metal")]
 pub mod apple_metal;

--- a/crates/bitnet-device-probe/tests/apple_backend_receipts.rs
+++ b/crates/bitnet-device-probe/tests/apple_backend_receipts.rs
@@ -1,0 +1,112 @@
+use bitnet_device_probe::{AppleBackendReceipt, AppleReceiptError, AppleResolvedDevice};
+
+fn m4_device() -> AppleResolvedDevice {
+    AppleResolvedDevice::new("Apple M4").with_gpu_cores(10).with_unified_memory(true)
+}
+
+#[test]
+fn apple_metal_smoke_receipt_preserves_backend_identity() {
+    let receipt = AppleBackendReceipt::new(
+        "apple-m4-mac-mini",
+        "smoke",
+        "apple-m4-metal",
+        Some("apple-m4-metal"),
+        "metal",
+        m4_device(),
+        false,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-smoke.json",
+    )
+    .with_kernel_id("tiny_metal_add_smoke")
+    .with_result("pass");
+
+    receipt.validate().expect("valid Apple Metal smoke receipt");
+
+    let value = serde_json::to_value(&receipt).expect("receipt serializes");
+    assert_eq!(value["requested_backend"], "apple-m4-metal");
+    assert_eq!(value["selected_backend"], "apple-m4-metal");
+    assert_eq!(value["runtime_api"], "metal");
+    assert_eq!(value["resolved_device"]["chip"], "Apple M4");
+    assert_eq!(value["resolved_device"]["gpu_cores"], 10);
+    assert_eq!(value["resolved_device"]["unified_memory"], true);
+    assert_eq!(value["fallback_used"], false);
+    assert_eq!(value["kernel_id"], "tiny_metal_add_smoke");
+    assert!(value.get("fallback_reason").is_none());
+}
+
+#[test]
+fn apple_mpsgraph_receipt_records_graph_not_native_kernel() {
+    let receipt = AppleBackendReceipt::new(
+        "apple-m4-mac-mini",
+        "smoke",
+        "apple-m4-mpsgraph",
+        Some("apple-m4-mpsgraph"),
+        "mpsgraph",
+        m4_device(),
+        false,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json",
+    )
+    .with_graph_id("tiny_mpsgraph_matmul")
+    .with_resolved_target("unknown")
+    .with_result("pass");
+
+    receipt.validate().expect("valid Apple MPSGraph smoke receipt");
+
+    let value = serde_json::to_value(&receipt).expect("receipt serializes");
+    assert_eq!(value["requested_backend"], "apple-m4-mpsgraph");
+    assert_eq!(value["selected_backend"], "apple-m4-mpsgraph");
+    assert_eq!(value["runtime_api"], "mpsgraph");
+    assert_eq!(value["graph_id"], "tiny_mpsgraph_matmul");
+    assert_eq!(value["resolved_target"], "unknown");
+    assert!(value.get("kernel_id").is_none());
+}
+
+#[test]
+fn fallback_receipts_require_a_reason() {
+    let receipt = AppleBackendReceipt::new(
+        "apple-m4-mac-mini",
+        "smoke",
+        "apple-m4-metal",
+        Some("apple-m4-cpu-neon"),
+        "cpu",
+        m4_device(),
+        true,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/fallback.json",
+    );
+
+    assert_eq!(receipt.validate(), Err(AppleReceiptError::MissingFallbackReason));
+}
+
+#[test]
+fn nonfallback_receipts_reject_fallback_reason() {
+    let receipt = AppleBackendReceipt::new(
+        "apple-m4-mac-mini",
+        "smoke",
+        "apple-m4-metal",
+        Some("apple-m4-metal"),
+        "metal",
+        m4_device(),
+        false,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-smoke.json",
+    )
+    .with_fallback_reason("Metal unavailable");
+
+    assert_eq!(receipt.validate(), Err(AppleReceiptError::UnexpectedFallbackReason));
+}
+
+#[test]
+fn receipts_reject_ambiguous_kernel_and_graph_identity() {
+    let receipt = AppleBackendReceipt::new(
+        "apple-m4-mac-mini",
+        "smoke",
+        "apple-m4-mpsgraph",
+        Some("apple-m4-mpsgraph"),
+        "mpsgraph",
+        m4_device(),
+        false,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json",
+    )
+    .with_kernel_id("native_metal_kernel")
+    .with_graph_id("tiny_mpsgraph_matmul");
+
+    assert_eq!(receipt.validate(), Err(AppleReceiptError::AmbiguousWorkId));
+}

--- a/crates/bitnet-device-probe/tests/apple_mpsgraph_smoke.rs
+++ b/crates/bitnet-device-probe/tests/apple_mpsgraph_smoke.rs
@@ -2,10 +2,10 @@
 
 use bitnet_device_probe::{
     APPLE_M4_MPSGRAPH_BACKEND, APPLE_M4_MPSGRAPH_RESOLVED_TARGET_UNKNOWN,
-    APPLE_M4_MPSGRAPH_RUNTIME_API, TINY_MPSGRAPH_MATMUL_GRAPH_ID, TinyMpsGraphSmokeComparison,
-    TinyMpsGraphSmokeReceipt, apple_mpsgraph_smoke_artifact_path,
-    compare_tiny_mpsgraph_matmul_outputs, expected_tiny_mpsgraph_matmul,
-    tiny_mpsgraph_matmul_inputs, tiny_mpsgraph_smoke_swift_source,
+    APPLE_M4_MPSGRAPH_RUNTIME_API, AppleBackendReceipt, AppleResolvedDevice,
+    TINY_MPSGRAPH_MATMUL_GRAPH_ID, TinyMpsGraphSmokeComparison, TinyMpsGraphSmokeReceipt,
+    apple_mpsgraph_smoke_artifact_path, compare_tiny_mpsgraph_matmul_outputs,
+    expected_tiny_mpsgraph_matmul, tiny_mpsgraph_matmul_inputs, tiny_mpsgraph_smoke_swift_source,
 };
 
 #[test]
@@ -105,25 +105,26 @@ mod live_mpsgraph {
         let receipt =
             TinyMpsGraphSmokeReceipt::passed(artifact_path.clone(), expected.len(), comparison);
 
-        let receipt_json = json!({
-            "machine_id": receipt.machine_id,
-            "artifact_kind": receipt.artifact_kind,
-            "requested_backend": receipt.requested_backend,
-            "selected_backend": receipt.selected_backend,
-            "runtime_api": receipt.runtime_api,
-            "resolved_device": {
-                "chip": device_name,
-                "unified_memory": true
-            },
-            "graph_id": receipt.graph_id,
-            "resolved_target": receipt.resolved_target,
-            "fallback_used": receipt.fallback_used,
-            "result": receipt.result,
-            "artifact_path": receipt.artifact_path,
-            "element_count": receipt.element_count,
-            "max_abs_error": receipt.max_abs_error,
-            "mean_abs_error": receipt.mean_abs_error
-        });
+        let backend_receipt = AppleBackendReceipt::new(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            AppleResolvedDevice::new(device_name).with_unified_memory(true),
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+        )
+        .with_graph_id(receipt.graph_id)
+        .with_resolved_target(receipt.resolved_target)
+        .with_result(receipt.result);
+        backend_receipt.validate()?;
+
+        let mut receipt_json = serde_json::to_value(backend_receipt)?;
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert("element_count".to_string(), json!(receipt.element_count));
+        object.insert("max_abs_error".to_string(), json!(receipt.max_abs_error));
+        object.insert("mean_abs_error".to_string(), json!(receipt.mean_abs_error));
 
         if let Ok(path) = std::env::var(RECEIPT_ENV) {
             if let Some(parent) = Path::new(&path).parent() {

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "metal")]
 
+use bitnet_device_probe::{AppleBackendReceipt, AppleResolvedDevice};
 use bitnet_kernels::metal::smoke::{
     ARTIFACT_KIND, MACHINE_ID, PARITY_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND,
     RUNTIME_API, SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SmokeComparison,
@@ -129,24 +130,25 @@ mod live_metal {
         let receipt =
             TinyMetalAddSmokeReceipt::passed(artifact_path.clone(), expected.len(), comparison);
 
-        let receipt_json = json!({
-            "machine_id": receipt.machine_id,
-            "artifact_kind": receipt.artifact_kind,
-            "requested_backend": receipt.requested_backend,
-            "selected_backend": receipt.selected_backend,
-            "runtime_api": receipt.runtime_api,
-            "resolved_device": {
-                "chip": smoke_output.adapter_name,
-                "unified_memory": true
-            },
-            "kernel_id": receipt.kernel_id,
-            "fallback_used": receipt.fallback_used,
-            "result": receipt.result,
-            "artifact_path": receipt.artifact_path,
-            "element_count": receipt.element_count,
-            "max_abs_error": receipt.max_abs_error,
-            "mean_abs_error": receipt.mean_abs_error
-        });
+        let mut receipt_json = apple_backend_receipt_json(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            smoke_output.adapter_name,
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+            Some(receipt.kernel_id),
+            None,
+            receipt.result,
+        )?;
+        extend_smoke_metrics(
+            &mut receipt_json,
+            receipt.element_count,
+            receipt.max_abs_error,
+            receipt.mean_abs_error,
+        );
 
         if let Ok(path) = std::env::var(RECEIPT_ENV) {
             if let Some(parent) = Path::new(&path).parent() {
@@ -186,29 +188,28 @@ mod live_metal {
         let receipt =
             TinyMetalAddParityReceipt::passed(artifact_path.clone(), expected.len(), comparison);
 
-        let receipt_json = json!({
-            "machine_id": receipt.machine_id,
-            "artifact_kind": receipt.artifact_kind,
-            "requested_backend": receipt.requested_backend,
-            "selected_backend": receipt.selected_backend,
-            "runtime_api": receipt.runtime_api,
-            "resolved_device": {
-                "chip": metal_output.adapter_name,
-                "unified_memory": true
-            },
-            "parity": {
-                "reference_backend": receipt.reference_backend,
-                "target_backend": receipt.target_backend,
-                "kernel_id": receipt.kernel_id,
-                "max_abs_error": receipt.max_abs_error,
-                "mean_abs_error": receipt.mean_abs_error,
-                "token_agreement_for_greedy": null
-            },
-            "fallback_used": receipt.fallback_used,
-            "result": receipt.result,
-            "artifact_path": receipt.artifact_path,
-            "element_count": receipt.element_count
-        });
+        let mut receipt_json = apple_backend_receipt_json(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            metal_output.adapter_name,
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+            Some(receipt.kernel_id),
+            None,
+            receipt.result,
+        )?;
+        extend_parity_metrics(
+            &mut receipt_json,
+            receipt.element_count,
+            receipt.reference_backend,
+            receipt.target_backend,
+            receipt.kernel_id,
+            receipt.max_abs_error,
+            receipt.mean_abs_error,
+        );
 
         if let Ok(path) = std::env::var(PARITY_RECEIPT_ENV) {
             if let Some(parent) = Path::new(&path).parent() {
@@ -365,6 +366,79 @@ mod live_metal {
 
     fn io_error(message: impl Into<String>) -> Box<dyn Error> {
         Box::new(io::Error::other(message.into()))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn apple_backend_receipt_json(
+        machine_id: &str,
+        artifact_kind: &str,
+        requested_backend: &str,
+        selected_backend: Option<&str>,
+        runtime_api: &str,
+        chip: String,
+        fallback_used: bool,
+        artifact_path: String,
+        kernel_id: Option<&str>,
+        graph_id: Option<&str>,
+        result: &str,
+    ) -> Result<serde_json::Value, Box<dyn Error>> {
+        let mut receipt = AppleBackendReceipt::new(
+            machine_id,
+            artifact_kind,
+            requested_backend,
+            selected_backend,
+            runtime_api,
+            AppleResolvedDevice::new(chip).with_unified_memory(true),
+            fallback_used,
+            artifact_path,
+        )
+        .with_result(result);
+
+        if let Some(kernel_id) = kernel_id {
+            receipt = receipt.with_kernel_id(kernel_id);
+        }
+        if let Some(graph_id) = graph_id {
+            receipt = receipt.with_graph_id(graph_id);
+        }
+
+        receipt.validate()?;
+        Ok(serde_json::to_value(receipt)?)
+    }
+
+    fn extend_smoke_metrics(
+        receipt_json: &mut serde_json::Value,
+        element_count: usize,
+        max_abs_error: f32,
+        mean_abs_error: f32,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert("element_count".to_string(), json!(element_count));
+        object.insert("max_abs_error".to_string(), json!(max_abs_error));
+        object.insert("mean_abs_error".to_string(), json!(mean_abs_error));
+    }
+
+    fn extend_parity_metrics(
+        receipt_json: &mut serde_json::Value,
+        element_count: usize,
+        reference_backend: &str,
+        target_backend: &str,
+        kernel_id: &str,
+        max_abs_error: f32,
+        mean_abs_error: f32,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert("element_count".to_string(), json!(element_count));
+        object.insert(
+            "parity".to_string(),
+            json!({
+                "reference_backend": reference_backend,
+                "target_backend": target_backend,
+                "kernel_id": kernel_id,
+                "max_abs_error": max_abs_error,
+                "mean_abs_error": mean_abs_error,
+                "token_agreement_for_greedy": null
+            }),
+        );
     }
 
     const TINY_ADD_SHADER: &str = r#"

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -256,7 +256,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-008"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-008-backend-receipts"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -256,7 +256,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-008"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-008-backend-receipts"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T111508Z-M4-008-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T111508Z-M4-008-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T11:15:08Z"
+campaign = "apple-m4"
+item = "M4-008"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started Apple backend receipt field work for validated probe, smoke, parity, and MPSGraph artifacts.",
+  "No BitNet inference, QK256, server, benchmark, performance, or Neural Engine claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T112014Z-M4-008-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T112014Z-M4-008-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T11:20:14Z"
+campaign = "apple-m4"
+item = "M4-008"
+event = "pr_open"
+pr = 3721
+head_sha = "090a5c4edfe11910c0e6c3dd7073fd251227b685"
+actor = "codex"
+
+notes = [
+  "Opened Apple backend receipt fields PR.",
+  "Receipt schema records requested backend, selected backend, runtime API, resolved device, fallback status, artifact path, and kernel or graph identity.",
+  "No BitNet inference, QK256, server, benchmark, performance, or Neural Engine claim is in scope.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -16,7 +16,7 @@
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
-| M4-008 | in_progress | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
+| M4-008 | pr_open | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -16,7 +16,7 @@
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
-| M4-008 | ready | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
+| M4-008 | in_progress | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-008 | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -9,7 +9,7 @@
 | apple-m4 | M4-005 | M4-004 | merged |
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
-| apple-m4 | M4-008 | M4-007 | ready |
+| apple-m4 | M4-008 | M4-007 | in_progress |
 | apple-m4 | M4-009 | M4-008 | proposed |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -9,7 +9,7 @@
 | apple-m4 | M4-005 | M4-004 | merged |
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
-| apple-m4 | M4-008 | M4-007 | in_progress |
+| apple-m4 | M4-008 | M4-007 | pr_open |
 | apple-m4 | M4-009 | M4-008 | proposed |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-008 | TBD | in_progress | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-008 | #3721 | pr_open | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-008 | TBD | ready | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-008 | TBD | in_progress | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- add a shared AppleBackendReceipt schema for requested backend, selected backend, runtime API, resolved device, fallback status, artifact path, and kernel/graph identity
- validate fallback_reason rules and keep kernel_id and graph_id mutually exclusive
- wire Metal smoke/parity and MPSGraph smoke test receipts through the shared Apple receipt shape
- mark M4-008 in progress and regenerate Apple campaign/global dashboards

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-device-probe --no-default-features --features metal --test apple_backend_receipts
- cargo test --locked -p bitnet-device-probe --no-default-features --features metal --test apple_mpsgraph_smoke
- cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke
- BITNET_RUN_M4_METAL_PARITY=1 BITNET_M4_METAL_PARITY_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/metal-parity.json BITNET_M4_METAL_PARITY_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/metal-parity-m4-008.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_add_matches_cpu_neon_reference_when_enabled -- --nocapture
- BITNET_RUN_M4_MPSGRAPH_SMOKE=1 BITNET_M4_MPSGRAPH_SMOKE_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke.json BITNET_M4_MPSGRAPH_SMOKE_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/mpsgraph-smoke-m4-008.json cargo test --locked -p bitnet-device-probe --no-default-features --features metal --test apple_mpsgraph_smoke tiny_m4_mpsgraph_matmul_smoke_runs_when_enabled -- --nocapture
- cargo test --locked -p bitnet-device-probe --no-default-features --features metal
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
No BitNet inference, QK256, server, benchmark, performance, or Neural Engine execution claims.