### PR TITLE
[codex][apple-m4] Close out M4-013

### DIFF
--- a/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4/CAMPAIGN.md
@@ -42,8 +42,8 @@ Make Apple Silicon a receipt-backed BitNet target by moving in order from machin
 | M4-010 | merged | Apple CPU/NEON BitNet reference merged in #3746. |
 | M4-011 | merged | Native Metal I2_S smoke/parity merged in #3769. |
 | M4-012 | merged | TL1 Apple layout-boundary investigation merged in #3775. |
-| M4-013 | pr_open | Add receipt-backed Metal prefill/decode contribution in #3783. |
-| M4-014 | proposed | Run strict real-model BitNet M4 proof with fallback disabled. |
+| M4-013 | merged | Metal prefill contribution merged in #3783. |
+| M4-014 | ready | Run strict real-model BitNet M4 proof with fallback disabled. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -422,7 +422,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-013"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-013-metal-prefill-decode"
 stackable = false
 requires_human_merge = true
@@ -455,7 +455,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-014"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T202227Z-M4-013-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T202227Z-M4-013-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T20:22:27Z"
+campaign = "apple-m4"
+item = "M4-013"
+event = "merged"
+pr = 3783
+merge_sha = "6dfb4041ebb875a26a6c7b9381ba67480303ab21"
+actor = "codex"
+
+notes = [
+  "M4-013 merged with the receipt-backed I2_S Metal prefill contribution fixture.",
+  "The proof records execution_phase=prefill, phase_scope=prefill_projection_fixture, fallback_used=false, and kv_cache_behavior=not_exercised.",
+  "M4-014 is now ready for strict real-model BitNet M4 proof work.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -21,8 +21,8 @@
 | M4-010 | merged | #3746 | `codex/apple-m4/M4-010-cpu-neon-bitnet-reference` | Prove the Apple CPU/NEON BitNet reference path before native Metal BitNet kernels. |
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
-| M4-013 | pr_open | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
-| M4-014 | proposed | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
+| M4-014 | ready | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-013 | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -14,8 +14,8 @@
 | apple-m4 | M4-010 | M4-009 | merged |
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
-| apple-m4 | M4-013 | M4-012 | pr_open |
-| apple-m4 | M4-014 | M4-013 | proposed |
+| apple-m4 | M4-013 | M4-012 | merged |
+| apple-m4 | M4-014 | M4-013 | ready |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-013 | #3783 | pr_open | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-014 | TBD | ready | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-003 | TBD | ready | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-013 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-003 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-013 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary

- Marks M4-013 merged with PR #3783 merge SHA `6dfb4041ebb875a26a6c7b9381ba67480303ab21`.
- Promotes M4-014 to ready for strict real-model BitNet M4 proof.
- Adds the append-only M4-013 merged event and regenerates campaign/global dashboards.

## Scope

Tracker-only closeout. No runtime code, kernels, QK256, server inference, MPSGraph execution, Neural Engine claims, benchmark claims, or hardware artifacts.

## Verification

- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
