### PR TITLE
fix(quantization): preserve AVX2 I2S upper lanes

### DIFF
--- a/crates/bitnet-quantization/src/simd_ops.rs
+++ b/crates/bitnet-quantization/src/simd_ops.rs
@@ -313,13 +313,17 @@ impl QuantizationKernels {
                 let rounded = _mm256_round_ps::<_MM_FROUND_TO_NEAREST_INT>(scaled);
                 let clamped = _mm256_max_ps(_mm256_min_ps(rounded, max_val_vec), min_val_vec);
 
-                // Convert to i32 and then to i8
+                // Convert to i32 and then to i8. AVX2 pack intrinsics operate
+                // within 128-bit lanes, so pack the low/high halves explicitly
+                // to preserve the order of all eight quantized values.
                 let i32_vec = _mm256_cvtps_epi32(clamped);
-                let i16_vec = _mm256_packs_epi32(i32_vec, i32_vec);
-                let i8_vec = _mm256_packs_epi16(i16_vec, i16_vec);
+                let i32_lo = _mm256_castsi256_si128(i32_vec);
+                let i32_hi = _mm256_extracti128_si256::<1>(i32_vec);
+                let i16_vec = _mm_packs_epi32(i32_lo, i32_hi);
+                let i8_vec = _mm_packs_epi16(i16_vec, _mm_setzero_si128());
 
                 // Store 8 bytes efficiently
-                let result = _mm256_extract_epi64::<0>(i8_vec);
+                let result = _mm_cvtsi128_si64(i8_vec);
                 std::ptr::write_unaligned(output.as_mut_ptr().add(i * 8) as *mut i64, result);
             }
         }
@@ -538,6 +542,26 @@ mod tests {
 
         let dequantized = kernels.dequantize_simd(&quantized, &scales, block_size).unwrap();
         assert_eq!(dequantized.len(), data.len());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_avx2_quantize_preserves_upper_lane_values() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let kernels = QuantizationKernels::with_capabilities(SimdCapabilities {
+            has_avx512: false,
+            has_avx2: true,
+            has_neon: false,
+            has_sse4_1: true,
+        });
+        let data = vec![-2.0, -1.0, 0.0, 1.0, 1.0, 0.0, -1.0, -2.0];
+        let scales = vec![1.0];
+        let quantized = kernels.quantize_simd(&data, &scales, 8, 2).unwrap();
+
+        assert_eq!(quantized, vec![-2, -1, 0, 1, 1, 0, -1, -2]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix AVX2 I2S quantization narrowing so lanes 4-7 are preserved instead of duplicating lanes 0-3
- add a targeted AVX2 lane-order regression test
- unblock the deterministic I2S round-trip accuracy test used by the CPU-BITNET-005c acceptance command

## Verification
- cargo test --locked -p bitnet-quantization --no-default-features simd_ops::tests::test_avx2_quantize_preserves_upper_lane_values -- --exact --nocapture
- cargo test --locked -p bitnet-quantization --no-default-features --test integration_tests test_quantize_dequantize_round_trip_accuracy -- --exact --nocapture
- cargo test --locked -p bitnet-quantization --no-default-features --test simd_compatibility
- cargo test --locked -p bitnet-quantization --lib --no-default-features
- cargo clippy --locked -p bitnet-quantization --no-default-features --all-targets -- -D warnings
- git diff --check

## Notes
- A broader `cargo test --locked -p bitnet-quantization --tests --no-default-features --features cpu,avx2` run gets past the I2S round-trip failure after this fix, then stops on pre-existing missing insta snapshots in `snapshot_tests`.