### PR TITLE
feat(cuda): route BitNet linear dispatch through CUDA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,7 @@ dependencies = [
  "bitnet-kernels",
  "bitnet-models",
  "bitnet-prompt-templates",
+ "bitnet-qk256-dispatch",
  "bitnet-quantization",
  "bitnet-repl-core",
  "bitnet-runtime-bootstrap",
@@ -1193,10 +1194,12 @@ name = "bitnet-qk256-dispatch"
 version = "0.2.1-dev"
 dependencies = [
  "bitnet-common",
+ "bitnet-kernels",
  "bitnet-qk256-layout-core",
  "bitnet-quantization",
  "bitnet-test-support",
  "candle-core",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/bitnet-cli/Cargo.toml
+++ b/crates/bitnet-cli/Cargo.toml
@@ -27,6 +27,7 @@ bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
 bitnet-models = { path = "../bitnet-models", version = "0.2.1-dev" }
 bitnet-inference = { path = "../bitnet-inference", version = "0.2.1-dev" }
 bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev" }
+bitnet-qk256-dispatch = { path = "../bitnet-qk256-dispatch", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 bitnet-tokenizers = { path = "../bitnet-tokenizers", version = "0.2.1-dev" }
 bitnet-tokenizer-discovery-core = { path = "../bitnet-tokenizer-discovery-core", version = "0.2.1-dev" }
@@ -86,6 +87,7 @@ runtime-profile-core = [
 cpu = [
   "bitnet-inference/cpu",
   "bitnet-kernels/cpu",
+  "bitnet-qk256-dispatch/cpu",
   "bitnet-device-probe/cpu",
   "runtime-profile-core",
   "bitnet-runtime-bootstrap/runtime-profile-cpu",
@@ -93,6 +95,7 @@ cpu = [
 cuda = [
   "bitnet-inference/cuda",
   "bitnet-kernels/cuda",
+  "bitnet-qk256-dispatch/cuda",
   "bitnet-device-probe/cuda",
   "runtime-profile-core",
   "bitnet-runtime-bootstrap/runtime-profile-cuda",
@@ -100,6 +103,7 @@ cuda = [
 metal = [
   "bitnet-common/metal",
   "bitnet-inference/metal",
+  "bitnet-qk256-dispatch/metal",
   "runtime-profile-core",
 ]
 gpu = ["cuda", "metal", "bitnet-runtime-bootstrap/runtime-profile-gpu"]

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1585,6 +1585,18 @@ async fn run_simple_generation(
             .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
             .unwrap_or(false);
     let backend_identity = resolve_run_backend_identity(requested_backend_label, strict_backend)?;
+    bitnet_qk256_dispatch::reset_qk256_dispatch_coverage();
+    unsafe {
+        std::env::set_var("BITNET_REQUESTED_BACKEND", backend_identity.requested_backend.as_str());
+        std::env::set_var("BITNET_SELECTED_BACKEND", backend_identity.selected_backend.as_str());
+        std::env::set_var("BITNET_RUNTIME_API", backend_identity.runtime_api.as_str());
+        if strict_backend && backend_identity.selected_backend.as_str() == "nvidia-rtx-5070-ti-cuda"
+        {
+            std::env::set_var("BITNET_STRICT_CUDA_BACKEND", "1");
+        } else {
+            std::env::remove_var("BITNET_STRICT_CUDA_BACKEND");
+        }
+    }
 
     // Parse and resolve template type
     use bitnet_inference::TemplateType;
@@ -2143,6 +2155,7 @@ async fn run_simple_generation(
         let selected_backend = backend_identity.selected_backend.as_str();
         let runtime_api = backend_identity.runtime_api.as_str();
         let apple_machine = apple_machine_receipt_json(requested_backend, selected_backend);
+        let bitnet_linear_coverage = bitnet_qk256_dispatch::qk256_dispatch_coverage();
         let strict_cpu_reference_artifact = strict_backend
             && canonical_bitnet_model
             && runtime_api == "cpu"
@@ -2211,6 +2224,13 @@ async fn run_simple_generation(
                 "runtime_api": runtime_api,
                 "fallback_used": backend_identity.fallback_used,
                 "fallback_reason": backend_identity.fallback_reason.as_deref(),
+            },
+            "execution_coverage": {
+                "bitnet_linear_layers_total": bitnet_linear_coverage.bitnet_linear_layers_total,
+                "bitnet_linear_layers_on_cuda": bitnet_linear_coverage.bitnet_linear_layers_on_cuda,
+                "bitnet_linear_layers_cpu_fallback": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
+                "unsupported_ops": bitnet_linear_coverage.unsupported_ops,
+                "execution_claim": bitnet_linear_coverage.execution_claim,
             },
             "kernel": {
                 "family": kernel_family,

--- a/crates/bitnet-qk256-dispatch/Cargo.toml
+++ b/crates/bitnet-qk256-dispatch/Cargo.toml
@@ -13,9 +13,11 @@ rust-version.workspace = true
 
 [dependencies]
 bitnet-common = { path = "../bitnet-common", version = "0.2.1-dev" }
+bitnet-kernels = { path = "../bitnet-kernels", version = "0.2.1-dev", optional = true, default-features = false }
 bitnet-qk256-layout-core = { path = "../bitnet-qk256-layout-core", version = "0.2.1-dev" }
 bitnet-quantization = { path = "../bitnet-quantization", version = "0.2.1-dev" }
 candle-core = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
 bitnet-test-support.workspace = true
@@ -23,6 +25,9 @@ bitnet-test-support.workspace = true
 [features]
 default = []
 cpu = ["bitnet-quantization/cpu"]
-cuda = ["bitnet-common/cuda", "candle-core/cuda", "bitnet-quantization/cuda"]
+cuda = [
+  "dep:bitnet-kernels",
+  "bitnet-kernels/cuda",
+]
 metal = ["bitnet-common/metal"]
 gpu = ["cuda", "metal"]

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -1,11 +1,234 @@
+//! QK256 linear dispatch for BitNet transformer layers.
+//!
+//! The public `forward_qk256` entry point is used by the transformer whenever a
+//! `.qk256_qs` raw tensor is present. It records coverage counters for the
+//! BitNet linear path and, when the selected backend is CUDA, attempts the CUDA
+//! QK256 kernel before falling back according to strict-mode policy.
+
 use bitnet_common::{BitNetError, Result};
-use bitnet_qk256_layout_core::{parse_input_shape, parse_qk256_layout, validate_input_cols};
+use bitnet_qk256_layout_core::{
+    Qk256InputShape, Qk256Layout, parse_input_shape, parse_qk256_layout, validate_input_cols,
+};
 use candle_core::Tensor;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static BITNET_LINEAR_TOTAL: AtomicU64 = AtomicU64::new(0);
+static BITNET_LINEAR_ON_CUDA: AtomicU64 = AtomicU64::new(0);
+static BITNET_LINEAR_CPU_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static BITNET_LINEAR_UNSUPPORTED: AtomicU64 = AtomicU64::new(0);
+
+/// Coverage counters for BitNet QK256 linear dispatch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qk256DispatchCoverageCounters {
+    /// Total BitNet linear dispatch points observed by this crate.
+    pub bitnet_linear_layers_total: u64,
+    /// Dispatch points routed through the CUDA QK256 kernel.
+    pub bitnet_linear_layers_on_cuda: u64,
+    /// Dispatch points that used CPU fallback while a CUDA backend was requested.
+    pub bitnet_linear_layers_cpu_fallback: u64,
+    /// Unsupported operations that prevent a full CUDA inference claim.
+    pub unsupported_ops: Vec<String>,
+    /// Human-readable claim boundary for partial routing.
+    pub execution_claim: &'static str,
+}
+
+/// Snapshot the current QK256 dispatch coverage counters.
+pub fn qk256_dispatch_coverage() -> Qk256DispatchCoverageCounters {
+    let cpu_fallback = BITNET_LINEAR_CPU_FALLBACK.load(Ordering::Relaxed);
+    let unsupported = BITNET_LINEAR_UNSUPPORTED.load(Ordering::Relaxed);
+    let on_cuda = BITNET_LINEAR_ON_CUDA.load(Ordering::Relaxed);
+    let mut unsupported_ops = Vec::new();
+    if cpu_fallback > 0 {
+        unsupported_ops.push("qk256_cpu_fallback".to_string());
+    }
+    if unsupported > 0 {
+        unsupported_ops.push("qk256_strict_cuda_unsupported".to_string());
+    }
+
+    Qk256DispatchCoverageCounters {
+        bitnet_linear_layers_total: BITNET_LINEAR_TOTAL.load(Ordering::Relaxed),
+        bitnet_linear_layers_on_cuda: on_cuda,
+        bitnet_linear_layers_cpu_fallback: cpu_fallback,
+        unsupported_ops,
+        execution_claim: if on_cuda > 0 {
+            "cuda_inference_contribution"
+        } else if cuda_bitnet_backend_requested() {
+            "cuda_bitnet_not_routed"
+        } else {
+            "cpu_reference"
+        },
+    }
+}
+
+/// Reset dispatch coverage counters.
+///
+/// This is public so CLI and integration tests can scope receipt counters to a
+/// single run without relying on process lifetime.
+pub fn reset_qk256_dispatch_coverage() {
+    BITNET_LINEAR_TOTAL.store(0, Ordering::Relaxed);
+    BITNET_LINEAR_ON_CUDA.store(0, Ordering::Relaxed);
+    BITNET_LINEAR_CPU_FALLBACK.store(0, Ordering::Relaxed);
+    BITNET_LINEAR_UNSUPPORTED.store(0, Ordering::Relaxed);
+}
+
+/// Record a BitNet linear CPU fallback outside the QK256 raw-tensor path.
+pub fn record_bitnet_linear_cpu_fallback() {
+    BITNET_LINEAR_TOTAL.fetch_add(1, Ordering::Relaxed);
+    if cuda_bitnet_backend_requested() {
+        BITNET_LINEAR_CPU_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Record a BitNet linear dispatch point that strict CUDA cannot support.
+pub fn record_bitnet_linear_unsupported() {
+    BITNET_LINEAR_TOTAL.fetch_add(1, Ordering::Relaxed);
+    BITNET_LINEAR_UNSUPPORTED.fetch_add(1, Ordering::Relaxed);
+}
+
+/// True when the run selected or requested the RTX 5070 Ti CUDA BitNet lane.
+pub fn cuda_bitnet_backend_requested() -> bool {
+    backend_env_matches("BITNET_SELECTED_BACKEND")
+        || backend_env_matches("BITNET_REQUESTED_BACKEND")
+        || backend_env_matches("BITNET_BACKEND")
+}
+
+/// True when strict mode forbids CPU fallback for the CUDA BitNet lane.
+pub fn strict_cuda_bitnet_backend_requested() -> bool {
+    (cuda_bitnet_backend_requested() && env_truthy("BITNET_STRICT_MODE"))
+        || env_truthy("BITNET_STRICT_CUDA_BACKEND")
+}
 
 /// Runs I2_S QK256 forward pass for input tensor shapes [B, T, H] or [B, H].
 pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -> Result<Tensor> {
+    BITNET_LINEAR_TOTAL.fetch_add(1, Ordering::Relaxed);
+
+    if cuda_bitnet_backend_requested() {
+        #[cfg(feature = "cuda")]
+        {
+            match forward_qk256_cuda(input, qk256_tensor, weight_name) {
+                Ok(output) => {
+                    BITNET_LINEAR_ON_CUDA.fetch_add(1, Ordering::Relaxed);
+                    return Ok(output);
+                }
+                Err(err) if strict_cuda_bitnet_backend_requested() => {
+                    return Err(BitNetError::Validation(format!(
+                        "strict CUDA BitNet linear dispatch failed for {weight_name}: {err}"
+                    )));
+                }
+                Err(err) => {
+                    BITNET_LINEAR_CPU_FALLBACK.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(
+                        "CUDA QK256 dispatch failed for {}; using CPU fallback: {}",
+                        weight_name,
+                        err
+                    );
+                }
+            }
+        }
+
+        #[cfg(not(feature = "cuda"))]
+        {
+            if strict_cuda_bitnet_backend_requested() {
+                return Err(BitNetError::Validation(format!(
+                    "strict CUDA BitNet linear dispatch requested for {weight_name}, but bitnet-qk256-dispatch was built without the cuda feature"
+                )));
+            }
+            BITNET_LINEAR_CPU_FALLBACK.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    forward_qk256_cpu(input, qk256_tensor, weight_name)
+}
+
+fn forward_qk256_cpu(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -> Result<Tensor> {
     use bitnet_quantization::i2s_qk256::gemv_qk256;
 
+    let prepared = prepare_qk256_forward(input, qk256_tensor, weight_name)?;
+    let mut output_rows = vec![
+        vec![0.0f32; prepared.layout.rows];
+        prepared.shape.batch_size * prepared.shape.seq_len
+    ];
+
+    if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
+    {
+        static DIM_LOGGED: std::sync::Once = std::sync::Once::new();
+        DIM_LOGGED.call_once(|| {
+            eprintln!(
+                "trace_qk256: weight={} rows={} cols={} row_stride_bytes={} qk256_shape={:?}",
+                weight_name,
+                prepared.layout.rows,
+                prepared.layout.cols,
+                prepared.layout.row_stride_bytes,
+                qk256_tensor.dims()
+            );
+        });
+    }
+
+    for (row_index, input_row) in prepared.input_rows.iter().enumerate() {
+        gemv_qk256(
+            &prepared.flat_bytes,
+            input_row,
+            &mut output_rows[row_index],
+            prepared.layout.rows,
+            prepared.layout.cols,
+            prepared.layout.row_stride_bytes,
+        )
+        .map_err(|e| {
+            BitNetError::Validation(format!(
+                "QK256 GEMV failed for {} at row {}: {}",
+                weight_name, row_index, e
+            ))
+        })?;
+    }
+
+    tensor_from_flat_output(
+        output_rows.into_iter().flatten().collect(),
+        &prepared.shape,
+        &prepared.layout,
+        input,
+    )
+}
+
+#[cfg(feature = "cuda")]
+fn forward_qk256_cuda(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -> Result<Tensor> {
+    let prepared = prepare_qk256_forward(input, qk256_tensor, weight_name)?;
+    let mut input_flat = Vec::with_capacity(prepared.input_rows.len() * prepared.layout.cols);
+    for row in &prepared.input_rows {
+        input_flat.extend_from_slice(row);
+    }
+    let mut output_flat =
+        vec![0.0f32; prepared.shape.batch_size * prepared.shape.seq_len * prepared.layout.rows];
+    let config = bitnet_kernels::cuda::Qk256GemvConfig::for_shape(
+        prepared.shape.batch_size * prepared.shape.seq_len,
+        prepared.layout.rows,
+        prepared.layout.cols,
+    )
+    .map_err(BitNetError::from)?;
+
+    bitnet_kernels::cuda::launch_qk256_gemv(
+        &prepared.flat_bytes,
+        &[],
+        &input_flat,
+        &mut output_flat,
+        &config,
+    )
+    .map_err(BitNetError::from)?;
+
+    tensor_from_flat_output(output_flat, &prepared.shape, &prepared.layout, input)
+}
+
+struct PreparedQk256Forward {
+    layout: Qk256Layout,
+    shape: Qk256InputShape,
+    flat_bytes: Vec<u8>,
+    input_rows: Vec<Vec<f32>>,
+}
+
+fn prepare_qk256_forward(
+    input: &Tensor,
+    qk256_tensor: &Tensor,
+    weight_name: &str,
+) -> Result<PreparedQk256Forward> {
     let qk256_dims = qk256_tensor.dims();
     let layout = parse_qk256_layout(weight_name, qk256_dims)
         .map_err(|e| BitNetError::Validation(e.to_string()))?;
@@ -23,52 +246,29 @@ pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -
         flat_bytes.extend_from_slice(&row);
     }
 
-    let input_dims = input.dims();
     let shape =
-        parse_input_shape(input_dims).map_err(|e| BitNetError::Validation(e.to_string()))?;
+        parse_input_shape(input.dims()).map_err(|e| BitNetError::Validation(e.to_string()))?;
 
     validate_input_cols(weight_name, shape.cols, layout.cols)
         .map_err(|e| BitNetError::Validation(e.to_string()))?;
 
     let input_flat = input.reshape(&[shape.batch_size * shape.seq_len, layout.cols])?;
-    let input_vec = input_flat.to_vec2::<f32>().map_err(|e| {
+    let input_rows = input_flat.to_vec2::<f32>().map_err(|e| {
         BitNetError::Validation(format!(
             "Failed to convert input to f32 for {}: {}",
             weight_name, e
         ))
     })?;
 
-    let mut output_vec = vec![vec![0.0f32; layout.rows]; shape.batch_size * shape.seq_len];
+    Ok(PreparedQk256Forward { layout, shape, flat_bytes, input_rows })
+}
 
-    if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && weight_name.contains("layers.0.")
-    {
-        static DIM_LOGGED: std::sync::Once = std::sync::Once::new();
-        DIM_LOGGED.call_once(|| {
-            eprintln!(
-                "trace_qk256: weight={} rows={} cols={} row_stride_bytes={} qk256_shape={:?}",
-                weight_name, layout.rows, layout.cols, layout.row_stride_bytes, qk256_dims
-            );
-        });
-    }
-
-    for (i, input_row) in input_vec.iter().enumerate() {
-        gemv_qk256(
-            &flat_bytes,
-            input_row,
-            &mut output_vec[i],
-            layout.rows,
-            layout.cols,
-            layout.row_stride_bytes,
-        )
-        .map_err(|e| {
-            BitNetError::Validation(format!(
-                "QK256 GEMV failed for {} at row {}: {}",
-                weight_name, i, e
-            ))
-        })?;
-    }
-
-    let output_flat: Vec<f32> = output_vec.into_iter().flatten().collect();
+fn tensor_from_flat_output(
+    output_flat: Vec<f32>,
+    shape: &Qk256InputShape,
+    layout: &Qk256Layout,
+    input: &Tensor,
+) -> Result<Tensor> {
     let output_tensor = if shape.input_rank == 3 {
         Tensor::from_vec(
             output_flat,
@@ -80,4 +280,16 @@ pub fn forward_qk256(input: &Tensor, qk256_tensor: &Tensor, weight_name: &str) -
     };
 
     Ok(output_tensor)
+}
+
+fn backend_env_matches(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|value| {
+        matches!(value.to_ascii_lowercase().as_str(), "nvidia-rtx-5070-ti-cuda" | "cuda")
+    })
+}
+
+fn env_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"))
+        .unwrap_or(false)
 }

--- a/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
+++ b/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
@@ -1,0 +1,108 @@
+use bitnet_qk256_dispatch::{
+    forward_qk256, qk256_dispatch_coverage, record_bitnet_linear_cpu_fallback,
+    record_bitnet_linear_unsupported, reset_qk256_dispatch_coverage,
+};
+use candle_core::{DType, Device, Tensor};
+use std::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn clear_backend_env() {
+    unsafe {
+        std::env::remove_var("BITNET_SELECTED_BACKEND");
+        std::env::remove_var("BITNET_REQUESTED_BACKEND");
+        std::env::remove_var("BITNET_BACKEND");
+        std::env::remove_var("BITNET_STRICT_MODE");
+        std::env::remove_var("BITNET_STRICT_CUDA_BACKEND");
+    }
+}
+
+fn qk256_tensor(rows: usize, cols: usize, device: &Device) -> Tensor {
+    let row_stride = cols.div_ceil(256) * 64;
+    Tensor::from_vec(vec![0xaa_u8; rows * row_stride], &[rows, row_stride], device).unwrap()
+}
+
+#[test]
+fn cpu_selected_qk256_forward_records_total_without_fallback() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    let device = Device::Cpu;
+    let input = Tensor::ones(&[1, 1, 256], DType::F32, &device).unwrap();
+    let qk256 = qk256_tensor(2, 256, &device);
+
+    let output =
+        forward_qk256(&input, &qk256, "layers.0.attention.q_proj.weight.qk256_qs").unwrap();
+    let coverage = qk256_dispatch_coverage();
+
+    assert_eq!(output.dims(), &[1, 1, 2]);
+    assert_eq!(coverage.bitnet_linear_layers_total, 1);
+    assert_eq!(coverage.bitnet_linear_layers_on_cuda, 0);
+    assert_eq!(coverage.bitnet_linear_layers_cpu_fallback, 0);
+    assert!(coverage.unsupported_ops.is_empty());
+    assert_eq!(coverage.execution_claim, "cpu_reference");
+}
+
+#[test]
+fn missing_qk256_tensor_fallback_counter_is_backend_aware() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    record_bitnet_linear_cpu_fallback();
+    assert_eq!(qk256_dispatch_coverage().bitnet_linear_layers_cpu_fallback, 0);
+
+    unsafe {
+        std::env::set_var("BITNET_SELECTED_BACKEND", "nvidia-rtx-5070-ti-cuda");
+    }
+    record_bitnet_linear_cpu_fallback();
+    let coverage = qk256_dispatch_coverage();
+    assert_eq!(coverage.bitnet_linear_layers_total, 2);
+    assert_eq!(coverage.bitnet_linear_layers_cpu_fallback, 1);
+    assert_eq!(coverage.unsupported_ops, vec!["qk256_cpu_fallback"]);
+    assert_eq!(coverage.execution_claim, "cuda_bitnet_not_routed");
+    clear_backend_env();
+}
+
+#[test]
+fn strict_unsupported_counter_records_receipt_boundary() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    unsafe {
+        std::env::set_var("BITNET_SELECTED_BACKEND", "nvidia-rtx-5070-ti-cuda");
+    }
+
+    record_bitnet_linear_unsupported();
+    let coverage = qk256_dispatch_coverage();
+
+    assert_eq!(coverage.bitnet_linear_layers_total, 1);
+    assert_eq!(coverage.bitnet_linear_layers_on_cuda, 0);
+    assert_eq!(coverage.bitnet_linear_layers_cpu_fallback, 0);
+    assert_eq!(coverage.unsupported_ops, vec!["qk256_strict_cuda_unsupported"]);
+    assert_eq!(coverage.execution_claim, "cuda_bitnet_not_routed");
+    clear_backend_env();
+}
+
+#[cfg(not(feature = "cuda"))]
+#[test]
+fn strict_cuda_request_rejects_cpu_qk256_fallback_without_cuda_feature() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+    unsafe {
+        std::env::set_var("BITNET_SELECTED_BACKEND", "nvidia-rtx-5070-ti-cuda");
+        std::env::set_var("BITNET_STRICT_MODE", "1");
+    }
+    let device = Device::Cpu;
+    let input = Tensor::ones(&[1, 1, 256], DType::F32, &device).unwrap();
+    let qk256 = qk256_tensor(2, 256, &device);
+
+    let result = forward_qk256(&input, &qk256, "layers.0.attention.q_proj.weight.qk256_qs");
+
+    assert!(result.is_err());
+    let coverage = qk256_dispatch_coverage();
+    assert_eq!(coverage.bitnet_linear_layers_total, 1);
+    assert_eq!(coverage.bitnet_linear_layers_on_cuda, 0);
+    assert_eq!(coverage.bitnet_linear_layers_cpu_fallback, 0);
+    clear_backend_env();
+}

--- a/crates/bitnet-transformer/src/lib.rs
+++ b/crates/bitnet-transformer/src/lib.rs
@@ -1,5 +1,8 @@
 use bitnet_common::{BitNetConfig, BitNetError, Result};
-use bitnet_qk256_dispatch::forward_qk256;
+use bitnet_qk256_dispatch::{
+    forward_qk256, record_bitnet_linear_cpu_fallback, record_bitnet_linear_unsupported,
+    strict_cuda_bitnet_backend_requested,
+};
 use bitnet_rope::{build_tables as build_rope_tables, resolve_base as resolve_rope_base};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_nn::{LayerNorm, Linear, VarBuilder};
@@ -562,6 +565,14 @@ impl MultiHeadAttention {
             return forward_qk256(input, qk256_tensor, &qk256_key);
         }
 
+        if strict_cuda_bitnet_backend_requested() {
+            record_bitnet_linear_unsupported();
+            return Err(BitNetError::Validation(format!(
+                "strict CUDA BitNet linear dispatch requires QK256 raw tensor {}; refusing CPU fallback",
+                qk256_key
+            )));
+        }
+
         // Probe: Why is QK256 not found? (layer 0 only, once)
         if std::env::var("BITNET_TRACE_RMS").as_deref() == Ok("1") && self.layer_idx == 0 {
             static FALLBACK_LOGGED: std::sync::Once = std::sync::Once::new();
@@ -583,6 +594,7 @@ impl MultiHeadAttention {
             self.layer_idx,
             proj_name
         );
+        record_bitnet_linear_cpu_fallback();
         linear.forward(input).map_err(BitNetError::from)
     }
 
@@ -701,12 +713,21 @@ impl FeedForward {
             return forward_qk256(input, qk256_tensor, &qk256_key);
         }
 
+        if strict_cuda_bitnet_backend_requested() {
+            record_bitnet_linear_unsupported();
+            return Err(BitNetError::Validation(format!(
+                "strict CUDA BitNet linear dispatch requires QK256 raw tensor {}; refusing CPU fallback",
+                qk256_key
+            )));
+        }
+
         // Fall back to standard linear
         tracing::trace!(
             "Using standard linear for layers.{}.feed_forward.{}",
             self.layer_idx,
             proj_name
         );
+        record_bitnet_linear_cpu_fallback();
         linear.forward(input).map_err(BitNetError::from)
     }
 }


### PR DESCRIPTION
## Summary
- route transformer QK256 linear dispatch through the selected CUDA backend when `nvidia-rtx-5070-ti-cuda`/`cuda` is active
- refuse CPU fallback under strict RTX 5070 Ti CUDA mode when raw QK256 tensors are missing or CUDA dispatch fails
- add QK256 dispatch coverage counters and CLI receipt fields for total, CUDA-routed, CPU fallback, unsupported ops, and conservative execution claim labels
- keep this as a CUDA inference contribution only; it does not claim full BitNet CUDA inference

## Validation
- cargo test --locked -p bitnet-qk256-dispatch --test cuda_coverage --no-default-features --features cpu
- cargo test --locked -p bitnet-qk256-dispatch --test forward_qk256 --no-default-features --features cpu
- cargo check --locked -p bitnet-qk256-dispatch --no-default-features --features cuda
- cargo check --locked -p bitnet-transformer --no-default-features --features cpu
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo clippy --locked -p bitnet-qk256-dispatch --no-default-features --features cpu -- -D warnings
- cargo clippy --locked -p bitnet-transformer --lib --no-default-features --features cpu -- -D warnings
- cargo clippy --locked -p bitnet-cli --bin bitnet --no-default-features --features cpu,full-cli -- -D warnings
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- rustfmt crates\\bitnet-qk256-dispatch\\src\\lib.rs crates\\bitnet-qk256-dispatch\\tests\\cuda_coverage.rs crates\\bitnet-transformer\\src\\lib.rs crates\\bitnet-cli\\src\\main.rs
- git diff --check

## Notes
- `cargo fmt --all -- --check` remains blocked locally by the known Windows `os error 206` path-length spawn issue; targeted rustfmt passed.
- Full `cargo test -p bitnet-qk256-dispatch` remains blocked locally by the pre-existing Windows UAC `os error 740` on the lib unit-test executable; the new tests are integration tests and passed directly.
- No QK256 scaffold work, dense CUDA lane, server inference, WGPU/D3D12 proof, benchmark, or full inference proof is included.

Closes #3672
