### PR TITLE
[codex] refactor: extract layer index parsing core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ name = "bitnet-gpu-hal"
 version = "0.2.1-dev"
 dependencies = [
  "bitnet-http-auth-core",
+ "bitnet-layer-index-core",
  "bitnet-tokenizer-text-core",
  "insta",
  "log",
@@ -1028,6 +1029,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitnet-layer-index-core"
+version = "0.2.1-dev"
+
+[[package]]
 name = "bitnet-logits"
 version = "0.2.1-dev"
 dependencies = [
@@ -1062,6 +1067,7 @@ dependencies = [
  "bitnet-common",
  "bitnet-ggml-ffi",
  "bitnet-gguf",
+ "bitnet-layer-index-core",
  "bitnet-qk256-layout-core",
  "bitnet-quantization",
  "bitnet-st2gguf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "crates/bitnet-tokenizer-discovery-core", # SRP: tokenizer path auto-discovery core
   "crates/bitnet-tokenizer-text-core", # SRP: tokenizer pre-tokenization/normalization primitives
   "crates/bitnet-weight-name-core", # SRP: vendor weight-name canonicalization helpers
+  "crates/bitnet-layer-index-core", # SRP: reusable transformer layer index parsing helpers
   "crates/bitnet-prompt-templates",
   "crates/bitnet-prompt-templates-core",
   "crates/bitnet-honest-compute",

--- a/crates/bitnet-gpu-hal/Cargo.toml
+++ b/crates/bitnet-gpu-hal/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 bitnet-tokenizer-text-core = { path = "../bitnet-tokenizer-text-core", version = "0.2.1-dev" }
 bitnet-http-auth-core = { path = "../bitnet-http-auth-core", version = "0.2.1-dev" }
+bitnet-layer-index-core = { path = "../bitnet-layer-index-core", version = "0.2.1-dev" }
 tokio = { workspace = true }
 log.workspace = true
 serde = { workspace = true }

--- a/crates/bitnet-gpu-hal/src/weight_loader.rs
+++ b/crates/bitnet-gpu-hal/src/weight_loader.rs
@@ -3,6 +3,7 @@
 //! Provides lazy loading, prefetch scheduling, multi-shard parallel loading,
 //! format detection, and conversion utilities for model weight tensors.
 
+use bitnet_layer_index_core::extract_any_layer_index;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, Instant};
@@ -451,12 +452,7 @@ impl PrefetchScheduler {
 
 /// Extract a layer index from a tensor name like `"layers.5.attention.wq"`.
 fn extract_layer_index(name: &str) -> Option<usize> {
-    for part in name.split('.') {
-        if let Ok(idx) = part.parse::<usize>() {
-            return Some(idx);
-        }
-    }
-    None
+    extract_any_layer_index(name)
 }
 
 // ── Shard info ──────────────────────────────────────────────────────────────

--- a/crates/bitnet-layer-index-core/Cargo.toml
+++ b/crates/bitnet-layer-index-core/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-layer-index-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "SRP core helpers for extracting transformer layer indices from tensor names"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/bitnet-layer-index-core/src/lib.rs
+++ b/crates/bitnet-layer-index-core/src/lib.rs
@@ -1,0 +1,143 @@
+//! Reusable helpers for extracting layer indices from tensor names.
+//!
+//! This crate centralizes low-level parsing used by model loading and GPU
+//! weight handling so tensor layer-name behavior follows one implementation.
+
+/// Parse an unsigned integer from the start of `bytes` until the first non-digit.
+///
+/// Returns `None` if no leading digits are found or on overflow.
+pub fn parse_usize_prefix(bytes: &[u8]) -> Option<usize> {
+    let mut value: usize = 0;
+    let mut found_any = false;
+
+    for &b in bytes {
+        if b.is_ascii_digit() {
+            value = value.checked_mul(10)?.checked_add((b - b'0') as usize)?;
+            found_any = true;
+        } else {
+            break;
+        }
+    }
+
+    found_any.then_some(value)
+}
+
+/// Extract the first numeric segment from a dot-separated tensor name.
+///
+/// Example: `"model.layers.12.attn.q_proj.weight" -> Some(12)`.
+pub fn extract_any_layer_index(name: &str) -> Option<usize> {
+    for part in name.split('.') {
+        if let Ok(idx) = part.parse::<usize>() {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// Extract a layer index from known GGUF/transformer patterns.
+///
+/// Supports `blk.<i>.*` and `layers.<i>.*`.
+pub fn extract_structured_layer_index(name: &str) -> Option<usize> {
+    if let Some(idx) = parse_prefix_layer_index(name, "blk.") {
+        return Some(idx);
+    }
+    if name.contains("blk.") {
+        return None;
+    }
+
+    parse_prefix_layer_index(name, "layers.")
+}
+
+/// Extract a layer index from `blk.<i>.*` or `layers.<i>.*` where `<i>` is a
+/// complete dot-separated segment.
+pub fn extract_structured_layer_index_segment(name: &str) -> Option<usize> {
+    if let Some(idx) = parse_segment_layer_index(name, "blk.") {
+        return Some(idx);
+    }
+    if name.contains("blk.") {
+        return None;
+    }
+
+    parse_segment_layer_index(name, "layers.")
+}
+
+/// Extract a `blk.<i>.*` block index.
+///
+/// Example: `"blk.3.attn_q.weight" -> Some(3)`.
+pub fn parse_block_index(name: &str) -> Option<usize> {
+    let mut parts = name.split('.');
+    match (parts.next(), parts.next()) {
+        (Some("blk"), Some(index)) => index.parse().ok(),
+        _ => None,
+    }
+}
+
+fn parse_prefix_layer_index(name: &str, prefix: &str) -> Option<usize> {
+    name.find(prefix)
+        .and_then(|pos| name.as_bytes().get(pos + prefix.len()..))
+        .and_then(parse_usize_prefix)
+}
+
+fn parse_segment_layer_index(name: &str, prefix: &str) -> Option<usize> {
+    let start = name.find(prefix)? + prefix.len();
+    let rest = name.get(start..)?;
+    let dot_pos = rest.find('.')?;
+    rest.get(..dot_pos)?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        extract_any_layer_index, extract_structured_layer_index,
+        extract_structured_layer_index_segment, parse_block_index, parse_usize_prefix,
+    };
+
+    #[test]
+    fn parse_prefix_digits() {
+        assert_eq!(parse_usize_prefix(b"123.attn"), Some(123));
+        assert_eq!(parse_usize_prefix(b"001"), Some(1));
+        assert_eq!(parse_usize_prefix(b"x1"), None);
+    }
+
+    #[test]
+    fn parse_prefix_digits_checks_overflow() {
+        let too_large = format!("{}0", usize::MAX);
+        assert_eq!(parse_usize_prefix(too_large.as_bytes()), None);
+    }
+
+    #[test]
+    fn extract_any_index_from_dotted_name() {
+        assert_eq!(extract_any_layer_index("model.layers.39.mlp"), Some(39));
+        assert_eq!(extract_any_layer_index("layers.0.wq"), Some(0));
+        assert_eq!(extract_any_layer_index("embed_tokens.weight"), None);
+    }
+
+    #[test]
+    fn extract_structured_index() {
+        assert_eq!(extract_structured_layer_index("blk.123.attn_q.weight"), Some(123));
+        assert_eq!(extract_structured_layer_index("model.layers.7.mlp.gate"), Some(7));
+        assert_eq!(extract_structured_layer_index("token_embd.weight"), None);
+    }
+
+    #[test]
+    fn extract_structured_index_preserves_blk_precedence() {
+        assert_eq!(extract_structured_layer_index("x.blk.foo.layers.7.weight"), None);
+    }
+
+    #[test]
+    fn extract_structured_segment_index() {
+        assert_eq!(extract_structured_layer_index_segment("blk.123.attn_q.weight"), Some(123));
+        assert_eq!(extract_structured_layer_index_segment("model.layers.7.mlp.gate"), Some(7));
+        assert_eq!(extract_structured_layer_index_segment("layers.3x.weight"), None);
+        assert_eq!(extract_structured_layer_index_segment("layers.3"), None);
+        assert_eq!(extract_structured_layer_index_segment("x.blk.foo.layers.7.weight"), None);
+    }
+
+    #[test]
+    fn parse_block_only() {
+        assert_eq!(parse_block_index("blk.3.attn_q.weight"), Some(3));
+        assert_eq!(parse_block_index("blk.x.attn_q.weight"), None);
+        assert_eq!(parse_block_index("layers.3.attn_q.weight"), None);
+        assert_eq!(parse_block_index("blk.3x.attn_q.weight"), None);
+    }
+}

--- a/crates/bitnet-models/Cargo.toml
+++ b/crates/bitnet-models/Cargo.toml
@@ -21,6 +21,7 @@ bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-transformer = { path = "../bitnet-transformer", version = "0.2.1-dev" }
 bitnet-gguf = { path = "../bitnet-gguf", version = "0.2.1-dev" }
 bitnet-weight-name-core = { path = "../bitnet-weight-name-core", version = "0.2.1-dev" }
+bitnet-layer-index-core = { path = "../bitnet-layer-index-core", version = "0.2.1-dev" }
 bitnet-ggml-ffi = { path = "../bitnet-ggml-ffi", version = "0.2.1-dev", optional = true }
 bitnet-trace = { path = "../bitnet-trace", version = "0.2.1-dev", optional = true }
 anyhow.workspace = true

--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -8,6 +8,7 @@ use crate::{BitNetModel, Model};
 use bitnet_common::{
     BitNetConfig, BitNetError, CorrectionRecord, Device, ModelError, ModelMetadata, Result,
 };
+use bitnet_layer_index_core::extract_structured_layer_index_segment;
 use candle_core::{DType, Tensor};
 use std::path::Path;
 use tracing::{debug, info};
@@ -170,29 +171,7 @@ impl GgufLoader {
 
     /// Extract layer number from tensor name patterns like "blk.N." or "layers.N."
     fn extract_layer_number(name: &str) -> Option<usize> {
-        // Check for "blk.N." pattern
-        if let Some(start) = name.find("blk.") {
-            let after_blk = &name[start + 4..];
-            if let Some(dot_pos) = after_blk.find('.') {
-                let number_str = &after_blk[..dot_pos];
-                if let Ok(layer_num) = number_str.parse::<usize>() {
-                    return Some(layer_num);
-                }
-            }
-        }
-
-        // Check for "layers.N." pattern
-        if let Some(start) = name.find("layers.") {
-            let after_layers = &name[start + 7..];
-            if let Some(dot_pos) = after_layers.find('.') {
-                let number_str = &after_layers[..dot_pos];
-                if let Ok(layer_num) = number_str.parse::<usize>() {
-                    return Some(layer_num);
-                }
-            }
-        }
-
-        None
+        extract_structured_layer_index_segment(name)
     }
 
     /// Infer number of KV heads from tensor shapes (for models without explicit metadata)

--- a/crates/bitnet-models/src/gguf_simple.rs
+++ b/crates/bitnet-models/src/gguf_simple.rs
@@ -3,6 +3,7 @@ use crate::loader::MmapFile;
 use crate::qk256_utils::{detect_qk256_orientation_by_bytes, expected_qk256_shape};
 use crate::quant::i2s_qk256::I2SQk256NoScale;
 use bitnet_common::{BitNetError, Device, QuantizationType, Result};
+use bitnet_layer_index_core::extract_structured_layer_index;
 use bitnet_quantization::{QuantizerTrait, TL1Quantizer, TL2Quantizer, qk256_tolerance_bytes};
 use candle_core::{DType, Device as CDevice, Tensor as CandleTensor};
 use std::collections::HashMap;
@@ -864,33 +865,7 @@ fn discover_n_layers_from_tensors(reader: &GgufReader) -> Result<usize> {
 
 /// Extract layer index from tensor name supporting blk.<i>.* and layers.<i>.* patterns
 fn extract_layer_index(name: &str) -> Option<usize> {
-    // Look for "blk.123." or "layers.123." patterns
-    if let Some(pos) = name.find("blk.") {
-        let rest = &name[pos + 4..];
-        parse_usize_prefix(rest.as_bytes())
-    } else if let Some(pos) = name.find("layers.") {
-        let rest = &name[pos + 7..];
-        parse_usize_prefix(rest.as_bytes())
-    } else {
-        None
-    }
-}
-
-/// Parse unsigned integer from start of byte slice until first non-digit
-fn parse_usize_prefix(bytes: &[u8]) -> Option<usize> {
-    let mut value: usize = 0;
-    let mut found_any = false;
-
-    for &b in bytes {
-        if b.is_ascii_digit() {
-            value = value.checked_mul(10)?.checked_add((b - b'0') as usize)?;
-            found_any = true;
-        } else {
-            break;
-        }
-    }
-
-    found_any.then_some(value)
+    extract_structured_layer_index(name)
 }
 
 /// AC3: Validate that all required transformer tensors are present

--- a/crates/bitnet-models/src/layer_inspector.rs
+++ b/crates/bitnet-models/src/layer_inspector.rs
@@ -3,6 +3,8 @@
 //! Enumerate, classify, and inspect transformer layers and their
 //! constituent tensors for debugging and validation.
 
+use bitnet_layer_index_core::extract_any_layer_index;
+
 /// Type of a transformer layer component.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComponentType {
@@ -181,12 +183,7 @@ impl Default for InspectionReport {
 
 /// Extract layer index from tensor name (e.g., "layers.5.attn.q_proj" → Some(5)).
 pub fn extract_layer_index(name: &str) -> Option<usize> {
-    for part in name.split('.') {
-        if let Ok(idx) = part.parse::<usize>() {
-            return Some(idx);
-        }
-    }
-    None
+    extract_any_layer_index(name)
 }
 
 #[cfg(test)]

--- a/crates/bitnet-models/src/validation.rs
+++ b/crates/bitnet-models/src/validation.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use crate::validator::ModelInfo;
+use bitnet_layer_index_core::parse_block_index;
 
 // ---------------------------------------------------------------------------
 // ValidationIssue
@@ -333,12 +334,6 @@ pub fn full_validation(model: &ModelInfo) -> ValidationReport {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Extract the block index from a tensor name like `blk.3.attn_q.weight`.
-fn parse_block_index(name: &str) -> Option<usize> {
-    let parts: Vec<&str> = name.split('.').collect();
-    if parts.len() >= 2 && parts[0] == "blk" { parts[1].parse().ok() } else { None }
-}
 
 /// Return `true` if the tensor name indicates a normalisation weight.
 fn is_norm_tensor(name: &str) -> bool {


### PR DESCRIPTION
## Summary

Extracts repeated transformer layer-index parsing into a new `bitnet-layer-index-core` workspace crate.

## Changes

- Adds `bitnet-layer-index-core` with helpers for dotted numeric segments, GGUF `blk.<i>` / `layers.<i>` patterns, and strict `blk.<i>.*` block parsing.
- Reuses the core helpers from GPU weight prefetching, model layer inspection, GGUF simple loading, full GGUF loading, and validation.
- Preserves prior parsing semantics by keeping prefix parsing for `gguf_simple` and segment parsing for the full GGUF loader.

## Validation

- `cargo metadata --locked --format-version=1 --no-deps`
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-layer-index-core`
- `cargo test --locked -p bitnet-models --lib --no-default-features --features cpu`
- `cargo test --locked -p bitnet-gpu-hal extract_layer_index`

## Notes

A broader `cargo test --locked -p bitnet-gpu-hal --lib --no-default-features --features cpu` run hit an unrelated timing-sensitive failure in `serving_runtime::tests::test_request_timed_out_with_zero_timeout`; the refactored weight-loader tests passed in the focused run.