### PR TITLE
docs(tracking): record CPU-BITNET-005b merge

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -230,7 +230,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005b"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-bitnet-005b-kernel-selection"
 stackable = false
 requires_human_merge = true
@@ -267,7 +267,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005c"
-status = "proposed"
+status = "ready"
 branch = "codex/cpu-bitnet-005c-avx2-parity-hardening"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T142417Z-CPU-BITNET-005b-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T142417Z-CPU-BITNET-005b-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T14:24:17Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005b"
+event = "merged"
+pr = 3748
+merge_sha = "0f993f22406bd00cb6c988ffd6fcc4bc21f0b1af"
+actor = "maintainer"
+
+notes = [
+  "Proof-level QK256 requested and selected kernel dispatch merged.",
+  "CPU-BITNET-005c AVX2 parity hardening remains next; no receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse are claimed.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -15,8 +15,8 @@
 | CPU-BITNET-003 | merged | #3690 | `codex/cpu-bitnet-003-canonical-packed-layout` | Canonical block geometry, alignment, stride, and row/block iteration API are defined. |
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | CPU-BITNET-005a | merged | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged. |
-| CPU-BITNET-005b | pr_open | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
-| CPU-BITNET-005c | proposed | TBD | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
+| CPU-BITNET-005b | merged | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
+| CPU-BITNET-005c | ready | TBD | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,7 +4,6 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | apple-m4 | M4-010 | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
-| cpu-proof | CPU-BITNET-005b | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -21,8 +21,8 @@
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
 | cpu-proof | CPU-BITNET-005a | CPU-BITNET-004 | merged |
-| cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | pr_open |
-| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | proposed |
+| cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | merged |
+| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-010 | #3746 | pr_open | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005b | #3748 | pr_open | CPU-BITNET-005c | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-005c | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | ARC140V-002 | #3727 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-005b | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | ARC140V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- mark CPU-BITNET-005b merged after #3748
- advance CPU-BITNET-005c to ready
- regenerate CPU proof and global campaign dashboards

## Validation
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

No runtime files changed. No receipts, benchmarks, transformer decode, server, GPU, NPU, or crate collapse work is included.