### PR TITLE
feat(quantization): CPU-BITNET-005b record QK256 kernel selection

### DIFF
--- a/crates/bitnet-quantization/src/i2s_qk256.rs
+++ b/crates/bitnet-quantization/src/i2s_qk256.rs
@@ -50,6 +50,95 @@ pub const QK256_SCALAR_GEMV_KERNEL_ID: &str = "qk256-scalar-gemv";
 /// Stable receipt/proof kernel ID for the canonical scalar QK256 prefill GEMM.
 pub const QK256_SCALAR_GEMM_KERNEL_ID: &str = "qk256-scalar-gemm";
 
+/// Stable receipt/proof kernel ID for the canonical AVX2/FMA QK256 decode GEMV.
+pub const QK256_AVX2_GEMV_KERNEL_ID: &str = "qk256-avx2-gemv";
+
+/// Proof-level QK256 kernel selection metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Qk256KernelSelection {
+    pub requested_kernel: Option<&'static str>,
+    pub selected_kernel: &'static str,
+    pub fallback_used: bool,
+    pub fallback_reason: Option<String>,
+    pub cpu_features: Vec<&'static str>,
+}
+
+fn qk256_cpu_features(avx2_fma_available: bool) -> Vec<&'static str> {
+    if avx2_fma_available { vec!["avx2", "fma"] } else { Vec::new() }
+}
+
+fn qk256_avx2_fma_available() -> bool {
+    #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
+    {
+        return bitnet_cpu_detect::avx2_fma_available();
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+fn select_qk256_gemv_kernel_for_availability(
+    requested_kernel: Option<&'static str>,
+    strict: bool,
+    avx2_fma_available: bool,
+) -> Result<Qk256KernelSelection> {
+    let cpu_features = qk256_cpu_features(avx2_fma_available);
+
+    match requested_kernel {
+        None if avx2_fma_available => Ok(Qk256KernelSelection {
+            requested_kernel,
+            selected_kernel: QK256_AVX2_GEMV_KERNEL_ID,
+            fallback_used: false,
+            fallback_reason: None,
+            cpu_features,
+        }),
+        None => Ok(Qk256KernelSelection {
+            requested_kernel,
+            selected_kernel: QK256_SCALAR_GEMV_KERNEL_ID,
+            fallback_used: false,
+            fallback_reason: None,
+            cpu_features,
+        }),
+        Some(QK256_SCALAR_GEMV_KERNEL_ID) => Ok(Qk256KernelSelection {
+            requested_kernel,
+            selected_kernel: QK256_SCALAR_GEMV_KERNEL_ID,
+            fallback_used: false,
+            fallback_reason: None,
+            cpu_features,
+        }),
+        Some(QK256_AVX2_GEMV_KERNEL_ID) if avx2_fma_available => Ok(Qk256KernelSelection {
+            requested_kernel,
+            selected_kernel: QK256_AVX2_GEMV_KERNEL_ID,
+            fallback_used: false,
+            fallback_reason: None,
+            cpu_features,
+        }),
+        Some(QK256_AVX2_GEMV_KERNEL_ID) if strict => {
+            bail!(
+                "I2S_QK256: strict requested kernel qk256-avx2-gemv cannot fall back because avx2/fma is unavailable"
+            )
+        }
+        Some(QK256_AVX2_GEMV_KERNEL_ID) => Ok(Qk256KernelSelection {
+            requested_kernel,
+            selected_kernel: QK256_SCALAR_GEMV_KERNEL_ID,
+            fallback_used: true,
+            fallback_reason: Some("avx2/fma unavailable".to_string()),
+            cpu_features,
+        }),
+        Some(other) => {
+            bail!("I2S_QK256: unsupported requested QK256 GEMV kernel '{other}'")
+        }
+    }
+}
+
+/// Select the QK256 decode GEMV kernel without executing it.
+pub fn select_qk256_gemv_kernel(
+    requested_kernel: Option<&'static str>,
+    strict: bool,
+) -> Result<Qk256KernelSelection> {
+    select_qk256_gemv_kernel_for_availability(requested_kernel, strict, qk256_avx2_fma_available())
+}
+
 /// Storage for GGML I2_S (QK=256) quantized weights without per-block scales
 ///
 /// This structure holds raw packed 2-bit codes for a weight tensor in the
@@ -422,6 +511,25 @@ pub fn gemv_qk256(
     cols: usize,
     row_stride_bytes: usize,
 ) -> Result<()> {
+    gemv_qk256_with_kernel_selection(qs_data, x, y_out, rows, cols, row_stride_bytes, None, false)
+        .map(|_| ())
+}
+
+/// Multi-row GEMV with requested/selected kernel metadata.
+///
+/// `requested_kernel = None` means automatic selection. In strict mode, a
+/// requested AVX2 kernel fails rather than silently falling back to scalar when
+/// AVX2/FMA is unavailable.
+pub fn gemv_qk256_with_kernel_selection(
+    qs_data: &[u8],
+    x: &[f32],
+    y_out: &mut [f32],
+    rows: usize,
+    cols: usize,
+    row_stride_bytes: usize,
+    requested_kernel: Option<&'static str>,
+    strict: bool,
+) -> Result<Qk256KernelSelection> {
     let expected_stride = qk256_row_stride_bytes(cols)?;
     if row_stride_bytes != expected_stride {
         bail!(
@@ -432,24 +540,25 @@ pub fn gemv_qk256(
         );
     }
 
-    // Runtime dispatch: QK256 AVX2 currently uses FMA intrinsics, so both AVX2 and FMA
-    // must be available before entering the target-feature-gated implementation.
+    let selection = select_qk256_gemv_kernel(requested_kernel, strict)?;
+
     #[cfg(all(target_arch = "x86_64", feature = "avx2"))]
     {
-        if bitnet_cpu_detect::avx2_fma_available() {
-            return super::i2s_qk256_avx2::gemv_qk256_avx2(
+        if selection.selected_kernel == QK256_AVX2_GEMV_KERNEL_ID {
+            super::i2s_qk256_avx2::gemv_qk256_avx2(
                 qs_data,
                 x,
                 y_out,
                 rows,
                 cols,
                 row_stride_bytes,
-            );
+            )?;
+            return Ok(selection);
         }
     }
 
-    // Fallback to scalar implementation
-    gemv_qk256_scalar_checked(qs_data, x, y_out, rows, cols, row_stride_bytes)
+    gemv_qk256_scalar_checked(qs_data, x, y_out, rows, cols, row_stride_bytes)?;
+    Ok(selection)
 }
 
 #[cfg(test)]
@@ -578,6 +687,115 @@ mod tests {
     fn qk256_scalar_kernel_ids_are_stable() {
         assert_eq!(QK256_SCALAR_GEMV_KERNEL_ID, "qk256-scalar-gemv");
         assert_eq!(QK256_SCALAR_GEMM_KERNEL_ID, "qk256-scalar-gemm");
+        assert_eq!(QK256_AVX2_GEMV_KERNEL_ID, "qk256-avx2-gemv");
+    }
+
+    #[test]
+    fn qk256_kernel_selection_auto_selects_avx2_when_available() -> Result<()> {
+        let selection = select_qk256_gemv_kernel_for_availability(None, false, true)?;
+        assert_eq!(selection.requested_kernel, None);
+        assert_eq!(selection.selected_kernel, QK256_AVX2_GEMV_KERNEL_ID);
+        assert!(!selection.fallback_used);
+        assert_eq!(selection.fallback_reason, None);
+        assert_eq!(selection.cpu_features, vec!["avx2", "fma"]);
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_kernel_selection_auto_selects_scalar_when_avx2_unavailable() -> Result<()> {
+        let selection = select_qk256_gemv_kernel_for_availability(None, false, false)?;
+        assert_eq!(selection.requested_kernel, None);
+        assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+        assert!(!selection.fallback_used);
+        assert_eq!(selection.fallback_reason, None);
+        assert!(selection.cpu_features.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_kernel_selection_requested_avx2_selects_avx2_when_available() -> Result<()> {
+        let selection =
+            select_qk256_gemv_kernel_for_availability(Some(QK256_AVX2_GEMV_KERNEL_ID), true, true)?;
+        assert_eq!(selection.requested_kernel, Some(QK256_AVX2_GEMV_KERNEL_ID));
+        assert_eq!(selection.selected_kernel, QK256_AVX2_GEMV_KERNEL_ID);
+        assert!(!selection.fallback_used);
+        assert_eq!(selection.fallback_reason, None);
+        assert_eq!(selection.cpu_features, vec!["avx2", "fma"]);
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_kernel_selection_requested_avx2_strict_fails_when_unavailable() {
+        let err =
+            select_qk256_gemv_kernel_for_availability(Some(QK256_AVX2_GEMV_KERNEL_ID), true, false)
+                .expect_err("strict requested AVX2 must fail without avx2/fma");
+        assert!(err.to_string().contains("cannot fall back"));
+    }
+
+    #[test]
+    fn qk256_kernel_selection_requested_avx2_non_strict_falls_back() -> Result<()> {
+        let selection = select_qk256_gemv_kernel_for_availability(
+            Some(QK256_AVX2_GEMV_KERNEL_ID),
+            false,
+            false,
+        )?;
+        assert_eq!(selection.requested_kernel, Some(QK256_AVX2_GEMV_KERNEL_ID));
+        assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+        assert!(selection.fallback_used);
+        assert_eq!(selection.fallback_reason.as_deref(), Some("avx2/fma unavailable"));
+        assert!(selection.cpu_features.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_kernel_selection_requested_scalar_is_not_a_fallback() -> Result<()> {
+        let selection = select_qk256_gemv_kernel_for_availability(
+            Some(QK256_SCALAR_GEMV_KERNEL_ID),
+            true,
+            true,
+        )?;
+        assert_eq!(selection.requested_kernel, Some(QK256_SCALAR_GEMV_KERNEL_ID));
+        assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+        assert!(!selection.fallback_used);
+        assert_eq!(selection.fallback_reason, None);
+        assert_eq!(selection.cpu_features, vec!["avx2", "fma"]);
+        Ok(())
+    }
+
+    #[test]
+    fn qk256_kernel_selection_rejects_unknown_requested_kernel() {
+        let err = select_qk256_gemv_kernel_for_availability(Some("qk256-made-up"), false, true)
+            .expect_err("unknown requested kernel must fail");
+        assert!(err.to_string().contains("unsupported requested QK256 GEMV kernel"));
+    }
+
+    #[test]
+    fn gemv_qk256_with_kernel_selection_can_force_scalar() -> Result<()> {
+        let rows = 2usize;
+        let cols = 256usize;
+        let row_stride_bytes = QK256_PACKED_BYTES;
+        let qs_data = vec![0xAAu8; rows * row_stride_bytes];
+        let x: Vec<f32> = (0..cols).map(|i| i as f32 * 0.25).collect();
+        let mut y_out = vec![0.0f32; rows];
+
+        let selection = gemv_qk256_with_kernel_selection(
+            &qs_data,
+            &x,
+            &mut y_out,
+            rows,
+            cols,
+            row_stride_bytes,
+            Some(QK256_SCALAR_GEMV_KERNEL_ID),
+            true,
+        )?;
+
+        assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+        assert!(!selection.fallback_used);
+        let expected: f32 = x.iter().sum();
+        for got in y_out {
+            assert!((got - expected).abs() < 1e-3, "expected {expected}, got {got}");
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
+++ b/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
@@ -6,7 +6,9 @@
 #![cfg(all(test, feature = "cpu"))]
 
 use bitnet_quantization::i2s_qk256::{
-    QK256_BLOCK, QK256_PACKED_BYTES, code_to_f32, gemv_qk256, gemv_qk256_row, unpack_qk256_block,
+    QK256_AVX2_GEMV_KERNEL_ID, QK256_BLOCK, QK256_PACKED_BYTES, QK256_SCALAR_GEMV_KERNEL_ID,
+    code_to_f32, gemv_qk256, gemv_qk256_row, gemv_qk256_with_kernel_selection,
+    select_qk256_gemv_kernel, unpack_qk256_block,
 };
 use bitnet_quantization::i2s_qk256_avx2::gemv_qk256_avx2;
 
@@ -81,7 +83,7 @@ fn assert_parity(
 
     // Explicit AVX2 path (only on x86_64 with runtime detection)
     #[cfg(target_arch = "x86_64")]
-    if is_x86_feature_detected!("avx2") {
+    if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
         let mut y_avx2 = vec![0.0f32; rows];
         gemv_qk256_avx2(qs_data, x, &mut y_avx2, rows, cols, row_stride).expect("avx2 gemv");
         for (i, (s, a)) in y_scalar.iter().zip(y_avx2.iter()).enumerate() {
@@ -90,6 +92,70 @@ fn assert_parity(
                 "row {i}: scalar={s} avx2={a} diff={}",
                 (s - a).abs()
             );
+        }
+    }
+}
+
+#[test]
+fn test_requested_scalar_selection_executes_scalar() {
+    let rows = 2;
+    let cols = 256;
+    let row_codes = vec![vec![2u8; cols], vec![1u8; cols]];
+    let (qs, stride) = build_qs_data(&row_codes, cols);
+    let x: Vec<f32> = (0..cols).map(|i| (i as f32 + 1.0) * 0.125).collect();
+    let mut y = vec![0.0f32; rows];
+
+    let selection = gemv_qk256_with_kernel_selection(
+        &qs,
+        &x,
+        &mut y,
+        rows,
+        cols,
+        stride,
+        Some(QK256_SCALAR_GEMV_KERNEL_ID),
+        true,
+    )
+    .expect("forced scalar selection");
+
+    assert_eq!(selection.requested_kernel, Some(QK256_SCALAR_GEMV_KERNEL_ID));
+    assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+    assert!(!selection.fallback_used);
+    assert_eq!(selection.fallback_reason, None);
+
+    assert!((y[0] - manual_dot(&row_codes[0], &x, cols)).abs() < 1e-4);
+    assert!((y[1] - manual_dot(&row_codes[1], &x, cols)).abs() < 1e-4);
+}
+
+#[test]
+fn test_requested_avx2_selection_is_explicit() {
+    let selection = select_qk256_gemv_kernel(Some(QK256_AVX2_GEMV_KERNEL_ID), false)
+        .expect("non-strict requested AVX2 selection");
+
+    if selection.selected_kernel == QK256_AVX2_GEMV_KERNEL_ID {
+        assert!(!selection.fallback_used);
+        assert_eq!(selection.fallback_reason, None);
+        assert!(selection.cpu_features.contains(&"avx2"));
+        assert!(selection.cpu_features.contains(&"fma"));
+    } else {
+        assert_eq!(selection.selected_kernel, QK256_SCALAR_GEMV_KERNEL_ID);
+        assert!(selection.fallback_used);
+        assert_eq!(selection.fallback_reason.as_deref(), Some("avx2/fma unavailable"));
+    }
+}
+
+#[test]
+fn test_requested_avx2_strict_matches_runtime_availability() {
+    let selection = select_qk256_gemv_kernel(Some(QK256_AVX2_GEMV_KERNEL_ID), true);
+
+    match selection {
+        Ok(selection) => {
+            assert_eq!(selection.selected_kernel, QK256_AVX2_GEMV_KERNEL_ID);
+            assert!(!selection.fallback_used);
+            assert!(selection.cpu_features.contains(&"avx2"));
+            assert!(selection.cpu_features.contains(&"fma"));
+        }
+        Err(err) => {
+            assert!(err.to_string().contains("cannot fall back"));
         }
     }
 }

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -230,7 +230,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005b"
-status = "ready"
+status = "pr_open"
 branch = "codex/cpu-bitnet-005b-kernel-selection"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T141320Z-CPU-BITNET-005b-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T141320Z-CPU-BITNET-005b-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T14:13:20Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005b"
+event = "pr_open"
+pr = 3748
+head_sha = "82c0e3f206ec95b097a0edd474e87dd44ead5005"
+actor = "codex"
+
+notes = [
+  "Started CPU-BITNET-005b for proof-level QK256 requested and selected kernel dispatch.",
+  "This PR does not add receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -15,7 +15,7 @@
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | CPU-BITNET-005a | merged | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged. |
-| CPU-BITNET-005b | ready | TBD | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
+| CPU-BITNET-005b | pr_open | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
 | CPU-BITNET-005c | proposed | TBD | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| cpu-proof | CPU-BITNET-005b | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | nvidia-5070ti | RTX5070TI-005 | #3723 | `codex/nvidia-5070ti/RTX5070TI-005-smoke-receipt` | Compile and run a tiny CUDA kernel on the selected RTX 5070 Ti with a fallback-free smoke receipt and no BitNet inference or speedup claim. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -21,7 +21,7 @@
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
 | cpu-proof | CPU-BITNET-005a | CPU-BITNET-004 | merged |
-| cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | ready |
+| cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | pr_open |
 | cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | proposed |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-010 | TBD | ready | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005b | TBD | ready | CPU-BITNET-005c | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## CPU-BITNET-005b

## Summary
- add Qk256KernelSelection with requested_kernel, selected_kernel, fallback_used, fallback_reason, and cpu_features
- add QK256 AVX2 GEMV kernel ID plus selector behavior for auto, forced scalar, requested AVX2, strict failure, and non-strict fallback
- add gemv_qk256_with_kernel_selection while preserving existing gemv_qk256 auto-dispatch behavior
- update CPU proof tracking for CPU-BITNET-005b

## Validation
- rustfmt crates\bitnet-quantization\src\i2s_qk256.rs crates\bitnet-quantization\tests\qk256_avx2_parity_tests.rs --edition 2024 --check
- cargo test --locked -p bitnet-quantization --no-default-features --features "cpu,avx2" i2s_qk256 --lib
- cargo test --locked -p bitnet-quantization --no-default-features --features "cpu,avx2" --test qk256_avx2_parity_tests
- cargo clippy --locked -p bitnet-quantization --all-targets --no-default-features --features "cpu,avx2" -- -D warnings
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

No receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse.
