### PR TITLE
[codex][apple-m4] Record M4-009 merge

### DIFF
--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -38,8 +38,8 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-006 | merged | CPU/Metal parity merged in #3709. |
 | M4-007 | merged | MPSGraph tiny graph smoke merged in #3719. |
 | M4-008 | merged | Apple backend receipt identity merged in #3721. |
-| M4-009 | pr_open | Add benchmark baseline after parity and receipt identity; open in #3732. |
-| M4-010 | proposed | Prove Apple CPU/NEON BitNet reference before native Metal BitNet kernels. |
+| M4-009 | merged | Benchmark baseline for the validated tiny Metal add kernel merged in #3732. |
+| M4-010 | ready | Prove Apple CPU/NEON BitNet reference before native Metal BitNet kernels. |
 | M4-011 | proposed | Run native Metal I2_S smoke/parity, not QK256. |
 | M4-012 | proposed | Investigate TL1 as an ARM-oriented Apple path. |
 | M4-013 | proposed | Add receipt-backed Metal prefill/decode contribution. |

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -289,7 +289,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-009"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-009-benchmark-baseline"
 stackable = false
 requires_human_merge = true
@@ -322,7 +322,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-010"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-010-cpu-neon-bitnet-reference"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T123400Z-M4-009-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T123400Z-M4-009-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:34:00Z"
+campaign = "apple-m4"
+item = "M4-009"
+event = "merged"
+pr = 3732
+merge_sha = "07f8e2e5a9657f792367e5f25355adf12a1afc50"
+actor = "maintainer"
+
+notes = [
+  "M4 benchmark baseline merged for the validated tiny Metal add kernel.",
+  "M4-010 Apple CPU/NEON BitNet reference is ready; no full BitNet-on-Metal inference or broad performance claim is made by this closeout.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -17,8 +17,8 @@
 | M4-006 | merged | #3709 | `codex/apple-m4/M4-006-metal-cpu-parity` | Compare one M4 Metal kernel or subgraph output against Apple CPU/NEON without claiming full inference. |
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
-| M4-009 | pr_open | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| M4-010 | proposed | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
+| M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
+| M4-010 | ready | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-009 | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -10,8 +10,8 @@
 | apple-m4 | M4-006 | M4-005 | merged |
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
-| apple-m4 | M4-009 | M4-008 | pr_open |
-| apple-m4 | M4-010 | M4-009 | proposed |
+| apple-m4 | M4-009 | M4-008 | merged |
+| apple-m4 | M4-010 | M4-009 | ready |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-009 | #3732 | pr_open | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | TBD | ready | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-009 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- mark M4-009 merged with PR #3732 merge SHA 07f8e2e5a9657f792367e5f25355adf12a1afc50
- promote M4-010 to ready for Apple CPU/NEON BitNet reference work
- add the append-only M4-009 merged event and regenerate campaign/global dashboards

## Scope
Tracker-only closeout. No runtime code, kernels, QK256, server inference, dependencies, BitNet Metal inference, or benchmark implementation changes.

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

Work item: M4-009 closeout
Campaign: apple-m4
