### PR TITLE
docs(intel): define LNL258V-002 platform probe bundle

### DIFF
--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -79,6 +79,55 @@ Record these before moving any 258V hardware lane beyond `scaffold`:
 - 258V CPU validation must record artifacts without reshaping shared CPU implementation unless explicitly scoped by a ledger item.
 - Arc 140V visibility must preserve `requested_backend`, `selected_backend`, runtime API, exact device identity evidence, and `fallback_used=false`; generic Intel GPU visibility is not enough.
 
+## Platform Probe Bundle Artifacts
+
+`LNL258V-002` documents the same-machine probe bundle that later runs should
+write under `ci/hardware/intel-258v/<date>/`. These paths are examples and
+placeholders for future evidence; adding them to the docs does not commit a
+real machine artifact and does not prove runtime execution.
+
+```text
+ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-runtime-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/npu-openvino-runtime-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/platform-comparison-index.json
+```
+
+The bundle must keep each lane independently addressable:
+
+| Artifact | Proof stage | Scope | Claim boundary |
+|---|---|---|---|
+| `platform-probe.json` | `runtime_detected` | OS, CPU, memory, power, OpenVINO device list, shared platform context | Machine visibility only |
+| `arc-140v-runtime-probe.json` | `runtime_detected` | Arc 140V OpenCL, Level Zero, OpenVINO `GPU.0`, exact device identity | No OpenCL kernel execution claim |
+| `npu-openvino-runtime-probe.json` | `runtime_detected` | OS NPU evidence, OpenVINO `NPU`, driver/compiler/memory properties | No graph execution claim |
+| `platform-comparison-index.json` | index only | Links CPU, Arc 140V, and NPU artifacts from the same machine/date | No independent proof claim |
+
+The comparison index should preserve artifact paths and lane identities so later
+CPU, GPU, and NPU receipts can be compared without inferring cross-lane proof:
+
+```json
+{
+  "machine_id": "intel-258v",
+  "date": "YYYY-MM-DD",
+  "proof_stage": "runtime_detected",
+  "artifacts": {
+    "platform": "ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json",
+    "arc140v": "ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-runtime-probe.json",
+    "npu": "ci/hardware/intel-258v/YYYY-MM-DD/npu-openvino-runtime-probe.json"
+  },
+  "lanes": {
+    "cpu": "intel-258v-cpu-avx2",
+    "gpu": "intel-arc-140v-opencl",
+    "openvino_gpu": "intel-arc-140v-openvino-gpu",
+    "npu": "intel-npu-openvino"
+  },
+  "fallback_used": false
+}
+```
+
+The bundle does not prove BitNet inference, Arc 140V execution, OpenVINO NPU
+graph execution, parity, or benchmark performance.
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
+++ b/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
@@ -144,6 +144,37 @@ Use that document for PR boundaries, probe structures, receipt fields, acceptanc
 
 Docs/tracking only. Add the 258V platform profile, claim boundaries, data bundles, and cross-links to CPU, Arc 140V, and NPU lanes.
 
+### LNL258V-002 - Platform Probe Bundle
+
+Docs/tracking only. Define the same-machine platform probe bundle that ties
+Lunar Lake CPU, Arc 140V, and Intel NPU visibility artifacts together without
+turning visibility into execution proof.
+
+The bundle documents these future artifact paths:
+
+```text
+ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-runtime-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/npu-openvino-runtime-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/platform-comparison-index.json
+```
+
+Required bundle fields:
+
+- `machine_id`, OS/build, native/WSL context, memory, power, and thermal context.
+- CPU model, topology, AVX2 visibility, and AVX-512 non-claim.
+- Arc 140V OpenCL, Level Zero, OpenVINO `GPU.0`, and exact identity evidence.
+- Intel NPU OS device evidence, OpenVINO `NPU`, driver/compiler/memory properties.
+- Requested backend, selected backend, runtime API, proof stage, fallback status, and artifact path for each lane.
+
+Claim boundaries:
+
+- The bundle records detection/runtime visibility only.
+- `platform-comparison-index.json` is an index, not an execution receipt.
+- Arc 140V visibility is not OpenCL kernel execution.
+- OpenVINO `NPU` visibility is not graph execution.
+- No BitNet inference, parity, benchmark, or accelerator contribution claim is allowed.
+
 ### CPU258V-001 - Add CPU AVX2 Validation Lane
 
 Document 258V CPU as a parallel Lunar Lake validation lane for the same CPU path. The 8250U remains the active AVX2 implementation/proof lane; 258V CPU validates behavior on the Lunar Lake platform and supports same-machine comparison against Arc 140V and NPU artifacts.

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -24,7 +24,7 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 
 | Work item | Status | Notes |
 |---|---|---|
-| LNL258V-002 | ready | Add 258V probe bundle and same-machine comparison hooks. |
+| LNL258V-002 | pr_open | Add 258V probe bundle and same-machine comparison hooks. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -110,7 +110,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "LNL258V-002"
-status = "ready"
+status = "pr_open"
 branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"
 stackable = false
 requires_human_merge = true
@@ -118,7 +118,8 @@ blocked_by = []
 acceptance = "Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims."
 commands = [
   "cargo fmt --all -- --check",
-  "Parse TOML tracker files",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
   "git diff --check",
 ]
 allowed_paths = [

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T201908Z-LNL258V-002-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T201908Z-LNL258V-002-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T20:19:08Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-002"
+event = "pr_open"
+pr = 3784
+branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"
+head_sha = "c056fd735763150e1cd53c43951e537b2b71715b"
+actor = "codex"
+
+notes = [
+  "Opened the docs-only platform probe bundle PR.",
+  "The PR documents artifact paths and comparison-index shape only; it does not add machine artifacts, runtime execution, graph smoke, BitNet inference, parity, or benchmark claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
-| LNL258V-002 | ready | TBD | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
+| LNL258V-002 | pr_open | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-258v-platform | LNL258V-002 | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-002 | #3784 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- document the LNL258V-002 same-machine platform probe bundle
- add future artifact path examples for platform, Arc 140V, NPU, and comparison-index JSON receipts
- preserve the visibility-only claim boundary for CPU, Arc 140V, and Intel NPU lanes
- mark LNL258V-002 as `pr_open` with PR #3784 and regenerate tracker dashboards

## Claim Boundary
Docs/tracking only. This PR does not add machine artifacts, run BitNet inference, prove Arc 140V execution, prove OpenVINO NPU graph execution, prove parity, or claim benchmark performance.

## Validation
- CMAKE_GENERATOR="Visual Studio 17 2022" GITHUB_EVENT_NAME=push cargo run --locked -p xtask --no-default-features -- campaign doctor
- CMAKE_GENERATOR="Visual Studio 17 2022" cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check HEAD~2..HEAD

Note: local Windows xtask builds require an explicit supported CMake generator on this host.