### PR TITLE
[codex][apple-m4] Add CPU/NEON BitNet reference proof (M4-010)

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -558,6 +558,7 @@ async fn main() -> Result<()> {
             no_warnings,
         }) => {
             run_simple_generation(
+                &requested_backend_label,
                 model,
                 model_format,
                 architecture,
@@ -1301,9 +1302,192 @@ fn detect_loader_mode_for_path(path: &std::path::Path, is_hf_directory: bool) ->
     }
 }
 
+#[derive(Debug, Clone)]
+struct RunBackendIdentity {
+    requested_backend: String,
+    selected_backend: String,
+    runtime_api: String,
+    fallback_used: bool,
+    fallback_reason: Option<String>,
+}
+
+fn resolve_run_backend_identity(
+    requested_backend_label: &str,
+    strict_backend: bool,
+) -> Result<RunBackendIdentity> {
+    use bitnet_common::{BackendRequest, select_backend};
+    use bitnet_kernels::device_features::current_kernel_capabilities;
+
+    let request =
+        BackendRequest::from_label(requested_backend_label).unwrap_or(BackendRequest::Auto);
+    let caps = current_kernel_capabilities();
+
+    match select_backend(request, &caps) {
+        Ok(result) => Ok(RunBackendIdentity {
+            requested_backend: result.requested_backend(),
+            selected_backend: result.selected_backend(),
+            runtime_api: result.runtime_api().to_string(),
+            fallback_used: result.fallback_used(),
+            fallback_reason: result.fallback_reason().map(str::to_string),
+        }),
+        Err(err) if strict_backend => Err(err.into()),
+        Err(err) => Ok(RunBackendIdentity {
+            requested_backend: request.to_string(),
+            selected_backend: "cpu".to_string(),
+            runtime_api: "cpu".to_string(),
+            fallback_used: request != BackendRequest::Auto && request != BackendRequest::Cpu,
+            fallback_reason: Some(err.to_string()),
+        }),
+    }
+}
+
+fn detected_cpu_feature_labels() -> Vec<String> {
+    let features = bitnet_common::runtime_diag::CpuFeatures::detect();
+    let mut labels = Vec::new();
+    if features.neon {
+        labels.push("neon".to_string());
+    }
+    if features.avx512f {
+        labels.push("avx512f".to_string());
+    }
+    if features.avx2 {
+        labels.push("avx2".to_string());
+    }
+    if features.avx {
+        labels.push("avx".to_string());
+    }
+    if features.fma {
+        labels.push("fma".to_string());
+    }
+    if features.sse42 {
+        labels.push("sse4.2".to_string());
+    }
+    if features.sse2 {
+        labels.push("sse2".to_string());
+    }
+    if labels.is_empty() {
+        labels.push("scalar".to_string());
+    }
+    labels
+}
+
+fn cpu_kernel_implementation(quantization: bitnet_common::QuantizationType) -> &'static str {
+    if matches!(quantization, bitnet_common::QuantizationType::I2S) && cfg!(target_arch = "aarch64")
+    {
+        // The current Apple CPU proof path has NEON available, but the packed
+        // GGUF I2_S reference kernel is still scalar. Keep the receipt honest.
+        return "scalar";
+    }
+    bitnet_common::runtime_diag::CpuFeatures::detect().best_simd()
+}
+
+fn effective_thread_count(threads: usize) -> usize {
+    if threads > 0 {
+        return threads;
+    }
+
+    std::env::var("RAYON_NUM_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+        .unwrap_or_else(|| std::thread::available_parallelism().map(|p| p.get()).unwrap_or(1))
+}
+
+fn kernel_family_for_quantization(quantization: bitnet_common::QuantizationType) -> &'static str {
+    match quantization {
+        bitnet_common::QuantizationType::I2S => "i2_s",
+        bitnet_common::QuantizationType::TL1 => "tl1",
+        bitnet_common::QuantizationType::TL2 => "tl2",
+    }
+}
+
+fn layout_source_for_quantization(quantization: bitnet_common::QuantizationType) -> &'static str {
+    match quantization {
+        bitnet_common::QuantizationType::I2S => "gguf_packed_i2_s_reference",
+        bitnet_common::QuantizationType::TL1 => "tl1_reference",
+        bitnet_common::QuantizationType::TL2 => "tl2_reference",
+    }
+}
+
+fn kernel_layout_for_quantization(quantization: bitnet_common::QuantizationType) -> &'static str {
+    match quantization {
+        bitnet_common::QuantizationType::I2S => "gguf_packed_i2_s",
+        bitnet_common::QuantizationType::TL1 => "tl1",
+        bitnet_common::QuantizationType::TL2 => "tl2",
+    }
+}
+
+fn dequantizes_before_compute(quantization: bitnet_common::QuantizationType) -> bool {
+    !matches!(quantization, bitnet_common::QuantizationType::I2S)
+}
+
+fn infer_model_repo(path: &std::path::Path) -> String {
+    let normalized = path.to_string_lossy().to_ascii_lowercase();
+    if normalized.contains("bitnet-b1.58-2b-4t")
+        || normalized.contains("microsoft-bitnet-b1.58-2b-4t")
+    {
+        "microsoft/bitnet-b1.58-2B-4T-gguf".to_string()
+    } else {
+        "local".to_string()
+    }
+}
+
+fn infer_model_architecture(path: &std::path::Path) -> String {
+    if infer_model_repo(path) == "microsoft/bitnet-b1.58-2B-4T-gguf" {
+        "bitnet_b1_58".to_string()
+    } else {
+        "unknown".to_string()
+    }
+}
+
+fn receipt_model_format(
+    path: &std::path::Path,
+    requested_format: &str,
+    is_hf_directory: bool,
+) -> String {
+    if is_hf_directory {
+        return "huggingface".to_string();
+    }
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .filter(|ext| ext == "gguf" || ext == "safetensors")
+        .unwrap_or_else(|| requested_format.to_string())
+}
+
+fn infer_tokenizer_label(
+    tokenizer: &dyn bitnet_tokenizers::Tokenizer,
+    source: bitnet_tokenizers::auto::TokenizerSource,
+) -> String {
+    if tokenizer.token_to_id("<|eot_id|>").is_some() {
+        "llama3".to_string()
+    } else {
+        source.as_str().to_string()
+    }
+}
+
+fn compute_model_sha256(path: &std::path::Path) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let mut file =
+        std::fs::File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 /// Run text generation with sampling
 #[allow(clippy::too_many_arguments)]
 async fn run_simple_generation(
+    requested_backend_label: &str,
     model_path: std::path::PathBuf,
     model_format: String,
     _architecture: Option<String>,
@@ -1388,6 +1572,12 @@ async fn run_simple_generation(
 
     // Override temperature if greedy mode
     let temperature = if greedy { 0.0 } else { temperature };
+
+    let strict_backend = strict_loader
+        || std::env::var("BITNET_STRICT_MODE")
+            .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
+    let backend_identity = resolve_run_backend_identity(requested_backend_label, strict_backend)?;
 
     // Parse and resolve template type
     use bitnet_inference::TemplateType;
@@ -1917,10 +2107,53 @@ async fn run_simple_generation(
             "minimal_fallback_allowed": std::env::var("BITNET_ALLOW_MINIMAL_LOADER").as_deref() == Ok("1"),
             "minimal_fallback_disabled": std::env::var("BITNET_DISABLE_MINIMAL_LOADER").as_deref() == Ok("1")
                 || std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1"),
+            "minimal_loader_fallback_used": loader_mode != bitnet_models::GgufLoaderMode::RealGguf.as_str(),
+            "tokenizer_source": tokenizer_source_str,
+            "mock_tensors_used": loader_mode != bitnet_models::GgufLoaderMode::RealGguf.as_str(),
         });
 
         let prompt_tokens_len = tokens.len() - generated_tokens.len();
+        let kernel_family = kernel_family_for_quantization(config.quantization.quantization_type);
+        let kernel_implementation =
+            cpu_kernel_implementation(config.quantization.quantization_type);
+        let selected_kernel = format!("{kernel_family}-{kernel_implementation}-reference");
+        let layout_source = layout_source_for_quantization(config.quantization.quantization_type);
+        let kernel_layout = kernel_layout_for_quantization(config.quantization.quantization_type);
+        let dequantizes_before_compute =
+            dequantizes_before_compute(config.quantization.quantization_type);
+        let model_sha256 = compute_model_sha256(&model_path)?;
+        let model_repo = infer_model_repo(&model_path);
+        let canonical_bitnet_model = model_repo == "microsoft/bitnet-b1.58-2B-4T-gguf";
+        let model_architecture = infer_model_architecture(&model_path);
+        let model_format_label = receipt_model_format(&model_path, &model_format, is_hf_directory);
+        let model_file =
+            model_path.file_name().and_then(|name| name.to_str()).unwrap_or_default().to_string();
+        let tokenizer_label = infer_tokenizer_label(tokenizer.as_ref(), tokenizer_source);
+        let thread_count = effective_thread_count(threads);
+        let cpu_features = detected_cpu_feature_labels();
+        let fallback_reason = backend_identity.fallback_reason.clone();
+        let requested_backend = backend_identity.requested_backend.as_str();
+        let selected_backend = backend_identity.selected_backend.as_str();
+        let runtime_api = backend_identity.runtime_api.as_str();
+        let strict_cpu_reference_artifact = strict_backend
+            && canonical_bitnet_model
+            && runtime_api == "cpu"
+            && loader_mode == bitnet_models::GgufLoaderMode::RealGguf.as_str();
+        let artifact_kind = if strict_cpu_reference_artifact {
+            "strict_bitnet_cpu_reference"
+        } else {
+            "inference_result"
+        };
         let output = serde_json::json!({
+            "schema_version": "1.0.0",
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "artifact_kind": artifact_kind,
+            "artifact_path": json_path.display().to_string(),
+            "requested_backend": requested_backend,
+            "selected_backend": selected_backend,
+            "runtime_api": runtime_api,
+            "fallback_used": backend_identity.fallback_used,
+            "fallback_reason": fallback_reason,
             "prompt": prompt,
             "text": generated_text,
             "tokens": {
@@ -1938,6 +2171,68 @@ async fn run_simple_generation(
                 "tokens_per_second": tok_per_sec,
                 "decoded_tokens": generated_tokens.len(),
             },
+            "model": {
+                "repo": model_repo,
+                "file": model_file,
+                "path": model_path.display().to_string(),
+                "sha256": model_sha256,
+                "format": model_format_label,
+                "architecture": model_architecture,
+                "context_length": config.model.max_position_embeddings,
+                "tokenizer": tokenizer_label,
+                "vocab_size": tokenizer.vocab_size(),
+                "loader_mode": loader_mode,
+            },
+            "bitnet": {
+                "weight_quantization": if canonical_bitnet_model { "W1.58" } else { "unknown" },
+                "activation_quantization": if canonical_bitnet_model { "A8" } else { "unknown" },
+                "kernel_format": kernel_family,
+                "kernel_family": kernel_family,
+                "execution_phase": "decode",
+                "layout_source": layout_source,
+                "fallback_layout": serde_json::Value::Null,
+            },
+            "execution": {
+                "phase": "decode",
+                "prompt_tokens": prompt_tokens_len,
+                "generated_tokens": generated_tokens.len(),
+                "batch_size": 1,
+                "thread_count": thread_count,
+                "requested_backend": requested_backend,
+                "selected_backend": selected_backend,
+                "runtime_api": runtime_api,
+                "fallback_used": backend_identity.fallback_used,
+                "fallback_reason": backend_identity.fallback_reason.as_deref(),
+            },
+            "kernel": {
+                "family": kernel_family,
+                "implementation": kernel_implementation,
+                "layout": kernel_layout,
+                "dequantizes_before_compute": dequantizes_before_compute,
+                "kernel_id": selected_kernel.as_str(),
+            },
+            "cpu": {
+                "arch": std::env::consts::ARCH,
+                "features": &cpu_features,
+                "threads": thread_count,
+            },
+            "strict_provenance": {
+                "requested_backend": requested_backend,
+                "selected_backend": selected_backend,
+                "requested_kernel": selected_kernel.as_str(),
+                "selected_kernel": selected_kernel.as_str(),
+                "loader_mode": loader_mode,
+                "tokenizer_source": tokenizer_source_str,
+                "model_family": "bitnet",
+                "quant_format": format!("{}", config.quantization.quantization_type),
+                "cpu_features": &cpu_features,
+                "thread_count": thread_count,
+                "fallback_used": backend_identity.fallback_used,
+                "fallback_reason": backend_identity.fallback_reason.as_deref(),
+                "prompt_tokens": prompt_tokens_len,
+                "decode_tokens": generated_tokens.len(),
+                "decode_tps": tok_per_sec,
+            },
             "counts": counts,
             "tokenizer": tokenizer_info,
             "loader": loader_info,
@@ -1954,8 +2249,7 @@ async fn run_simple_generation(
                 None
             },
         });
-        std::fs::write(&json_path, serde_json::to_string_pretty(&output)?)?;
-        println!("JSON output written to: {}", json_path.display());
+        write_json_output(Some(&json_path), &output)?;
     }
 
     // Dump IDs if requested
@@ -2078,6 +2372,61 @@ fn compute_rms(xs: &[f32]) -> f32 {
     }
     let sum_sq: f32 = xs.iter().map(|x| x * x).sum();
     (sum_sq / (xs.len() as f32)).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_cpu_neon_identity_is_preserved_or_visible_fallback() {
+        let identity = resolve_run_backend_identity("apple-m4-cpu-neon", false).unwrap();
+
+        assert_eq!(identity.requested_backend, "apple-m4-cpu-neon");
+        assert_eq!(identity.runtime_api, "cpu");
+        assert!(
+            identity.selected_backend == "apple-m4-cpu-neon" || identity.selected_backend == "cpu",
+            "unexpected selected backend: {}",
+            identity.selected_backend
+        );
+        if identity.selected_backend == "cpu" {
+            assert!(identity.fallback_used);
+            assert!(identity.fallback_reason.is_some());
+        }
+    }
+
+    #[test]
+    fn i2s_receipt_kernel_family_is_stable() {
+        assert_eq!(kernel_family_for_quantization(bitnet_common::QuantizationType::I2S), "i2_s");
+    }
+
+    #[test]
+    fn i2s_receipt_records_packed_reference_layout() {
+        assert_eq!(
+            layout_source_for_quantization(bitnet_common::QuantizationType::I2S),
+            "gguf_packed_i2_s_reference"
+        );
+        assert_eq!(
+            kernel_layout_for_quantization(bitnet_common::QuantizationType::I2S),
+            "gguf_packed_i2_s"
+        );
+        assert!(!dequantizes_before_compute(bitnet_common::QuantizationType::I2S));
+    }
+
+    #[test]
+    fn apple_i2s_receipt_does_not_overclaim_neon_kernel() {
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(cpu_kernel_implementation(bitnet_common::QuantizationType::I2S), "scalar");
+    }
+
+    #[test]
+    fn known_bitnet_model_path_records_canonical_repo() {
+        let repo = infer_model_repo(std::path::Path::new(
+            "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+        ));
+
+        assert_eq!(repo, "microsoft/bitnet-b1.58-2B-4T-gguf");
+    }
 }
 
 /// Show system information

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -294,6 +294,8 @@ impl GgufLoader {
     /// Validate LayerNorm gamma statistics to catch quantization artifacts.
     ///
     /// LayerNorm gamma RMS should be near 1.0 (acceptable envelope: [0.5, 2.0]).
+    /// BitNet GGUFs can also store pre-scaled RMSNorm weights near
+    /// 1/sqrt(hidden_size); accept that narrow envelope for real hidden vectors.
     /// If stats are suspicious, fail in strict mode or warn otherwise.
     ///
     /// Set BITNET_STRICT_MODE=1 to fail on invalid LN gamma.
@@ -304,12 +306,25 @@ impl GgufLoader {
         let w32 = w.to_dtype(DType::F32).map_err(|e| BitNetError::Validation(e.to_string()))?;
         let rms = Self::rms_f32(&w32)?;
 
-        // Acceptable envelope for γ RMS
-        let ok = (0.5..=2.0).contains(&rms) && rms.is_finite();
+        // Acceptable envelopes for γ RMS.
+        let unit_scaled_ok = (0.5..=2.0).contains(&rms);
+        let hidden_scaled_ok = w32
+            .dims()
+            .last()
+            .copied()
+            .filter(|hidden| *hidden >= 512)
+            .map(|hidden| {
+                let target = 1.0 / (hidden as f32).sqrt();
+                ((target * 0.5)..=(target * 1.5)).contains(&rms)
+            })
+            .unwrap_or(false);
+        let ok = rms.is_finite() && (unit_scaled_ok || hidden_scaled_ok);
 
         if !ok {
-            let msg =
-                format!("LayerNorm gamma '{}' suspicious: rms={:.5} (expected ≈1.0)", name, rms);
+            let msg = format!(
+                "LayerNorm gamma '{}' suspicious: rms={:.5} (expected ≈1.0 or pre-scaled ≈1/sqrt(hidden_size))",
+                name, rms
+            );
 
             // In strict mode, fail immediately
             if Self::env_truthy("BITNET_STRICT_MODE") {
@@ -877,22 +892,29 @@ impl GgufLoader {
 
         let mut missing = Vec::new();
 
-        if !has_any(&[
+        let has_token_embedding = has_any(&[
             "token_embd.weight".to_string(),
             "tok_embeddings.weight".to_string(),
             "embed_tokens.weight".to_string(),
             "model.embed_tokens.weight".to_string(),
             "transformer.wte.weight".to_string(),
-        ]) {
+        ]);
+        if !has_token_embedding {
             missing.push("token embedding weight".to_string());
         }
 
-        if !has_any(&[
+        let has_output_head = has_any(&[
             "output.weight".to_string(),
             "lm_head.weight".to_string(),
             "model.lm_head.weight".to_string(),
-        ]) {
+            "head.weight".to_string(),
+        ]);
+        if !has_output_head && !has_token_embedding {
             missing.push("output/lm head weight".to_string());
+        } else if !has_output_head {
+            tracing::info!(
+                "Strict real_gguf load: no output/lm head tensor; using tied token embeddings"
+            );
         }
 
         let layer_prefixes = ["blk", "layers", "model.layers", "transformer.h"];
@@ -1565,10 +1587,35 @@ impl GgufLoader {
 
                     let blocks_per_row = cols.div_ceil(256); // 256 elements per block
                     let row_stride_bytes = blocks_per_row * 64; // 64 bytes per 256-element block
+                    let expected_raw_bytes =
+                        rows.checked_mul(row_stride_bytes).ok_or_else(|| {
+                            BitNetError::Validation(format!(
+                                "QK256 '{}': raw byte shape overflow for rows={} stride={}",
+                                info.name, rows, row_stride_bytes
+                            ))
+                        })?;
+                    if data.len() < expected_raw_bytes {
+                        return Err(BitNetError::Validation(format!(
+                            "QK256 '{}': missing raw bytes: available={}, expected={}",
+                            info.name,
+                            data.len(),
+                            expected_raw_bytes
+                        )));
+                    }
+                    let raw_data = if data.len() > expected_raw_bytes {
+                        tracing::debug!(
+                            "QK256 '{}': ignoring {} trailing alignment padding bytes",
+                            info.name,
+                            data.len() - expected_raw_bytes
+                        );
+                        &data[..expected_raw_bytes]
+                    } else {
+                        data
+                    };
 
                     // Store raw bytes as U8 tensor [rows, row_stride_bytes]
                     let raw_tensor = Tensor::from_raw_buffer(
-                        data,
+                        raw_data,
                         DType::U8,
                         &[rows, row_stride_bytes],
                         &candle_device,

--- a/crates/bitnet-models/src/formats/gguf/tests.rs
+++ b/crates/bitnet-models/src/formats/gguf/tests.rs
@@ -1092,6 +1092,20 @@ fn test_ln_gamma_validator_envelope() {
         let result = GgufLoader::check_ln_gamma_stats("test.norm.weight", &edge_high_tensor);
         assert!(result.is_ok(), "RMS at upper boundary should pass");
     }
+
+    // Test 6: BitNet RMSNorm weights may be pre-scaled near 1/sqrt(hidden)
+    {
+        let _guard = EnvGuard::new("BITNET_STRICT_MODE");
+        _guard.set("1");
+        let hidden_size = 2560usize;
+        let target = 1.0 / (hidden_size as f32).sqrt();
+        let data = vec![target * 0.91; hidden_size];
+        let bitnet_scaled_tensor =
+            Tensor::from_vec(data, &[hidden_size], &candle_core::Device::Cpu).unwrap();
+        let result =
+            GgufLoader::check_ln_gamma_stats("blk.0.attn_norm.weight", &bitnet_scaled_tensor);
+        assert!(result.is_ok(), "BitNet pre-scaled RMSNorm gamma should pass strict mode");
+    }
 }
 
 // ---------- Extended validation tests ----------

--- a/crates/bitnet-models/src/formats/gguf/types.rs
+++ b/crates/bitnet-models/src/formats/gguf/types.rs
@@ -862,7 +862,7 @@ impl I2SFlavor {
 ///    - split_need = blocks32 * 8
 ///    - inline_need = blocks32 * 10
 ///    - qk256_need = blocks256 * 64
-/// 2. Match available bytes against expected (with ±64 byte tolerance for alignment)
+/// 2. Match available bytes against expected (with bounded tolerance for alignment)
 /// 3. Priority: Split32WithSibling (if sibling) > BitNet32F16 > GgmlQk256NoScale
 /// 4. Fail-closed with detailed error if no match
 pub fn detect_i2s_flavor(
@@ -878,11 +878,11 @@ pub fn detect_i2s_flavor(
     let available = info.size as usize;
 
     // AC2: Centralized tolerance
-    // - Strict mode: tight 8 bytes (fail-fast)
+    // - Strict mode: bounded 64-byte trailing alignment padding only
     // - Default: size-proportional (~0.1%) using quantization helper
     let strict = std::env::var("BITNET_STRICT_MODE").as_deref() == Ok("1");
     let tolerance = if strict {
-        8usize
+        64usize
     } else {
         // pick a representative expected size (qk256/split) to compute tolerance bytes
         let expected_any = core::cmp::min(split_need, qk256_need);
@@ -904,10 +904,14 @@ pub fn detect_i2s_flavor(
         strict
     );
 
-    // Calculate diff for each flavor
+    // Calculate diff for each flavor. Strict mode permits small trailing
+    // alignment padding from real GGUF files, but still rejects missing bytes.
     let diff_split32 = available.abs_diff(split_need);
     let diff_inline = available.abs_diff(inline_need);
     let diff_qk256 = available.abs_diff(qk256_need);
+    let within_tolerance = |expected: usize, diff: usize| {
+        if strict { available >= expected && diff <= tolerance } else { diff <= tolerance }
+    };
 
     //  Priority logic with adaptive tolerance:
     // 1. Exact matches (diff == 0) - prefer larger block sizes (qk256 > inline > split32)
@@ -971,7 +975,7 @@ pub fn detect_i2s_flavor(
     }
 
     // Priority 2: Close matches (within tolerance) - prefer QK256 for specificity
-    if diff_qk256 <= tolerance {
+    if within_tolerance(qk256_need, diff_qk256) {
         tracing::debug!(
             "I2_S '{}': detected GgmlQk256NoScale (close match: available={}, qk256_need={}, diff={}) - GGML format",
             info.name,
@@ -990,7 +994,7 @@ pub fn detect_i2s_flavor(
 
         return Ok(I2SFlavor::GgmlQk256NoScale);
     }
-    if has_scale_sibling && diff_split32 <= tolerance {
+    if has_scale_sibling && within_tolerance(split_need, diff_split32) {
         tracing::debug!(
             "I2_S '{}': detected Split32WithSibling (close match: available={}, split_need={}, diff={}, has_sibling=true)",
             info.name,
@@ -1009,7 +1013,7 @@ pub fn detect_i2s_flavor(
 
         return Ok(I2SFlavor::Split32WithSibling);
     }
-    if diff_inline <= tolerance {
+    if within_tolerance(inline_need, diff_inline) {
         tracing::debug!(
             "I2_S '{}': detected BitNet32F16 (close match: available={}, inline_need={}, diff={})",
             info.name,
@@ -1030,7 +1034,7 @@ pub fn detect_i2s_flavor(
     }
 
     // Priority 3: Split32 without sibling (data-only, warn about missing scales)
-    if diff_split32 <= tolerance {
+    if within_tolerance(split_need, diff_split32) {
         tracing::warn!(
             "I2_S '{}': bytes match split layout (close match: available={}, split_need={}, diff={}) but no scale sibling found - may be incomplete",
             info.name,
@@ -1049,7 +1053,7 @@ pub fn detect_i2s_flavor(
          - inline_need (32-elem blocks, 10B/block): {} (diff: {})\n\
          - qk256_need (256-elem blocks, 64B/block): {} (diff: {})\n\
          - has_scale_sibling: {}\n\
-         - tolerance: ±{} bytes ({})\n\
+         - tolerance: {} bytes ({})\n\
          All diffs exceed tolerance. This indicates an unsupported I2_S variant or corrupted data.",
         info.name,
         available,
@@ -1061,7 +1065,7 @@ pub fn detect_i2s_flavor(
         available.abs_diff(qk256_need),
         has_scale_sibling,
         tolerance,
-        if strict { "strict mode" } else { "~0.1% size-proportional" }
+        if strict { "strict mode trailing padding only" } else { "±~0.1% size-proportional" }
     )))
 }
 

--- a/crates/bitnet-models/tests/i2s_flavor_detection.rs
+++ b/crates/bitnet-models/tests/i2s_flavor_detection.rs
@@ -286,3 +286,32 @@ fn tolerance_boundary_negative() {
 
     assert!(result.is_err(), "should fail beyond tolerance");
 }
+
+#[test]
+#[serial_test::serial]
+fn strict_mode_accepts_small_trailing_alignment_padding() {
+    temp_env::with_var("BITNET_STRICT_MODE", Some("1"), || {
+        let nelems = 256 * 17;
+        let qk256_need = 17 * 64;
+        let info = mk_info("blk.0.ffn_down.weight", &[256, 17], (qk256_need + 32) as u64);
+
+        let flavor = detect_i2s_flavor(&info, false, nelems)
+            .expect("strict mode should accept bounded trailing alignment padding");
+
+        assert_eq!(flavor, I2SFlavor::GgmlQk256NoScale);
+    });
+}
+
+#[test]
+#[serial_test::serial]
+fn strict_mode_rejects_missing_bytes_within_alignment_tolerance() {
+    temp_env::with_var("BITNET_STRICT_MODE", Some("1"), || {
+        let nelems = 256 * 17;
+        let qk256_need = 17 * 64;
+        let info = mk_info("blk.0.ffn_down.weight", &[256, 17], (qk256_need - 32) as u64);
+
+        let result = detect_i2s_flavor(&info, false, nelems);
+
+        assert!(result.is_err(), "strict mode must not accept missing packed bytes");
+    });
+}

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -1161,11 +1161,11 @@ mod tests {
         let provenance = receipt.strict_provenance.as_mut().unwrap();
         provenance.requested_backend = "apple-m4-cpu-neon".to_string();
         provenance.selected_backend = "apple-m4-cpu-neon".to_string();
-        provenance.selected_kernel = Some("i2_s-neon-reference".to_string());
-        provenance.requested_kernel = Some("i2_s-neon-reference".to_string());
+        provenance.selected_kernel = Some("i2_s-scalar-reference".to_string());
+        provenance.requested_kernel = Some("i2_s-scalar-reference".to_string());
         provenance.quant_format = Some("I2_S".to_string());
         provenance.cpu_features = vec!["neon".to_string()];
-        receipt.kernels = vec!["i2_s-neon-reference".to_string()];
+        receipt.kernels = vec!["i2_s-scalar-reference".to_string()];
 
         assert!(receipt.validate_strict_cpu_proof().is_ok());
     }

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -178,9 +178,9 @@ pub struct ParityMetadata {
 /// tokenizer authorities were used, and whether any fallback was taken.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct StrictInferenceProvenance {
-    /// Backend requested by the caller (for strict CPU proofs this must be `cpu`).
+    /// Backend requested by the caller (for strict CPU proofs this must be a CPU proof label).
     pub requested_backend: String,
-    /// Backend selected by runtime dispatch (for strict CPU proofs this must be `cpu`).
+    /// Backend selected by runtime dispatch (for strict CPU proofs this must be a CPU proof label).
     pub selected_backend: String,
     /// Kernel requested by the caller, for example `qk256-avx2-gemv`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -545,13 +545,13 @@ impl InferenceReceipt {
             .as_ref()
             .ok_or_else(|| anyhow!("strict CPU proof missing strict_provenance"))?;
 
-        if provenance.requested_backend != "cpu" {
+        if !is_strict_cpu_backend_label(&provenance.requested_backend) {
             return Err(anyhow!(
-                "strict CPU proof requested backend must be cpu, got {:?}",
+                "strict CPU proof requested backend must be a CPU proof label, got {:?}",
                 provenance.requested_backend
             ));
         }
-        if provenance.selected_backend != "cpu" || self.backend != "cpu" {
+        if !is_strict_cpu_backend_label(&provenance.selected_backend) || self.backend != "cpu" {
             return Err(anyhow!(
                 "strict CPU proof selected backend mismatch: receipt backend={:?}, selected={:?}",
                 self.backend,
@@ -745,6 +745,10 @@ impl InferenceReceipt {
     pub fn add_correction(&mut self, correction: CorrectionRecord) {
         self.corrections.push(correction);
     }
+}
+
+fn is_strict_cpu_backend_label(label: &str) -> bool {
+    matches!(label, "cpu" | "apple-m4-cpu-neon")
 }
 
 /// Detect CPU brand string (best-effort).
@@ -1147,6 +1151,21 @@ mod tests {
     #[test]
     fn test_validate_strict_cpu_proof_accepts_authoritative_lane() {
         let receipt = strict_cpu_proof_receipt();
+
+        assert!(receipt.validate_strict_cpu_proof().is_ok());
+    }
+
+    #[test]
+    fn test_validate_strict_cpu_proof_accepts_apple_cpu_neon_label() {
+        let mut receipt = strict_cpu_proof_receipt();
+        let provenance = receipt.strict_provenance.as_mut().unwrap();
+        provenance.requested_backend = "apple-m4-cpu-neon".to_string();
+        provenance.selected_backend = "apple-m4-cpu-neon".to_string();
+        provenance.selected_kernel = Some("i2_s-neon-reference".to_string());
+        provenance.requested_kernel = Some("i2_s-neon-reference".to_string());
+        provenance.quant_format = Some("I2_S".to_string());
+        provenance.cpu_features = vec!["neon".to_string()];
+        receipt.kernels = vec!["i2_s-neon-reference".to_string()];
 
         assert!(receipt.validate_strict_cpu_proof().is_ok());
     }

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -211,6 +211,36 @@ When a later artifact claims BitNet progress, it must also include the BitNet co
 
 M4-002 probe artifacts do not claim BitNet inference, Metal kernel execution, MPSGraph graph execution, or Neural Engine execution.
 
+## M4-010 CPU/NEON BitNet Reference
+
+The Apple CPU/NEON BitNet reference proof uses the CLI `--json-out` artifact as
+the receipt path:
+
+```bash
+BITNET_DISABLE_MINIMAL_LOADER=1 \
+BITNET_STRICT_MODE=1 \
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- run \
+  --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --prompt "Answer with a single digit: 2+2=" \
+  --max-tokens 1 \
+  --temperature 0.0 \
+  --greedy \
+  --device apple-m4-cpu-neon \
+  --json-out ci/hardware/apple-m4-mac-mini/<date>/strict-bitnet-cpu-neon-proof.json
+```
+
+The receipt must record `requested_backend`, `selected_backend`,
+`runtime_api`, `fallback_used`, model repo/file/SHA-256, tokenizer source,
+loader mode, kernel family, execution phase, CPU features, and generated token
+count. The M4-010 reference path records the canonical GGUF packed I2_S layout
+and selected scalar reference kernel explicitly; NEON may be present as a CPU
+feature, but this proof must not claim a NEON-optimized packed kernel unless one
+is actually selected. It also does not claim Metal BitNet execution, QK256
+optimization on Apple Silicon, or Apple CPU performance.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -259,6 +259,41 @@ It is not a general Metal performance claim and is not a BitNet inference claim.
 Run a BitNet reference path on Apple CPU/NEON or scalar fallback with model,
 tokenizer, kernel family, and fallback status recorded.
 
+The proof artifact is emitted through the CLI JSON path and must include:
+
+```json
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "sha256": "...",
+    "tokenizer": "llama3",
+    "loader_mode": "real_gguf"
+  },
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "decode",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "fallback_layout": null
+  },
+  "kernel": {
+    "implementation": "scalar",
+    "layout": "gguf_packed_i2_s",
+    "dequantizes_before_compute": false,
+    "kernel_id": "i2_s-scalar-reference"
+  }
+}
+```
+
+If scalar fallback is selected, the receipt must say so with
+`fallback_used=true` and cannot count as Apple CPU/NEON proof. M4-010 does not
+claim Metal BitNet execution, QK256 on Apple Silicon, or Apple CPU performance.
+
 ### M4-011 - Native Metal I2_S Smoke/Parity
 
 Start BitNet-specific native Metal work with an I2_S-adjacent kernel or

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -322,7 +322,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-010"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-010-cpu-neon-bitnet-reference"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -322,7 +322,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-010"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-010-cpu-neon-bitnet-reference"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T131414Z-M4-010-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T131414Z-M4-010-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-06T13:14:14Z"
+campaign = "apple-m4"
+item = "M4-010"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started the Apple CPU/NEON BitNet reference proof item after M4-009 closeout.",
+  "Scope is strict real-GGUF CPU reference receipt fields and Apple campaign tracking only; no Metal BitNet execution, QK256, server inference, MPSGraph, Neural Engine, or performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T134340Z-M4-010-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T134340Z-M4-010-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T13:43:40Z"
+campaign = "apple-m4"
+item = "M4-010"
+event = "pr_open"
+pr = 3746
+head_sha = "735a3d68f7292a78cef2828c5a3b0b12c07c2360"
+actor = "codex"
+
+notes = [
+  "Opened Apple CPU/NEON BitNet reference proof PR.",
+  "Receipt fields record real GGUF, real tokenizer, selected Apple CPU backend, fallback_used=false, packed I2_S scalar reference kernel, and decode phase.",
+  "No Metal BitNet execution, QK256 optimization on Apple Silicon, MPSGraph, Neural Engine, or performance claim is made.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -18,7 +18,7 @@
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| M4-010 | in_progress | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
+| M4-010 | pr_open | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -18,7 +18,7 @@
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| M4-010 | ready | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
+| M4-010 | in_progress | TBD | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-010 | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | cpu-proof | CPU-BITNET-005b | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -11,7 +11,7 @@
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
-| apple-m4 | M4-010 | M4-009 | in_progress |
+| apple-m4 | M4-010 | M4-009 | pr_open |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -11,7 +11,7 @@
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
-| apple-m4 | M4-010 | M4-009 | ready |
+| apple-m4 | M4-010 | M4-009 | in_progress |
 | apple-m4 | M4-011 | M4-010 | proposed |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-010 | TBD | in_progress | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | #3746 | pr_open | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-010 | TBD | ready | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-010 | TBD | in_progress | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-010
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- adds strict M4 CPU reference proof fields to CLI JSON output for real GGUF runs
- preserves requested/selected Apple CPU backend identity with fallback status
- records canonical BitNet model repo/file/SHA, tokenizer, packed I2_S layout, kernel family, execution phase, CPU features, and artifact path
- allows strict real GGUF loading for the canonical tied-embedding model and bounded trailing I2_S alignment padding while still failing missing bytes
- updates Apple M4 campaign docs/tracking and generated dashboards

## Proof boundary
- proves Apple CPU lane BitNet reference execution with fallback_used=false
- does not claim Metal BitNet execution, QK256 optimization on Apple Silicon, MPSGraph, Neural Engine, or performance
- receipt records the selected packed I2_S scalar reference kernel; NEON is recorded only as an available CPU feature

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet
- cargo test --locked -p bitnet-models --no-default-features --features cpu test_ln_gamma_validator_envelope
- cargo test --locked -p bitnet-models --no-default-features --features cpu strict_mode_
- cargo test --locked -p bitnet-receipts-core
- strict Apple CPU/NEON BitNet proof command with real GGUF and receipt artifact succeeded locally
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check