### PR TITLE
[codex][apple-m4] Expand Metal I2_S subgraph coverage (M4-017)

### DIFF
--- a/crates/bitnet-kernels/src/metal/smoke.rs
+++ b/crates/bitnet-kernels/src/metal/smoke.rs
@@ -6,6 +6,7 @@ pub const MACHINE_ID: &str = "apple-m4-mac-mini";
 pub const ARTIFACT_KIND: &str = "smoke";
 pub const PARITY_ARTIFACT_KIND: &str = "parity";
 pub const PHASE_CONTRIBUTION_ARTIFACT_KIND: &str = "phase_contribution";
+pub const SUBGRAPH_ARTIFACT_KIND: &str = "subgraph";
 pub const REQUESTED_BACKEND: &str = "apple-m4-metal";
 pub const SELECTED_BACKEND: &str = "apple-m4-metal";
 pub const REFERENCE_BACKEND: &str = "apple-m4-cpu-neon";
@@ -14,11 +15,16 @@ pub const TINY_METAL_ADD_SMOKE_KERNEL_ID: &str = "tiny_metal_add_smoke";
 pub const TINY_METAL_ADD_PARITY_KERNEL_ID: &str = "tiny_metal_add_parity";
 pub const I2S_METAL_PARITY_KERNEL_ID: &str = "tiny_metal_i2s_parity";
 pub const I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID: &str = "tiny_metal_i2s_prefill_contribution";
+pub const I2S_METAL_PROJECTION_RESIDUAL_KERNEL_ID: &str = "tiny_metal_i2s_projection_residual";
+pub const I2S_PROJECTION_RESIDUAL_GRAPH_ID: &str = "tiny_i2s_projection_residual_subgraph";
 pub const I2S_KERNEL_FAMILY: &str = "i2_s";
 pub const I2S_EXECUTION_PHASE: &str = "parity";
 pub const I2S_PREFILL_EXECUTION_PHASE: &str = "prefill";
 pub const I2S_PREFILL_PHASE_SCOPE: &str = "prefill_projection_fixture";
 pub const I2S_PREFILL_KV_CACHE_BEHAVIOR: &str = "not_exercised";
+pub const I2S_PROJECTION_RESIDUAL_EXECUTION_PHASE: &str = "parity";
+pub const I2S_PROJECTION_RESIDUAL_PHASE_SCOPE: &str = "projection_residual_subgraph";
+pub const I2S_PROJECTION_RESIDUAL_OPS: [&str; 2] = ["packed_i2_s_matmul", "residual_add"];
 pub const I2S_LAYOUT_SOURCE: &str = "fixture_packed_i2_s";
 pub const I2S_TRANSPORT_LAYOUT: &str = "u32_le_words_from_i2s_bytes";
 pub const I2S_PARITY_M: usize = 1;
@@ -138,6 +144,33 @@ pub struct I2sMetalPrefillContributionReceipt {
     pub mean_abs_error: f32,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct I2sMetalProjectionResidualReceipt {
+    pub machine_id: &'static str,
+    pub artifact_kind: &'static str,
+    pub requested_backend: &'static str,
+    pub selected_backend: &'static str,
+    pub runtime_api: &'static str,
+    pub reference_backend: &'static str,
+    pub target_backend: &'static str,
+    pub graph_id: &'static str,
+    pub kernel_id: &'static str,
+    pub kernel_family: &'static str,
+    pub execution_phase: &'static str,
+    pub phase_scope: &'static str,
+    pub layout_source: &'static str,
+    pub transport_layout: &'static str,
+    pub fallback_used: bool,
+    pub result: &'static str,
+    pub artifact_path: String,
+    pub tokens: usize,
+    pub n: usize,
+    pub k: usize,
+    pub block_size: usize,
+    pub max_abs_error: f32,
+    pub mean_abs_error: f32,
+}
+
 impl TinyMetalAddParityReceipt {
     pub fn passed(
         artifact_path: impl Into<String>,
@@ -221,6 +254,36 @@ impl I2sMetalPrefillContributionReceipt {
     }
 }
 
+impl I2sMetalProjectionResidualReceipt {
+    pub fn passed(artifact_path: impl Into<String>, comparison: SmokeComparison) -> Self {
+        Self {
+            machine_id: MACHINE_ID,
+            artifact_kind: SUBGRAPH_ARTIFACT_KIND,
+            requested_backend: REQUESTED_BACKEND,
+            selected_backend: SELECTED_BACKEND,
+            runtime_api: RUNTIME_API,
+            reference_backend: REFERENCE_BACKEND,
+            target_backend: SELECTED_BACKEND,
+            graph_id: I2S_PROJECTION_RESIDUAL_GRAPH_ID,
+            kernel_id: I2S_METAL_PROJECTION_RESIDUAL_KERNEL_ID,
+            kernel_family: I2S_KERNEL_FAMILY,
+            execution_phase: I2S_PROJECTION_RESIDUAL_EXECUTION_PHASE,
+            phase_scope: I2S_PROJECTION_RESIDUAL_PHASE_SCOPE,
+            layout_source: I2S_LAYOUT_SOURCE,
+            transport_layout: I2S_TRANSPORT_LAYOUT,
+            fallback_used: false,
+            result: "pass",
+            artifact_path: artifact_path.into(),
+            tokens: I2S_PREFILL_TOKENS,
+            n: I2S_PARITY_N,
+            k: I2S_PARITY_K,
+            block_size: I2S_PARITY_BLOCK_SIZE,
+            max_abs_error: comparison.max_abs_error,
+            mean_abs_error: comparison.mean_abs_error,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct I2sMetalParityFixture {
     pub activations: Vec<f32>,
@@ -232,6 +295,13 @@ pub struct I2sMetalParityFixture {
     pub n: usize,
     pub k: usize,
     pub block_size: usize,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct I2sMetalProjectionResidualFixture {
+    pub base: I2sMetalParityFixture,
+    pub residual: Vec<f32>,
+    pub expected: Vec<f32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -284,6 +354,10 @@ pub fn metal_i2s_prefill_contribution_artifact_path(date: &str) -> String {
     format!("ci/hardware/{MACHINE_ID}/{date}/metal-i2s-prefill-contribution.json")
 }
 
+pub fn metal_i2s_projection_residual_artifact_path(date: &str) -> String {
+    format!("ci/hardware/{MACHINE_ID}/{date}/metal-i2s-projection-residual.json")
+}
+
 pub fn tiny_add_inputs() -> (Vec<f32>, Vec<f32>) {
     let lhs = (0..SMOKE_ELEMENT_COUNT).map(|i| i as f32).collect();
     let rhs = (0..SMOKE_ELEMENT_COUNT).map(|i| (i as f32) * 2.0).collect();
@@ -307,6 +381,25 @@ pub fn i2s_metal_parity_fixture() -> I2sMetalParityFixture {
 
 pub fn i2s_metal_prefill_fixture() -> I2sMetalParityFixture {
     i2s_metal_fixture(I2S_PREFILL_TOKENS)
+}
+
+pub fn i2s_metal_projection_residual_fixture() -> I2sMetalProjectionResidualFixture {
+    let base = i2s_metal_fixture(I2S_PREFILL_TOKENS);
+    let residual = (0..base.expected.len())
+        .map(|index| {
+            let row = index / base.n;
+            let col = index % base.n;
+            ((row as i32 * 3 + col as i32 * 2) % 7 - 3) as f32 * 0.125
+        })
+        .collect::<Vec<_>>();
+    let expected = base
+        .expected
+        .iter()
+        .zip(residual.iter())
+        .map(|(value, residual)| value + residual)
+        .collect();
+
+    I2sMetalProjectionResidualFixture { base, residual, expected }
 }
 
 fn i2s_metal_fixture(m: usize) -> I2sMetalParityFixture {

--- a/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
+++ b/crates/bitnet-kernels/tests/metal_tiny_smoke.rs
@@ -3,17 +3,21 @@
 use bitnet_device_probe::{AppleBackendReceipt, AppleResolvedDevice};
 use bitnet_kernels::metal::smoke::{
     ARTIFACT_KIND, I2S_EXECUTION_PHASE, I2S_KERNEL_FAMILY, I2S_LAYOUT_SOURCE,
-    I2S_METAL_PARITY_KERNEL_ID, I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID, I2S_PARITY_BLOCK_SIZE,
-    I2S_PARITY_K, I2S_PARITY_M, I2S_PARITY_N, I2S_PREFILL_EXECUTION_PHASE,
-    I2S_PREFILL_KV_CACHE_BEHAVIOR, I2S_PREFILL_PHASE_SCOPE, I2S_PREFILL_TOKENS,
-    I2S_TRANSPORT_LAYOUT, I2sMetalParityFixture, I2sMetalParityReceipt,
-    I2sMetalPrefillContributionReceipt, MACHINE_ID, PARITY_ARTIFACT_KIND,
+    I2S_METAL_PARITY_KERNEL_ID, I2S_METAL_PREFILL_CONTRIBUTION_KERNEL_ID,
+    I2S_METAL_PROJECTION_RESIDUAL_KERNEL_ID, I2S_PARITY_BLOCK_SIZE, I2S_PARITY_K, I2S_PARITY_M,
+    I2S_PARITY_N, I2S_PREFILL_EXECUTION_PHASE, I2S_PREFILL_KV_CACHE_BEHAVIOR,
+    I2S_PREFILL_PHASE_SCOPE, I2S_PREFILL_TOKENS, I2S_PROJECTION_RESIDUAL_EXECUTION_PHASE,
+    I2S_PROJECTION_RESIDUAL_GRAPH_ID, I2S_PROJECTION_RESIDUAL_OPS,
+    I2S_PROJECTION_RESIDUAL_PHASE_SCOPE, I2S_TRANSPORT_LAYOUT, I2sMetalParityFixture,
+    I2sMetalParityReceipt, I2sMetalPrefillContributionReceipt, I2sMetalProjectionResidualFixture,
+    I2sMetalProjectionResidualReceipt, MACHINE_ID, PARITY_ARTIFACT_KIND,
     PHASE_CONTRIBUTION_ARTIFACT_KIND, REFERENCE_BACKEND, REQUESTED_BACKEND, RUNTIME_API,
-    SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SmokeComparison, TINY_METAL_ADD_PARITY_KERNEL_ID,
-    TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt, TinyMetalAddSmokeReceipt,
-    compare_tiny_add_outputs, expected_tiny_add, i2s_metal_parity_fixture,
-    i2s_metal_prefill_fixture, i2s_parity_shape_words, is_apple_m4_adapter_name,
-    metal_i2s_parity_artifact_path, metal_i2s_prefill_contribution_artifact_path,
+    SELECTED_BACKEND, SMOKE_WORKGROUP_SIZE, SUBGRAPH_ARTIFACT_KIND, SmokeComparison,
+    TINY_METAL_ADD_PARITY_KERNEL_ID, TINY_METAL_ADD_SMOKE_KERNEL_ID, TinyMetalAddParityReceipt,
+    TinyMetalAddSmokeReceipt, compare_tiny_add_outputs, expected_tiny_add,
+    i2s_metal_parity_fixture, i2s_metal_prefill_fixture, i2s_metal_projection_residual_fixture,
+    i2s_parity_shape_words, is_apple_m4_adapter_name, metal_i2s_parity_artifact_path,
+    metal_i2s_prefill_contribution_artifact_path, metal_i2s_projection_residual_artifact_path,
     metal_parity_artifact_path, metal_smoke_artifact_path, tiny_add_inputs,
 };
 
@@ -155,6 +159,52 @@ fn i2s_prefill_contribution_receipt_records_phase_and_fallback_status() {
 }
 
 #[test]
+fn i2s_projection_residual_fixture_extends_packed_i2s_reference() {
+    let fixture = i2s_metal_projection_residual_fixture();
+
+    assert_eq!(fixture.base.m, I2S_PREFILL_TOKENS);
+    assert_eq!(fixture.base.n, I2S_PARITY_N);
+    assert_eq!(fixture.base.k, I2S_PARITY_K);
+    assert_eq!(fixture.base.block_size, I2S_PARITY_BLOCK_SIZE);
+    assert_eq!(fixture.residual.len(), fixture.base.expected.len());
+    assert_eq!(fixture.expected.len(), fixture.base.expected.len());
+    assert!(fixture.residual.iter().any(|value| *value != 0.0));
+    for ((projected, residual), expected) in
+        fixture.base.expected.iter().zip(fixture.residual.iter()).zip(fixture.expected.iter())
+    {
+        assert_eq!(*expected, projected + residual);
+    }
+}
+
+#[test]
+fn i2s_projection_residual_receipt_records_subgraph_without_inference_claim() {
+    let receipt = I2sMetalProjectionResidualReceipt::passed(
+        metal_i2s_projection_residual_artifact_path("2026-05-06"),
+        SmokeComparison { max_abs_error: 0.0, mean_abs_error: 0.0 },
+    );
+
+    assert_eq!(receipt.machine_id, MACHINE_ID);
+    assert_eq!(receipt.artifact_kind, SUBGRAPH_ARTIFACT_KIND);
+    assert_eq!(receipt.requested_backend, REQUESTED_BACKEND);
+    assert_eq!(receipt.selected_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.runtime_api, RUNTIME_API);
+    assert_eq!(receipt.reference_backend, REFERENCE_BACKEND);
+    assert_eq!(receipt.target_backend, SELECTED_BACKEND);
+    assert_eq!(receipt.graph_id, I2S_PROJECTION_RESIDUAL_GRAPH_ID);
+    assert_eq!(receipt.kernel_id, I2S_METAL_PROJECTION_RESIDUAL_KERNEL_ID);
+    assert_eq!(receipt.kernel_family, I2S_KERNEL_FAMILY);
+    assert_eq!(receipt.execution_phase, I2S_PROJECTION_RESIDUAL_EXECUTION_PHASE);
+    assert_eq!(receipt.phase_scope, I2S_PROJECTION_RESIDUAL_PHASE_SCOPE);
+    assert_eq!(receipt.layout_source, I2S_LAYOUT_SOURCE);
+    assert_eq!(receipt.transport_layout, I2S_TRANSPORT_LAYOUT);
+    assert!(!receipt.fallback_used);
+    assert_eq!(
+        receipt.artifact_path,
+        "ci/hardware/apple-m4-mac-mini/2026-05-06/metal-i2s-projection-residual.json"
+    );
+}
+
+#[test]
 fn comparison_fails_instead_of_falling_back_to_cpu() {
     let expected = [1.0_f32, 2.0, 3.0];
     let actual = [1.0_f32, 20.0, 3.0];
@@ -199,6 +249,11 @@ mod live_metal {
     const RUN_I2S_PREFILL_ENV: &str = "BITNET_RUN_M4_METAL_I2S_PREFILL";
     const I2S_PREFILL_RECEIPT_ENV: &str = "BITNET_M4_METAL_I2S_PREFILL_RECEIPT";
     const I2S_PREFILL_ARTIFACT_PATH_ENV: &str = "BITNET_M4_METAL_I2S_PREFILL_ARTIFACT_PATH";
+    const RUN_I2S_PROJECTION_RESIDUAL_ENV: &str = "BITNET_RUN_M4_METAL_I2S_PROJECTION_RESIDUAL";
+    const I2S_PROJECTION_RESIDUAL_RECEIPT_ENV: &str =
+        "BITNET_M4_METAL_I2S_PROJECTION_RESIDUAL_RECEIPT";
+    const I2S_PROJECTION_RESIDUAL_ARTIFACT_PATH_ENV: &str =
+        "BITNET_M4_METAL_I2S_PROJECTION_RESIDUAL_ARTIFACT_PATH";
     const TINY_KERNEL_SMOKE_PROFILE: &str = "tiny_kernel_smoke";
 
     struct MetalSmokeOutput {
@@ -522,6 +577,62 @@ mod live_metal {
         Ok(())
     }
 
+    #[test]
+    fn tiny_m4_metal_i2s_projection_residual_subgraph_matches_cpu_reference_when_enabled()
+    -> Result<(), Box<dyn Error>> {
+        if std::env::var(RUN_I2S_PROJECTION_RESIDUAL_ENV).as_deref() != Ok("1") {
+            eprintln!(
+                "skipping live M4 Metal I2_S projection residual subgraph; set {RUN_I2S_PROJECTION_RESIDUAL_ENV}=1 to run it"
+            );
+            return Ok(());
+        }
+
+        let fixture = i2s_metal_projection_residual_fixture();
+        let metal_output = run_i2s_metal_projection_residual_fixture(&fixture)?;
+
+        if !is_apple_m4_adapter_name(&metal_output.adapter_name) {
+            return Err(io_error(format!(
+                "M4-017 I2_S projection residual subgraph requires an Apple M4-family Metal adapter; found '{}'",
+                metal_output.adapter_name
+            )));
+        }
+
+        let comparison = compare_tiny_add_outputs(&fixture.expected, &metal_output.output, 1e-5)?;
+        let artifact_path = std::env::var(I2S_PROJECTION_RESIDUAL_ARTIFACT_PATH_ENV)
+            .or_else(|_| std::env::var(I2S_PROJECTION_RESIDUAL_RECEIPT_ENV))
+            .unwrap_or_else(|_| {
+                "ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-projection-residual.json"
+                    .to_string()
+            });
+        let receipt = I2sMetalProjectionResidualReceipt::passed(artifact_path.clone(), comparison);
+
+        let mut receipt_json = apple_backend_receipt_json(
+            receipt.machine_id,
+            receipt.artifact_kind,
+            receipt.requested_backend,
+            Some(receipt.selected_backend),
+            receipt.runtime_api,
+            metal_output.adapter_name,
+            receipt.fallback_used,
+            receipt.artifact_path.clone(),
+            None,
+            Some(receipt.graph_id),
+            receipt.result,
+        )?;
+        extend_i2s_projection_residual_metrics(&mut receipt_json, &receipt, &fixture);
+
+        if let Ok(path) = std::env::var(I2S_PROJECTION_RESIDUAL_RECEIPT_ENV) {
+            let output_path = receipt_output_path(&path);
+            if let Some(parent) = output_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(output_path, serde_json::to_string_pretty(&receipt_json)?)?;
+        }
+
+        println!("{}", serde_json::to_string_pretty(&receipt_json)?);
+        Ok(())
+    }
+
     fn run_tiny_add_smoke(lhs: &[f32], rhs: &[f32]) -> Result<MetalSmokeOutput, Box<dyn Error>> {
         pollster::block_on(async move {
             let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
@@ -802,6 +913,181 @@ mod live_metal {
             rx.recv()
                 .map_err(|error| io_error(format!("failed to receive Metal map result: {error}")))?
                 .map_err(|error| io_error(format!("failed to map Metal I2_S output: {error}")))?;
+
+            let data = slice.get_mapped_range();
+            let output = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
+            drop(data);
+            staging_buffer.unmap();
+
+            Ok(MetalI2sParityOutput { adapter_name: adapter_info.name, output })
+        })
+    }
+
+    fn run_i2s_metal_projection_residual_fixture(
+        fixture: &I2sMetalProjectionResidualFixture,
+    ) -> Result<MetalI2sParityOutput, Box<dyn Error>> {
+        pollster::block_on(async move {
+            let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+                backends: wgpu::Backends::METAL,
+                ..Default::default()
+            });
+            let adapter = instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: None,
+                    force_fallback_adapter: false,
+                })
+                .await
+                .ok_or_else(|| {
+                    io_error("no Metal adapter found for M4-017 I2_S projection residual subgraph")
+                })?;
+
+            let adapter_info = adapter.get_info();
+            if adapter_info.backend != wgpu::Backend::Metal {
+                return Err(io_error(format!(
+                    "M4-017 I2_S projection residual subgraph requires Metal backend, found {:?}",
+                    adapter_info.backend
+                )));
+            }
+
+            let (device, queue) = adapter
+                .request_device(&wgpu::DeviceDescriptor::default(), None)
+                .await
+                .map_err(|error| io_error(format!("failed to create Metal device: {error}")))?;
+
+            let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(I2S_METAL_PROJECTION_RESIDUAL_KERNEL_ID),
+                source: wgpu::ShaderSource::Wgsl(I2S_PROJECTION_RESIDUAL_SHADER.into()),
+            });
+
+            let activations_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_activations"),
+                contents: bytemuck::cast_slice(&fixture.base.activations),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let weights_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_weights_u32_le"),
+                contents: bytemuck::cast_slice(&fixture.base.weights_packed_words),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let scales_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_scales"),
+                contents: bytemuck::cast_slice(&fixture.base.scales),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let shape_words = i2s_parity_shape_words(&fixture.base);
+            let shape_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_shape"),
+                contents: bytemuck::cast_slice(&shape_words),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let residual_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_residual"),
+                contents: bytemuck::cast_slice(&fixture.residual),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+            let byte_len = std::mem::size_of_val(&fixture.expected[..]) as u64;
+            let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_output"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            });
+            let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_staging"),
+                size: byte_len,
+                usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            });
+
+            let bind_group_layout =
+                device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("tiny_metal_i2s_projection_residual_layout"),
+                    entries: &[
+                        storage_buffer_entry(0, true),
+                        storage_buffer_entry(1, true),
+                        storage_buffer_entry(2, true),
+                        storage_buffer_entry(3, false),
+                        storage_buffer_entry(4, true),
+                        storage_buffer_entry(5, true),
+                    ],
+                });
+
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_bind_group"),
+                layout: &bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: activations_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: weights_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: scales_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: output_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry { binding: 4, resource: shape_buffer.as_entire_binding() },
+                    wgpu::BindGroupEntry {
+                        binding: 5,
+                        resource: residual_buffer.as_entire_binding(),
+                    },
+                ],
+            });
+
+            let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_pipeline_layout"),
+                bind_group_layouts: &[&bind_group_layout],
+                push_constant_ranges: &[],
+            });
+            let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_pipeline"),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some("main"),
+                compilation_options: Default::default(),
+                cache: None,
+            });
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("tiny_metal_i2s_projection_residual_encoder"),
+            });
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("tiny_metal_i2s_projection_residual_pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&pipeline);
+                pass.set_bind_group(0, &bind_group, &[]);
+                pass.dispatch_workgroups(
+                    (fixture.expected.len() as u32).div_ceil(SMOKE_WORKGROUP_SIZE),
+                    1,
+                    1,
+                );
+            }
+
+            encoder.copy_buffer_to_buffer(&output_buffer, 0, &staging_buffer, 0, byte_len);
+            queue.submit(std::iter::once(encoder.finish()));
+
+            let slice = staging_buffer.slice(..);
+            let (tx, rx) = std::sync::mpsc::channel();
+            slice.map_async(wgpu::MapMode::Read, move |result| {
+                tx.send(result).unwrap();
+            });
+            device.poll(wgpu::Maintain::Wait);
+            rx.recv()
+                .map_err(|error| io_error(format!("failed to receive Metal map result: {error}")))?
+                .map_err(|error| {
+                    io_error(format!(
+                        "failed to map Metal I2_S projection residual output: {error}"
+                    ))
+                })?;
 
             let data = slice.get_mapped_range();
             let output = bytemuck::cast_slice::<u8, f32>(&data).to_vec();
@@ -1243,6 +1529,66 @@ mod live_metal {
         );
     }
 
+    fn extend_i2s_projection_residual_metrics(
+        receipt_json: &mut serde_json::Value,
+        receipt: &I2sMetalProjectionResidualReceipt,
+        fixture: &I2sMetalProjectionResidualFixture,
+    ) {
+        let object = receipt_json.as_object_mut().expect("Apple receipt JSON is an object");
+        object.insert(
+            "bitnet".to_string(),
+            json!({
+                "kernel_family": receipt.kernel_family,
+                "execution_phase": receipt.execution_phase,
+                "phase_scope": receipt.phase_scope,
+                "layout_source": receipt.layout_source,
+                "fallback_layout": null
+            }),
+        );
+        object.insert("model".to_string(), serde_json::Value::Null);
+        object.insert(
+            "subgraph".to_string(),
+            json!({
+                "graph_id": receipt.graph_id,
+                "kernel_id": receipt.kernel_id,
+                "operations": I2S_PROJECTION_RESIDUAL_OPS,
+                "phase_scope": receipt.phase_scope,
+                "tokens": receipt.tokens,
+                "full_bitnet_inference": false,
+                "full_autoregressive_decode": false,
+                "kv_cache_behavior": "not_exercised"
+            }),
+        );
+        object.insert(
+            "layout".to_string(),
+            json!({
+                "source": receipt.layout_source,
+                "transport_layout": receipt.transport_layout,
+                "canonical_packed_bytes": fixture.base.weights_packed.len(),
+                "transport_words_u32": fixture.base.weights_packed_words.len(),
+                "consumes_packed_i2_s_directly": true,
+                "dequantizes_before_compute": false,
+                "residual_elements": fixture.residual.len(),
+                "m": fixture.base.m,
+                "n": fixture.base.n,
+                "k": fixture.base.k,
+                "block_size": fixture.base.block_size
+            }),
+        );
+        object.insert(
+            "parity".to_string(),
+            json!({
+                "reference_backend": receipt.reference_backend,
+                "target_backend": receipt.target_backend,
+                "kernel_id": receipt.kernel_id,
+                "kernel_family": receipt.kernel_family,
+                "max_abs_error": receipt.max_abs_error,
+                "mean_abs_error": receipt.mean_abs_error,
+                "token_agreement_for_greedy": null
+            }),
+        );
+    }
+
     fn duration_ms(duration: Duration) -> f64 {
         duration.as_secs_f64() * 1_000.0
     }
@@ -1332,6 +1678,64 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     }
 
     output[output_index] = acc;
+}
+"#;
+
+    const I2S_PROJECTION_RESIDUAL_SHADER: &str = r#"
+@group(0) @binding(0) var<storage, read> activations: array<f32>;
+@group(0) @binding(1) var<storage, read> weights_words: array<u32>;
+@group(0) @binding(2) var<storage, read> scales: array<f32>;
+@group(0) @binding(3) var<storage, read_write> output: array<f32>;
+@group(0) @binding(4) var<storage, read> shape: array<u32>;
+@group(0) @binding(5) var<storage, read> residual: array<f32>;
+
+fn decode_i2s(bits: u32) -> f32 {
+    if bits == 1u {
+        return 1.0;
+    }
+    if bits == 3u {
+        return -1.0;
+    }
+    return 0.0;
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let output_index = global_id.x;
+    let m = shape[0];
+    let n = shape[1];
+    let k = shape[2];
+    let packed_k = shape[3];
+    let block_size = shape[4];
+    let num_blocks_k = shape[5];
+
+    if output_index >= m * n {
+        return;
+    }
+
+    let row = output_index / n;
+    let col = output_index % n;
+    var acc = 0.0;
+
+    var k_index = 0u;
+    loop {
+        if k_index >= k {
+            break;
+        }
+
+        let packed_byte_index = col * packed_k + k_index / 4u;
+        let word_index = packed_byte_index / 4u;
+        let byte_shift = (packed_byte_index % 4u) * 8u;
+        let packed_byte = (weights_words[word_index] >> byte_shift) & 0xffu;
+        let bit_shift = (k_index % 4u) * 2u;
+        let bits = (packed_byte >> bit_shift) & 0x03u;
+        let block_index = k_index / block_size;
+        let scale = scales[col * num_blocks_k + block_index];
+        acc = acc + activations[row * k + k_index] * decode_i2s(bits) * scale;
+        k_index = k_index + 1u;
+    }
+
+    output[output_index] = acc + residual[output_index];
 }
 "#;
 }

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -541,6 +541,79 @@ compute-bound unless the receipt separates allocation overhead. It must not
 claim QK256 acceleration, Neural Engine execution, Metal execution, or general
 M4 performance.
 
+## M4-017 Metal I2_S Projection Residual Subgraph
+
+The Metal kernel-family expansion adds a tiny I2_S subgraph fixture:
+
+```text
+packed I2_S projection
+-> residual add
+-> CPU/NEON parity comparison
+```
+
+This is still a narrow kernel/subgraph proof. It consumes the fixture's packed
+I2_S transport words directly, dispatches `tiny_metal_i2s_projection_residual`,
+adds a deterministic residual buffer, and compares the output with the
+Apple CPU/NEON reference. It does not load a BitNet model, run a tokenizer,
+exercise KV-cache behavior, benchmark performance, or claim full Metal
+inference.
+
+Run the non-live contract tests with:
+
+```bash
+cargo test --locked -p bitnet-kernels \
+  --no-default-features \
+  --features metal \
+  --test metal_tiny_smoke i2s_projection_residual -- --nocapture
+```
+
+Run the live M4 Metal subgraph smoke with:
+
+```bash
+BITNET_RUN_M4_METAL_I2S_PROJECTION_RESIDUAL=1 \
+BITNET_M4_METAL_I2S_PROJECTION_RESIDUAL_RECEIPT=ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-projection-residual.json \
+cargo test --locked -p bitnet-kernels \
+  --no-default-features \
+  --features metal \
+  --test metal_tiny_smoke tiny_m4_metal_i2s_projection_residual_subgraph_matches_cpu_reference_when_enabled -- --nocapture
+```
+
+The receipt must preserve the subgraph and kernel-family boundaries:
+
+```json
+{
+  "artifact_kind": "subgraph",
+  "requested_backend": "apple-m4-metal",
+  "selected_backend": "apple-m4-metal",
+  "runtime_api": "metal",
+  "graph_id": "tiny_i2s_projection_residual_subgraph",
+  "fallback_used": false,
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "parity",
+    "phase_scope": "projection_residual_subgraph",
+    "layout_source": "fixture_packed_i2_s"
+  },
+  "subgraph": {
+    "kernel_id": "tiny_metal_i2s_projection_residual",
+    "operations": ["packed_i2_s_matmul", "residual_add"],
+    "full_bitnet_inference": false,
+    "kv_cache_behavior": "not_exercised"
+  },
+  "parity": {
+    "reference_backend": "apple-m4-cpu-neon",
+    "target_backend": "apple-m4-metal",
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0
+  }
+}
+```
+
+M4-017 may claim only that this specific Apple Metal I2_S subgraph passes CPU
+reference parity with `fallback_used=false`. It must not claim full Metal
+inference, QK256 acceleration, Neural Engine execution, MPSGraph execution, or
+general M4 performance.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -568,6 +568,65 @@ compute-bound unless allocation overhead is separated in the receipt, and it
 must not claim QK256 acceleration, Neural Engine execution, Metal execution, or
 general M4 performance.
 
+### M4-017 - Metal I2_S Projection Residual Subgraph
+
+Expand Metal kernel-family coverage with a tiny I2_S projection plus residual
+subgraph. This keeps the proof below full inference while exercising more than a
+single projection kernel:
+
+```text
+fixture_packed_i2_s
+-> tiny_metal_i2s_projection_residual
+-> residual_add
+-> CPU/NEON parity
+```
+
+The live test is opt-in and writes a subgraph receipt:
+
+```bash
+BITNET_RUN_M4_METAL_I2S_PROJECTION_RESIDUAL=1 \
+BITNET_M4_METAL_I2S_PROJECTION_RESIDUAL_RECEIPT=ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-projection-residual.json \
+cargo test --locked -p bitnet-kernels \
+  --no-default-features \
+  --features metal \
+  --test metal_tiny_smoke tiny_m4_metal_i2s_projection_residual_subgraph_matches_cpu_reference_when_enabled -- --nocapture
+```
+
+The receipt records:
+
+```json
+{
+  "artifact_kind": "subgraph",
+  "graph_id": "tiny_i2s_projection_residual_subgraph",
+  "requested_backend": "apple-m4-metal",
+  "selected_backend": "apple-m4-metal",
+  "runtime_api": "metal",
+  "fallback_used": false,
+  "bitnet": {
+    "kernel_family": "i2_s",
+    "execution_phase": "parity",
+    "phase_scope": "projection_residual_subgraph"
+  },
+  "subgraph": {
+    "kernel_id": "tiny_metal_i2s_projection_residual",
+    "operations": ["packed_i2_s_matmul", "residual_add"],
+    "full_bitnet_inference": false,
+    "full_autoregressive_decode": false
+  },
+  "parity": {
+    "reference_backend": "apple-m4-cpu-neon",
+    "target_backend": "apple-m4-metal",
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0
+  }
+}
+```
+
+M4-017 may claim only that this specific Apple Metal I2_S subgraph passes CPU
+reference parity with `fallback_used=false`. It must not claim full Metal
+inference, QK256 acceleration, Neural Engine execution, MPSGraph execution, or
+general M4 performance.
+
 ## Do Not
 
 - Do not start with Apple Neural Engine inference claims.

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -560,7 +560,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-017"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-017-metal-kernel-family-expansion"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -560,11 +560,12 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-017"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-017-metal-kernel-family-expansion"
 stackable = false
 requires_human_merge = true
 blocked_by = ["M4-016"]
+pr = 3818
 acceptance = "Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present."
 commands = [
   "cargo fmt --all -- --check",

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T012615Z-M4-017-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T012615Z-M4-017-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-07T01:26:15Z"
+campaign = "apple-m4"
+item = "M4-017"
+event = "in_progress"
+branch = "codex/apple-m4/M4-017-metal-kernel-family-expansion"
+actor = "codex"
+
+notes = [
+  "Started Apple Metal BitNet kernel-family expansion with a tiny I2_S projection residual subgraph.",
+  "Scope remains CPU-reference parity and fallback=false receipt evidence only; no QK256, server, MPSGraph, Neural Engine, full inference, or general performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T013347Z-M4-017-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T013347Z-M4-017-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T01:33:47Z"
+campaign = "apple-m4"
+item = "M4-017"
+event = "pr_open"
+pr = 3818
+head_sha = "6440589d3c7668e24c0cc7da5e55c7233749faea"
+actor = "codex"
+
+notes = [
+  "Opened Apple Metal I2_S projection residual subgraph PR.",
+  "Receipt scope remains a specific subgraph parity proof with fallback_used=false; no full Metal inference, QK256, MPSGraph, Neural Engine, or general performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -25,7 +25,7 @@
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
-| M4-017 | ready | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
+| M4-017 | in_progress | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -25,7 +25,7 @@
 | M4-014 | merged | #3789 | `codex/apple-m4/M4-014-strict-bitnet-proof` | Run strict real GGUF, real tokenizer, selected Apple backend, fallback_used=false, deterministic prompt, and receipt emission. |
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
-| M4-017 | in_progress | TBD | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
+| M4-017 | pr_open | #3818 | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | M4-018 | proposed | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-017 | #3818 | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -18,7 +18,7 @@
 | apple-m4 | M4-014 | M4-013 | merged |
 | apple-m4 | M4-015 | M4-014 | merged |
 | apple-m4 | M4-016 | M4-015 | merged |
-| apple-m4 | M4-017 | M4-016 | ready |
+| apple-m4 | M4-017 | M4-016 | in_progress |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -18,7 +18,7 @@
 | apple-m4 | M4-014 | M4-013 | merged |
 | apple-m4 | M4-015 | M4-014 | merged |
 | apple-m4 | M4-016 | M4-015 | merged |
-| apple-m4 | M4-017 | M4-016 | in_progress |
+| apple-m4 | M4-017 | M4-016 | pr_open |
 | apple-m4 | M4-018 | M4-017 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-017 | TBD | ready | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-017 | TBD | in_progress | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-017 | TBD | in_progress | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-017 | #3818 | pr_open | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-017
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Scope
- Adds `tiny_i2s_projection_residual_subgraph`, a narrow Apple Metal I2_S fixture that consumes packed I2_S transport words directly and adds a deterministic residual buffer.
- Emits a subgraph receipt with requested/selected backend, runtime API, graph/kernel identity, I2_S family, parity phase, layout handling, CPU/NEON reference parity, and `fallback_used=false`.
- Updates Apple M4 campaign state/docs and regenerated dashboards.

## Claim Boundary
May claim: this specific Apple Metal I2_S projection residual subgraph passes CPU reference parity with `fallback_used=false`.

Must not claim: full Metal inference, QK256 on Apple Silicon, MPSGraph execution, Neural Engine execution, or general M4 performance.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke i2s_projection_residual -- --nocapture`
- `cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke -- --nocapture`
- `BITNET_RUN_M4_METAL_I2S_PROJECTION_RESIDUAL=1 BITNET_M4_METAL_I2S_PROJECTION_RESIDUAL_RECEIPT=target/m4-017/metal-i2s-projection-residual.json cargo test --locked -p bitnet-kernels --no-default-features --features metal --test metal_tiny_smoke tiny_m4_metal_i2s_projection_residual_subgraph_matches_cpu_reference_when_enabled -- --nocapture`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

Known out-of-scope broad check: `cargo test --locked -p bitnet-kernels --no-default-features --features metal` currently fails in existing Issue #439 validation tests that hardcode `/home/steven/code/Rust/BitNet-rs/...` and then surface CUDA gate violations outside the M4-017 allowed scope. Focused M4-017 tests and campaign gates pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation and testing support for I2S projection residual subgraph on Apple M4 Mac mini with CPU/NEON parity verification.

* **Tests**
  * Expanded test coverage with fixture validation and live execution tests for the projection residual subgraph.

* **Documentation**
  * Added validation specification and hardware validation documentation for I2S projection residual subgraph parity proof.

* **Chores**
  * Updated project tracking and roadmap to reflect new M4-017 validation work item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->