### PR TITLE
docs(hardware): record KBL8250U-003 AVX2 parity proof

### DIFF
--- a/ci/hardware/intel-i5-8250u-cpu-avx2/avx2-parity-receipt.json
+++ b/ci/hardware/intel-i5-8250u-cpu-avx2/avx2-parity-receipt.json
@@ -1,0 +1,60 @@
+{
+  "schema": 1,
+  "artifact_kind": "avx2_parity_receipt",
+  "machine_id": "intel-i5-8250u-cpu-avx2",
+  "hardware_lane": "i5_8250u",
+  "timestamp_utc": "2026-05-06T20:15:59Z",
+  "requested_backend": "cpu",
+  "selected_backend": "intel-i5-8250u-cpu-avx2",
+  "runtime_api": "cpu",
+  "requested_kernel": "qk256-avx2-gemv",
+  "selected_kernel": "qk256-avx2-gemv",
+  "oracle_kernel": "qk256-scalar-gemv",
+  "fallback_used": false,
+  "fallback_reason": null,
+  "cpu": {
+    "model": "Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz",
+    "cores": 4,
+    "threads": 8,
+    "features": {
+      "avx2": true,
+      "fma": true,
+      "avx512": false
+    }
+  },
+  "workload": {
+    "crate": "bitnet-quantization",
+    "test": "qk256_avx2_parity_tests",
+    "parity_scope": [
+      "forced scalar",
+      "forced AVX2",
+      "auto dispatch",
+      "strict requested AVX2",
+      "direct AVX2 output",
+      "repeated-run equality",
+      "rows 1, 2, 7, 32",
+      "cols 256, 300, 512, 513, 1024",
+      "all-zero, repeating, alternating-row, and deterministic pseudo-random code patterns"
+    ],
+    "tolerance": {
+      "absolute": 0.0001,
+      "relative": null
+    }
+  },
+  "validation": [
+    {
+      "command": "cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2 -- --nocapture",
+      "result": "ok",
+      "passed": 4
+    },
+    {
+      "command": "cargo test --locked -p bitnet-quantization --no-default-features --features \"cpu,avx2\" --test qk256_avx2_parity_tests -- --nocapture",
+      "result": "ok",
+      "passed": 17
+    }
+  ],
+  "gpu_or_npu_used": false,
+  "performance_claim": false,
+  "claim_boundary": "Parity and selected-kernel proof only; no throughput, sustained-performance, GPU, OpenVINO, UHD 620, NPU, transformer decode, or strict receipt claim.",
+  "artifact_path": "ci/hardware/intel-i5-8250u-cpu-avx2/avx2-parity-receipt.json"
+}

--- a/ci/hardware/intel-i5-8250u-cpu-avx2/cpu-flags.txt
+++ b/ci/hardware/intel-i5-8250u-cpu-avx2/cpu-flags.txt
@@ -1,0 +1,22 @@
+timestamp_utc=2026-05-06T20:15:59Z
+machine_id=intel-i5-8250u-cpu-avx2
+cpu_model=Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz
+cores=4
+threads=8
+os=Microsoft Windows 11 Home 10.0.26200 build 26200
+power_scheme=Balanced
+memory=34359738368 bytes DDR4-2400 SODIMM Kingston KF3200C20S4/32GX
+
+dotnet_runtime_intrinsics:
+avx2=true
+fma=true
+avx512f=false
+
+cargo_validation:
+cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2 -- --nocapture
+result=ok, 4 passed
+
+cargo test --locked -p bitnet-quantization --no-default-features --features "cpu,avx2" --test qk256_avx2_parity_tests -- --nocapture
+result=ok, 17 passed
+
+claim_boundary=CPU scalar/AVX2 selection and parity evidence only; no GPU, OpenVINO, UHD 620, NPU, throughput, or sustained-performance claim.

--- a/ci/hardware/intel-i5-8250u-cpu-avx2/profile.json
+++ b/ci/hardware/intel-i5-8250u-cpu-avx2/profile.json
@@ -1,0 +1,56 @@
+{
+  "schema": 1,
+  "artifact_kind": "machine_profile",
+  "machine_id": "intel-i5-8250u-cpu-avx2",
+  "hardware_lane": "i5_8250u",
+  "timestamp_utc": "2026-05-06T20:15:59Z",
+  "os": {
+    "name": "Microsoft Windows 11 Home",
+    "version": "10.0.26200",
+    "kernel_or_build": "26200",
+    "native_or_virtualized": "native"
+  },
+  "cpu": {
+    "model": "Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz",
+    "cores": 4,
+    "threads": 8,
+    "flags": [
+      "avx2",
+      "fma"
+    ],
+    "selected_backend": "intel-i5-8250u-cpu-avx2"
+  },
+  "accelerator": {
+    "requested_backend": "cpu",
+    "selected_backend": "intel-i5-8250u-cpu-avx2",
+    "runtime_api": "cpu",
+    "device_name": "Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz",
+    "device_id": null,
+    "driver_version": null,
+    "fallback_used": false,
+    "fallback_reason": null
+  },
+  "memory": {
+    "kind": "DDR4-2400 SODIMM",
+    "total_bytes": 34359738368,
+    "vram_bytes": null,
+    "shared_memory": false
+  },
+  "power": {
+    "mode": "Balanced",
+    "thermal_profile": null,
+    "sustained_run": false
+  },
+  "lane_extension": {
+    "i5_8250u": {
+      "avx2_detected": true,
+      "fma_detected": true,
+      "avx512_detected": false,
+      "tdp_context": "15 W nominal mobile CPU; cTDP-up/down not measured in this artifact",
+      "sustained_frequency": null
+    }
+  },
+  "gpu_or_npu_used": false,
+  "claim_boundary": "CPU feature and parity artifact only; no throughput, sustained performance, GPU, OpenVINO, UHD 620, or NPU claim.",
+  "artifact_path": "ci/hardware/intel-i5-8250u-cpu-avx2/profile.json"
+}

--- a/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
@@ -26,7 +26,7 @@ Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2
 
 | Work item | Status | Notes |
 |---|---|---|
-| KBL8250U-003 | in_progress | Prove i5-8250U scalar and AVX2 dispatch. |
+| KBL8250U-003 | pr_open | Prove i5-8250U scalar and AVX2 dispatch. |
 | KBL8250U-004 | proposed | Add strict CPU proof run on the i5-8250U lane. |
 
 ## Review Policy

--- a/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
@@ -26,7 +26,7 @@ Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2
 
 | Work item | Status | Notes |
 |---|---|---|
-| KBL8250U-003 | ready | Prove i5-8250U scalar and AVX2 dispatch. |
+| KBL8250U-003 | in_progress | Prove i5-8250U scalar and AVX2 dispatch. |
 | KBL8250U-004 | proposed | Add strict CPU proof run on the i5-8250U lane. |
 
 ## Review Policy

--- a/docs/tracking/campaigns/cpu-qk256-performance/active.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/active.toml
@@ -20,7 +20,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "KBL8250U-003"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/cpu-qk256-performance/active.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/active.toml
@@ -20,21 +20,21 @@ hard_constraints = [
 
 [[work_item]]
 id = "KBL8250U-003"
-status = "ready"
-branch = "codex/cpu-qk256-performance/KBL8250U-003-scalar-avx2-dispatch"
+status = "in_progress"
+branch = "codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact"
 stackable = false
 requires_human_merge = true
 blocked_by = []
 acceptance = "Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback."
 commands = [
   "cargo fmt --all -- --check",
-  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features cpu",
-  "cargo test --locked -p bitnet-kernels --no-default-features --features cpu,avx2",
+  "cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2 -- --nocapture",
+  "cargo test --locked -p bitnet-quantization --no-default-features --features cpu,avx2 --test qk256_avx2_parity_tests -- --nocapture",
 ]
 allowed_paths = [
   "crates/bitnet-cpu-detect/**",
-  "crates/bitnet-kernels/**",
-  "crates/bitnet-receipts/**",
+  "crates/bitnet-quantization/**",
+  "ci/hardware/intel-i5-8250u-cpu-avx2/**",
   "docs/tracking/campaigns/cpu-qk256-performance/**",
 ]
 forbidden_paths = [

--- a/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-06T201559Z-KBL8250U-003-in-progress.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-06T201559Z-KBL8250U-003-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T20:15:59Z"
+campaign = "cpu-qk256-performance"
+item = "KBL8250U-003"
+event = "in_progress"
+branch = "codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact"
+actor = "codex"
+
+notes = [
+  "Started the i5-8250U CPU-only AVX2 parity artifact lane after CPU-BITNET-005c merged.",
+  "Artifacts record AVX2=true, FMA=true, AVX-512=false, selected qk256-avx2-gemv, scalar oracle qk256-scalar-gemv, and fallback_used=false; no throughput, sustained-performance, GPU, OpenVINO, UHD 620, or NPU claim is made.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-06T202200Z-KBL8250U-003-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-06T202200Z-KBL8250U-003-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T20:22:00Z"
+campaign = "cpu-qk256-performance"
+item = "KBL8250U-003"
+event = "pr_open"
+pr = 3785
+head_sha = "d4e6ecd64937c9c25b9902f72fe2b8d21b98726d"
+actor = "codex"
+
+notes = [
+  "Opened KBL8250U-003 with CPU-only i5-8250U AVX2/FMA profile, flags, and parity receipt artifacts.",
+  "The PR proves selected qk256-avx2-gemv against qk256-scalar-gemv with fallback_used=false; no throughput, sustained-performance, GPU, OpenVINO, UHD 620, NPU, transformer decode, or strict receipt claim is made.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| KBL8250U-003 | in_progress | TBD | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
+| KBL8250U-003 | pr_open | #3785 | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
 | KBL8250U-004 | proposed | TBD | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Acceptance |
 |---|---|---:|---|---|
-| KBL8250U-003 | ready | TBD | `codex/cpu-qk256-performance/KBL8250U-003-scalar-avx2-dispatch` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
+| KBL8250U-003 | in_progress | TBD | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
 | KBL8250U-004 | proposed | TBD | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| cpu-qk256-performance | KBL8250U-003 | #3785 | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-013 | TBD | ready | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
-| cpu-qk256-performance | KBL8250U-003 | TBD | in_progress | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
+| cpu-qk256-performance | KBL8250U-003 | #3785 | pr_open | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-013 | TBD | ready | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
-| cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
+| cpu-qk256-performance | KBL8250U-003 | TBD | in_progress | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | LNL258V-002 | TBD | ready | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |


### PR DESCRIPTION
## Summary
- add CPU-only i5-8250U AVX2/FMA machine profile and flags artifact
- add AVX2 parity receipt showing requested/selected qk256-avx2-gemv with scalar oracle qk256-scalar-gemv and fallback_used=false
- mark KBL8250U-003 in progress in the CPU QK256 performance tracker

## Claim Boundary
This proves CPU feature detection, selected-kernel identity, and scalar-vs-AVX2 parity on the i5-8250U lane. It does not claim throughput, sustained performance, transformer decode, strict receipts, GPU, OpenVINO, UHD 620, or NPU execution.

## Validation
- [System.Runtime.Intrinsics.X86.Avx2]::IsSupported => true
- [System.Runtime.Intrinsics.X86.Fma]::IsSupported => true
- [System.Runtime.Intrinsics.X86.Avx512F]::IsSupported => false
- cargo test --locked -p bitnet-cpu-detect --no-default-features --features avx2 -- --nocapture
- cargo test --locked -p bitnet-quantization --no-default-features --features "cpu,avx2" --test qk256_avx2_parity_tests -- --nocapture
- JSON parse via ConvertFrom-Json
- cargo run -p xtask --no-default-features -- campaign generate
- cargo run -p xtask --no-default-features -- campaign doctor
- git diff --check