### PR TITLE
[codex] Fix locked cargo argument placement

### DIFF
--- a/.github/workflows/crossval.yml
+++ b/.github/workflows/crossval.yml
@@ -339,8 +339,7 @@ jobs:
       - name: Build Rust implementation
         run: |
           echo "🔨 Building Rust implementation with crossval features..."
-          cargo build --workspace \ --locked
-            --locked \
+          cargo build --workspace --locked \
             --no-default-features \
             --features "cpu,ffi,crossval"
 
@@ -354,8 +353,7 @@ jobs:
           echo "🧪 Running Lane B cross-validation tests..."
 
           # Run crossval tests with llama.cpp backend
-          cargo test -p bitnet-crossval \ --locked
-            --locked \
+          cargo test -p bitnet-crossval --locked \
             --features "cpu,ffi,crossval" \
             --test dual_backend_integration \
             -- --nocapture
@@ -479,8 +477,7 @@ jobs:
       - name: Build Rust implementation
         run: |
           echo "🔨 Building Rust with BitNet crossval features..."
-          cargo build --workspace \ --locked
-            --locked \
+          cargo build --workspace --locked \
             --no-default-features \
             --features "cpu,ffi,crossval"
 
@@ -491,8 +488,7 @@ jobs:
         run: |
           echo "🧪 Running Lane A cross-validation tests..."
 
-          cargo test -p bitnet-crossval \ --locked
-            --locked \
+          cargo test -p bitnet-crossval --locked \
             --features "cpu,ffi,crossval" \
             --test dual_backend_integration \
             -- --nocapture --ignored

--- a/.github/workflows/quant-matrix.yml
+++ b/.github/workflows/quant-matrix.yml
@@ -68,8 +68,7 @@ jobs:
     - name: Clippy Check
       if: steps.probe.outputs.available == 'true'
       run: |
-        cargo clippy --workspace \ --locked
-          --locked \
+        cargo clippy --workspace --locked \
           --no-default-features \
           --features "${{ matrix.features }}" \
           --all-targets \
@@ -78,8 +77,7 @@ jobs:
     - name: Build
       if: steps.probe.outputs.available == 'true'
       run: |
-        cargo build -p bitnet-cli \ --locked
-          --locked \
+        cargo build -p bitnet-cli --locked \
           --no-default-features \
           --features "${{ matrix.features }}" \
           --release || true
@@ -87,8 +85,7 @@ jobs:
     - name: Run tests
       if: steps.probe.outputs.available == 'true'
       run: |
-        cargo test --workspace \ --locked
-          --locked \
+        cargo test --workspace --locked \
           --no-default-features \
           --features "${{ matrix.features }}" \
           -- --nocapture || true
@@ -185,7 +182,7 @@ jobs:
     - name: Run IQ2_S parity test
       run: |
         # When test slices are committed:
-        cargo test -p bitnet-models \ --locked
+        cargo test -p bitnet-models --locked \
           --no-default-features \
           --features "cpu,iq2s-ffi" \
           --test iq2s_tests \

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       run: cargo deny check
 
     - name: Run clippy security lints
-      run: cargo clippy --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic --locked
+      run: cargo clippy --locked --all-targets --all-features -- -D warnings -D clippy::all -D clippy::pedantic
 
     - name: Check for unsafe code
       run: |


### PR DESCRIPTION
## Summary
- fix malformed `\ --locked` line continuations in quant and crossval workflows
- remove duplicate `--locked` arguments from those cargo commands
- move security clippy `--locked` before cargo's standalone `--` so cargo receives it

## Validation
- `git diff --check`
- `rg -n '\\\\ --locked' .github/workflows/quant-matrix.yml .github/workflows/crossval.yml .github/workflows/security.yml` returned no matches\n- `rg -n --pcre2 '(cargo|cross)\\s+(build|test|run|bench|clippy)[^\\n]*\\s--\\s[^\\n]*--locked'` returned no matches for touched workflows\n- `ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/quant-matrix.yml .github/workflows/crossval.yml .github/workflows/security.yml`\n- workflow guard command confirmed all cargo/cross build/test/run/bench/clippy commands include `--locked`\n