### PR TITLE
docs(cuda): add RTX5070TI-005 smoke receipt

### DIFF
--- a/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json
+++ b/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json
@@ -1,0 +1,48 @@
+{
+  "artifact_kind": "cuda_smoke",
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json",
+  "claim": "kernel_smoke_tested",
+  "cuda": {
+    "available": true,
+    "compute_capability": "12.0",
+    "cuda_runtime_version": "12.9",
+    "cuda_toolkit_version": "12.9",
+    "device_count": 1,
+    "device_index": 0,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "driver_version": "591.86",
+    "nvml_available": true,
+    "nvrtc_version": "12.9",
+    "power_draw_watts": 34.97,
+    "power_limit_watts": 300.0,
+    "temperature_c": 38.0,
+    "vram_bytes": 17094475776
+  },
+  "error": null,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "fallback_used": false,
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "input_len": 1024,
+  "kernel_stats": [
+    {
+      "device_to_host_bytes": 4096,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": 8192,
+      "invocations": 1,
+      "kernel_id": "cuda_tiny_vector_add",
+      "kernel_launches": 1,
+      "kernel_time_ms": null
+    }
+  ],
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "max_abs_error": 0.0,
+  "mean_abs_error": 0.0,
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "result": "pass",
+  "runtime_api": "cuda",
+  "schema": 1,
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "2026-05-06T11:27:54Z"
+}

--- a/docs/hardware/windows-9950x3d-rtx5070ti-validation.md
+++ b/docs/hardware/windows-9950x3d-rtx5070ti-validation.md
@@ -122,6 +122,16 @@ ci/hardware/windows-9950x3d-rtx5070ti/<date>/strict-bitnet-cuda-proof.json
 Do not commit bulky local logs, raw command transcripts, GGUFs, model files, or
 binary traces in normal docs or implementation PRs.
 
+Current normalized artifacts:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json
+```
+
+This RTX5070TI-005 artifact is a tiny CUDA kernel smoke receipt only. It records
+`claim=kernel_smoke_tested` and does not claim BitNet inference, parity, or
+speedup.
+
 ## Claim Boundary
 
 - `nvidia-smi` visibility is not CUDA kernel execution.


### PR DESCRIPTION
## Summary
- add the normalized RTX 5070 Ti CUDA tiny-kernel smoke receipt
- add a docs pointer that labels the artifact as RTX5070TI-005 tiny-kernel smoke only
- preserve `requested_backend=nvidia-rtx-5070-ti-cuda`, `selected_backend=nvidia-rtx-5070-ti-cuda`, `runtime_api=cuda`, and `fallback_used=false`
- record `kernel_id=cuda_tiny_vector_add`, invocation/transfer counts, device identity, CUDA/NVRTC versions, and zero error against CPU expected output

## Validation
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- --device nvidia-rtx-5070-ti-cuda cuda-smoke --device-index 0 --json-out ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-smoke.json
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

## Notes
- No CUDA kernels, QK256, transformer routing, server inference, dense CUDA work, benchmarks, or bulky local logs are changed.
- This claims only `kernel_smoke_tested`; it does not claim BitNet inference, parity, or speedup.
- The `RTX5070TI-005` pr_open tracker state is already on `main`.

Closes #3664