### PR TITLE
Preserve Intel NPU / Arc 140V identities and make NPU selection strict

### DIFF
--- a/crates/bitnet-common/src/backend_selection.rs
+++ b/crates/bitnet-common/src/backend_selection.rs
@@ -54,6 +54,14 @@ pub enum BackendRequest {
     Hip,
     /// Require Intel oneAPI specifically.
     OneApi,
+    /// Require Intel NPU identity without aliasing to Metal or GPU.
+    IntelNpu,
+    /// Require OpenVINO NPU runtime identity.
+    OpenVinoNpu,
+    /// Require Intel Arc 140V GPU identity.
+    IntelArc140v,
+    /// Require Intel Arc 140V through OpenVINO GPU runtime identity.
+    IntelArc140vOpenVinoGpu,
     /// Require native Metal compute without assuming a specific Apple machine.
     Metal,
     /// Require MPSGraph graph execution without treating it as native Metal kernels.
@@ -76,6 +84,12 @@ impl BackendRequest {
             "cuda" => Some(BackendRequest::Cuda),
             "hip" | "rocm" => Some(BackendRequest::Hip),
             "oneapi" => Some(BackendRequest::OneApi),
+            "npu" | "intel-npu" => Some(BackendRequest::IntelNpu),
+            "openvino-npu" => Some(BackendRequest::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Some(BackendRequest::IntelArc140v),
+            "intel-arc-140v-openvino-gpu" | "openvino-gpu" => {
+                Some(BackendRequest::IntelArc140vOpenVinoGpu)
+            }
             "metal" => Some(BackendRequest::Metal),
             "mpsgraph" => Some(BackendRequest::MpsGraph),
             "apple-m4-metal" => Some(BackendRequest::AppleM4Metal),
@@ -95,6 +109,12 @@ impl fmt::Display for BackendRequest {
             BackendRequest::Cuda => write!(f, "cuda"),
             BackendRequest::Hip => write!(f, "hip"),
             BackendRequest::OneApi => write!(f, "oneapi"),
+            BackendRequest::IntelNpu => write!(f, "intel-npu"),
+            BackendRequest::OpenVinoNpu => write!(f, "openvino-npu"),
+            BackendRequest::IntelArc140v => write!(f, "intel-arc-140v"),
+            BackendRequest::IntelArc140vOpenVinoGpu => {
+                write!(f, "intel-arc-140v-openvino-gpu")
+            }
             BackendRequest::Metal => write!(f, "metal"),
             BackendRequest::MpsGraph => write!(f, "mpsgraph"),
             BackendRequest::AppleM4Metal => write!(f, "apple-m4-metal"),
@@ -153,6 +173,8 @@ impl BackendSelectionResult {
             "hip" => "hip",
             "oneapi" => "oneapi",
             "opencl" => "opencl",
+            "intel-npu" | "openvino-npu" => "openvino-npu",
+            "intel-arc-140v" | "intel-arc-140v-openvino-gpu" => "openvino-gpu",
             "apple-m4-metal" | "metal" => "metal",
             "apple-m4-mpsgraph" | "mpsgraph" => "mpsgraph",
             _ => "cpu",
@@ -168,7 +190,11 @@ impl BackendSelectionResult {
             BackendRequest::Cuda => self.selected != KernelBackend::Cuda,
             BackendRequest::Hip => self.selected != KernelBackend::Hip,
             BackendRequest::OneApi => self.selected != KernelBackend::OneApi,
-            BackendRequest::Metal
+            BackendRequest::IntelNpu
+            | BackendRequest::OpenVinoNpu
+            | BackendRequest::IntelArc140v
+            | BackendRequest::IntelArc140vOpenVinoGpu
+            | BackendRequest::Metal
             | BackendRequest::MpsGraph
             | BackendRequest::AppleM4Metal
             | BackendRequest::AppleM4MpsGraph
@@ -280,7 +306,12 @@ pub fn select_backend(
                 });
             }
         }
-        BackendRequest::Metal | BackendRequest::AppleM4Metal => {
+        BackendRequest::IntelNpu
+        | BackendRequest::OpenVinoNpu
+        | BackendRequest::IntelArc140v
+        | BackendRequest::IntelArc140vOpenVinoGpu
+        | BackendRequest::Metal
+        | BackendRequest::AppleM4Metal => {
             return Err(BackendSelectionError::RequestedUnavailable {
                 requested: request,
                 available: detected.clone(),
@@ -453,6 +484,16 @@ mod tests {
     #[test]
     fn apple_backend_labels_parse_without_aliasing() {
         assert_eq!(BackendRequest::from_label("metal"), Some(BackendRequest::Metal));
+        assert_eq!(BackendRequest::from_label("npu"), Some(BackendRequest::IntelNpu));
+        assert_eq!(BackendRequest::from_label("openvino-npu"), Some(BackendRequest::OpenVinoNpu));
+        assert_eq!(
+            BackendRequest::from_label("intel-arc-140v"),
+            Some(BackendRequest::IntelArc140v)
+        );
+        assert_eq!(
+            BackendRequest::from_label("openvino-gpu"),
+            Some(BackendRequest::IntelArc140vOpenVinoGpu)
+        );
         assert_eq!(
             BackendRequest::from_label("apple-m4-metal"),
             Some(BackendRequest::AppleM4Metal)
@@ -466,6 +507,20 @@ mod tests {
             BackendRequest::from_label("apple-m4-cpu-neon"),
             Some(BackendRequest::AppleM4CpuNeon)
         );
+    }
+
+    #[test]
+    fn npu_and_arc_identity_requests_are_strict_until_probe_work_lands() {
+        for request in [
+            BackendRequest::IntelNpu,
+            BackendRequest::OpenVinoNpu,
+            BackendRequest::IntelArc140v,
+            BackendRequest::IntelArc140vOpenVinoGpu,
+        ] {
+            let err = select_backend(request, &cpu_only_caps()).unwrap_err();
+            assert!(matches!(err, BackendSelectionError::RequestedUnavailable { .. }));
+            assert!(err.to_string().contains(&request.to_string()));
+        }
     }
 
     #[test]

--- a/crates/bitnet-device-config-core/src/lib.rs
+++ b/crates/bitnet-device-config-core/src/lib.rs
@@ -15,6 +15,14 @@ pub enum DeviceConfig {
     Cpu,
     /// Force GPU execution on specific device ID.
     Gpu(usize),
+    /// Preserve Intel NPU identity without aliasing to GPU or Metal.
+    IntelNpu(usize),
+    /// Preserve OpenVINO NPU runtime identity.
+    OpenVinoNpu,
+    /// Preserve Intel Arc 140V GPU identity.
+    IntelArc140v(usize),
+    /// Preserve OpenVINO GPU runtime identity.
+    OpenVinoGpu(usize),
     /// Preserve a native Metal backend identity.
     Metal,
     /// Preserve an MPSGraph graph/reference backend identity.
@@ -34,7 +42,11 @@ impl FromStr for DeviceConfig {
         match s.to_lowercase().as_str() {
             "auto" => Ok(DeviceConfig::Auto),
             "cpu" => Ok(DeviceConfig::Cpu),
-            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" | "npu" => Ok(DeviceConfig::Gpu(0)),
+            "gpu" | "cuda" | "vulkan" | "opencl" | "ocl" => Ok(DeviceConfig::Gpu(0)),
+            "npu" | "intel-npu" => Ok(DeviceConfig::IntelNpu(0)),
+            "openvino-npu" => Ok(DeviceConfig::OpenVinoNpu),
+            "intel-arc-140v" | "arc-140v" => Ok(DeviceConfig::IntelArc140v(0)),
+            "openvino-gpu" | "intel-arc-140v-openvino-gpu" => Ok(DeviceConfig::OpenVinoGpu(0)),
             "metal" => Ok(DeviceConfig::Metal),
             "mpsgraph" => Ok(DeviceConfig::MpsGraph),
             "apple-m4-metal" => Ok(DeviceConfig::AppleM4Metal),
@@ -45,6 +57,15 @@ impl FromStr for DeviceConfig {
             s if s.starts_with("vulkan:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("opencl:") => Ok(DeviceConfig::Gpu(s[7..].parse::<usize>()?)),
             s if s.starts_with("ocl:") => Ok(DeviceConfig::Gpu(s[4..].parse::<usize>()?)),
+            s if s.starts_with("intel-npu:") => {
+                Ok(DeviceConfig::IntelNpu(s[10..].parse::<usize>()?))
+            }
+            s if s.starts_with("intel-arc-140v:") => {
+                Ok(DeviceConfig::IntelArc140v(s[15..].parse::<usize>()?))
+            }
+            s if s.starts_with("openvino-gpu:") => {
+                Ok(DeviceConfig::OpenVinoGpu(s[13..].parse::<usize>()?))
+            }
             _ => anyhow::bail!("Unknown device config: {}", s),
         }
     }
@@ -68,6 +89,8 @@ impl DeviceConfig {
             }
             DeviceConfig::Cpu => Device::Cpu,
             DeviceConfig::Gpu(id) => Device::Cuda(*id),
+            DeviceConfig::IntelNpu(_) | DeviceConfig::OpenVinoNpu => Device::Npu,
+            DeviceConfig::IntelArc140v(id) | DeviceConfig::OpenVinoGpu(id) => Device::OpenCL(*id),
             DeviceConfig::Metal | DeviceConfig::AppleM4Metal => Device::Metal,
             // MPSGraph is a separate proof label; runtime execution is introduced in a later item.
             DeviceConfig::MpsGraph | DeviceConfig::AppleM4MpsGraph => Device::Cpu,
@@ -82,6 +105,10 @@ impl DeviceConfig {
             DeviceConfig::Auto => BackendRequest::Auto,
             DeviceConfig::Cpu => BackendRequest::Cpu,
             DeviceConfig::Gpu(_) => BackendRequest::Gpu,
+            DeviceConfig::IntelNpu(_) => BackendRequest::IntelNpu,
+            DeviceConfig::OpenVinoNpu => BackendRequest::OpenVinoNpu,
+            DeviceConfig::IntelArc140v(_) => BackendRequest::IntelArc140v,
+            DeviceConfig::OpenVinoGpu(_) => BackendRequest::IntelArc140vOpenVinoGpu,
             DeviceConfig::Metal => BackendRequest::Metal,
             DeviceConfig::MpsGraph => BackendRequest::MpsGraph,
             DeviceConfig::AppleM4Metal => BackendRequest::AppleM4Metal,
@@ -106,6 +133,13 @@ mod tests {
         assert_eq!("cpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Cpu);
         assert_eq!("auto".parse::<DeviceConfig>().unwrap(), DeviceConfig::Auto);
         assert_eq!("gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+        assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(0));
+        assert_eq!("openvino-npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoNpu);
+        assert_eq!(
+            "intel-arc-140v".parse::<DeviceConfig>().unwrap(),
+            DeviceConfig::IntelArc140v(0)
+        );
+        assert_eq!("openvino-gpu".parse::<DeviceConfig>().unwrap(), DeviceConfig::OpenVinoGpu(0));
         assert_eq!("cuda:2".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(2));
         assert_eq!("vulkan:3".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(3));
         assert_eq!("metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::Metal);
@@ -134,11 +168,19 @@ mod tests {
         let apple_metal = "apple-m4-metal".parse::<DeviceConfig>().unwrap();
         let mpsgraph = "mpsgraph".parse::<DeviceConfig>().unwrap();
         let apple_mpsgraph = "apple-m4-mpsgraph".parse::<DeviceConfig>().unwrap();
+        let intel_npu = "npu".parse::<DeviceConfig>().unwrap();
+        let openvino_npu = "openvino-npu".parse::<DeviceConfig>().unwrap();
+        let arc = "intel-arc-140v".parse::<DeviceConfig>().unwrap();
+        let openvino_gpu = "openvino-gpu".parse::<DeviceConfig>().unwrap();
         let apple_cpu = "apple-m4-cpu-neon".parse::<DeviceConfig>().unwrap();
 
         assert_eq!(metal.backend_label(), "metal");
         assert_eq!(apple_metal.backend_label(), "apple-m4-metal");
         assert_eq!(mpsgraph.backend_label(), "mpsgraph");
+        assert_eq!(intel_npu.backend_label(), "intel-npu");
+        assert_eq!(openvino_npu.backend_label(), "openvino-npu");
+        assert_eq!(arc.backend_label(), "intel-arc-140v");
+        assert_eq!(openvino_gpu.backend_label(), "intel-arc-140v-openvino-gpu");
         assert_eq!(apple_mpsgraph.backend_label(), "apple-m4-mpsgraph");
         assert_eq!(apple_cpu.backend_label(), "apple-m4-cpu-neon");
     }

--- a/crates/bitnet-inference/src/backends.rs
+++ b/crates/bitnet-inference/src/backends.rs
@@ -146,9 +146,8 @@ pub struct GpuBackend {
 
 /// NPU backend implementation.
 ///
-/// The current implementation routes execution through the model's Metal path and
-/// provides an explicit backend surface for NPU-oriented deployment policy,
-/// warm-up behavior, and capability reporting.
+/// This identity-preserving surface is reserved for Intel/OpenVINO NPU work.
+/// It deliberately does not alias NPU requests to Metal or generic GPU paths.
 pub struct NpuBackend {
     model: Arc<dyn Model>,
     device: Device,
@@ -160,17 +159,19 @@ impl NpuBackend {
     pub fn new(model: Arc<dyn Model>, device: Device) -> Result<Self> {
         if !Self::is_available() {
             return Err(anyhow::anyhow!(
-                "NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and compile with metal support on macOS"
+                "Intel NPU backend unavailable. Set {NPU_ENABLE_ENV}=1 and ensure an Intel NPU runtime is visible"
             ));
         }
 
-        if !matches!(device, Device::Metal) {
-            return Err(anyhow::anyhow!("NPU backend currently requires Device::Metal"));
+        if !matches!(device, Device::Npu) {
+            return Err(anyhow::anyhow!(
+                "Intel NPU backend requires Device::Npu and must not alias to Metal or GPU"
+            ));
         }
 
         let allow_cpu_fallback = std::env::var(NPU_FALLBACK_ENV)
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
+            .unwrap_or(false);
 
         info!(
             "Created NPU backend (device={:?}, allow_cpu_fallback={})",
@@ -186,7 +187,7 @@ impl NpuBackend {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
 
-        enabled && cfg!(target_os = "macos")
+        enabled && intel_npu_runtime_visible()
     }
 
     fn ensure_npu_tensor(&self, input: &ConcreteTensor) -> Result<ConcreteTensor> {
@@ -254,7 +255,7 @@ impl GpuBackend {
 #[async_trait]
 impl Backend for NpuBackend {
     fn backend_type(&self) -> String {
-        "npu_ane".to_string()
+        "intel-npu-openvino".to_string()
     }
 
     fn clone_backend(&self) -> Box<dyn Backend> {
@@ -384,14 +385,11 @@ pub fn select_backend(
             Ok(Box::new(CpuBackend::new(model)?))
         }
         Device::Metal => {
-            if NpuBackend::is_available() {
-                info!("Selected NPU backend");
-                Ok(Box::new(NpuBackend::new(model, device)?))
-            } else if GpuBackend::is_available() {
+            if GpuBackend::is_available() {
                 info!("Selected GPU backend for Metal device");
                 Ok(Box::new(GpuBackend::new(model, device)?))
             } else {
-                warn!("Metal/NPU requested but unavailable, falling back to CPU");
+                warn!("Metal requested but unavailable, falling back to CPU");
                 Ok(Box::new(CpuBackend::new(model)?))
             }
         }
@@ -415,11 +413,12 @@ pub fn select_backend(
         }
         Device::Npu => {
             if NpuBackend::is_available() {
-                info!("Selected NPU backend");
+                info!("Selected Intel NPU backend");
                 Ok(Box::new(NpuBackend::new(model, device)?))
             } else {
-                warn!("NPU requested but not available, falling back to CPU");
-                Ok(Box::new(CpuBackend::new(model)?))
+                Err(anyhow::anyhow!(
+                    "Intel NPU requested but unavailable; refusing CPU/GPU fallback for strict identity"
+                ))
             }
         }
         Device::OpenCL(_) => {
@@ -434,6 +433,27 @@ pub fn select_backend(
             // quantized linear layers; the high-level backend uses CPU tensors.
             Ok(Box::new(CpuBackend::new(model)?))
         }
+    }
+}
+
+fn intel_npu_runtime_visible() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_dir("/dev/accel")
+            .map(|mut entries| entries.any(|entry| entry.is_ok()))
+            .unwrap_or(false)
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // OpenVINO NPU probing is introduced in the platform probe lane. Until
+        // that lands, keep Windows NPU identity opt-in via BITNET_ENABLE_NPU.
+        true
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        false
     }
 }
 
@@ -537,6 +557,16 @@ mod tests {
     }
 
     #[test]
+    fn test_npu_request_fails_without_runtime_identity() {
+        let model = Arc::new(MockModel::new());
+
+        match select_backend(model, Some(Device::Npu)) {
+            Ok(backend) => panic!("expected NPU selection to fail, got {}", backend.backend_type()),
+            Err(err) => assert!(err.to_string().contains("Intel NPU requested but unavailable")),
+        }
+    }
+
+    #[test]
     fn test_metal_request_falls_back_without_npu() {
         let model = Arc::new(MockModel::new());
 
@@ -544,7 +574,7 @@ mod tests {
         let backend_type = backend.backend_type();
         assert!(
             backend_type == "cpu" || backend_type.contains("gpu"),
-            "expected CPU/GPU fallback when NPU disabled, got {}",
+            "expected CPU/GPU fallback when Metal disabled, got {}",
             backend_type
         );
     }

--- a/crates/bitnet-inference/src/npu.rs
+++ b/crates/bitnet-inference/src/npu.rs
@@ -2,7 +2,7 @@
 //!
 //! This module centralizes environment-driven controls for the NPU path so the
 //! engine and CLI can expose a stable "npu" target while backend wiring to
-//! Qualcomm QNN/SNPE matures.
+//! Intel OpenVINO NPU probing and graph execution mature.
 
 use bitnet_common::Device;
 
@@ -21,8 +21,27 @@ pub fn map_device_token(token: &str) -> Option<Device> {
     match token {
         "cpu" => Some(Device::Cpu),
         "cuda" | "gpu" => Some(Device::Cuda(0)),
-        "metal" | "npu" => Some(Device::Metal),
-        "oneapi" | "opencl" | "intel-gpu" => Some(Device::OpenCL(0)),
+        "metal" => Some(Device::Metal),
+        "npu" | "intel-npu" | "openvino-npu" => Some(Device::Npu),
+        "oneapi" | "opencl" | "intel-gpu" | "intel-arc-140v" => Some(Device::OpenCL(0)),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::map_device_token;
+    use bitnet_common::Device;
+
+    #[test]
+    fn npu_tokens_preserve_npu_identity() {
+        assert_eq!(map_device_token("npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("intel-npu"), Some(Device::Npu));
+        assert_eq!(map_device_token("openvino-npu"), Some(Device::Npu));
+    }
+
+    #[test]
+    fn metal_token_stays_metal() {
+        assert_eq!(map_device_token("metal"), Some(Device::Metal));
     }
 }


### PR DESCRIPTION
### Motivation
- Avoid aliasing `npu` to Metal/generic GPU and ensure NPU/Arc identities are provable and auditable for Lunar Lake validation and receipts. 
- Make NPU selection an identity-first operation that refuses silent CPU/GPU fallbacks when `Device::Npu` is explicitly requested. 
- Provide distinct CLI/config tokens and device-config labels so platform probes and receipts can record requested vs selected backends precisely.

### Description
- Added explicit backend request variants `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `IntelArc140vOpenVinoGpu` to `bitnet-common::backend_selection::BackendRequest` and extended parsing/display to accept tokens like `npu`, `intel-npu`, `openvino-npu`, `intel-arc-140v`, and `openvino-gpu`.
- Extended `DeviceConfig` in `crates/bitnet-device-config-core` with `IntelNpu`, `OpenVinoNpu`, `IntelArc140v`, and `OpenVinoGpu`, changed parsing so these tokens resolve to `Device::Npu` or `Device::OpenCL` as appropriate, and preserved unique backend labels for receipts.
- Changed `crates/bitnet-inference` NPU surface: `map_device_token` preserves `Device::Npu` for NPU tokens, `NpuBackend` now requires `Device::Npu`, reports `intel-npu-openvino` as `backend_type`, uses a runtime probe helper `intel_npu_runtime_visible()` (checks `/dev/accel` on Linux / opt-in on Windows), and defaults `BITNET_NPU_ALLOW_FALLBACK` to false so the NPU path will no longer silently fall back to CPU/GPU when explicitly requested.
- Updated `select_backend` behavior to: prefer GPU for `Device::Metal`/`Device::Cuda` as before, refuse to silently accept `Device::Npu` when NPU runtime is not visible (return an error instead of falling back), and keep Metal behavior unchanged for GPU selection.
- Added unit/regression tests for token->device mapping and strict identity behavior across `crates/bitnet-common`, `crates/bitnet-device-config-core`, `crates/bitnet-inference`, and `crates/bitnet-inference/src/npu.rs` test modules.

### Testing
- Ran `cargo fmt --all -- --check` and it passed.
- Ran targeted test suites and they passed: `cargo test --locked -p bitnet-device-config-core`, `cargo test --locked -p bitnet-common --features cpu backend_selection::tests::`, and `cargo test --locked -p bitnet-inference npu` all succeeded.
- An earlier broader combined test run hit a temporary build/disk-space interruption during a large workspace CI run; after cleaning target artifacts the focused tests above were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab59f65848333b28a58f6df6fd41c)