### PR TITLE
ci: fix http auth const clippy lint

### DIFF
--- a/crates/bitnet-http-auth-core/src/lib.rs
+++ b/crates/bitnet-http-auth-core/src/lib.rs
@@ -36,7 +36,7 @@ fn trim_http_auth_whitespace(value: &str) -> &str {
     value.trim_matches(|c| matches!(c, ' ' | '\t'))
 }
 
-fn is_http_auth_whitespace(byte: u8) -> bool {
+const fn is_http_auth_whitespace(byte: u8) -> bool {
     matches!(byte, b' ' | b'\t')
 }
 


### PR DESCRIPTION
## Scope
- Makes `is_http_auth_whitespace` a `const fn` to satisfy the current CI `clippy::missing_const_for_fn` warning under `-D warnings`.

## Why
- This unblocks the workspace CPU-feature clippy check that is currently failing unrelated PRs on the newer CI toolchain.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --no-default-features --features cpu -- -D warnings`
