### PR TITLE
[codex] fix(workspace): remove duplicate download core member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ members = [
   "crates/bitnet-atomic-file-core", # SRP: shared atomic file write primitive
   "crates/bitnet-download-core", # SRP: core download validation and atomic file helpers
   "crates/bitnet-download",      # SRP: download mechanics primitives
-  "crates/bitnet-download-core", # SRP: pure download utility helpers
   "crates/bitnet-http-retry",    # SRP: reusable HTTP Retry-After/backoff timing primitives
   "crates/bitnet-http-auth-core", # SRP: reusable Authorization Bearer parsing helpers
   "crates/bitnet-gpu-hal",       # GPU hardware abstraction layer


### PR DESCRIPTION
## Summary

Removes the duplicate `crates/bitnet-download-core` entry from `[workspace].members`.

## Why

The crate was listed twice in the workspace members list, which is noisy for workspace hygiene and overlaps with stale PRs that attempted the same cleanup.

## Validation

- `cargo metadata --locked --format-version=1 --no-deps`
- Workspace member duplicate scan for `crates/*` entries before `default-members`
- `git diff --check`