### PR TITLE
perf(ci): narrow ci-core triggers to compile-affecting paths

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,9 +1,9 @@
 name: CI (Core)
 
 # Core gating checks that MUST pass for PR merges (Linux-only).
-# This workflow is designed to be fast, reliable, and reproducible locally via ci/local.sh
-# Note: This workflow triggers on changes to crates/**, crossval/**, tests/**, xtask/**, fuzz/**, Cargo.{toml,lock}, .github/workflows/**, .github/images/**, .github/pull_request_template.md, .github/ISSUE_TEMPLATE/**, README.md, docs/**, SECURITY.md
-# Workflow hardening: concurrency + timeouts applied across all workflows in #485
+# This workflow is designed to be fast, reliable, and reproducible locally via ci/local.sh.
+# Triggers are scoped to inputs that affect Rust compilation/tests. Docs and meta-only
+# changes are handled by markdownlint, link-check, docs-automation, and similar workflows.
 
 on:
   pull_request:
@@ -13,24 +13,11 @@ on:
       - 'crossval/**'
       - 'tests/**'
       - 'xtask/**'
+      - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/**'
-      - '.github/images/**'
-      - '.github/pull_request_template.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/copilot-instructions.md'
-      - '.gitignore'
-      - 'README.md'
-      - 'docs/**'
-      - 'CLAUDE.md'
-      - 'CHANGELOG.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'COMPATIBILITY.md'
-      - 'THIRD_PARTY.md'
-      - '.github/settings.yml'
-      - 'fuzz/**'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/ci-core.yml'
   push:
     branches: [ main ]
     paths:
@@ -38,24 +25,11 @@ on:
       - 'crossval/**'
       - 'tests/**'
       - 'xtask/**'
+      - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - '.github/workflows/**'
-      - '.github/images/**'
-      - '.github/pull_request_template.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/copilot-instructions.md'
-      - '.gitignore'
-      - 'README.md'
-      - 'docs/**'
-      - 'CLAUDE.md'
-      - 'CHANGELOG.md'
-      - 'CONTRIBUTING.md'
-      - 'SECURITY.md'
-      - 'COMPATIBILITY.md'
-      - 'THIRD_PARTY.md'
-      - '.github/settings.yml'
-      - 'fuzz/**'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/ci-core.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

CI (Core) currently triggers on docs and meta-only paths (`README.md`, `docs/**`, `CLAUDE.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `COMPATIBILITY.md`, `THIRD_PARTY.md`, `.gitignore`, `.github/images/**`, `.github/ISSUE_TEMPLATE/**`, `.github/pull_request_template.md`, `.github/copilot-instructions.md`, `.github/settings.yml`, and the entirety of `.github/workflows/**`).

None of those paths can change Rust compilation or test outcomes, but each one currently pays the full Linux build/test, BDD grid, Linux clippy, macOS ARM64 clippy, and docs-build cost on every PR.

This PR narrows the trigger paths to inputs that actually affect Rust compilation/tests:
- `crates/**`, `crossval/**`, `tests/**`, `xtask/**`, `fuzz/**`
- `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`
- `.github/workflows/ci-core.yml` (so changes to this workflow itself are still tested)

Docs and meta paths are already covered by `markdownlint.yml`, `link-check.yml`, `docs-automation.yml`, `guards.yml`, and `pr-size-guard.yml`.

This is part of the multi-PR CI efficiency program; subsequent PRs will narrow GPU CI paths, normalize cache policy across compile-heavy lanes, demote the property-tests smoke job, and area-gate compatibility lanes.

## Test plan

- [ ] Confirm CI Core does not run on a docs-only PR.
- [ ] Confirm CI Core still runs when this workflow file is edited.
- [ ] Confirm CI Core still runs on `crates/**` / `Cargo.lock` / `tests/**` PRs.
- [ ] Verify branch protection still resolves: `ci-core-success` (the existing summary gate) is unchanged.

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_