### PR TITLE
feat(cuda): add reusable I2S linear primitive

### DIFF
--- a/crates/bitnet-kernels/src/cuda/bitnet_context.rs
+++ b/crates/bitnet-kernels/src/cuda/bitnet_context.rs
@@ -6,17 +6,31 @@
 //! It does not route transformer inference or launch BitNet kernels.
 
 use bitnet_common::{KernelError, Result};
-use std::collections::HashMap;
 #[cfg(feature = "cuda")]
-use std::sync::Arc;
+use std::any::Any;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "cuda")]
+use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "cuda")]
+use super::quantized_matmul::{I2S_MATMUL_KERNEL_SRC, I2sMatmulConfig};
 #[cfg(feature = "cuda")]
 use cudarc::driver::{
-    CudaContext, CudaSlice, CudaStream, result::device as cu_device, sys::CUdevice_attribute,
+    CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
+    result::device as cu_device, sys::CUdevice_attribute,
 };
+#[cfg(feature = "cuda")]
+use cudarc::nvrtc::{Ptx, compile_ptx};
 
 static NEXT_WEIGHT_ID: AtomicU64 = AtomicU64::new(1);
+#[cfg(feature = "cuda")]
+static NVRTC_COMPILE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Kernel ID recorded by the reusable CUDA I2_S GEMV primitive.
+pub const CUDA_BITNET_I2S_GEMV_KERNEL_ID: &str = "i2s_gemv_cuda";
+#[cfg(feature = "cuda")]
+const I2S_MATMUL_FUNCTION_NAME: &str = "i2s_matmul_f32";
 
 /// CUDA device identity recorded by the persistent BitNet context.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +128,8 @@ pub struct CudaWeightHandle {
     pub packed_bytes: usize,
     /// Scale or side-table payload size.
     pub scale_bytes: usize,
+    /// Quantization block size for packed linear kernels, when applicable.
+    pub block_size: Option<usize>,
     /// True when this handle was uploaded or registered once at context lifetime.
     pub uploaded_once: bool,
 }
@@ -162,6 +178,182 @@ pub struct CudaBitnetRuntimeStats {
     pub workspace_reuses: u64,
 }
 
+/// Packed I2_S weights for one BitNet linear projection.
+///
+/// The logical weight shape is `[output_features, input_features]`. Packed
+/// bytes are grouped per output feature with `ceil(input_features / 4)` bytes
+/// per row, matching the existing I2_S CUDA kernel source.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PackedI2sWeights {
+    /// Output feature count.
+    pub output_features: usize,
+    /// Input feature count.
+    pub input_features: usize,
+    /// Scale block size along the input dimension.
+    pub block_size: usize,
+    /// Packed I2_S payload, 4 ternary weights per byte.
+    pub packed_weights: Vec<u8>,
+    /// Per-output, per-block scales.
+    pub scales: Vec<f32>,
+}
+
+impl PackedI2sWeights {
+    /// Construct and validate packed I2_S weight metadata.
+    pub fn new(
+        output_features: usize,
+        input_features: usize,
+        block_size: usize,
+        packed_weights: Vec<u8>,
+        scales: Vec<f32>,
+    ) -> Result<Self> {
+        let weights = Self { output_features, input_features, block_size, packed_weights, scales };
+        weights.validate()?;
+        Ok(weights)
+    }
+
+    /// Logical shape used by CUDA weight handles.
+    pub fn shape(&self) -> Result<CudaTensorShape> {
+        CudaTensorShape::matrix(self.output_features, self.input_features)
+    }
+
+    /// Minimum packed byte count required for the logical shape.
+    pub fn expected_packed_bytes(&self) -> usize {
+        self.output_features * self.packed_row_bytes()
+    }
+
+    /// Minimum scale count required for the logical shape.
+    pub fn expected_scale_count(&self) -> usize {
+        self.output_features * self.blocks_per_output()
+    }
+
+    /// Number of packed bytes consumed per output feature.
+    pub fn packed_row_bytes(&self) -> usize {
+        self.input_features.div_ceil(4)
+    }
+
+    /// Number of scale blocks consumed per output feature.
+    pub fn blocks_per_output(&self) -> usize {
+        self.input_features.div_ceil(self.block_size)
+    }
+
+    /// Scale payload byte count.
+    pub fn scale_bytes_len(&self) -> usize {
+        self.scales.len() * std::mem::size_of::<f32>()
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.output_features == 0 || self.input_features == 0 {
+            return Err(invalid_arguments(format!(
+                "I2S weights require non-zero shape: output_features={} input_features={}",
+                self.output_features, self.input_features
+            )));
+        }
+        if self.block_size != 32 && self.block_size != 256 {
+            return Err(invalid_arguments(format!(
+                "I2S weights require block_size 32 or 256, got {}",
+                self.block_size
+            )));
+        }
+        let expected_packed = self.expected_packed_bytes();
+        if self.packed_weights.len() < expected_packed {
+            return Err(invalid_arguments(format!(
+                "I2S packed weights too small: expected at least {expected_packed}, got {}",
+                self.packed_weights.len()
+            )));
+        }
+        let expected_scales = self.expected_scale_count();
+        if self.scales.len() < expected_scales {
+            return Err(invalid_arguments(format!(
+                "I2S scales too small: expected at least {expected_scales}, got {}",
+                self.scales.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Per-kernel stats recorded by the CUDA BitNet linear primitive.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CudaBitnetKernelInvocationStats {
+    /// Stable kernel ID.
+    pub kernel_id: String,
+    /// Successful primitive invocations.
+    pub invocations: u64,
+    /// CPU fallback invocations. Strict CUDA proof requires this to stay zero.
+    pub fallback_invocations: u64,
+    /// Host-to-device activation bytes for primitive calls.
+    pub host_to_device_bytes: u64,
+    /// Device-to-host output bytes for primitive calls.
+    pub device_to_host_bytes: u64,
+    /// CUDA kernel launches.
+    pub kernel_launches: u64,
+    /// Optional measured kernel time in milliseconds.
+    pub kernel_time_ms: Option<f64>,
+    /// True when the associated weight handle was upload-once.
+    pub weights_uploaded_once: bool,
+    /// True if a per-token weight upload was recorded.
+    pub per_token_weight_upload: bool,
+}
+
+impl CudaBitnetKernelInvocationStats {
+    /// Construct empty stats for a kernel ID.
+    pub fn new(kernel_id: impl Into<String>) -> Self {
+        Self {
+            kernel_id: kernel_id.into(),
+            invocations: 0,
+            fallback_invocations: 0,
+            host_to_device_bytes: 0,
+            device_to_host_bytes: 0,
+            kernel_launches: 0,
+            kernel_time_ms: None,
+            weights_uploaded_once: false,
+            per_token_weight_upload: false,
+        }
+    }
+
+    #[cfg(feature = "cuda")]
+    fn record_i2s_gemv(
+        &mut self,
+        host_to_device_bytes: u64,
+        device_to_host_bytes: u64,
+        weights_uploaded_once: bool,
+        per_token_weight_upload: bool,
+    ) {
+        self.kernel_id = CUDA_BITNET_I2S_GEMV_KERNEL_ID.to_string();
+        self.invocations += 1;
+        self.kernel_launches += 1;
+        self.host_to_device_bytes += host_to_device_bytes;
+        self.device_to_host_bytes += device_to_host_bytes;
+        self.weights_uploaded_once = weights_uploaded_once;
+        self.per_token_weight_upload = per_token_weight_upload;
+    }
+}
+
+impl Default for CudaBitnetKernelInvocationStats {
+    fn default() -> Self {
+        Self::new(CUDA_BITNET_I2S_GEMV_KERNEL_ID)
+    }
+}
+
+/// Reusable CUDA BitNet linear backend surface.
+pub trait CudaBitnetLinearBackend {
+    /// Upload I2_S weights once and return a stable CUDA handle.
+    fn upload_i2s_weights(
+        &mut self,
+        tensor_name: &str,
+        weights: &PackedI2sWeights,
+    ) -> Result<CudaWeightHandle>;
+
+    /// Run one I2_S GEMV using a CUDA-resident weight handle.
+    fn i2s_gemv(
+        &mut self,
+        weights: &CudaWeightHandle,
+        activation: &[f32],
+        output: &mut [f32],
+        stats: &mut CudaBitnetKernelInvocationStats,
+    ) -> Result<()>;
+}
+
 /// Receipt-oriented summary of persistent CUDA BitNet lifetime state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CudaBitnetReceiptFields {
@@ -203,12 +395,17 @@ pub struct CudaBitnetContext {
     device_weight_buffers: HashMap<CudaWeightId, CudaDeviceWeightBuffers>,
     #[cfg(feature = "cuda")]
     workspace_buffers: CudaActivationDeviceBuffers,
+    #[cfg(feature = "cuda")]
+    i2s_matmul_module: Option<Arc<CudaModule>>,
+    #[cfg(feature = "cuda")]
+    i2s_matmul_function: Option<CudaFunction>,
 }
 
 #[cfg(feature = "cuda")]
 struct CudaDeviceWeightBuffers {
-    _packed: CudaSlice<u8>,
-    _scales: Option<CudaSlice<u8>>,
+    packed: CudaSlice<u8>,
+    _scale_bytes: Option<CudaSlice<u8>>,
+    i2s_scales: Option<CudaSlice<f32>>,
 }
 
 #[cfg(feature = "cuda")]
@@ -241,6 +438,8 @@ impl CudaBitnetContext {
             stats: CudaBitnetRuntimeStats::default(),
             device_weight_buffers: HashMap::new(),
             workspace_buffers: CudaActivationDeviceBuffers::default(),
+            i2s_matmul_module: None,
+            i2s_matmul_function: None,
         })
     }
 
@@ -269,6 +468,10 @@ impl CudaBitnetContext {
             device_weight_buffers: HashMap::new(),
             #[cfg(feature = "cuda")]
             workspace_buffers: CudaActivationDeviceBuffers::default(),
+            #[cfg(feature = "cuda")]
+            i2s_matmul_module: None,
+            #[cfg(feature = "cuda")]
+            i2s_matmul_function: None,
         }
     }
 
@@ -338,6 +541,7 @@ impl CudaBitnetContext {
             kernel_family,
             packed_bytes: packed_weights.len(),
             scale_bytes: scale_bytes.len(),
+            block_size: None,
             uploaded_once: true,
         };
 
@@ -356,8 +560,10 @@ impl CudaBitnetContext {
                     ),
                 })?)
             };
-            self.device_weight_buffers
-                .insert(id, CudaDeviceWeightBuffers { _packed: packed, _scales: scales });
+            self.device_weight_buffers.insert(
+                id,
+                CudaDeviceWeightBuffers { packed, _scale_bytes: scales, i2s_scales: None },
+            );
         }
 
         let upload_bytes =
@@ -479,6 +685,230 @@ impl CudaBitnetContext {
     const fn reallocate_activation_workspace(&mut self) -> Result<()> {
         Ok(())
     }
+
+    #[cfg(feature = "cuda")]
+    fn ensure_i2s_matmul_function(&mut self) -> Result<()> {
+        if self.i2s_matmul_function.is_some() {
+            return Ok(());
+        }
+
+        let context = self.context.as_ref().ok_or_else(|| KernelError::DeviceUnavailable {
+            reason: "CUDA I2S GEMV requires a CUDA-backed BitNet context".to_string(),
+        })?;
+        let ptx = compile_cuda_bitnet_ptx(I2S_MATMUL_KERNEL_SRC, "BitNet I2S GEMV")?;
+        let module = context.load_module(ptx).map_err(|err| KernelError::GpuError {
+            reason: format!("failed to load CUDA I2S GEMV module: {err:?}"),
+        })?;
+        let function = module.load_function(I2S_MATMUL_FUNCTION_NAME).map_err(|err| {
+            KernelError::GpuError {
+                reason: format!("failed to load CUDA I2S GEMV kernel: {err:?}"),
+            }
+        })?;
+
+        self.i2s_matmul_module = Some(module);
+        self.i2s_matmul_function = Some(function);
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    fn launch_i2s_gemv_cuda(
+        &mut self,
+        weights: &CudaWeightHandle,
+        activation: &[f32],
+        output: &mut [f32],
+        config: &I2sMatmulConfig,
+    ) -> Result<()> {
+        self.ensure_i2s_matmul_function()?;
+
+        let stream = self.stream.as_ref().ok_or_else(|| KernelError::DeviceUnavailable {
+            reason: "CUDA I2S GEMV requires a CUDA-backed BitNet stream".to_string(),
+        })?;
+        let function = self.i2s_matmul_function.as_ref().ok_or_else(|| KernelError::GpuError {
+            reason: "CUDA I2S GEMV kernel was not loaded".to_string(),
+        })?;
+        let buffers = self.device_weight_buffers.get(&weights.id).ok_or_else(|| {
+            KernelError::DeviceUnavailable {
+                reason: format!(
+                    "CUDA I2S GEMV weight '{}' is not resident on the selected device",
+                    weights.tensor_name
+                ),
+            }
+        })?;
+        let scales = buffers.i2s_scales.as_ref().ok_or_else(|| KernelError::GpuError {
+            reason: format!("CUDA I2S GEMV scales for '{}' are not resident", weights.tensor_name),
+        })?;
+
+        let activation_dev =
+            stream.memcpy_stod(activation).map_err(|err| KernelError::GpuError {
+                reason: format!("failed to copy CUDA I2S GEMV activation to device: {err:?}"),
+            })?;
+        let mut output_dev: CudaSlice<f32> =
+            stream.alloc_zeros(config.n).map_err(|err| KernelError::GpuError {
+                reason: format!("failed to allocate CUDA I2S GEMV output: {err:?}"),
+            })?;
+
+        let launch_config = LaunchConfig {
+            grid_dim: config.grid_dim(),
+            block_dim: config.block_dim(),
+            shared_mem_bytes: config.shared_mem_bytes,
+        };
+        let mut builder = stream.launch_builder(function);
+        builder.arg(&activation_dev);
+        builder.arg(&buffers.packed);
+        builder.arg(scales);
+        builder.arg(&mut output_dev);
+        let m_arg = 1_i32;
+        let n_arg = i32::try_from(config.n).map_err(|_| KernelError::InvalidArguments {
+            reason: format!("CUDA I2S GEMV output dimension exceeds i32: n={}", config.n),
+        })?;
+        let k_arg = i32::try_from(config.k).map_err(|_| KernelError::InvalidArguments {
+            reason: format!("CUDA I2S GEMV input dimension exceeds i32: k={}", config.k),
+        })?;
+        let block_size_arg =
+            i32::try_from(config.block_size).map_err(|_| KernelError::InvalidArguments {
+                reason: format!(
+                    "CUDA I2S GEMV block size exceeds i32: block_size={}",
+                    config.block_size
+                ),
+            })?;
+        builder.arg(&m_arg);
+        builder.arg(&n_arg);
+        builder.arg(&k_arg);
+        builder.arg(&block_size_arg);
+
+        unsafe { builder.launch(launch_config) }.map_err(|err| KernelError::GpuError {
+            reason: format!("failed to launch CUDA I2S GEMV kernel: {err:?}"),
+        })?;
+        stream.synchronize().map_err(|err| KernelError::GpuError {
+            reason: format!("failed to synchronize CUDA I2S GEMV kernel: {err:?}"),
+        })?;
+
+        let output_host: Vec<f32> =
+            stream.memcpy_dtov(&output_dev).map_err(|err| KernelError::GpuError {
+                reason: format!("failed to copy CUDA I2S GEMV output to host: {err:?}"),
+            })?;
+        output[..config.n].copy_from_slice(&output_host[..config.n]);
+        Ok(())
+    }
+}
+
+impl CudaBitnetLinearBackend for CudaBitnetContext {
+    fn upload_i2s_weights(
+        &mut self,
+        tensor_name: &str,
+        weights: &PackedI2sWeights,
+    ) -> Result<CudaWeightHandle> {
+        weights.validate()?;
+        validate_weight_upload(tensor_name, &weights.packed_weights)?;
+        let shape = weights.shape()?;
+
+        if let Some(existing) = self.weight_cache.get(tensor_name) {
+            validate_existing_i2s_handle(existing, &shape, weights)?;
+            return Ok(existing.clone());
+        }
+
+        let id = CudaWeightId(NEXT_WEIGHT_ID.fetch_add(1, Ordering::Relaxed));
+        let handle = CudaWeightHandle {
+            id,
+            tensor_name: tensor_name.to_string(),
+            shape,
+            kernel_family: CudaBitnetKernelFamily::I2s,
+            packed_bytes: weights.packed_weights.len(),
+            scale_bytes: weights.scale_bytes_len(),
+            block_size: Some(weights.block_size),
+            uploaded_once: true,
+        };
+
+        #[cfg(feature = "cuda")]
+        if let Some(stream) = &self.stream {
+            let packed = stream.memcpy_stod(&weights.packed_weights).map_err(|err| {
+                KernelError::GpuError {
+                    reason: format!(
+                        "failed to upload CUDA I2S weight '{}': {err:?}",
+                        handle.tensor_name
+                    ),
+                }
+            })?;
+            let scales =
+                stream.memcpy_stod(&weights.scales).map_err(|err| KernelError::GpuError {
+                    reason: format!(
+                        "failed to upload CUDA I2S scales for '{}': {err:?}",
+                        handle.tensor_name
+                    ),
+                })?;
+            self.device_weight_buffers.insert(
+                id,
+                CudaDeviceWeightBuffers { packed, _scale_bytes: None, i2s_scales: Some(scales) },
+            );
+        }
+
+        let upload_bytes =
+            u64::try_from(handle.total_bytes()).map_err(|_| KernelError::InvalidArguments {
+                reason: format!(
+                    "CUDA I2S weight '{}' byte count exceeds receipt counter range",
+                    handle.tensor_name
+                ),
+            })?;
+        self.stats.weight_uploads += 1;
+        self.stats.weight_upload_bytes += upload_bytes;
+        self.weight_cache.insert(handle.tensor_name.clone(), handle.clone());
+        Ok(handle)
+    }
+
+    fn i2s_gemv(
+        &mut self,
+        weights: &CudaWeightHandle,
+        activation: &[f32],
+        output: &mut [f32],
+        stats: &mut CudaBitnetKernelInvocationStats,
+    ) -> Result<()> {
+        let gemv_shape = validate_i2s_gemv_args(weights, activation, output)?;
+        let output_features = gemv_shape.output_features;
+        let input_features = gemv_shape.input_features;
+        #[cfg(feature = "cuda")]
+        let block_size = gemv_shape.block_size;
+        #[cfg(not(feature = "cuda"))]
+        let _ = gemv_shape.block_size;
+        let activation_bytes = checked_f32_bytes(input_features, "I2S activation")?;
+        let output_bytes = checked_f32_bytes(output_features, "I2S output")?;
+        self.ensure_activation_workspace(activation_bytes, output_bytes, 0)?;
+
+        #[cfg(feature = "cuda")]
+        {
+            let config =
+                I2sMatmulConfig::for_shape(1, output_features, input_features, block_size)?;
+            self.launch_i2s_gemv_cuda(weights, &activation[..input_features], output, &config)?;
+            stats.record_i2s_gemv(
+                u64::try_from(activation_bytes).map_err(|_| KernelError::InvalidArguments {
+                    reason: "I2S activation byte count exceeds receipt counter range".to_string(),
+                })?,
+                u64::try_from(output_bytes).map_err(|_| KernelError::InvalidArguments {
+                    reason: "I2S output byte count exceeds receipt counter range".to_string(),
+                })?,
+                weights.uploaded_once,
+                self.stats.per_token_weight_uploads > 0,
+            );
+            return Ok(());
+        }
+
+        #[cfg(not(feature = "cuda"))]
+        {
+            let _ = weights;
+            let _ = activation;
+            let _ = output;
+            let _ = stats;
+            Err(KernelError::DeviceUnavailable {
+                reason: "CUDA I2S GEMV requires the cuda feature".to_string(),
+            }
+            .into())
+        }
+    }
+}
+
+struct I2sGemvShape {
+    output_features: usize,
+    input_features: usize,
+    block_size: usize,
 }
 
 fn validate_weight_upload(tensor_name: &str, packed_weights: &[u8]) -> Result<()> {
@@ -501,7 +931,8 @@ fn validate_existing_handle(
     let matches = existing.shape == *shape
         && existing.kernel_family == kernel_family
         && existing.packed_bytes == packed_weights.len()
-        && existing.scale_bytes == scale_bytes.len();
+        && existing.scale_bytes == scale_bytes.len()
+        && existing.block_size.is_none();
 
     if matches {
         Ok(())
@@ -513,8 +944,114 @@ fn validate_existing_handle(
     }
 }
 
+fn validate_existing_i2s_handle(
+    existing: &CudaWeightHandle,
+    shape: &CudaTensorShape,
+    weights: &PackedI2sWeights,
+) -> Result<()> {
+    let matches = existing.shape == *shape
+        && existing.kernel_family == CudaBitnetKernelFamily::I2s
+        && existing.packed_bytes == weights.packed_weights.len()
+        && existing.scale_bytes == weights.scale_bytes_len()
+        && existing.block_size == Some(weights.block_size);
+
+    if matches {
+        Ok(())
+    } else {
+        Err(invalid_arguments(format!(
+            "CUDA I2S weight '{}' is already cached with different metadata",
+            existing.tensor_name
+        )))
+    }
+}
+
+fn validate_i2s_gemv_args(
+    weights: &CudaWeightHandle,
+    activation: &[f32],
+    output: &[f32],
+) -> Result<I2sGemvShape> {
+    if weights.kernel_family != CudaBitnetKernelFamily::I2s {
+        return Err(invalid_arguments(format!(
+            "CUDA I2S GEMV requires an I2S weight handle, got {}",
+            weights.kernel_family.as_str()
+        )));
+    }
+    if weights.shape.dims.len() != 2 {
+        return Err(invalid_arguments(format!(
+            "CUDA I2S GEMV requires matrix weights, got {:?}",
+            weights.shape.dims
+        )));
+    }
+    let output_features = weights.shape.dims[0];
+    let input_features = weights.shape.dims[1];
+    let block_size = weights.block_size.ok_or_else(|| {
+        invalid_arguments(format!(
+            "CUDA I2S GEMV weight '{}' is missing block size metadata",
+            weights.tensor_name
+        ))
+    })?;
+
+    if activation.len() < input_features {
+        return Err(invalid_arguments(format!(
+            "CUDA I2S GEMV activation too small: expected at least {input_features}, got {}",
+            activation.len()
+        )));
+    }
+    if output.len() < output_features {
+        return Err(invalid_arguments(format!(
+            "CUDA I2S GEMV output too small: expected at least {output_features}, got {}",
+            output.len()
+        )));
+    }
+    Ok(I2sGemvShape { output_features, input_features, block_size })
+}
+
+fn checked_f32_bytes(count: usize, label: &str) -> Result<usize> {
+    count.checked_mul(std::mem::size_of::<f32>()).ok_or_else(|| {
+        KernelError::InvalidArguments {
+            reason: format!("{label} byte count overflow for {count} f32 values"),
+        }
+        .into()
+    })
+}
+
 fn invalid_arguments(reason: impl Into<String>) -> bitnet_common::BitNetError {
     KernelError::InvalidArguments { reason: reason.into() }.into()
+}
+
+#[cfg(feature = "cuda")]
+fn compile_cuda_bitnet_ptx(source: &str, label: &str) -> Result<Ptx> {
+    let _hook_guard = NVRTC_COMPILE_LOCK.lock().ok();
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let compile_result = std::panic::catch_unwind(|| compile_ptx(source));
+    std::panic::set_hook(previous_hook);
+
+    match compile_result {
+        Ok(Ok(ptx)) => Ok(ptx),
+        Ok(Err(err)) => {
+            Err(KernelError::GpuError { reason: format!("failed to compile {label} PTX: {err:?}") }
+                .into())
+        }
+        Err(payload) => Err(KernelError::GpuError {
+            reason: format!(
+                "failed to compile {label} PTX because NVRTC was unavailable: {}",
+                panic_payload_message(&*payload)
+            ),
+        }
+        .into()),
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn panic_payload_message(payload: &(dyn Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic payload".to_string()
+    }
 }
 
 #[cfg(feature = "cuda")]
@@ -570,11 +1107,68 @@ mod tests {
         })
     }
 
+    fn i2s_fixture() -> PackedI2sWeights {
+        PackedI2sWeights::new(
+            3,
+            5,
+            32,
+            vec![
+                pack_i2s_row([1, 0, -1, 1, 0]),
+                pack_i2s_tail([0]),
+                pack_i2s_row([-1, 1, 0, 0, 1]),
+                pack_i2s_tail([1]),
+                pack_i2s_row([0, -1, 1, 0, -1]),
+                pack_i2s_tail([-1]),
+            ],
+            vec![1.0, 0.5, 2.0],
+        )
+        .unwrap()
+    }
+
+    fn pack_i2s_row(vals: [i8; 5]) -> u8 {
+        pack_i2s_nibble([vals[0], vals[1], vals[2], vals[3]])
+    }
+
+    fn pack_i2s_tail(vals: [i8; 1]) -> u8 {
+        pack_i2s_nibble([vals[0], 0, 0, 0])
+    }
+
+    fn pack_i2s_nibble(vals: [i8; 4]) -> u8 {
+        vals.iter().enumerate().fold(0_u8, |byte, (index, value)| {
+            let code = match value {
+                1 => 0b01,
+                -1 => 0b11,
+                _ => 0b00,
+            };
+            byte | (code << (index * 2))
+        })
+    }
+
     #[test]
     fn tensor_shape_rejects_empty_or_zero_dims() {
         assert!(CudaTensorShape::new(Vec::<usize>::new()).is_err());
         assert!(CudaTensorShape::new(vec![4, 0]).is_err());
         assert_eq!(CudaTensorShape::matrix(4, 8).unwrap().element_count(), 32);
+    }
+
+    #[test]
+    fn packed_i2s_weights_accept_tail_bits() {
+        let weights = i2s_fixture();
+
+        assert_eq!(weights.output_features, 3);
+        assert_eq!(weights.input_features, 5);
+        assert_eq!(weights.packed_row_bytes(), 2);
+        assert_eq!(weights.blocks_per_output(), 1);
+        assert_eq!(weights.expected_packed_bytes(), 6);
+        assert_eq!(weights.expected_scale_count(), 3);
+        assert_eq!(weights.shape().unwrap().dims, vec![3, 5]);
+    }
+
+    #[test]
+    fn packed_i2s_weights_reject_incomplete_payloads() {
+        assert!(PackedI2sWeights::new(3, 5, 32, vec![0; 5], vec![1.0; 3]).is_err());
+        assert!(PackedI2sWeights::new(3, 5, 32, vec![0; 6], vec![1.0; 2]).is_err());
+        assert!(PackedI2sWeights::new(3, 5, 64, vec![0; 6], vec![1.0; 3]).is_err());
     }
 
     #[test]
@@ -631,6 +1225,57 @@ mod tests {
     }
 
     #[test]
+    fn upload_i2s_weights_reuses_handle_without_second_upload() {
+        let mut context = test_context();
+        let weights = i2s_fixture();
+        let first = context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+        let second = context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.kernel_family, CudaBitnetKernelFamily::I2s);
+        assert_eq!(first.block_size, Some(32));
+        assert_eq!(first.packed_bytes, weights.packed_weights.len());
+        assert_eq!(first.scale_bytes, weights.scale_bytes_len());
+        assert_eq!(context.stats().weight_uploads, 1);
+        assert_eq!(
+            context.stats().weight_upload_bytes,
+            u64::try_from(weights.packed_weights.len() + weights.scale_bytes_len()).unwrap()
+        );
+    }
+
+    #[test]
+    fn upload_i2s_weights_rejects_cached_metadata_mismatch() {
+        let mut context = test_context();
+        let weights = i2s_fixture();
+        context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+        let different = PackedI2sWeights::new(4, 5, 32, vec![0; 8], vec![1.0; 4]).unwrap();
+
+        assert!(context.upload_i2s_weights("layers.0.feed_forward.w1", &different).is_err());
+    }
+
+    #[test]
+    fn i2s_gemv_rejects_wrong_family_before_launch() {
+        let mut context = test_context();
+        let handle = context
+            .upload_weight_once(
+                "layers.0.attention.wq",
+                CudaTensorShape::matrix(3, 5).unwrap(),
+                CudaBitnetKernelFamily::Qk256,
+                &[1, 2, 3, 4, 5, 6],
+                &[],
+            )
+            .unwrap();
+        let mut output = vec![0.0; 3];
+        let mut stats = CudaBitnetKernelInvocationStats::default();
+
+        let result = context.i2s_gemv(&handle, &[1.0; 5], &mut output, &mut stats);
+
+        assert!(result.is_err());
+        assert_eq!(stats.invocations, 0);
+        assert_eq!(stats.fallback_invocations, 0);
+    }
+
+    #[test]
     fn activation_workspace_grows_then_reuses_capacity() {
         let mut context = test_context();
         context.ensure_activation_workspace(128, 256, 64).unwrap();
@@ -673,7 +1318,88 @@ mod tests {
 
     #[cfg(not(feature = "cuda"))]
     #[test]
+    fn i2s_gemv_reports_unavailable_without_cuda_feature() {
+        let mut context = test_context();
+        let weights = i2s_fixture();
+        let handle = context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+        let mut output = vec![0.0; weights.output_features];
+        let mut stats = CudaBitnetKernelInvocationStats::default();
+
+        let result = context.i2s_gemv(&handle, &[1.0; 5], &mut output, &mut stats);
+
+        assert!(result.is_err());
+        assert_eq!(stats.invocations, 0);
+        assert_eq!(stats.fallback_invocations, 0);
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    #[test]
     fn cuda_context_creation_reports_unavailable_without_cuda_feature() {
         assert!(CudaBitnetContext::new(0).is_err());
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn i2s_gemv_requires_cuda_backed_context_with_cuda_feature() {
+        let mut context = test_context();
+        let weights = i2s_fixture();
+        let handle = context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+        let mut output = vec![0.0; weights.output_features];
+        let mut stats = CudaBitnetKernelInvocationStats::default();
+
+        let result = context.i2s_gemv(&handle, &[1.0; 5], &mut output, &mut stats);
+
+        assert!(result.is_err());
+        assert_eq!(stats.invocations, 0);
+        assert_eq!(stats.fallback_invocations, 0);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn live_i2s_gemv_matches_cpu_reference_when_enabled() {
+        if std::env::var("BITNET_RUN_CUDA_BITNET_I2S_GEMV").as_deref() != Ok("1") {
+            eprintln!("skipping live CUDA BitNet I2S GEMV; set BITNET_RUN_CUDA_BITNET_I2S_GEMV=1");
+            return;
+        }
+
+        let device_index = std::env::var("BITNET_RTX5070TI_CUDA_DEVICE_INDEX")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+        let weights = i2s_fixture();
+        let activation = vec![0.5, -1.0, 2.0, 3.0, -0.25];
+        let mut expected = vec![0.0; weights.output_features];
+        let config = super::super::quantized_matmul::I2sMatmulConfig::for_shape(
+            1,
+            weights.output_features,
+            weights.input_features,
+            weights.block_size,
+        )
+        .unwrap();
+        super::super::quantized_matmul::i2s_matmul_cpu(
+            &activation,
+            &weights.packed_weights,
+            &weights.scales,
+            &mut expected,
+            &config,
+        )
+        .unwrap();
+
+        let mut context = CudaBitnetContext::new(device_index).unwrap();
+        let handle = context.upload_i2s_weights("layers.0.feed_forward.w1", &weights).unwrap();
+        let mut actual = vec![0.0; weights.output_features];
+        let mut stats = CudaBitnetKernelInvocationStats::default();
+
+        context.i2s_gemv(&handle, &activation, &mut actual, &mut stats).unwrap();
+
+        for (expected, actual) in expected.iter().zip(&actual) {
+            assert!((expected - actual).abs() <= f32::EPSILON);
+        }
+        assert_eq!(stats.kernel_id, CUDA_BITNET_I2S_GEMV_KERNEL_ID);
+        assert_eq!(stats.invocations, 1);
+        assert_eq!(stats.kernel_launches, 1);
+        assert_eq!(stats.fallback_invocations, 0);
+        assert!(stats.weights_uploaded_once);
+        assert!(!stats.per_token_weight_upload);
     }
 }

--- a/crates/bitnet-kernels/src/cuda/mod.rs
+++ b/crates/bitnet-kernels/src/cuda/mod.rs
@@ -132,9 +132,10 @@ pub use batch_norm::{
     batch_norm_cpu_fallback, batch_norm_inference_cpu_fallback,
 };
 pub use bitnet_context::{
-    CudaActivationWorkspace, CudaBitnetContext, CudaBitnetDeviceInfo, CudaBitnetKernelFamily,
-    CudaBitnetReceiptFields, CudaBitnetRuntimeStats, CudaTensorShape, CudaWeightHandle,
-    CudaWeightId,
+    CUDA_BITNET_I2S_GEMV_KERNEL_ID, CudaActivationWorkspace, CudaBitnetContext,
+    CudaBitnetDeviceInfo, CudaBitnetKernelFamily, CudaBitnetKernelInvocationStats,
+    CudaBitnetLinearBackend, CudaBitnetReceiptFields, CudaBitnetRuntimeStats, CudaTensorShape,
+    CudaWeightHandle, CudaWeightId, PackedI2sWeights,
 };
 pub use conv1d::{Conv1dConfig, PaddingMode, conv1d_cpu, conv1d_forward, launch_conv1d};
 pub use kv_cache::{CacheDtype, CacheStats, KvCacheBuffer, KvCacheConfig, launch_append_kv};


### PR DESCRIPTION
## Summary
- add `PackedI2sWeights` and a `CudaBitnetLinearBackend` surface for upload-once I2S weights
- add context-backed `i2s_gemv` that lazily compiles the existing I2S CUDA kernel source and launches it through the persistent CUDA context/stream
- record `i2s_gemv_cuda` invocation stats, transfer bytes, fallback count, and upload-once/per-token-upload flags
- add CPU-only and CUDA-feature tests for tails, metadata reuse, strict unavailable errors, and opt-in live CPU/CUDA parity

## Boundaries
- no QK256 changes
- no transformer or inference routing changes
- no server changes
- no dense regular-LLM CUDA work
- no WGPU/D3D12/Vulkan proof
- no full BitNet CUDA inference claim
- no hardware receipt artifacts committed

## Validation
- `rustfmt --check crates\\bitnet-kernels\\src\\cuda\\bitnet_context.rs crates\\bitnet-kernels\\src\\cuda\\mod.rs`
- `cargo test --locked -p bitnet-kernels --lib --no-default-features --features cpu bitnet_context`
- `cargo check --locked -p bitnet-kernels --no-default-features --features cuda`
- `cargo test --locked -p bitnet-kernels --lib --no-default-features --features cuda bitnet_context`
- `cargo clippy --locked -p bitnet-kernels --lib --no-default-features --features cpu -- -D warnings`
- `cargo test --locked -p bitnet-kernels --lib --no-default-features --features cpu`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

## Local blockers / notes
- `cargo fmt --all -- --check` is still blocked locally by Windows `os error 206`.
- `cargo clippy --locked -p bitnet-kernels --lib --no-default-features --features cuda -- -D warnings` still fails in pre-existing `crates/bitnet-device-probe/src/nvidia_cuda.rs` lints (`cast_sign_loss`, `borrow_as_ptr`, `missing_const_for_fn`).
- The optional live I2S GEMV parity test was not run because `nvcc` and `nvrtc64_120*.dll` are not visible on PATH. `nvidia-smi` does identify `NVIDIA GeForce RTX 5070 Ti`, driver `591.86`, compute capability `12.0`.

Closes #3669