### PR TITLE
[codex] Use shared bearer parser in GPU API server

### DIFF
--- a/crates/bitnet-gpu-hal/src/api_server.rs
+++ b/crates/bitnet-gpu-hal/src/api_server.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, Instant};
 
+use bitnet_http_auth_core::bearer_token;
+
 // ---------------------------------------------------------------------------
 // ServerConfig
 // ---------------------------------------------------------------------------
@@ -547,7 +549,7 @@ impl AuthMiddleware {
 
     /// Parse a bearer token from an `Authorization` header value.
     pub fn parse_bearer(header: &str) -> Option<&str> {
-        header.strip_prefix("Bearer ")
+        bearer_token(header)
     }
 
     /// Authenticate from a raw `Authorization` header value.


### PR DESCRIPTION
## Summary
- route `bitnet-gpu-hal` API-server bearer parsing through `bitnet-http-auth-core`
- keep the existing `AuthMiddleware::parse_bearer` public surface while removing the duplicated local parsing logic

## Validation
- `cargo test -p bitnet-http-auth-core --locked`
- `cargo test -p bitnet-gpu-hal test_auth_parse_bearer --locked`
- `git diff --check`
- `rg -n "strip_prefix\(\"Bearer \"\)|parse_bearer" crates/bitnet-gpu-hal/src/api_server.rs crates/bitnet-gpu-hal/src/api_gateway.rs crates/bitnet-server/src/security.rs crates/bitnet-http-auth-core/src/lib.rs`
