### PR TITLE
[codex][apple-m4] Close out M4-015 profile item

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -489,7 +489,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-015"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-015-steady-decode-profile"
 stackable = false
 requires_human_merge = true
@@ -524,7 +524,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-016"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-016-hot-loop-allocation-audit"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-06T235644Z-M4-015-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-06T235644Z-M4-015-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-06T23:56:44Z"
+campaign = "apple-m4"
+item = "M4-015"
+event = "merged"
+pr = 3804
+merge_sha = "8ec65c36bbb78af8edb891919023e92fbc89cd90"
+actor = "codex"
+
+notes = [
+  "Closed out steady decode and prefill timing profile after PR #3804 merged.",
+  "Recorded selected Apple backend timing profile context without claiming general M4 performance, Neural Engine execution, QK256 acceleration, or unsupported Apple Silicon acceleration.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -23,8 +23,8 @@
 | M4-012 | merged | #3775 | `codex/apple-m4/M4-012-tl1-arm-investigation` | Investigate TL1 as an Apple CPU/NEON-oriented BitNet path and document any Metal conversion boundaries honestly. |
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
-| M4-015 | pr_open | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
-| M4-016 | proposed | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
+| M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
+| M4-016 | ready | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | proposed | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-015 | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | nvidia-5070ti | CUDA-BITNET-006 | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -16,8 +16,8 @@
 | apple-m4 | M4-012 | M4-011 | merged |
 | apple-m4 | M4-013 | M4-012 | merged |
 | apple-m4 | M4-014 | M4-013 | merged |
-| apple-m4 | M4-015 | M4-014 | pr_open |
-| apple-m4 | M4-016 | M4-015 | proposed |
+| apple-m4 | M4-015 | M4-014 | merged |
+| apple-m4 | M4-016 | M4-015 | ready |
 | apple-m4 | M4-017 | M4-016 | proposed |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-015 | #3804 | pr_open | M4-016 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-016 | TBD | ready | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-015 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-016 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-008 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-015
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Marks M4-015 merged after #3804 landed as `8ec65c36bbb78af8edb891919023e92fbc89cd90`.
- Promotes M4-016 hot-loop allocation audit to ready.
- Adds an append-only M4-015 merged event and regenerates campaign/global dashboards.

## Boundaries
- Tracker-only closeout.
- No runtime, kernel, QK256, server, dependency, or legacy global tracker edits.
- Does not claim general M4 performance, Neural Engine execution, QK256 acceleration, or unsupported Apple Silicon acceleration.

## Verification
- `cargo run --locked -p xtask --no-default-features -- campaign status apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo fmt --all -- --check`
- `git diff --check`
