### PR TITLE
docs(tracking): record CPU-BITNET-005a merge

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -187,13 +187,13 @@ must_not_claim = [
 ]
 
 [[work_item]]
-id = "CPU-BITNET-005"
-status = "pr_open"
+id = "CPU-BITNET-005a"
+status = "merged"
 branch = "codex/cpu-bitnet-005a-avx2-fma-gating"
 stackable = false
 requires_human_merge = true
 blocked_by = ["CPU-BITNET-004"]
-acceptance = "CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity."
+acceptance = "AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged."
 commands = [
   "rustfmt crates/bitnet-cpu-detect/src/lib.rs crates/bitnet-quantization/src/i2s_qk256.rs crates/bitnet-quantization/src/i2s_qk256_avx2.rs --edition 2024 --check",
   "cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2",
@@ -217,7 +217,81 @@ forbidden_paths = [
   "crates/bitnet-receipts/**",
 ]
 may_claim = [
-  "AVX2/FMA GEMV dispatch parity against the scalar QK256 oracle exists after merge.",
+  "QK256 AVX2 execution is gated on both AVX2 and FMA after merge.",
+  "FMA-using AVX2 helpers advertise target_feature(avx2,fma) after merge.",
+]
+must_not_claim = [
+  "Requested versus selected kernel dispatch is complete.",
+  "Transformer decode is complete.",
+  "Strict receipts are complete.",
+  "Benchmark or throughput performance is proven.",
+  "GPU or NPU execution is involved.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-005b"
+status = "ready"
+branch = "codex/cpu-bitnet-005b-kernel-selection"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-005a"]
+acceptance = "QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure."
+commands = [
+  "rustfmt crates/bitnet-quantization/src/i2s_qk256.rs crates/bitnet-quantization/src/i2s_qk256_avx2.rs --edition 2024 --check",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 i2s_qk256 --lib",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests",
+  "cargo clippy --locked -p bitnet-quantization --all-targets --no-default-features --features cpu,avx2 -- -D warnings",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/src/i2s_qk256.rs",
+  "crates/bitnet-quantization/src/i2s_qk256_avx2.rs",
+  "crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-receipts/**",
+]
+may_claim = [
+  "QK256 requested and selected kernel identity is explicit after merge.",
+  "Strict requested AVX2 fallback failure exists after merge.",
+]
+must_not_claim = [
+  "Transformer decode is complete.",
+  "Strict receipts are complete.",
+  "Benchmark or throughput performance is proven.",
+  "GPU or NPU execution is involved.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-005c"
+status = "proposed"
+branch = "codex/cpu-bitnet-005c-avx2-parity-hardening"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-005b"]
+acceptance = "AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality."
+commands = [
+  "cargo test --locked -p bitnet-quantization --tests --no-default-features --features cpu,avx2",
+  "cargo bench --locked -p bitnet-quantization --bench qk256_gemv --features cpu,avx2 --no-run",
+]
+allowed_paths = [
+  "crates/bitnet-quantization/src/i2s_qk256.rs",
+  "crates/bitnet-quantization/src/i2s_qk256_avx2.rs",
+  "crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs",
+  "crates/bitnet-quantization/benches/qk256_gemv.rs",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-receipts/**",
+]
+may_claim = [
+  "AVX2 decode GEMV parity against scalar is hardened after merge.",
 ]
 must_not_claim = [
   "Transformer decode is complete.",

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T123315Z-CPU-BITNET-005a-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T123315Z-CPU-BITNET-005a-pr-open.toml
@@ -1,6 +1,6 @@
 timestamp = "2026-05-06T12:33:15Z"
 campaign = "cpu-proof"
-item = "CPU-BITNET-005"
+item = "CPU-BITNET-005a"
 event = "pr_open"
 pr = 3735
 head_sha = "ba2245e4bcebb81218d9337975b5c75187b1e664"

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T132435Z-CPU-BITNET-005a-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T132435Z-CPU-BITNET-005a-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T13:24:35Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005a"
+event = "merged"
+pr = 3735
+merge_sha = "d6b7b0f2f560d50d79415e0edde034a36b7c9926"
+actor = "maintainer"
+
+notes = [
+  "AVX2/FMA feature plumbing merged for QK256 GEMV gating.",
+  "CPU-BITNET-005b requested versus selected kernel dispatch remains next; no receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse are claimed.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -14,7 +14,9 @@
 | CPU-BITNET-002 | merged | #3680 | `codex/cpu-proof/CPU-BITNET-002-tokenizer-authority` | Strict tokenizer resolution uses explicit override, GGUF metadata, sibling tokenizer assets, then strict failure. |
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
-| CPU-BITNET-005 | pr_open | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
+| CPU-BITNET-005a | merged | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged. |
+| CPU-BITNET-005b | ready | TBD | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
+| CPU-BITNET-005c | proposed | TBD | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-proof | CPU-BITNET-005 | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | CPUID-gated AVX2/FMA QK256 GEMV dispatch matches the scalar packed oracle and records requested versus selected kernel identity. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-002 | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -20,7 +20,9 @@
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
-| cpu-proof | CPU-BITNET-005 | CPU-BITNET-004 | pr_open |
+| cpu-proof | CPU-BITNET-005a | CPU-BITNET-004 | merged |
+| cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | ready |
+| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | proposed |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-010 | TBD | ready | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005 | #3735 | pr_open | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-005b | TBD | ready | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-005 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-005b | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- record #3735 / CPU-BITNET-005a as merged with merge SHA d6b7b0f2f560d50d79415e0edde034a36b7c9926
- split CPU-BITNET-005 tracker scope into 005a merged, 005b ready, and 005c proposed
- regenerate campaign dashboards so CPU proof points at CPU-BITNET-005b next

## Validation
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

No runtime code, receipts, benchmarks, transformer decode, server, GPU, NPU, or crate-collapse work.