### PR TITLE
NPU-002: preserve Intel NPU backend identity

### DIFF
--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -137,7 +137,7 @@ impl CliConfig {
     pub fn validate(&self) -> Result<()> {
         if !is_supported_device_label(&self.default_device) {
             anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
+                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, intel-npu, openvino-npu, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
                 self.default_device
             );
         }
@@ -167,8 +167,9 @@ impl CliConfig {
 }
 
 fn is_supported_device_label(label: &str) -> bool {
+    let label = label.trim().to_ascii_lowercase();
     matches!(
-        label,
+        label.as_str(),
         "cpu"
             | "cuda"
             | "gpu"
@@ -176,6 +177,9 @@ fn is_supported_device_label(label: &str) -> bool {
             | "opencl"
             | "ocl"
             | "npu"
+            | "intel-npu"
+            | "openvino-npu"
+            | "intel-npu-openvino"
             | "nvidia-rtx-5070-ti-cuda"
             | "nvidia-rtx-5070-ti-wgpu"
             | "metal"
@@ -184,7 +188,8 @@ fn is_supported_device_label(label: &str) -> bool {
             | "apple-m4-mpsgraph"
             | "apple-m4-cpu-neon"
             | "auto"
-    )
+    ) || label.strip_prefix("npu:").is_some_and(|index| index.parse::<usize>().is_ok())
+        || label.strip_prefix("intel-npu:").is_some_and(|index| index.parse::<usize>().is_ok())
 }
 
 /// Configuration builder for command-line usage
@@ -234,5 +239,32 @@ impl ConfigBuilder {
         self.config.merge_with_env();
         self.config.validate()?;
         Ok(self.config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CliConfig, ConfigBuilder};
+
+    #[test]
+    fn validates_intel_npu_labels_without_aliasing() {
+        for device in ["npu", "intel-npu", "intel-npu:1", "openvino-npu", "intel-npu-openvino"] {
+            let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
+            config.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_intel_npu_index() {
+        for device in ["npu:", "npu:abc", "intel-npu:", "intel-npu:abc"] {
+            let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
+            assert!(config.validate().is_err(), "{device} should be rejected");
+        }
+    }
+
+    #[test]
+    fn builder_preserves_intel_npu_device_label() {
+        let config = ConfigBuilder::new().device(Some("intel-npu:2".to_string())).build().unwrap();
+        assert_eq!(config.default_device, "intel-npu:2");
     }
 }

--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -58,6 +58,10 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require Intel NPU identity without treating it as GPU, Metal, or CPU fallback.
+    IntelNpu,
+    /// Require Intel NPU through the OpenVINO runtime.
+    OpenVinoNpu,
     /// Require native Metal compute without assuming a specific Apple machine.
     Metal,
     /// Require MPSGraph graph execution without treating it as native Metal kernels.
@@ -82,6 +86,8 @@ impl BackendRequest {
             "nvidia-rtx-5070-ti-wgpu" => Some(BackendRequest::NvidiaRtx5070TiWgpu),
             "hip" | "rocm" => Some(BackendRequest::Hip),
             "oneapi" => Some(BackendRequest::OneApi),
+            "npu" | "intel-npu" => Some(BackendRequest::IntelNpu),
+            "openvino-npu" | "intel-npu-openvino" => Some(BackendRequest::OpenVinoNpu),
             "metal" => Some(BackendRequest::Metal),
             "mpsgraph" => Some(BackendRequest::MpsGraph),
             "apple-m4-metal" => Some(BackendRequest::AppleM4Metal),
@@ -103,6 +109,8 @@ impl fmt::Display for BackendRequest {
             BackendRequest::NvidiaRtx5070TiWgpu => write!(f, "nvidia-rtx-5070-ti-wgpu"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::IntelNpu => write!(f, "intel-npu"),
+            BackendRequest::OpenVinoNpu => write!(f, "openvino-npu"),
             BackendRequest::Metal => write!(f, "metal"),
             BackendRequest::MpsGraph => write!(f, "mpsgraph"),
             BackendRequest::AppleM4Metal => write!(f, "apple-m4-metal"),
@@ -181,6 +189,8 @@ impl BackendSelectionResult {
             BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
             BackendRequest::NvidiaRtx5070TiCuda
             | BackendRequest::NvidiaRtx5070TiWgpu
+            | BackendRequest::IntelNpu
+            | BackendRequest::OpenVinoNpu
             | BackendRequest::Metal
             | BackendRequest::MpsGraph
             | BackendRequest::AppleM4Metal
@@ -313,6 +323,15 @@ pub fn select_backend(
                     available: detected.clone(),
                 });
             }
+        }
+        BackendRequest::IntelNpu | BackendRequest::OpenVinoNpu => {
+            // NPU-002 preserves the requested identity only. Runtime probing and
+            // OpenVINO graph execution land later, so CPU/GPU fallback is never
+            // selected here.
+            return Err(BackendSelectionError::RequestedUnavailable {
+                requested: request,
+                available: detected.clone(),
+            });
         }
         BackendRequest::Metal | BackendRequest::AppleM4Metal => {
             return Err(BackendSelectionError::RequestedUnavailable {
@@ -517,6 +536,21 @@ mod tests {
     }
 
     #[test]
+    fn intel_npu_labels_parse_without_aliasing() {
+        assert_eq!(BackendRequest::from_label("npu"), Some(BackendRequest::IntelNpu));
+        assert_eq!(BackendRequest::from_label("intel-npu"), Some(BackendRequest::IntelNpu));
+        assert_eq!(BackendRequest::from_label("openvino-npu"), Some(BackendRequest::OpenVinoNpu));
+        assert_eq!(
+            BackendRequest::from_label("intel-npu-openvino"),
+            Some(BackendRequest::OpenVinoNpu)
+        );
+        assert_ne!(BackendRequest::from_label("npu"), Some(BackendRequest::Gpu));
+        assert_ne!(BackendRequest::from_label("npu"), Some(BackendRequest::Metal));
+        assert_eq!(BackendRequest::IntelNpu.to_string(), "intel-npu");
+        assert_eq!(BackendRequest::OpenVinoNpu.to_string(), "openvino-npu");
+    }
+
+    #[test]
     fn rtx_5070_ti_cuda_request_preserves_identity_when_cuda_available() {
         let result = select_backend(BackendRequest::NvidiaRtx5070TiCuda, &cuda_caps()).unwrap();
 
@@ -555,6 +589,15 @@ mod tests {
         let err = select_backend(BackendRequest::AppleM4Metal, &cpu_only_caps()).unwrap_err();
         assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
         assert!(err.to_string().contains("apple-m4-metal"));
+    }
+
+    #[test]
+    fn intel_npu_requests_are_strict_until_openvino_runtime_lands() {
+        for request in [BackendRequest::IntelNpu, BackendRequest::OpenVinoNpu] {
+            let err = select_backend(request, &cpu_only_caps()).unwrap_err();
+            assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+            assert!(err.to_string().contains(&request.to_string()));
+        }
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -15,6 +15,10 @@ pub enum DeviceConfig {
     Cpu,
     /// Force GPU execution on specific device ID.
     Gpu(usize),
+    /// Preserve Intel NPU backend identity without mapping through GPU/Metal/CPU.
+    IntelNpu(usize),
+    /// Preserve Intel NPU through OpenVINO backend identity.
+    OpenVinoNpu,
     /// Preserve the RTX 5070 Ti CUDA proof-lane backend identity.
     NvidiaRtx5070TiCuda,
     /// Preserve the RTX 5070 Ti WGPU reference-lane backend identity.
@@ -38,7 +42,9 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
+            "npu" | "intel-npu" => Ok(DeviceConfig::IntelNpu(0)),
+            "openvino-npu" | "intel-npu-openvino" => Ok(DeviceConfig::OpenVinoNpu),
             "nvidia-rtx-5070-ti-cuda" => Ok(DeviceConfig::NvidiaRtx5070TiCuda),
             "nvidia-rtx-5070-ti-wgpu" => Ok(DeviceConfig::NvidiaRtx5070TiWgpu),
             "metal" => Ok(DeviceConfig::Metal),
@@ -51,6 +57,10 @@ impl FromStr for DeviceConfig {
             s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("opencl:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("ocl:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("npu:") => Ok(DeviceConfig::IntelNpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("intel-npu:") => {
+                Ok(DeviceConfig::IntelNpu(s[10..].parse::<usize>()?))
+            }
             _ => anyhow::bail!("Unknown device config: {}", s),
         }
     }
@@ -74,6 +84,7 @@ impl DeviceConfig {
             }
             DeviceConfig::Cpu => Device::Cpu,
             DeviceConfig::Gpu(id) => Device::Cuda(*id),
+            DeviceConfig::IntelNpu(_) | DeviceConfig::OpenVinoNpu => Device::Npu,
             DeviceConfig::NvidiaRtx5070TiCuda => Device::Cuda(0),
             // WGPU is a reference-lane identity; execution lands in a later item.
             DeviceConfig::NvidiaRtx5070TiWgpu => Device::Cpu,
@@ -91,6 +102,8 @@ impl DeviceConfig {
             DeviceConfig::Auto => BackendRequest::Auto,
             DeviceConfig::Cpu => BackendRequest::Cpu,
             DeviceConfig::Gpu(_) => BackendRequest::Gpu,
+            DeviceConfig::IntelNpu(_) => BackendRequest::IntelNpu,
+            DeviceConfig::OpenVinoNpu => BackendRequest::OpenVinoNpu,
             DeviceConfig::NvidiaRtx5070TiCuda => BackendRequest::NvidiaRtx5070TiCuda,
             DeviceConfig::NvidiaRtx5070TiWgpu => BackendRequest::NvidiaRtx5070TiWgpu,
             DeviceConfig::Metal => BackendRequest::Metal,
@@ -104,7 +117,11 @@ impl DeviceConfig {
     /// Stable label for logs and planned receipt fields.
     #[must_use]
     pub fn backend_label(&self) -> String {
-        self.backend_request().to_string()
+        match self {
+            DeviceConfig::IntelNpu(0) => "intel-npu".to_string(),
+            DeviceConfig::IntelNpu(index) => format!("intel-npu:{index}"),
+            _ => self.backend_request().to_string(),
+        }
     }
 }
 
@@ -119,6 +136,9 @@ mod tests {
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
         assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
+        assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(0));
+        assert_eq!("intel-npu:1".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(1));
+        assert_eq!("openvino-npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoNpu);
         assert_eq!(
             "nvidia-rtx-5070-ti-cuda".parse::<DeviceConfig>().unwrap(),
             DeviceConfig::NvidiaRtx5070TiCuda
@@ -145,6 +165,8 @@ mod tests {
         assert!("unknown".parse::<DeviceConfig>().is_err());
         assert!("gpu:".parse::<DeviceConfig>().is_err());
         assert!("gpu:abc".parse::<DeviceConfig>().is_err());
+        assert!("npu:".parse::<DeviceConfig>().is_err());
+        assert!("intel-npu:abc".parse::<DeviceConfig>().is_err());
     }
 
     #[test]
@@ -175,5 +197,25 @@ mod tests {
         assert_ne!(rtx_cuda.backend_label(), generic_cuda.backend_label());
         assert_ne!(rtx_wgpu.backend_label(), generic_gpu.backend_label());
         assert_ne!(rtx_wgpu.backend_label(), generic_cuda.backend_label());
+    }
+
+    #[test]
+    fn intel_npu_backend_labels_do_not_alias_gpu_or_cpu_labels() {
+        let generic_gpu = "gpu".parse::<DeviceConfig>().unwrap();
+        let generic_cuda = "cuda".parse::<DeviceConfig>().unwrap();
+        let cpu = "cpu".parse::<DeviceConfig>().unwrap();
+        let npu = "npu".parse::<DeviceConfig>().unwrap();
+        let indexed_npu = "intel-npu:1".parse::<DeviceConfig>().unwrap();
+        let openvino_npu = "openvino-npu".parse::<DeviceConfig>().unwrap();
+
+        assert_eq!(npu.backend_label(), "intel-npu");
+        assert_eq!(indexed_npu.backend_label(), "intel-npu:1");
+        assert_eq!(openvino_npu.backend_label(), "openvino-npu");
+        assert_eq!(npu.resolve(), bitnet_common::Device::Npu);
+        assert_eq!(indexed_npu.resolve(), bitnet_common::Device::Npu);
+        assert_eq!(openvino_npu.resolve(), bitnet_common::Device::Npu);
+        assert_ne!(npu.backend_label(), generic_gpu.backend_label());
+        assert_ne!(npu.backend_label(), generic_cuda.backend_label());
+        assert_ne!(npu.backend_label(), cpu.backend_label());
     }
 }

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -256,7 +256,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-008"
-status = "ready"
+status = "pr_open"
 branch = "codex/apple-m4/M4-008-backend-receipts"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T112632Z-M4-008-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T112632Z-M4-008-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T11:26:32Z"
+campaign = "apple-m4"
+item = "M4-008"
+event = "pr_open"
+pr = 3721
+head_sha = "7a772c12ac9bc5463aff758ad56ce39f0ca9f606"
+actor = "codex"
+
+notes = [
+  "Recorded live GitHub state for the Apple M4 backend receipt PR so campaign doctor can reconcile open PR claims.",
+  "Tracker-only CI reconciliation; no runtime or receipt behavior changed here.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -16,7 +16,7 @@
 | M4-005 | merged | #3699 | `codex/apple-m4/M4-005-metal-smoke` | Run a tiny native Metal compute smoke on M4 with fallback_used=false. |
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
-| M4-008 | ready | TBD | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
+| M4-008 | pr_open | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | proposed | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -20,27 +20,35 @@ hard_constraints = [
 
 [[work_item]]
 id = "NPU-002"
-status = "ready"
-branch = "codex/intel-npu/NPU-002-backend-identity"
+status = "pr_open"
+branch = "codex/intel-npu/NPU-002-lite-backend-identity"
 stackable = false
 requires_human_merge = true
 blocked_by = []
 acceptance = "Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback."
 commands = [
-  "cargo fmt --all -- --check",
-  "cargo test --locked -p bitnet-cli-config-core --no-default-features --features cpu",
+  "rustfmt --check crates/bitnet-common/src/backend_selection.rs crates/bitnet-device-config-core/src/lib.rs crates/bitnet-cli-config-core/src/lib.rs",
+  "cargo test --locked -p bitnet-common --lib intel_npu --no-default-features -- --nocapture",
+  "cargo test --locked -p bitnet-device-config-core --no-default-features",
+  "cargo test --locked -p bitnet-cli-config-core --no-default-features",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
 ]
 allowed_paths = [
-  "crates/bitnet-common/src/types.rs",
-  "crates/bitnet-inference/src/npu.rs",
+  "crates/bitnet-common/src/backend_selection.rs",
   "crates/bitnet-device-config-core/src/lib.rs",
   "crates/bitnet-cli-config-core/src/lib.rs",
-  "crates/bitnet-cli/src/main.rs",
   "docs/tracking/campaigns/intel-npu/**",
 ]
 forbidden_paths = [
+  "crates/bitnet-inference/**",
+  "crates/bitnet-cli/src/main.rs",
+  "crates/bitnet-cli/src/commands/inference.rs",
   "crates/bitnet-quantization/src/qk256/**",
   "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-server/**",
 ]
 may_claim = [
   "Intel NPU backend identity is preserved through config and help surfaces.",

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T111902Z-NPU-002-pr-open.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T111902Z-NPU-002-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T11:19:02Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "pr_open"
+pr = 3722
+branch = "codex/intel-npu/NPU-002-lite-backend-identity"
+head_sha = "a73607286e9d65381bafc6d86e4000141ee9f72c"
+actor = "codex"
+
+notes = [
+  "Opened identity-only Intel NPU config/common PR.",
+  "Keeps npu, intel-npu, and openvino-npu distinct from GPU, Metal, CUDA, CPU fallback, and runtime execution.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| NPU-002 | ready | TBD | `codex/intel-npu/NPU-002-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-002 | pr_open | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -5,3 +5,4 @@
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-008 | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | cpu-proof | CPU-BITNET-004 | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -9,7 +9,7 @@
 | apple-m4 | M4-005 | M4-004 | merged |
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
-| apple-m4 | M4-008 | M4-007 | ready |
+| apple-m4 | M4-008 | M4-007 | pr_open |
 | apple-m4 | M4-009 | M4-008 | proposed |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-008 | TBD | ready | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-008 | #3721 | pr_open | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-004 | #3696 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | TBD | ready | none | Device-node detection is not inference. |
+| intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-005 | TBD | ready | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-001 | #3660 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- add Intel NPU and OpenVINO NPU requested-backend identities without mapping them to GPU, CUDA, Metal, or CPU fallback
- parse npu/intel-npu/openvino-npu device labels, including indexed Intel NPU config labels, while resolving them to Device::Npu
- keep NPU backend selection strict and unavailable until runtime probe/OpenVINO execution work lands
- update the intel-npu campaign tracker for NPU-002

## Claim boundary
- identity only: no OpenVINO dependency, no graph execution, no runtime NPU probe, and no BitNet inference claim
- does not touch GGUF loader, tokenizer, QK256 layout/dispatch, CPU kernels, transformer inference, or server code

## Verification
- rustfmt --check crates/bitnet-common/src/backend_selection.rs crates/bitnet-device-config-core/src/lib.rs crates/bitnet-cli-config-core/src/lib.rs
- cargo test --locked -p bitnet-common --lib intel_npu --no-default-features -- --nocapture
- cargo test --locked -p bitnet-common --no-default-features backend_request -- --nocapture
- cargo check --locked -p bitnet-common --no-default-features
- cargo test --locked -p bitnet-device-config-core --no-default-features
- cargo test --locked -p bitnet-cli-config-core --no-default-features
- cargo run --locked -p xtask --no-default-features -- campaign generate
- git diff --check

Note: cargo fmt --all -- --check is blocked locally by Windows error 206, so formatting was checked on the touched Rust files only.