### PR TITLE
[codex][apple-m4] Close out M4-012

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -388,7 +388,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-012"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-012-tl1-arm-investigation"
 stackable = false
 requires_human_merge = true
@@ -422,7 +422,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-013"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-013-metal-prefill-decode"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T192019Z-M4-012-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T192019Z-M4-012-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-06T19:20:19Z"
+campaign = "apple-m4"
+item = "M4-012"
+event = "merged"
+pr = 3775
+head_sha = "ed19f578464d89345688a23fb94756d17f4e5396"
+merge_sha = "b995985d3c58c435ef357d3a04be3de983ec4c0e"
+actor = "codex"
+
+notes = [
+  "Merged TL1 Apple layout-boundary investigation.",
+  "The contract records TL1 as Apple CPU/NEON-oriented evidence with unsigned 2-bit LUT codes, per-block scales, optional zero points, kernel_family=tl1, execution_phase=investigation, and direct Metal TL1 consumption unclaimed.",
+  "No QK256, server inference, benchmarks, MPSGraph execution, Neural Engine proof, or full BitNet inference claim was made.",
+  "M4-013 is ready for named Apple Metal prefill/decode contribution work with CPU reference and explicit fallback status.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -20,8 +20,8 @@
 | M4-009 | merged | #3732 | `codex/apple-m4/M4-009-benchmark-baseline` | Compare Apple CPU/NEON and M4 Metal for a validated kernel or subgraph after parity exists. |
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
-| M4-012 | pr_open | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
-| M4-013 | proposed | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
+| M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
+| M4-013 | ready | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,7 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-012 | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | cpu-proof | CPU-BITNET-005c | #3753 | `codex/cpu-bitnet-005c-avx2-parity-hardening` | AVX2 decode GEMV parity is hardened against scalar across rows, tail-column shapes, deterministic patterns, and repeated-run equality. |
 | intel-258v-platform | ARC140V-002 | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | intel-npu | NPU-003 | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -13,8 +13,8 @@
 | apple-m4 | M4-009 | M4-008 | merged |
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
-| apple-m4 | M4-012 | M4-011 | pr_open |
-| apple-m4 | M4-013 | M4-012 | proposed |
+| apple-m4 | M4-012 | M4-011 | merged |
+| apple-m4 | M4-013 | M4-012 | ready |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-012 | #3775 | pr_open | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-013 | TBD | ready | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-005c | #3753 | pr_open | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-012 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-005c | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
## Summary
- record PR #3775 as the merged M4-012 TL1 Apple layout-boundary item
- promote M4-013 Metal prefill/decode contribution to ready
- regenerate Apple campaign and global dashboards

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Scope
Tracker-only closeout. No runtime code, kernels, QK256, server inference, MPSGraph, benchmark, dependency, or full BitNet inference changes.