### PR TITLE
feat(quantization): gate QK256 AVX2 on FMA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,7 @@ version = "0.2.1-dev"
 dependencies = [
  "anyhow",
  "bitnet-common",
+ "bitnet-cpu-detect",
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-qk256-layout-core",

--- a/crates/bitnet-cpu-detect/src/lib.rs
+++ b/crates/bitnet-cpu-detect/src/lib.rs
@@ -45,6 +45,18 @@ pub fn avx2_available() -> bool {
     false
 }
 
+/// Returns true when AVX2 and FMA are both compiled and available at runtime.
+#[must_use]
+pub fn avx2_fma_available() -> bool {
+    #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
+    {
+        return is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
 /// Returns true when NEON is both compiled and available at runtime.
 #[must_use]
 pub fn neon_available() -> bool {
@@ -89,7 +101,7 @@ pub fn best_tier() -> CpuExecutionTier {
 
 #[cfg(test)]
 mod tests {
-    use super::{CpuExecutionTier, available_tiers, best_tier};
+    use super::{CpuExecutionTier, available_tiers, avx2_available, avx2_fma_available, best_tier};
 
     #[test]
     fn scalar_tier_is_always_present() {
@@ -110,5 +122,12 @@ mod tests {
         let tiers = available_tiers();
         let first = tiers.first().copied().unwrap_or(CpuExecutionTier::Scalar);
         assert_eq!(best_tier(), first);
+    }
+
+    #[test]
+    fn avx2_fma_implies_avx2() {
+        if avx2_fma_available() {
+            assert!(avx2_available());
+        }
     }
 }

--- a/crates/bitnet-quantization/Cargo.toml
+++ b/crates/bitnet-quantization/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 tracing.workspace = true
 bitnet-quantization-bits.workspace = true
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true }
+bitnet-cpu-detect = { path = "../bitnet-cpu-detect", version = "0.2.1-dev", default-features = false, optional = true }
 
 [dev-dependencies]
 proptest.workspace = true
@@ -43,6 +44,7 @@ bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev", features = [
 default = []
 cpu = ["bitnet-kernels/cpu"]
 simd = []
+avx2 = ["dep:bitnet-cpu-detect", "bitnet-cpu-detect/avx2"]
 integration-tests = []
 cuda = ["bitnet-kernels/cuda"]
 rocm = ["bitnet-kernels/rocm"]

--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -394,7 +394,7 @@ pub fn qk256_gemm_scalar(
 /// Multi-row GEMV with runtime dispatch: y = Ax where A is quantized QK256, x is dense
 ///
 /// This function automatically selects the best available implementation:
-/// - **AVX2**: x86_64 with AVX2 support (3-5× speedup over scalar)
+/// - **AVX2**: x86_64 with AVX2 and FMA support
 /// - **Scalar**: Fallback for all other cases
 ///
 /// # Arguments
@@ -432,11 +432,11 @@ pub fn gemv_qk256(
         );
     }
 
-    // Runtime dispatch: probe for AVX2 support on x86_64
-    #[cfg(target_arch = "x86_64")]
+    // Runtime dispatch: QK256 AVX2 currently uses FMA intrinsics, so both AVX2 and FMA
+    // must be available before entering the target-feature-gated implementation.
+    #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
     {
-        if is_x86_feature_detected!("avx2") {
-            // Use AVX2 path (3-5× speedup over scalar)
+        if bitnet_cpu_detect::avx2_fma_available() {
             return super::i2s_qk256_avx2::gemv_qk256_avx2(
                 qs_data,
                 x,

--- a/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256_avx2.rs
@@ -21,8 +21,9 @@
 //!
 //! ## Safety
 //!
-//! This module uses `unsafe` blocks for AVX2 intrinsics. All functions are marked
-//! with `#[target_feature(enable = "avx2")]` to ensure proper CPU feature detection.
+//! This module uses `unsafe` blocks for AVX2/FMA intrinsics. FMA-using functions
+//! are marked with `#[target_feature(enable = "avx2,fma")]` and must only be
+//! called after runtime AVX2+FMA detection.
 
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::*;
@@ -38,7 +39,7 @@ use anyhow::Result;
 ///
 /// Then maps codes [0,1,2,3] → weights [-2,-1,+1,+2] via: `weight = code - 2 + (code >> 1) & 1`.
 #[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2")]
+#[target_feature(enable = "avx2,fma")]
 unsafe fn decode_8_weights_avx2(
     byte0: u8,
     byte1: u8,
@@ -77,7 +78,7 @@ unsafe fn decode_8_weights_avx2(
 ///
 /// Requires AVX2 + FMA. Caller must verify via `is_x86_feature_detected!`.
 #[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx2")]
+#[target_feature(enable = "avx2,fma")]
 unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
     let blocks_needed = cols.div_ceil(QK256_BLOCK);
     let expected_bytes = blocks_needed * QK256_PACKED_BYTES;
@@ -231,7 +232,7 @@ unsafe fn gemv_qk256_row_avx2(qs_row: &[u8], x: &[f32], cols: usize) -> f32 {
 /// AVX2-accelerated multi-row GEMV: y = Ax where A is quantized QK256, x is dense
 ///
 /// This is the public interface for AVX2-accelerated QK256 GEMV operations.
-/// Runtime dispatch ensures this function is only called when AVX2 is available.
+/// Runtime dispatch ensures this function is only called when AVX2 and FMA are available.
 ///
 /// # Arguments
 ///
@@ -273,8 +274,12 @@ pub fn gemv_qk256_avx2(
         bail!("AVX2: data too short: {} < {}", qs_data.len(), expected_total);
     }
 
-    // SAFETY: We've verified AVX2 availability via runtime dispatch before calling this function.
-    // All AVX2 intrinsics are properly guarded by #[target_feature(enable = "avx2")].
+    if !avx2_fma_runtime_available() {
+        bail!("AVX2: avx2/fma CPU features are required for qk256 AVX2 GEMV");
+    }
+
+    // SAFETY: AVX2 and FMA availability is verified above before calling target-feature code.
+    // All FMA-using intrinsics are guarded by #[target_feature(enable = "avx2,fma")].
     unsafe {
         for (row, output) in y_out.iter_mut().enumerate().take(rows) {
             // Prefetch next row's first cache line to overlap decode with memory.
@@ -292,6 +297,12 @@ pub fn gemv_qk256_avx2(
     }
 
     Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn avx2_fma_runtime_available() -> bool {
+    is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
 }
 
 /// Stub implementation for non-x86_64 architectures
@@ -321,9 +332,9 @@ mod tests {
     #[test]
     #[cfg(target_arch = "x86_64")]
     fn test_avx2_smoke() {
-        // Skip if AVX2 not available
-        if !is_x86_feature_detected!("avx2") {
-            eprintln!("Skipping AVX2 smoke test: AVX2 not available");
+        // Skip if AVX2/FMA not available
+        if !avx2_fma_runtime_available() {
+            eprintln!("Skipping AVX2 smoke test: AVX2/FMA not available");
             return;
         }
 
@@ -371,9 +382,9 @@ mod tests {
         use rand::{Rng, SeedableRng};
         use rand_chacha::ChaCha8Rng;
 
-        // Skip if AVX2 not available
-        if !is_x86_feature_detected!("avx2") {
-            eprintln!("Skipping AVX2 smoke test: AVX2 not available");
+        // Skip if AVX2/FMA not available
+        if !avx2_fma_runtime_available() {
+            eprintln!("Skipping AVX2 smoke test: AVX2/FMA not available");
             return;
         }
 
@@ -471,9 +482,9 @@ mod tests {
         use rand_chacha::ChaCha8Rng;
         use std::time::Instant;
 
-        // Skip if AVX2 not available
-        if !is_x86_feature_detected!("avx2") {
-            eprintln!("Skipping AVX2 benchmark: AVX2 not available");
+        // Skip if AVX2/FMA not available
+        if !avx2_fma_runtime_available() {
+            eprintln!("Skipping AVX2 benchmark: AVX2/FMA not available");
             return;
         }
 

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -188,18 +188,23 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005"
-status = "ready"
-branch = "codex/cpu-bitnet-005-avx2-gemv"
+status = "pr_open"
+branch = "codex/cpu-bitnet-005a-avx2-fma-gating"
 stackable = false
 requires_human_merge = true
 blocked_by = ["CPU-BITNET-004"]
 acceptance = "CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity."
 commands = [
-  "cargo fmt --all -- --check",
+  "rustfmt crates/bitnet-cpu-detect/src/lib.rs crates/bitnet-quantization/src/i2s_qk256.rs crates/bitnet-quantization/src/i2s_qk256_avx2.rs --edition 2024 --check",
+  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2",
   "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256",
   "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests",
+  "cargo clippy --locked -p bitnet-quantization --all-targets --no-default-features --features cpu,avx2 -- -D warnings",
 ]
 allowed_paths = [
+  "Cargo.lock",
+  "crates/bitnet-cpu-detect/src/lib.rs",
+  "crates/bitnet-quantization/Cargo.toml",
   "crates/bitnet-quantization/src/i2s_qk256.rs",
   "crates/bitnet-quantization/src/i2s_qk256_avx2.rs",
   "crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs",

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T123315Z-CPU-BITNET-005-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T123315Z-CPU-BITNET-005-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:33:15Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005"
+event = "pr_open"
+pr = 3735
+head_sha = "ba2245e4bcebb81218d9337975b5c75187b1e664"
+actor = "codex"
+
+notes = [
+  "Started CPU-BITNET-005 as split PR 005a for AVX2/FMA feature plumbing and safe target-feature gating.",
+  "This PR does not complete proof-level requested/selected kernel dispatch, receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -14,7 +14,7 @@
 | CPU-BITNET-002 | merged | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
-| CPU-BITNET-005 | ready | TBD | `codex/cpu-bitnet-005-avx2-gemv` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
+| CPU-BITNET-005 | pr_open | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| cpu-proof | CPU-BITNET-005 | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -20,7 +20,7 @@
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
-| cpu-proof | CPU-BITNET-005 | CPU-BITNET-004 | ready |
+| cpu-proof | CPU-BITNET-005 | CPU-BITNET-004 | pr_open |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-010 | TBD | ready | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005 | TBD | ready | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-005 | #3735 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- add `avx2_fma_available()` to CPU detection and expose `bitnet-quantization`'s `avx2` feature
- gate QK256 AVX2 runtime dispatch on both AVX2 and FMA instead of AVX2 alone
- mark FMA-using QK256 AVX2 helpers with `#[target_feature(enable = "avx2,fma")]` and keep scalar fallback unchanged

## Scope
CPU-BITNET-005a only. This does not add proof-level requested/selected kernel dispatch, receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse work.

Work item: CPU-BITNET-005
Campaign: cpu-proof

## Validation
- rustfmt crates/bitnet-cpu-detect/src/lib.rs crates/bitnet-quantization/src/i2s_qk256.rs crates/bitnet-quantization/src/i2s_qk256_avx2.rs --edition 2024 --check
- cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2
- cargo test --locked -p bitnet-quantization --lib --no-default-features --features "cpu,avx2" i2s_qk256
- cargo test --locked -p bitnet-quantization --no-default-features --features "cpu,avx2" --test qk256_avx2_parity_tests
- cargo clippy --locked -p bitnet-quantization --all-targets --no-default-features --features "cpu,avx2" -- -D warnings
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check