### PR TITLE
ARC140V-002: add Arc 140V runtime identity probe

### DIFF
--- a/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
@@ -258,6 +258,7 @@ mod tests {
                 device: "GPU.0".to_owned(),
                 full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
                 supported_properties: Vec::new(),
+                properties: Vec::new(),
             }],
             error: None,
         };
@@ -298,6 +299,7 @@ mod tests {
                 device: "GPU.0".to_owned(),
                 full_name: Some("Intel(R) UHD Graphics 620".to_owned()),
                 supported_properties: Vec::new(),
+                properties: Vec::new(),
             }],
             error: None,
         };

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
@@ -7,16 +7,35 @@ use crate::runtimes::{LevelZeroProbe, OpenClRuntimeProbe, OpenVinoProbe};
 
 use super::platform::{PlatformMemoryProbe, PlatformPowerProbe};
 
-const ARC_140V_PCI_DEVICE_ID: &str = "0x64A0";
+/// Stable requested backend label for the Lunar Lake integrated GPU lane.
+pub const INTEL_ARC_140V_REQUESTED_BACKEND: &str = "intel-arc-140v";
+/// Native OpenCL proof label for Arc 140V.
+pub const INTEL_ARC_140V_OPENCL_BACKEND: &str = "intel-arc-140v-opencl";
+/// OpenVINO GPU reference proof label for Arc 140V.
+pub const INTEL_ARC_140V_OPENVINO_GPU_BACKEND: &str = "intel-arc-140v-openvino-gpu";
+/// Expected PCI device ID for Arc 140V.
+pub const INTEL_ARC_140V_PCI_DEVICE_ID: &str = "0x64A0";
+/// Universal proof stage for this probe.
+pub const INTEL_ARC_140V_PROOF_STAGE_RUNTIME_DETECTED: &str = "runtime_detected";
 
 /// Visibility facts for the Lunar Lake integrated Arc 140V GPU.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct IntelArc140vProbe {
+    /// Universal proof stage for this visibility-only lane probe.
+    pub proof_stage: String,
+    /// Requested backend identity for receipts.
+    pub requested_backend: String,
+    /// Selected backend when an exact runtime identity is visible.
+    pub selected_backend: Option<String>,
+    /// Runtime API associated with the selected backend.
+    pub runtime_api: Option<String>,
     /// Whether the probe found evidence that the Arc 140V is visible.
     pub available: bool,
     /// Expected PCI device ID when it can be resolved.
     pub pci_device_id: Option<String>,
+    /// Identity evidence that matched Arc 140V by name or PCI ID.
+    pub identity_evidence: Vec<String>,
     /// Whether OpenCL runtime visibility includes Arc 140V.
     pub opencl_available: bool,
     /// OpenCL platform name when available.
@@ -39,6 +58,8 @@ pub struct IntelArc140vProbe {
     pub shared_memory_bytes: Option<u64>,
     /// Power mode context when available.
     pub power_mode: Option<String>,
+    /// Always false: this probe never substitutes CPU or another GPU as Arc 140V.
+    pub fallback_used: bool,
     /// Non-fatal reason explaining why exact Arc 140V identity was not found.
     pub failure_reason: Option<String>,
 }
@@ -56,6 +77,8 @@ pub fn probe_intel_arc_140v(
 
     let level_zero_devices: Vec<String> =
         level_zero.devices.iter().filter(|device| name_matches_arc_140v(device)).cloned().collect();
+    let level_zero_pci_match =
+        level_zero.device_ids.iter().any(|device_id| device_id_matches_arc_140v(device_id));
 
     let openvino_gpu_device = openvino.gpu_device_token();
     let openvino_gpu_full_name =
@@ -64,8 +87,27 @@ pub fn probe_intel_arc_140v(
     let openvino_name_matches =
         openvino_gpu_full_name.as_deref().is_some_and(name_matches_arc_140v);
 
-    let available =
-        opencl_device.is_some() || !level_zero_devices.is_empty() || openvino_name_matches;
+    let mut identity_evidence = Vec::new();
+    if let Some(device) = opencl_device {
+        identity_evidence.push(format!("opencl:{}", device.device_name));
+    }
+    identity_evidence
+        .extend(level_zero_devices.iter().map(|device| format!("level_zero:{device}")));
+    if level_zero_pci_match {
+        identity_evidence.push(format!("level_zero_pci_device_id:{INTEL_ARC_140V_PCI_DEVICE_ID}"));
+    }
+    if let (Some(token), Some(full_name)) = (&openvino_gpu_device, &openvino_gpu_full_name) {
+        if openvino_name_matches {
+            identity_evidence.push(format!("openvino:{token}:{full_name}"));
+        }
+    }
+
+    let opencl_available = opencl_device.is_some();
+    let level_zero_available = !level_zero_devices.is_empty() || level_zero_pci_match;
+    let available = opencl_available || level_zero_available || openvino_name_matches;
+    let selected_backend = selected_backend(opencl_available, openvino_name_matches);
+    let runtime_api =
+        selected_runtime_api(opencl_available, level_zero_available, openvino_name_matches);
     let failure_reason = if available {
         None
     } else {
@@ -73,19 +115,25 @@ pub fn probe_intel_arc_140v(
     };
 
     IntelArc140vProbe {
+        proof_stage: INTEL_ARC_140V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        requested_backend: INTEL_ARC_140V_REQUESTED_BACKEND.to_owned(),
+        selected_backend,
+        runtime_api,
         available,
-        pci_device_id: available.then_some(ARC_140V_PCI_DEVICE_ID.to_owned()),
-        opencl_available: opencl_device.is_some(),
+        pci_device_id: available.then_some(INTEL_ARC_140V_PCI_DEVICE_ID.to_owned()),
+        identity_evidence,
+        opencl_available,
         opencl_platform_name: opencl_device.and_then(|device| device.platform_name.clone()),
         opencl_device_name: opencl_device.map(|device| device.device_name.clone()),
         opencl_driver_version: opencl_device.and_then(|device| device.driver_version.clone()),
-        level_zero_available: !level_zero_devices.is_empty(),
+        level_zero_available,
         level_zero_devices,
         openvino_gpu_visible,
         openvino_gpu_device,
         openvino_gpu_full_name,
         shared_memory_bytes: memory.shared_memory_bytes,
         power_mode: power.mode.clone(),
+        fallback_used: false,
         failure_reason,
     }
 }
@@ -93,4 +141,175 @@ pub fn probe_intel_arc_140v(
 fn name_matches_arc_140v(value: &str) -> bool {
     let lower = value.to_ascii_lowercase();
     (lower.contains("arc") && lower.contains("140v")) || lower.contains("64a0")
+}
+
+fn device_id_matches_arc_140v(value: &str) -> bool {
+    let normalized = value.trim().to_ascii_uppercase();
+    normalized == INTEL_ARC_140V_PCI_DEVICE_ID
+        || normalized.trim_start_matches("0X") == "64A0"
+        || normalized.contains("64A0")
+}
+
+fn selected_backend(opencl_available: bool, openvino_name_matches: bool) -> Option<String> {
+    if opencl_available {
+        Some(INTEL_ARC_140V_OPENCL_BACKEND.to_owned())
+    } else if openvino_name_matches {
+        Some(INTEL_ARC_140V_OPENVINO_GPU_BACKEND.to_owned())
+    } else {
+        None
+    }
+}
+
+fn selected_runtime_api(
+    opencl_available: bool,
+    level_zero_available: bool,
+    openvino_name_matches: bool,
+) -> Option<String> {
+    if opencl_available {
+        Some("opencl".to_owned())
+    } else if openvino_name_matches {
+        Some("openvino".to_owned())
+    } else if level_zero_available {
+        Some("level_zero".to_owned())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtimes::{
+        LevelZeroProbe, OpenClRuntimeDevice, OpenClRuntimeProbe, OpenVinoDeviceProbe, OpenVinoProbe,
+    };
+
+    fn memory() -> PlatformMemoryProbe {
+        PlatformMemoryProbe {
+            total_bytes: Some(32 * 1024 * 1024 * 1024),
+            shared_memory_bytes: Some(32 * 1024 * 1024 * 1024),
+            shared_memory: true,
+        }
+    }
+
+    fn power() -> PlatformPowerProbe {
+        PlatformPowerProbe {
+            mode: Some("balanced".to_owned()),
+            thermal_profile: None,
+            ac_power: Some(true),
+        }
+    }
+
+    #[test]
+    fn opencl_arc_140v_identity_selects_native_lane_without_fallback() {
+        let opencl = OpenClRuntimeProbe {
+            runtime_available: true,
+            devices: vec![OpenClRuntimeDevice {
+                platform_name: Some("Intel(R) OpenCL Graphics".to_owned()),
+                device_name: "Intel(R) Arc(TM) 140V Graphics".to_owned(),
+                vendor: "Intel(R) Corporation".to_owned(),
+                driver_version: Some("test-driver".to_owned()),
+                is_gpu: true,
+            }],
+            error: None,
+        };
+        let level_zero = LevelZeroProbe::unavailable("not installed");
+        let openvino = OpenVinoProbe::unavailable("not installed");
+
+        let probe = probe_intel_arc_140v(&opencl, &level_zero, &openvino, &memory(), &power());
+
+        assert!(probe.available);
+        assert!(probe.opencl_available);
+        assert_eq!(probe.selected_backend.as_deref(), Some(INTEL_ARC_140V_OPENCL_BACKEND));
+        assert_eq!(probe.runtime_api.as_deref(), Some("opencl"));
+        assert_eq!(probe.pci_device_id.as_deref(), Some(INTEL_ARC_140V_PCI_DEVICE_ID));
+        assert!(!probe.fallback_used);
+        assert!(probe.identity_evidence.iter().any(|entry| entry.starts_with("opencl:")));
+    }
+
+    #[test]
+    fn level_zero_pci_id_is_sufficient_for_runtime_detected_identity() {
+        let opencl = OpenClRuntimeProbe::unavailable("not installed");
+        let level_zero = LevelZeroProbe {
+            runtime_available: true,
+            devices: Vec::new(),
+            device_ids: vec!["0x64A0".to_owned()],
+            error: None,
+        };
+        let openvino = OpenVinoProbe::unavailable("not installed");
+
+        let probe = probe_intel_arc_140v(&opencl, &level_zero, &openvino, &memory(), &power());
+
+        assert!(probe.available);
+        assert!(probe.level_zero_available);
+        assert_eq!(probe.selected_backend, None);
+        assert_eq!(probe.runtime_api.as_deref(), Some("level_zero"));
+        assert!(probe.identity_evidence.iter().any(|entry| entry.contains("64A0")));
+    }
+
+    #[test]
+    fn openvino_gpu_full_name_selects_reference_lane() {
+        let opencl = OpenClRuntimeProbe::unavailable("not installed");
+        let level_zero = LevelZeroProbe::unavailable("not installed");
+        let openvino = OpenVinoProbe {
+            runtime_available: true,
+            version: Some("2026.1".to_owned()),
+            available_devices: vec!["CPU".to_owned(), "GPU.0".to_owned()],
+            devices: vec![OpenVinoDeviceProbe {
+                device: "GPU.0".to_owned(),
+                full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
+                supported_properties: Vec::new(),
+            }],
+            error: None,
+        };
+
+        let probe = probe_intel_arc_140v(&opencl, &level_zero, &openvino, &memory(), &power());
+
+        assert!(probe.available);
+        assert!(probe.openvino_gpu_visible);
+        assert_eq!(probe.selected_backend.as_deref(), Some(INTEL_ARC_140V_OPENVINO_GPU_BACKEND));
+        assert_eq!(probe.runtime_api.as_deref(), Some("openvino"));
+        assert!(probe.identity_evidence.iter().any(|entry| entry.starts_with("openvino:")));
+    }
+
+    #[test]
+    fn generic_gpu_visibility_is_not_arc_140v_identity() {
+        let opencl = OpenClRuntimeProbe {
+            runtime_available: true,
+            devices: vec![OpenClRuntimeDevice {
+                platform_name: Some("Intel(R) OpenCL Graphics".to_owned()),
+                device_name: "Intel(R) UHD Graphics".to_owned(),
+                vendor: "Intel(R) Corporation".to_owned(),
+                driver_version: Some("test-driver".to_owned()),
+                is_gpu: true,
+            }],
+            error: None,
+        };
+        let level_zero = LevelZeroProbe {
+            runtime_available: true,
+            devices: vec!["Intel(R) UHD Graphics".to_owned()],
+            device_ids: vec!["0x5917".to_owned()],
+            error: None,
+        };
+        let openvino = OpenVinoProbe {
+            runtime_available: true,
+            version: Some("2026.1".to_owned()),
+            available_devices: vec!["GPU.0".to_owned()],
+            devices: vec![OpenVinoDeviceProbe {
+                device: "GPU.0".to_owned(),
+                full_name: Some("Intel(R) UHD Graphics 620".to_owned()),
+                supported_properties: Vec::new(),
+            }],
+            error: None,
+        };
+
+        let probe = probe_intel_arc_140v(&opencl, &level_zero, &openvino, &memory(), &power());
+
+        assert!(!probe.available);
+        assert!(!probe.opencl_available);
+        assert!(!probe.level_zero_available);
+        assert!(probe.openvino_gpu_visible);
+        assert_eq!(probe.selected_backend, None);
+        assert_eq!(probe.runtime_api, None);
+        assert!(probe.failure_reason.is_some());
+    }
 }

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs
@@ -96,10 +96,10 @@ pub fn probe_intel_arc_140v(
     if level_zero_pci_match {
         identity_evidence.push(format!("level_zero_pci_device_id:{INTEL_ARC_140V_PCI_DEVICE_ID}"));
     }
-    if let (Some(token), Some(full_name)) = (&openvino_gpu_device, &openvino_gpu_full_name) {
-        if openvino_name_matches {
-            identity_evidence.push(format!("openvino:{token}:{full_name}"));
-        }
+    if let (Some(token), Some(full_name)) = (&openvino_gpu_device, &openvino_gpu_full_name)
+        && openvino_name_matches
+    {
+        identity_evidence.push(format!("openvino:{token}:{full_name}"));
     }
 
     let opencl_available = opencl_device.is_some();

--- a/crates/bitnet-device-probe/src/runtimes/level_zero.rs
+++ b/crates/bitnet-device-probe/src/runtimes/level_zero.rs
@@ -11,6 +11,8 @@ pub struct LevelZeroProbe {
     pub runtime_available: bool,
     /// Best-effort device names parsed from `ze_info` or `sycl-ls`.
     pub devices: Vec<String>,
+    /// Best-effort PCI/device IDs parsed from `ze_info`.
+    pub device_ids: Vec<String>,
     /// Non-fatal probe error when the runtime tooling was absent or unusable.
     pub error: Option<String>,
 }
@@ -18,7 +20,12 @@ pub struct LevelZeroProbe {
 impl LevelZeroProbe {
     /// Build an unavailable Level Zero probe result.
     pub fn unavailable(reason: impl Into<String>) -> Self {
-        Self { runtime_available: false, devices: Vec::new(), error: Some(reason.into()) }
+        Self {
+            runtime_available: false,
+            devices: Vec::new(),
+            device_ids: Vec::new(),
+            error: Some(reason.into()),
+        }
     }
 }
 
@@ -27,12 +34,18 @@ pub fn probe_level_zero() -> LevelZeroProbe {
     match command_output("ze_info", std::iter::empty::<&str>()) {
         Ok(stdout) => {
             let devices = parse_ze_info_devices(&stdout);
-            LevelZeroProbe { runtime_available: true, devices, error: None }
+            let device_ids = parse_ze_info_device_ids(&stdout);
+            LevelZeroProbe { runtime_available: true, devices, device_ids, error: None }
         }
         Err(ze_error) => match command_output("sycl-ls", std::iter::empty::<&str>()) {
             Ok(stdout) => {
                 let devices = parse_sycl_ls_level_zero_devices(&stdout);
-                LevelZeroProbe { runtime_available: !devices.is_empty(), devices, error: None }
+                LevelZeroProbe {
+                    runtime_available: !devices.is_empty(),
+                    devices,
+                    device_ids: Vec::new(),
+                    error: None,
+                }
             }
             Err(sycl_error) => LevelZeroProbe::unavailable(format!("{ze_error}; {sycl_error}")),
         },
@@ -52,6 +65,24 @@ pub(crate) fn parse_ze_info_devices(output: &str) -> Vec<String> {
         .collect()
 }
 
+pub(crate) fn parse_ze_info_device_ids(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            let lower = trimmed.to_ascii_lowercase();
+            if !(lower.starts_with("device id") || lower.starts_with("deviceid")) {
+                return None;
+            }
+            let value = trimmed
+                .split_once(':')
+                .map(|(_, value)| value.trim())
+                .or_else(|| trimmed.split_once('=').map(|(_, value)| value.trim()))?;
+            normalize_device_id(value)
+        })
+        .collect()
+}
+
 pub(crate) fn parse_sycl_ls_level_zero_devices(output: &str) -> Vec<String> {
     output
         .lines()
@@ -59,4 +90,32 @@ pub(crate) fn parse_sycl_ls_level_zero_devices(output: &str) -> Vec<String> {
         .map(|line| line.trim().to_owned())
         .filter(|line| !line.is_empty())
         .collect()
+}
+
+fn normalize_device_id(value: &str) -> Option<String> {
+    let trimmed = value.trim().trim_matches(['"', '\'']);
+    if trimmed.is_empty() {
+        return None;
+    }
+    let hex = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")).unwrap_or(trimmed);
+    if hex.is_empty() || !hex.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(format!("0x{}", hex.to_ascii_uppercase()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_level_zero_device_ids_from_ze_info() {
+        let output = r#"
+            Device Name       : Intel(R) Arc(TM) 140V Graphics
+            Device ID         : 0x64a0
+            DeviceId          : 64A0
+        "#;
+
+        assert_eq!(parse_ze_info_device_ids(output), vec!["0x64A0", "0x64A0"]);
+    }
 }

--- a/crates/bitnet-device-probe/src/runtimes/level_zero.rs
+++ b/crates/bitnet-device-probe/src/runtimes/level_zero.rs
@@ -110,11 +110,11 @@ mod tests {
 
     #[test]
     fn parses_level_zero_device_ids_from_ze_info() {
-        let output = r#"
+        let output = r"
             Device Name       : Intel(R) Arc(TM) 140V Graphics
             Device ID         : 0x64a0
             DeviceId          : 64A0
-        "#;
+        ";
 
         assert_eq!(parse_ze_info_device_ids(output), vec!["0x64A0", "0x64A0"]);
     }

--- a/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
+++ b/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
@@ -26,8 +26,13 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
             scheduler_hint: Some("record topology context".to_owned()),
         },
         arc140v: IntelArc140vProbe {
+            proof_stage: LNL258V_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+            requested_backend: "intel-arc-140v".to_owned(),
+            selected_backend: Some("intel-arc-140v-opencl".to_owned()),
+            runtime_api: Some("opencl".to_owned()),
             available: true,
             pci_device_id: Some("0x64A0".to_owned()),
+            identity_evidence: vec!["opencl:Intel(R) Arc(TM) 140V Graphics".to_owned()],
             opencl_available: true,
             opencl_platform_name: Some("Intel(R) OpenCL Graphics".to_owned()),
             opencl_device_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
@@ -39,6 +44,7 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
             openvino_gpu_full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
             shared_memory_bytes: Some(32 * 1024 * 1024 * 1024),
             power_mode: Some("balanced".to_owned()),
+            fallback_used: false,
             failure_reason: None,
         },
         npu: IntelNpuProbe {
@@ -113,7 +119,11 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
     assert_eq!(value["fallback_used"], false);
     assert_eq!(value["cpu"]["has_avx2"], true);
     assert_eq!(value["cpu"]["has_avx512"], false);
+    assert_eq!(value["arc140v"]["proof_stage"], "runtime_detected");
+    assert_eq!(value["arc140v"]["selected_backend"], "intel-arc-140v-opencl");
+    assert_eq!(value["arc140v"]["runtime_api"], "opencl");
     assert_eq!(value["arc140v"]["openvino_gpu_device"], "GPU.0");
+    assert_eq!(value["arc140v"]["fallback_used"], false);
     assert_eq!(value["npu"]["requested_backend"], "intel-npu");
     assert_eq!(value["npu"]["selected_backend"], "intel-npu-openvino");
     assert_eq!(value["npu"]["runtime_api"], "openvino");

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -77,6 +77,7 @@ Record these before moving any 258V hardware lane beyond `scaffold`:
 - OpenVINO `NPU` smoke does not prove full BitNet inference.
 - CPU or GPU fallback cannot count as NPU execution.
 - 258V CPU validation must record artifacts without reshaping shared CPU implementation unless explicitly scoped by a ledger item.
+- Arc 140V visibility must preserve `requested_backend`, `selected_backend`, runtime API, exact device identity evidence, and `fallback_used=false`; generic Intel GPU visibility is not enough.
 
 ## Windows PowerShell Bundle
 

--- a/docs/specs/intel-lunar-lake-gpu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-gpu-roadmap.md
@@ -104,8 +104,13 @@ Suggested probe result:
 
 ```rust
 pub struct IntelArc140vProbe {
+    pub proof_stage: String,
+    pub requested_backend: String,
+    pub selected_backend: Option<String>,
+    pub runtime_api: Option<String>,
     pub available: bool,
     pub pci_device_id: Option<String>,
+    pub identity_evidence: Vec<String>,
     pub opencl_available: bool,
     pub opencl_platform_name: Option<String>,
     pub opencl_device_name: Option<String>,
@@ -116,9 +121,12 @@ pub struct IntelArc140vProbe {
     pub openvino_gpu_full_name: Option<String>,
     pub shared_memory_bytes: Option<u64>,
     pub power_mode: Option<String>,
+    pub fallback_used: bool,
     pub failure_reason: Option<String>,
 }
 ```
+
+For `ARC140V-002`, exact identity can come from OpenCL device name, Level Zero device name, Level Zero PCI/device ID `0x64A0`, or OpenVINO `GPU.0` full device name. Generic Intel GPU visibility is not sufficient.
 
 ## Receipt Fields
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "LNL258V-RUN-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v/LNL258V-RUN-001-platform-probe"
 stackable = false
 requires_human_merge = true
@@ -61,6 +61,51 @@ must_not_claim = [
   "Arc 140V execution works.",
   "Intel NPU execution works.",
   "NPU accelerates BitNet.",
+]
+
+[[work_item]]
+id = "ARC140V-002"
+status = "in_progress"
+branch = "codex/intel-arc/ARC140V-002-runtime-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = ["LNL258V-RUN-001"]
+acceptance = "Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false."
+commands = [
+  "cargo test --locked -p bitnet-device-probe --no-default-features lunar_lake -- --nocapture",
+  "cargo test --locked -p bitnet-device-probe --no-default-features level_zero -- --nocapture",
+  "cargo test --locked -p bitnet-device-probe --no-default-features --features cpu",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs",
+  "crates/bitnet-device-probe/src/runtimes/opencl.rs",
+  "crates/bitnet-device-probe/src/runtimes/level_zero.rs",
+  "crates/bitnet-device-probe/src/runtimes/openvino.rs",
+  "crates/bitnet-device-probe/tests/**",
+  "docs/specs/intel-lunar-lake-gpu-roadmap.md",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Arc 140V runtime visibility is recorded when OpenCL, Level Zero, or OpenVINO GPU.0 exact identity evidence is present.",
+]
+must_not_claim = [
+  "Arc 140V OpenCL execution works.",
+  "OpenVINO GPU.0 smoke proves native OpenCL kernels.",
+  "BitNet inference works on Arc 140V.",
 ]
 
 [[work_item]]

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -65,7 +65,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "ARC140V-002"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/intel-arc/ARC140V-002-runtime-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120135Z-LNL258V-RUN-001-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120135Z-LNL258V-RUN-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:01:35Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-RUN-001"
+event = "merged"
+pr = 3714
+merge_sha = "4dfd156a7e731ccf57f70213566ad63f668a98af"
+actor = "codex"
+
+notes = [
+  "Recorded merge of the Lunar Lake platform visibility probe.",
+  "Next non-overlapping platform work is exact Arc 140V runtime visibility.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120136Z-ARC140V-002-in-progress.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120136Z-ARC140V-002-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T12:01:36Z"
+campaign = "intel-258v-platform"
+item = "ARC140V-002"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started exact Arc 140V runtime visibility probe work on the Lunar Lake validation lane.",
+  "Scope is device-probe and tracker only; no inference, OpenCL kernel execution, or OpenVINO graph smoke claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120506Z-ARC140V-002-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T120506Z-ARC140V-002-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:05:06Z"
+campaign = "intel-258v-platform"
+item = "ARC140V-002"
+event = "pr_open"
+pr = 3727
+head_sha = "af4453347a798e0520be6d47516096a10a490d21"
+actor = "codex"
+
+notes = [
+  "Opened the exact Arc 140V runtime identity probe PR.",
+  "The PR records runtime_detected visibility only and does not claim OpenCL execution, OpenVINO graph smoke, or BitNet inference.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| ARC140V-002 | in_progress | TBD | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
+| ARC140V-002 | pr_open | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -9,7 +9,8 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| LNL258V-RUN-001 | pr_open | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
+| ARC140V-002 | in_progress | TBD | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T120354Z-NPU-002-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T120354Z-NPU-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:03:54Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "merged"
+pr = 3722
+merge_sha = "20688198547dbb29a14e31fbdcf46c8c703a2a86"
+actor = "codex"
+
+notes = [
+  "Recorded merge of Intel NPU backend identity preservation.",
+  "Runtime detection, OpenVINO NPU probing, graph smoke, and BitNet subgraph work remain follow-up items.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T120935Z-RTX5070TI-005-pr-open.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-06T120935Z-RTX5070TI-005-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:09:35Z"
+campaign = "nvidia-5070ti"
+item = "RTX5070TI-005"
+event = "pr_open"
+pr = 3723
+head_sha = "425bc737ac6170e2b6865bb359d84f01d067c469"
+actor = "codex"
+
+notes = [
+  "Synced live GitHub PR state for the RTX 5070 Ti CUDA smoke receipt PR.",
+  "Tracker-only reconciliation so campaign doctor can match the open RTX5070TI-005 claim.",
+]

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,6 +4,5 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-005b | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,5 +4,6 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-005b | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
+| intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -25,6 +25,7 @@
 | cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | proposed |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
+| intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | in_progress |
 | intel-npu | NPU-003 | NPU-002 | pr_open |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -25,7 +25,7 @@
 | cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | proposed |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
-| intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | in_progress |
+| intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | pr_open |
 | intel-npu | NPU-003 | NPU-002 | pr_open |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | ARC140V-002 | TBD | in_progress | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-003 | #3739 | pr_open | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-006 | TBD | ready | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | ARC140V-002 | TBD | in_progress | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | ARC140V-002 | #3727 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-003 | #3739 | pr_open | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-006 | TBD | ready | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005b | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | ARC140V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-006 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
Work item: ARC140V-002

## Summary
- tighten the Lunar Lake Arc 140V probe into a lane-specific runtime identity record with proof_stage, requested/selected backend, runtime API, identity evidence, and fallback_used=false
- parse Level Zero device IDs so PCI ID 0x64A0 can establish Arc 140V runtime_detected visibility even when names are sparse
- update the 258V/Arc docs and record completed LNL258V-RUN-001 and NPU-002 tracker state

## Claim boundary
- detection/runtime visibility only
- no BitNet inference
- no OpenCL kernel execution
- no OpenVINO graph smoke
- no Arc 140V acceleration claim

## Verification
- rustfmt --check crates/bitnet-device-probe/src/intel/lunar_lake/arc140v.rs crates/bitnet-device-probe/src/runtimes/level_zero.rs crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
- cargo test --locked -p bitnet-device-probe --no-default-features lunar_lake -- --nocapture
- cargo test --locked -p bitnet-device-probe --no-default-features level_zero -- --nocapture
- cargo test --locked -p bitnet-device-probe --no-default-features
- cargo test --locked -p bitnet-device-probe --no-default-features --features cpu
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Intel Arc 140V GPU detection now exposes enhanced metadata including selected backend, runtime API, device identity evidence, and fallback status.
  * Level Zero runtime probing now extracts and reports PCI device IDs.

* **Documentation**
  * Updated Arc 140V GPU specification and validation documentation with new metadata field definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->