### PR TITLE
docs(intel): record 258V platform probe artifact

### DIFF
--- a/ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json
+++ b/ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "artifact_kind": "arc-140v-runtime-probe",
+  "machine_id": "intel-258v",
+  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "requested_backend": "intel-arc-140v",
+  "selected_backend": null,
+  "runtime_api": null,
+  "proof_stage": "detected",
+  "fallback_used": false,
+  "device": {
+    "os_device_visible": true,
+    "class": "Display",
+    "status": "OK",
+    "name": "Intel(R) Arc(TM) 140V GPU (16GB)",
+    "instance_id": "PCI\\VEN_8086&DEV_64A0&SUBSYS_383E17AA&REV_04\\3&11583659&0&10",
+    "pci_vendor_id": "0x8086",
+    "pci_device_id": "0x64A0"
+  },
+  "runtime_visibility": {
+    "opencl_tool_present": false,
+    "opencl_visible": null,
+    "level_zero_tool_present": false,
+    "level_zero_visible": null,
+    "openvino_python_module_available": false,
+    "openvino_gpu_visible": false,
+    "openvino_gpu_device": null,
+    "openvino_gpu_full_name": null
+  },
+  "claim_allowed": "Arc 140V device identity is OS-visible by PCI PnP evidence.",
+  "claims_not_allowed": [
+    "OpenCL runtime sees Arc 140V",
+    "Level Zero runtime sees Arc 140V",
+    "OpenVINO GPU.0 sees Arc 140V",
+    "Arc 140V kernel execution works",
+    "BitNet inference works on Arc 140V"
+  ]
+}

--- a/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
+++ b/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
@@ -1,0 +1,77 @@
+{
+  "schema": 1,
+  "artifact_kind": "cpu-bitnet-validation",
+  "machine_id": "intel-258v",
+  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "proof_stage": "blocked_preflight",
+  "status": "blocked_missing_canonical_model",
+  "fallback_used": false,
+  "validation_attempted": false,
+  "blocked_before_inference": true,
+  "blocker": {
+    "stage": "load_model",
+    "reason": "canonical BitNet GGUF fixture was not present at checked local paths",
+    "checked_paths": [
+      "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+      "models/BitNet-b1.58-2B-4T/tokenizer.json",
+      "C:\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+      "C:\\models\\BitNet-b1.58-2B-4T\\tokenizer.json"
+    ]
+  },
+  "hardware": {
+    "requested_backend": "cpu",
+    "selected_backend": "intel-258v-cpu-avx2",
+    "runtime_api": "cpu",
+    "cpu": {
+      "model": "Intel(R) Core(TM) Ultra 7 258V",
+      "cores": 8,
+      "threads": 8,
+      "avx2_detected": true,
+      "avx512_detected": false,
+      "fma_detected": true,
+      "sse42_detected": true
+    },
+    "platform_artifact": "ci/hardware/intel-258v/2026-05-06/platform-probe.json"
+  },
+  "model": {
+    "expected_repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "expected_file": "ggml-model-i2_s.gguf",
+    "sha256": null,
+    "format": "gguf",
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "tokenizer": "llama3",
+    "vocab_size": 128256,
+    "loader_mode": null
+  },
+  "bitnet": {
+    "weight_quantization": "W1.58",
+    "activation_quantization": "A8",
+    "weight_domain": "ternary",
+    "kernel_family": "i2_s|tl2|qk256",
+    "layout": null,
+    "layout_source": null,
+    "fallback_layout": null
+  },
+  "execution": {
+    "phase": "load_model",
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "batch_size": 1,
+    "thread_count": 8,
+    "requested_backend": "intel-258v-cpu-avx2",
+    "selected_backend": "intel-258v-cpu-avx2",
+    "requested_kernel": null,
+    "selected_kernel": null,
+    "fallback_used": false,
+    "fallback_reason": null
+  },
+  "claim_allowed": "The 258V CPU lane is ready for strict validation once the canonical GGUF/tokenizer fixture is available locally.",
+  "claims_not_allowed": [
+    "Strict BitNet GGUF loaded on 258V",
+    "Tokenizer authority resolved on 258V",
+    "QK256 or TL2 execution ran on 258V",
+    "BitNet inference works on 258V",
+    "258V CPU benchmark performance"
+  ]
+}

--- a/ci/hardware/intel-258v/2026-05-06/npu-openvino-runtime-probe.json
+++ b/ci/hardware/intel-258v/2026-05-06/npu-openvino-runtime-probe.json
@@ -1,0 +1,37 @@
+{
+  "schema": 1,
+  "artifact_kind": "npu-openvino-runtime-probe",
+  "machine_id": "intel-258v",
+  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "requested_backend": "intel-npu",
+  "selected_backend": null,
+  "runtime_api": null,
+  "proof_stage": "detected",
+  "fallback_used": false,
+  "device": {
+    "os_device_visible": true,
+    "class": "ComputeAccelerator",
+    "status": "OK",
+    "name": "Intel(R) AI Boost",
+    "instance_id": "PCI\\VEN_8086&DEV_643E&SUBSYS_380617AA&REV_04\\3&11583659&0&58",
+    "pci_vendor_id": "0x8086",
+    "pci_device_id": "0x643E"
+  },
+  "runtime_visibility": {
+    "openvino_python_module_available": false,
+    "openvino_import_error": "ModuleNotFoundError(\"No module named 'openvino'\")",
+    "openvino_available_devices": [],
+    "openvino_npu_visible": false,
+    "openvino_npu_full_name": null,
+    "driver_version": null,
+    "compiler_version": null,
+    "total_mem_size": null
+  },
+  "claim_allowed": "Intel AI Boost NPU device identity is OS-visible by PCI PnP evidence.",
+  "claims_not_allowed": [
+    "OpenVINO sees NPU",
+    "OpenVINO NPU graph execution works",
+    "Intel NPU accelerates BitNet",
+    "BitNet inference works on Intel NPU"
+  ]
+}

--- a/ci/hardware/intel-258v/2026-05-06/platform-comparison-index.json
+++ b/ci/hardware/intel-258v/2026-05-06/platform-comparison-index.json
@@ -1,0 +1,38 @@
+{
+  "schema": 1,
+  "artifact_kind": "platform-comparison-index",
+  "machine_id": "intel-258v",
+  "date": "2026-05-06",
+  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "proof_stage": "detected",
+  "artifacts": {
+    "platform": "ci/hardware/intel-258v/2026-05-06/platform-probe.json",
+    "cpu_bitnet_validation": "ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json",
+    "arc140v": "ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json",
+    "npu": "ci/hardware/intel-258v/2026-05-06/npu-openvino-runtime-probe.json"
+  },
+  "lanes": {
+    "cpu": {
+      "proof_label": "intel-258v-cpu-avx2",
+      "proof_stage": "blocked_preflight",
+      "artifact": "ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json"
+    },
+    "arc140v": {
+      "proof_label": "intel-arc-140v-opencl",
+      "proof_stage": "detected",
+      "artifact": "ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json"
+    },
+    "npu": {
+      "proof_label": "intel-npu-openvino",
+      "proof_stage": "detected",
+      "artifact": "ci/hardware/intel-258v/2026-05-06/npu-openvino-runtime-probe.json"
+    }
+  },
+  "fallback_used": false,
+  "claim_allowed": "Same-machine 258V OS visibility artifacts are linked for later runtime and BitNet validation.",
+  "claims_not_allowed": [
+    "Arc 140V runtime execution works",
+    "Intel NPU OpenVINO execution works",
+    "BitNet inference works on 258V"
+  ]
+}

--- a/ci/hardware/intel-258v/2026-05-06/platform-probe-notes.md
+++ b/ci/hardware/intel-258v/2026-05-06/platform-probe-notes.md
@@ -1,0 +1,29 @@
+# Intel 258V Platform Probe Notes - 2026-05-06
+
+This bundle records OS-visible hardware identity on the local Lunar Lake laptop.
+It does not claim OpenCL, Level Zero, OpenVINO, Arc 140V execution, NPU
+execution, BitNet inference, parity, or benchmark performance.
+
+## Captured Facts
+
+- Machine: Lenovo `83MC`
+- OS: Microsoft Windows 11 Home `10.0.26200`
+- CPU: Intel Core Ultra 7 258V, 8 cores / 8 logical processors
+- CPU runtime features: AVX2, FMA, SSE4.2 visible; AVX-512F not visible
+- Memory: 32 GiB class system memory, reported as 8 x 4 GiB at 8533 MT/s
+- Power scheme: Balanced
+- Arc 140V: OS-visible as `Intel(R) Arc(TM) 140V GPU (16GB)`, PCI `8086:64A0`
+- NPU: OS-visible as `Intel(R) AI Boost`, PCI `8086:643E`
+
+## Runtime Gaps
+
+- `clinfo` is not installed in PATH, so this bundle does not prove OpenCL runtime visibility.
+- `sycl-ls` and `ze_info` are not installed in PATH, so this bundle does not prove Level Zero runtime visibility.
+- Python cannot import `openvino`, so this bundle does not prove OpenVINO GPU or NPU visibility.
+- The canonical BitNet GGUF fixture was not present at the checked local paths, so CPU BitNet validation is recorded as `blocked_preflight`.
+
+## Claim Boundary
+
+Detection is not execution. These artifacts only establish same-machine hardware
+visibility and the absence of the runtime tooling needed for OpenCL, Level Zero,
+and OpenVINO claims on this Windows host at capture time.

--- a/ci/hardware/intel-258v/2026-05-06/platform-probe.json
+++ b/ci/hardware/intel-258v/2026-05-06/platform-probe.json
@@ -1,0 +1,129 @@
+{
+  "schema": 1,
+  "artifact_kind": "platform-probe",
+  "machine_id": "intel-258v",
+  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "proof_stage": "detected",
+  "status": "partial_platform_detected",
+  "fallback_used": false,
+  "claim_allowed": "Core Ultra 7 258V platform hardware is OS-visible on this Windows host.",
+  "claims_not_allowed": [
+    "BitNet inference works on 258V",
+    "Arc 140V OpenCL execution works",
+    "Level Zero execution works",
+    "OpenVINO GPU execution works",
+    "OpenVINO NPU execution works",
+    "Intel NPU accelerates BitNet"
+  ],
+  "os": {
+    "name": "Microsoft Windows 11 Home",
+    "version": "10.0.26200",
+    "windows_version": "2009",
+    "native_or_virtualized": "native",
+    "arch": "x86_64"
+  },
+  "system": {
+    "manufacturer": "LENOVO",
+    "model": "83MC",
+    "system_type": "x64-based PC"
+  },
+  "cpu": {
+    "requested_backend": "cpu",
+    "selected_backend": "intel-258v-cpu-avx2",
+    "runtime_api": "cpu",
+    "model": "Intel(R) Core(TM) Ultra 7 258V",
+    "cores": 8,
+    "threads": 8,
+    "p_core_count": 4,
+    "lp_e_core_count": 4,
+    "max_clock_mhz": 2200,
+    "l2_cache_kib": 14336,
+    "l3_cache_kib": 12288,
+    "flags": [
+      "avx2",
+      "fma",
+      "sse4.2"
+    ],
+    "avx2_detected": true,
+    "avx512_detected": false,
+    "fma_detected": true,
+    "sse42_detected": true,
+    "scheduler_hint": "Lunar Lake validation should record P-core / low-power E-core and power context before benchmark claims."
+  },
+  "memory": {
+    "kind": "shared LPDDR-class system memory",
+    "total_bytes": 33873780736,
+    "reported_modules": 8,
+    "reported_module_bytes": 4294967296,
+    "reported_speed_mt_s": 8533,
+    "reported_manufacturer": "Micron Technology",
+    "shared_memory": true
+  },
+  "power": {
+    "mode": "Balanced",
+    "power_scheme_guid": "381b4222-f694-41f0-9685-ff5bb260df2e",
+    "thermal_profile": null,
+    "sustained_run": false
+  },
+  "arc140v": {
+    "requested_backend": "intel-arc-140v",
+    "selected_backend": null,
+    "runtime_api": null,
+    "proof_stage": "detected",
+    "os_device_visible": true,
+    "device_name": "Intel(R) Arc(TM) 140V GPU (16GB)",
+    "pci_vendor_id": "0x8086",
+    "pci_device_id": "0x64A0",
+    "pnp_status": "OK",
+    "opencl_tool_present": false,
+    "opencl_visible": null,
+    "level_zero_tool_present": false,
+    "level_zero_visible": null,
+    "openvino_gpu_visible": false,
+    "fallback_used": false
+  },
+  "npu": {
+    "requested_backend": "intel-npu",
+    "selected_backend": null,
+    "runtime_api": null,
+    "proof_stage": "detected",
+    "os_device_visible": true,
+    "device_name": "Intel(R) AI Boost",
+    "pci_vendor_id": "0x8086",
+    "pci_device_id": "0x643E",
+    "pnp_status": "OK",
+    "openvino_runtime_available": false,
+    "openvino_npu_visible": false,
+    "fallback_used": false
+  },
+  "openvino": {
+    "python_module_available": false,
+    "python_error": "ModuleNotFoundError(\"No module named 'openvino'\")",
+    "available_devices": []
+  },
+  "tools": {
+    "clinfo": {
+      "present_in_path": false
+    },
+    "sycl-ls": {
+      "present_in_path": false
+    },
+    "ze_info": {
+      "present_in_path": false
+    },
+    "python": {
+      "present_in_path": true,
+      "path": "C:\\Python314\\python.exe"
+    }
+  },
+  "evidence_commands": [
+    "Get-ComputerInfo | Select-Object OsName,OsVersion,WindowsVersion,CsSystemType,CsManufacturer,CsModel",
+    "Get-CimInstance Win32_Processor",
+    "Get-CimInstance Win32_PhysicalMemory",
+    "powercfg /GETACTIVESCHEME",
+    "Get-PnpDevice",
+    "Get-Command clinfo,sycl-ls,ze_info,python,python3",
+    "python -c \"import openvino as ov\"",
+    "rustc std::is_x86_feature_detected probe"
+  ]
+}

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -110,7 +110,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "LNL258V-002"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v-platform/LNL258V-002-probe-bundle"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T211242Z-LNL258V-002-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T211242Z-LNL258V-002-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T21:12:42Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-002"
+event = "merged"
+pr = 3784
+merge_sha = "69da7744f832ab71abbec60f27e7c1422630a5c0"
+actor = "codex"
+
+notes = [
+  "Recorded merge of the docs-only 258V platform probe bundle.",
+  "The merge defined artifact paths and same-machine comparison shape without runtime execution claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
-| LNL258V-002 | pr_open | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
+| LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-258v-platform | LNL258V-002 | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-002 | #3784 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-002 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- record the local Core Ultra 7 258V platform probe artifacts under `ci/hardware/intel-258v/2026-05-06/`
- capture conservative CPU, Arc 140V, Intel NPU, OpenVINO-preflight, and same-machine comparison evidence
- close out the already-merged LNL258V-002 tracker state so the dashboards no longer list #3784 as active

## Claim boundary
- OS/PnP hardware visibility is recorded for this laptop
- OpenCL, Level Zero, and OpenVINO runtime execution are not proven by these artifacts
- CPU BitNet validation is blocked at preflight because the canonical GGUF/tokenizer files were not present on this machine
- no BitNet inference, Arc 140V execution, NPU execution, graph smoke, parity, or performance claim is made

## Validation
- parsed all JSON artifacts with PowerShell `ConvertFrom-Json`
- `cargo test --locked -p bitnet-device-probe --no-default-features`
- `cargo test --locked -p bitnet-device-probe --no-default-features --features cpu`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check HEAD~1..HEAD`