### PR TITLE
[codex][apple-m4] Add hot-loop allocation audit (M4-016)

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -16,8 +16,65 @@ use candle_core::{DType, IndexOp};
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use console::style;
+use std::alloc::{GlobalAlloc, Layout, System};
 use std::io;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use tracing::{debug, error, info, warn};
+
+#[global_allocator]
+static ALLOCATION_AUDIT_ALLOCATOR: AllocationAuditAllocator = AllocationAuditAllocator;
+
+static ALLOCATION_AUDIT_ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOCATION_AUDIT_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_DEALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
+static ALLOCATION_AUDIT_DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+
+struct AllocationAuditAllocator;
+
+unsafe impl GlobalAlloc for AllocationAuditAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc_zeroed(layout) };
+        if !ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_dealloc(layout.size());
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() && ALLOCATION_AUDIT_ENABLED.load(Ordering::Relaxed) {
+            record_allocation_audit_dealloc(layout.size());
+            record_allocation_audit_alloc(new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_allocation_audit_alloc(size: usize) {
+    ALLOCATION_AUDIT_ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    ALLOCATION_AUDIT_ALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
+}
+
+fn record_allocation_audit_dealloc(size: usize) {
+    ALLOCATION_AUDIT_DEALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+    ALLOCATION_AUDIT_DEALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
+}
 
 #[cfg(feature = "full-cli")]
 mod commands;
@@ -295,6 +352,10 @@ enum Commands {
         /// Profile label to record in JSON receipts (for example: smoke_1, prefill_512, decode_128)
         #[arg(long, value_name = "PROFILE")]
         profile_id: Option<String>,
+
+        /// Measure scoped hot-loop allocation counter deltas in profile receipts
+        #[arg(long, default_value_t = false)]
+        allocation_audit: bool,
     },
 
     /// Tokenize text and output token IDs as JSON
@@ -612,6 +673,7 @@ async fn main() -> Result<()> {
             assert_greedy,
             no_warnings,
             profile_id,
+            allocation_audit,
         }) => {
             run_simple_generation(
                 &requested_backend_label,
@@ -645,6 +707,7 @@ async fn main() -> Result<()> {
                 assert_greedy,
                 no_warnings,
                 profile_id,
+                allocation_audit,
             )
             .await
         }
@@ -1980,6 +2043,7 @@ async fn run_simple_generation(
     assert_greedy: bool,
     no_warnings: bool,
     profile_id: Option<String>,
+    allocation_audit: bool,
 ) -> Result<()> {
     use bitnet_common::Device;
     use bitnet_models::{Model, transformer::KVCache};
@@ -2314,15 +2378,30 @@ async fn run_simple_generation(
     // M4-015 profiles measure prompt prefix prefill only when explicitly requested.
     // Default generation behavior remains unchanged for non-profile runs.
     let profile_requested = profile_id.is_some();
+    if allocation_audit && !profile_requested {
+        anyhow::bail!(
+            "--allocation-audit requires --profile-id so allocation claims are receipt-scoped"
+        );
+    }
+    if allocation_audit && json_out.is_none() {
+        anyhow::bail!("--allocation-audit requires --json-out so allocation claims are durable");
+    }
+    let allocation_audit_enabled = allocation_audit;
+    let allocation_audit_guard = AllocationAuditGuard::enable(allocation_audit_enabled);
     let mut prefill_token_count = 0usize;
     let mut prefill_step_ms = Vec::new();
+    let mut prefill_step_allocs = Vec::new();
     let prefill_start = std::time::Instant::now();
     if profile_requested && tokens.len() > 1 {
         for token in &tokens[..tokens.len() - 1] {
             let step_start = std::time::Instant::now();
+            let step_alloc_start = AllocationAuditSnapshot::current();
             let x = model.embed(&[*token])?;
             let _ = model.forward(&x, any_cache.as_mut())?;
             prefill_step_ms.push(elapsed_ms(step_start));
+            if allocation_audit_enabled {
+                prefill_step_allocs.push(AllocationAuditSnapshot::delta_since(step_alloc_start));
+            }
             prefill_token_count += 1;
         }
     }
@@ -2362,15 +2441,26 @@ async fn run_simple_generation(
     let mut logits_step_ms = Vec::with_capacity(max_new_tokens);
     let mut sample_step_ms = Vec::with_capacity(max_new_tokens);
     let mut token_decode_step_ms = Vec::with_capacity(max_new_tokens);
+    let mut decode_step_allocs = Vec::with_capacity(max_new_tokens);
+    let mut embed_step_allocs = Vec::with_capacity(max_new_tokens);
+    let mut forward_step_allocs = Vec::with_capacity(max_new_tokens);
+    let mut logits_step_allocs = Vec::with_capacity(max_new_tokens);
+    let mut sample_step_allocs = Vec::with_capacity(max_new_tokens);
+    let mut token_decode_step_allocs = Vec::with_capacity(max_new_tokens);
     for step_idx in 0..max_new_tokens {
         let decode_step_start = std::time::Instant::now();
+        let decode_alloc_start = AllocationAuditSnapshot::current();
         // Embed only the LAST token (incremental)
         // KV cache already maintains historical context
         let last_token = tokens.last().copied().expect("tokens must be non-empty");
 
         let t0 = std::time::Instant::now();
+        let embed_alloc_start = AllocationAuditSnapshot::current();
         let x = model.embed(&[last_token])?;
         let embed_ms = elapsed_ms(t0);
+        if allocation_audit_enabled {
+            embed_step_allocs.push(AllocationAuditSnapshot::delta_since(embed_alloc_start));
+        }
         embed_step_ms.push(embed_ms);
         if timing_enabled {
             eprintln!("timing: embed_us={}", ms_to_us(embed_ms));
@@ -2378,8 +2468,12 @@ async fn run_simple_generation(
 
         // Forward pass (with KV cache handling history)
         let t1 = std::time::Instant::now();
+        let forward_alloc_start = AllocationAuditSnapshot::current();
         let h = model.forward(&x, any_cache.as_mut())?;
         let forward_ms = elapsed_ms(t1);
+        if allocation_audit_enabled {
+            forward_step_allocs.push(AllocationAuditSnapshot::delta_since(forward_alloc_start));
+        }
         forward_step_ms.push(forward_ms);
         if timing_enabled {
             eprintln!("timing: forward_us={}", ms_to_us(forward_ms));
@@ -2397,6 +2491,7 @@ async fn run_simple_generation(
 
         // Get logits from last token hidden state
         let t2 = std::time::Instant::now();
+        let logits_alloc_start = AllocationAuditSnapshot::current();
         let logits = model.logits(&last_hidden)?;
         let logits_ms = elapsed_ms(t2);
         logits_step_ms.push(logits_ms);
@@ -2406,6 +2501,9 @@ async fn run_simple_generation(
 
         // Extract logits vector with robust shape handling
         let logits_vec = extract_logits_2d(&logits)?;
+        if allocation_audit_enabled {
+            logits_step_allocs.push(AllocationAuditSnapshot::delta_since(logits_alloc_start));
+        }
         let greedy_top1_token = greedy_top1_token_id(&logits_vec);
         if let Some(token_id) = greedy_top1_token {
             top1_tokens.push(token_id);
@@ -2468,8 +2566,12 @@ async fn run_simple_generation(
 
         // Sample next token
         let t3 = std::time::Instant::now();
+        let sample_alloc_start = AllocationAuditSnapshot::current();
         let next_token = sampler.sample(&logits_vec, &generated_tokens)?;
         let sample_ms = elapsed_ms(t3);
+        if allocation_audit_enabled {
+            sample_step_allocs.push(AllocationAuditSnapshot::delta_since(sample_alloc_start));
+        }
         sample_step_ms.push(sample_ms);
         if timing_enabled {
             eprintln!("timing: sample_us={}", ms_to_us(sample_ms));
@@ -2524,7 +2626,12 @@ async fn run_simple_generation(
 
         // Decode and print the new token
         let token_decode_start = std::time::Instant::now();
+        let token_decode_alloc_start = AllocationAuditSnapshot::current();
         let token_text = tokenizer.decode(&[next_token])?;
+        if allocation_audit_enabled {
+            token_decode_step_allocs
+                .push(AllocationAuditSnapshot::delta_since(token_decode_alloc_start));
+        }
         token_decode_step_ms.push(elapsed_ms(token_decode_start));
         print!("{}", token_text);
         std::io::Write::flush(&mut std::io::stdout())?;
@@ -2549,6 +2656,9 @@ async fn run_simple_generation(
             first_token_decode_ms = Some(step_ms);
         }
         decode_step_ms.push(step_ms);
+        if allocation_audit_enabled {
+            decode_step_allocs.push(AllocationAuditSnapshot::delta_since(decode_alloc_start));
+        }
 
         // 1) Token-ID stops (includes template-resolved IDs like <|eot_id|>)
         if all_stop_ids.contains(&next_token) {
@@ -2575,6 +2685,7 @@ async fn run_simple_generation(
             break;
         }
     }
+    drop(allocation_audit_guard);
 
     // Calculate timing metrics
     let total_ms = start_time.elapsed().as_millis() as u64;
@@ -2711,6 +2822,7 @@ async fn run_simple_generation(
             "inference_result"
         };
         let steady_decode_step_ms = decode_step_ms.get(1..).unwrap_or(&[]);
+        let steady_decode_step_allocs = decode_step_allocs.get(1..).unwrap_or(&[]);
         let decode_total_ms = decode_step_ms.iter().sum::<f64>();
         let sampling_ms_per_token = if sample_step_ms.is_empty() {
             None
@@ -2718,6 +2830,8 @@ async fn run_simple_generation(
             Some(sample_step_ms.iter().sum::<f64>() / sample_step_ms.len() as f64)
         };
         let steady_decode_tps = steady_decode_tps_ms(&decode_step_ms);
+        let steady_alloc_count_per_token = mean_alloc_count(steady_decode_step_allocs);
+        let steady_alloc_bytes_per_token = mean_alloc_bytes(steady_decode_step_allocs);
         let profile_label = profile_id.as_deref().unwrap_or("default");
         let profile_claim_scope = profile_claim_scope(runtime_api, selected_backend);
         let profile_machine_context_recorded = profile_machine_context_recorded(
@@ -2767,6 +2881,55 @@ async fn run_simple_generation(
                 "logits_ms": timing_samples_json(&logits_step_ms),
                 "sample_ms": timing_samples_json(&sample_step_ms),
                 "token_decode_ms": timing_samples_json(&token_decode_step_ms),
+            },
+            "allocation_audit": {
+                "enabled": allocation_audit_enabled,
+                "method": if allocation_audit_enabled {
+                    "process_global_allocator_counter_delta"
+                } else {
+                    "not_requested"
+                },
+                "scope": if allocation_audit_enabled {
+                    "selected Apple BitNet prompt-prefill and decode hot loop"
+                } else {
+                    "not_requested"
+                },
+                "claim_scope": "allocation counter deltas for the selected Apple BitNet profile only",
+                "warmup_tokens": usize::from(!decode_step_allocs.is_empty()),
+                "measured_tokens": decode_step_allocs.len().saturating_sub(1),
+                "per_token_alloc_count_delta": allocation_count_delta_json(&decode_step_allocs),
+                "per_token_alloc_bytes_delta": allocation_bytes_delta_json(&decode_step_allocs),
+                "steady_state_alloc_count_per_token": steady_alloc_count_per_token.map(rounded_ms),
+                "steady_state_alloc_bytes_per_token": steady_alloc_bytes_per_token.map(rounded_ms),
+                "instrumentation_included": [
+                    "prompt_prefill_step",
+                    "decode_step_total",
+                    "model.embed",
+                    "model.forward",
+                    "model.logits_and_extract",
+                    "sampler.sample",
+                    "tokenizer.decode",
+                    "stdout_text_write",
+                    "token_vector_updates",
+                    "stop_tail_updates"
+                ],
+                "instrumentation_excluded": [
+                    "model_load",
+                    "tokenizer_load",
+                    "prompt_tokenize",
+                    "json_receipt_serialization",
+                    "debug_logit_dump_topk_unless_enabled"
+                ],
+                "prompt_prefill": allocation_samples_json(&prefill_step_allocs),
+                "decode": {
+                    "total": allocation_samples_json(&decode_step_allocs),
+                    "steady_state": allocation_samples_json(steady_decode_step_allocs),
+                    "embed": allocation_samples_json(&embed_step_allocs),
+                    "forward": allocation_samples_json(&forward_step_allocs),
+                    "logits": allocation_samples_json(&logits_step_allocs),
+                    "sample": allocation_samples_json(&sample_step_allocs),
+                    "token_decode": allocation_samples_json(&token_decode_step_allocs),
+                },
             },
             "model_load_ms": rounded_ms(model_load_ms),
             "tokenizer_load_ms": rounded_ms(tokenizer_load_ms),
@@ -3228,6 +3391,52 @@ fn rounded_ms(ms: f64) -> f64 {
     (ms * 1000.0).round() / 1000.0
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct AllocationAuditSnapshot {
+    alloc_count: u64,
+    alloc_bytes: u64,
+    dealloc_count: u64,
+    dealloc_bytes: u64,
+}
+
+impl AllocationAuditSnapshot {
+    fn current() -> Self {
+        Self {
+            alloc_count: ALLOCATION_AUDIT_ALLOC_COUNT.load(Ordering::Relaxed),
+            alloc_bytes: ALLOCATION_AUDIT_ALLOC_BYTES.load(Ordering::Relaxed),
+            dealloc_count: ALLOCATION_AUDIT_DEALLOC_COUNT.load(Ordering::Relaxed),
+            dealloc_bytes: ALLOCATION_AUDIT_DEALLOC_BYTES.load(Ordering::Relaxed),
+        }
+    }
+
+    fn delta_since(start: Self) -> Self {
+        let current = Self::current();
+        Self {
+            alloc_count: current.alloc_count.saturating_sub(start.alloc_count),
+            alloc_bytes: current.alloc_bytes.saturating_sub(start.alloc_bytes),
+            dealloc_count: current.dealloc_count.saturating_sub(start.dealloc_count),
+            dealloc_bytes: current.dealloc_bytes.saturating_sub(start.dealloc_bytes),
+        }
+    }
+}
+
+struct AllocationAuditGuard {
+    previous: bool,
+}
+
+impl AllocationAuditGuard {
+    fn enable(enabled: bool) -> Self {
+        let previous = ALLOCATION_AUDIT_ENABLED.swap(enabled, Ordering::Relaxed);
+        Self { previous }
+    }
+}
+
+impl Drop for AllocationAuditGuard {
+    fn drop(&mut self) {
+        ALLOCATION_AUDIT_ENABLED.store(self.previous, Ordering::Relaxed);
+    }
+}
+
 fn timing_samples_json(samples: &[f64]) -> serde_json::Value {
     if samples.is_empty() {
         return serde_json::json!({
@@ -3255,6 +3464,102 @@ fn timing_samples_json(samples: &[f64]) -> serde_json::Value {
         "p95_ms": rounded_ms(percentile_nearest(&sorted, 95)),
         "max_ms": rounded_ms(sorted[sorted.len() - 1]),
     })
+}
+
+fn allocation_samples_json(samples: &[AllocationAuditSnapshot]) -> serde_json::Value {
+    if samples.is_empty() {
+        return serde_json::json!({
+            "count": 0,
+            "alloc_count_total": 0,
+            "alloc_bytes_total": 0,
+            "dealloc_count_total": 0,
+            "dealloc_bytes_total": 0,
+            "net_bytes_total": 0,
+            "mean_alloc_count_per_token": serde_json::Value::Null,
+            "mean_alloc_bytes_per_token": serde_json::Value::Null,
+            "max_alloc_count_per_token": serde_json::Value::Null,
+            "max_alloc_bytes_per_token": serde_json::Value::Null,
+        });
+    }
+
+    let total_alloc_count = samples.iter().map(|sample| sample.alloc_count).sum::<u64>();
+    let total_alloc_bytes = samples.iter().map(|sample| sample.alloc_bytes).sum::<u64>();
+    let total_dealloc_count = samples.iter().map(|sample| sample.dealloc_count).sum::<u64>();
+    let total_dealloc_bytes = samples.iter().map(|sample| sample.dealloc_bytes).sum::<u64>();
+    let max_alloc_count = samples.iter().map(|sample| sample.alloc_count).max().unwrap_or(0);
+    let max_alloc_bytes = samples.iter().map(|sample| sample.alloc_bytes).max().unwrap_or(0);
+    let count = samples.len() as f64;
+
+    let net_bytes_total = total_alloc_bytes as i64 - total_dealloc_bytes as i64;
+
+    serde_json::json!({
+        "count": samples.len(),
+        "alloc_count_total": total_alloc_count,
+        "alloc_bytes_total": total_alloc_bytes,
+        "dealloc_count_total": total_dealloc_count,
+        "dealloc_bytes_total": total_dealloc_bytes,
+        "net_bytes_total": net_bytes_total,
+        "mean_alloc_count_per_token": rounded_ms(total_alloc_count as f64 / count),
+        "mean_alloc_bytes_per_token": rounded_ms(total_alloc_bytes as f64 / count),
+        "max_alloc_count_per_token": max_alloc_count,
+        "max_alloc_bytes_per_token": max_alloc_bytes,
+    })
+}
+
+fn allocation_count_delta_json(samples: &[AllocationAuditSnapshot]) -> serde_json::Value {
+    if samples.is_empty() {
+        return serde_json::json!({
+            "count": 0,
+            "total": 0,
+            "mean_per_token": serde_json::Value::Null,
+            "max_per_token": serde_json::Value::Null,
+        });
+    }
+
+    let total = samples.iter().map(|sample| sample.alloc_count).sum::<u64>();
+    let max = samples.iter().map(|sample| sample.alloc_count).max().unwrap_or(0);
+
+    serde_json::json!({
+        "count": samples.len(),
+        "total": total,
+        "mean_per_token": rounded_ms(total as f64 / samples.len() as f64),
+        "max_per_token": max,
+    })
+}
+
+fn allocation_bytes_delta_json(samples: &[AllocationAuditSnapshot]) -> serde_json::Value {
+    if samples.is_empty() {
+        return serde_json::json!({
+            "count": 0,
+            "total": 0,
+            "mean_per_token": serde_json::Value::Null,
+            "max_per_token": serde_json::Value::Null,
+        });
+    }
+
+    let total = samples.iter().map(|sample| sample.alloc_bytes).sum::<u64>();
+    let max = samples.iter().map(|sample| sample.alloc_bytes).max().unwrap_or(0);
+
+    serde_json::json!({
+        "count": samples.len(),
+        "total": total,
+        "mean_per_token": rounded_ms(total as f64 / samples.len() as f64),
+        "max_per_token": max,
+    })
+}
+
+fn mean_alloc_count(samples: &[AllocationAuditSnapshot]) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+    Some(samples.iter().map(|sample| sample.alloc_count).sum::<u64>() as f64 / samples.len() as f64)
+}
+
+fn mean_alloc_bytes(samples: &[AllocationAuditSnapshot]) -> Option<f64> {
+    if samples.is_empty() {
+        return None;
+    }
+    Some(samples.iter().map(|sample| sample.alloc_bytes).sum::<u64>() as f64 / samples.len() as f64)
 }
 
 fn percentile_nearest(sorted_samples: &[f64], percentile: usize) -> f64 {
@@ -3603,6 +3908,63 @@ mod tests {
             &cpu_features,
             false
         ));
+    }
+
+    #[test]
+    fn allocation_samples_json_records_counter_deltas() {
+        let summary = allocation_samples_json(&[
+            AllocationAuditSnapshot {
+                alloc_count: 3,
+                alloc_bytes: 128,
+                dealloc_count: 1,
+                dealloc_bytes: 32,
+            },
+            AllocationAuditSnapshot {
+                alloc_count: 1,
+                alloc_bytes: 64,
+                dealloc_count: 1,
+                dealloc_bytes: 96,
+            },
+        ]);
+
+        assert_eq!(summary["count"], 2);
+        assert_eq!(summary["alloc_count_total"], 4);
+        assert_eq!(summary["alloc_bytes_total"], 192);
+        assert_eq!(summary["dealloc_count_total"], 2);
+        assert_eq!(summary["dealloc_bytes_total"], 128);
+        assert_eq!(summary["net_bytes_total"], 64);
+        assert_eq!(summary["mean_alloc_count_per_token"], 2.0);
+        assert_eq!(summary["mean_alloc_bytes_per_token"], 96.0);
+        assert_eq!(summary["max_alloc_count_per_token"], 3);
+        assert_eq!(summary["max_alloc_bytes_per_token"], 128);
+    }
+
+    #[test]
+    fn allocation_delta_helpers_record_per_token_means() {
+        let samples = [
+            AllocationAuditSnapshot {
+                alloc_count: 2,
+                alloc_bytes: 80,
+                dealloc_count: 0,
+                dealloc_bytes: 0,
+            },
+            AllocationAuditSnapshot {
+                alloc_count: 4,
+                alloc_bytes: 160,
+                dealloc_count: 0,
+                dealloc_bytes: 0,
+            },
+        ];
+
+        let count = allocation_count_delta_json(&samples);
+        let bytes = allocation_bytes_delta_json(&samples);
+
+        assert_eq!(count["total"], 6);
+        assert_eq!(count["mean_per_token"], 3.0);
+        assert_eq!(count["max_per_token"], 4);
+        assert_eq!(bytes["total"], 240);
+        assert_eq!(bytes["mean_per_token"], 120.0);
+        assert_eq!(bytes["max_per_token"], 160);
     }
 
     #[test]

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -2386,6 +2386,15 @@ async fn run_simple_generation(
     if allocation_audit && json_out.is_none() {
         anyhow::bail!("--allocation-audit requires --json-out so allocation claims are durable");
     }
+    if allocation_audit && !allocation_audit_backend_supported(&backend_identity) {
+        anyhow::bail!(
+            "--allocation-audit is currently scoped to --device apple-m4-cpu-neon with fallback_used=false; got requested_backend={}, selected_backend={}, runtime_api={}, fallback_used={}",
+            backend_identity.requested_backend,
+            backend_identity.selected_backend,
+            backend_identity.runtime_api,
+            backend_identity.fallback_used
+        );
+    }
     let allocation_audit_enabled = allocation_audit;
     let allocation_audit_guard = AllocationAuditGuard::enable(allocation_audit_enabled);
     let mut prefill_token_count = 0usize;
@@ -2890,11 +2899,15 @@ async fn run_simple_generation(
                     "not_requested"
                 },
                 "scope": if allocation_audit_enabled {
-                    "selected Apple BitNet prompt-prefill and decode hot loop"
+                    "selected Apple M4 CPU/NEON BitNet prompt-prefill and decode hot loop"
                 } else {
                     "not_requested"
                 },
-                "claim_scope": "allocation counter deltas for the selected Apple BitNet profile only",
+                "claim_scope": if allocation_audit_enabled {
+                    "allocation counter deltas for the selected Apple M4 CPU/NEON BitNet profile only"
+                } else {
+                    "not_requested"
+                },
                 "warmup_tokens": usize::from(!decode_step_allocs.is_empty()),
                 "measured_tokens": decode_step_allocs.len().saturating_sub(1),
                 "per_token_alloc_count_delta": allocation_count_delta_json(&decode_step_allocs),
@@ -3611,6 +3624,13 @@ fn profile_machine_context_recorded(
     apple_machine_present || cpu_model_present || !cpu_features.is_empty()
 }
 
+fn allocation_audit_backend_supported(identity: &RunBackendIdentity) -> bool {
+    identity.requested_backend == "apple-m4-cpu-neon"
+        && identity.selected_backend == "apple-m4-cpu-neon"
+        && identity.runtime_api == "cpu"
+        && !identity.fallback_used
+}
+
 fn apple_machine_receipt_json(
     requested_backend: &str,
     selected_backend: &str,
@@ -3965,6 +3985,32 @@ mod tests {
         assert_eq!(bytes["total"], 240);
         assert_eq!(bytes["mean_per_token"], 120.0);
         assert_eq!(bytes["max_per_token"], 160);
+    }
+
+    #[test]
+    fn allocation_audit_requires_selected_apple_cpu_neon_without_fallback() {
+        assert!(allocation_audit_backend_supported(&RunBackendIdentity {
+            requested_backend: "apple-m4-cpu-neon".to_string(),
+            selected_backend: "apple-m4-cpu-neon".to_string(),
+            runtime_api: "cpu".to_string(),
+            fallback_used: false,
+            fallback_reason: None,
+        }));
+
+        assert!(!allocation_audit_backend_supported(&RunBackendIdentity {
+            requested_backend: "apple-m4-cpu-neon".to_string(),
+            selected_backend: "cpu".to_string(),
+            runtime_api: "cpu".to_string(),
+            fallback_used: true,
+            fallback_reason: Some("Apple CPU/NEON unavailable".to_string()),
+        }));
+        assert!(!allocation_audit_backend_supported(&RunBackendIdentity {
+            requested_backend: "cpu".to_string(),
+            selected_backend: "cpu-rust".to_string(),
+            runtime_api: "cpu".to_string(),
+            fallback_used: false,
+            fallback_reason: None,
+        }));
     }
 
     #[test]

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -475,6 +475,72 @@ This may claim only that M4 timing is recorded for the named BitNet phase and
 profile under captured machine context. It is not a general M4 performance
 claim, Neural Engine claim, QK256 acceleration claim, or Metal BitNet proof.
 
+## M4-016 Hot-Loop Allocation Audit
+
+The hot-loop allocation audit extends the named profile receipt with an opt-in
+allocation counter. It measures scoped allocator counter deltas for prompt
+prefill and decode steps so compute timing can be separated from allocation
+churn. The audit is profile-scoped and must be requested explicitly with
+`--allocation-audit`.
+
+Run the live audit with:
+
+```bash
+BITNET_DISABLE_MINIMAL_LOADER=1 \
+BITNET_STRICT_MODE=1 \
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- \
+  --device apple-m4-cpu-neon \
+  run \
+  --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --prompt "Answer with a single digit: 2+2=" \
+  --max-tokens 4 \
+  --temperature 0.0 \
+  --greedy \
+  --deterministic \
+  --strict-loader \
+  --strict-tokenizer \
+  --prompt-template raw \
+  --profile-id smoke_4 \
+  --allocation-audit \
+  --no-warnings \
+  --json-out ci/hardware/apple-m4-mac-mini/<date>/strict-bitnet-cpu-neon-allocation-audit.json
+```
+
+The receipt must keep allocation evidence separate from timing evidence:
+
+```json
+{
+  "artifact_kind": "strict_bitnet_cpu_profile",
+  "profile": {
+    "allocation_audit": {
+      "enabled": true,
+      "method": "process_global_allocator_counter_delta",
+      "scope": "selected Apple BitNet prompt-prefill and decode hot loop",
+      "warmup_tokens": 1,
+      "measured_tokens": 3,
+      "steady_state_alloc_count_per_token": 0.0,
+      "steady_state_alloc_bytes_per_token": 0.0,
+      "decode": {
+        "total": {
+          "alloc_count_total": 0,
+          "alloc_bytes_total": 0
+        }
+      }
+    }
+  },
+  "fallback_used": false
+}
+```
+
+M4-016 may claim only that per-token allocation behavior is measured or bounded
+for the selected Apple BitNet path. It must not claim decode performance is
+compute-bound unless the receipt separates allocation overhead. It must not
+claim QK256 acceleration, Neural Engine execution, Metal execution, or general
+M4 performance.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -517,6 +517,57 @@ profile under captured machine context. It must not claim general M4
 performance, Neural Engine execution, QK256 acceleration on Apple Silicon, or
 Metal BitNet inference.
 
+### M4-016 - Hot-Loop Allocation Audit
+
+Add an opt-in allocation audit to the strict Apple profile path. The audit is
+not a benchmark by itself; it records allocator counter deltas around prompt
+prefill and decode steps so later performance claims can distinguish compute
+timing from allocation overhead.
+
+The receipt records:
+
+```json
+{
+  "profile": {
+    "allocation_audit": {
+      "enabled": true,
+      "method": "process_global_allocator_counter_delta",
+      "claim_scope": "allocation counter deltas for the selected Apple BitNet profile only",
+      "warmup_tokens": 1,
+      "measured_tokens": 3,
+      "per_token_alloc_count_delta": {
+        "count": 4,
+        "total": 0,
+        "mean_per_token": 0.0
+      },
+      "per_token_alloc_bytes_delta": {
+        "count": 4,
+        "total": 0,
+        "mean_per_token": 0.0
+      },
+      "decode": {
+        "total": {
+          "alloc_count_total": 0,
+          "alloc_bytes_total": 0,
+          "net_bytes_total": 0
+        },
+        "embed": {},
+        "forward": {},
+        "logits": {},
+        "sample": {},
+        "token_decode": {}
+      }
+    }
+  }
+}
+```
+
+The audit may claim only that per-token allocation behavior is measured or
+bounded for the selected Apple BitNet path. It must not claim the decode path is
+compute-bound unless allocation overhead is separated in the receipt, and it
+must not claim QK256 acceleration, Neural Engine execution, Metal execution, or
+general M4 performance.
+
 ## Do Not
 
 - Do not start with Apple Neural Engine inference claims.

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -524,11 +524,12 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-016"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-016-hot-loop-allocation-audit"
 stackable = false
 requires_human_merge = true
 blocked_by = ["M4-015"]
+pr = 3811
 acceptance = "Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead."
 commands = [
   "cargo fmt --all -- --check",

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -505,6 +505,7 @@ allowed_paths = [
   "crates/**/tests/**",
   "crates/**/benches/**",
   "docs/tracking/campaigns/apple-m4/**",
+  "docs/tracking/generated/**",
   "docs/hardware/apple-m4-mac-mini-validation.md",
   "docs/specs/apple-m4-mac-mini-roadmap.md",
 ]

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -524,7 +524,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-016"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-016-hot-loop-allocation-audit"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T001651Z-M4-016-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T001651Z-M4-016-in-progress.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-07T00:16:51Z"
+campaign = "apple-m4"
+item = "M4-016"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started hot-loop allocation audit for the selected Apple BitNet profile path.",
+  "Scope is allocation counter evidence only; no QK256, server, Neural Engine, Metal execution, or general M4 performance claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T002900Z-M4-016-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T002900Z-M4-016-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T00:29:00Z"
+campaign = "apple-m4"
+item = "M4-016"
+event = "pr_open"
+pr = 3811
+head_sha = "79dc70bfee7f55bddf89c0a10809396b6963781f"
+actor = "codex"
+
+notes = [
+  "Opened hot-loop allocation audit PR.",
+  "Records profile-scoped allocation counter deltas without claiming decode is compute-bound, general M4 performance, QK256 acceleration, Metal execution, MPSGraph execution, or Neural Engine execution.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -24,7 +24,7 @@
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
-| M4-016 | in_progress | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
+| M4-016 | pr_open | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | proposed | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -24,7 +24,7 @@
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
-| M4-016 | ready | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
+| M4-016 | in_progress | TBD | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | proposed | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,6 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-016 | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | nvidia-5070ti | CUDA-BITNET-006 | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -17,7 +17,7 @@
 | apple-m4 | M4-013 | M4-012 | merged |
 | apple-m4 | M4-014 | M4-013 | merged |
 | apple-m4 | M4-015 | M4-014 | merged |
-| apple-m4 | M4-016 | M4-015 | in_progress |
+| apple-m4 | M4-016 | M4-015 | pr_open |
 | apple-m4 | M4-017 | M4-016 | proposed |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -17,7 +17,7 @@
 | apple-m4 | M4-013 | M4-012 | merged |
 | apple-m4 | M4-014 | M4-013 | merged |
 | apple-m4 | M4-015 | M4-014 | merged |
-| apple-m4 | M4-016 | M4-015 | ready |
+| apple-m4 | M4-016 | M4-015 | in_progress |
 | apple-m4 | M4-017 | M4-016 | proposed |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-016 | TBD | in_progress | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-016 | #3811 | pr_open | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-016 | TBD | ready | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-016 | TBD | in_progress | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-016
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Adds opt-in `--allocation-audit` for `bitnet run` profile receipts.
- Records scoped allocator counter deltas for prompt prefill and decode hot-loop sections under `profile.allocation_audit`.
- Documents M4-016 receipt shape and live Apple CPU/NEON audit command.
- Marks M4-016 `in_progress`, adds an append-only event, and regenerates dashboards.

## Claim Boundary
- May claim only that per-token allocation behavior is measured or bounded for the selected Apple BitNet path.
- Does not claim decode is compute-bound, general M4 performance, QK256 acceleration, Metal execution, MPSGraph execution, or Neural Engine execution.

## Live Proof
Ran a short strict real-model Apple CPU/NEON audit without committing the output artifact:

```text
BITNET_DISABLE_MINIMAL_LOADER=1 BITNET_STRICT_MODE=1 \
cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- \
  --device apple-m4-cpu-neon run \
  --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
  --prompt "2+2=" \
  --max-tokens 2 \
  --temperature 0.0 \
  --greedy \
  --deterministic \
  --strict-loader \
  --strict-tokenizer \
  --prompt-template raw \
  --profile-id smoke_2 \
  --allocation-audit \
  --no-warnings \
  --json-out target/m4-016/strict-bitnet-cpu-neon-allocation-audit.json
```

Receipt summary:
- `artifact_kind=strict_bitnet_cpu_profile`
- `requested_backend=apple-m4-cpu-neon`
- `selected_backend=apple-m4-cpu-neon`
- `runtime_api=cpu`
- `fallback_used=false`
- `profile.allocation_audit.enabled=true`
- `profile.allocation_audit.method=process_global_allocator_counter_delta`
- `profile.allocation_audit.measured_tokens=1`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli allocation_ -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli help_text -- --nocapture`
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
