### PR TITLE
feat(ci): promote ripr advisory → soft-gate (warn-on-new)

### DIFF
--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -8,12 +8,10 @@ name: ripr (static exposure)
 # outcomes. See docs/ci/cost-and-verification-policy.md for the
 # verification ladder and why this layer matters.
 #
-# Initial posture: ADVISORY (non-blocking).
-# - continue-on-error: true at the job level
-# - no merge gate
-# - JSON + SARIF + GitHub annotations only
-# - production Rust paths only; skips docs-only PRs
-# - workflow_dispatch + label-triggered runs supported
+# Posture: SOFT-GATE (advisory, warn-on-new). PR P promotes ripr from a
+# pure advisory dump to a warn-on-new step-summary block, while keeping
+# the workflow non-blocking via continue-on-error. Labels `ripr-ack`,
+# `ripr-waive`, and `full-ci` suppress the warning summary.
 #
 # Toolchain note: ripr targets Rust 2024 and requires Rust >= 1.93.
 # BitNet-rs MSRV (rust-toolchain.toml) is currently 1.92, so we install a
@@ -32,6 +30,7 @@ on:
       - 'Cargo.lock'
       - 'ripr.toml'
       - 'policy/ripr-suppressions.toml'
+      - 'policy/ripr-baseline.json'
       - '.github/workflows/ripr.yml'
   workflow_dispatch:
 
@@ -118,6 +117,96 @@ jobs:
           ripr check --base "$base_arg" --format github || true
           # SARIF artifact (for label opt-in code-scanning surfacing later).
           ripr check --base "$base_arg" --format sarif > target/ripr/ripr.sarif || true
+
+      - name: Soft-gate promotion (warn-on-new)
+        # Stage 3 promotion (PR P): emit a high-visibility "soft gate" block
+        # in the run step summary listing reachable_unrevealed and
+        # weakly_exposed findings on production Rust changes. Honours the
+        # `ripr-ack`, `ripr-waive`, and `full-ci` labels as escape hatches.
+        # Does NOT fail the run — `continue-on-error: true` is preserved.
+        if: env.RIPR_INSTALL_FAILED != '1'
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: |
+          set -euo pipefail
+          if [ ! -s target/ripr/ripr.json ]; then
+            exit 0
+          fi
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, os, pathlib
+
+          labels = set(json.loads(os.environ.get("LABELS_JSON") or "[]"))
+          # Escape hatches.
+          if labels & {"ripr-ack", "ripr-waive", "full-ci"}:
+              print("## ripr soft gate")
+              print()
+              print(f"_Suppressed by label_: `{', '.join(sorted(labels))}`")
+              print()
+              print("Findings still uploaded as JSON / SARIF artifacts.")
+              raise SystemExit(0)
+
+          # Load baseline so we can flag genuinely new findings. PR P ships
+          # an empty baseline; until calibration begins, every diff-scoped
+          # finding is "new" — which is fine because the gate is advisory.
+          baseline = set()
+          baseline_path = pathlib.Path("policy/ripr-baseline.json")
+          if baseline_path.is_file():
+              try:
+                  data = json.loads(baseline_path.read_text())
+                  for f in data.get("findings", []):
+                      key = (f.get("path"), f.get("symbol"), f.get("classification"))
+                      baseline.add(key)
+              except Exception:
+                  pass  # baseline read errors are non-fatal in soft-gate stage.
+
+          report = json.loads(pathlib.Path("target/ripr/ripr.json").read_text())
+          findings = report.get("findings") or report.get("results") or []
+
+          flagged = []
+          counts = {"reachable_unrevealed": 0, "weakly_exposed": 0, "other": 0}
+          for f in findings:
+              c = f.get("classification") or f.get("class") or ""
+              if c in ("reachable_unrevealed", "weakly_exposed"):
+                  counts[c] += 1
+                  key = (f.get("path"), f.get("symbol"), c)
+                  if key in baseline:
+                      continue
+                  flagged.append(f)
+              else:
+                  counts["other"] += 1
+
+          print("## ripr soft gate")
+          print()
+          print(f"- **reachable_unrevealed**: {counts['reachable_unrevealed']}")
+          print(f"- **weakly_exposed**: {counts['weakly_exposed']}")
+          print(f"- **baseline-suppressed**: {sum(counts.values()) - len(flagged) - counts['other']}")
+          print(f"- **flagged (new)**: {len(flagged)}")
+          print()
+          if not flagged:
+              print("_No new oracle-exposure gaps in this diff. Advisory layer remains green._")
+              raise SystemExit(0)
+
+          print("### Top flagged findings")
+          print()
+          print("| Path | Symbol | Class | Reason |")
+          print("|---|---|---|---|")
+          for f in flagged[:20]:
+              path = f.get("path", "?")
+              line = f.get("line")
+              loc = f"`{path}`" + (f":{line}" if line else "")
+              sym = f.get("symbol", f.get("name", "?"))
+              cls = f.get("classification", "?")
+              reason = (f.get("reason") or f.get("explanation") or "—").replace("|", "\\|")
+              print(f"| {loc} | `{sym}` | `{cls}` | {reason} |")
+          if len(flagged) > 20:
+              print()
+              print(f"_… {len(flagged) - 20} more findings in `target/ripr/ripr.json`._")
+          print()
+          print("> Soft gate is advisory: this run does not fail. Apply `ripr-ack` "
+                "(accept), `ripr-waive` (waive permanently), or `full-ci` to "
+                "suppress this block. To accept many findings as the new baseline, "
+                "regenerate `policy/ripr-baseline.json`.")
+          PY
 
       - name: PR step summary
         if: always()

--- a/policy/ripr-baseline.json
+++ b/policy/ripr-baseline.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": 1,
+  "comment": "Baseline inventory of ripr findings that exist on `main` and should not be treated as new on PRs. The first real ripr runs on BitNet-rs are expected to surface a baseline that lands here. Until calibration begins, this file is empty: the soft-gate (PR P) treats every diff-scoped finding as new, but the warning is informational only — failures are advisory and labels `ripr-ack` / `ripr-waive` / `full-ci` suppress the warning entirely.",
+  "findings": []
+}

--- a/ripr.toml
+++ b/ripr.toml
@@ -4,11 +4,16 @@
 # diff, builds mutation-shaped static probes, and asks whether the changed
 # behavior appears exposed to a meaningful test discriminator.
 #
-# Initial BitNet-rs posture: ADVISORY.
+# BitNet-rs posture: SOFT-GATE (advisory, warn-on-new).
 # - Diff-scoped (no full-repo scan).
-# - No merge gate. Findings are reported via PR step summary + JSON/SARIF.
-# - Promotion to soft-gate or hard-gate requires calibration: see
-#   docs/ci/cost-and-verification-policy.md and the staged plan in PR P.
+# - No merge gate. `continue-on-error: true` preserved at the workflow level.
+# - The workflow's promotion step emits a high-visibility step-summary
+#   block when `reachable_unrevealed` or `weakly_exposed` findings appear
+#   on production Rust changes, but does NOT fail the run.
+# - Labels `ripr-ack`, `ripr-waive`, and `full-ci` suppress the soft-gate
+#   summary (JSON / SARIF artifacts still upload for inspection).
+# - Hard-gate (status-check enforcement) requires baseline calibration
+#   via policy/ripr-baseline.json plus several weeks of observed signal.
 #
 # See https://github.com/EffortlessMetrics/ripr for the schema reference.
 


### PR DESCRIPTION
## Summary

Adds the **Stage 3** ripr promotion described in `docs/ci/cost-and-verification-policy.md` and the multi-PR roadmap. Promotes ripr from "pure advisory dump" to **soft-gate (warn-on-new)** while keeping the workflow non-blocking.

This is **PR P** in the multi-PR CI roadmap. Stacked on PR J (#3757); will retarget `main` once J merges.

## What changes

- **`.github/workflows/ripr.yml`** — new `Soft-gate promotion` step parses `target/ripr/ripr.json`, diffs it against `policy/ripr-baseline.json`, and emits a high-visibility step-summary block listing the new `reachable_unrevealed` and `weakly_exposed` findings (top 20).
- **`policy/ripr-baseline.json`** — empty placeholder (`"findings": []`). The first calibrated runs are expected to populate this file; until then, every diff-scoped finding shows as "new" — which is fine because the gate is advisory.
- **`ripr.toml`** — header comments updated to reflect the soft-gate stage and the `ripr-ack` / `ripr-waive` / `full-ci` escape hatches.

## Critically, this PR does NOT block merges

- `continue-on-error: true` preserved at the workflow level.
- The soft-gate step itself never fails; it only writes to `GITHUB_STEP_SUMMARY`.
- Labels `ripr-ack`, `ripr-waive`, and `full-ci` suppress the summary block entirely (artifacts still upload for inspection).

## Example summary output

> ## ripr soft gate
> - **reachable_unrevealed**: 3
> - **weakly_exposed**: 1
> - **baseline-suppressed**: 0
> - **flagged (new)**: 4
>
> ### Top flagged findings
> | Path | Symbol | Class | Reason |
> |---|---|---|---|
> | `crates/bitnet-quantization/src/i2s_qk256.rs:88` | `pack_block` | `reachable_unrevealed` | predicate flip not asserted |
> | … | … | … | … |
>
> > Soft gate is advisory: this run does not fail. Apply `ripr-ack` (accept), `ripr-waive` (waive permanently), or `full-ci` to suppress this block. To accept many findings as the new baseline, regenerate `policy/ripr-baseline.json`.

## Test plan

- [ ] Verify the workflow runs on this PR (touches `ripr.yml` and adds a baseline file).
- [ ] Verify the soft-gate step does not fail the run regardless of finding count.
- [ ] Verify `ripr-ack` label suppresses the summary block on a follow-up PR.
- [ ] Verify the workflow still emits JSON / SARIF artifacts.

## Out of scope (Stage 4+)

- Hard-gate (status-check enforcement).
- Programmatic baseline regeneration (e.g. `xtask ripr baseline-write`).
- Severity-aware prioritization (treating high-confidence `reachable_unrevealed` as merge-blocking).

https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2yTnEYJcA3G2CyZn9bY4v)_