### PR TITLE
docs(tracking): close Arc 140V and NPU probes

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -65,7 +65,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "ARC140V-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-arc/ARC140V-002-runtime-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T145936Z-ARC140V-002-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T145936Z-ARC140V-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T14:59:36Z"
+campaign = "intel-258v-platform"
+item = "ARC140V-002"
+event = "merged"
+pr = 3727
+merge_sha = "2d17cb5811b254bbfbe9e41569e770db905b9b54"
+actor = "maintainer"
+
+notes = [
+  "Arc 140V runtime identity probe merged.",
+  "This records runtime visibility only; Arc 140V execution, OpenCL kernels, and BitNet inference remain follow-up work.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
-| ARC140V-002 | pr_open | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
+| ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
@@ -27,7 +27,7 @@ Validate Intel Lunar Lake NPU through OpenVINO static-shape detection, smoke, pa
 | Work item | Status | Notes |
 |---|---|---|
 | NPU-002 | merged | Preserve Intel NPU backend identity. |
-| NPU-003 | pr_open | Add runtime detection. |
+| NPU-003 | merged | Add runtime detection. |
 | NPU-004 | proposed | Add smoke probe command. |
 | NPU-005 | proposed | Run tiny OpenVINO NPU graph smoke. |
 | NPU-006 | proposed | Add receipt fields. |

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -61,7 +61,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "NPU-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-npu/NPU-003-openvino-runtime-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-06T133329Z-NPU-003-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-06T133329Z-NPU-003-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T13:33:29Z"
+campaign = "intel-npu"
+item = "NPU-003"
+event = "merged"
+pr = 3739
+merge_sha = "62fbc27bad331fb800c1ad1f080eb4bb80b143a3"
+actor = "maintainer"
+
+notes = [
+  "Intel NPU OpenVINO runtime visibility fields merged.",
+  "This records runtime visibility only; graph execution, BitNet inference, and NPU acceleration remain follow-up work.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
 | NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
-| NPU-003 | pr_open | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
+| NPU-003 | merged | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,6 +4,4 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | cpu-proof | CPU-BITNET-005c | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
-| intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
-| intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -25,8 +25,8 @@
 | cpu-proof | CPU-BITNET-005c | CPU-BITNET-005b | pr_open |
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | proposed |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
-| intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | pr_open |
-| intel-npu | NPU-003 | NPU-002 | pr_open |
+| intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
+| intel-npu | NPU-003 | NPU-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,9 +9,9 @@
 | cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | ARC140V-002 | #3727 | pr_open | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-003 | #3739 | pr_open | none | Device-node detection is not inference. |
+| intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,9 +9,9 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | ARC140V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
-| intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
+| intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- record ARC140V-002 as merged from #3727 at 2d17cb5811b254bbfbe9e41569e770db905b9b54
- record NPU-003 as merged from #3739 at 62fbc27bad331fb800c1ad1f080eb4bb80b143a3
- regenerate dashboards so LNL258V-002 is the next Lunar Lake platform item and the stale Arc/NPU PR rows are removed

## Claim Boundary
This is tracker-only. It records merged runtime visibility/probe work. It does not claim Arc 140V OpenCL execution, OpenVINO NPU graph execution, BitNet inference, GPU/NPU acceleration, strict CPU proof, or benchmarks.

## Validation
- CMAKE_GENERATOR="Visual Studio 17 2022" GITHUB_EVENT_NAME=push cargo run --locked -p xtask --no-default-features -- campaign doctor
- CMAKE_GENERATOR="Visual Studio 17 2022" cargo run --locked -p xtask --no-default-features -- campaign generate --check
- CMAKE_GENERATOR="Visual Studio 17 2022" cargo run --locked -p xtask --no-default-features -- campaign check intel-258v-platform
- CMAKE_GENERATOR="Visual Studio 17 2022" cargo run --locked -p xtask --no-default-features -- campaign check intel-npu
- git diff --check HEAD~1..HEAD

Note: local Windows xtask builds require an explicit supported CMake generator on this host; without it, sentencepiece-sys asks for unsupported generator Visual Studio 18 2026.