### PR TITLE
docs(tracking): record CPU-BITNET-005c merge

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -32,10 +32,12 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 | CPU-BITNET-000 | merged | Real BitNet CPU path plan merged in #3642. |
 | CPU-BITNET-001 | merged | Strict GGUF loader authority merged in #3651. |
 | CPU-BITNET-002 | merged | Strict tokenizer authority merged in #3680. |
-| CPU-BITNET-003 | pr_open | Canonical packed layout open in #3690. |
-| CPU-BITNET-004 | proposed | Scalar truth kernels. |
-| CPU-BITNET-005 | proposed | AVX2 decode GEMV. |
-| CPU-BITNET-006 | proposed | CPU transformer decode ops. |
+| CPU-BITNET-003 | merged | Canonical packed layout merged in #3690. |
+| CPU-BITNET-004 | merged | Scalar truth kernels merged in #3696. |
+| CPU-BITNET-005a | merged | AVX2/FMA feature plumbing merged in #3735. |
+| CPU-BITNET-005b | merged | Requested/selected QK256 kernel dispatch merged in #3748. |
+| CPU-BITNET-005c | merged | AVX2 parity hardening merged in #3753. |
+| CPU-BITNET-006 | ready | CPU transformer decode ops. |
 | CPU-BITNET-007 | proposed | Strict receipts and fallback behavior. |
 | CPU-BITNET-008 | proposed | CPU phase benchmark profiles. |
 

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -267,7 +267,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005c"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-bitnet-005c-avx2-parity-hardening"
 stackable = false
 requires_human_merge = true
@@ -297,5 +297,42 @@ must_not_claim = [
   "Transformer decode is complete.",
   "Strict receipts are complete.",
   "Benchmark or throughput performance is proven.",
+  "GPU or NPU execution is involved.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-006"
+status = "ready"
+branch = "codex/cpu-bitnet-006-transformer-decode"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-005c"]
+acceptance = "One real-model CPU decode step runs with real tensors, deterministic KV-cache behavior, visible selected kernel family, and explicit failure for missing runtime pieces."
+commands = [
+  "cargo test --locked -p bitnet-inference --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/cpu/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-inference/src/backends.rs",
+  "crates/bitnet-inference/**",
+  "tests/**",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-receipts/**",
+]
+may_claim = [
+  "A real CPU transformer decode step exists after merge.",
+  "Selected CPU kernel family is visible in the decode path after merge.",
+]
+must_not_claim = [
+  "Strict receipts are complete.",
+  "Benchmark or throughput performance is proven.",
+  "Server inference is complete.",
   "GPU or NPU execution is involved.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T184645Z-CPU-BITNET-005c-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T184645Z-CPU-BITNET-005c-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T18:46:45Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005c"
+event = "merged"
+pr = 3753
+merge_sha = "653839943eb177e590a750bc3ce33934eb27039a"
+actor = "maintainer"
+
+notes = [
+  "AVX2 decode GEMV parity hardening merged against the scalar QK256 oracle.",
+  "CPU-BITNET-006 real transformer decode is next; no strict receipts, benchmarks, server, GPU, NPU, or crate collapse are claimed.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -16,7 +16,8 @@
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | CPU-BITNET-005a | merged | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged. |
 | CPU-BITNET-005b | merged | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
-| CPU-BITNET-005c | pr_open | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
+| CPU-BITNET-005c | merged | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
+| CPU-BITNET-006 | ready | TBD | `codex/cpu-bitnet-006-transformer-decode` | One real-model CPU decode step runs with real tensors, deterministic KV-cache behavior, visible selected kernel family, and explicit failure for missing runtime pieces. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-proof | CPU-BITNET-005c | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -22,7 +22,8 @@
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
 | cpu-proof | CPU-BITNET-005a | CPU-BITNET-004 | merged |
 | cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | merged |
-| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | pr_open |
+| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | merged |
+| cpu-proof | CPU-BITNET-006 | CPU-BITNET-005c | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-012 | TBD | ready | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | ARC140V-002 | #3727 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | ARC140V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- mark CPU-BITNET-005c merged after #3753
- record merge SHA 653839943eb177e590a750bc3ce33934eb27039a
- advance CPU-BITNET-006 as the next ready CPU proof item
- regenerate campaign dashboards

## Validation
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check

No runtime files changed.