### PR TITLE
[codex][apple-m4] Close out strict BitNet M4 proof (M4-014)

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -455,7 +455,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-014"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-014-strict-bitnet-proof"
 stackable = false
 requires_human_merge = true
@@ -485,4 +485,141 @@ must_not_claim = [
   "General M4 performance.",
   "Neural Engine execution unless resolved target is receipt-backed.",
   "Unsupported model, tokenizer, quantization, or kernel-family claims.",
+]
+
+[[work_item]]
+id = "M4-015"
+status = "ready"
+branch = "codex/apple-m4/M4-015-steady-decode-profile"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-014"]
+acceptance = "Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded."
+commands = [
+  "cargo fmt --all -- --check",
+  "Manual M4 steady decode or prefill profile command with receipt artifact",
+]
+allowed_paths = [
+  "crates/**/src/**",
+  "crates/**/tests/**",
+  "crates/**/benches/**",
+  "docs/tracking/campaigns/apple-m4/**",
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "M4 timing is recorded for the named BitNet phase and profile under captured machine context.",
+]
+must_not_claim = [
+  "General M4 performance.",
+  "Neural Engine execution.",
+  "QK256 acceleration on Apple Silicon.",
+]
+
+[[work_item]]
+id = "M4-016"
+status = "proposed"
+branch = "codex/apple-m4/M4-016-hot-loop-allocation-audit"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-015"]
+acceptance = "Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead."
+commands = [
+  "cargo fmt --all -- --check",
+  "Manual M4 decode allocation audit command with receipt or report artifact",
+]
+allowed_paths = [
+  "crates/**/src/**",
+  "crates/**/tests/**",
+  "crates/**/benches/**",
+  "docs/tracking/campaigns/apple-m4/**",
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Per-token allocation behavior is measured or bounded for the selected Apple BitNet path.",
+]
+must_not_claim = [
+  "Decode performance is compute-bound unless allocation overhead is separated.",
+  "QK256 acceleration on Apple Silicon.",
+  "General M4 performance.",
+]
+
+[[work_item]]
+id = "M4-017"
+status = "proposed"
+branch = "codex/apple-m4/M4-017-metal-kernel-family-expansion"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-016"]
+acceptance = "Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features metal",
+  "Manual M4 Metal kernel-family parity command with receipt artifact",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-kernels/tests/**",
+  "crates/**/tests/**",
+  "docs/tracking/campaigns/apple-m4/**",
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Specific Apple Metal BitNet kernels or subgraphs pass CPU reference parity with fallback_used=false receipts.",
+]
+must_not_claim = [
+  "Full Metal inference works unless strict real-model proof covers it.",
+  "QK256 works on Apple Silicon.",
+  "General M4 performance without benchmark receipts.",
+]
+
+[[work_item]]
+id = "M4-018"
+status = "proposed"
+branch = "codex/apple-m4/M4-018-cli-package-polish"
+stackable = false
+requires_human_merge = true
+blocked_by = ["M4-017"]
+acceptance = "Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
+]
+allowed_paths = [
+  "crates/bitnet-cli*/src/**",
+  "crates/**/tests/**",
+  "docs/tracking/campaigns/apple-m4/**",
+  "docs/hardware/apple-m4-mac-mini-validation.md",
+  "docs/specs/apple-m4-mac-mini-roadmap.md",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+]
+may_claim = [
+  "Apple backend CLI and package surfaces describe supported backend labels and failure modes accurately.",
+]
+must_not_claim = [
+  "New Metal kernel execution.",
+  "Neural Engine execution.",
+  "General M4 performance.",
 ]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T220554Z-M4-014-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T220554Z-M4-014-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T22:05:54Z"
+campaign = "apple-m4"
+item = "M4-014"
+event = "merged"
+pr = 3789
+merge_sha = "bc4e53f76fc984add799dd4da2e1c40d1b05acf1"
+actor = "codex"
+
+notes = [
+  "Closed out strict BitNet M4 proof after PR #3789 merged.",
+  "Recorded receipt-backed real GGUF, real tokenizer, selected Apple CPU/NEON backend, and fallback_used=false proof without claiming Metal, Neural Engine, QK256, or general performance.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -22,7 +22,11 @@
 | M4-011 | merged | #3769 | `codex/apple-m4/M4-011-metal-i2s-smoke-parity` | Run an I2_S-adjacent native Metal smoke or parity target against Apple CPU/NEON without claiming full inference. |
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
-| M4-014 | pr_open | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
+| M4-015 | ready | TBD | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
+| M4-016 | proposed | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
+| M4-017 | proposed | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
+| M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-014 | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -15,7 +15,11 @@
 | apple-m4 | M4-011 | M4-010 | merged |
 | apple-m4 | M4-012 | M4-011 | merged |
 | apple-m4 | M4-013 | M4-012 | merged |
-| apple-m4 | M4-014 | M4-013 | pr_open |
+| apple-m4 | M4-014 | M4-013 | merged |
+| apple-m4 | M4-015 | M4-014 | ready |
+| apple-m4 | M4-016 | M4-015 | proposed |
+| apple-m4 | M4-017 | M4-016 | proposed |
+| apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-014 | #3789 | pr_open | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-015 | TBD | ready | M4-016 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-007 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-014 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-015 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-007 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-014 closeout
Stackable: false

## Summary
- Marks M4-014 merged after #3789 landed at `bc4e53f76fc984add799dd4da2e1c40d1b05acf1`.
- Adds the append-only M4-014 merged event.
- Seeds the next Apple production-shaping items: M4-015 ready, M4-016 through M4-018 proposed.
- Regenerates campaign and global dashboards.

## Claim boundaries
- This is tracker-only.
- Does not touch runtime code, kernels, QK256, server inference, dependencies, or hardware artifacts.
- Does not add Metal, Neural Engine, QK256, or general performance claims.

## Verification
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
