### PR TITLE
perf(ci): gate macOS ARM64 clippy to main/labels

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -261,13 +261,21 @@ jobs:
             -p bitnet-sampling
 
   # Job 5: Clippy linting (macOS ARM64 / Apple Silicon)
-  # Non-blocking: reports status but does not gate merges until runners
-  # are confirmed available in the GitHub Actions pool.
+  # macOS minutes are 10x Linux. Even with continue-on-error and
+  # exclusion from the required summary, this job pays setup + cargo
+  # clippy on every default PR for a non-blocking signal. Move it to
+  # main / dispatch / explicit `macos` or `full-ci` label, where the
+  # platform delta is actually worth measuring.
   clippy-macos-arm64:
     name: Clippy (macOS ARM64)
     runs-on: macos-14
     continue-on-error: true
     timeout-minutes: 15
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'macos') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     env:
       # Allow NEON-idiomatic patterns common in SIMD intrinsic code (~120 files).
       # Linux x86 Clippy remains strict (-D warnings with no allows).


### PR DESCRIPTION
## Summary

`clippy-macos-arm64` in CI (Core) is already non-blocking (`continue-on-error: true`) and excluded from the required `ci-core-success` summary. But every ordinary PR still pays macOS-14 minutes (billed at ~10x Linux multiplier) for a clippy pass that does not gate the merge.

Gate it to main / dispatch / `macos` / `full-ci`. The macOS clippy delta is still measured on every main push, on demand via labels, and dedicated `apple-silicon.yml` / `macos-arm64.yml` workflows continue to own deeper macOS validation outside the Core path.

This is a follow-up to the multi-PR CI efficiency program (PRs A–E in #3728-#3733). The next remaining easy win is making the BDD `grid-check` job conditional on BDD/policy crate paths.

## Test plan

- [ ] Verify `clippy-macos-arm64` is skipped on a normal PR.
- [ ] Verify it runs on main pushes.
- [ ] Verify it runs when `macos` or `full-ci` label is applied.
- [ ] Verify the required `ci-core-success` summary remains green when this job is skipped (it already lists only the four required jobs).

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_