### PR TITLE
[codex][apple-m4] Close out M4-016 allocation audit

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -525,7 +525,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-016"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-016-hot-loop-allocation-audit"
 stackable = false
 requires_human_merge = true
@@ -560,7 +560,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-017"
-status = "proposed"
+status = "ready"
 branch = "codex/apple-m4/M4-017-metal-kernel-family-expansion"
 stackable = false
 requires_human_merge = true
@@ -576,6 +576,7 @@ allowed_paths = [
   "crates/bitnet-kernels/tests/**",
   "crates/**/tests/**",
   "docs/tracking/campaigns/apple-m4/**",
+  "docs/tracking/generated/**",
   "docs/hardware/apple-m4-mac-mini-validation.md",
   "docs/specs/apple-m4-mac-mini-roadmap.md",
 ]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T010619Z-M4-016-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T010619Z-M4-016-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-07T01:06:19Z"
+campaign = "apple-m4"
+item = "M4-016"
+event = "merged"
+pr = 3811
+merge_sha = "3ffa32d711ee697c1df2e9a3e53600c1b7864b08"
+actor = "codex"
+
+notes = [
+  "M4-016 hot-loop allocation audit merged.",
+  "Allocation audit is scoped to apple-m4-cpu-neon with fallback_used=false and records allocation counter deltas separately from timing.",
+  "No QK256, qk256-dispatch, server inference, or general M4 performance claim was added.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -24,8 +24,8 @@
 | M4-013 | merged | #3783 | `codex/apple-m4/M4-013-metal-prefill-decode` | Move from isolated Apple Metal kernels toward a named BitNet inference phase with CPU reference and explicit fallback status. |
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
-| M4-016 | pr_open | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
-| M4-017 | proposed | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
+| M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
+| M4-017 | ready | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-016 | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | nvidia-5070ti | CUDA-BITNET-006 | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -17,8 +17,8 @@
 | apple-m4 | M4-013 | M4-012 | merged |
 | apple-m4 | M4-014 | M4-013 | merged |
 | apple-m4 | M4-015 | M4-014 | merged |
-| apple-m4 | M4-016 | M4-015 | pr_open |
-| apple-m4 | M4-017 | M4-016 | proposed |
+| apple-m4 | M4-016 | M4-015 | merged |
+| apple-m4 | M4-017 | M4-016 | ready |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-016 | #3811 | pr_open | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-017 | TBD | ready | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | Apple M4 Mac mini validation | M4-016 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | Apple M4 Mac mini validation | M4-017 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-BITNET-008 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-016 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Record M4-016 as merged with PR #3811 merge SHA `3ffa32d711ee697c1df2e9a3e53600c1b7864b08`
- Promote M4-017 to ready
- Regenerate campaign/global dashboards
- Keep the closeout tracker-only; no runtime, kernel, QK256, qk256-dispatch, server, or dependency changes

## Verification
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
