### PR TITLE
[codex][apple-m4] Add Metal I2_S parity smoke (M4-011)

### DIFF
--- a/crates/bitnet-kernels/src/metal/smoke.rs
+++ b/crates/bitnet-kernels/src/metal/smoke.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use crate::cpu::quantized_matmul::{i2s_matmul_f32, pack_i2s};
+
 pub const MACHINE_ID: &str = "apple-m4-mac-mini";
 pub const ARTIFACT_KIND: &str = "smoke";
 pub const PARITY_ARTIFACT_KIND: &str = "parity";
@@ -9,6 +11,15 @@ pub const REFERENCE_BACKEND: &str = "apple-m4-cpu-neon";
 pub const RUNTIME_API: &str = "metal";
 pub const TINY_METAL_ADD_SMOKE_KERNEL_ID: &str = "tiny_metal_add_smoke";
 pub const TINY_METAL_ADD_PARITY_KERNEL_ID: &str = "tiny_metal_add_parity";
+pub const I2S_METAL_PARITY_KERNEL_ID: &str = "tiny_metal_i2s_parity";
+pub const I2S_KERNEL_FAMILY: &str = "i2_s";
+pub const I2S_EXECUTION_PHASE: &str = "parity";
+pub const I2S_LAYOUT_SOURCE: &str = "fixture_packed_i2_s";
+pub const I2S_TRANSPORT_LAYOUT: &str = "u32_le_words_from_i2s_bytes";
+pub const I2S_PARITY_M: usize = 1;
+pub const I2S_PARITY_N: usize = 4;
+pub const I2S_PARITY_K: usize = 32;
+pub const I2S_PARITY_BLOCK_SIZE: usize = 32;
 pub const SMOKE_ELEMENT_COUNT: usize = 64;
 pub const SMOKE_WORKGROUP_SIZE: u32 = 64;
 
@@ -69,6 +80,31 @@ pub struct TinyMetalAddParityReceipt {
     pub mean_abs_error: f32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct I2sMetalParityReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub reference_backend: &'static str,
+    pub target_backend: &'static str,
+    pub kernel_id: &'static str,
+    pub kernel_family: &'static str,
+    pub execution_phase: &'static str,
+    pub layout_source: &'static str,
+    pub transport_layout: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub m: usize,
+    pub n: usize,
+    pub k: usize,
+    pub block_size: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
 impl TinyMetalAddParityReceipt {
     pub fn passed(
         artifact_path: impl Into<String>,
@@ -92,6 +128,47 @@ impl TinyMetalAddParityReceipt {
             mean_abs_error: comparison.mean_abs_error,
         }
     }
+}
+
+impl I2sMetalParityReceipt {
+    pub fn passed(artifact_path: impl Into<String>, comparison: SmokeComparison) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: PARITY_ARTIFACT_KIND,
+            requested_backend: REQUESTED_BACKEND,
+            selected_backend: SELECTED_BACKEND,
+            runtime_api: RUNTIME_API,
+            reference_backend: REFERENCE_BACKEND,
+            target_backend: SELECTED_BACKEND,
+            kernel_id: I2S_METAL_PARITY_KERNEL_ID,
+            kernel_family: I2S_KERNEL_FAMILY,
+            execution_phase: I2S_EXECUTION_PHASE,
+            layout_source: I2S_LAYOUT_SOURCE,
+            transport_layout: I2S_TRANSPORT_LAYOUT,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            m: I2S_PARITY_M,
+            n: I2S_PARITY_N,
+            k: I2S_PARITY_K,
+            block_size: I2S_PARITY_BLOCK_SIZE,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct I2sMetalParityFixture {
+    pub activations: Vec<f32>,
+    pub weights_packed: Vec<u8>,
+    pub weights_packed_words: Vec<u32>,
+    pub scales: Vec<f32>,
+    pub expected: Vec<f32>,
+    pub m: usize,
+    pub n: usize,
+    pub k: usize,
+    pub block_size: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -136,6 +213,10 @@ pub fn metal_parity_artifact_path(date: &str) -> String {
     format!("ci/hardware/{MACHINE_ID}/{date}/metal-parity.json")
 }
 
+pub fn metal_i2s_parity_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/metal-i2s-parity.json")
+}
+
 pub fn tiny_add_inputs() -> (Vec<f32>, Vec<f32>) {
     let lhs = (0..SMOKE_ELEMENT_COUNT).map(|i| i as f32).collect();
     let rhs = (0..SMOKE_ELEMENT_COUNT).map(|i| (i as f32) * 2.0).collect();
@@ -151,6 +232,75 @@ pub fn expected_tiny_add(lhs: &[f32], rhs: &[f32]) -> Result<Vec<f32>, TinyMetal
     }
 
     Ok(lhs.iter().zip(rhs.iter()).map(|(left, right)| left + right).collect())
+}
+
+pub fn i2s_metal_parity_fixture() -> I2sMetalParityFixture {
+    let activations =
+        (0..I2S_PARITY_K).map(|index| ((index as i32 % 9) - 4) as f32 * 0.25).collect::<Vec<_>>();
+    let scales = vec![0.25, 0.5, 0.75, 1.0];
+
+    let mut weights_packed = Vec::with_capacity((I2S_PARITY_K / 4) * I2S_PARITY_N);
+    for col in 0..I2S_PARITY_N {
+        for chunk_start in (0..I2S_PARITY_K).step_by(4) {
+            let vals = std::array::from_fn(|offset| {
+                let selector = (chunk_start + offset + col * 3) % 5;
+                match selector {
+                    0 | 3 => -1,
+                    1 => 0,
+                    _ => 1,
+                }
+            });
+            weights_packed.push(pack_i2s(vals));
+        }
+    }
+
+    let weights_packed_words = pack_i2s_bytes_to_u32_words(&weights_packed);
+    let mut expected = vec![0.0; I2S_PARITY_M * I2S_PARITY_N];
+    i2s_matmul_f32(
+        &activations,
+        &weights_packed,
+        &scales,
+        &mut expected,
+        I2S_PARITY_M,
+        I2S_PARITY_N,
+        I2S_PARITY_K,
+        I2S_PARITY_BLOCK_SIZE,
+    )
+    .expect("deterministic M4 I2_S parity fixture is valid");
+
+    I2sMetalParityFixture {
+        activations,
+        weights_packed,
+        weights_packed_words,
+        scales,
+        expected,
+        m: I2S_PARITY_M,
+        n: I2S_PARITY_N,
+        k: I2S_PARITY_K,
+        block_size: I2S_PARITY_BLOCK_SIZE,
+    }
+}
+
+pub fn i2s_parity_shape_words(fixture: &I2sMetalParityFixture) -> [u32; 6] {
+    [
+        fixture.m as u32,
+        fixture.n as u32,
+        fixture.k as u32,
+        fixture.k.div_ceil(4) as u32,
+        fixture.block_size as u32,
+        fixture.k.div_ceil(fixture.block_size) as u32,
+    ]
+}
+
+pub fn pack_i2s_bytes_to_u32_words(bytes: &[u8]) -> Vec<u32> {
+    bytes
+        .chunks(4)
+        .map(|chunk| {
+            let mut padded = [0_u8; 4];
+            padded[..chunk.len()].copy_from_slice(chunk);
+            u32::from_le_bytes(padded)
+        })
+        .collect()
 }
 
 pub fn compare_tiny_add_outputs(

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -2,12 +2,15 @@
 
 use bitnet_device_probe::{AppleBackendReceipt, AppleResolvedDevice};
 use bitnet_kernels::metal::smoke::{
-    ARTIFACT_KIND, MACHINE_ID, PARITY_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND,
-    RUNTIME_API, SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SmokeComparison,
-    TINY_METAL_ADD_PARITY_KERNEL_ID, TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt,
-    TinyMetalAddSmokeReceipt, compare_tiny_add_outputs, expected_tiny_add,
-    is_apple_m4_adapter_name, metal_parity_artifact_path, metal_smoke_artifact_path,
-    tiny_add_inputs,
+    ARTIFACT_KIND, I2S_EXECUTION_PHASE, I2S_KERNEL_FAMILY, I2S_LAYOUT_SOURCE,
+    I2S_METAL_PARITY_KERNEL_ID, I2S_PARITY_BLOCK_SIZE, I2S_PARITY_K, I2S_PARITY_M, I2S_PARITY_N,
+    I2S_TRANSPORT_LAYOUT, I2sMetalParityFixture, I2sMetalParityReceipt, MACHINE_ID,
+    PARITY_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND, RUNTIME_API, SELECTED_BACKEND,
+    SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_PARITY_KERNEL_ID,
+    TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt, TinyMetalAddSmokeReceipt,
+    compare_tiny_add_outputs, expected_tiny_add, i2s_metal_parity_fixture, i2s_parity_shape_words,
+    is_apple_m4_adapter_name, metal_i2s_parity_artifact_path, metal_parity_artifact_path,
+    metal_smoke_artifact_path, tiny_add_inputs,
 };
 
 #[test]
@@ -64,6 +67,48 @@ fn parity_receipt_contract_records_cpu_neon_reference_and_metal_target() {
 }
 
 #[test]
+fn i2s_fixture_records_packed_layout_and_cpu_reference() {
+    let fixture = i2s_metal_parity_fixture();
+
+    assert_eq!(fixture.m, I2S_PARITY_M);
+    assert_eq!(fixture.n, I2S_PARITY_N);
+    assert_eq!(fixture.k, I2S_PARITY_K);
+    assert_eq!(fixture.block_size, I2S_PARITY_BLOCK_SIZE);
+    assert_eq!(fixture.activations.len(), I2S_PARITY_M * I2S_PARITY_K);
+    assert_eq!(fixture.weights_packed.len(), I2S_PARITY_N * I2S_PARITY_K.div_ceil(4));
+    assert_eq!(fixture.weights_packed_words.len(), fixture.weights_packed.len().div_ceil(4));
+    assert_eq!(fixture.scales.len(), I2S_PARITY_N * I2S_PARITY_K.div_ceil(I2S_PARITY_BLOCK_SIZE));
+    assert_eq!(fixture.expected.len(), I2S_PARITY_M * I2S_PARITY_N);
+    assert!(fixture.expected.iter().any(|value| *value != 0.0));
+}
+
+#[test]
+fn i2s_receipt_contract_records_kernel_family_without_inference_claim() {
+    let receipt = I2sMetalParityReceipt::passed(
+        metal_i2s_parity_artifact_path("2026-05-06"),
+        SmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, MACHINE_ID);
+    assert_eq!(receipt.artifact_kind, PARITY_ARTIFACT_KIND);
+    assert_eq!(receipt.requested_backend, REQUESTED_BACKEND);
+    assert_eq!(receipt.selected_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.runtime_api, RUNTIME_API);
+    assert_eq!(receipt.reference_backend, REFERENCE_BACKEND);
+    assert_eq!(receipt.target_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.kernel_id, I2S_METAL_PARITY_KERNEL_ID);
+    assert_eq!(receipt.kernel_family, I2S_KERNEL_FAMILY);
+    assert_eq!(receipt.execution_phase, I2S_EXECUTION_PHASE);
+    assert_eq!(receipt.layout_source, I2S_LAYOUT_SOURCE);
+    assert_eq!(receipt.transport_layout, I2S_TRANSPORT_LAYOUT);
+    assert!(!receipt.fallback_used);
+    assert_eq!(
+        receipt.artifact_path,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-i2s-parity.json"
+    );
+}
+
+#[test]
 fn comparison_fails_instead_of_falling_back_to_cpu() {
     let expected = [1.0_f32, 2.0, 3.0];
     let actual = [1.0_f32, 20.0, 3.0];
@@ -102,6 +147,9 @@ mod live_metal {
     const BENCHMARK_RECEIPT_ENV: &str = "BITNET_M4_METAL_BENCHMARK_RECEIPT";
     const BENCHMARK_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_BENCHMARK_ARTIFACT_PATH";
     const BENCHMARK_ITERATIONS_ENV: &str = "BITNET_M4_METAL_BENCHMARK_ITERATIONS";
+    const RUN_I2S_PARITY_ENV: &str = "BITNET_RUN_M4_METAL_I2S_PARITY";
+    const I2S_PARITY_RECEIPT_ENV: &str = "BITNET_M4_METAL_I2S_PARITY_RECEIPT";
+    const I2S_PARITY_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_I2S_PARITY_ARTIFACT_PATH";
     const TINY_KERNEL_SMOKE_PROFILE: &str = "tiny_kernel_smoke";
 
     struct MetalSmokeOutput {
@@ -113,6 +161,11 @@ mod live_metal {
         adapter_name: String,
         output: Vec<f32>,
         timing: BenchmarkTiming,
+    }
+
+    struct MetalI2sParityOutput {
+        adapter_name: String,
+        output: Vec<f32>,
     }
 
     struct BenchmarkTiming {
@@ -171,10 +224,11 @@ mod live_metal {
         );
 
         if let Ok(path) = std::env::var(RECEIPT_ENV) {
-            if let Some(parent) = Path::new(&path).parent() {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
         }
 
         println!("{}", serde_json::to_string_pretty(&receipt_json)?);
@@ -232,10 +286,11 @@ mod live_metal {
         );
 
         if let Ok(path) = std::env::var(PARITY_RECEIPT_ENV) {
-            if let Some(parent) = Path::new(&path).parent() {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
         }
 
         println!("{}", serde_json::to_string_pretty(&receipt_json)?);
@@ -294,10 +349,63 @@ mod live_metal {
         );
 
         if let Ok(path) = std::env::var(BENCHMARK_RECEIPT_ENV) {
-            if let Some(parent) = Path::new(&path).parent() {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::write(&path, serde_json::to_string_pretty(&receipt_json)?)?;
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiny_m4_metal_i2s_matches_cpu_neon_reference_when_enabled() -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_I2S_PARITY_ENV).as_deref() != Ok("1") {
+            eprintln!("skipping live M4 Metal I2_S parity; set {RUN_I2S_PARITY_ENV}=1 to run it");
+            return Ok(());
+        }
+
+        let fixture = i2s_metal_parity_fixture();
+        let metal_output = run_i2s_metal_parity(&fixture)?;
+
+        if !is_apple_m4_adapter_name(&metal_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-011 I2_S parity requires an Apple M4-family Metal adapter; found '{}'",
+                metal_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&fixture.expected, &metal_output.output, 1e-5)?;
+        let artifact_path = std::env::var(I2S_PARITY_ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(I2S_PARITY_RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-parity.json".to_string()
+            });
+        let receipt = I2sMetalParityReceipt::passed(artifact_path.clone(), comparison);
+
+        let mut receipt_json = apple_backend_receipt_json(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            metal_output.adapter_name,
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+            Some(receipt.kernel_id),
+            None,
+            receipt.result,
+        )?;
+        extend_i2s_parity_metrics(&mut receipt_json, &receipt, &fixture);
+
+        if let Ok(path) = std::env::var(I2S_PARITY_RECEIPT_ENV) {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
         }
 
         println!("{}", serde_json::to_string_pretty(&receipt_json)?);
@@ -430,6 +538,165 @@ mod live_metal {
             staging_buffer.unmap();
 
             Ok(MetalSmokeOutput { adapter_name: adapter_info.name, output })
+        })
+    }
+
+    fn run_i2s_metal_parity(
+        fixture: &I2sMetalParityFixture,
+    ) -> Result<MetalI2sParityOutput, Box<dyn Error>> {
+        pollster::block_on(async move {
+            let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::METAL,
+                ..Default::default()
+            });
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .ok_or_else(|| io_error("no Metal adapter found for M4-011 I2_S parity"))?;
+
+            let adapter_info = adapter.get_info();
+            if adapter_info.backend != wgpu::Backend::Metal {
+                return Err(io_error(format!(
+                    "M4-011 I2_S parity requires Metal backend, found {:?}",
+                    adapter_info.backend
+                )));
+            }
+
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .map_err(|error| io_error(format!("failed to create Metal device: {error}")))?;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(I2S_METAL_PARITY_KERNEL_ID),
+                source: wgpu::ShaderSource::Wgsl(I2S_PARITY_SHADER.into()),
+            });
+
+            let activations_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_activations"),
+                contents: bytemuck::cast_slice(&fixture.activations),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let weights_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_weights_u32_le"),
+                contents: bytemuck::cast_slice(&fixture.weights_packed_words),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let scales_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_scales"),
+                contents: bytemuck::cast_slice(&fixture.scales),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let shape_words = i2s_parity_shape_words(fixture);
+            let shape_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_shape"),
+                contents: bytemuck::cast_slice(&shape_words),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let byte_len = std::mem::size_of_val(&fixture.expected[..]) as u64;
+            let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_i2s_output"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_i2s_staging"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("tiny_metal_i2s_layout"),
+                    entries: &[
+                        storage_buffer_entry(0, true),
+                        storage_buffer_entry(1, true),
+                        storage_buffer_entry(2, true),
+                        storage_buffer_entry(3, false),
+                        storage_buffer_entry(4, true),
+                    ],
+                });
+
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("tiny_metal_i2s_bind_group"),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: activations_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: weights_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: scales_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: output_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry { binding: 4, resource: shape_buffer.as_entire_binding() },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("tiny_metal_i2s_pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tiny_metal_i2s_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tiny_metal_i2s_encoder"),
+            });
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("tiny_metal_i2s_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.dispatch_workgroups(
+                    (fixture.expected.len() as u32).div_ceil(SMOKE_WORKGROUP_SIZE),
+                    1,
+                    1,
+                );
+            }
+
+            encoder.copy_buffer_to_buffer(&output_buffer, 0, &staging_buffer, 0, byte_len);
+            queue.submit(std::iter::once(encoder.finish()));
+
+            let slice = staging_buffer.slice(..);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |result| {
+                tx.send(result).unwrap();
+            });
+            device.poll(wgpu::Maintain::Wait);
+            rx.recv()
+                .map_err(|error| io_error(format!("failed to receive Metal map result: {error}")))?
+                .map_err(|error| io_error(format!("failed to map Metal I2_S output: {error}")))?;
+
+            let data = slice.get_mapped_range();
+            let output = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+            drop(data);
+            staging_buffer.unmap();
+
+            Ok(MetalI2sParityOutput { adapter_name: adapter_info.name, output })
         })
     }
 
@@ -636,6 +903,15 @@ mod live_metal {
         Box::new(io::Error::other(message.into()))
     }
 
+    fn receipt_output_path(path: &str) -> std::path::PathBuf {
+        let path = Path::new(path);
+        if path.is_absolute() {
+            return path.to_path_buf();
+        }
+
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path)
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn apple_backend_receipt_json(
         machine_id: &str,
@@ -754,6 +1030,51 @@ mod live_metal {
         );
     }
 
+    fn extend_i2s_parity_metrics(
+        receipt_json: &mut serde_json::Value,
+        receipt: &I2sMetalParityReceipt,
+        fixture: &I2sMetalParityFixture,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert(
+            "bitnet".to_string(),
+            json!({
+                "kernel_family": receipt.kernel_family,
+                "execution_phase": receipt.execution_phase,
+                "layout_source": receipt.layout_source,
+                "fallback_layout": null
+            }),
+        );
+        object.insert("model".to_string(), serde_json::Value::Null);
+        object.insert(
+            "layout".to_string(),
+            json!({
+                "source": receipt.layout_source,
+                "transport_layout": receipt.transport_layout,
+                "canonical_packed_bytes": fixture.weights_packed.len(),
+                "transport_words_u32": fixture.weights_packed_words.len(),
+                "consumes_packed_i2_s_directly": true,
+                "dequantizes_before_compute": false,
+                "m": fixture.m,
+                "n": fixture.n,
+                "k": fixture.k,
+                "block_size": fixture.block_size
+            }),
+        );
+        object.insert(
+            "parity".to_string(),
+            json!({
+                "reference_backend": receipt.reference_backend,
+                "target_backend": receipt.target_backend,
+                "kernel_id": receipt.kernel_id,
+                "kernel_family": receipt.kernel_family,
+                "max_abs_error": receipt.max_abs_error,
+                "mean_abs_error": receipt.mean_abs_error,
+                "token_agreement_for_greedy": null
+            }),
+        );
+    }
+
     fn duration_ms(duration: Duration) -> f64 {
         duration.as_secs_f64() * 1_000.0
     }
@@ -786,6 +1107,63 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     if index < arrayLength(&lhs) {
         output[index] = lhs[index] + rhs[index];
     }
+}
+"#;
+
+    const I2S_PARITY_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read> activations: array<f32>;
+@group(0) @binding(1) var<storage, read> weights_words: array<u32>;
+@group(0) @binding(2) var<storage, read> scales: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+@group(0) @binding(4) var<storage, read> shape: array<u32>;
+
+fn decode_i2s(bits: u32) -> f32 {
+    if bits == 1u {
+        return 1.0;
+    }
+    if bits == 3u {
+        return -1.0;
+    }
+    return 0.0;
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let output_index = global_id.x;
+    let m = shape[0];
+    let n = shape[1];
+    let k = shape[2];
+    let packed_k = shape[3];
+    let block_size = shape[4];
+    let num_blocks_k = shape[5];
+
+    if output_index >= m * n {
+        return;
+    }
+
+    let row = output_index / n;
+    let col = output_index % n;
+    var acc = 0.0;
+
+    var k_index = 0u;
+    loop {
+        if k_index >= k {
+            break;
+        }
+
+        let packed_byte_index = col * packed_k + k_index / 4u;
+        let word_index = packed_byte_index / 4u;
+        let byte_shift = (packed_byte_index % 4u) * 8u;
+        let packed_byte = (weights_words[word_index] >> byte_shift) & 0xffu;
+        let bit_shift = (k_index % 4u) * 2u;
+        let bits = (packed_byte >> bit_shift) & 0x03u;
+        let block_index = k_index / block_size;
+        let scale = scales[col * num_blocks_k + block_index];
+        acc = acc + activations[row * k + k_index] * decode_i2s(bits) * scale;
+        k_index = k_index + 1u;
+    }
+
+    output[output_index] = acc;
 }
 "#;
 }

--- a/crates/bitnet-request-router-core/src/lib.rs
+++ b/crates/bitnet-request-router-core/src/lib.rs
@@ -16,7 +16,7 @@ pub enum Method {
 
 impl Method {
     #[must_use]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Get => "GET",
             Self::Post => "POST",
@@ -91,7 +91,7 @@ impl RequestRouter {
     }
 
     #[must_use]
-    pub fn route_count(&self) -> usize {
+    pub const fn route_count(&self) -> usize {
         self.routes.len()
     }
 
@@ -137,12 +137,14 @@ impl RequestRouter {
 /// Simple path matching (supports `:param` wildcards).
 #[must_use]
 pub fn path_matches(pattern: &str, path: &str) -> bool {
-    let pat_parts: Vec<&str> = pattern.split('/').collect();
-    let path_parts: Vec<&str> = path.split('/').collect();
-    if pat_parts.len() != path_parts.len() {
+    let pattern_parts: Vec<&str> = pattern.split('/').collect();
+    let route_parts: Vec<&str> = path.split('/').collect();
+    if pattern_parts.len() != route_parts.len() {
         return false;
     }
-    pat_parts.iter().zip(path_parts.iter()).all(|(p, a)| p.starts_with(':') || *p == *a)
+    pattern_parts.iter().zip(route_parts.iter()).all(|(pattern_part, route_part)| {
+        pattern_part.starts_with(':') || *pattern_part == *route_part
+    })
 }
 
 #[cfg(test)]

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -241,6 +241,39 @@ feature, but this proof must not claim a NEON-optimized packed kernel unless one
 is actually selected. It also does not claim Metal BitNet execution, QK256
 optimization on Apple Silicon, or Apple CPU performance.
 
+## M4-011 Native Metal I2_S Smoke/Parity
+
+The first BitNet-specific native Metal proof is a tiny I2_S-adjacent parity
+fixture, not full model inference. It uses a 1x4 output fixture with `k=32`,
+canonical I2_S packed bytes, and a `u32_le_words_from_i2s_bytes` transport buffer
+for Metal storage-buffer alignment. The receipt must say both things: the source
+layout is packed I2_S, and the Metal test transports those bytes as little-endian
+`u32` words.
+
+Run the non-live contract tests with:
+
+```bash
+cargo test --locked -p bitnet-kernels \
+  --no-default-features --features metal \
+  --test metal_tiny_smoke i2s -- --nocapture
+```
+
+Run the live M4 receipt-backed proof with:
+
+```bash
+BITNET_RUN_M4_METAL_I2S_PARITY=1 \
+BITNET_M4_METAL_I2S_PARITY_RECEIPT=ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-parity.json \
+cargo test --locked -p bitnet-kernels \
+  --no-default-features --features metal \
+  --test metal_tiny_smoke tiny_m4_metal_i2s_matches_cpu_neon_reference_when_enabled -- --nocapture
+```
+
+The receipt may claim only that `tiny_metal_i2s_parity` runs on
+`apple-m4-metal`, consumes the declared packed I2_S fixture layout without CPU
+fallback, and matches the Apple CPU/NEON reference lane for that fixture. It must
+not claim full BitNet Metal inference, QK256 on Metal, benchmark performance,
+server inference, MPSGraph execution, or Neural Engine execution.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -297,7 +297,44 @@ claim Metal BitNet execution, QK256 on Apple Silicon, or Apple CPU performance.
 ### M4-011 - Native Metal I2_S Smoke/Parity
 
 Start BitNet-specific native Metal work with an I2_S-adjacent kernel or
-subgraph, not QK256, and compare against Apple CPU/NEON.
+subgraph, not QK256, and compare against Apple CPU/NEON. The first proof target
+is `tiny_metal_i2s_parity`: a 1x4 output fixture with `k=32`, canonical I2_S
+packed bytes, per-column scales, and a Metal storage-buffer transport layout of
+`u32_le_words_from_i2s_bytes`.
+
+The receipt must record:
+
+```json
+{
+  "requested_backend": "apple-m4-metal",
+  "selected_backend": "apple-m4-metal",
+  "runtime_api": "metal",
+  "kernel_id": "tiny_metal_i2s_parity",
+  "fallback_used": false,
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "parity",
+    "layout_source": "fixture_packed_i2_s",
+    "fallback_layout": null
+  },
+  "layout": {
+    "source": "fixture_packed_i2_s",
+    "transport_layout": "u32_le_words_from_i2s_bytes",
+    "consumes_packed_i2_s_directly": true,
+    "dequantizes_before_compute": false
+  },
+  "parity": {
+    "reference_backend": "apple-m4-cpu-neon",
+    "target_backend": "apple-m4-metal",
+    "kernel_id": "tiny_metal_i2s_parity",
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0
+  }
+}
+```
+
+M4-011 does not claim full BitNet Metal inference, QK256 on Metal, MPSGraph
+execution, Neural Engine execution, or performance.
 
 ### M4-012 - TL1 / ARM-Oriented Investigation
 

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -355,7 +355,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-011"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-011-metal-i2s-smoke-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -355,7 +355,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-011"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-011-metal-i2s-smoke-parity"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T171254Z-M4-011-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T171254Z-M4-011-in-progress.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T17:12:54Z"
+campaign = "apple-m4"
+item = "M4-011"
+event = "in_progress"
+branch = "codex/apple-m4/M4-011-metal-i2s-smoke-parity"
+actor = "codex"
+
+notes = [
+  "Started native Metal I2_S smoke/parity after M4-010 closeout merged.",
+  "Scope remains limited to a tiny I2_S-adjacent Metal parity fixture, Apple campaign tracking, and receipt metadata.",
+  "No QK256, server inference, benchmarks, MPSGraph execution, or full BitNet Metal inference claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T172058Z-M4-011-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T172058Z-M4-011-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T17:20:58Z"
+campaign = "apple-m4"
+item = "M4-011"
+event = "pr_open"
+pr = 3769
+head_sha = "7ffa2aca5519cd157b35656f02be2a6fe017ed31"
+actor = "codex"
+
+notes = [
+  "Opened native Metal I2_S smoke/parity PR.",
+  "Live Apple M4 Metal proof passed with fallback_used=false, kernel_family=i2_s, execution_phase=parity, and model=null.",
+  "No QK256, server inference, benchmarks, MPSGraph execution, Neural Engine execution, or full BitNet Metal inference claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -19,7 +19,7 @@
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
-| M4-011 | ready | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
+| M4-011 | in_progress | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -19,7 +19,7 @@
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
-| M4-011 | in_progress | TBD | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
+| M4-011 | pr_open | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-011 | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | nvidia-5070ti | RTX5070TI-007 | #3756 | `codex/nvidia-5070ti/RTX5070TI-007-cuda-receipts-counters` | Record CUDA runtime identity and kernel invocation counters in smoke and parity receipts, including fallback-free strict validation, without adding benchmarks or BitNet inference claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -12,7 +12,7 @@
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
-| apple-m4 | M4-011 | M4-010 | in_progress |
+| apple-m4 | M4-011 | M4-010 | pr_open |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -12,7 +12,7 @@
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
-| apple-m4 | M4-011 | M4-010 | ready |
+| apple-m4 | M4-011 | M4-010 | in_progress |
 | apple-m4 | M4-012 | M4-011 | proposed |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-011 | TBD | ready | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-011 | TBD | in_progress | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-011 | TBD | in_progress | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-011 | #3769 | pr_open | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-011
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- adds a deterministic tiny I2_S packed fixture and CPU reference for Apple M4 Metal parity
- adds an opt-in live Metal test that compiles/dispatches an I2_S-adjacent shader, reads output back, compares against CPU/NEON reference, and emits a parity receipt
- records kernel_family=i2_s, execution_phase=parity, packed layout handling, requested/selected backend, runtime API, fallback=false, and model=null
- updates Apple M4 hardware/roadmap docs and campaign-generated dashboards

## Claims
May claim: an I2_S-adjacent Apple M4 Metal kernel/subgraph passes CPU/NEON comparison for the tiny parity fixture.

Must not claim: full BitNet inference, QK256, server inference, MPSGraph, Neural Engine execution, or general M4 Metal performance.

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke i2s -- --nocapture
- BITNET_RUN_M4_METAL_I2S_PARITY=1 BITNET_M4_METAL_I2S_PARITY_RECEIPT=ci/hardware/apple-m4-mac-mini/2026-05-06/metal-i2s-parity.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_i2s_matches_cpu_neon_reference_when_enabled -- --nocapture
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check
