### PR TITLE
[codex][apple-m4] Add M4 Metal benchmark baseline (M4-009)

### DIFF
--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -89,6 +89,7 @@ mod live_metal {
     use std::error::Error;
     use std::io;
     use std::path::Path;
+    use std::time::{Duration, Instant};
     use wgpu::util::DeviceExt;
 
     const RUN_ENV: &str = "BITNET_RUN_M4_METAL_SMOKE";
@@ -97,10 +98,29 @@ mod live_metal {
     const RUN_PARITY_ENV: &str = "BITNET_RUN_M4_METAL_PARITY";
     const PARITY_RECEIPT_ENV: &str = "BITNET_M4_METAL_PARITY_RECEIPT";
     const PARITY_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_PARITY_ARTIFACT_PATH";
+    const RUN_BENCHMARK_ENV: &str = "BITNET_RUN_M4_METAL_BENCHMARK";
+    const BENCHMARK_RECEIPT_ENV: &str = "BITNET_M4_METAL_BENCHMARK_RECEIPT";
+    const BENCHMARK_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_BENCHMARK_ARTIFACT_PATH";
+    const BENCHMARK_ITERATIONS_ENV: &str = "BITNET_M4_METAL_BENCHMARK_ITERATIONS";
+    const TINY_KERNEL_SMOKE_PROFILE: &str = "tiny_kernel_smoke";
 
     struct MetalSmokeOutput {
         adapter_name: String,
         output: Vec<f32>,
+    }
+
+    struct MetalBenchmarkOutput {
+        adapter_name: String,
+        output: Vec<f32>,
+        timing: BenchmarkTiming,
+    }
+
+    struct BenchmarkTiming {
+        compile: Duration,
+        first_dispatch: Duration,
+        steady_state: Duration,
+        cpu_reference: Duration,
+        iterations: u32,
     }
 
     #[test]
@@ -212,6 +232,68 @@ mod live_metal {
         );
 
         if let Ok(path) = std::env::var(PARITY_RECEIPT_ENV) {
+            if let Some(parent) = Path::new(&path).parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiny_m4_metal_add_benchmark_records_cpu_reference_when_enabled() -> Result<(), Box<dyn Error>>
+    {
+        if std::env::var(RUN_BENCHMARK_ENV).as_deref() != Ok("1") {
+            eprintln!("skipping live M4 Metal benchmark; set {RUN_BENCHMARK_ENV}=1 to run it");
+            return Ok(());
+        }
+
+        let iterations = benchmark_iterations()?;
+        let (lhs, rhs) = tiny_add_inputs();
+
+        let cpu_reference_start = Instant::now();
+        let expected = expected_tiny_add(&lhs, &rhs)?;
+        let cpu_reference = cpu_reference_start.elapsed();
+
+        let benchmark_output = run_tiny_add_benchmark(&lhs, &rhs, iterations, cpu_reference)?;
+        if !is_apple_m4_adapter_name(&benchmark_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-009 benchmark requires an Apple M4-family Metal adapter; found '{}'",
+                benchmark_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&expected, &benchmark_output.output, 1e-6)?;
+        let artifact_path = std::env::var(BENCHMARK_ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(BENCHMARK_RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-benchmark.json".to_string()
+            });
+
+        let mut receipt_json = apple_backend_receipt_json(
+            MACHINE_ID,
+            "benchmark",
+            REQUESTED_BACKEND,
+            Some(SELECTED_BACKEND),
+            RUNTIME_API,
+            benchmark_output.adapter_name,
+            false,
+            artifact_path.clone(),
+            Some(TINY_METAL_ADD_SMOKE_KERNEL_ID),
+            None,
+            "pass",
+        )?;
+        extend_benchmark_metrics(
+            &mut receipt_json,
+            expected.len(),
+            &benchmark_output.timing,
+            comparison.max_abs_error,
+            comparison.mean_abs_error,
+        );
+
+        if let Ok(path) = std::env::var(BENCHMARK_RECEIPT_ENV) {
             if let Some(parent) = Path::new(&path).parent() {
                 std::fs::create_dir_all(parent)?;
             }
@@ -351,6 +433,192 @@ mod live_metal {
         })
     }
 
+    fn run_tiny_add_benchmark(
+        lhs: &[f32],
+        rhs: &[f32],
+        iterations: u32,
+        cpu_reference: Duration,
+    ) -> Result<MetalBenchmarkOutput, Box<dyn Error>> {
+        pollster::block_on(async move {
+            let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::METAL,
+                ..Default::default()
+            });
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .ok_or_else(|| io_error("no Metal adapter found for M4-009 benchmark"))?;
+
+            let adapter_info = adapter.get_info();
+            if adapter_info.backend != wgpu::Backend::Metal {
+                return Err(io_error(format!(
+                    "M4-009 benchmark requires Metal backend, found {:?}",
+                    adapter_info.backend
+                )));
+            }
+
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .map_err(|error| io_error(format!("failed to create Metal device: {error}")))?;
+
+            let compile_start = Instant::now();
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(TINY_METAL_ADD_SMOKE_KERNEL_ID),
+                source: wgpu::ShaderSource::Wgsl(TINY_ADD_SHADER.into()),
+            });
+
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("tiny_metal_add_benchmark_layout"),
+                    entries: &[
+                        storage_buffer_entry(0, true),
+                        storage_buffer_entry(1, true),
+                        storage_buffer_entry(2, false),
+                    ],
+                });
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("tiny_metal_add_benchmark_pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tiny_metal_add_benchmark_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+            let compile = compile_start.elapsed();
+
+            let lhs_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_add_benchmark_lhs"),
+                contents: bytemuck::cast_slice(lhs),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let rhs_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_add_benchmark_rhs"),
+                contents: bytemuck::cast_slice(rhs),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let byte_len = std::mem::size_of_val(lhs) as u64;
+            let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_add_benchmark_output"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_add_benchmark_staging"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("tiny_metal_add_benchmark_bind_group"),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry { binding: 0, resource: lhs_buffer.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 1, resource: rhs_buffer.as_entire_binding() },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: output_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+
+            let first_dispatch_start = Instant::now();
+            let mut output = dispatch_tiny_add(
+                &device,
+                &queue,
+                &pipeline,
+                &bind_group,
+                &output_buffer,
+                &staging_buffer,
+                byte_len,
+                lhs.len(),
+            )?;
+            let first_dispatch = first_dispatch_start.elapsed();
+
+            let steady_start = Instant::now();
+            for _ in 0..iterations {
+                output = dispatch_tiny_add(
+                    &device,
+                    &queue,
+                    &pipeline,
+                    &bind_group,
+                    &output_buffer,
+                    &staging_buffer,
+                    byte_len,
+                    lhs.len(),
+                )?;
+            }
+            let steady_state = steady_start.elapsed() / iterations;
+
+            Ok(MetalBenchmarkOutput {
+                adapter_name: adapter_info.name,
+                output,
+                timing: BenchmarkTiming {
+                    compile,
+                    first_dispatch,
+                    steady_state,
+                    cpu_reference,
+                    iterations,
+                },
+            })
+        })
+    }
+
+    fn dispatch_tiny_add(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        pipeline: &wgpu::ComputePipeline,
+        bind_group: &wgpu::BindGroup,
+        output_buffer: &wgpu::Buffer,
+        staging_buffer: &wgpu::Buffer,
+        byte_len: u64,
+        element_count: usize,
+    ) -> Result<Vec<f32>, Box<dyn Error>> {
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("tiny_metal_add_benchmark_encoder"),
+        });
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("tiny_metal_add_benchmark_pass"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(pipeline);
+            pass.set_bind_group(0, bind_group, &[]);
+            pass.dispatch_workgroups((element_count as u32).div_ceil(SMOKE_WORKGROUP_SIZE), 1, 1);
+        }
+
+        encoder.copy_buffer_to_buffer(output_buffer, 0, staging_buffer, 0, byte_len);
+        queue.submit(std::iter::once(encoder.finish()));
+
+        let slice = staging_buffer.slice(..);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).unwrap();
+        });
+        device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .map_err(|error| io_error(format!("failed to receive Metal map result: {error}")))?
+            .map_err(|error| io_error(format!("failed to map Metal benchmark output: {error}")))?;
+
+        let data = slice.get_mapped_range();
+        let output = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+        drop(data);
+        staging_buffer.unmap();
+
+        Ok(output)
+    }
+
     fn storage_buffer_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
         wgpu::BindGroupLayoutEntry {
             binding,
@@ -439,6 +707,72 @@ mod live_metal {
                 "token_agreement_for_greedy": null
             }),
         );
+    }
+
+    fn extend_benchmark_metrics(
+        receipt_json: &mut serde_json::Value,
+        element_count: usize,
+        timing: &BenchmarkTiming,
+        max_abs_error: f32,
+        mean_abs_error: f32,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert("element_count".to_string(), json!(element_count));
+        object.insert(
+            "benchmark".to_string(),
+            json!({
+                "profile": TINY_KERNEL_SMOKE_PROFILE,
+                "reference_backend": REFERENCE_BACKEND,
+                "target_backend": SELECTED_BACKEND,
+                "kernel_id": TINY_METAL_ADD_SMOKE_KERNEL_ID,
+                "max_abs_error": max_abs_error,
+                "mean_abs_error": mean_abs_error
+            }),
+        );
+        object.insert(
+            "timing".to_string(),
+            json!({
+                "compile_ms": duration_ms(timing.compile),
+                "first_dispatch_ms": duration_ms(timing.first_dispatch),
+                "steady_state_ms": duration_ms(timing.steady_state),
+                "cpu_reference_ms": duration_ms(timing.cpu_reference),
+                "iterations": timing.iterations
+            }),
+        );
+        object.insert(
+            "machine".to_string(),
+            json!({
+                "chip": object
+                    .get("resolved_device")
+                    .and_then(|value| value.get("chip"))
+                    .cloned()
+                    .unwrap_or_else(|| json!("unknown")),
+                "memory_gb": null,
+                "power_mode": "unknown",
+                "thermal_state": "unknown"
+            }),
+        );
+    }
+
+    fn duration_ms(duration: Duration) -> f64 {
+        duration.as_secs_f64() * 1_000.0
+    }
+
+    fn benchmark_iterations() -> Result<u32, Box<dyn Error>> {
+        match std::env::var(BENCHMARK_ITERATIONS_ENV) {
+            Ok(value) => {
+                let iterations = value.parse::<u32>().map_err(|error| {
+                    io_error(format!(
+                        "{BENCHMARK_ITERATIONS_ENV} must be a positive integer: {error}"
+                    ))
+                })?;
+                if iterations == 0 {
+                    return Err(io_error(format!("{BENCHMARK_ITERATIONS_ENV} must be positive")));
+                }
+                Ok(iterations)
+            }
+            Err(_) => Ok(10),
+        }
     }
 
     const TINY_ADD_SHADER: &str = r#"

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -249,6 +249,10 @@ Record chip, GPU core count, unified memory, selected backend, fallback status, 
 ### M4-009 - Benchmark Baseline
 
 Compare Apple CPU/NEON against M4 Metal for the validated kernel/subgraph.
+The first baseline is limited to the validated `tiny_metal_add_smoke` kernel and
+records `compile_ms`, `first_dispatch_ms`, `steady_state_ms`, and
+`cpu_reference_ms` in `ci/hardware/apple-m4-mac-mini/<date>/metal-benchmark.json`.
+It is not a general Metal performance claim and is not a BitNet inference claim.
 
 ### M4-010 - Apple CPU/NEON BitNet Reference
 

--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -38,7 +38,7 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-006 | merged | CPU/Metal parity merged in #3709. |
 | M4-007 | merged | MPSGraph tiny graph smoke merged in #3719. |
 | M4-008 | merged | Apple backend receipt identity merged in #3721. |
-| M4-009 | in_progress | Add benchmark baseline after parity and receipt identity. |
+| M4-009 | pr_open | Add benchmark baseline after parity and receipt identity; open in #3732. |
 | M4-010 | proposed | Prove Apple CPU/NEON BitNet reference before native Metal BitNet kernels. |
 | M4-011 | proposed | Run native Metal I2_S smoke/parity, not QK256. |
 | M4-012 | proposed | Investigate TL1 as an ARM-oriented Apple path. |

--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -38,7 +38,7 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-006 | merged | CPU/Metal parity merged in #3709. |
 | M4-007 | merged | MPSGraph tiny graph smoke merged in #3719. |
 | M4-008 | merged | Apple backend receipt identity merged in #3721. |
-| M4-009 | ready | Add benchmark baseline after parity and receipt identity. |
+| M4-009 | in_progress | Add benchmark baseline after parity and receipt identity. |
 | M4-010 | proposed | Prove Apple CPU/NEON BitNet reference before native Metal BitNet kernels. |
 | M4-011 | proposed | Run native Metal I2_S smoke/parity, not QK256. |
 | M4-012 | proposed | Investigate TL1 as an ARM-oriented Apple path. |

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T121238Z-M4-009-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T121238Z-M4-009-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T12:12:38Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started the Apple M4 benchmark baseline for the validated tiny Metal add kernel.",
+  "Scope remains benchmark/test and Apple campaign tracking only; no BitNet inference, QK256, server inference, MPSGraph, Neural Engine, or broad performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T121531Z-M4-009-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T121531Z-M4-009-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:15:31Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "pr_open"
+pr = 3732
+head_sha = "1bd2aa6b5955516d1bbe88aec16ec4e5c0a00231"
+actor = "codex"
+
+notes = [
+  "Opened the M4 Metal benchmark baseline PR.",
+  "Benchmark scope is limited to the validated tiny Metal add kernel with CPU/NEON reference timing; no BitNet inference, QK256, MPSGraph, Neural Engine, or broad performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,7 +17,7 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | in_progress | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-009 | pr_open | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,7 +17,7 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | ready | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-009 | in_progress | TBD | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-009 | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,7 +10,7 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | in_progress |
+| apple-m4 | M4-009 | M4-008 | pr_open |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,7 +10,7 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | ready |
+| apple-m4 | M4-009 | M4-008 | in_progress |
 | apple-m4 | M4-010 | M4-009 | proposed |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | TBD | ready | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-009 | TBD | in_progress | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | TBD | in_progress | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-009 | #3732 | pr_open | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- add an opt-in live M4 Metal benchmark test for the already-validated `tiny_metal_add_smoke` kernel
- emit a benchmark receipt with requested/selected backend, runtime API, fallback=false, CPU reference timing, compile/dispatch timing, and machine context
- update the Apple M4 campaign tracker and roadmap for M4-009

## Claim boundary
This benchmarks only the validated tiny add kernel/subgraph. It does not claim general M4 Metal performance, BitNet inference acceleration, QK256 support, MPSGraph execution, or Neural Engine execution.

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke
- BITNET_RUN_M4_METAL_BENCHMARK=1 BITNET_M4_METAL_BENCHMARK_ARTIFACT_PATH=ci/hardware/apple-m4-mac-mini/2026-05-06/metal-benchmark.json BITNET_M4_METAL_BENCHMARK_RECEIPT=target/bitnet/hardware/apple-m4-mac-mini/2026-05-06/metal-benchmark.json BITNET_M4_METAL_BENCHMARK_ITERATIONS=10 cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_add_benchmark_records_cpu_reference_when_enabled -- --nocapture
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

Note: a broader targeted clippy run with `--features metal --test metal_tiny_smoke` is currently blocked by an existing `manual_is_multiple_of` lint in `crates/bitnet-kernels/src/metal_compute.rs`, outside this item's allowed test/bench scope.

Work item: M4-009
Campaign: apple-m4
