### PR TITLE
feat(cli): add CPU258V-001 validation preflight

### DIFF
--- a/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
+++ b/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
@@ -1,77 +1,95 @@
 {
-  "schema": 1,
   "artifact_kind": "cpu-bitnet-validation",
-  "machine_id": "intel-258v",
-  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
-  "proof_stage": "blocked_preflight",
-  "status": "blocked_missing_canonical_model",
-  "fallback_used": false,
-  "validation_attempted": false,
-  "blocked_before_inference": true,
-  "blocker": {
-    "stage": "load_model",
-    "reason": "canonical BitNet GGUF fixture was not present at checked local paths",
-    "checked_paths": [
-      "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
-      "models/BitNet-b1.58-2B-4T/tokenizer.json",
-      "C:\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
-      "C:\\models\\BitNet-b1.58-2B-4T\\tokenizer.json"
-    ]
-  },
-  "hardware": {
-    "requested_backend": "cpu",
-    "selected_backend": "intel-258v-cpu-avx2",
-    "runtime_api": "cpu",
-    "cpu": {
-      "model": "Intel(R) Core(TM) Ultra 7 258V",
-      "cores": 8,
-      "threads": 8,
-      "avx2_detected": true,
-      "avx512_detected": false,
-      "fma_detected": true,
-      "sse42_detected": true
-    },
-    "platform_artifact": "ci/hardware/intel-258v/2026-05-06/platform-probe.json"
-  },
-  "model": {
-    "expected_repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
-    "expected_file": "ggml-model-i2_s.gguf",
-    "sha256": null,
-    "format": "gguf",
-    "architecture": "bitnet_b1_58",
-    "context_length": 4096,
-    "tokenizer": "llama3",
-    "vocab_size": 128256,
-    "loader_mode": null
-  },
+  "artifact_path": "ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json",
   "bitnet": {
-    "weight_quantization": "W1.58",
     "activation_quantization": "A8",
-    "weight_domain": "ternary",
+    "fallback_layout": null,
     "kernel_family": "i2_s|tl2|qk256",
     "layout": null,
     "layout_source": null,
-    "fallback_layout": null
+    "weight_domain": "ternary",
+    "weight_quantization": "W1.58"
   },
-  "execution": {
-    "phase": "load_model",
-    "prompt_tokens": 0,
-    "generated_tokens": 0,
-    "batch_size": 1,
-    "thread_count": 8,
-    "requested_backend": "intel-258v-cpu-avx2",
-    "selected_backend": "intel-258v-cpu-avx2",
-    "requested_kernel": null,
-    "selected_kernel": null,
-    "fallback_used": false,
-    "fallback_reason": null
+  "bitnet_inference": false,
+  "blocked_before_inference": true,
+  "blocker": {
+    "reason": "model path does not exist: models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+    "stage": "load_model"
   },
-  "claim_allowed": "The 258V CPU lane is ready for strict validation once the canonical GGUF/tokenizer fixture is available locally.",
+  "claim_allowed": "The 258V CPU lane emitted a structured validation blocker before inference.",
   "claims_not_allowed": [
     "Strict BitNet GGUF loaded on 258V",
-    "Tokenizer authority resolved on 258V",
+    "Tokenizer authority resolved through the inference path on 258V",
     "QK256 or TL2 execution ran on 258V",
     "BitNet inference works on 258V",
     "258V CPU benchmark performance"
-  ]
+  ],
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 0,
+    "max_tokens_requested": 1,
+    "phase": "load_model",
+    "prompt_tokens": 0,
+    "requested_backend": "intel-258v-cpu-avx2",
+    "requested_kernel": null,
+    "selected_backend": "intel-258v-cpu-avx2",
+    "selected_kernel": null,
+    "thread_count": 8
+  },
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "fallback_used": false,
+  "hardware": {
+    "cpu": {
+      "avx2_detected": true,
+      "avx512_detected": false,
+      "cores": 8,
+      "features": [
+        "avx2",
+        "avx",
+        "fma",
+        "sse4.2",
+        "sse2"
+      ],
+      "fma_detected": true,
+      "lp_e_core_count": 4,
+      "model": "Intel(R) Core(TM) Ultra 7 258V",
+      "p_core_count": 4,
+      "sse42_detected": true,
+      "threads": 8
+    },
+    "platform_artifact": "ci/hardware/intel-258v/2026-05-06/platform-probe.json",
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "intel-258v-cpu-avx2"
+  },
+  "hardware_lane": "intel-258v-cpu-avx2",
+  "kernel_execution": false,
+  "machine_id": "intel-258v",
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "exists": false,
+    "expected_file": "ggml-model-i2_s.gguf",
+    "expected_repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "format": "gguf",
+    "loader_mode": null,
+    "path": "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+    "sha256": null,
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "proof_stage": "blocked_preflight",
+  "schema": 1,
+  "status": "blocked_missing_canonical_model",
+  "strict": true,
+  "timestamp_utc": "2026-05-06T23:08:57Z",
+  "tokenizer": {
+    "path": null,
+    "source": null,
+    "strict": true
+  },
+  "validation_attempted": false
 }

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -400,6 +400,12 @@ enum Commands {
         json_out: Option<std::path::PathBuf>,
     },
 
+    /// Run validation-only preflight checks
+    Validate {
+        #[command(subcommand)]
+        action: ValidateAction,
+    },
+
     /// Compile and launch a tiny CUDA vector-add kernel
     CudaSmoke {
         /// CUDA device index to probe and launch on
@@ -449,6 +455,44 @@ enum Commands {
         /// Output in JSON format
         #[arg(long)]
         json: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum ValidateAction {
+    /// Emit a CPU BitNet validation preflight receipt without running inference
+    CpuBitnet {
+        /// Machine label for the validation target
+        #[arg(long, default_value = "intel-258v")]
+        machine: String,
+
+        /// Canonical BitNet GGUF model path
+        #[arg(long)]
+        model: std::path::PathBuf,
+
+        /// Optional tokenizer artifact path
+        #[arg(long)]
+        tokenizer: Option<std::path::PathBuf>,
+
+        /// Requested backend identity
+        #[arg(long, default_value = "cpu")]
+        backend: String,
+
+        /// Require strict, no-fallback validation semantics
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+
+        /// Maximum tokens intended for the eventual validation run
+        #[arg(long, visible_aliases = ["max-tokens", "n-predict"], default_value_t = 1)]
+        max_tokens: usize,
+
+        /// Same-machine platform artifact to cross-link
+        #[arg(long)]
+        platform_artifact: Option<std::path::PathBuf>,
+
+        /// Output JSON validation receipt to file
+        #[arg(long)]
+        json_out: Option<std::path::PathBuf>,
     },
 }
 
@@ -620,6 +664,7 @@ async fn main() -> Result<()> {
         Some(Commands::LunarLakeProbe { json_out }) => {
             handle_lunar_lake_probe_command(json_out).await
         }
+        Some(Commands::Validate { action }) => handle_validate_command(action).await,
         Some(Commands::CudaSmoke { device_index, json_out }) => {
             handle_cuda_smoke_command(&requested_backend_label, device_index, json_out).await
         }
@@ -988,6 +1033,273 @@ async fn handle_lunar_lake_probe_command(json_out: Option<std::path::PathBuf>) -
     write_json_output(json_out.as_ref(), &receipt)?;
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct CpuBitnetValidationPreflight {
+    status: &'static str,
+    proof_stage: &'static str,
+    validation_attempted: bool,
+    blocked_before_inference: bool,
+    blocker_stage: Option<&'static str>,
+    blocker_reason: Option<String>,
+    tokenizer_source: Option<String>,
+    tokenizer_path: Option<std::path::PathBuf>,
+    model_sha256: Option<String>,
+}
+
+fn sibling_tokenizer_path(model_path: &std::path::Path) -> Option<std::path::PathBuf> {
+    let parent = model_path.parent()?;
+    for name in ["tokenizer.json", "tokenizer.model"] {
+        let candidate = parent.join(name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn cpu_bitnet_validation_preflight(
+    model_path: &std::path::Path,
+    tokenizer_path: Option<&std::path::Path>,
+    backend: &str,
+    strict: bool,
+) -> CpuBitnetValidationPreflight {
+    if backend != "cpu" && backend != "intel-258v-cpu-avx2" {
+        return CpuBitnetValidationPreflight {
+            status: "blocked_wrong_backend",
+            proof_stage: "blocked_preflight",
+            validation_attempted: false,
+            blocked_before_inference: true,
+            blocker_stage: Some("backend_selection"),
+            blocker_reason: Some(format!(
+                "CPU258V validation is CPU-only; requested backend was {backend:?}"
+            )),
+            tokenizer_source: None,
+            tokenizer_path: None,
+            model_sha256: None,
+        };
+    }
+
+    if !model_path.exists() {
+        return CpuBitnetValidationPreflight {
+            status: "blocked_missing_canonical_model",
+            proof_stage: "blocked_preflight",
+            validation_attempted: false,
+            blocked_before_inference: true,
+            blocker_stage: Some("load_model"),
+            blocker_reason: Some(format!("model path does not exist: {}", model_path.display())),
+            tokenizer_source: None,
+            tokenizer_path: None,
+            model_sha256: None,
+        };
+    }
+
+    let resolved_tokenizer = if let Some(path) = tokenizer_path {
+        if path.exists() { Some(("explicit".to_string(), path.to_path_buf())) } else { None }
+    } else {
+        sibling_tokenizer_path(model_path).map(|path| {
+            let source =
+                if path.file_name().and_then(|name| name.to_str()) == Some("tokenizer.json") {
+                    "sibling_tokenizer_json"
+                } else {
+                    "sibling_sentencepiece"
+                };
+            (source.to_string(), path)
+        })
+    };
+
+    let Some((tokenizer_source, tokenizer_path)) = resolved_tokenizer else {
+        return CpuBitnetValidationPreflight {
+            status: "blocked_missing_tokenizer",
+            proof_stage: "blocked_preflight",
+            validation_attempted: false,
+            blocked_before_inference: true,
+            blocker_stage: Some("tokenize_prompt"),
+            blocker_reason: Some(if strict {
+                "strict validation requires an explicit tokenizer or sibling tokenizer asset"
+                    .to_string()
+            } else {
+                "tokenizer artifact was not found; no fallback tokenizer is used by CPU258V validation"
+                    .to_string()
+            }),
+            tokenizer_source: None,
+            tokenizer_path: None,
+            model_sha256: None,
+        };
+    };
+
+    let model_sha256 = compute_model_sha256(model_path).ok();
+
+    CpuBitnetValidationPreflight {
+        status: "preflight_ready",
+        proof_stage: "runtime_detected",
+        validation_attempted: false,
+        blocked_before_inference: false,
+        blocker_stage: None,
+        blocker_reason: None,
+        tokenizer_source: Some(tokenizer_source),
+        tokenizer_path: Some(tokenizer_path),
+        model_sha256,
+    }
+}
+
+struct CpuBitnetValidationReceiptInput {
+    machine: String,
+    model: std::path::PathBuf,
+    tokenizer: Option<std::path::PathBuf>,
+    backend: String,
+    strict: bool,
+    max_tokens: usize,
+    platform_artifact: Option<std::path::PathBuf>,
+    json_out: Option<std::path::PathBuf>,
+    timestamp_utc: String,
+}
+
+fn build_cpu_bitnet_validation_receipt(
+    input: CpuBitnetValidationReceiptInput,
+) -> serde_json::Value {
+    let platform = bitnet_device_probe::probe_lnl258v_platform();
+    let preflight = cpu_bitnet_validation_preflight(
+        &input.model,
+        input.tokenizer.as_deref(),
+        &input.backend,
+        input.strict,
+    );
+    let cpu_features = detected_cpu_feature_labels();
+    let thread_count = platform.cpu.threads.max(1);
+    let artifact_path = input.json_out.as_ref().map(|path| path.display().to_string());
+    let platform_artifact = input.platform_artifact.as_ref().map(|path| path.display().to_string());
+    let tokenizer_path = preflight.tokenizer_path.as_ref().map(|path| path.display().to_string());
+    let blocker = match (preflight.blocker_stage, preflight.blocker_reason.as_ref()) {
+        (Some(stage), Some(reason)) => serde_json::json!({
+            "stage": stage,
+            "reason": reason,
+        }),
+        _ => serde_json::Value::Null,
+    };
+
+    serde_json::json!({
+        "schema": 1,
+        "artifact_kind": "cpu-bitnet-validation",
+        "machine_id": input.machine,
+        "hardware_lane": "intel-258v-cpu-avx2",
+        "timestamp_utc": input.timestamp_utc,
+        "proof_stage": preflight.proof_stage,
+        "status": preflight.status,
+        "validation_attempted": preflight.validation_attempted,
+        "blocked_before_inference": preflight.blocked_before_inference,
+        "blocker": blocker,
+        "strict": input.strict,
+        "fallback_used": false,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "kernel_execution": false,
+        "bitnet_inference": false,
+        "hardware": {
+            "requested_backend": input.backend,
+            "selected_backend": "intel-258v-cpu-avx2",
+            "runtime_api": "cpu",
+            "cpu": {
+                "model": platform.cpu.brand,
+                "cores": platform.cpu.cores,
+                "threads": platform.cpu.threads,
+                "p_core_count": platform.cpu.p_core_count,
+                "lp_e_core_count": platform.cpu.lp_e_core_count,
+                "avx2_detected": platform.cpu.has_avx2,
+                "avx512_detected": platform.cpu.has_avx512,
+                "fma_detected": platform.cpu.has_fma,
+                "sse42_detected": platform.cpu.has_sse42,
+                "features": cpu_features,
+            },
+            "platform_artifact": platform_artifact,
+        },
+        "model": {
+            "expected_repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+            "expected_file": "ggml-model-i2_s.gguf",
+            "path": input.model.display().to_string(),
+            "exists": input.model.exists(),
+            "sha256": preflight.model_sha256,
+            "format": "gguf",
+            "architecture": "bitnet_b1_58",
+            "context_length": 4096,
+            "tokenizer": "llama3",
+            "vocab_size": 128256,
+            "loader_mode": null,
+        },
+        "tokenizer": {
+            "path": tokenizer_path,
+            "source": preflight.tokenizer_source,
+            "strict": input.strict,
+        },
+        "bitnet": {
+            "weight_quantization": "W1.58",
+            "activation_quantization": "A8",
+            "weight_domain": "ternary",
+            "kernel_family": "i2_s|tl2|qk256",
+            "layout": null,
+            "layout_source": null,
+            "fallback_layout": null,
+        },
+        "execution": {
+            "phase": "load_model",
+            "prompt_tokens": 0,
+            "generated_tokens": 0,
+            "max_tokens_requested": input.max_tokens,
+            "batch_size": 1,
+            "thread_count": thread_count,
+            "requested_backend": "intel-258v-cpu-avx2",
+            "selected_backend": "intel-258v-cpu-avx2",
+            "requested_kernel": null,
+            "selected_kernel": null,
+            "fallback_used": false,
+            "fallback_reason": null,
+        },
+        "claim_allowed": if preflight.status == "preflight_ready" {
+            "The 258V CPU lane preflight found the requested model and tokenizer artifacts; no inference was run."
+        } else {
+            "The 258V CPU lane emitted a structured validation blocker before inference."
+        },
+        "claims_not_allowed": [
+            "Strict BitNet GGUF loaded on 258V",
+            "Tokenizer authority resolved through the inference path on 258V",
+            "QK256 or TL2 execution ran on 258V",
+            "BitNet inference works on 258V",
+            "258V CPU benchmark performance"
+        ],
+        "artifact_path": artifact_path,
+    })
+}
+
+async fn handle_validate_command(action: ValidateAction) -> Result<()> {
+    match action {
+        ValidateAction::CpuBitnet {
+            machine,
+            model,
+            tokenizer,
+            backend,
+            strict,
+            max_tokens,
+            platform_artifact,
+            json_out,
+        } => {
+            let timestamp_utc =
+                chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let receipt = build_cpu_bitnet_validation_receipt(CpuBitnetValidationReceiptInput {
+                machine,
+                model,
+                tokenizer,
+                backend,
+                strict,
+                max_tokens,
+                platform_artifact,
+                json_out: json_out.clone(),
+                timestamp_utc,
+            });
+            write_json_output(json_out.as_ref(), &receipt)?;
+            Ok(())
+        }
+    }
 }
 
 struct CudaSmokeReceiptFields {
@@ -2731,6 +3043,53 @@ mod tests {
         assert_eq!(receipt["bitnet_inference"], false);
         assert_eq!(receipt["fallback_used"], false);
         assert!(receipt["platform"]["cpu"]["has_avx512"].is_boolean());
+    }
+
+    #[test]
+    fn cpu258v_validation_blocks_missing_model_before_inference() {
+        let missing_model = std::env::temp_dir()
+            .join(format!("bitnet-missing-{}-ggml-model-i2_s.gguf", std::process::id()));
+        let receipt = build_cpu_bitnet_validation_receipt(CpuBitnetValidationReceiptInput {
+            machine: "intel-258v".to_string(),
+            model: missing_model,
+            tokenizer: None,
+            backend: "cpu".to_string(),
+            strict: true,
+            max_tokens: 1,
+            platform_artifact: None,
+            json_out: None,
+            timestamp_utc: "2026-05-06T00:00:00Z".to_string(),
+        });
+
+        assert_eq!(receipt["artifact_kind"], "cpu-bitnet-validation");
+        assert_eq!(receipt["hardware_lane"], "intel-258v-cpu-avx2");
+        assert_eq!(receipt["proof_stage"], "blocked_preflight");
+        assert_eq!(receipt["status"], "blocked_missing_canonical_model");
+        assert_eq!(receipt["blocked_before_inference"], true);
+        assert_eq!(receipt["kernel_execution"], false);
+        assert_eq!(receipt["bitnet_inference"], false);
+        assert_eq!(receipt["fallback_used"], false);
+        assert_eq!(receipt["blocker"]["stage"], "load_model");
+    }
+
+    #[test]
+    fn cpu258v_validation_rejects_accelerator_backend() {
+        let receipt = build_cpu_bitnet_validation_receipt(CpuBitnetValidationReceiptInput {
+            machine: "intel-258v".to_string(),
+            model: std::path::PathBuf::from("models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf"),
+            tokenizer: None,
+            backend: "intel-npu".to_string(),
+            strict: true,
+            max_tokens: 1,
+            platform_artifact: None,
+            json_out: None,
+            timestamp_utc: "2026-05-06T00:00:00Z".to_string(),
+        });
+
+        assert_eq!(receipt["status"], "blocked_wrong_backend");
+        assert_eq!(receipt["blocker"]["stage"], "backend_selection");
+        assert_eq!(receipt["hardware"]["requested_backend"], "intel-npu");
+        assert_eq!(receipt["bitnet_inference"], false);
     }
 }
 

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -145,6 +145,31 @@ The command records `proof_stage=runtime_detected`, `runtime_api=platform_probe`
 `fallback_used=false`, and a `must_not_claim` list. It does not replace the
 lane-specific Arc 140V, NPU, CPU BitNet, parity, or benchmark artifacts.
 
+### CPU BitNet Validation Preflight
+
+Use the CPU validation command to emit the Lunar Lake CPU lane artifact without
+taking ownership of CPU implementation internals:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- validate cpu-bitnet \
+  --machine intel-258v \
+  --model /models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --tokenizer /models/BitNet-b1.58-2B-4T/tokenizer.json \
+  --backend cpu \
+  --strict \
+  --max-tokens 1 \
+  --platform-artifact ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json \
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/cpu-bitnet-validation.json
+```
+
+This command is validation-only. If the canonical GGUF or tokenizer is absent,
+it writes `proof_stage=blocked_preflight` with a structured blocker. It does not
+load BitNet tensors, run QK256/TL2 kernels, decode tokens, or make benchmark
+claims.
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -28,6 +28,7 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 | ARC140V-002 | merged | Add exact Arc 140V runtime identity probe logic. |
 | LNL258V-002 | merged | Add 258V probe bundle and same-machine comparison hooks. |
 | LNL258V-003 | merged | Add CLI platform probe emission for the current 258V machine. |
+| CPU258V-001 | ready | Add a validation-only CPU BitNet preflight harness for the 258V lane. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -181,6 +181,51 @@ may_claim = [
 must_not_claim = [
   "BitNet inference works on 258V.",
   "Arc 140V execution works.",
-  "Intel NPU execution works.",
-  "OpenVINO graph execution works.",
+    "Intel NPU execution works.",
+    "OpenVINO graph execution works.",
+]
+
+[[work_item]]
+id = "CPU258V-001"
+status = "pr_open"
+branch = "codex/intel-258v-platform/CPU258V-001-validation-harness"
+stackable = false
+requires_human_merge = true
+blocked_by = ["LNL258V-003"]
+acceptance = "Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals."
+commands = [
+  "cargo fmt -p bitnet-cli -- --check",
+  "cargo test --locked -p bitnet-cli --bin bitnet tests::cpu258v_validation_blocks_missing_model_before_inference -- --exact --nocapture",
+  "cargo test --locked -p bitnet-cli --bin bitnet tests::cpu258v_validation_rejects_accelerator_backend -- --exact --nocapture",
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- validate cpu-bitnet --machine intel-258v --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --tokenizer models/BitNet-b1.58-2B-4T/tokenizer.json --backend cpu --strict --max-tokens 1 --platform-artifact ci/hardware/intel-258v/2026-05-06/platform-probe.json --json-out target/cpu258v-bitnet-validation.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/main.rs",
+  "ci/hardware/intel-258v/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-buildout-plan.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "The 258V CPU validation harness can emit blocked_preflight or preflight_ready artifacts.",
+]
+must_not_claim = [
+  "Strict BitNet GGUF loaded on 258V.",
+  "QK256 or TL2 execution ran on 258V.",
+  "BitNet inference works on 258V.",
+  "258V CPU benchmark performance.",
 ]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T231430Z-CPU258V-001-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T231430Z-CPU258V-001-pr-open.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-06T23:14:30Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-001"
+event = "pr_open"
+pr = 3802
+branch = "codex/intel-258v-platform/CPU258V-001-validation-harness"
+head_sha = "7c242d1ee2e3993d390e2c34a843423f6f9380f9"
+actor = "codex"
+
+notes = [
+  "Opened CPU258V-001 as a validation-only CPU BitNet preflight harness.",
+  "The PR emits structured blocked_preflight artifacts without touching loader, tokenizer, QK256, CPU kernel, or transformer decode internals.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -13,6 +13,7 @@
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 | LNL258V-003 | merged | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
+| CPU258V-001 | pr_open | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-258v-platform | CPU258V-001 | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -33,6 +33,7 @@
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
+| intel-258v-platform | CPU258V-001 | LNL258V-003 | pr_open |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-007 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | CPU258V-001 | #3802 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | RTX5070TI-003 | #3679 | merged | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-007 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | RTX5070TI-003 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- implement itnet validate cpu-bitnet for the Core Ultra 7 258V validation lane
- emit validation-only CPU BitNet receipts with structured locked_preflight or preflight_ready status
- refresh the 258V CPU validation artifact from this device; the canonical GGUF/tokenizer are absent, so it records a load-model blocker before inference
- add CPU258V-001 to the 258V platform campaign as validation-only work

## Claim boundary
- this does not run BitNet inference
- this does not load QK256/TL2 kernels, launch CPU kernels, or touch transformer decode internals
- this does not transfer CPU implementation ownership from the 8250U lane
- this does not make benchmark or performance claims

## Validation
- cargo test --locked -p bitnet-cli --bin bitnet tests::cpu258v_validation_blocks_missing_model_before_inference -- --exact --nocapture
- cargo test --locked -p bitnet-cli --bin bitnet tests::cpu258v_validation_rejects_accelerator_backend -- --exact --nocapture
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- validate cpu-bitnet --machine intel-258v --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --tokenizer models/BitNet-b1.58-2B-4T/tokenizer.json --backend cpu --strict --max-tokens 1 --platform-artifact ci/hardware/intel-258v/2026-05-06/platform-probe.json --json-out target/cpu258v-bitnet-validation-rebased.json
- parsed the emitted JSON with PowerShell ConvertFrom-Json
- cargo run --locked -p xtask --no-default-features -- campaign generate
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check HEAD~1..HEAD

Note: local Windows cargo fmt -p bitnet-cli -- --check is blocked by existing newline-style drift across unrelated itnet-cli files. I ran cargo fmt -p bitnet-cli, restored unrelated line-ending-only files, and kept only the formatted main.rs changes.