### PR TITLE
[codex][apple-m4] Add Metal prefill contribution (M4-013)

### DIFF
--- a/crates/bitnet-kernels/src/metal/smoke.rs
+++ b/crates/bitnet-kernels/src/metal/smoke.rs
@@ -5,6 +5,7 @@ use crate::cpu::quantized_matmul::{i2s_matmul_f32, pack_i2s};
 pub const MACHINE_ID: &str = "apple-m4-mac-mini";
 pub const ARTIFACT_KIND: &str = "smoke";
 pub const PARITY_ARTIFACT_KIND: &str = "parity";
+pub const PHASE_CONTRIBUTION_ARTIFACT_KIND: &str = "phase_contribution";
 pub const REQUESTED_BACKEND: &str = "apple-m4-metal";
 pub const SELECTED_BACKEND: &str = "apple-m4-metal";
 pub const REFERENCE_BACKEND: &str = "apple-m4-cpu-neon";
@@ -12,14 +13,19 @@ pub const RUNTIME_API: &str = "metal";
 pub const TINY_METAL_ADD_SMOKE_KERNEL_ID: &str = "tiny_metal_add_smoke";
 pub const TINY_METAL_ADD_PARITY_KERNEL_ID: &str = "tiny_metal_add_parity";
 pub const I2S_METAL_PARITY_KERNEL_ID: &str = "tiny_metal_i2s_parity";
+pub const I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID: &str = "tiny_metal_i2s_prefill_contribution";
 pub const I2S_KERNEL_FAMILY: &str = "i2_s";
 pub const I2S_EXECUTION_PHASE: &str = "parity";
+pub const I2S_PREFILL_EXECUTION_PHASE: &str = "prefill";
+pub const I2S_PREFILL_PHASE_SCOPE: &str = "prefill_projection_fixture";
+pub const I2S_PREFILL_KV_CACHE_BEHAVIOR: &str = "not_exercised";
 pub const I2S_LAYOUT_SOURCE: &str = "fixture_packed_i2_s";
 pub const I2S_TRANSPORT_LAYOUT: &str = "u32_le_words_from_i2s_bytes";
 pub const I2S_PARITY_M: usize = 1;
 pub const I2S_PARITY_N: usize = 4;
 pub const I2S_PARITY_K: usize = 32;
 pub const I2S_PARITY_BLOCK_SIZE: usize = 32;
+pub const I2S_PREFILL_TOKENS: usize = 2;
 pub const SMOKE_ELEMENT_COUNT: usize = 64;
 pub const SMOKE_WORKGROUP_SIZE: u32 = 64;
 
@@ -105,6 +111,33 @@ pub struct I2sMetalParityReceipt {
     pub mean_abs_error: f32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct I2sMetalPrefillContributionReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub reference_backend: &'static str,
+    pub target_backend: &'static str,
+    pub kernel_id: &'static str,
+    pub kernel_family: &'static str,
+    pub execution_phase: &'static str,
+    pub phase_scope: &'static str,
+    pub layout_source: &'static str,
+    pub transport_layout: &'static str,
+    pub kv_cache_behavior: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub prefill_tokens: usize,
+    pub n: usize,
+    pub k: usize,
+    pub block_size: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
 impl TinyMetalAddParityReceipt {
     pub fn passed(
         artifact_path: impl Into<String>,
@@ -149,6 +182,36 @@ impl I2sMetalParityReceipt {
             result: "pass",
             artifact_path: artifact_path.into(),
             m: I2S_PARITY_M,
+            n: I2S_PARITY_N,
+            k: I2S_PARITY_K,
+            block_size: I2S_PARITY_BLOCK_SIZE,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
+impl I2sMetalPrefillContributionReceipt {
+    pub fn passed(artifact_path: impl Into<String>, comparison: SmokeComparison) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: PHASE_CONTRIBUTION_ARTIFACT_KIND,
+            requested_backend: REQUESTED_BACKEND,
+            selected_backend: SELECTED_BACKEND,
+            runtime_api: RUNTIME_API,
+            reference_backend: REFERENCE_BACKEND,
+            target_backend: SELECTED_BACKEND,
+            kernel_id: I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID,
+            kernel_family: I2S_KERNEL_FAMILY,
+            execution_phase: I2S_PREFILL_EXECUTION_PHASE,
+            phase_scope: I2S_PREFILL_PHASE_SCOPE,
+            layout_source: I2S_LAYOUT_SOURCE,
+            transport_layout: I2S_TRANSPORT_LAYOUT,
+            kv_cache_behavior: I2S_PREFILL_KV_CACHE_BEHAVIOR,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            prefill_tokens: I2S_PREFILL_TOKENS,
             n: I2S_PARITY_N,
             k: I2S_PARITY_K,
             block_size: I2S_PARITY_BLOCK_SIZE,
@@ -217,6 +280,10 @@ pub fn metal_i2s_parity_artifact_path(date: &str) -> String {
     format!("ci/hardware/{MACHINE_ID}/{date}/metal-i2s-parity.json")
 }
 
+pub fn metal_i2s_prefill_contribution_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/metal-i2s-prefill-contribution.json")
+}
+
 pub fn tiny_add_inputs() -> (Vec<f32>, Vec<f32>) {
     let lhs = (0..SMOKE_ELEMENT_COUNT).map(|i| i as f32).collect();
     let rhs = (0..SMOKE_ELEMENT_COUNT).map(|i| (i as f32) * 2.0).collect();
@@ -235,8 +302,20 @@ pub fn expected_tiny_add(lhs: &[f32], rhs: &[f32]) -> Result<Vec<f32>, TinyMetal
 }
 
 pub fn i2s_metal_parity_fixture() -> I2sMetalParityFixture {
-    let activations =
-        (0..I2S_PARITY_K).map(|index| ((index as i32 % 9) - 4) as f32 * 0.25).collect::<Vec<_>>();
+    i2s_metal_fixture(I2S_PARITY_M)
+}
+
+pub fn i2s_metal_prefill_fixture() -> I2sMetalParityFixture {
+    i2s_metal_fixture(I2S_PREFILL_TOKENS)
+}
+
+fn i2s_metal_fixture(m: usize) -> I2sMetalParityFixture {
+    let activations = (0..m * I2S_PARITY_K)
+        .map(|index| {
+            let row = index / I2S_PARITY_K;
+            ((index as i32 + row as i32 * 2) % 9 - 4) as f32 * 0.25
+        })
+        .collect::<Vec<_>>();
     let scales = vec![0.25, 0.5, 0.75, 1.0];
 
     let mut weights_packed = Vec::with_capacity((I2S_PARITY_K / 4) * I2S_PARITY_N);
@@ -255,13 +334,13 @@ pub fn i2s_metal_parity_fixture() -> I2sMetalParityFixture {
     }
 
     let weights_packed_words = pack_i2s_bytes_to_u32_words(&weights_packed);
-    let mut expected = vec![0.0; I2S_PARITY_M * I2S_PARITY_N];
+    let mut expected = vec![0.0; m * I2S_PARITY_N];
     i2s_matmul_f32(
         &activations,
         &weights_packed,
         &scales,
         &mut expected,
-        I2S_PARITY_M,
+        m,
         I2S_PARITY_N,
         I2S_PARITY_K,
         I2S_PARITY_BLOCK_SIZE,
@@ -274,7 +353,7 @@ pub fn i2s_metal_parity_fixture() -> I2sMetalParityFixture {
         weights_packed_words,
         scales,
         expected,
-        m: I2S_PARITY_M,
+        m,
         n: I2S_PARITY_N,
         k: I2S_PARITY_K,
         block_size: I2S_PARITY_BLOCK_SIZE,

--- a/crates/bitnet-kernels/src/metal_compute.rs
+++ b/crates/bitnet-kernels/src/metal_compute.rs
@@ -156,7 +156,7 @@ pub fn align_buffer_size(size: usize) -> usize {
 /// Validate that `offset` satisfies Metal's 256-byte alignment rule.
 #[inline]
 pub fn is_aligned(offset: usize) -> bool {
-    offset % METAL_BUFFER_ALIGNMENT == 0
+    offset.is_multiple_of(METAL_BUFFER_ALIGNMENT)
 }
 
 // ── Pipeline configuration ──────────────────────────────────────────

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -3,14 +3,18 @@
 use bitnet_device_probe::{AppleBackendReceipt, AppleResolvedDevice};
 use bitnet_kernels::metal::smoke::{
     ARTIFACT_KIND, I2S_EXECUTION_PHASE, I2S_KERNEL_FAMILY, I2S_LAYOUT_SOURCE,
-    I2S_METAL_PARITY_KERNEL_ID, I2S_PARITY_BLOCK_SIZE, I2S_PARITY_K, I2S_PARITY_M, I2S_PARITY_N,
-    I2S_TRANSPORT_LAYOUT, I2sMetalParityFixture, I2sMetalParityReceipt, MACHINE_ID,
-    PARITY_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND, RUNTIME_API, SELECTED_BACKEND,
-    SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_PARITY_KERNEL_ID,
+    I2S_METAL_PARITY_KERNEL_ID, I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID, I2S_PARITY_BLOCK_SIZE,
+    I2S_PARITY_K, I2S_PARITY_M, I2S_PARITY_N, I2S_PREFILL_EXECUTION_PHASE,
+    I2S_PREFILL_KV_CACHE_BEHAVIOR, I2S_PREFILL_PHASE_SCOPE, I2S_PREFILL_TOKENS,
+    I2S_TRANSPORT_LAYOUT, I2sMetalParityFixture, I2sMetalParityReceipt,
+    I2sMetalPrefillContributionReceipt, MACHINE_ID, PARITY_ARTIFACT_KIND,
+    PHASE_CONTRIBUTION_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND, RUNTIME_API,
+    SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_PARITY_KERNEL_ID,
     TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt, TinyMetalAddSmokeReceipt,
-    compare_tiny_add_outputs, expected_tiny_add, i2s_metal_parity_fixture, i2s_parity_shape_words,
-    is_apple_m4_adapter_name, metal_i2s_parity_artifact_path, metal_parity_artifact_path,
-    metal_smoke_artifact_path, tiny_add_inputs,
+    compare_tiny_add_outputs, expected_tiny_add, i2s_metal_parity_fixture,
+    i2s_metal_prefill_fixture, i2s_parity_shape_words, is_apple_m4_adapter_name,
+    metal_i2s_parity_artifact_path, metal_i2s_prefill_contribution_artifact_path,
+    metal_parity_artifact_path, metal_smoke_artifact_path, tiny_add_inputs,
 };
 
 #[test]
@@ -109,6 +113,48 @@ fn i2s_receipt_contract_records_kernel_family_without_inference_claim() {
 }
 
 #[test]
+fn i2s_prefill_fixture_records_named_phase_without_kv_cache_claim() {
+    let fixture = i2s_metal_prefill_fixture();
+
+    assert_eq!(fixture.m, I2S_PREFILL_TOKENS);
+    assert_eq!(fixture.n, I2S_PARITY_N);
+    assert_eq!(fixture.k, I2S_PARITY_K);
+    assert_eq!(fixture.block_size, I2S_PARITY_BLOCK_SIZE);
+    assert_eq!(fixture.activations.len(), I2S_PREFILL_TOKENS * I2S_PARITY_K);
+    assert_eq!(fixture.expected.len(), I2S_PREFILL_TOKENS * I2S_PARITY_N);
+    assert!(fixture.expected.iter().any(|value| *value != 0.0));
+}
+
+#[test]
+fn i2s_prefill_contribution_receipt_records_phase_and_fallback_status() {
+    let receipt = I2sMetalPrefillContributionReceipt::passed(
+        metal_i2s_prefill_contribution_artifact_path("2026-05-06"),
+        SmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, MACHINE_ID);
+    assert_eq!(receipt.artifact_kind, PHASE_CONTRIBUTION_ARTIFACT_KIND);
+    assert_eq!(receipt.requested_backend, REQUESTED_BACKEND);
+    assert_eq!(receipt.selected_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.runtime_api, RUNTIME_API);
+    assert_eq!(receipt.reference_backend, REFERENCE_BACKEND);
+    assert_eq!(receipt.target_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.kernel_id, I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID);
+    assert_eq!(receipt.kernel_family, I2S_KERNEL_FAMILY);
+    assert_eq!(receipt.execution_phase, I2S_PREFILL_EXECUTION_PHASE);
+    assert_eq!(receipt.phase_scope, I2S_PREFILL_PHASE_SCOPE);
+    assert_eq!(receipt.layout_source, I2S_LAYOUT_SOURCE);
+    assert_eq!(receipt.transport_layout, I2S_TRANSPORT_LAYOUT);
+    assert_eq!(receipt.kv_cache_behavior, I2S_PREFILL_KV_CACHE_BEHAVIOR);
+    assert_eq!(receipt.prefill_tokens, I2S_PREFILL_TOKENS);
+    assert!(!receipt.fallback_used);
+    assert_eq!(
+        receipt.artifact_path,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-i2s-prefill-contribution.json"
+    );
+}
+
+#[test]
 fn comparison_fails_instead_of_falling_back_to_cpu() {
     let expected = [1.0_f32, 2.0, 3.0];
     let actual = [1.0_f32, 20.0, 3.0];
@@ -150,6 +196,9 @@ mod live_metal {
     const RUN_I2S_PARITY_ENV: &str = "BITNET_RUN_M4_METAL_I2S_PARITY";
     const I2S_PARITY_RECEIPT_ENV: &str = "BITNET_M4_METAL_I2S_PARITY_RECEIPT";
     const I2S_PARITY_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_I2S_PARITY_ARTIFACT_PATH";
+    const RUN_I2S_PREFILL_ENV: &str = "BITNET_RUN_M4_METAL_I2S_PREFILL";
+    const I2S_PREFILL_RECEIPT_ENV: &str = "BITNET_M4_METAL_I2S_PREFILL_RECEIPT";
+    const I2S_PREFILL_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_I2S_PREFILL_ARTIFACT_PATH";
     const TINY_KERNEL_SMOKE_PROFILE: &str = "tiny_kernel_smoke";
 
     struct MetalSmokeOutput {
@@ -368,7 +417,8 @@ mod live_metal {
         }
 
         let fixture = i2s_metal_parity_fixture();
-        let metal_output = run_i2s_metal_parity(&fixture)?;
+        let metal_output =
+            run_i2s_metal_fixture(&fixture, I2S_METAL_PARITY_KERNEL_ID, "M4-011 I2_S parity")?;
 
         if !is_apple_m4_adapter_name(&metal_output.adapter_name) {
             return Err(io_error(format!(
@@ -401,6 +451,66 @@ mod live_metal {
         extend_i2s_parity_metrics(&mut receipt_json, &receipt, &fixture);
 
         if let Ok(path) = std::env::var(I2S_PARITY_RECEIPT_ENV) {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
+    #[test]
+    fn tiny_m4_metal_i2s_prefill_contribution_matches_cpu_reference_when_enabled()
+    -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_I2S_PREFILL_ENV).as_deref() != Ok("1") {
+            eprintln!(
+                "skipping live M4 Metal I2_S prefill contribution; set {RUN_I2S_PREFILL_ENV}=1 to run it"
+            );
+            return Ok(());
+        }
+
+        let fixture = i2s_metal_prefill_fixture();
+        let metal_output = run_i2s_metal_fixture(
+            &fixture,
+            I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID,
+            "M4-013 I2_S prefill contribution",
+        )?;
+
+        if !is_apple_m4_adapter_name(&metal_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-013 I2_S prefill contribution requires an Apple M4-family Metal adapter; found '{}'",
+                metal_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&fixture.expected, &metal_output.output, 1e-5)?;
+        let artifact_path = std::env::var(I2S_PREFILL_ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(I2S_PREFILL_RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-prefill-contribution.json"
+                    .to_string()
+            });
+        let receipt = I2sMetalPrefillContributionReceipt::passed(artifact_path.clone(), comparison);
+
+        let mut receipt_json = apple_backend_receipt_json(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            metal_output.adapter_name,
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+            Some(receipt.kernel_id),
+            None,
+            receipt.result,
+        )?;
+        extend_i2s_prefill_contribution_metrics(&mut receipt_json, &receipt, &fixture);
+
+        if let Ok(path) = std::env::var(I2S_PREFILL_RECEIPT_ENV) {
             let output_path = receipt_output_path(&path);
             if let Some(parent) = output_path.parent() {
                 std::fs::create_dir_all(parent)?;
@@ -541,8 +651,10 @@ mod live_metal {
         })
     }
 
-    fn run_i2s_metal_parity(
+    fn run_i2s_metal_fixture(
         fixture: &I2sMetalParityFixture,
+        kernel_id: &'static str,
+        proof_label: &str,
     ) -> Result<MetalI2sParityOutput, Box<dyn Error>> {
         pollster::block_on(async move {
             let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
@@ -556,12 +668,12 @@ mod live_metal {
                     force_fallback_adapter: false,
                 })
                 .await
-                .ok_or_else(|| io_error("no Metal adapter found for M4-011 I2_S parity"))?;
+                .ok_or_else(|| io_error(format!("no Metal adapter found for {proof_label}")))?;
 
             let adapter_info = adapter.get_info();
             if adapter_info.backend != wgpu::Backend::Metal {
                 return Err(io_error(format!(
-                    "M4-011 I2_S parity requires Metal backend, found {:?}",
+                    "{proof_label} requires Metal backend, found {:?}",
                     adapter_info.backend
                 )));
             }
@@ -572,7 +684,7 @@ mod live_metal {
                 .map_err(|error| io_error(format!("failed to create Metal device: {error}")))?;
 
             let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-                label: Some(I2S_METAL_PARITY_KERNEL_ID),
+                label: Some(kernel_id),
                 source: wgpu::ShaderSource::Wgsl(I2S_PARITY_SHADER.into()),
             });
 
@@ -1046,6 +1158,62 @@ mod live_metal {
             }),
         );
         object.insert("model".to_string(), serde_json::Value::Null);
+        object.insert(
+            "layout".to_string(),
+            json!({
+                "source": receipt.layout_source,
+                "transport_layout": receipt.transport_layout,
+                "canonical_packed_bytes": fixture.weights_packed.len(),
+                "transport_words_u32": fixture.weights_packed_words.len(),
+                "consumes_packed_i2_s_directly": true,
+                "dequantizes_before_compute": false,
+                "m": fixture.m,
+                "n": fixture.n,
+                "k": fixture.k,
+                "block_size": fixture.block_size
+            }),
+        );
+        object.insert(
+            "parity".to_string(),
+            json!({
+                "reference_backend": receipt.reference_backend,
+                "target_backend": receipt.target_backend,
+                "kernel_id": receipt.kernel_id,
+                "kernel_family": receipt.kernel_family,
+                "max_abs_error": receipt.max_abs_error,
+                "mean_abs_error": receipt.mean_abs_error,
+                "token_agreement_for_greedy": null
+            }),
+        );
+    }
+
+    fn extend_i2s_prefill_contribution_metrics(
+        receipt_json: &mut serde_json::Value,
+        receipt: &I2sMetalPrefillContributionReceipt,
+        fixture: &I2sMetalParityFixture,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert(
+            "bitnet".to_string(),
+            json!({
+                "kernel_family": receipt.kernel_family,
+                "execution_phase": receipt.execution_phase,
+                "phase_scope": receipt.phase_scope,
+                "layout_source": receipt.layout_source,
+                "fallback_layout": null
+            }),
+        );
+        object.insert("model".to_string(), serde_json::Value::Null);
+        object.insert(
+            "phase".to_string(),
+            json!({
+                "name": receipt.execution_phase,
+                "scope": receipt.phase_scope,
+                "prefill_tokens": receipt.prefill_tokens,
+                "kv_cache_behavior": receipt.kv_cache_behavior,
+                "full_autoregressive_decode": false
+            }),
+        );
         object.insert(
             "layout".to_string(),
             json!({

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -309,6 +309,40 @@ runs natively on Metal until a later receipt proves that Metal consumes the TL1
 layout directly or names the exact conversion/dequantization path before
 compute.
 
+## M4-013 Metal Prefill Contribution
+
+M4-013 moves the native Metal I2_S fixture from a generic parity proof to a
+named BitNet phase contribution. The first phase target is intentionally small:
+`tiny_metal_i2s_prefill_contribution` runs the existing packed I2_S Metal
+fixture across two prompt-token rows, compares against the Apple CPU/NEON
+reference, and records `execution_phase = "prefill"` with `fallback_used =
+false`.
+
+Run the non-live contract tests with:
+
+```bash
+cargo test --locked -p bitnet-kernels \
+  --no-default-features --features metal \
+  --test metal_tiny_smoke i2s_prefill -- --nocapture
+```
+
+Run the live M4 receipt-backed proof with:
+
+```bash
+BITNET_RUN_M4_METAL_I2S_PREFILL=1 \
+BITNET_M4_METAL_I2S_PREFILL_RECEIPT=ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-prefill-contribution.json \
+cargo test --locked -p bitnet-kernels \
+  --no-default-features --features metal \
+  --test metal_tiny_smoke tiny_m4_metal_i2s_prefill_contribution_matches_cpu_reference_when_enabled -- --nocapture
+```
+
+The receipt must record the phase scope as `prefill_projection_fixture` and
+`kv_cache_behavior = "not_exercised"`. This means M4-013 may claim only that one
+I2_S-adjacent Metal prefill contribution is receipt-backed against CPU/NEON. It
+must not claim full autoregressive decode, KV-cache correctness, full BitNet
+inference, QK256 on Metal, MPSGraph execution, Neural Engine execution, or
+performance.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -378,6 +378,45 @@ path before compute.
 Move from isolated kernels to a named BitNet phase such as prefill or decode
 contribution, with CPU reference and explicit fallback status.
 
+The first contribution target is `tiny_metal_i2s_prefill_contribution`, not a
+full decode loop. It reuses the packed I2_S Metal fixture, expands it to two
+prompt-token rows, and records the proof as a prefill projection fixture:
+
+```json
+{
+  "artifact_kind": "phase_contribution",
+  "requested_backend": "apple-m4-metal",
+  "selected_backend": "apple-m4-metal",
+  "runtime_api": "metal",
+  "kernel_id": "tiny_metal_i2s_prefill_contribution",
+  "fallback_used": false,
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "prefill",
+    "phase_scope": "prefill_projection_fixture",
+    "layout_source": "fixture_packed_i2_s",
+    "fallback_layout": null
+  },
+  "phase": {
+    "name": "prefill",
+    "prefill_tokens": 2,
+    "kv_cache_behavior": "not_exercised",
+    "full_autoregressive_decode": false
+  },
+  "parity": {
+    "reference_backend": "apple-m4-cpu-neon",
+    "target_backend": "apple-m4-metal",
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0
+  }
+}
+```
+
+M4-013 may claim only that the named prefill contribution is receipt-backed
+against CPU/NEON. It must not claim full decode, KV-cache correctness, full
+BitNet inference, M4 acceleration, QK256 on Metal, MPSGraph execution, or Neural
+Engine execution.
+
 ### M4-014 - Strict BitNet M4 Proof Run
 
 Run strict real GGUF, real tokenizer, selected Apple backend,

--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -42,7 +42,7 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-010 | merged | Apple CPU/NEON BitNet reference merged in #3746. |
 | M4-011 | merged | Native Metal I2_S smoke/parity merged in #3769. |
 | M4-012 | merged | TL1 Apple layout-boundary investigation merged in #3775. |
-| M4-013 | in_progress | Add receipt-backed Metal prefill/decode contribution. |
+| M4-013 | pr_open | Add receipt-backed Metal prefill/decode contribution in #3783. |
 | M4-014 | proposed | Run strict real-model BitNet M4 proof with fallback disabled. |
 
 ## Review Policy

--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -39,10 +39,10 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-007 | merged | MPSGraph tiny graph smoke merged in #3719. |
 | M4-008 | merged | Apple backend receipt identity merged in #3721. |
 | M4-009 | merged | Benchmark baseline for the validated tiny Metal add kernel merged in #3732. |
-| M4-010 | ready | Prove Apple CPU/NEON BitNet reference before native Metal BitNet kernels. |
-| M4-011 | proposed | Run native Metal I2_S smoke/parity, not QK256. |
-| M4-012 | proposed | Investigate TL1 as an ARM-oriented Apple path. |
-| M4-013 | proposed | Add receipt-backed Metal prefill/decode contribution. |
+| M4-010 | merged | Apple CPU/NEON BitNet reference merged in #3746. |
+| M4-011 | merged | Native Metal I2_S smoke/parity merged in #3769. |
+| M4-012 | merged | TL1 Apple layout-boundary investigation merged in #3775. |
+| M4-013 | in_progress | Add receipt-backed Metal prefill/decode contribution. |
 | M4-014 | proposed | Run strict real-model BitNet M4 proof with fallback disabled. |
 
 ## Review Policy

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -422,7 +422,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-013"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-013-metal-prefill-decode"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -422,7 +422,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-013"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-013-metal-prefill-decode"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T200001Z-M4-013-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T200001Z-M4-013-in-progress.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T20:00:01Z"
+campaign = "apple-m4"
+item = "M4-013"
+event = "in_progress"
+branch = "codex/apple-m4/M4-013-metal-prefill-decode"
+actor = "codex"
+
+notes = [
+  "Started the named Apple Metal prefill/decode contribution item.",
+  "Scope is a receipt-backed I2_S prefill contribution fixture with CPU/NEON reference and explicit fallback status.",
+  "No QK256, server inference, MPSGraph execution, Neural Engine proof, benchmarks, full autoregressive decode, or full BitNet inference claim is included.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T200505Z-M4-013-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T200505Z-M4-013-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T20:05:05Z"
+campaign = "apple-m4"
+item = "M4-013"
+event = "pr_open"
+pr = 3783
+head_sha = "172cbaebee87f01eccdf463ef79f02580b146035"
+actor = "codex"
+
+notes = [
+  "Opened Metal prefill contribution PR.",
+  "The PR records a tiny I2_S prefill projection fixture with CPU/NEON reference, requested/selected Apple Metal backend identity, explicit fallback_used=false, and KV-cache behavior marked not_exercised.",
+  "No QK256, server inference, MPSGraph execution, Neural Engine proof, benchmark, full autoregressive decode, or full BitNet inference claim is included.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -21,7 +21,7 @@
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
-| M4-013 | ready | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
+| M4-013 | in_progress | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -21,7 +21,7 @@
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
-| M4-013 | in_progress | TBD | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
+| M4-013 | pr_open | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-013 | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -14,7 +14,7 @@
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
-| apple-m4 | M4-013 | M4-012 | ready |
+| apple-m4 | M4-013 | M4-012 | in_progress |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -14,7 +14,7 @@
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
-| apple-m4 | M4-013 | M4-012 | in_progress |
+| apple-m4 | M4-013 | M4-012 | pr_open |
 | apple-m4 | M4-014 | M4-013 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-013 | TBD | ready | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-013 | TBD | in_progress | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-013 | TBD | in_progress | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-013 | #3783 | pr_open | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-013
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary

- Adds a fixture-scoped `tiny_metal_i2s_prefill_contribution` receipt contract for the Apple M4 Metal lane.
- Reuses the packed I2_S CPU/Metal fixture across two prompt-token rows and records `execution_phase = "prefill"`, `phase_scope = "prefill_projection_fixture"`, `fallback_used = false`, and `kv_cache_behavior = "not_exercised"`.
- Documents the M4-013 command and claim boundary, updates the Apple campaign tracker, and regenerates dashboards.

## Claim Boundary

This PR may claim only that a named I2_S-adjacent Apple Metal prefill contribution is receipt-backed against the Apple CPU/NEON reference. It does not claim full autoregressive decode, KV-cache correctness, full BitNet inference, QK256 on Metal, MPSGraph execution, Neural Engine execution, or performance.

## Verification

- `cargo test --locked -p bitnet-kernels --no-default-features --features metal i2s_prefill -- --nocapture`
- `BITNET_RUN_M4_METAL_I2S_PREFILL=1 BITNET_M4_METAL_I2S_PREFILL_RECEIPT=target/m4-013/metal-i2s-prefill-contribution.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_i2s_prefill_contribution_matches_cpu_reference_when_enabled -- --nocapture`
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke -- --nocapture`
- `cargo clippy --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke -- -D warnings`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
