### PR TITLE
feat(xtask): add ci plan subcommand (Rust-native PR planner)

### DIFF
--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -9,6 +9,9 @@ name: PR Plan
 # - LEM = Linux-equivalent minutes (macOS is treated as 10x, GPU Docker as 6x).
 # - Estimates are rough heuristics. Actual cost is recorded in the GitHub
 #   Actions metrics UI; this job exists to give a per-PR forecast.
+#
+# Implementation: see `xtask::ci_plan` (xtask/src/ci_plan.rs). The planner is
+# Rust-native and unit-testable; this workflow just wires it up.
 
 on:
   pull_request:
@@ -26,172 +29,44 @@ jobs:
   plan:
     name: PR Plan
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 8
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
         with:
           fetch-depth: 0
 
-      - name: Compute changed files
-        id: diff
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.92.0"
+
+      - name: Cache xtask build
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: xtask-ci-plan
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # Restrict cache to xtask + its deps to keep this lane small.
+          workspaces: ". -> target"
+
+      - name: Run xtask ci plan
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: |
           set -euo pipefail
-          # Fetch base if needed (workflow_dispatch has no PR base).
-          if [ -z "${BASE_SHA:-}" ]; then
-            base_ref="refs/heads/main"
-            git fetch --no-tags --depth=1 origin main || true
-            BASE_SHA="$(git rev-parse origin/main 2>/dev/null || echo "")"
+          # Make sure the base ref is fetched for diff computation.
+          if [ -n "${BASE_SHA:-}" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA" 2>/dev/null || true
           fi
-          if [ -n "${BASE_SHA:-}" ] && git cat-file -e "$BASE_SHA" 2>/dev/null; then
-            git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed.txt || true
-          else
-            # Fall back to last commit on this branch.
-            git diff --name-only HEAD~1..HEAD > changed.txt || true
-          fi
-          count=$(wc -l < changed.txt | tr -d ' ')
-          echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Changed files ($count):"
-          sed -n '1,200p' changed.txt
 
-      - name: Build PR plan
-        id: plan
-        env:
-          LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          set -euo pipefail
-          python3 - <<'PY'
-          import json, os, re, pathlib
-
-          changed = pathlib.Path("changed.txt").read_text().splitlines()
-          changed = [c for c in changed if c]
-          labels = set(json.loads(os.environ.get("LABELS") or "[]"))
-
-          AREAS = {
-              "docs":        [r"^docs/", r"\.md$", r"^README", r"^CHANGELOG", r"^CONTRIBUTING",
-                              r"^SECURITY", r"^COMPATIBILITY", r"^THIRD_PARTY", r"^CLAUDE\.md$"],
-              "tracking":    [r"^\.codex/campaigns/", r"^docs/tracking/"],
-              "workflow":    [r"^\.github/workflows/", r"^\.github/actions/"],
-              "rust_core":   [r"^crates/", r"^tests/", r"^xtask/", r"^Cargo\.(toml|lock)$",
-                              r"^rust-toolchain\.toml$"],
-              "gpu":         [r"^crates/bitnet-kernels/", r"^crates/bitnet-gpu-hal/",
-                              r"^crates/bitnet-device-probe/", r"^crates/bitnet-device-config-core/",
-                              r"^crates/bitnet-inference/", r"^crates/bitnet-metal/",
-                              r"^crates/bitnet-opencl/", r"^crates/bitnet-vulkan",
-                              r"^crates/bitnet-wgpu", r"^crates/bitnet-webgpu/",
-                              r"^crates/bitnet-rocm/", r"^crates/bitnet-intel-gpu-id/",
-                              r"^docker/"],
-              "ffi":         [r"^crates/bitnet-ffi/", r"^crates/bitnet-sys/",
-                              r"^crates/bitnet-ggml-ffi/", r"^crossval/"],
-              "tokenizer":   [r"^crates/bitnet-tokenizers/", r"^tests/fixtures/tokenizers/"],
-              "bdd":         [r"^crates/bitnet-bdd-", r"^crates/bitnet-testing-policy",
-                              r"^crates/bitnet-testing-scenarios", r"^crates/bitnet-runtime-feature-flags",
-                              r"^crates/bitnet-startup-contract", r"^crates/bitnet-feature-contract"],
-              "fuzz":        [r"^fuzz/"],
-              "manifest":    [r"^Cargo\.(toml|lock)$", r"^rust-toolchain\.toml$"],
-          }
-
-          touched = {area: False for area in AREAS}
-          for path in changed:
-              for area, patterns in AREAS.items():
-                  if any(re.search(p, path) for p in patterns):
-                      touched[area] = True
-
-          # Lanes that will run on the default PR path, given gating rules.
-          lanes = []  # list of (lane_name, lem, reason)
-
-          # CI Core triggers on rust_core (after PR A merges).
-          if touched["rust_core"]:
-              lanes.append(("CI (Core) — build/test/clippy/docs", 22, "rust_core changed"))
-          # BDD grid: gated to bdd/grid/full-ci or main (after PR G).
-          if "bdd" in labels or "grid" in labels or "full-ci" in labels:
-              lanes.append(("BDD Grid Check", 4, "bdd/grid/full-ci label"))
-          # macOS clippy: gated to macos/full-ci (after PR F). 10x multiplier.
-          if "macos" in labels or "full-ci" in labels:
-              lanes.append(("Clippy (macOS ARM64)", 15 * 10, "macos/full-ci label"))
-          # Feature matrix: 3-combo PR matrix; full matrix on label.
-          if touched["rust_core"] or touched["manifest"]:
-              if "feature-matrix" in labels or "full-ci" in labels:
-                  lanes.append(("Feature Matrix (full ~21 jobs)", 70, "feature-matrix/full-ci label"))
-              else:
-                  lanes.append(("Feature Matrix (PR 3-combo)", 12, "rust/manifest changed"))
-          # GPU CI: triggers on gpu paths (after PR B).
-          if touched["gpu"]:
-              lanes.append(("GPU CI Matrix (native compile)", 18, "GPU paths changed"))
-              if "gpu-ci" in labels or "docker" in labels or "full-ci" in labels:
-                  lanes.append(("GPU CI Matrix (Docker, ~6x)", 90, "gpu-ci/docker/full-ci label"))
-          # Compatibility lanes (after PR E).
-          if touched["rust_core"]:
-              lanes.append(("Compatibility (MSRV)", 12, "rust_core changed"))
-          if touched["ffi"] or "ffi" in labels or "abi" in labels or "full-ci" in labels:
-              lanes.append(("Compatibility (ABI/FFI)", 8, "ffi area / label"))
-          if touched["tokenizer"] or "tokenizer" in labels or "full-ci" in labels:
-              lanes.append(("Compatibility (tokenizer)", 6, "tokenizer area / label"))
-          # Property smoke (after PR D).
-          if "property-tests" in labels or "full-ci" in labels:
-              lanes.append(("Property Tests (smoke)", 4, "property-tests/full-ci label"))
-          # Always-on cheap guards.
-          if changed:
-              lanes.append(("Guards / PR Size Guard / Markdownlint / Link Check", 4, "always-on"))
-
-          total = sum(lem for _, lem, _ in lanes)
-
-          # Categorize.
-          if not changed:
-              posture = "empty"
-          elif touched["docs"] and not (touched["rust_core"] or touched["gpu"] or touched["ffi"] or touched["tokenizer"]):
-              posture = "docs-only"
-          elif touched["tracking"] and not (touched["rust_core"] or touched["gpu"] or touched["ffi"]):
-              posture = "tracking-only"
-          else:
-              posture = "rust"
-
-          # Budget banding.
-          if total <= 12:
-              band = "✅ pennies (< 12 LEM)"
-          elif total <= 35:
-              band = "✅ default budget (< 35 LEM)"
-          elif total <= 75:
-              band = "⚠️  elevated (35–75 LEM)"
-          elif total <= 125:
-              band = "⚠️  high (75–125 LEM)"
-          else:
-              band = "🚨 over hard ceiling (> 125 LEM)"
-
-          summary_path = os.environ["GITHUB_STEP_SUMMARY"]
-          with open(summary_path, "a") as f:
-              f.write(f"# PR Plan\n\n")
-              f.write(f"- **Posture:** {posture}\n")
-              f.write(f"- **Touched areas:** "
-                      f"{', '.join(a for a, t in touched.items() if t) or '(none)'}\n")
-              f.write(f"- **Labels:** {', '.join(sorted(labels)) or '(none)'}\n")
-              f.write(f"- **Estimated LEM:** {total}  ·  {band}\n\n")
-              f.write("| Lane | Estimated LEM | Reason |\n")
-              f.write("|---|---:|---|\n")
-              for name, lem, reason in lanes:
-                  f.write(f"| {name} | {lem} | {reason} |\n")
-              if not lanes:
-                  f.write("| (no lanes expected) | 0 | nothing matched |\n")
-              f.write("\n")
-              f.write("> Estimates are rough heuristics derived from path globs + labels. ")
-              f.write("Actual minutes are recorded in the GitHub Actions metrics UI. ")
-              f.write("This job is advisory only and does not gate merges.\n")
-
-          # Also emit machine-readable artifact for future LEM-aware routing.
-          plan = {
-              "posture": posture,
-              "touched": touched,
-              "labels": sorted(labels),
-              "lanes": [{"name": n, "lem": l, "reason": r} for n, l, r in lanes],
-              "estimated_lem": total,
-              "band": band,
-          }
-          pathlib.Path("ci-plan.json").write_text(json.dumps(plan, indent=2))
-          print(json.dumps(plan, indent=2))
-          PY
+          cargo run --locked -p xtask --no-default-features -- ci plan \
+            --base "${BASE_SHA:-origin/main}" \
+            --head "${HEAD_SHA:-HEAD}" \
+            --labels-json "${LABELS_JSON:-[]}" \
+            --json-out ci-plan.json \
+            --github-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload plan artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0

--- a/xtask/src/ci_plan.rs
+++ b/xtask/src/ci_plan.rs
@@ -1,0 +1,576 @@
+//! `xtask ci plan` — Rust-native PR planner / LEM forecaster.
+//!
+//! Replaces the inline Python planner that previously lived in
+//! `.github/workflows/pr-plan.yml`. The Rust version is unit-testable with
+//! fixtures and emits a stable `ci-plan.json` schema for downstream tooling
+//! (budget warnings, label-aware gating, future learned-budget calibration).
+//!
+//! Conventions:
+//!   - LEM = Linux-equivalent minutes. macOS treated as 10x, GPU Docker as 6x.
+//!   - Estimates are rough heuristics. Actual cost is recorded in the GitHub
+//!     Actions metrics UI; this module exists to give a per-PR forecast.
+//!
+//! See `docs/ci/cost-and-verification-policy.md` for rationale.
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+/// Touched-area buckets considered by the planner.
+///
+/// Matched against the list of changed files via the regexes in [`area_patterns`].
+const AREAS: &[&str] = &[
+    "docs",
+    "tracking",
+    "workflow",
+    "rust_core",
+    "rust_production",
+    "ripr",
+    "gpu",
+    "ffi",
+    "tokenizer",
+    "bdd",
+    "fuzz",
+    "manifest",
+];
+
+fn area_patterns() -> Vec<(&'static str, Vec<&'static str>)> {
+    vec![
+        (
+            "docs",
+            vec![
+                r"^docs/",
+                r"\.md$",
+                r"^README",
+                r"^CHANGELOG",
+                r"^CONTRIBUTING",
+                r"^SECURITY",
+                r"^COMPATIBILITY",
+                r"^THIRD_PARTY",
+                r"^CLAUDE\.md$",
+            ],
+        ),
+        ("tracking", vec![r"^\.codex/campaigns/", r"^docs/tracking/"]),
+        ("workflow", vec![r"^\.github/workflows/", r"^\.github/actions/"]),
+        (
+            "rust_core",
+            vec![
+                r"^crates/",
+                r"^tests/",
+                r"^xtask/",
+                r"^Cargo\.(toml|lock)$",
+                r"^rust-toolchain\.toml$",
+            ],
+        ),
+        (
+            // ripr triggers on production Rust (crates/*/src, xtask/src,
+            // crossval/src) and on its own config files. Test-only diffs do
+            // not invoke ripr by default.
+            "rust_production",
+            vec![r"^crates/[^/]+/src/", r"^crossval/src/", r"^xtask/src/"],
+        ),
+        ("ripr", vec![r"^ripr\.toml$", r"^policy/ripr-"]),
+        (
+            "gpu",
+            vec![
+                r"^crates/bitnet-kernels/",
+                r"^crates/bitnet-gpu-hal/",
+                r"^crates/bitnet-device-probe/",
+                r"^crates/bitnet-device-config-core/",
+                r"^crates/bitnet-inference/",
+                r"^crates/bitnet-metal/",
+                r"^crates/bitnet-opencl/",
+                r"^crates/bitnet-vulkan",
+                r"^crates/bitnet-wgpu",
+                r"^crates/bitnet-webgpu/",
+                r"^crates/bitnet-rocm/",
+                r"^crates/bitnet-intel-gpu-id/",
+                r"^docker/",
+            ],
+        ),
+        (
+            "ffi",
+            vec![
+                r"^crates/bitnet-ffi/",
+                r"^crates/bitnet-sys/",
+                r"^crates/bitnet-ggml-ffi/",
+                r"^crossval/",
+            ],
+        ),
+        ("tokenizer", vec![r"^crates/bitnet-tokenizers/", r"^tests/fixtures/tokenizers/"]),
+        (
+            "bdd",
+            vec![
+                r"^crates/bitnet-bdd-",
+                r"^crates/bitnet-testing-policy",
+                r"^crates/bitnet-testing-scenarios",
+                r"^crates/bitnet-runtime-feature-flags",
+                r"^crates/bitnet-startup-contract",
+                r"^crates/bitnet-feature-contract",
+            ],
+        ),
+        ("fuzz", vec![r"^fuzz/"]),
+        ("manifest", vec![r"^Cargo\.(toml|lock)$", r"^rust-toolchain\.toml$"]),
+    ]
+}
+
+#[derive(Debug, Serialize)]
+pub struct Lane {
+    pub name: String,
+    pub lem: u32,
+    pub reason: String,
+    pub blocking: bool,
+    pub stage: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Plan {
+    pub posture: &'static str,
+    pub touched: BTreeMap<String, bool>,
+    pub labels: Vec<String>,
+    pub lanes: Vec<Lane>,
+    pub estimated_lem: u32,
+    pub band: &'static str,
+}
+
+/// Pure planner: given the changed files and labels, produce the plan.
+///
+/// This is the core function exercised by the unit tests. The [`run`] entry
+/// point wraps this with git-diff invocation and JSON / step-summary output.
+pub fn plan_for(changed: &[String], labels: &[String]) -> Plan {
+    let mut touched: BTreeMap<String, bool> =
+        AREAS.iter().map(|a| ((*a).to_string(), false)).collect();
+
+    let compiled: Vec<(&str, Vec<Regex>)> = area_patterns()
+        .into_iter()
+        .map(|(area, pats)| {
+            let regs = pats.iter().map(|p| Regex::new(p).expect("static regex")).collect();
+            (area, regs)
+        })
+        .collect();
+
+    for path in changed {
+        for (area, regs) in &compiled {
+            if regs.iter().any(|r| r.is_match(path)) {
+                touched.insert((*area).to_string(), true);
+            }
+        }
+    }
+
+    let mut lanes: Vec<Lane> = Vec::new();
+    let label_set: std::collections::HashSet<&str> = labels.iter().map(|s| s.as_str()).collect();
+    let has = |l: &str| label_set.contains(l);
+
+    let touched_or = |area: &str| -> bool { *touched.get(area).unwrap_or(&false) };
+
+    // CI Core triggers on rust_core (post PR A).
+    if touched_or("rust_core") {
+        lanes.push(Lane {
+            name: "CI (Core) — build/test/clippy/docs".to_string(),
+            lem: 22,
+            reason: "rust_core changed".to_string(),
+            blocking: true,
+            stage: "required",
+        });
+    }
+    // BDD grid: gated to bdd/grid/full-ci or main (post PR G).
+    if has("bdd") || has("grid") || has("full-ci") {
+        lanes.push(Lane {
+            name: "BDD Grid Check".to_string(),
+            lem: 4,
+            reason: "bdd/grid/full-ci label".to_string(),
+            blocking: false,
+            stage: "label",
+        });
+    }
+    // macOS clippy: gated to macos/full-ci (post PR F). 10x multiplier already baked in.
+    if has("macos") || has("full-ci") {
+        lanes.push(Lane {
+            name: "Clippy (macOS ARM64)".to_string(),
+            lem: 15 * 10,
+            reason: "macos/full-ci label".to_string(),
+            blocking: false,
+            stage: "label",
+        });
+    }
+    // Feature matrix: 3-combo PR matrix; full matrix on label.
+    if touched_or("rust_core") || touched_or("manifest") {
+        if has("feature-matrix") || has("full-ci") {
+            lanes.push(Lane {
+                name: "Feature Matrix (full ~21 jobs)".to_string(),
+                lem: 70,
+                reason: "feature-matrix/full-ci label".to_string(),
+                blocking: false,
+                stage: "label",
+            });
+        } else {
+            lanes.push(Lane {
+                name: "Feature Matrix (PR 3-combo)".to_string(),
+                lem: 12,
+                reason: "rust/manifest changed".to_string(),
+                blocking: false,
+                stage: "default",
+            });
+        }
+    }
+    // GPU CI: triggers on gpu paths (post PR B).
+    if touched_or("gpu") {
+        lanes.push(Lane {
+            name: "GPU CI Matrix (native compile)".to_string(),
+            lem: 18,
+            reason: "GPU paths changed".to_string(),
+            blocking: false,
+            stage: "default",
+        });
+        if has("gpu-ci") || has("docker") || has("full-ci") {
+            lanes.push(Lane {
+                name: "GPU CI Matrix (Docker, ~6x)".to_string(),
+                lem: 90,
+                reason: "gpu-ci/docker/full-ci label".to_string(),
+                blocking: false,
+                stage: "label",
+            });
+        }
+    }
+    // Compatibility lanes (post PR E).
+    if touched_or("rust_core") {
+        lanes.push(Lane {
+            name: "Compatibility (MSRV)".to_string(),
+            lem: 12,
+            reason: "rust_core changed".to_string(),
+            blocking: false,
+            stage: "default",
+        });
+    }
+    if touched_or("ffi") || has("ffi") || has("abi") || has("full-ci") {
+        lanes.push(Lane {
+            name: "Compatibility (ABI/FFI)".to_string(),
+            lem: 8,
+            reason: "ffi area / label".to_string(),
+            blocking: false,
+            stage: "label",
+        });
+    }
+    if touched_or("tokenizer") || has("tokenizer") || has("full-ci") {
+        lanes.push(Lane {
+            name: "Compatibility (tokenizer)".to_string(),
+            lem: 6,
+            reason: "tokenizer area / label".to_string(),
+            blocking: false,
+            stage: "label",
+        });
+    }
+    // Property smoke (post PR D).
+    if has("property-tests") || has("full-ci") {
+        lanes.push(Lane {
+            name: "Property Tests (smoke)".to_string(),
+            lem: 4,
+            reason: "property-tests/full-ci label".to_string(),
+            blocking: false,
+            stage: "label",
+        });
+    }
+    // ripr static exposure (post PR J): production Rust diffs or explicit label.
+    // Advisory only — does not gate merges.
+    if touched_or("rust_production") || touched_or("ripr") || has("ripr") || has("full-ci") {
+        lanes.push(Lane {
+            name: "ripr static exposure (advisory)".to_string(),
+            lem: 4,
+            reason: "production Rust diff / ripr label".to_string(),
+            blocking: false,
+            stage: "advisory",
+        });
+    }
+    // Always-on cheap guards.
+    if !changed.is_empty() {
+        lanes.push(Lane {
+            name: "Guards / PR Size Guard / Markdownlint / Link Check".to_string(),
+            lem: 4,
+            reason: "always-on".to_string(),
+            blocking: false,
+            stage: "default",
+        });
+    }
+
+    let total: u32 = lanes.iter().map(|l| l.lem).sum();
+
+    let posture: &'static str = if changed.is_empty() {
+        "empty"
+    } else if touched_or("docs")
+        && !(touched_or("rust_core")
+            || touched_or("gpu")
+            || touched_or("ffi")
+            || touched_or("tokenizer"))
+    {
+        "docs-only"
+    } else if touched_or("tracking")
+        && !(touched_or("rust_core") || touched_or("gpu") || touched_or("ffi"))
+    {
+        "tracking-only"
+    } else {
+        "rust"
+    };
+
+    let band: &'static str = if total <= 12 {
+        "✅ pennies (< 12 LEM)"
+    } else if total <= 35 {
+        "✅ default budget (< 35 LEM)"
+    } else if total <= 75 {
+        "⚠️  elevated (35–75 LEM)"
+    } else if total <= 125 {
+        "⚠️  high (75–125 LEM)"
+    } else {
+        "🚨 over hard ceiling (> 125 LEM)"
+    };
+
+    let mut sorted_labels: Vec<String> = labels.to_vec();
+    sorted_labels.sort();
+
+    Plan { posture, touched, labels: sorted_labels, lanes, estimated_lem: total, band }
+}
+
+fn render_summary(plan: &Plan) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    let _ = writeln!(s, "# PR Plan");
+    let _ = writeln!(s);
+    let _ = writeln!(s, "- **Posture:** {}", plan.posture);
+    let touched_areas: Vec<&str> =
+        plan.touched.iter().filter_map(|(a, t)| if *t { Some(a.as_str()) } else { None }).collect();
+    let _ = writeln!(
+        s,
+        "- **Touched areas:** {}",
+        if touched_areas.is_empty() { "(none)".to_string() } else { touched_areas.join(", ") }
+    );
+    let _ = writeln!(
+        s,
+        "- **Labels:** {}",
+        if plan.labels.is_empty() { "(none)".to_string() } else { plan.labels.join(", ") }
+    );
+    let _ = writeln!(s, "- **Estimated LEM:** {}  ·  {}", plan.estimated_lem, plan.band);
+    let _ = writeln!(s);
+    let _ = writeln!(s, "| Lane | Estimated LEM | Reason |");
+    let _ = writeln!(s, "|---|---:|---|");
+    if plan.lanes.is_empty() {
+        let _ = writeln!(s, "| (no lanes expected) | 0 | nothing matched |");
+    } else {
+        for lane in &plan.lanes {
+            let _ = writeln!(s, "| {} | {} | {} |", lane.name, lane.lem, lane.reason);
+        }
+    }
+    let _ = writeln!(s);
+    let _ = writeln!(
+        s,
+        "> Estimates are rough heuristics derived from path globs + labels. \
+         Actual minutes are recorded in the GitHub Actions metrics UI. \
+         This job is advisory only and does not gate merges. \
+         See [docs/ci/cost-and-verification-policy.md](../blob/main/docs/ci/cost-and-verification-policy.md)."
+    );
+    s
+}
+
+/// Compute changed files via `git diff --name-only base...head`.
+///
+/// Falls back to `HEAD~1..HEAD` if the base is missing locally (e.g. shallow
+/// clones without the base branch fetched).
+pub fn git_changed_files(base: Option<&str>, head: Option<&str>) -> Result<Vec<String>> {
+    let head_ref = head.unwrap_or("HEAD");
+
+    if let Some(base) = base {
+        // Verify base exists.
+        let exists = Command::new("git")
+            .args(["cat-file", "-e", base])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if exists {
+            let out = Command::new("git")
+                .args(["diff", "--name-only", &format!("{base}..{head_ref}")])
+                .output()
+                .context("git diff failed")?;
+            return Ok(parse_git_output(&out.stdout));
+        }
+    }
+
+    let out = Command::new("git")
+        .args(["diff", "--name-only", "HEAD~1..HEAD"])
+        .output()
+        .context("git diff (fallback) failed")?;
+    Ok(parse_git_output(&out.stdout))
+}
+
+fn parse_git_output(stdout: &[u8]) -> Vec<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Entry point invoked by `xtask ci plan`.
+pub fn run(
+    base: Option<String>,
+    head: Option<String>,
+    labels_json: Option<String>,
+    json_out: Option<PathBuf>,
+    github_summary: Option<PathBuf>,
+    dry_run: bool,
+) -> Result<()> {
+    let labels: Vec<String> = match labels_json.as_deref() {
+        Some(s) if !s.trim().is_empty() => {
+            serde_json::from_str(s).context("--labels-json must be a JSON array of strings")?
+        }
+        _ => Vec::new(),
+    };
+
+    let changed =
+        if dry_run { Vec::new() } else { git_changed_files(base.as_deref(), head.as_deref())? };
+
+    let plan = plan_for(&changed, &labels);
+    let json = serde_json::to_string_pretty(&plan).context("serialize plan to JSON")?;
+    println!("{json}");
+
+    if let Some(path) = json_out {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            fs::create_dir_all(parent).ok();
+        }
+        fs::write(&path, &json).with_context(|| format!("write {}", path.display()))?;
+    }
+
+    if let Some(path) = github_summary {
+        let summary = render_summary(&plan);
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("open {}", path.display()))?;
+        f.write_all(summary.as_bytes()).context("write step summary")?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lanes_named(plan: &Plan) -> Vec<&str> {
+        plan.lanes.iter().map(|l| l.name.as_str()).collect()
+    }
+
+    #[test]
+    fn empty_pr_has_only_no_lanes_and_pennies_band() {
+        let plan = plan_for(&[], &[]);
+        assert_eq!(plan.posture, "empty");
+        assert_eq!(plan.lanes.len(), 0);
+        assert_eq!(plan.estimated_lem, 0);
+        assert!(plan.band.contains("pennies"));
+    }
+
+    #[test]
+    fn docs_only_posture_skips_rust_lanes() {
+        let plan =
+            plan_for(&["docs/ci/cost-and-verification-policy.md".into(), "README.md".into()], &[]);
+        assert_eq!(plan.posture, "docs-only");
+        let names = lanes_named(&plan);
+        // Only the always-on guards lane should fire.
+        assert_eq!(names, vec!["Guards / PR Size Guard / Markdownlint / Link Check"]);
+        assert_eq!(plan.estimated_lem, 4);
+        assert!(plan.band.contains("pennies"));
+    }
+
+    #[test]
+    fn rust_crate_change_runs_core_msrv_feature_matrix_ripr_guards() {
+        let plan = plan_for(&["crates/bitnet-quantization/src/i2s_qk256.rs".into()], &[]);
+        assert_eq!(plan.posture, "rust");
+        let names: Vec<&str> = lanes_named(&plan);
+        assert!(names.contains(&"CI (Core) — build/test/clippy/docs"));
+        assert!(names.contains(&"Feature Matrix (PR 3-combo)"));
+        assert!(names.contains(&"Compatibility (MSRV)"));
+        assert!(names.contains(&"ripr static exposure (advisory)"));
+        assert!(names.contains(&"Guards / PR Size Guard / Markdownlint / Link Check"));
+        // No GPU lane on a quantization-only diff.
+        assert!(!names.iter().any(|n| n.starts_with("GPU CI")));
+        // 22 (Core) + 12 (Feature Matrix PR) + 12 (MSRV) + 4 (ripr) + 4 (guards) = 54.
+        // That sits in the elevated band (35–75) — still well below the $1 ceiling
+        // but worth surfacing so engineers see the cost of a normal Rust PR.
+        assert_eq!(plan.estimated_lem, 54);
+        assert!(plan.band.contains("elevated"));
+    }
+
+    #[test]
+    fn gpu_kernel_change_includes_gpu_native_compile() {
+        let plan = plan_for(&["crates/bitnet-kernels/src/cuda_smoke.rs".into()], &[]);
+        let names = lanes_named(&plan);
+        assert!(names.contains(&"GPU CI Matrix (native compile)"));
+        // Without the gpu-ci/docker label, Docker build does NOT fire.
+        assert!(!names.contains(&"GPU CI Matrix (Docker, ~6x)"));
+    }
+
+    #[test]
+    fn full_ci_label_fires_all_label_gated_lanes() {
+        let plan =
+            plan_for(&["crates/bitnet-kernels/src/cuda_smoke.rs".into()], &["full-ci".into()]);
+        let names = lanes_named(&plan);
+        assert!(names.contains(&"BDD Grid Check"));
+        assert!(names.contains(&"Clippy (macOS ARM64)"));
+        assert!(names.contains(&"Feature Matrix (full ~21 jobs)"));
+        assert!(names.contains(&"GPU CI Matrix (Docker, ~6x)"));
+        assert!(names.contains(&"Compatibility (ABI/FFI)"));
+        assert!(names.contains(&"Compatibility (tokenizer)"));
+        assert!(names.contains(&"Property Tests (smoke)"));
+        assert!(names.contains(&"ripr static exposure (advisory)"));
+    }
+
+    #[test]
+    fn ripr_eligible_pr_includes_advisory_lane() {
+        let plan = plan_for(&["crates/bitnet-inference/src/decoder.rs".into()], &[]);
+        assert!(lanes_named(&plan).iter().any(|n| *n == "ripr static exposure (advisory)"));
+    }
+
+    #[test]
+    fn test_only_rust_diff_skips_ripr_advisory() {
+        // tests/ counts as rust_core but NOT rust_production, and ripr does not
+        // fire for test-only diffs unless the `ripr` label is applied.
+        let plan = plan_for(&["tests/regression/cpu_only.rs".into()], &[]);
+        let names = lanes_named(&plan);
+        assert!(names.contains(&"CI (Core) — build/test/clippy/docs"));
+        assert!(!names.iter().any(|n| n.starts_with("ripr ")));
+    }
+
+    #[test]
+    fn label_only_ripr_runs_advisory_even_on_docs_pr() {
+        let plan = plan_for(&["docs/ci/cost-and-verification-policy.md".into()], &["ripr".into()]);
+        assert!(lanes_named(&plan).iter().any(|n| *n == "ripr static exposure (advisory)"));
+    }
+
+    #[test]
+    fn band_classifies_high_when_full_ci_on_kernel_change() {
+        let plan =
+            plan_for(&["crates/bitnet-kernels/src/cuda_smoke.rs".into()], &["full-ci".into()]);
+        // 22 (Core) + 4 (BDD) + 150 (macOS) + 70 (Feature full)
+        // + 18 (GPU native) + 90 (GPU Docker) + 12 (MSRV) + 8 (FFI) + 6 (tok)
+        // + 4 (property) + 4 (ripr) + 4 (guards) ≈ 392
+        assert!(plan.estimated_lem > 125);
+        assert!(plan.band.contains("over hard ceiling"));
+    }
+
+    #[test]
+    fn parse_git_output_strips_blank_lines() {
+        let raw = b"crates/foo.rs\n\ndocs/bar.md\n";
+        assert_eq!(
+            parse_git_output(raw),
+            vec!["crates/foo.rs".to_string(), "docs/bar.md".to_string()]
+        );
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,6 +37,7 @@ use std::{
 use walkdir::WalkDir;
 
 mod campaign;
+mod ci_plan;
 mod cpp_setup_auto;
 mod crossval;
 pub mod ffi;
@@ -1003,6 +1004,44 @@ enum Cmd {
         #[command(subcommand)]
         command: campaign::CampaignCmd,
     },
+
+    /// CI planning and budget tools (LEM forecast, lane selection).
+    ///
+    /// See docs/ci/cost-and-verification-policy.md for the verification
+    /// economics model and what each lane buys.
+    Ci {
+        #[command(subcommand)]
+        command: CiCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum CiCmd {
+    /// Forecast which CI lanes will run for this PR and estimate Linux-equivalent minutes.
+    ///
+    /// Replaces the inline Python planner that previously lived in
+    /// `.github/workflows/pr-plan.yml`. Emits `ci-plan.json` with a stable
+    /// schema for downstream tooling.
+    Plan {
+        /// Base SHA / ref for the diff (e.g. PR base). Defaults to origin/main.
+        #[arg(long)]
+        base: Option<String>,
+        /// Head SHA / ref for the diff. Defaults to HEAD.
+        #[arg(long)]
+        head: Option<String>,
+        /// JSON array of label strings (e.g. `["full-ci","gpu-ci"]`).
+        #[arg(long)]
+        labels_json: Option<String>,
+        /// Write `ci-plan.json` to this path.
+        #[arg(long)]
+        json_out: Option<PathBuf>,
+        /// Append a Markdown summary to this file (typically `$GITHUB_STEP_SUMMARY`).
+        #[arg(long)]
+        github_summary: Option<PathBuf>,
+        /// Skip git diff and emit a plan for an empty diff (useful for fixture testing).
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1329,6 +1368,11 @@ fn real_main() -> Result<()> {
             grid_check::run(cpu_only, verbose, dry_run)
         }
         Cmd::Campaign { command } => campaign::run(command),
+        Cmd::Ci { command } => match command {
+            CiCmd::Plan { base, head, labels_json, json_out, github_summary, dry_run } => {
+                ci_plan::run(base, head, labels_json, json_out, github_summary, dry_run)
+            }
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

Replaces the inline Python planner in `.github/workflows/pr-plan.yml` (added in #3742) with a Rust-native, unit-testable `xtask ci plan` subcommand. This is **PR K** in the multi-PR CI roadmap (A–H merged; I, J, K open).

```bash
cargo run --locked -p xtask -- ci plan \
  --base "$BASE_SHA" \
  --head "$HEAD_SHA" \
  --labels-json '["full-ci"]' \
  --json-out ci-plan.json \
  --github-summary "$GITHUB_STEP_SUMMARY"
```

## Why

The inline Python version was the right first move (#3742 shipped fast and exercised the LEM model end-to-end) but it could not be tested without a CI run. A YAML-embedded planner drifts; a Rust planner can be tested with fixtures and held to the same review bar as the rest of the codebase. This is the foundation for everything that follows: PR L (policy files), PR N (actuals), PR O (budget warnings), and PR P (ripr promotion rules) all consume `ci-plan.json`.

## Implementation

- **`xtask/src/ci_plan.rs`** — pure `plan_for(changed, labels) -> Plan` function + `git_changed_files(...)` wrapper + `run(...)` entry point. Same touched-area buckets and lane logic as the Python version, plus the ripr lane (`rust_production`, `ripr` label).
- **`xtask/src/main.rs`** — new `Cmd::Ci { command: CiCmd }` subcommand and `CiCmd::Plan` variant.
- **`.github/workflows/pr-plan.yml`** — drops ~120 lines of inline Python in favor of a single `cargo run` invocation. Adds a small Rust toolchain install + `Swatinem/rust-cache` for the xtask compile.

## Schema

Two additions vs the inline Python version:

| Field | Type | Purpose |
|---|---|---|
| `lane.blocking` | `bool` | Whether this lane blocks merges today (placeholder for budget enforcement). |
| `lane.stage` | `"required" \| "default" \| "label" \| "advisory"` | Lane-class taxonomy for PR P (ripr promotion). |

The rest of the schema (`posture`, `touched`, `labels`, `lanes[].name/lem/reason`, `estimated_lem`, `band`) is unchanged from #3742.

## Tests (10/10 passing)

| Test | Asserts |
|---|---|
| empty PR | 0 lanes, pennies band |
| docs-only PR | guards lane only, posture=`docs-only` |
| rust crate change | Core / Feature Matrix PR / MSRV / ripr / guards (54 LEM, elevated band) |
| GPU kernel change | native compile fires; Docker does **not** without label |
| full-ci label | all label-gated lanes fire |
| ripr-eligible PR | advisory lane fires |
| test-only Rust diff | ripr advisory does **not** fire (tests/ ≠ rust_production) |
| ripr label on docs-only PR | ripr advisory still fires |
| full-ci on kernel change | >125 LEM, over-hard-ceiling band |
| parse_git_output | strips blank lines |

```bash
cargo test --locked --no-default-features -p xtask --bin xtask ci_plan
# test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured
```

## Smoke output

```
$ cargo run -q -p xtask -- ci plan --dry-run --labels-json '["full-ci"]'
{
  "posture": "empty",
  "touched": { ... },
  "labels": ["full-ci"],
  "lanes": [
    { "name": "BDD Grid Check", "lem": 4, "stage": "label", "blocking": false, ... },
    { "name": "Clippy (macOS ARM64)", "lem": 150, "stage": "label", ... },
    { "name": "Compatibility (ABI/FFI)", "lem": 8, ... },
    { "name": "Compatibility (tokenizer)", "lem": 6, ... },
    { "name": "Property Tests (smoke)", "lem": 4, ... },
    { "name": "ripr static exposure (advisory)", "lem": 4, "stage": "advisory", ... }
  ],
  "estimated_lem": 176,
  "band": "🚨 over hard ceiling (> 125 LEM)"
}
```

## Test plan

- [ ] CI Core green on the new xtask code (clippy + tests).
- [ ] PR Plan workflow runs the new Rust planner on this PR and posts the same shape of step summary.
- [ ] `ci-plan.json` artifact uploaded with new schema.
- [ ] No behavior change for downstream consumers — all existing fields preserved.

## Out of scope (future PRs)

- PR L: hoist hard-coded LEM estimates and lane definitions into `policy/ci-budget.toml`, `policy/ci-lanes.toml`, `policy/ci-risk-packs.toml`.
- PR M: nextest profile + JUnit upload + per-test duration history.
- PR N: actual LEM collection (`ci-actuals.json`).
- PR O: soft budget warnings (warn at 35 / 75 LEM; hard at 125 without `full-ci`).
- PR P: ripr promotion rules using `lane.stage` taxonomy added here.

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_