### PR TITLE
[codex][apple-m4] Record TL1 Apple layout boundary (M4-012)

### DIFF
--- a/crates/bitnet-quantization/src/tl1.rs
+++ b/crates/bitnet-quantization/src/tl1.rs
@@ -15,6 +15,64 @@ use candle_core::Device;
 use rayon::prelude::*;
 use std::collections::HashMap;
 
+/// Receipt/kernel-family label for TL1 work.
+pub const TL1_KERNEL_FAMILY: &str = "tl1";
+
+/// Execution phase for the Apple TL1 investigation item.
+pub const TL1_EXECUTION_PHASE: &str = "investigation";
+
+/// Current receipt layout source for TL1.
+pub const TL1_LAYOUT_SOURCE: &str = "tl1_reference";
+
+/// Current packed TL1 transport shape: unsigned 2-bit LUT codes plus per-block
+/// scales, with optional zero points for asymmetric quantization.
+pub const TL1_TRANSPORT_LAYOUT: &str = "tl1_packed_u2_codes_with_scales";
+
+/// Boundary name used until a Metal path proves direct TL1 layout consumption.
+pub const TL1_METAL_CONVERSION_BOUNDARY: &str = "tl1_to_metal_transport_not_proven";
+
+/// Apple TL1 layout contract for receipts and docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TL1AppleLayoutContract {
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub kernel_family: &'static str,
+    pub execution_phase: &'static str,
+    pub layout_source: &'static str,
+    pub fallback_layout: Option<&'static str>,
+    pub transport_layout: &'static str,
+    pub conversion_boundary: &'static str,
+    pub block_size: usize,
+    pub precision_bits: u8,
+    pub consumes_packed_tl1_directly_on_metal: bool,
+    pub dequantizes_before_compute: bool,
+    pub metal_supported: bool,
+}
+
+/// Return the current Apple TL1 contract.
+///
+/// This records TL1 as CPU/NEON-oriented evidence. It does not claim native
+/// Metal TL1 execution or direct Metal consumption of the packed TL1 layout.
+pub const fn apple_m4_tl1_layout_contract() -> TL1AppleLayoutContract {
+    TL1AppleLayoutContract {
+        requested_backend: "apple-m4-cpu-neon",
+        selected_backend: "apple-m4-cpu-neon",
+        runtime_api: "cpu",
+        kernel_family: TL1_KERNEL_FAMILY,
+        execution_phase: TL1_EXECUTION_PHASE,
+        layout_source: TL1_LAYOUT_SOURCE,
+        fallback_layout: None,
+        transport_layout: TL1_TRANSPORT_LAYOUT,
+        conversion_boundary: TL1_METAL_CONVERSION_BOUNDARY,
+        block_size: TL1Config::DEFAULT_BLOCK_SIZE,
+        precision_bits: TL1Config::DEFAULT_PRECISION_BITS,
+        consumes_packed_tl1_directly_on_metal: false,
+        dequantizes_before_compute: true,
+        metal_supported: false,
+    }
+}
+
 /// Configuration for TL1 quantization loaded from .ini files
 #[derive(Debug, Clone)]
 pub struct TL1Config {
@@ -26,8 +84,19 @@ pub struct TL1Config {
 
 impl Default for TL1Config {
     fn default() -> Self {
-        Self { block_size: 64, lookup_table_size: 256, use_asymmetric: false, precision_bits: 2 }
+        Self {
+            block_size: Self::DEFAULT_BLOCK_SIZE,
+            lookup_table_size: Self::DEFAULT_LOOKUP_TABLE_SIZE,
+            use_asymmetric: false,
+            precision_bits: Self::DEFAULT_PRECISION_BITS,
+        }
     }
+}
+
+impl TL1Config {
+    pub const DEFAULT_BLOCK_SIZE: usize = 64;
+    pub const DEFAULT_LOOKUP_TABLE_SIZE: usize = 256;
+    pub const DEFAULT_PRECISION_BITS: u8 = 2;
 }
 
 /// Lookup table for TL1 quantization
@@ -605,8 +674,8 @@ mod tests {
     fn test_tl1_config_loading() {
         // Test default config
         let quantizer = TL1Quantizer::new();
-        assert_eq!(quantizer.config.block_size, 64);
-        assert_eq!(quantizer.config.precision_bits, 2);
+        assert_eq!(quantizer.config.block_size, TL1Config::DEFAULT_BLOCK_SIZE);
+        assert_eq!(quantizer.config.precision_bits, TL1Config::DEFAULT_PRECISION_BITS);
 
         // Test custom config
         let config = TL1Config {
@@ -618,6 +687,45 @@ mod tests {
         let quantizer = TL1Quantizer::with_config(config.clone());
         assert_eq!(quantizer.config.block_size, 128);
         assert!(quantizer.config.use_asymmetric);
+    }
+
+    #[test]
+    fn test_apple_m4_tl1_layout_contract_is_cpu_neon_only() {
+        let contract = apple_m4_tl1_layout_contract();
+
+        assert_eq!(contract.requested_backend, "apple-m4-cpu-neon");
+        assert_eq!(contract.selected_backend, "apple-m4-cpu-neon");
+        assert_eq!(contract.runtime_api, "cpu");
+        assert_eq!(contract.kernel_family, "tl1");
+        assert_eq!(contract.execution_phase, "investigation");
+        assert_eq!(contract.layout_source, "tl1_reference");
+        assert_eq!(contract.fallback_layout, None);
+        assert_eq!(contract.transport_layout, "tl1_packed_u2_codes_with_scales");
+        assert_eq!(contract.block_size, 64);
+        assert_eq!(contract.precision_bits, 2);
+        assert!(!contract.consumes_packed_tl1_directly_on_metal);
+        assert!(contract.dequantizes_before_compute);
+        assert!(!contract.metal_supported);
+    }
+
+    #[test]
+    fn test_tl1_default_quantization_records_packed_u2_codes_and_scales() {
+        let device = Device::Cpu;
+        let data = (0..128).map(|i| (i as f32 - 64.0) / 16.0).collect::<Vec<_>>();
+        let tensor = create_tensor_from_f32(data, &[128], &device).unwrap();
+        let quantizer = TL1Quantizer::new();
+
+        let quantized = quantizer.quantize_tensor(&tensor).unwrap();
+
+        assert_eq!(quantized.qtype, QuantizationType::TL1);
+        assert_eq!(quantized.block_size, TL1Config::DEFAULT_BLOCK_SIZE);
+        assert_eq!(quantized.data.len(), 32);
+        assert_eq!(quantized.scales.len(), 2);
+        assert!(quantized.zero_points.is_none());
+
+        let unpacked = quantizer.unpack_tl1_values(&quantized.data, 128);
+        assert_eq!(unpacked.len(), 128);
+        assert!(unpacked.iter().all(|code| (0..4).contains(code)));
     }
 
     #[test]

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -274,6 +274,41 @@ fallback, and matches the Apple CPU/NEON reference lane for that fixture. It mus
 not claim full BitNet Metal inference, QK256 on Metal, benchmark performance,
 server inference, MPSGraph execution, or Neural Engine execution.
 
+## M4-012 TL1 Apple CPU/NEON Investigation
+
+TL1 is currently an Apple CPU/NEON-oriented BitNet layout investigation item,
+not a native Metal proof. The TL1 quantizer records unsigned 2-bit LUT codes
+packed four values per byte, per-block scales, and optional zero points for
+asymmetric quantization. The default Apple contract uses:
+
+```json
+{
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "bitnet": {
+    "kernel_family": "tl1",
+    "execution_phase": "investigation",
+    "layout_source": "tl1_reference",
+    "fallback_layout": null
+  },
+  "layout": {
+    "source": "tl1_reference",
+    "transport_layout": "tl1_packed_u2_codes_with_scales",
+    "conversion_boundary": "tl1_to_metal_transport_not_proven",
+    "consumes_packed_tl1_directly_on_metal": false,
+    "dequantizes_before_compute": true
+  },
+  "fallback_used": false
+}
+```
+
+The contract may claim only that TL1 CPU/NEON behavior and the current Metal
+conversion boundary are documented or receipt-backed. It must not claim TL1
+runs natively on Metal until a later receipt proves that Metal consumes the TL1
+layout directly or names the exact conversion/dequantization path before
+compute.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -341,6 +341,38 @@ execution, Neural Engine execution, or performance.
 Investigate whether TL1 is the right Apple CPU/NEON-oriented path and document
 any layout conversion boundary before claiming Metal consumption.
 
+Current TL1 evidence is CPU-oriented. The default TL1 layout uses unsigned
+2-bit LUT codes packed four per byte, per-block scales, and optional zero
+points for asymmetric quantization. Apple receipts should identify this as
+`kernel_family = "tl1"`, `layout_source = "tl1_reference"`, and
+`transport_layout = "tl1_packed_u2_codes_with_scales"`.
+
+M4-012 may record:
+
+```json
+{
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "bitnet": {
+    "kernel_family": "tl1",
+    "execution_phase": "investigation",
+    "layout_source": "tl1_reference"
+  },
+  "layout": {
+    "transport_layout": "tl1_packed_u2_codes_with_scales",
+    "conversion_boundary": "tl1_to_metal_transport_not_proven",
+    "consumes_packed_tl1_directly_on_metal": false,
+    "dequantizes_before_compute": true
+  },
+  "fallback_used": false
+}
+```
+
+M4-012 must not claim native Metal TL1 execution. A later Metal item must either
+prove direct packed TL1 consumption or record the exact conversion/dequantization
+path before compute.
+
 ### M4-013 - Metal Prefill/Decode Contribution
 
 Move from isolated kernels to a named BitNet phase such as prefill or decode

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -388,7 +388,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-012"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-012-tl1-arm-investigation"
 stackable = false
 requires_human_merge = true
@@ -396,7 +396,8 @@ blocked_by = ["M4-011"]
 acceptance = "Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly."
 commands = [
   "cargo fmt --all -- --check",
-  "Focused TL1/Apple investigation checks",
+  "cargo test --locked -p bitnet-quantization --no-default-features test_apple_m4_tl1_layout_contract_is_cpu_neon_only -- --nocapture",
+  "cargo test --locked -p bitnet-quantization --no-default-features test_tl1_default_quantization_records_packed_u2_codes_and_scales -- --nocapture",
 ]
 allowed_paths = [
   "crates/**/src/**",

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -388,7 +388,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-012"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-012-tl1-arm-investigation"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T181719Z-M4-012-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T181719Z-M4-012-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T18:17:19Z"
+campaign = "apple-m4"
+item = "M4-012"
+event = "in_progress"
+branch = "codex/apple-m4/M4-012-tl1-arm-investigation"
+actor = "codex"
+
+notes = [
+  "Started TL1 Apple CPU/NEON investigation and Metal conversion-boundary documentation.",
+  "Scope excludes QK256, server inference, benchmarks, MPSGraph execution, Neural Engine claims, and full BitNet inference claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T182507Z-M4-012-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T182507Z-M4-012-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T18:25:07Z"
+campaign = "apple-m4"
+item = "M4-012"
+event = "pr_open"
+pr = 3775
+head_sha = "933203e8b563aa3115ba79b8fdcf64a89af9b9c2"
+actor = "codex"
+
+notes = [
+  "Opened TL1 Apple layout-boundary PR.",
+  "The PR records TL1 as CPU/NEON-oriented evidence, documents packed unsigned 2-bit LUT codes with scales, and keeps direct Metal TL1 consumption unclaimed.",
+  "No QK256, server inference, benchmarks, MPSGraph execution, Neural Engine proof, or full BitNet inference claim is included.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -20,7 +20,7 @@
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
-| M4-012 | in_progress | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
+| M4-012 | pr_open | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -20,7 +20,7 @@
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
-| M4-012 | ready | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
+| M4-012 | in_progress | TBD | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,7 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-012 | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | cpu-proof | CPU-BITNET-005c | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -13,7 +13,7 @@
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
-| apple-m4 | M4-012 | M4-011 | ready |
+| apple-m4 | M4-012 | M4-011 | in_progress |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -13,7 +13,7 @@
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
-| apple-m4 | M4-012 | M4-011 | in_progress |
+| apple-m4 | M4-012 | M4-011 | pr_open |
 | apple-m4 | M4-013 | M4-012 | proposed |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-012 | TBD | in_progress | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-012 | #3775 | pr_open | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-012 | TBD | ready | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-012 | TBD | in_progress | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- add an Apple TL1 layout contract that records TL1 as CPU/NEON-oriented evidence
- document the TL1 packed unsigned 2-bit code layout, scale metadata, and current Metal conversion boundary
- mark M4-012 in progress and regenerate Apple/global campaign dashboards

## Claim boundary
This does not claim native TL1 Metal execution, QK256 on Apple Silicon, server inference, MPSGraph, Neural Engine execution, benchmarks, or full BitNet inference on M4.

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p bitnet-quantization --no-default-features test_apple_m4_tl1_layout_contract_is_cpu_neon_only -- --nocapture
- cargo test --locked -p bitnet-quantization --no-default-features test_tl1_default_quantization_records_packed_u2_codes_and_scales -- --nocapture
- cargo clippy --locked -p bitnet-quantization --no-default-features -- -D warnings
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check