### PR TITLE
[codex][apple-m4] Close out M4-011

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -355,7 +355,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-011"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-011-metal-i2s-smoke-parity"
 stackable = false
 requires_human_merge = true
@@ -388,7 +388,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-012"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-012-tl1-arm-investigation"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T174758Z-M4-011-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T174758Z-M4-011-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-06T17:47:58Z"
+campaign = "apple-m4"
+item = "M4-011"
+event = "merged"
+pr = 3769
+head_sha = "8ea48147a0fcbbc06ce50b2ea51dd8f2d41b5ceb"
+merge_sha = "1fa0c1e5bf86557bc4f6b1e77eea5aa28f823a00"
+actor = "codex"
+
+notes = [
+  "Merged native Metal I2_S smoke/parity proof.",
+  "The receipt-backed live path preserved requested_backend=apple-m4-metal, selected_backend=apple-m4-metal, runtime_api=metal, fallback_used=false, kernel_family=i2_s, execution_phase=parity, and CPU/NEON reference parity metrics.",
+  "No full BitNet Metal inference, QK256 on Metal, Metal performance, MPSGraph, server inference, or Neural Engine proof was claimed.",
+  "M4-012 is ready for TL1 Apple CPU/NEON investigation and Metal conversion-boundary documentation.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -19,8 +19,8 @@
 | M4-008 | merged | #3721 | `codex/apple-m4/M4-008-backend-receipts` | Record Apple requested backend, selected backend, runtime API, resolved device identity, fallback status, and artifact path in receipts. |
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
-| M4-011 | pr_open | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
-| M4-012 | proposed | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
+| M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
+| M4-012 | ready | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-011 | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -12,8 +12,8 @@
 | apple-m4 | M4-008 | M4-007 | merged |
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
-| apple-m4 | M4-011 | M4-010 | pr_open |
-| apple-m4 | M4-012 | M4-011 | proposed |
+| apple-m4 | M4-011 | M4-010 | merged |
+| apple-m4 | M4-012 | M4-011 | ready |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-011 | #3769 | pr_open | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-012 | TBD | ready | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-011 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- record PR #3769 as the merged M4-011 Apple Metal I2_S smoke/parity item
- promote M4-012 TL1 Apple path investigation to ready
- regenerate campaign and global dashboards

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
Tracker-only closeout. No runtime code, kernels, QK256, server inference, MPSGraph, benchmark, or dependency changes.