### PR TITLE
docs(intel): record 258V CPU BitNet preflight readiness

### DIFF
--- a/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
+++ b/ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json
@@ -11,12 +11,9 @@
     "weight_quantization": "W1.58"
   },
   "bitnet_inference": false,
-  "blocked_before_inference": true,
-  "blocker": {
-    "reason": "model path does not exist: models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
-    "stage": "load_model"
-  },
-  "claim_allowed": "The 258V CPU lane emitted a structured validation blocker before inference.",
+  "blocked_before_inference": false,
+  "blocker": null,
+  "claim_allowed": "The 258V CPU lane preflight found the requested model and tokenizer artifacts; no inference was run.",
   "claims_not_allowed": [
     "Strict BitNet GGUF loaded on 258V",
     "Tokenizer authority resolved through the inference path on 258V",
@@ -71,24 +68,24 @@
   "model": {
     "architecture": "bitnet_b1_58",
     "context_length": 4096,
-    "exists": false,
+    "exists": true,
     "expected_file": "ggml-model-i2_s.gguf",
     "expected_repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
     "format": "gguf",
     "loader_mode": null,
     "path": "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
-    "sha256": null,
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
     "tokenizer": "llama3",
     "vocab_size": 128256
   },
-  "proof_stage": "blocked_preflight",
+  "proof_stage": "runtime_detected",
   "schema": 1,
-  "status": "blocked_missing_canonical_model",
+  "status": "preflight_ready",
   "strict": true,
-  "timestamp_utc": "2026-05-06T23:08:57Z",
+  "timestamp_utc": "2026-05-07T00:06:02Z",
   "tokenizer": {
-    "path": null,
-    "source": null,
+    "path": "models/BitNet-b1.58-2B-4T/tokenizer.json",
+    "source": "explicit",
     "strict": true
   },
   "validation_attempted": false

--- a/ci/hardware/intel-258v/2026-05-06/platform-comparison-index.json
+++ b/ci/hardware/intel-258v/2026-05-06/platform-comparison-index.json
@@ -3,7 +3,7 @@
   "artifact_kind": "platform-comparison-index",
   "machine_id": "intel-258v",
   "date": "2026-05-06",
-  "captured_at_utc": "2026-05-06T20:40:07.8183866Z",
+  "captured_at_utc": "2026-05-07T00:06:02Z",
   "proof_stage": "detected",
   "artifacts": {
     "platform": "ci/hardware/intel-258v/2026-05-06/platform-probe.json",
@@ -15,7 +15,7 @@
   "lanes": {
     "cpu": {
       "proof_label": "intel-258v-cpu-avx2",
-      "proof_stage": "blocked_preflight",
+      "proof_stage": "preflight_ready",
       "artifact": "ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json"
     },
     "arc140v": {
@@ -30,7 +30,7 @@
     }
   },
   "fallback_used": false,
-  "claim_allowed": "Same-machine 258V OS visibility artifacts are linked for later runtime and BitNet validation.",
+  "claim_allowed": "Same-machine 258V OS visibility artifacts and CPU BitNet preflight readiness are linked for later runtime and BitNet validation.",
   "claims_not_allowed": [
     "Arc 140V runtime execution works",
     "Intel NPU OpenVINO execution works",

--- a/ci/hardware/intel-258v/2026-05-06/platform-probe-notes.md
+++ b/ci/hardware/intel-258v/2026-05-06/platform-probe-notes.md
@@ -9,6 +9,12 @@ after the CLI receipt path landed. It is a runtime-visibility receipt only and
 keeps `kernel_execution=false`, `graph_execution=false`, and
 `bitnet_inference=false`.
 
+`cpu-bitnet-validation.json` was refreshed after the canonical BitNet GGUF and
+explicit tokenizer were made available locally under the ignored `models/`
+tree. It records `status=preflight_ready`, the GGUF SHA-256, explicit tokenizer
+source, CPU AVX2 visibility, and `fallback_used=false` without running BitNet
+inference or CPU kernels.
+
 ## Captured Facts
 
 - Machine: Lenovo `83MC`
@@ -25,7 +31,11 @@ keeps `kernel_execution=false`, `graph_execution=false`, and
 - `clinfo` is not installed in PATH, so this bundle does not prove OpenCL runtime visibility.
 - `sycl-ls` and `ze_info` are not installed in PATH, so this bundle does not prove Level Zero runtime visibility.
 - Python cannot import `openvino`, so this bundle does not prove OpenVINO GPU or NPU visibility.
-- The canonical BitNet GGUF fixture was not present at the checked local paths, so CPU BitNet validation is recorded as `blocked_preflight`.
+- The canonical BitNet GGUF and explicit tokenizer are present locally, so CPU
+  BitNet validation is recorded as `preflight_ready`.
+- CPU BitNet preflight readiness is not strict GGUF loading through the
+  inference path, tokenizer resolution through the inference path, QK256/TL2
+  kernel execution, or BitNet generation.
 - The CLI probe reports Arc 140V runtime identity as unavailable because the
   OpenCL, Level Zero, and OpenVINO runtime tools were not available to the
   command, even though the OS/PnP artifact records the Arc 140V device identity.

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-07T005900Z-CPU258V-001-preflight-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-07T005900Z-CPU258V-001-preflight-ready.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-07T00:59:00Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-001"
+event = "in_progress"
+actor = "codex"
+
+artifacts = [
+  "ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json",
+  "ci/hardware/intel-258v/2026-05-06/platform-comparison-index.json",
+]
+
+notes = [
+  "Recorded the 258V CPU BitNet validation artifact advancing from blocked_missing_canonical_model to preflight_ready.",
+  "The artifact proves strict preflight readiness only; it does not claim BitNet inference, kernel execution, parity, or benchmark performance.",
+]


### PR DESCRIPTION
## Summary
- refresh the Core Ultra 7 258V CPU BitNet validation artifact after placing the canonical GGUF and explicit tokenizer in the ignored local `models/` tree
- advance `cpu-bitnet-validation.json` from `blocked_missing_canonical_model` to `preflight_ready`
- update the platform comparison index and notes while preserving the no-inference/no-kernel claim boundary

## Evidence
- model: `models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf`
- tokenizer: `models/BitNet-b1.58-2B-4T/tokenizer.json`
- model SHA-256 recorded in artifact: `4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162`
- artifact keeps `bitnet_inference=false`, `kernel_execution=false`, and `fallback_used=false`

## Verification
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- validate cpu-bitnet --machine intel-258v --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --tokenizer models/BitNet-b1.58-2B-4T/tokenizer.json --backend cpu --strict --max-tokens 1 --platform-artifact ci/hardware/intel-258v/2026-05-06/platform-probe.json --json-out ci/hardware/intel-258v/2026-05-06/cpu-bitnet-validation.json`
- parsed `cpu-bitnet-validation.json` and `platform-comparison-index.json` with PowerShell `ConvertFrom-Json`
- `git diff --check HEAD~1..HEAD`