### PR TITLE
perf(ci): make matrix caches restore-only on PRs

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -133,7 +133,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          key: feature-matrix-${{ matrix.label }}
+          shared-key: feature-matrix-${{ matrix.label }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo check ${{ matrix.label }}
         # continue-on-error at step level: step conclusion = success even on failure,
@@ -202,7 +203,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          key: crate-check-${{ matrix.crate }}-${{ matrix.label }}
+          shared-key: crate-check-${{ matrix.crate }}-${{ matrix.label }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: cargo check -p ${{ matrix.crate }} (${{ matrix.label }})
         # continue-on-error for GPU/oneapi checks that require CUDA/OpenCL runtime

--- a/.github/workflows/gpu-ci-matrix.yml
+++ b/.github/workflows/gpu-ci-matrix.yml
@@ -114,7 +114,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          key: gpu-ci-${{ matrix.label }}
+          shared-key: gpu-ci-${{ matrix.label }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Compile check (${{ matrix.label }})
         continue-on-error: ${{ matrix.allow_failure == true }}
@@ -147,7 +148,8 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
-          key: gpu-ci-cpu-test
+          shared-key: gpu-ci-cpu-test
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Run CPU tests
         run: |


### PR DESCRIPTION
## Summary

Several matrix lanes call `Swatinem/rust-cache` with `key:` (exact-match, always-save). Every PR run therefore writes a fresh cache for its shard. With ~13 entries in the full feature matrix, ~8 in the targeted crate-check matrix, and 5 in the GPU native-compile matrix, this is upwards of 25 cache writes per opt-in PR / main run — wasted Actions minutes and pressure on the 10 GiB per-repo cache limit (which evicts useful caches).

Switch those callsites to `shared-key:` plus `save-if: ${{ github.ref == 'refs/heads/main' }}`. PR runs still **restore** the most recent main cache for warm builds but no longer save back, so saves are limited to the canonical mainline jobs. This matches the policy `ci-core.yml` already uses and the report's recommendation.

Touched lanes:
- `feature-matrix.yml`: `compile-check` (full matrix), `crate-feature-check`
- `gpu-ci-matrix.yml`: `native-compile`, `cpu-tests`

## Test plan

- [ ] PR run shows cache restore (hit/miss) but no cache save step.
- [ ] Main-branch run (or workflow_dispatch from main) writes the cache.
- [ ] First PR after merge benefits from a warm restore.

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_