### PR TITLE
docs(tracking): close CPU-BITNET-005c

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -35,7 +35,7 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 | CPU-BITNET-003 | pr_open | Canonical packed layout open in #3690. |
 | CPU-BITNET-004 | proposed | Scalar truth kernels. |
 | CPU-BITNET-005 | proposed | AVX2 decode GEMV. |
-| CPU-BITNET-006 | proposed | CPU transformer decode ops. |
+| CPU-BITNET-006 | ready | CPU transformer decode ops. |
 | CPU-BITNET-007 | proposed | Strict receipts and fallback behavior. |
 | CPU-BITNET-008 | proposed | CPU phase benchmark profiles. |
 

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -267,7 +267,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU-BITNET-005c"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-bitnet-005c-avx2-parity-hardening"
 stackable = false
 requires_human_merge = true
@@ -297,5 +297,41 @@ must_not_claim = [
   "Transformer decode is complete.",
   "Strict receipts are complete.",
   "Benchmark or throughput performance is proven.",
+  "GPU or NPU execution is involved.",
+]
+
+[[work_item]]
+id = "CPU-BITNET-006"
+status = "ready"
+branch = "codex/cpu-bitnet-006-transformer-decode-ops"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CPU-BITNET-005c"]
+acceptance = "Embedding gather, RMSNorm/subln, RoPE, attention scores, softmax, A/V, FFN, KV-cache, output head, logits handoff, and sampling handoff are authoritative for CPU decode; prefill and decode scheduling are separated; one real-model decode step can run with real tensors; missing ops fail explicitly; KV-cache append/read is deterministic."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-inference --no-default-features --features cpu",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/cpu/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-inference/src/backends.rs",
+  "crates/bitnet-inference/**",
+  "tests/**",
+  "docs/bitnet/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+  "docs/tracking/bitnet-alignment/status.md",
+  "docs/tracking/bitnet-alignment/workstream-ledger.yaml",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "CPU decode op coverage exists after merge.",
+]
+must_not_claim = [
+  "Full inference quality or performance is proven without receipts.",
   "GPU or NPU execution is involved.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-06T184645Z-CPU-BITNET-005c-merged.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-06T184645Z-CPU-BITNET-005c-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T18:46:45Z"
+campaign = "cpu-proof"
+item = "CPU-BITNET-005c"
+event = "merged"
+pr = 3753
+merge_sha = "653839943eb177e590a750bc3ce33934eb27039a"
+actor = "maintainer"
+
+notes = [
+  "QK256 AVX2 decode GEMV parity hardening merged with scalar comparisons across rows, tail-column shapes, deterministic patterns, and repeated-run equality.",
+  "CPU-BITNET-006 transformer decode ops remains next; no strict receipts, benchmarks, server, GPU, NPU, or full inference completion are claimed.",
+]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -16,7 +16,8 @@
 | CPU-BITNET-004 | merged | #3696 | `codex/cpu-bitnet-004-scalar-packed-truth` | Canonical scalar packed QK256 GEMV/GEMM kernels are deterministic correctness oracles for decode and prefill. |
 | CPU-BITNET-005a | merged | #3735 | `codex/cpu-bitnet-005a-avx2-fma-gating` | AVX2/FMA feature plumbing is explicit, FMA-using QK256 helpers are target-feature gated, and scalar fallback remains unchanged. |
 | CPU-BITNET-005b | merged | #3748 | `codex/cpu-bitnet-005b-kernel-selection` | QK256 decode GEMV selection reports requested kernel, selected kernel, fallback status, fallback reason, and CPU features with strict AVX2 fallback failure. |
-| CPU-BITNET-005c | pr_open | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
+| CPU-BITNET-005c | merged | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
+| CPU-BITNET-006 | ready | TBD | `codex/cpu-bitnet-006-transformer-decode-ops` | Embedding gather, RMSNorm/subln, RoPE, attention scores, softmax, A/V, FFN, KV-cache, output head, logits handoff, and sampling handoff are authoritative for CPU decode; prefill and decode scheduling are separated; one real-model decode step can run with real tensors; missing ops fail explicitly; KV-cache append/read is deterministic. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-proof | CPU-BITNET-005c | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -22,7 +22,8 @@
 | cpu-proof | CPU-BITNET-004 | CPU-BITNET-003 | merged |
 | cpu-proof | CPU-BITNET-005a | CPU-BITNET-004 | merged |
 | cpu-proof | CPU-BITNET-005b | CPU-BITNET-005a | merged |
-| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | pr_open |
+| cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | merged |
+| cpu-proof | CPU-BITNET-006 | CPU-BITNET-005c | ready |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | M4-013 | TBD | ready | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
+| cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -6,7 +6,7 @@
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-m4 | Apple M4 Mac mini validation | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |


### PR DESCRIPTION
## Summary
- record CPU-BITNET-005c as merged from #3753 at 653839943eb177e590a750bc3ce33934eb27039a
- remove #3753 from active CPU proof PRs
- mark CPU-BITNET-006 ready as the next CPU proof item

## Claim Boundary
This is tracker-only. It does not claim transformer decode, strict receipts, benchmarks, server, GPU, NPU, or full inference completion.

## Validation
- GITHUB_EVENT_NAME=push cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign check cpu-proof
- cargo run --locked -p xtask --no-default-features -- campaign next cpu-proof
- git diff --check HEAD~1..HEAD

Note: local Windows generator runs rewrite unrelated generated status files as line-ending-only changes; the committed diff is CPU proof closeout only.