### PR TITLE
NPU-003: add OpenVINO NPU runtime visibility fields

### DIFF
--- a/crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs
@@ -8,7 +8,10 @@ pub mod platform;
 pub use crate::runtimes::OpenVinoProbe;
 pub use arc140v::{IntelArc140vProbe, probe_intel_arc_140v};
 pub use cpu::{Lnl258vCpuProbe, probe_lnl258v_cpu};
-pub use npu::{IntelNpuProbe, probe_intel_npu};
+pub use npu::{
+    INTEL_NPU_OPENVINO_BACKEND, INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED,
+    INTEL_NPU_REQUESTED_BACKEND, INTEL_NPU_RUNTIME_API_OPENVINO, IntelNpuProbe, probe_intel_npu,
+};
 pub use platform::{
     LNL258V_PROOF_STAGE_RUNTIME_DETECTED, Lnl258vPlatformProbe, PlatformMemoryProbe,
     PlatformPowerProbe, probe_lnl258v_platform,

--- a/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
+++ b/crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs
@@ -5,10 +5,33 @@ use serde::{Deserialize, Serialize};
 
 use crate::runtimes::OpenVinoProbe;
 
+/// Requested backend label for the Intel NPU lane.
+pub const INTEL_NPU_REQUESTED_BACKEND: &str = "intel-npu";
+/// Selected backend label once OpenVINO reports an NPU runtime device.
+pub const INTEL_NPU_OPENVINO_BACKEND: &str = "intel-npu-openvino";
+/// Runtime API used by the Intel NPU lane.
+pub const INTEL_NPU_RUNTIME_API_OPENVINO: &str = "openvino";
+/// Proof stage emitted by runtime visibility probes.
+pub const INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED: &str = "runtime_detected";
+
 /// Visibility facts for the Intel AI Boost NPU lane.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct IntelNpuProbe {
+    /// Universal proof stage for this visibility-only probe.
+    pub proof_stage: String,
+    /// Requested backend identity preserved before runtime selection.
+    pub requested_backend: String,
+    /// Selected backend identity when OpenVINO reports an NPU device.
+    pub selected_backend: Option<String>,
+    /// Runtime API used by the selected backend.
+    pub runtime_api: Option<String>,
+    /// Concrete OpenVINO runtime device token, normally `NPU`.
+    pub runtime_device: Option<String>,
+    /// OS family.
+    pub os: String,
+    /// CPU architecture.
+    pub arch: String,
     /// Whether any OS or OpenVINO NPU evidence was visible.
     pub available: bool,
     /// Whether Linux `/dev/accel` devices are present.
@@ -23,6 +46,8 @@ pub struct IntelNpuProbe {
     pub openvino_runtime_available: bool,
     /// OpenVINO version when available.
     pub openvino_version: Option<String>,
+    /// OpenVINO available device tokens.
+    pub openvino_available_devices: Vec<String>,
     /// Whether OpenVINO exposes an NPU device token.
     pub openvino_npu_visible: bool,
     /// OpenVINO NPU full name when available.
@@ -35,6 +60,12 @@ pub struct IntelNpuProbe {
     pub compiler_version: Option<String>,
     /// NPU total memory size when available.
     pub total_mem_size: Option<u64>,
+    /// NPU allocated memory size when available.
+    pub alloc_mem_size: Option<u64>,
+    /// OpenVINO NPU tile count when available.
+    pub max_tiles: Option<u32>,
+    /// Always false: this probe never substitutes CPU/GPU fallback.
+    pub fallback_used: bool,
     /// Non-fatal reason explaining unavailable state.
     pub failure_reason: Option<String>,
 }
@@ -43,26 +74,38 @@ pub struct IntelNpuProbe {
 pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
     let accel_devices = accel_devices();
     let accel_device_present = !accel_devices.is_empty();
-    let openvino_npu_visible = openvino.npu_visible();
-    let npu_device = openvino
-        .available_devices
-        .iter()
-        .find(|device| device.as_str() == "NPU" || device.starts_with("NPU."))
-        .cloned();
+    let npu_device = openvino.npu_device_token();
+    let openvino_npu_visible = npu_device.is_some();
     let openvino_npu_full_name =
         npu_device.as_deref().and_then(|token| openvino.full_name_for(token));
     let supported_properties = npu_device
         .as_deref()
         .and_then(|token| {
-            openvino
-                .devices
-                .iter()
-                .find(|device| device.device == token)
-                .map(|device| device.supported_properties.clone())
+            openvino.device_for(token).map(|device| device.supported_properties.clone())
         })
         .unwrap_or_default();
+    let driver_version = npu_device
+        .as_deref()
+        .and_then(|token| openvino.property_value_for(token, "NPU_DRIVER_VERSION"));
+    let compiler_version = npu_device
+        .as_deref()
+        .and_then(|token| openvino.property_value_for(token, "NPU_COMPILER_VERSION"));
+    let total_mem_size = npu_device
+        .as_deref()
+        .and_then(|token| openvino.property_value_for(token, "NPU_DEVICE_TOTAL_MEM_SIZE"))
+        .and_then(|value| parse_u64_property(&value));
+    let alloc_mem_size = npu_device
+        .as_deref()
+        .and_then(|token| openvino.property_value_for(token, "NPU_DEVICE_ALLOC_MEM_SIZE"))
+        .and_then(|value| parse_u64_property(&value));
+    let max_tiles = npu_device
+        .as_deref()
+        .and_then(|token| openvino.property_value_for(token, "NPU_MAX_TILES"))
+        .and_then(|value| parse_u32_property(&value));
     let intel_vpu_driver_seen = intel_vpu_driver_seen();
     let available = accel_device_present || openvino_npu_visible || intel_vpu_driver_seen;
+    let selected_backend = openvino_npu_visible.then_some(INTEL_NPU_OPENVINO_BACKEND.to_owned());
+    let runtime_api = openvino_npu_visible.then_some(INTEL_NPU_RUNTIME_API_OPENVINO.to_owned());
     let failure_reason = if available {
         None
     } else {
@@ -70,6 +113,13 @@ pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
     };
 
     IntelNpuProbe {
+        proof_stage: INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED.to_owned(),
+        requested_backend: INTEL_NPU_REQUESTED_BACKEND.to_owned(),
+        selected_backend,
+        runtime_api,
+        runtime_device: npu_device,
+        os: std::env::consts::OS.to_owned(),
+        arch: std::env::consts::ARCH.to_owned(),
         available,
         accel_device_present,
         accel_devices,
@@ -77,14 +127,32 @@ pub fn probe_intel_npu(openvino: &OpenVinoProbe) -> IntelNpuProbe {
         driver_hint: intel_vpu_driver_seen.then_some("intel_vpu/ivpu evidence".to_owned()),
         openvino_runtime_available: openvino.runtime_available,
         openvino_version: openvino.version.clone(),
+        openvino_available_devices: openvino.available_devices.clone(),
         openvino_npu_visible,
         openvino_npu_full_name,
         supported_properties,
-        driver_version: None,
-        compiler_version: None,
-        total_mem_size: None,
+        driver_version,
+        compiler_version,
+        total_mem_size,
+        alloc_mem_size,
+        max_tiles,
+        fallback_used: false,
         failure_reason,
     }
+}
+
+fn parse_u64_property(value: &str) -> Option<u64> {
+    value.trim().parse::<u64>().ok().or_else(|| first_ascii_digit_run(value)?.parse().ok())
+}
+
+fn parse_u32_property(value: &str) -> Option<u32> {
+    value.trim().parse::<u32>().ok().or_else(|| first_ascii_digit_run(value)?.parse().ok())
+}
+
+fn first_ascii_digit_run(value: &str) -> Option<&str> {
+    let start = value.find(|ch: char| ch.is_ascii_digit())?;
+    let len = value[start..].find(|ch: char| !ch.is_ascii_digit()).unwrap_or(value.len() - start);
+    Some(&value[start..start + len])
 }
 
 #[allow(clippy::missing_const_for_fn)]
@@ -133,5 +201,86 @@ fn intel_vpu_driver_seen() -> bool {
     #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        INTEL_NPU_OPENVINO_BACKEND, INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED,
+        INTEL_NPU_REQUESTED_BACKEND, INTEL_NPU_RUNTIME_API_OPENVINO, probe_intel_npu,
+    };
+    use crate::runtimes::{OpenVinoDeviceProbe, OpenVinoProbe, OpenVinoPropertyProbe};
+
+    #[test]
+    fn openvino_npu_identity_selects_openvino_backend_without_fallback() {
+        let openvino = OpenVinoProbe {
+            runtime_available: true,
+            version: Some("2026.1".to_owned()),
+            available_devices: vec!["CPU".to_owned(), "GPU.0".to_owned(), "NPU".to_owned()],
+            devices: vec![OpenVinoDeviceProbe {
+                device: "NPU".to_owned(),
+                full_name: Some("Intel(R) AI Boost".to_owned()),
+                supported_properties: vec![
+                    "FULL_DEVICE_NAME".to_owned(),
+                    "NPU_DRIVER_VERSION".to_owned(),
+                    "NPU_COMPILER_VERSION".to_owned(),
+                ],
+                properties: vec![
+                    OpenVinoPropertyProbe {
+                        name: "NPU_DRIVER_VERSION".to_owned(),
+                        value: "1.2.3".to_owned(),
+                    },
+                    OpenVinoPropertyProbe {
+                        name: "NPU_COMPILER_VERSION".to_owned(),
+                        value: "4.5.6".to_owned(),
+                    },
+                    OpenVinoPropertyProbe {
+                        name: "NPU_DEVICE_TOTAL_MEM_SIZE".to_owned(),
+                        value: "1048576".to_owned(),
+                    },
+                    OpenVinoPropertyProbe {
+                        name: "NPU_DEVICE_ALLOC_MEM_SIZE".to_owned(),
+                        value: "524288".to_owned(),
+                    },
+                    OpenVinoPropertyProbe {
+                        name: "NPU_MAX_TILES".to_owned(),
+                        value: "2".to_owned(),
+                    },
+                ],
+            }],
+            error: None,
+        };
+
+        let probe = probe_intel_npu(&openvino);
+
+        assert_eq!(probe.proof_stage, INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED);
+        assert_eq!(probe.requested_backend, INTEL_NPU_REQUESTED_BACKEND);
+        assert_eq!(probe.selected_backend.as_deref(), Some(INTEL_NPU_OPENVINO_BACKEND));
+        assert_eq!(probe.runtime_api.as_deref(), Some(INTEL_NPU_RUNTIME_API_OPENVINO));
+        assert_eq!(probe.runtime_device.as_deref(), Some("NPU"));
+        assert_eq!(probe.openvino_available_devices, ["CPU", "GPU.0", "NPU"]);
+        assert_eq!(probe.openvino_npu_full_name.as_deref(), Some("Intel(R) AI Boost"));
+        assert_eq!(probe.driver_version.as_deref(), Some("1.2.3"));
+        assert_eq!(probe.compiler_version.as_deref(), Some("4.5.6"));
+        assert_eq!(probe.total_mem_size, Some(1_048_576));
+        assert_eq!(probe.alloc_mem_size, Some(524_288));
+        assert_eq!(probe.max_tiles, Some(2));
+        assert!(!probe.fallback_used);
+        assert!(probe.failure_reason.is_none());
+    }
+
+    #[test]
+    fn missing_openvino_npu_does_not_select_backend() {
+        let openvino = OpenVinoProbe::unavailable("not installed");
+        let probe = probe_intel_npu(&openvino);
+
+        assert_eq!(probe.proof_stage, INTEL_NPU_PROOF_STAGE_RUNTIME_DETECTED);
+        assert_eq!(probe.requested_backend, INTEL_NPU_REQUESTED_BACKEND);
+        assert_eq!(probe.selected_backend, None);
+        assert_eq!(probe.runtime_api, None);
+        assert_eq!(probe.runtime_device, None);
+        assert!(!probe.openvino_npu_visible);
+        assert!(!probe.fallback_used);
     }
 }

--- a/crates/bitnet-device-probe/src/runtimes/mod.rs
+++ b/crates/bitnet-device-probe/src/runtimes/mod.rs
@@ -11,7 +11,7 @@ pub mod openvino;
 
 pub use level_zero::LevelZeroProbe;
 pub use opencl::{OpenClRuntimeDevice, OpenClRuntimeProbe};
-pub use openvino::{OpenVinoDeviceProbe, OpenVinoProbe};
+pub use openvino::{OpenVinoDeviceProbe, OpenVinoProbe, OpenVinoPropertyProbe};
 
 pub(crate) fn command_output<I, S>(command: &str, args: I) -> Result<String, String>
 where

--- a/crates/bitnet-device-probe/src/runtimes/openvino.rs
+++ b/crates/bitnet-device-probe/src/runtimes/openvino.rs
@@ -5,6 +5,15 @@ use serde::{Deserialize, Serialize};
 
 use super::command_output;
 
+/// OpenVINO property value captured without compiling a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OpenVinoPropertyProbe {
+    /// OpenVINO property name.
+    pub name: String,
+    /// Stringified property value reported by OpenVINO.
+    pub value: String,
+}
+
 /// OpenVINO device facts used in platform receipts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct OpenVinoDeviceProbe {
@@ -14,6 +23,8 @@ pub struct OpenVinoDeviceProbe {
     pub full_name: Option<String>,
     /// Supported property names when collected.
     pub supported_properties: Vec<String>,
+    /// Selected property values collected for runtime identity receipts.
+    pub properties: Vec<OpenVinoPropertyProbe>,
 }
 
 /// OpenVINO runtime visibility result.
@@ -54,15 +65,37 @@ impl OpenVinoProbe {
 
     /// Return the full name for an OpenVINO device token.
     pub fn full_name_for(&self, token: &str) -> Option<String> {
-        self.devices
-            .iter()
-            .find(|device| device.device == token)
-            .and_then(|device| device.full_name.clone())
+        self.device_for(token).and_then(|device| device.full_name.clone())
+    }
+
+    /// Return per-device facts for an OpenVINO device token.
+    pub fn device_for(&self, token: &str) -> Option<&OpenVinoDeviceProbe> {
+        self.devices.iter().find(|device| device.device == token)
     }
 
     /// Return whether OpenVINO exposes an `NPU` device.
     pub fn npu_visible(&self) -> bool {
         self.available_devices.iter().any(|device| device == "NPU" || device.starts_with("NPU."))
+    }
+
+    /// Return the first OpenVINO NPU token, preferring the unindexed `NPU` alias.
+    pub fn npu_device_token(&self) -> Option<String> {
+        self.available_devices
+            .iter()
+            .find(|device| device.as_str() == "NPU")
+            .or_else(|| self.available_devices.iter().find(|device| device.starts_with("NPU.")))
+            .cloned()
+    }
+
+    /// Return a stringified OpenVINO property value for a device.
+    pub fn property_value_for(&self, token: &str, property: &str) -> Option<String> {
+        self.device_for(token).and_then(|device| {
+            device
+                .properties
+                .iter()
+                .find(|entry| entry.name == property)
+                .map(|entry| entry.value.clone())
+        })
     }
 }
 
@@ -73,9 +106,23 @@ import openvino as ov
 
 core = ov.Core()
 print("OPENVINO_VERSION=" + str(ov.__version__))
+common_props = [
+    "FULL_DEVICE_NAME",
+    "SUPPORTED_PROPERTIES",
+]
+npu_props = [
+    "NPU_DRIVER_VERSION",
+    "NPU_COMPILER_VERSION",
+    "NPU_DEVICE_TOTAL_MEM_SIZE",
+    "NPU_DEVICE_ALLOC_MEM_SIZE",
+    "NPU_MAX_TILES",
+]
 for dev in core.available_devices:
     print("DEVICE=" + str(dev))
-    for prop in ["FULL_DEVICE_NAME", "SUPPORTED_PROPERTIES"]:
+    props = list(common_props)
+    if str(dev) == "NPU" or str(dev).startswith("NPU."):
+        props.extend(npu_props)
+    for prop in props:
         try:
             print("PROP=" + str(dev) + "=" + prop + "=" + str(core.get_property(dev, prop)))
         except Exception as exc:
@@ -110,6 +157,7 @@ pub(crate) fn parse_openvino_line_output(output: &str) -> OpenVinoProbe {
                     device: value.to_owned(),
                     full_name: None,
                     supported_properties: Vec::new(),
+                    properties: Vec::new(),
                 });
             }
         } else if let Some(rest) = line.strip_prefix("PROP=") {
@@ -144,6 +192,7 @@ fn apply_property_line(probe: &mut OpenVinoProbe, rest: &str) {
                 device: device_token.to_owned(),
                 full_name: None,
                 supported_properties: Vec::new(),
+                properties: Vec::new(),
             });
             probe.devices.len() - 1
         };
@@ -160,6 +209,55 @@ fn apply_property_line(probe: &mut OpenVinoProbe, rest: &str) {
                 .filter(|entry| !entry.is_empty())
                 .collect();
         }
-        _ => {}
+        _ => upsert_property_value(&mut probe.devices[idx], property, value),
+    }
+}
+
+fn upsert_property_value(device: &mut OpenVinoDeviceProbe, property: &str, value: &str) {
+    let value = value.trim();
+    if value.is_empty() {
+        return;
+    }
+
+    if let Some(entry) = device.properties.iter_mut().find(|entry| entry.name == property) {
+        value.clone_into(&mut entry.value);
+    } else {
+        device
+            .properties
+            .push(OpenVinoPropertyProbe { name: property.to_owned(), value: value.to_owned() });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_openvino_line_output;
+
+    #[test]
+    fn parses_openvino_npu_runtime_properties() {
+        let output = r"
+OPENVINO_VERSION=2026.1
+DEVICE=CPU
+PROP=CPU=FULL_DEVICE_NAME=Intel CPU
+DEVICE=NPU
+PROP=NPU=FULL_DEVICE_NAME=Intel(R) AI Boost
+PROP=NPU=SUPPORTED_PROPERTIES=['FULL_DEVICE_NAME', 'NPU_DRIVER_VERSION']
+PROP=NPU=NPU_DRIVER_VERSION=1.2.3
+PROP=NPU=NPU_COMPILER_VERSION=4.5.6
+PROP=NPU=NPU_DEVICE_TOTAL_MEM_SIZE=123456
+PROP=NPU=NPU_DEVICE_ALLOC_MEM_SIZE=65432
+PROP=NPU=NPU_MAX_TILES=2
+";
+
+        let probe = parse_openvino_line_output(output);
+
+        assert!(probe.runtime_available);
+        assert_eq!(probe.version.as_deref(), Some("2026.1"));
+        assert_eq!(probe.npu_device_token().as_deref(), Some("NPU"));
+        assert_eq!(probe.full_name_for("NPU").as_deref(), Some("Intel(R) AI Boost"));
+        assert_eq!(probe.property_value_for("NPU", "NPU_DRIVER_VERSION").as_deref(), Some("1.2.3"));
+        assert_eq!(
+            probe.property_value_for("NPU", "NPU_DEVICE_TOTAL_MEM_SIZE").as_deref(),
+            Some("123456")
+        );
     }
 }

--- a/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
+++ b/crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs
@@ -5,6 +5,7 @@ use bitnet_device_probe::intel::lunar_lake::{
 use bitnet_device_probe::runtimes::{OpenVinoDeviceProbe, OpenVinoProbe};
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
     let probe = Lnl258vPlatformProbe {
         machine_id: "intel-258v".to_owned(),
@@ -41,6 +42,13 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
             failure_reason: None,
         },
         npu: IntelNpuProbe {
+            proof_stage: "runtime_detected".to_owned(),
+            requested_backend: "intel-npu".to_owned(),
+            selected_backend: Some("intel-npu-openvino".to_owned()),
+            runtime_api: Some("openvino".to_owned()),
+            runtime_device: Some("NPU".to_owned()),
+            os: "linux".to_owned(),
+            arch: "x86_64".to_owned(),
             available: true,
             accel_device_present: true,
             accel_devices: vec!["/dev/accel/accel0".to_owned()],
@@ -48,12 +56,20 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
             driver_hint: Some("intel_vpu/ivpu evidence".to_owned()),
             openvino_runtime_available: true,
             openvino_version: Some("2026.1".to_owned()),
+            openvino_available_devices: vec![
+                "CPU".to_owned(),
+                "GPU.0".to_owned(),
+                "NPU".to_owned(),
+            ],
             openvino_npu_visible: true,
             openvino_npu_full_name: Some("Intel(R) AI Boost".to_owned()),
             supported_properties: vec!["FULL_DEVICE_NAME".to_owned()],
-            driver_version: None,
-            compiler_version: None,
-            total_mem_size: None,
+            driver_version: Some("1.2.3".to_owned()),
+            compiler_version: Some("4.5.6".to_owned()),
+            total_mem_size: Some(1_048_576),
+            alloc_mem_size: Some(524_288),
+            max_tiles: Some(2),
+            fallback_used: false,
             failure_reason: None,
         },
         openvino: OpenVinoProbe {
@@ -65,11 +81,13 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
                     device: "GPU.0".to_owned(),
                     full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_owned()),
                     supported_properties: Vec::new(),
+                    properties: Vec::new(),
                 },
                 OpenVinoDeviceProbe {
                     device: "NPU".to_owned(),
                     full_name: Some("Intel(R) AI Boost".to_owned()),
                     supported_properties: vec!["FULL_DEVICE_NAME".to_owned()],
+                    properties: Vec::new(),
                 },
             ],
             error: None,
@@ -96,7 +114,12 @@ fn lunar_lake_platform_probe_serializes_visibility_receipt_shape() {
     assert_eq!(value["cpu"]["has_avx2"], true);
     assert_eq!(value["cpu"]["has_avx512"], false);
     assert_eq!(value["arc140v"]["openvino_gpu_device"], "GPU.0");
+    assert_eq!(value["npu"]["requested_backend"], "intel-npu");
+    assert_eq!(value["npu"]["selected_backend"], "intel-npu-openvino");
+    assert_eq!(value["npu"]["runtime_api"], "openvino");
+    assert_eq!(value["npu"]["runtime_device"], "NPU");
     assert_eq!(value["npu"]["openvino_npu_visible"], true);
+    assert_eq!(value["npu"]["fallback_used"], false);
 }
 
 #[test]

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -124,6 +124,11 @@ for dev in core.available_devices:
         "FULL_DEVICE_NAME",
         "SUPPORTED_PROPERTIES",
         "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "NPU_DRIVER_VERSION",
+        "NPU_COMPILER_VERSION",
+        "NPU_DEVICE_TOTAL_MEM_SIZE",
+        "NPU_DEVICE_ALLOC_MEM_SIZE",
+        "NPU_MAX_TILES",
     ]:
         try:
             props[prop] = str(core.get_property(dev, prop))
@@ -190,6 +195,11 @@ for dev in core.available_devices:
         "FULL_DEVICE_NAME",
         "SUPPORTED_PROPERTIES",
         "OPTIMAL_NUMBER_OF_INFER_REQUESTS",
+        "NPU_DRIVER_VERSION",
+        "NPU_COMPILER_VERSION",
+        "NPU_DEVICE_TOTAL_MEM_SIZE",
+        "NPU_DEVICE_ALLOC_MEM_SIZE",
+        "NPU_MAX_TILES",
     ]:
         try:
             props[prop] = str(core.get_property(dev, prop))
@@ -211,6 +221,12 @@ The first 258V platform receipt should establish visibility only:
   "gpu_backend": "intel-arc-140v-opencl",
   "npu_backend": "intel-npu-openvino",
   "openvino_available_devices": ["CPU", "GPU", "NPU"],
+  "openvino_npu_full_name": "...",
+  "npu_driver_version": "...",
+  "npu_compiler_version": "...",
+  "npu_total_mem_size": 0,
+  "npu_alloc_mem_size": 0,
+  "npu_max_tiles": 1,
   "opencl_arc_140v_visible": true,
   "level_zero_visible": true,
   "npu_visible": true,

--- a/docs/specs/intel-lunar-lake-npu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-npu-roadmap.md
@@ -226,6 +226,12 @@ Suggested probe result:
 
 ```rust
 pub struct IntelNpuProbe {
+    pub proof_stage: String,
+    pub requested_backend: String,
+    pub selected_backend: Option<String>,
+    pub runtime_api: Option<String>,
+    pub runtime_device: Option<String>,
+
     pub available: bool,
 
     pub os: String,
@@ -237,8 +243,8 @@ pub struct IntelNpuProbe {
     pub intel_vpu_driver_seen: bool,
     pub driver_version: Option<String>,
 
-    pub openvino_runtime_present: bool,
-    pub runtime_version: Option<String>,
+    pub openvino_runtime_available: bool,
+    pub openvino_version: Option<String>,
 
     pub openvino_npu_visible: bool,
     pub openvino_available_devices: Vec<String>,
@@ -249,6 +255,7 @@ pub struct IntelNpuProbe {
     pub device_alloc_mem_size: Option<u64>,
     pub max_tiles: Option<u32>,
 
+    pub fallback_used: bool,
     pub failure_reason: Option<String>,
 }
 ```
@@ -468,6 +475,12 @@ Expected capability shape:
 
 ```rust
 pub struct IntelNpuProbe {
+    pub proof_stage: String,
+    pub requested_backend: String,
+    pub selected_backend: Option<String>,
+    pub runtime_api: Option<String>,
+    pub runtime_device: Option<String>,
+
     pub available: bool,
 
     pub os: String,
@@ -479,8 +492,8 @@ pub struct IntelNpuProbe {
     pub intel_vpu_driver_seen: bool,
     pub driver_version: Option<String>,
 
-    pub openvino_runtime_present: bool,
-    pub runtime_version: Option<String>,
+    pub openvino_runtime_available: bool,
+    pub openvino_version: Option<String>,
 
     pub openvino_npu_visible: bool,
     pub openvino_available_devices: Vec<String>,
@@ -491,6 +504,7 @@ pub struct IntelNpuProbe {
     pub device_alloc_mem_size: Option<u64>,
     pub max_tiles: Option<u32>,
 
+    pub fallback_used: bool,
     pub failure_reason: Option<String>,
 }
 ```
@@ -508,15 +522,23 @@ Example artifact shape:
 ```json
 {
   "requested_backend": "intel-npu",
-  "selected_backend": null,
-  "status": "runtime_detected",
+  "selected_backend": "intel-npu-openvino",
+  "runtime_api": "openvino",
+  "runtime_device": "NPU",
+  "proof_stage": "runtime_detected",
   "accel_device_present": true,
   "intel_vpu_driver_seen": true,
-  "openvino_runtime_present": true,
+  "openvino_runtime_available": true,
   "openvino_version": "2026.1",
   "openvino_available_devices": ["CPU", "GPU", "NPU"],
   "openvino_npu_visible": true,
+  "openvino_npu_full_name": "Intel(R) AI Boost",
   "driver_hint": "intel_vpu",
+  "driver_version": "...",
+  "compiler_version": "...",
+  "device_total_mem_size": 0,
+  "device_alloc_mem_size": 0,
+  "max_tiles": 1,
   "strict_mode": true,
   "fallback_used": false
 }

--- a/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
@@ -26,8 +26,8 @@ Validate Intel Lunar Lake NPU through OpenVINO static-shape detection, smoke, pa
 
 | Work item | Status | Notes |
 |---|---|---|
-| NPU-002 | ready | Preserve Intel NPU backend identity. |
-| NPU-003 | proposed | Add runtime detection. |
+| NPU-002 | merged | Preserve Intel NPU backend identity. |
+| NPU-003 | pr_open | Add runtime detection. |
 | NPU-004 | proposed | Add smoke probe command. |
 | NPU-005 | proposed | Run tiny OpenVINO NPU graph smoke. |
 | NPU-006 | proposed | Add receipt fields. |

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "NPU-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-npu/NPU-002-lite-backend-identity"
 stackable = false
 requires_human_merge = true
@@ -57,4 +57,49 @@ must_not_claim = [
   "Intel NPU runtime detection works.",
   "OpenVINO NPU graph execution works.",
   "BitNet inference works on Intel NPU.",
+]
+
+[[work_item]]
+id = "NPU-003"
+status = "pr_open"
+branch = "codex/intel-npu/NPU-003-openvino-runtime-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = ["NPU-002"]
+acceptance = "Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims."
+commands = [
+  "rustfmt --check crates/bitnet-device-probe/src/runtimes/openvino.rs crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs crates/bitnet-device-probe/src/runtimes/mod.rs crates/bitnet-device-probe/tests/lunar_lake_platform_probe.rs",
+  "cargo test --locked -p bitnet-device-probe --no-default-features",
+  "cargo test --locked -p bitnet-device-probe --no-default-features --features cpu",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-device-probe/src/intel/lunar_lake/npu.rs",
+  "crates/bitnet-device-probe/src/intel/lunar_lake/mod.rs",
+  "crates/bitnet-device-probe/src/runtimes/openvino.rs",
+  "crates/bitnet-device-probe/src/runtimes/mod.rs",
+  "crates/bitnet-device-probe/tests/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-npu-roadmap.md",
+  "docs/tracking/campaigns/intel-npu/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Intel NPU runtime visibility fields can be recorded after merge.",
+]
+must_not_claim = [
+  "OpenVINO NPU graph execution works.",
+  "BitNet inference works on Intel NPU.",
+  "Intel NPU accelerates BitNet.",
 ]

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T125449Z-NPU-002-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T125449Z-NPU-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T12:54:49Z"
+campaign = "intel-npu"
+item = "NPU-002"
+event = "merged"
+pr = 3722
+merge_sha = "20688198547dbb29a14e31fbdcf46c8c703a2a86"
+actor = "maintainer"
+
+notes = [
+  "Intel NPU backend identity merged.",
+  "NPU runtime detection, OpenVINO graph smoke, and BitNet inference remain follow-up work.",
+]

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T125450Z-NPU-003-in-progress.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T125450Z-NPU-003-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T12:54:50Z"
+campaign = "intel-npu"
+item = "NPU-003"
+event = "in_progress"
+branch = "codex/intel-npu/NPU-003-openvino-runtime-probe"
+actor = "codex"
+
+notes = [
+  "Started Intel NPU OpenVINO runtime detection work.",
+  "Scope is visibility-only: no OpenVINO graph execution, NPU inference, or BitNet acceleration claim.",
+]

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T132500Z-NPU-003-pr-open.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T132500Z-NPU-003-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T13:25:00Z"
+campaign = "intel-npu"
+item = "NPU-003"
+event = "pr_open"
+pr = 3739
+branch = "codex/intel-npu/NPU-003-openvino-runtime-probe"
+head_sha = "777c9f0f"
+actor = "codex"
+
+notes = [
+  "Opened Intel NPU OpenVINO runtime visibility PR.",
+  "Scope remains visibility-only: no OpenVINO graph execution, NPU smoke, BitNet inference, or acceleration claim.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -9,7 +9,8 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| NPU-002 | pr_open | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| NPU-003 | pr_open | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,6 +4,6 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
+| intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -23,6 +23,7 @@
 | cpu-proof | CPU-BITNET-005 | CPU-BITNET-004 | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
+| intel-npu | NPU-003 | NPU-002 | pr_open |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | pr_open |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | #3722 | pr_open | none | Device-node detection is not inference. |
+| intel-npu | NPU-003 | #3739 | pr_open | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | pr_open | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -11,7 +11,7 @@
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
-| intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
+| intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-005 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
Work item: NPU-003

Adds visibility-only Intel NPU runtime probe fields for Lunar Lake through the existing device-probe path.

Scope:
- record requested backend `intel-npu` and selected backend `intel-npu-openvino` only when OpenVINO reports an `NPU` device
- keep OS accelerator evidence separate from OpenVINO NPU visibility
- capture OpenVINO NPU full name plus driver, compiler, memory, and tile properties when available
- update 258V/NPU docs and tracker state

No OpenVINO graph execution, NPU smoke, BitNet inference, or acceleration claim is added.