### PR TITLE
fix(startup-guard): align profile snapshots with report context

### DIFF
--- a/crates/bitnet-startup-contract-guard/src/lib.rs
+++ b/crates/bitnet-startup-contract-guard/src/lib.rs
@@ -33,12 +33,25 @@ impl StartupContractGuard {
     /// Evaluate the startup contract and return a reusable snapshot.
     pub fn evaluate(component: RuntimeComponent, policy: ContractPolicy) -> Result<Self> {
         let report = StartupContractReport::evaluate(component, policy)?;
+        let profile_summary = report.profile_summary();
+        let profile_violations = if report.contract.required_features().is_empty()
+            && report.contract.optional_features().is_empty()
+            && report.contract.forbidden_features().is_empty()
+        {
+            None
+        } else {
+            Some((
+                report.contract.missing_required().to_vec(),
+                report.contract.forbidden_active().to_vec(),
+            ))
+        };
+
         Ok(Self {
             component,
             policy,
             feature_line: feature_line(),
-            profile_summary: active_profile_summary(),
-            profile_violations: active_profile_violation_labels(),
+            profile_summary,
+            profile_violations,
             report,
         })
     }

--- a/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
+++ b/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
@@ -78,6 +78,13 @@ fn guard_profile_summary_not_empty() {
     assert!(!guard.profile_summary.is_empty());
 }
 
+#[test]
+fn guard_profile_summary_matches_report_context() {
+    let guard =
+        StartupContractGuard::evaluate(RuntimeComponent::Test, ContractPolicy::Observe).unwrap();
+    assert_eq!(guard.profile_summary, guard.report.profile_summary());
+}
+
 // ---------------------------------------------------------------------------
 // StartupContractGuard: is_compatible
 // ---------------------------------------------------------------------------
@@ -145,6 +152,25 @@ fn guard_profile_violations_is_option() {
         }
         None => {}
     }
+}
+
+#[test]
+fn guard_profile_violations_match_report_contract() {
+    let guard =
+        StartupContractGuard::evaluate(RuntimeComponent::Cli, ContractPolicy::Observe).unwrap();
+    let expected = if guard.report.contract.required_features().is_empty()
+        && guard.report.contract.optional_features().is_empty()
+        && guard.report.contract.forbidden_features().is_empty()
+    {
+        None
+    } else {
+        Some((
+            guard.report.contract.missing_required().to_vec(),
+            guard.report.contract.forbidden_active().to_vec(),
+        ))
+    };
+
+    assert_eq!(guard.profile_violations, expected);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary
- Derive `StartupContractGuard.profile_summary` from the component-specific `StartupContractReport` instead of global active-profile helpers.
- Derive `profile_violations` from the resolved report contract so the snapshot matches `guard.report.contract`.
- Preserve the existing `active_profile_summary` and `active_profile_violation_labels` public reexports to avoid facade API churn.

Supersedes stale PR #3572 with the same behavior fix but without removing public reexports.

### Validation
- `cargo fmt --check -p bitnet-startup-contract-guard`
- `cargo test --locked -p bitnet-startup-contract-guard`
- `git diff --check`