### PR TITLE
feat(ci): add ripr advisory lane (mutation-testing-lite)

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -92,6 +92,15 @@ jobs:
                               r"^crates/bitnet-startup-contract", r"^crates/bitnet-feature-contract"],
               "fuzz":        [r"^fuzz/"],
               "manifest":    [r"^Cargo\.(toml|lock)$", r"^rust-toolchain\.toml$"],
+              # ripr triggers on production Rust (i.e. crates/*/src, xtask/src,
+              # crossval/src) and on its own config files. Test-only diffs do
+              # not invoke ripr by default — there is no behavior to probe.
+              "rust_production": [
+                  r"^crates/[^/]+/src/",
+                  r"^crossval/src/",
+                  r"^xtask/src/",
+              ],
+              "ripr":        [r"^ripr\.toml$", r"^policy/ripr-"],
           }
 
           touched = {area: False for area in AREAS}
@@ -133,6 +142,10 @@ jobs:
           # Property smoke (after PR D).
           if "property-tests" in labels or "full-ci" in labels:
               lanes.append(("Property Tests (smoke)", 4, "property-tests/full-ci label"))
+          # ripr static exposure (PR J): production Rust diffs or explicit label.
+          # Advisory only — does not gate merges.
+          if touched["rust_production"] or touched["ripr"] or "ripr" in labels or "full-ci" in labels:
+              lanes.append(("ripr static exposure (advisory)", 4, "production Rust diff / ripr label"))
           # Always-on cheap guards.
           if changed:
               lanes.append(("Guards / PR Size Guard / Markdownlint / Link Check", 4, "always-on"))

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -1,0 +1,155 @@
+name: ripr (static exposure)
+
+# Mutation-testing-lite static exposure analysis on PR diffs.
+#
+# ripr asks: for the behavior changed in this diff, do the current tests
+# appear to contain a discriminator that would notice if the behavior were
+# wrong? It does NOT run mutants and does NOT report killed/survived
+# outcomes. See docs/ci/cost-and-verification-policy.md for the
+# verification ladder and why this layer matters.
+#
+# Initial posture: ADVISORY (non-blocking).
+# - continue-on-error: true at the job level
+# - no merge gate
+# - JSON + SARIF + GitHub annotations only
+# - production Rust paths only; skips docs-only PRs
+# - workflow_dispatch + label-triggered runs supported
+#
+# Toolchain note: ripr targets Rust 2024 and requires Rust >= 1.93.
+# BitNet-rs MSRV (rust-toolchain.toml) is currently 1.92, so we install a
+# separate stable toolchain just for the ripr install + invocation. This
+# keeps the BitNet-rs MSRV decision orthogonal to ripr adoption.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/**'
+      - 'crossval/**'
+      - 'tests/**'
+      - 'xtask/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'ripr.toml'
+      - 'policy/ripr-suppressions.toml'
+      - '.github/workflows/ripr.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ripr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Allow uploading SARIF for native code-scanning surfacing on label opt-in.
+  security-events: write
+
+jobs:
+  ripr:
+    name: ripr static exposure
+    runs-on: ubuntu-22.04
+    timeout-minutes: 8
+    # Advisory only. Findings do not gate merges yet.
+    continue-on-error: true
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout (with full history for diff)
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+        with:
+          fetch-depth: 0
+
+      # Install a separate stable Rust toolchain just for ripr. We do NOT
+      # change rust-toolchain.toml — BitNet-rs MSRV stays at 1.92 for
+      # ordinary CI lanes. This step is the one that requires Rust >= 1.93.
+      - name: Install Rust (stable, for ripr)
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: stable
+
+      - name: Cache ripr install
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: ripr-install-stable
+          # Save on main only — PR runs are restore-only.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # ripr is installed via cargo install; cache its target dir but
+          # not the BitNet-rs workspace target (different toolchain).
+          cache-targets: false
+
+      - name: Install ripr (locked)
+        # Pin via --locked so we can later promote to a release artifact /
+        # prebuilt binary without changing the workflow shape.
+        run: |
+          cargo install ripr --locked || {
+            echo "::warning::ripr install failed; advisory job emits no findings."
+            echo "RIPR_INSTALL_FAILED=1" >> "$GITHUB_ENV"
+            exit 0
+          }
+
+      - name: ripr doctor
+        if: env.RIPR_INSTALL_FAILED != '1'
+        run: ripr doctor || true
+
+      - name: Run ripr (diff-scoped)
+        if: env.RIPR_INSTALL_FAILED != '1'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/ripr
+
+          # Ensure the base ref is fetched for diff computation.
+          if [ -n "${BASE_SHA:-}" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
+          fi
+
+          base_arg="origin/main"
+          if [ -n "${BASE_SHA:-}" ] && git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            base_arg="$BASE_SHA"
+          fi
+
+          # JSON artifact (machine-readable).
+          ripr check --base "$base_arg" --json > target/ripr/ripr.json || true
+          # GitHub annotations (visible in Files tab).
+          ripr check --base "$base_arg" --format github || true
+          # SARIF artifact (for label opt-in code-scanning surfacing later).
+          ripr check --base "$base_arg" --format sarif > target/ripr/ripr.sarif || true
+
+      - name: PR step summary
+        if: always()
+        run: |
+          set -euo pipefail
+          {
+            echo "## ripr static exposure (advisory)"
+            echo
+            echo "ripr asks whether the behavior changed in this diff appears exposed"
+            echo "to a meaningful test discriminator. It does **not** run mutants."
+            echo
+            if [ -s target/ripr/ripr.json ]; then
+              echo '```json'
+              head -c 8000 target/ripr/ripr.json || true
+              echo
+              echo '```'
+            else
+              echo "_No ripr JSON produced (install failure or no findings)._"
+            fi
+            echo
+            echo "Findings here are advisory and do not gate merges. See"
+            echo "[docs/ci/cost-and-verification-policy.md](../blob/main/docs/ci/cost-and-verification-policy.md)"
+            echo "for the verification ladder and ripr's role in it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload ripr artifacts
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: ripr-report
+          path: |
+            target/ripr/ripr.json
+            target/ripr/ripr.sarif
+          retention-days: 14
+          if-no-files-found: ignore

--- a/policy/ripr-suppressions.toml
+++ b/policy/ripr-suppressions.toml
@@ -1,0 +1,22 @@
+# BitNet-rs ripr suppressions.
+#
+# Format and semantics are defined by ripr (see https://github.com/EffortlessMetrics/ripr).
+# This file is intentionally empty at landing.
+#
+# Rationale:
+# - The first real ripr runs on BitNet-rs are expected to surface a baseline
+#   inventory of historical oracle-exposure gaps. That is signal, not failure.
+# - We do NOT want to silence the entire baseline by default. The advisory
+#   workflow (.github/workflows/ripr.yml) is non-blocking, so historical gaps
+#   are visible in the PR step summary without blocking merges.
+# - Use this file only for findings that have been triaged and consciously
+#   accepted. Each entry should include rationale + owner + expiration.
+#
+# Example shape (keep commented until calibration begins):
+#
+# [[suppress]]
+# path = "crates/bitnet-quantization/src/i2s_qk256.rs"
+# classification = "reachable_unrevealed"
+# rationale = "Path is unreachable from public API in 0.2.x; see #1234."
+# owner = "@user"
+# expires = "2026-09-01"

--- a/ripr.toml
+++ b/ripr.toml
@@ -1,0 +1,39 @@
+# BitNet-rs ripr policy.
+#
+# ripr is mutation-testing-lite at static-analysis prices. It analyzes the
+# diff, builds mutation-shaped static probes, and asks whether the changed
+# behavior appears exposed to a meaningful test discriminator.
+#
+# Initial BitNet-rs posture: ADVISORY.
+# - Diff-scoped (no full-repo scan).
+# - No merge gate. Findings are reported via PR step summary + JSON/SARIF.
+# - Promotion to soft-gate or hard-gate requires calibration: see
+#   docs/ci/cost-and-verification-policy.md and the staged plan in PR P.
+#
+# See https://github.com/EffortlessMetrics/ripr for the schema reference.
+
+[analysis]
+mode = "diff"
+
+[policy]
+# Start advisory: nothing fails the build. Promotion happens incrementally
+# once the noise profile is observed (PR P in the CI roadmap).
+fail_on = []
+
+[report]
+max_related_tests = 8
+include_context = true
+
+[severity]
+# Map ripr classifications to GitHub annotation severity. Initial values
+# bias toward `notice` so the first runs do not flood the Files tab.
+exposed = "notice"
+weakly_exposed = "warning"
+reachable_unrevealed = "warning"
+no_static_path = "notice"
+infection_unknown = "notice"
+propagation_unknown = "notice"
+static_unknown = "notice"
+
+[suppressions]
+path = "policy/ripr-suppressions.toml"


### PR DESCRIPTION
## Summary

Lands the **advisory** layer of the ripr verification ladder described in [`docs/ci/cost-and-verification-policy.md`](https://github.com/EffortlessMetrics/BitNet-rs/blob/main/docs/ci/cost-and-verification-policy.md).

> ripr asks: for the behavior changed in this diff, do the current tests appear to contain a discriminator that would notice if the behavior were wrong? It does **not** run mutants and does **not** report killed/survived outcomes.

This PR is part of the multi-PR CI roadmap (PRs A–I merged; J–P remaining). It is **PR J — ripr advisory lane**.

## What's included

- `ripr.toml` — repo-root config. Diff-scoped, empty `fail_on`, severity biased toward `notice` for first runs. Suppression file pointer.
- `policy/ripr-suppressions.toml` — empty placeholder. Each future entry requires rationale + owner + expiration.
- `.github/workflows/ripr.yml` — PR-only, non-blocking workflow (`continue-on-error: true`). Runs on production Rust paths and ripr config; skips docs-only PRs. Emits JSON, SARIF, GitHub annotations, step summary, artifact upload. **Does not block merges.**
- `.github/workflows/pr-plan.yml` — adds `rust_production` and `ripr` touched-area buckets and a `ripr static exposure (advisory)` lane (~4 LEM) to the LEM forecast.

## Toolchain note

ripr targets Rust 2024 and requires Rust ≥ 1.93. BitNet-rs MSRV (`rust-toolchain.toml`) is still 1.92, so `ripr.yml` installs a separate `stable` toolchain *only* for the ripr install + invocation. This keeps the BitNet-rs MSRV decision orthogonal to ripr adoption.

If `cargo install ripr --locked` fails (e.g. transient registry / version-resolve issue), the job emits a warning and exits successfully. Advisory mode means the absence of findings does not block merges either.

## Why advisory first

Per the cost policy: the first real ripr runs are expected to surface a baseline inventory of historical oracle-exposure gaps. That is signal, not failure. We do not silence the baseline; we let it sit visible in the step summary.

Promotion to soft-gate (warn on new `reachable_unrevealed` / `weakly_exposed` in touched code) and hard-gate (require waiver on selected high-confidence new gaps) is a deliberately separate PR (PR P), gated on observed noise profile.

## Test plan

- [ ] Verify `ripr` workflow runs on this PR (touches `crates/`-adjacent? No — but does touch `ripr.toml` and the workflow file, both in `paths`).
- [ ] Verify `ripr install` either succeeds or emits the install-failure warning gracefully.
- [ ] Verify the run's step summary shows the "ripr static exposure (advisory)" header.
- [ ] Verify artifacts (`ripr.json`, `ripr.sarif`) upload (or artifact step exits cleanly with `if-no-files-found: ignore`).
- [ ] Verify `pr-plan` shows the new `ripr static exposure (advisory)` lane on the LEM forecast for this PR.
- [ ] Verify ripr is **not** in the required-checks list (advisory only).

## Out of scope (future PRs)

- PR K: Move PR Plan inline-Python into Rust-native `xtask ci plan` with fixture tests.
- PR L: Hoist hard-coded LEM estimates into `policy/ci-budget.toml`, `policy/ci-lanes.toml`, `policy/ci-risk-packs.toml`.
- PR M: nextest profile + JUnit upload + per-test duration history.
- PR N: actual LEM collection (`ci-actuals.json`).
- PR O: soft budget warnings (warn at 35 / 75 LEM; hard at 125 without `full-ci` label).
- PR P: ripr promotion rules (warn-on-new-finding) once noise profile is observed.

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_