### PR TITLE
feat(cli): emit Lunar Lake platform probe receipt

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -393,6 +393,13 @@ enum Commands {
         json_out: Option<std::path::PathBuf>,
     },
 
+    /// Probe Lunar Lake 258V platform visibility without launching kernels
+    LunarLakeProbe {
+        /// Output JSON probe receipt to file
+        #[arg(long)]
+        json_out: Option<std::path::PathBuf>,
+    },
+
     /// Compile and launch a tiny CUDA vector-add kernel
     CudaSmoke {
         /// CUDA device index to probe and launch on
@@ -609,6 +616,9 @@ async fn main() -> Result<()> {
         Some(Commands::Info) => show_system_info().await,
         Some(Commands::DeviceSmoke { json_out }) => {
             handle_device_smoke_command(&requested_backend_label, json_out).await
+        }
+        Some(Commands::LunarLakeProbe { json_out }) => {
+            handle_lunar_lake_probe_command(json_out).await
         }
         Some(Commands::CudaSmoke { device_index, json_out }) => {
             handle_cuda_smoke_command(&requested_backend_label, device_index, json_out).await
@@ -932,6 +942,50 @@ async fn handle_device_smoke_command(
     if let Some(error) = receipt.get("error").and_then(serde_json::Value::as_str) {
         anyhow::bail!("{error}");
     }
+
+    Ok(())
+}
+
+fn build_lunar_lake_probe_receipt(
+    probe: bitnet_device_probe::Lnl258vPlatformProbe,
+    timestamp_utc: String,
+    artifact_path: Option<String>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "schema": 1,
+        "artifact_kind": "lnl258v_platform_probe",
+        "machine_id": probe.machine_id.clone(),
+        "hardware_lane": "core-ultra-7-258v",
+        "proof_stage": probe.proof_stage.clone(),
+        "timestamp_utc": timestamp_utc,
+        "requested_backend": "core-ultra-7-258v",
+        "selected_backend": "core-ultra-7-258v",
+        "runtime_api": "platform_probe",
+        "fallback_used": probe.fallback_used,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "platform": probe,
+        "kernel_execution": false,
+        "graph_execution": false,
+        "bitnet_inference": false,
+        "claim": "lunar_lake_runtime_visibility_recorded",
+        "must_not_claim": [
+            "BitNet inference works on 258V",
+            "Arc 140V execution works",
+            "Intel NPU execution works",
+            "NPU accelerates BitNet"
+        ],
+        "artifact_path": artifact_path,
+    })
+}
+
+async fn handle_lunar_lake_probe_command(json_out: Option<std::path::PathBuf>) -> Result<()> {
+    let probe = bitnet_device_probe::probe_lnl258v_platform();
+    let timestamp_utc = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let artifact_path = json_out.as_ref().map(|path| path.display().to_string());
+    let receipt = build_lunar_lake_probe_receipt(probe, timestamp_utc, artifact_path);
+
+    write_json_output(json_out.as_ref(), &receipt)?;
 
     Ok(())
 }
@@ -2637,6 +2691,26 @@ mod tests {
         assert!(receipt_metal_text_reports_visibility(
             "Graphics/Displays:\n\n    Apple M4:\n      Chipset Model: Apple M4\n      Metal Support: Metal 4\n",
         ));
+    }
+
+    #[test]
+    fn lunar_lake_probe_receipt_is_visibility_only() {
+        let probe = bitnet_device_probe::probe_lnl258v_platform();
+        let receipt = build_lunar_lake_probe_receipt(
+            probe,
+            "2026-05-06T00:00:00Z".to_string(),
+            Some("ci/hardware/intel-258v/2026-05-06/platform-probe.json".to_string()),
+        );
+
+        assert_eq!(receipt["artifact_kind"], "lnl258v_platform_probe");
+        assert_eq!(receipt["hardware_lane"], "core-ultra-7-258v");
+        assert_eq!(receipt["proof_stage"], "runtime_detected");
+        assert_eq!(receipt["runtime_api"], "platform_probe");
+        assert_eq!(receipt["kernel_execution"], false);
+        assert_eq!(receipt["graph_execution"], false);
+        assert_eq!(receipt["bitnet_inference"], false);
+        assert_eq!(receipt["fallback_used"], false);
+        assert!(receipt["platform"]["cpu"]["has_avx512"].is_boolean());
     }
 }
 

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -128,6 +128,23 @@ CPU, GPU, and NPU receipts can be compared without inferring cross-lane proof:
 The bundle does not prove BitNet inference, Arc 140V execution, OpenVINO NPU
 graph execution, parity, or benchmark performance.
 
+### CLI Platform Probe
+
+Use the CLI probe command to emit the visibility-only platform receipt from the
+current machine without launching kernels or compiling OpenVINO graphs:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- lunar-lake-probe \
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json
+```
+
+The command records `proof_stage=runtime_detected`, `runtime_api=platform_probe`,
+`fallback_used=false`, and a `must_not_claim` list. It does not replace the
+lane-specific Arc 140V, NPU, CPU BitNet, parity, or benchmark artifacts.
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -24,7 +24,10 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 
 | Work item | Status | Notes |
 |---|---|---|
-| LNL258V-002 | pr_open | Add 258V probe bundle and same-machine comparison hooks. |
+| LNL258V-RUN-001 | merged | Add JSON-ready Lunar Lake platform probe structs. |
+| ARC140V-002 | merged | Add exact Arc 140V runtime identity probe logic. |
+| LNL258V-002 | merged | Add 258V probe bundle and same-machine comparison hooks. |
+| LNL258V-003 | pr_open | Add CLI platform probe emission for the current 258V machine. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -141,3 +141,46 @@ must_not_claim = [
   "Intel NPU execution works.",
   "BitNet inference works on 258V.",
 ]
+
+[[work_item]]
+id = "LNL258V-003"
+status = "pr_open"
+branch = "codex/intel-258v-platform/LNL258V-003-cli-platform-probe"
+stackable = false
+requires_human_merge = true
+blocked_by = ["LNL258V-002"]
+acceptance = "Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims."
+commands = [
+  "cargo fmt -p bitnet-cli -- --check",
+  "cargo test --locked -p bitnet-cli --bin bitnet tests::lunar_lake_probe_receipt_is_visibility_only -- --exact --nocapture",
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- lunar-lake-probe --json-out target/lnl258v-platform-probe.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/main.rs",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+  "tests/**",
+]
+may_claim = [
+  "The CLI can emit a Lunar Lake runtime visibility receipt.",
+]
+must_not_claim = [
+  "BitNet inference works on 258V.",
+  "Arc 140V execution works.",
+  "Intel NPU execution works.",
+  "OpenVINO graph execution works.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T220037Z-LNL258V-003-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T220037Z-LNL258V-003-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T22:00:37Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-003"
+event = "pr_open"
+pr = 3795
+branch = "codex/intel-258v-platform/LNL258V-003-cli-platform-probe"
+head_sha = "7877b48bb80b55c0bbfc159cf598b82a0b019d37"
+actor = "codex"
+
+notes = [
+  "Opened the CLI Lunar Lake platform probe emission PR.",
+  "The command emits a visibility-only receipt and does not launch kernels, compile OpenVINO graphs, or load BitNet models.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -12,6 +12,7 @@
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
+| LNL258V-003 | pr_open | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,4 +4,5 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | apple-m4 | M4-014 | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| intel-258v-platform | LNL258V-003 | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -27,6 +27,7 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | ready |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
+| intel-258v-platform | LNL258V-003 | LNL258V-002 | pr_open |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-003 | #3795 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-003 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- add `bitnet lunar-lake-probe` to emit the existing Core Ultra 7 258V platform probe as JSON
- keep the receipt visibility-only with `kernel_execution=false`, `graph_execution=false`, and `bitnet_inference=false`
- document the command in the 258V validation guide and add LNL258V-003 tracker wiring

## Claim boundary
- this records Lunar Lake platform runtime visibility only
- it does not run BitNet inference, OpenCL kernels, CUDA/Metal/WGPU, or OpenVINO graph compilation
- it does not prove Arc 140V execution, Intel NPU execution, parity, or performance

## Validation
- `cargo fmt -p bitnet-cli -- --check`
- `cargo test --locked -p bitnet-cli --bin bitnet tests::lunar_lake_probe_receipt_is_visibility_only -- --exact --nocapture`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- lunar-lake-probe --json-out target/lnl258v-platform-probe.json`
- parsed `target/lnl258v-platform-probe.json` with PowerShell `ConvertFrom-Json`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

Note: `cargo fmt --all` is blocked locally on Windows with `The filename or extension is too long. (os error 206)`, so I used the scoped `cargo fmt -p bitnet-cli -- --check` for the touched package.