### PR TITLE
[codex][apple-m4] Close out M4-010

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -15,11 +15,12 @@ on:
       - 'crossval/**'
       - 'tests/**'
       - 'xtask/**'
+      - 'docs/tracking/**'
+      - '.codex/campaigns/**'
       - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
-      - 'docs/tracking/**'
       - '.github/workflows/ci-core.yml'
   push:
     branches: [ main ]
@@ -28,11 +29,12 @@ on:
       - 'crossval/**'
       - 'tests/**'
       - 'xtask/**'
+      - 'docs/tracking/**'
+      - '.codex/campaigns/**'
       - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
-      - 'docs/tracking/**'
       - '.github/workflows/ci-core.yml'
   workflow_dispatch:
 

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -322,7 +322,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-010"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-010-cpu-neon-bitnet-reference"
 stackable = false
 requires_human_merge = true
@@ -355,7 +355,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-011"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-011-metal-i2s-smoke-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T152742Z-M4-010-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T152742Z-M4-010-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-06T15:27:42Z"
+campaign = "apple-m4"
+item = "M4-010"
+event = "merged"
+pr = 3746
+head_sha = "04c18711b5ebb1041da673439a8e5184b897262c"
+merge_sha = "876cc267852e6083c5d7fca3413ecdfa83f08d45"
+actor = "codex"
+
+notes = [
+  "Merged Apple CPU/NEON BitNet reference proof.",
+  "Strict real-GGUF proof preserved requested_backend=apple-m4-cpu-neon, selected_backend=apple-m4-cpu-neon, runtime_api=cpu, fallback_used=false, model/tokenizer identity, i2_s kernel family, decode phase, and scalar packed-reference kernel identity.",
+  "No Metal BitNet execution, QK256 on Apple Silicon, Apple CPU performance, server inference, or Neural Engine proof was claimed.",
+  "M4-011 is ready for native Metal I2_S smoke/parity.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -18,8 +18,8 @@
 | M4-007 | merged | #3719 | `codex/apple-m4/M4-007-mpsgraph-smoke` | Run a tiny MPSGraph graph smoke as reference-lane evidence without claiming native Metal or Neural Engine proof. |
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
-| M4-010 | pr_open | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
-| M4-011 | proposed | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
+| M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
+| M4-011 | ready | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-010 | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -11,8 +11,8 @@
 | apple-m4 | M4-007 | M4-006 | merged |
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
-| apple-m4 | M4-010 | M4-009 | pr_open |
-| apple-m4 | M4-011 | M4-010 | proposed |
+| apple-m4 | M4-010 | M4-009 | merged |
+| apple-m4 | M4-011 | M4-010 | ready |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-010 | #3746 | pr_open | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-011 | TBD | ready | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-010 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-010 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Marks M4-010 merged after PR #3746 landed with merge SHA 876cc267852e6083c5d7fca3413ecdfa83f08d45.
- Adds the append-only M4-010 merged event.
- Promotes M4-011 to ready and regenerates campaign/global dashboards.
- Updates CI Core path filters so campaign tracker closeout PRs produce the required Core CI contexts instead of getting stuck behind ruleset checks that never trigger.

## Claims
- Apple CPU/NEON BitNet reference proof is recorded as merged.
- M4-011 is ready for native Metal I2_S smoke/parity.

## Non-claims
- No Metal BitNet execution.
- No QK256 on Apple Silicon.
- No Apple CPU performance proof.
- No server inference or Neural Engine proof.

## Verification
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo fmt --all -- --check
- git diff --check
- Manual workflow_dispatch CI Core on abbacae171feada79cf433f5165947eb0af64e7b passed, including CI Core Success; this PR now also triggers CI Core as pull_request via the path-filter fix.