### PR TITLE
docs(tracking): close CUDA-BITNET-007

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -428,7 +428,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CUDA-BITNET-007"
-status = "pr_open"
+status = "merged"
 branch = "codex/cuda-bitnet-007-short-decode-proof"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T011650Z-CUDA-BITNET-007-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T011650Z-CUDA-BITNET-007-merged.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-07T01:16:50Z"
+campaign = "nvidia-5070ti"
+item = "CUDA-BITNET-007"
+event = "merged"
+previous_status = "pr_open"
+new_status = "merged"
+pr = 3806
+merge_sha = "d9a1dd19048b0367300cfd8d085572acda148280"
+actor = "codex"
+
+notes = [
+  "Merged the strict short-decode BitNet CUDA proof.",
+  "The proof receipt records 37 prompt tokens, 8 generated tokens, 1680 qk256_gemv_cuda invocations, zero BitNet linear CPU fallback, CUDA memory high-water sampling, KV-cache behavior, and speedup_claim=false.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -21,7 +21,7 @@
 | CUDA-BITNET-004 | merged | #3790 | `codex/cuda-bitnet-004-upload-once-weights` | Prepack and upload BitNet weights once for CUDA with per-layer handles and receipt fields for packed_at_load and uploaded_once. |
 | CUDA-BITNET-005 | merged | #3792 | `codex/cuda-bitnet-005-route-linear` | Route actual BitNetLinear transformer dispatch through the selected CUDA backend with coverage counters and strict CPU fallback rejection. |
 | CUDA-BITNET-006 | merged | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
-| CUDA-BITNET-007 | pr_open | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
+| CUDA-BITNET-007 | merged | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
 | CUDA-BITNET-008 | proposed | TBD | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
 | CUDA-DENSE-001 | proposed | TBD | `codex/cuda-dense-001-reference-lane` | Add regular LLM CUDA dense-kernel reference lane with dense_regular_llm receipt labels that cannot satisfy BitNet packed I2S or QK256 proof acceptance. |
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| nvidia-5070ti | CUDA-BITNET-007 | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -47,7 +47,7 @@
 | nvidia-5070ti | CUDA-BITNET-004 | CUDA-BITNET-002, CUDA-BITNET-003 | merged |
 | nvidia-5070ti | CUDA-BITNET-005 | CUDA-BITNET-004 | merged |
 | nvidia-5070ti | CUDA-BITNET-006 | CUDA-BITNET-005 | merged |
-| nvidia-5070ti | CUDA-BITNET-007 | CUDA-BITNET-006 | pr_open |
+| nvidia-5070ti | CUDA-BITNET-007 | CUDA-BITNET-006 | merged |
 | nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | proposed |
 | nvidia-5070ti | CUDA-DENSE-001 | RTX5070TI-007 | proposed |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
-| nvidia-5070ti | CUDA-BITNET-007 | #3806 | pr_open | CUDA-BITNET-008 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | CUDA-BITNET-008 | TBD | proposed | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-007 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-008 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
Work item: CUDA-BITNET-007

## Summary
- record #3806 as the completed CUDA-BITNET-007 short-decode proof PR
- add the NVIDIA campaign merged event with merge SHA `d9a1dd19048b0367300cfd8d085572acda148280`
- regenerate campaign dashboards so CUDA-BITNET-008 is the next NVIDIA item

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Notes
- Tracker closeout only; no runtime, kernel, QK256, server, dense CUDA, benchmark, or receipt behavior changes.