### PR TITLE
docs(tracker): record LNL258V-003 merge

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -144,7 +144,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "LNL258V-003"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v-platform/LNL258V-003-cli-platform-probe"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T221411Z-LNL258V-003-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T221411Z-LNL258V-003-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T22:14:11Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-003"
+event = "merged"
+pr = 3795
+merge_sha = "1c4490708f4119368f831b393e4cab482f13890b"
+actor = "codex"
+
+notes = [
+  "Recorded merge of the visibility-only Lunar Lake platform probe CLI command.",
+  "The command emits platform probe receipts without BitNet inference, kernel execution, or OpenVINO graph execution claims.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -12,7 +12,7 @@
 | LNL258V-RUN-001 | merged | #3714 | `codex/intel-258v/LNL258V-RUN-001-platform-probe` | Add a JSON-ready Lunar Lake 258V platform probe that records CPU AVX2 facts, Arc 140V OpenCL/Level Zero/OpenVINO GPU visibility, Intel NPU OS/OpenVINO visibility, memory, power, OS, proof_stage=runtime_detected, and fallback_used=false without inference claims. |
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
-| LNL258V-003 | pr_open | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
+| LNL258V-003 | merged | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -4,5 +4,4 @@
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
 | apple-m4 | M4-014 | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
-| intel-258v-platform | LNL258V-003 | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -27,7 +27,7 @@
 | cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | ready |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
-| intel-258v-platform | LNL258V-003 | LNL258V-002 | pr_open |
+| intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-006 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-003 | #3795 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-006 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-003 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- mark LNL258V-003 merged after #3795 landed
- add the LNL258V-003 merge event with PR and merge SHA
- regenerate campaign dashboards to remove #3795 from active PR tracking

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign generate
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

Note: local Windows campaign generate --check and campaign doctor require the generator's temporary CRLF dashboard output. I restored unrelated EOL-only generated files before committing; the semantic tracker check passed locally.