### PR TITLE
docs(tracker): record CPU258V-001 merge

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -187,7 +187,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU258V-001"
-status = "pr_open"
+status = "merged"
 branch = "codex/intel-258v-platform/CPU258V-001-validation-harness"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T232309Z-CPU258V-001-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-06T232309Z-CPU258V-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T23:23:09Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-001"
+event = "merged"
+pr = 3802
+merge_sha = "38827fc2caa73726b35f4f5d0b53c2c3b1f1f876"
+actor = "codex"
+
+notes = [
+  "Recorded merge of the 258V CPU BitNet validation preflight harness.",
+  "The merged command emits structured blocked_preflight or preflight_ready artifacts without claiming inference or performance.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -13,7 +13,7 @@
 | ARC140V-002 | merged | #3727 | `codex/intel-arc/ARC140V-002-runtime-probe` | Probe exact Arc 140V runtime visibility by name or PCI ID 0x64A0 across OpenCL, Level Zero, and OpenVINO GPU.0 while recording proof_stage=runtime_detected, requested/selected backend identity, runtime API, and fallback_used=false. |
 | LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 | LNL258V-003 | merged | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
-| CPU258V-001 | pr_open | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
+| CPU258V-001 | merged | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-258v-platform | CPU258V-001 | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
 | nvidia-5070ti | CUDA-BITNET-006 | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -33,7 +33,7 @@
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
-| intel-258v-platform | CPU258V-001 | LNL258V-003 | pr_open |
+| intel-258v-platform | CPU258V-001 | LNL258V-003 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | CPU-BITNET-007 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-001 | #3802 | pr_open | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | CUDA-BITNET-006 | #3801 | pr_open | CUDA-BITNET-007 | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,7 +9,7 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-007 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-006 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Summary
- mark `CPU258V-001` merged in the Intel 258V platform campaign
- add the merge event for #3802 at merge SHA `38827fc2caa73726b35f4f5d0b53c2c3b1f1f876`
- refresh generated tracking dashboards so the item leaves the active/blocked PR views

## Verification
- `cargo run --locked -p xtask --no-default-features -- campaign generate`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

Note: On Windows, unrelated generated campaign status files were restored after validation to avoid CRLF-only churn.