### PR TITLE
perf(ci): make BDD grid-check conditional on label/main

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -193,10 +193,21 @@ jobs:
             -- --nocapture
 
   # Job 2: BDD Grid Check (separate job for parallel execution and clear gate signal)
+  # The xtask grid-check validates BDD/policy/runtime-flag coverage. Most PRs
+  # do not touch those crates, so the work is wasted on the default path.
+  # Gate to main / dispatch / `bdd` / `grid` / `full-ci` label. The
+  # build-test-linux job still runs the policy / BDD crate unit tests on every
+  # PR, so functional regressions to those crates are caught regardless.
   grid-check:
     name: BDD Grid Check
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    if: >-
+      github.ref == 'refs/heads/main' ||
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'bdd') ||
+      contains(github.event.pull_request.labels.*.name, 'grid') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
     env:
       RUSTFLAGS: "-D warnings"
       CARGO_TERM_COLOR: always
@@ -362,11 +373,17 @@ jobs:
           bad=0
           # Required jobs (must succeed)
           for r in "${{ needs.build-test-linux.result }}" \
-                   "${{ needs.grid-check.result }}" \
                    "${{ needs.clippy.result }}" \
                    "${{ needs.docs.result }}"; do
             [ "$r" = "success" ] || bad=1
           done
+          # grid-check is conditionally skipped on PRs that do not touch
+          # BDD / policy crates (gated by label / main / dispatch). Treat
+          # skipped as acceptable, but do not allow failures or cancellations.
+          case "${{ needs.grid-check.result }}" in
+            success|skipped) ;;
+            *) bad=1 ;;
+          esac
           if [ $bad -ne 0 ]; then
             echo "❌ One or more core CI jobs failed (or were cancelled)"; exit 1
           fi


### PR DESCRIPTION
## Summary

The `grid-check` job runs `xtask grid-check --cpu-only --verbose`, which validates BDD / policy / runtime-flag cross-cell coverage. Most PRs do not touch those crates, so the job spends ~3-4 Linux-equivalent minutes per PR on unrelated work.

This PR:
1. Gates `grid-check` to main / dispatch / `bdd` / `grid` / `full-ci` label.
2. Updates `ci-core-success` to accept `skipped` for `grid-check` while keeping `failure` / `cancelled` blocking. The other three required jobs (`build-test-linux`, `clippy`, `docs`) still must succeed.

The `build-test-linux` job continues to run the policy / BDD crate unit tests on every PR (the existing `Run unit tests: policy / BDD crates` step), so functional regressions to those crates remain caught on the default path. Only the cross-cell coverage validation is moved behind labels.

This is the seventh PR in the multi-PR CI efficiency program (A: #3728, B: #3729, C: #3730, D: #3731, E: #3733, F: #3740). Larger items remaining (CI planner, JUnit/nextest profile, learned budget) are tracked separately.

## Test plan

- [ ] Verify `grid-check` is skipped on a normal PR.
- [ ] Verify `ci-core-success` reports green when `grid-check` is skipped.
- [ ] Verify `grid-check` runs on main pushes.
- [ ] Verify `grid-check` runs when `bdd` / `grid` / `full-ci` label is applied.
- [ ] Verify branch protection still resolves: only `ci-core-success` (the existing summary) is required.

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_