### PR TITLE
Preserve Intel NPU identity, add Intel/Arc backend labels, and extend receipts for 258V validation

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -54,6 +54,14 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require an Intel NPU backend without collapsing to Metal or generic GPU.
+    IntelNpu,
+    /// Require OpenVINO execution on an Intel NPU.
+    OpenVinoNpu,
+    /// Require the Intel Arc 140V integrated GPU lane.
+    IntelArc140v,
+    /// Require OpenVINO GPU execution on Intel Arc 140V.
+    IntelArc140vOpenVinoGpu,
     /// Require native Metal compute without assuming a specific Apple machine.
     Metal,
     /// Require MPSGraph graph execution without treating it as native Metal kernels.
@@ -76,6 +84,12 @@ impl BackendRequest {
             "cuda" => Some(BackendRequest::Cuda),
             "hip" | "rocm" => Some(BackendRequest::Hip),
             "oneapi" => Some(BackendRequest::OneApi),
+            "npu" | "intel-npu" => Some(BackendRequest::IntelNpu),
+            "openvino-npu" | "intel-npu-openvino" => Some(BackendRequest::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Some(BackendRequest::IntelArc140v),
+            "intel-arc-140v-openvino-gpu" | "openvino-gpu" | "openvino-gpu.0" => {
+                Some(BackendRequest::IntelArc140vOpenVinoGpu)
+            }
             "metal" => Some(BackendRequest::Metal),
             "mpsgraph" => Some(BackendRequest::MpsGraph),
             "apple-m4-metal" => Some(BackendRequest::AppleM4Metal),
@@ -95,6 +109,12 @@ impl fmt::Display for BackendRequest {
             BackendRequest::Cuda => write!(f, "cuda"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::IntelNpu => write!(f, "intel-npu"),
+            BackendRequest::OpenVinoNpu => write!(f, "intel-npu-openvino"),
+            BackendRequest::IntelArc140v => write!(f, "intel-arc-140v"),
+            BackendRequest::IntelArc140vOpenVinoGpu => {
+                write!(f, "intel-arc-140v-openvino-gpu")
+            }
             BackendRequest::Metal => write!(f, "metal"),
             BackendRequest::MpsGraph => write!(f, "mpsgraph"),
             BackendRequest::AppleM4Metal => write!(f, "apple-m4-metal"),
@@ -153,6 +173,9 @@ impl BackendSelectionResult {
             "hip" => "hip",
             "oneapi" => "oneapi",
             "opencl" => "opencl",
+            "intel-npu" | "intel-npu-openvino" => "openvino-npu",
+            "intel-arc-140v" => "opencl",
+            "intel-arc-140v-openvino-gpu" => "openvino-gpu",
             "apple-m4-metal" | "metal" => "metal",
             "apple-m4-mpsgraph" | "mpsgraph" => "mpsgraph",
             _ => "cpu",
@@ -168,7 +191,11 @@ impl BackendSelectionResult {
             BackendRequest::Cuda => self.selected != KernelBackend::Cuda,
             BackendRequest::Hip => self.selected != KernelBackend::Hip,
             BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
-            BackendRequest::Metal
+            BackendRequest::IntelNpu
+            | BackendRequest::OpenVinoNpu
+            | BackendRequest::IntelArc140v
+            | BackendRequest::IntelArc140vOpenVinoGpu
+            | BackendRequest::Metal
             | BackendRequest::MpsGraph
             | BackendRequest::AppleM4Metal
             | BackendRequest::AppleM4MpsGraph
@@ -280,7 +307,12 @@ pub fn select_backend(
                 });
             }
         }
-        BackendRequest::Metal | BackendRequest::AppleM4Metal => {
+        BackendRequest::IntelNpu
+        | BackendRequest::OpenVinoNpu
+        | BackendRequest::IntelArc140v
+        | BackendRequest::IntelArc140vOpenVinoGpu
+        | BackendRequest::Metal
+        | BackendRequest::AppleM4Metal => {
             return Err(BackendSelectionError::RequestedUnavailable {
                 requested: request,
                 available: detected.clone(),
@@ -466,6 +498,28 @@ mod tests {
             BackendRequest::from_label("apple-m4-cpu-neon"),
             Some(BackendRequest::AppleM4CpuNeon)
         );
+    }
+
+    #[test]
+    fn intel_lunar_lake_labels_parse_without_aliasing() {
+        assert_eq!(BackendRequest::from_label("npu"), Some(BackendRequest::IntelNpu));
+        assert_eq!(BackendRequest::from_label("openvino-npu"), Some(BackendRequest::OpenVinoNpu));
+        assert_eq!(
+            BackendRequest::from_label("intel-arc-140v"),
+            Some(BackendRequest::IntelArc140v)
+        );
+        assert_eq!(
+            BackendRequest::from_label("openvino-gpu"),
+            Some(BackendRequest::IntelArc140vOpenVinoGpu)
+        );
+        assert_eq!(BackendRequest::from_label("metal"), Some(BackendRequest::Metal));
+    }
+
+    #[test]
+    fn intel_npu_request_is_strict_until_openvino_probe_lands() {
+        let err = select_backend(BackendRequest::OpenVinoNpu, &cpu_only_caps()).unwrap_err();
+        assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+        assert!(err.to_string().contains("intel-npu-openvino"));
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -15,6 +15,14 @@ pub enum DeviceConfig {
     Cpu,
     /// Force GPU execution on specific device ID.
     Gpu(usize),
+    /// Preserve Intel NPU identity for OpenVINO/runtime probing.
+    IntelNpu(usize),
+    /// Preserve strict OpenVINO NPU identity.
+    OpenVinoNpu,
+    /// Preserve Intel Arc 140V GPU identity.
+    IntelArc140v(usize),
+    /// Preserve OpenVINO GPU identity for Intel graphics devices.
+    OpenVinoGpu(usize),
     /// Preserve a native Metal backend identity.
     Metal,
     /// Preserve an MPSGraph graph/reference backend identity.
@@ -34,7 +42,11 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
+            "npu" | "intel-npu" => Ok(DeviceConfig::IntelNpu(0)),
+            "openvino-npu" | "intel-npu-openvino" => Ok(DeviceConfig::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Ok(DeviceConfig::IntelArc140v(0)),
+            "openvino-gpu" | "openvino-gpu.0" => Ok(DeviceConfig::OpenVinoGpu(0)),
             "metal" => Ok(DeviceConfig::Metal),
             "mpsgraph" => Ok(DeviceConfig::MpsGraph),
             "apple-m4-metal" => Ok(DeviceConfig::AppleM4Metal),
@@ -45,6 +57,16 @@ impl FromStr for DeviceConfig {
             s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("opencl:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("ocl:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("npu:") => Ok(DeviceConfig::IntelNpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("intel-npu:") => {
+                Ok(DeviceConfig::IntelNpu(s[10..].parse::<usize>()?))
+            }
+            s if s.starts_with("intel-arc-140v:") => {
+                Ok(DeviceConfig::IntelArc140v(s[15..].parse::<usize>()?))
+            }
+            s if s.starts_with("openvino-gpu:") => {
+                Ok(DeviceConfig::OpenVinoGpu(s[13..].parse::<usize>()?))
+            }
             _ => anyhow::bail!("Unknown device config: {}", s),
         }
     }
@@ -68,6 +90,8 @@ impl DeviceConfig {
             }
             DeviceConfig::Cpu => Device::Cpu,
             DeviceConfig::Gpu(id) => Device::Cuda(*id),
+            DeviceConfig::IntelNpu(_) | DeviceConfig::OpenVinoNpu => Device::Npu,
+            DeviceConfig::IntelArc140v(id) | DeviceConfig::OpenVinoGpu(id) => Device::OpenCL(*id),
             DeviceConfig::Metal | DeviceConfig::AppleM4Metal => Device::Metal,
             // MPSGraph is a separate proof label; runtime execution is introduced in a later item.
             DeviceConfig::MpsGraph | DeviceConfig::AppleM4MpsGraph => Device::Cpu,
@@ -82,6 +106,10 @@ impl DeviceConfig {
             DeviceConfig::Auto => BackendRequest::Auto,
             DeviceConfig::Cpu => BackendRequest::Cpu,
             DeviceConfig::Gpu(_) => BackendRequest::Gpu,
+            DeviceConfig::IntelNpu(_) => BackendRequest::IntelNpu,
+            DeviceConfig::OpenVinoNpu => BackendRequest::OpenVinoNpu,
+            DeviceConfig::IntelArc140v(_) => BackendRequest::IntelArc140v,
+            DeviceConfig::OpenVinoGpu(_) => BackendRequest::IntelArc140vOpenVinoGpu,
             DeviceConfig::Metal => BackendRequest::Metal,
             DeviceConfig::MpsGraph => BackendRequest::MpsGraph,
             DeviceConfig::AppleM4Metal => BackendRequest::AppleM4Metal,
@@ -106,6 +134,13 @@ mod tests {
         assert_eq!("cpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Cpu);
         assert_eq!("auto".parse::<DeviceConfig>().unwrap(), DeviceConfig::Auto);
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(0));
+        assert_eq!("openvino-npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoNpu);
+        assert_eq!(
+            "intel-arc-140v".parse::<DeviceConfig>().unwrap(),
+            DeviceConfig::IntelArc140v(0)
+        );
+        assert_eq!("openvino-gpu:1".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoGpu(1));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
         assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
         assert_eq!("metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::Metal);

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -146,9 +146,9 @@ pub struct GpuBackend {
 
 /// NPU backend implementation.
 ///
-/// The current implementation routes execution through the model's Metal path and
-/// provides an explicit backend surface for NPU-oriented deployment policy,
-/// warm-up behavior, and capability reporting.
+/// This backend preserves a distinct Intel/OpenVINO NPU identity. Until real
+/// OpenVINO graph execution lands, NPU requests fail strictly when the runtime
+/// identity probe is unavailable instead of aliasing to Metal or generic GPU.
 pub struct NpuBackend {
     model: Arc<dyn Model>,
     device: Device,
@@ -160,12 +160,15 @@ impl NpuBackend {
     pub fn new(model: Arc<dyn Model>, device: Device) -> Result<Self> {
         if !Self::is_available() {
             return Err(anyhow::anyhow!(
-                "NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and compile with metal support on macOS"
+                "Intel NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and ensure an Intel NPU runtime device is visible"
             ));
         }
 
-        if !matches!(device, Device::Metal) {
-            return Err(anyhow::anyhow!("NPU backend currently requires Device::Metal"));
+        if !matches!(device, Device::Npu) {
+            return Err(anyhow::anyhow!(
+                "NPU backend requires Device::Npu; refusing to alias {:?} to NPU",
+                device
+            ));
         }
 
         let allow_cpu_fallback = std::env::var(NPU_FALLBACK_ENV)
@@ -186,7 +189,7 @@ impl NpuBackend {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        enabled && cfg!(target_os = "macos")
+        enabled && intel_npu_runtime_visible()
     }
 
     fn ensure_npu_tensor(&self, input: &ConcreteTensor) -> Result<ConcreteTensor> {
@@ -209,6 +212,29 @@ impl NpuBackend {
             "NPU tensor transfer is not available and fallback is disabled via {NPU_FALLBACK_ENV}=0"
         ))
     }
+}
+
+fn intel_npu_runtime_visible() -> bool {
+    std::env::var("BITNET_NPU_FAKE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("intel"))
+        .unwrap_or(false)
+        || linux_accel_device_present()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_accel_device_present() -> bool {
+    std::fs::read_dir("/dev/accel")
+        .map(|entries| {
+            entries.filter_map(Result::ok).any(|entry| {
+                entry.file_name().to_str().map(|name| name.starts_with("accel")).unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn linux_accel_device_present() -> bool {
+    false
 }
 
 impl GpuBackend {
@@ -384,14 +410,11 @@ pub fn select_backend(
             Ok(Box::new(CpuBackend::new(model)?))
         }
         Device::Metal => {
-            if NpuBackend::is_available() {
-                info!("Selected NPU backend");
-                Ok(Box::new(NpuBackend::new(model, device)?))
-            } else if GpuBackend::is_available() {
+            if GpuBackend::is_available() {
                 info!("Selected GPU backend for Metal device");
                 Ok(Box::new(GpuBackend::new(model, device)?))
             } else {
-                warn!("Metal/NPU requested but unavailable, falling back to CPU");
+                warn!("Metal requested but unavailable, falling back to CPU");
                 Ok(Box::new(CpuBackend::new(model)?))
             }
         }
@@ -418,8 +441,9 @@ pub fn select_backend(
                 info!("Selected NPU backend");
                 Ok(Box::new(NpuBackend::new(model, device)?))
             } else {
-                warn!("NPU requested but not available, falling back to CPU");
-                Ok(Box::new(CpuBackend::new(model)?))
+                Err(anyhow::anyhow!(
+                    "NPU requested but Intel NPU runtime is not available; refusing CPU/GPU fallback"
+                ))
             }
         }
         Device::OpenCL(_) => {

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -1,8 +1,8 @@
 //! NPU integration utilities for inference.
 //!
 //! This module centralizes environment-driven controls for the NPU path so the
-//! engine and CLI can expose a stable "npu" target while backend wiring to
-//! Qualcomm QNN/SNPE matures.
+//! engine and CLI can expose a stable Intel/OpenVINO NPU target without
+//! collapsing it to Metal, CUDA, OpenCL, or generic GPU identities.
 
 use bitnet_common::Device;
 
@@ -18,11 +18,30 @@ pub fn npu_requested() -> bool {
 
 /// Map an external `--device` style token to an internal device preference.
 pub fn map_device_token(token: &str) -> Option<Device> {
-    match token {
+    match token.trim().to_ascii_lowercase().as_str() {
         "cpu" => Some(Device::Cpu),
         "cuda" | "gpu" => Some(Device::Cuda(0)),
-        "metal" | "npu" => Some(Device::Metal),
-        "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
+        "oneapi" | "opencl" | "intel-gpu" | "intel-arc-140v" => Some(Device::OpenCL(0)),
+        "npu" | "intel-npu" | "openvino-npu" | "intel-npu-openvino" => Some(Device::Npu),
+        "metal" => Some(Device::Metal),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_device_token;
+    use bitnet_common::Device;
+
+    #[test]
+    fn npu_tokens_preserve_npu_identity() {
+        assert_eq!(map_device_token("npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("intel-npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("openvino-npu"), Some(Device::Npu));
+    }
+
+    #[test]
+    fn metal_token_stays_separate_from_npu() {
+        assert_eq!(map_device_token("metal"), Some(Device::Metal));
     }
 }

--- a/crates/bitnet-receipts-core/src/lib.rs
+++ b/crates/bitnet-receipts-core/src/lib.rs
@@ -228,6 +228,45 @@ pub struct StrictInferenceProvenance {
     pub decode_tps: Option<f64>,
 }
 
+/// BitNet-specific kernel/layout metadata for strict receipts.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BitnetExecutionMetadata {
+    pub kernel_family: String,
+    pub kernel_format: String,
+    pub layout: String,
+    pub layout_source: String,
+    pub requested_kernel: String,
+    pub selected_kernel: String,
+    pub dequantizes_before_compute: bool,
+}
+
+/// Loader and tokenizer authority metadata for strict receipts.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LoaderMetadata {
+    pub mode: String,
+    pub minimal_loader_fallback_used: bool,
+    pub tokenizer_source: String,
+    pub mock_tensors_used: bool,
+}
+
+/// Same-machine platform metadata for CPU/GPU/NPU validation receipts.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PlatformRuntimeMetadata {
+    pub machine: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cpu_features: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub opencl_device_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub openvino_available_devices: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_device: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub power_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thermal_profile: Option<String>,
+}
+
 /// Main inference receipt structure (AC4)
 ///
 /// # Schema Version: 1.0.0
@@ -291,6 +330,18 @@ pub struct InferenceReceipt {
     /// Strict CPU proof provenance (optional for legacy receipts).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strict_provenance: Option<StrictInferenceProvenance>,
+
+    /// BitNet-specific execution metadata for requested-vs-selected kernel receipts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bitnet: Option<BitnetExecutionMetadata>,
+
+    /// Loader/tokenizer authority metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loader: Option<LoaderMetadata>,
+
+    /// Platform runtime context for same-machine CPU/GPU/NPU comparisons.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform_runtime: Option<PlatformRuntimeMetadata>,
 }
 
 impl InferenceReceipt {
@@ -338,6 +389,9 @@ impl InferenceReceipt {
             parity: None,
             corrections: Vec::new(),
             strict_provenance: None,
+            bitnet: None,
+            loader: None,
+            platform_runtime: None,
         })
     }
 


### PR DESCRIPTION
### Motivation
- Prevent Intel NPU from being aliased to Metal or a generic GPU and make `npu`/Arc/OpenVINO targets a first-class, auditable request surface for Lunar Lake validation.
- Ensure runtime selection refuses silent fallback for explicit NPU/OpenVINO requests so platform probes/receipts remain trustworthy for 258V cross-device comparisons.
- Add BitNet-specific receipt fields so strict CPU/GPU/NPU validation runs can record requested-vs-selected backend/kernel and platform context for later proof/benchmarking.

### Description
- Add explicit backend request variants for Intel NPU and Arc 140V: `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `IntelArc140vOpenVinoGpu`, with parsing/display support in `bitnet-common::BackendRequest`.
- Extend `DeviceConfig` parsing/resolution to preserve `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `OpenVinoGpu` identities and map them to `Device::Npu` / `Device::OpenCL` as appropriate (`crates/bitnet-device-config-core/src/lib.rs`).
- Change device token mapping so `npu|intel-npu|openvino-npu` map to `Device::Npu` and `intel-arc-140v` maps via `OpenCL`, keeping `metal` separate (`crates/bitnet-inference/src/npu.rs`).
- Harden NPU backend: require `Device::Npu`, add a runtime probe `intel_npu_runtime_visible()` (Linux `/dev/accel` and `BITNET_NPU_FAKE` override), and make explicit NPU requests fail when the Intel NPU runtime is absent instead of aliasing to Metal/CPU/GPU; adjust `select_backend()` behavior accordingly (`crates/bitnet-inference/src/backends.rs`).
- Extend inference receipts with BitNet-specific metadata types: `BitnetExecutionMetadata`, `LoaderMetadata`, and `PlatformRuntimeMetadata`, and wire them into `InferenceReceipt` for same-machine validation artifacts (`crates/bitnet-receipts-core/src/lib.rs`).
- Add/adjust unit tests to validate parsing and identity preservation for NPU/Arc tokens and maintain existing backend-selection invariants.

### Testing
- Ran `cargo fmt --all -- --check` which passed after formatting adjustments.
- Ran targeted unit tests: `cargo test --locked -p bitnet-common --features cpu backend_selection::tests` (passed), `cargo test --locked -p bitnet-device-config-core` (passed), `cargo test --locked -p bitnet-inference --lib npu -- --nocapture` (passed), and `cargo test --locked -p bitnet-receipts-core` (passed).
- Note: an earlier combined invocation `cargo test -p bitnet-common -p bitnet-device-config-core` run without enabling `bitnet-common`'s `cpu` feature surfaced an existing assertion expecting the `cpu` feature; rerunning the relevant backend-selection suite with `--features cpu` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab59f65848333b28a58f6df6fd41c)