### PR TITLE
[codex][apple-m4] Add strict BitNet M4 proof receipts (M4-014)

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -2142,6 +2142,7 @@ async fn run_simple_generation(
         let requested_backend = backend_identity.requested_backend.as_str();
         let selected_backend = backend_identity.selected_backend.as_str();
         let runtime_api = backend_identity.runtime_api.as_str();
+        let apple_machine = apple_machine_receipt_json(requested_backend, selected_backend);
         let strict_cpu_reference_artifact = strict_backend
             && canonical_bitnet_model
             && runtime_api == "cpu"
@@ -2151,7 +2152,7 @@ async fn run_simple_generation(
         } else {
             "inference_result"
         };
-        let output = serde_json::json!({
+        let mut output = serde_json::json!({
             "schema_version": "1.0.0",
             "timestamp": chrono::Utc::now().to_rfc3339(),
             "artifact_kind": artifact_kind,
@@ -2256,6 +2257,13 @@ async fn run_simple_generation(
                 None
             },
         });
+        if let Some(apple_machine) = apple_machine
+            && let Some(object) = output.as_object_mut()
+        {
+            object.insert("machine_id".to_string(), apple_machine["machine_id"].clone());
+            object.insert("resolved_device".to_string(), apple_machine["resolved_device"].clone());
+            object.insert("apple".to_string(), apple_machine);
+        }
         write_json_output(Some(&json_path), &output)?;
     }
 
@@ -2381,6 +2389,165 @@ fn compute_rms(xs: &[f32]) -> f32 {
     (sum_sq / (xs.len() as f32)).sqrt()
 }
 
+fn apple_machine_receipt_json(
+    requested_backend: &str,
+    selected_backend: &str,
+) -> Option<serde_json::Value> {
+    if !is_apple_m4_backend_label(requested_backend) && !is_apple_m4_backend_label(selected_backend)
+    {
+        return None;
+    }
+
+    let probe = probe_apple_cli_machine();
+    Some(apple_machine_receipt_json_from_probe(&probe))
+}
+
+fn is_apple_m4_backend_label(label: &str) -> bool {
+    label.trim().to_ascii_lowercase().starts_with("apple-m4-")
+}
+
+#[derive(Debug, Clone, Default)]
+struct AppleCliMachineProbe {
+    chip: Option<String>,
+    cpu_cores: Option<usize>,
+    gpu_cores: Option<usize>,
+    unified_memory: Option<bool>,
+    unified_memory_bytes: Option<u64>,
+    macos_version: Option<String>,
+    macos_build: Option<String>,
+    native_or_virtualized: Option<String>,
+    metal_visible: bool,
+}
+
+fn probe_apple_cli_machine() -> AppleCliMachineProbe {
+    if std::env::consts::OS != "macos" {
+        return AppleCliMachineProbe {
+            native_or_virtualized: Some("not-macos".to_string()),
+            ..AppleCliMachineProbe::default()
+        };
+    }
+
+    let sw_vers = command_stdout_text("sw_vers", &[]).0;
+    let hardware = command_stdout_text("system_profiler", &["SPHardwareDataType"]).0;
+    let displays = command_stdout_text("system_profiler", &["SPDisplaysDataType"]).0;
+    let (metal, metal_success) = command_stdout_text("system_profiler", &["SPMetalDataType"]);
+    let memsize = command_stdout_text("sysctl", &["hw.memsize"]).0;
+    let virtualization = command_stdout_text("sysctl", &["kern.hv_vmm_present"]).0;
+
+    let chip = parse_receipt_colon_value(&hardware, "Chip")
+        .or_else(|| parse_receipt_colon_value(&metal, "Chipset Model"))
+        .or_else(|| parse_receipt_colon_value(&displays, "Chipset Model"));
+    let unified_memory = if chip.as_deref().is_some_and(|value| value.starts_with("Apple M")) {
+        Some(true)
+    } else if chip.is_some() {
+        Some(false)
+    } else {
+        None
+    };
+
+    AppleCliMachineProbe {
+        chip,
+        cpu_cores: parse_receipt_colon_value(&hardware, "Total Number of Cores")
+            .and_then(|value| parse_receipt_first_usize(&value)),
+        gpu_cores: parse_receipt_colon_value(&metal, "Total Number of Cores")
+            .or_else(|| parse_receipt_colon_value(&displays, "Total Number of Cores"))
+            .and_then(|value| parse_receipt_first_usize(&value)),
+        unified_memory,
+        unified_memory_bytes: parse_receipt_colon_value(&memsize, "hw.memsize").and_then(|value| {
+            value.split_whitespace().next().and_then(|number| number.parse::<u64>().ok())
+        }),
+        macos_version: parse_receipt_colon_value(&sw_vers, "ProductVersion"),
+        macos_build: parse_receipt_colon_value(&sw_vers, "BuildVersion"),
+        native_or_virtualized: parse_receipt_virtualization_state(&virtualization),
+        metal_visible: (metal_success && receipt_metal_text_reports_visibility(&metal))
+            || receipt_metal_text_reports_visibility(&displays),
+    }
+}
+
+fn command_stdout_text(command: &str, args: &[&str]) -> (String, bool) {
+    std::process::Command::new(command)
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map_or_else(
+            |_| (String::new(), false),
+            |output| {
+                (String::from_utf8_lossy(&output.stdout).into_owned(), output.status.success())
+            },
+        )
+}
+
+fn parse_receipt_colon_value(output: &str, key: &str) -> Option<String> {
+    output.lines().find_map(|line| {
+        let trimmed = line.trim();
+        let value = trimmed.strip_prefix(key)?.trim_start().strip_prefix(':')?.trim();
+        (!value.is_empty()).then(|| value.to_owned())
+    })
+}
+
+fn parse_receipt_first_usize(value: &str) -> Option<usize> {
+    let mut digits = String::new();
+    for ch in value.chars() {
+        if ch.is_ascii_digit() {
+            digits.push(ch);
+        } else if !digits.is_empty() {
+            break;
+        }
+    }
+    digits.parse().ok()
+}
+
+fn parse_receipt_virtualization_state(output: &str) -> Option<String> {
+    let value = parse_receipt_colon_value(output, "kern.hv_vmm_present")?;
+    match value.split_whitespace().next() {
+        Some("0") => Some("native-macos".to_string()),
+        Some("1") => Some("virtualized-macos".to_string()),
+        _ => Some("unknown".to_string()),
+    }
+}
+
+fn receipt_metal_text_reports_visibility(output: &str) -> bool {
+    let lower = output.to_ascii_lowercase();
+    lower.contains("metal")
+        && (lower.contains("chipset model")
+            || lower.contains("metal support")
+            || lower.contains("metal family")
+            || lower.contains("gpu"))
+}
+
+fn apple_machine_receipt_json_from_probe(probe: &AppleCliMachineProbe) -> serde_json::Value {
+    let mut resolved_device = serde_json::Map::new();
+    resolved_device.insert(
+        "chip".to_string(),
+        serde_json::Value::String(probe.chip.clone().unwrap_or_else(|| "unknown".to_string())),
+    );
+    if let Some(cpu_cores) = probe.cpu_cores {
+        resolved_device.insert("cpu_cores".to_string(), serde_json::json!(cpu_cores));
+    }
+    if let Some(gpu_cores) = probe.gpu_cores {
+        resolved_device.insert("gpu_cores".to_string(), serde_json::json!(gpu_cores));
+    }
+    if let Some(unified_memory) = probe.unified_memory {
+        resolved_device.insert("unified_memory".to_string(), serde_json::json!(unified_memory));
+    }
+    if let Some(unified_memory_bytes) = probe.unified_memory_bytes {
+        resolved_device
+            .insert("unified_memory_bytes".to_string(), serde_json::json!(unified_memory_bytes));
+    }
+
+    serde_json::json!({
+        "machine_id": "apple-m4-mac-mini",
+        "resolved_device": resolved_device,
+        "macos": {
+            "version": probe.macos_version,
+            "build": probe.macos_build,
+            "native_or_virtualized": probe.native_or_virtualized,
+        },
+        "metal_visible": probe.metal_visible,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2433,6 +2600,43 @@ mod tests {
         ));
 
         assert_eq!(repo, "microsoft/bitnet-b1.58-2B-4T-gguf");
+    }
+
+    #[test]
+    fn apple_m4_receipt_includes_resolved_machine_fields() {
+        let probe = AppleCliMachineProbe {
+            chip: Some("Apple M4".to_string()),
+            cpu_cores: Some(10),
+            gpu_cores: Some(10),
+            unified_memory: Some(true),
+            unified_memory_bytes: Some(17_179_869_184),
+            macos_version: Some("15.4".to_string()),
+            macos_build: Some("24E248".to_string()),
+            native_or_virtualized: Some("native-macos".to_string()),
+            metal_visible: true,
+        };
+        let receipt = apple_machine_receipt_json_from_probe(&probe);
+
+        assert_eq!(receipt["machine_id"], "apple-m4-mac-mini");
+        assert_eq!(receipt["resolved_device"]["chip"], "Apple M4");
+        assert_eq!(receipt["resolved_device"]["cpu_cores"], 10);
+        assert_eq!(receipt["resolved_device"]["gpu_cores"], 10);
+        assert_eq!(receipt["resolved_device"]["unified_memory"], true);
+        assert_eq!(receipt["resolved_device"]["unified_memory_bytes"], 17_179_869_184_u64);
+        assert_eq!(receipt["macos"]["native_or_virtualized"], "native-macos");
+        assert_eq!(receipt["metal_visible"], true);
+    }
+
+    #[test]
+    fn non_apple_backend_does_not_probe_apple_machine_fields() {
+        assert!(apple_machine_receipt_json("cpu", "cpu").is_none());
+    }
+
+    #[test]
+    fn apple_receipt_metal_visibility_accepts_display_profiler_output() {
+        assert!(receipt_metal_text_reports_visibility(
+            "Graphics/Displays:\n\n    Apple M4:\n      Chipset Model: Apple M4\n      Metal Support: Metal 4\n",
+        ));
     }
 }
 

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -343,6 +343,71 @@ must not claim full autoregressive decode, KV-cache correctness, full BitNet
 inference, QK256 on Metal, MPSGraph execution, Neural Engine execution, or
 performance.
 
+## M4-014 Strict BitNet M4 Proof
+
+The strict BitNet M4 proof uses the same real-GGUF CLI path, but it is the first
+Apple campaign item that may claim BitNet inference works for the selected Apple
+backend and configuration. It must still be precise about the backend:
+`apple-m4-cpu-neon` proof is CPU/NEON proof, not Metal proof.
+
+Run the live proof with:
+
+```bash
+BITNET_DISABLE_MINIMAL_LOADER=1 \
+BITNET_STRICT_MODE=1 \
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- \
+  --device apple-m4-cpu-neon \
+  run \
+  --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --prompt "Answer with a single digit: 2+2=" \
+  --max-tokens 1 \
+  --temperature 0.0 \
+  --greedy \
+  --deterministic \
+  --strict-loader \
+  --strict-tokenizer \
+  --prompt-template raw \
+  --no-warnings \
+  --json-out ci/hardware/apple-m4-mac-mini/<date>/strict-bitnet-cpu-neon-proof.json
+```
+
+The receipt must record:
+
+```json
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "machine_id": "apple-m4-mac-mini",
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "resolved_device": {
+    "chip": "Apple M4",
+    "gpu_cores": 10,
+    "unified_memory": true
+  },
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "tokenizer": "llama3",
+    "loader_mode": "real_gguf"
+  },
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "decode",
+    "layout_source": "gguf_packed_i2_s_reference"
+  }
+}
+```
+
+This may claim that BitNet inference works on M4 for `apple-m4-cpu-neon` with
+the recorded model, tokenizer, quantization, kernel family, and decode proof.
+It must not claim Metal BitNet inference, Neural Engine execution, QK256 on
+Metal, or general M4 performance.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -423,6 +423,49 @@ Run strict real GGUF, real tokenizer, selected Apple backend,
 `fallback_used=false`, deterministic prompt, and receipt emission before
 claiming BitNet inference on M4.
 
+The first proof target is `apple-m4-cpu-neon` with the canonical
+`microsoft/bitnet-b1.58-2B-4T-gguf` I2_S GGUF. The receipt must keep Apple
+machine identity, model identity, tokenizer authority, kernel family, execution
+phase, and fallback state together:
+
+```json
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "machine_id": "apple-m4-mac-mini",
+  "requested_backend": "apple-m4-cpu-neon",
+  "selected_backend": "apple-m4-cpu-neon",
+  "runtime_api": "cpu",
+  "fallback_used": false,
+  "resolved_device": {
+    "chip": "Apple M4",
+    "gpu_cores": 10,
+    "unified_memory": true
+  },
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "sha256": "...",
+    "tokenizer": "llama3",
+    "loader_mode": "real_gguf"
+  },
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "decode",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "fallback_layout": null
+  },
+  "kernel": {
+    "kernel_id": "i2_s-scalar-reference",
+    "implementation": "scalar",
+    "layout": "gguf_packed_i2_s"
+  }
+}
+```
+
+This proves BitNet inference only for the selected Apple backend and recorded
+configuration. It is not Metal BitNet proof, QK256-on-Metal proof, Neural Engine
+proof, or a performance claim.
+
 ## Do Not
 
 - Do not start with Apple Neural Engine inference claims.

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -455,11 +455,12 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-014"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
 stackable = false
 requires_human_merge = true
 blocked_by = ["M4-013"]
+pr = 3789
 acceptance = "Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission."
 commands = [
   "cargo fmt --all -- --check",

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -455,7 +455,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-014"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T205418Z-M4-014-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T205418Z-M4-014-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-06T20:54:18Z"
+campaign = "apple-m4"
+item = "M4-014"
+event = "in_progress"
+actor = "codex"
+branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
+
+notes = [
+  "Started strict real-model BitNet M4 proof work from merged M4-013 closeout.",
+  "Scope remains selected Apple backend proof with fallback_used=false; no QK256, server inference, Neural Engine, or general performance claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T210559Z-M4-014-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T210559Z-M4-014-pr-open.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-06T21:05:59Z"
+campaign = "apple-m4"
+item = "M4-014"
+event = "pr_open"
+actor = "codex"
+pr = 3789
+head_sha = "53f38bb959f7a065c1b58263483714f4304f8d42"
+branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
+
+notes = [
+  "Opened strict BitNet M4 proof PR.",
+  "Live proof emitted a strict real-GGUF apple-m4-cpu-neon receipt with fallback_used=false and Apple resolved-device fields.",
+  "No Metal BitNet inference, QK256 on Metal, Neural Engine execution, server inference, or general performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -22,7 +22,7 @@
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
-| M4-014 | ready | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| M4-014 | in_progress | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -22,7 +22,7 @@
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
-| M4-014 | in_progress | TBD | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| M4-014 | pr_open | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-014 | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -15,7 +15,7 @@
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
 | apple-m4 | M4-013 | M4-012 | merged |
-| apple-m4 | M4-014 | M4-013 | in_progress |
+| apple-m4 | M4-014 | M4-013 | pr_open |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -15,7 +15,7 @@
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
 | apple-m4 | M4-013 | M4-012 | merged |
-| apple-m4 | M4-014 | M4-013 | ready |
+| apple-m4 | M4-014 | M4-013 | in_progress |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-014 | TBD | in_progress | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-014 | #3789 | pr_open | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-014 | TBD | ready | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-014 | TBD | in_progress | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-014
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Enrich `bitnet run --json-out` receipts for Apple backend runs with `machine_id`, `resolved_device`, and Apple machine context while keeping CPU/NEON and Metal claims separate.
- Document the M4-014 strict real-GGUF proof command and receipt contract.
- Move M4-014 to `in_progress` and add the append-only campaign event.

## Claim boundary
This PR may claim strict BitNet inference works on M4 for the selected `apple-m4-cpu-neon` backend/configuration when the live receipt has `fallback_used=false`. It does not claim Metal BitNet inference, QK256 on Metal, Neural Engine execution, or general M4 performance.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli apple_ -- --nocapture`
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings`
- live strict proof:
  `BITNET_DISABLE_MINIMAL_LOADER=1 BITNET_STRICT_MODE=1 cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- --device apple-m4-cpu-neon run --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --prompt "Answer with a single digit: 2+2=" --max-tokens 1 --temperature 0.0 --greedy --deterministic --strict-loader --strict-tokenizer --prompt-template raw --no-warnings --json-out target/m4-014/strict-bitnet-cpu-neon-proof.json`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
