### PR TITLE
feat(cuda): add CUDA-BITNET-008 benchmark receipt

### DIFF
--- a/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json
+++ b/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json
@@ -1,0 +1,181 @@
+{
+  "artifact_kind": "strict_bitnet_cuda_benchmark",
+  "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json",
+  "benchmark": {
+    "cpu_avx512_first_token_ms": 18323.0,
+    "cpu_avx512_tokens_per_second": 0.0565135385245728,
+    "cpu_avx512_total_ms": 141559.0,
+    "cpu_avx512_total_ms_div_cuda_total_ms": 0.7445418636820265,
+    "cpu_cuda_output_match": true,
+    "cpu_reference_backend": "amd-9950x3d-cpu-avx512",
+    "cuda_backend": "nvidia-rtx-5070-ti-cuda",
+    "cuda_first_token_ms": 27119.0,
+    "cuda_kernel_invocations": 1680,
+    "cuda_tokens_per_second": 0.04207669529635143,
+    "cuda_total_ms": 190129.0,
+    "cuda_total_ms_div_cpu_avx512_total_ms": 1.3431078207673126,
+    "profile": "short_decode_8",
+    "prompt_profile": "short_decode_37_prompt_tokens_8_generated_tokens",
+    "speedup_claim": false
+  },
+  "bitnet": {
+    "kernel_family": "qk256",
+    "layout": "gguf_packed_i2_s",
+    "per_token_weight_upload": true,
+    "quantization": "W1.58A8",
+    "weights_uploaded_once": false
+  },
+  "claim": "strict_bitnet_cuda_benchmark_baseline",
+  "claim_boundaries": [
+    "speedup_claim=false; this receipt records a same-model baseline only.",
+    "CPU scalar and AVX2 strict end-to-end profiles are present as explicit not_run entries unless matching strict receipts are supplied.",
+    "The source CUDA receipt records weights_uploaded_once=false and per_token_weight_upload=true, so this benchmark does not claim upload-once optimized inference."
+  ],
+  "comparison_contract": {
+    "fallback_free": true,
+    "same_generated_token_count": true,
+    "same_model": true,
+    "same_prompt": true,
+    "same_sampling_policy": true,
+    "same_strict_loader_mode": true,
+    "same_tokenizer": true
+  },
+  "cuda": {
+    "available": true,
+    "compute_capability": "12.0",
+    "cuda_kernel_invocations": 1680,
+    "cuda_runtime_version": "12.9",
+    "cuda_toolkit_version": "12.9",
+    "device_count": 1,
+    "device_index": 0,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "driver_version": "591.86",
+    "memory_hwm_bytes": 5949620224,
+    "memory_hwm_source": "nvidia-smi-memory.used-sampled",
+    "nvrtc_version": "12.9",
+    "vram_bytes": 17094475776
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 1680,
+    "bitnet_linear_layers_total": 1680,
+    "execution_claim": "cuda_inference_contribution",
+    "unsupported_ops": []
+  },
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "fallback_used": false,
+  "hardware_lane": "nvidia_rtx_5070_ti_cuda",
+  "kernel_stats": [
+    {
+      "device_to_host_bytes": null,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": null,
+      "invocations": 1680,
+      "kernel_id": "qk256_gemv_cuda",
+      "kernel_launches": 1680,
+      "kernel_time_ms": null
+    }
+  ],
+  "loader": {
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "strict_mode": true
+  },
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "strict",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "source_loader_mode": "real_gguf"
+  },
+  "profiles": [
+    {
+      "backend": "amd-9950x3d-cpu-scalar",
+      "reason": "current CLI does not expose a strict end-to-end selector for this CPU SIMD mode",
+      "runtime_api": "cpu",
+      "status": "not_run"
+    },
+    {
+      "backend": "amd-9950x3d-cpu-avx2",
+      "reason": "current CLI does not expose a strict end-to-end selector for this CPU SIMD mode",
+      "runtime_api": "cpu",
+      "status": "not_run"
+    },
+    {
+      "backend": "amd-9950x3d-cpu-avx512",
+      "fallback_used": false,
+      "first_token_ms": 18323.0,
+      "generated_tokens": 8,
+      "kernel_id": "i2_s-avx512-reference",
+      "kernel_implementation": "avx512",
+      "prompt_tokens": 37,
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust",
+      "status": "measured",
+      "tokens_per_second": 0.0565135385245728,
+      "total_ms": 141559.0
+    },
+    {
+      "backend": "nvidia-rtx-5070-ti-cuda",
+      "fallback_used": false,
+      "first_token_ms": 27119.0,
+      "generated_tokens": 8,
+      "kernel_id": "qk256_gemv_cuda",
+      "kernel_implementation": "cuda",
+      "prompt_tokens": 37,
+      "runtime_api": "cuda",
+      "selected_backend": "nvidia-rtx-5070-ti-cuda",
+      "status": "measured",
+      "tokens_per_second": 0.04207669529635143,
+      "total_ms": 190129.0
+    }
+  ],
+  "proof_inputs": {
+    "cpu_avx2_short_decode_receipt": null,
+    "cpu_avx512_short_decode_receipt": "target/cuda-bitnet-008/strict-bitnet-cpu-short-decode.json",
+    "cpu_scalar_short_decode_receipt": null,
+    "cuda_short_decode_receipt": "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-short-decode.json"
+  },
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "sampling": {
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "schema": 1,
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "speedup_claim": false,
+  "timestamp_utc": "2026-05-07T02:01:03Z",
+  "tokenizer": {
+    "source": "explicit",
+    "strict": true,
+    "type": "sentencepiece"
+  },
+  "workload": {
+    "cpu_cuda_output_match": true,
+    "generated_text": "'E'E'E'E'E'E'E'E",
+    "generated_token_ids": [
+      89048,
+      89048,
+      89048,
+      89048,
+      89048,
+      89048,
+      89048,
+      89048
+    ],
+    "generated_tokens": 8,
+    "profile": "short_decode_8",
+    "prompt": "In one compact line, name four common colors, then name four common shapes, separated by commas, and do not include explanations.",
+    "prompt_tokens": 37
+  }
+}

--- a/crates/bitnet-bench-receipts/src/bin/strict_bitnet_cuda_benchmark_receipt.rs
+++ b/crates/bitnet-bench-receipts/src/bin/strict_bitnet_cuda_benchmark_receipt.rs
@@ -1,0 +1,386 @@
+use bitnet_bench_receipts::validate_strict_bitnet_cuda_benchmark_receipt_json;
+use serde_json::{Value, json};
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const DEFAULT_RECEIPT_OUT: &str =
+    "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json";
+const CPU_SELECTOR_REASON: &str =
+    "current CLI does not expose a strict end-to-end selector for this CPU SIMD mode";
+
+#[derive(Debug)]
+struct Args {
+    cuda_receipt: PathBuf,
+    cpu_avx512_receipt: PathBuf,
+    cpu_scalar_receipt: Option<PathBuf>,
+    cpu_avx2_receipt: Option<PathBuf>,
+    receipt_out: PathBuf,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+    let cuda = read_json(&args.cuda_receipt)?;
+    let cpu_avx512 = read_json(&args.cpu_avx512_receipt)?;
+    let cpu_scalar = read_optional_json(args.cpu_scalar_receipt.as_deref())?;
+    let cpu_avx2 = read_optional_json(args.cpu_avx2_receipt.as_deref())?;
+
+    assert_same_strict_decode_inputs(&cuda, &cpu_avx512)?;
+    if let Some(cpu_scalar) = &cpu_scalar {
+        assert_same_strict_decode_inputs(&cuda, cpu_scalar)?;
+    }
+    if let Some(cpu_avx2) = &cpu_avx2 {
+        assert_same_strict_decode_inputs(&cuda, cpu_avx2)?;
+    }
+
+    let receipt = build_receipt(&args, &cuda, &cpu_avx512, cpu_scalar.as_ref(), cpu_avx2.as_ref())?;
+    validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt)?;
+
+    if let Some(parent) = args.receipt_out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(&args.receipt_out, serde_json::to_string_pretty(&receipt)?)?;
+
+    Ok(())
+}
+
+fn parse_args() -> Result<Args, Box<dyn Error>> {
+    let mut cuda_receipt = None;
+    let mut cpu_avx512_receipt = None;
+    let mut cpu_scalar_receipt = None;
+    let mut cpu_avx2_receipt = None;
+    let mut receipt_out = PathBuf::from(DEFAULT_RECEIPT_OUT);
+    let mut iter = env::args().skip(1);
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--cuda-receipt" => cuda_receipt = Some(PathBuf::from(next_value(&mut iter, &arg)?)),
+            "--cpu-avx512-receipt" => {
+                cpu_avx512_receipt = Some(PathBuf::from(next_value(&mut iter, &arg)?));
+            }
+            "--cpu-scalar-receipt" => {
+                cpu_scalar_receipt = Some(PathBuf::from(next_value(&mut iter, &arg)?));
+            }
+            "--cpu-avx2-receipt" => {
+                cpu_avx2_receipt = Some(PathBuf::from(next_value(&mut iter, &arg)?));
+            }
+            "--receipt-out" => receipt_out = PathBuf::from(next_value(&mut iter, &arg)?),
+            "--help" | "-h" => {
+                print_help();
+                std::process::exit(0);
+            }
+            other => return Err(format!("unknown argument: {other}").into()),
+        }
+    }
+
+    Ok(Args {
+        cuda_receipt: cuda_receipt.ok_or("--cuda-receipt is required")?,
+        cpu_avx512_receipt: cpu_avx512_receipt.ok_or("--cpu-avx512-receipt is required")?,
+        cpu_scalar_receipt,
+        cpu_avx2_receipt,
+        receipt_out,
+    })
+}
+
+fn next_value(
+    iter: &mut impl Iterator<Item = String>,
+    flag: &str,
+) -> Result<String, Box<dyn Error>> {
+    iter.next().ok_or_else(|| format!("{flag} requires a value").into())
+}
+
+fn print_help() {
+    println!(
+        "Usage: strict_bitnet_cuda_benchmark_receipt --cuda-receipt PATH --cpu-avx512-receipt PATH [--cpu-scalar-receipt PATH] [--cpu-avx2-receipt PATH] [--receipt-out PATH]"
+    );
+}
+
+fn read_json(path: &Path) -> Result<Value, Box<dyn Error>> {
+    Ok(serde_json::from_slice(&fs::read(path)?)?)
+}
+
+fn read_optional_json(path: Option<&Path>) -> Result<Option<Value>, Box<dyn Error>> {
+    path.map(read_json).transpose()
+}
+
+fn build_receipt(
+    args: &Args,
+    cuda: &Value,
+    cpu_avx512: &Value,
+    cpu_scalar: Option<&Value>,
+    cpu_avx2: Option<&Value>,
+) -> Result<Value, Box<dyn Error>> {
+    let cpu_total_ms = total_ms(cpu_avx512)?;
+    let cuda_total_ms = total_ms(cuda)?;
+    let cpu_cuda_ratio = if cuda_total_ms > 0.0 { cpu_total_ms / cuda_total_ms } else { 0.0 };
+    let cuda_kernel_invocations = u64_at(cuda, "/cuda/cuda_kernel_invocations")
+        .or_else(|_| u64_at(cuda, "/cuda_kernel_invocations"))?;
+
+    Ok(json!({
+        "schema": 1,
+        "artifact_kind": "strict_bitnet_cuda_benchmark",
+        "machine_id": "windows-9950x3d-rtx5070ti",
+        "hardware_lane": "nvidia_rtx_5070_ti_cuda",
+        "timestamp_utc": timestamp_label(),
+        "requested_backend": "nvidia-rtx-5070-ti-cuda",
+        "selected_backend": "nvidia-rtx-5070-ti-cuda",
+        "reference_backend": "amd-9950x3d-cpu-avx512",
+        "runtime_api": "cuda",
+        "claim": "strict_bitnet_cuda_benchmark_baseline",
+        "speedup_claim": false,
+        "fallback_used": false,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "proof_inputs": {
+            "cuda_short_decode_receipt": path_label(&args.cuda_receipt),
+            "cpu_avx512_short_decode_receipt": path_label(&args.cpu_avx512_receipt),
+            "cpu_scalar_short_decode_receipt": args.cpu_scalar_receipt.as_ref().map(|path| path_label(path)),
+            "cpu_avx2_short_decode_receipt": args.cpu_avx2_receipt.as_ref().map(|path| path_label(path))
+        },
+        "model": {
+            "repo": str_at(cuda, "/model/repo")?,
+            "file": str_at(cuda, "/model/file")?,
+            "sha256": str_at(cuda, "/model/sha256")?,
+            "format": str_at(cuda, "/model/format")?,
+            "architecture": str_at(cuda, "/model/architecture")?,
+            "loader_mode": "strict",
+            "source_loader_mode": str_at(cuda, "/model/loader_mode")?,
+            "fallback_loader_used": bool_at(cuda, "/model/fallback_loader_used")?
+        },
+        "loader": {
+            "mode": str_at(cuda, "/loader/mode")?,
+            "strict_mode": strict_loader_mode(cuda)?,
+            "minimal_loader_fallback_used": bool_at(cuda, "/loader/minimal_loader_fallback_used")?,
+            "mock_tensors_used": bool_at(cuda, "/loader/mock_tensors_used")?
+        },
+        "tokenizer": {
+            "source": str_at(cuda, "/tokenizer/source")?,
+            "strict": bool_at(cuda, "/tokenizer/strict")?,
+            "type": str_at(cuda, "/tokenizer/type")?
+        },
+        "bitnet": {
+            "quantization": str_at(cuda, "/bitnet/quantization")?,
+            "kernel_family": str_at(cuda, "/kernel/family")?,
+            "layout": str_at(cuda, "/kernel/layout")?,
+            "weights_uploaded_once": bool_at(cuda, "/bitnet/weights_uploaded_once")?,
+            "per_token_weight_upload": bool_at(cuda, "/bitnet/per_token_weight_upload")?
+        },
+        "workload": {
+            "profile": "short_decode_8",
+            "prompt": str_at(cuda, "/prompt")?,
+            "prompt_tokens": execution_u64(cuda, "prompt_tokens")?,
+            "generated_tokens": execution_u64(cuda, "generated_tokens")?,
+            "generated_text": str_at(cuda, "/text")?,
+            "generated_token_ids": cuda.pointer("/tokens/ids").cloned().unwrap_or(Value::Null),
+            "cpu_cuda_output_match": generated_output_matches(cuda, cpu_avx512)
+        },
+        "sampling": {
+            "greedy": bool_at(cuda, "/gen_policy/greedy")?,
+            "deterministic": bool_at(cuda, "/gen_policy/deterministic")?,
+            "temperature": number_at(cuda, "/gen_policy/temperature")?,
+            "seed": u64_at(cuda, "/gen_policy/seed")?
+        },
+        "comparison_contract": {
+            "same_model": same_model(cuda, cpu_avx512),
+            "same_tokenizer": same_tokenizer(cuda, cpu_avx512),
+            "same_prompt": str_at(cuda, "/prompt")? == str_at(cpu_avx512, "/prompt")?,
+            "same_generated_token_count": execution_u64(cuda, "generated_tokens")? == execution_u64(cpu_avx512, "generated_tokens")?,
+            "same_strict_loader_mode": strict_loader_mode(cuda)? && strict_loader_mode(cpu_avx512)?,
+            "same_sampling_policy": same_sampling_policy(cuda, cpu_avx512),
+            "fallback_free": !bool_at(cuda, "/fallback_used")? && !bool_at(cpu_avx512, "/fallback_used")?
+        },
+        "cuda": {
+            "available": bool_at(cuda, "/cuda/available")?,
+            "device_count": u64_at(cuda, "/cuda/device_count")?,
+            "device_index": u64_at(cuda, "/cuda/device_index")?,
+            "device_name": str_at(cuda, "/cuda/device_name")?,
+            "compute_capability": str_at(cuda, "/cuda/compute_capability")?,
+            "driver_version": str_at(cuda, "/cuda/driver_version")?,
+            "cuda_runtime_version": str_at(cuda, "/cuda/cuda_runtime_version")?,
+            "cuda_toolkit_version": str_at(cuda, "/cuda/cuda_toolkit_version")?,
+            "nvrtc_version": str_at(cuda, "/cuda/nvrtc_version")?,
+            "vram_bytes": u64_at(cuda, "/cuda/vram_bytes")?,
+            "memory_hwm_bytes": u64_at(cuda, "/cuda/memory_hwm_bytes")?,
+            "memory_hwm_source": str_at(cuda, "/cuda/memory_hwm_source")?,
+            "cuda_kernel_invocations": cuda_kernel_invocations
+        },
+        "benchmark": {
+            "profile": "short_decode_8",
+            "prompt_profile": "short_decode_37_prompt_tokens_8_generated_tokens",
+            "cpu_reference_backend": "amd-9950x3d-cpu-avx512",
+            "cuda_backend": "nvidia-rtx-5070-ti-cuda",
+            "cpu_avx512_total_ms": cpu_total_ms,
+            "cuda_total_ms": cuda_total_ms,
+            "cpu_avx512_first_token_ms": first_token_ms(cpu_avx512)?,
+            "cuda_first_token_ms": first_token_ms(cuda)?,
+            "cpu_avx512_tokens_per_second": tokens_per_second(cpu_avx512)?,
+            "cuda_tokens_per_second": tokens_per_second(cuda)?,
+            "cpu_avx512_total_ms_div_cuda_total_ms": cpu_cuda_ratio,
+            "cuda_total_ms_div_cpu_avx512_total_ms": if cpu_total_ms > 0.0 { cuda_total_ms / cpu_total_ms } else { 0.0 },
+            "cuda_kernel_invocations": cuda_kernel_invocations,
+            "cpu_cuda_output_match": generated_output_matches(cuda, cpu_avx512),
+            "speedup_claim": false
+        },
+        "profiles": [
+            profile_or_not_run(cpu_scalar, "amd-9950x3d-cpu-scalar")?,
+            profile_or_not_run(cpu_avx2, "amd-9950x3d-cpu-avx2")?,
+            measured_profile(cpu_avx512, "amd-9950x3d-cpu-avx512", "cpu")?,
+            measured_profile(cuda, "nvidia-rtx-5070-ti-cuda", "cuda")?
+        ],
+        "kernel_stats": cuda.pointer("/kernel_stats").cloned().unwrap_or_else(|| json!([])),
+        "execution_coverage": cuda.pointer("/execution_coverage").cloned().unwrap_or(Value::Null),
+        "claim_boundaries": [
+            "speedup_claim=false; this receipt records a same-model baseline only.",
+            "CPU scalar and AVX2 strict end-to-end profiles are present as explicit not_run entries unless matching strict receipts are supplied.",
+            "The source CUDA receipt records weights_uploaded_once=false and per_token_weight_upload=true, so this benchmark does not claim upload-once optimized inference."
+        ],
+        "artifact_path": path_label(&args.receipt_out)
+    }))
+}
+
+fn assert_same_strict_decode_inputs(cuda: &Value, cpu: &Value) -> Result<(), Box<dyn Error>> {
+    if !same_model(cuda, cpu) {
+        return Err("model identity differs between CUDA and CPU receipts".into());
+    }
+    if !same_tokenizer(cuda, cpu) {
+        return Err("tokenizer identity differs between CUDA and CPU receipts".into());
+    }
+    if str_at(cuda, "/prompt")? != str_at(cpu, "/prompt")? {
+        return Err("prompt differs between CUDA and CPU receipts".into());
+    }
+    if execution_u64(cuda, "generated_tokens")? != execution_u64(cpu, "generated_tokens")? {
+        return Err("generated token count differs between CUDA and CPU receipts".into());
+    }
+    if !strict_loader_mode(cuda)? || !strict_loader_mode(cpu)? {
+        return Err("both receipts must use strict loader mode".into());
+    }
+    if bool_at(cuda, "/fallback_used")? || bool_at(cpu, "/fallback_used")? {
+        return Err("fallback_used must be false for both receipts".into());
+    }
+    Ok(())
+}
+
+fn same_model(left: &Value, right: &Value) -> bool {
+    str_at(left, "/model/repo").ok() == str_at(right, "/model/repo").ok()
+        && str_at(left, "/model/file").ok() == str_at(right, "/model/file").ok()
+        && str_at(left, "/model/sha256").ok() == str_at(right, "/model/sha256").ok()
+}
+
+fn same_tokenizer(left: &Value, right: &Value) -> bool {
+    str_at(left, "/tokenizer/source").ok() == str_at(right, "/tokenizer/source").ok()
+        && bool_at(left, "/tokenizer/strict").ok() == bool_at(right, "/tokenizer/strict").ok()
+        && str_at(left, "/tokenizer/type").ok() == str_at(right, "/tokenizer/type").ok()
+}
+
+fn same_sampling_policy(left: &Value, right: &Value) -> bool {
+    bool_at(left, "/gen_policy/greedy").ok() == bool_at(right, "/gen_policy/greedy").ok()
+        && bool_at(left, "/gen_policy/deterministic").ok()
+            == bool_at(right, "/gen_policy/deterministic").ok()
+        && number_at(left, "/gen_policy/temperature").ok()
+            == number_at(right, "/gen_policy/temperature").ok()
+}
+
+fn strict_loader_mode(receipt: &Value) -> Result<bool, Box<dyn Error>> {
+    Ok(bool_at(receipt, "/loader/minimal_fallback_disabled")?
+        && !bool_at(receipt, "/loader/minimal_loader_fallback_used")?
+        && !bool_at(receipt, "/loader/mock_tensors_used")?
+        && !bool_at(receipt, "/model/fallback_loader_used")?)
+}
+
+fn generated_output_matches(left: &Value, right: &Value) -> bool {
+    str_at(left, "/text").ok() == str_at(right, "/text").ok()
+        && left.pointer("/tokens/ids") == right.pointer("/tokens/ids")
+}
+
+fn profile_or_not_run(receipt: Option<&Value>, backend: &str) -> Result<Value, Box<dyn Error>> {
+    receipt.map_or_else(
+        || {
+            Ok(json!({
+                "backend": backend,
+                "runtime_api": "cpu",
+                "status": "not_run",
+                "reason": CPU_SELECTOR_REASON
+            }))
+        },
+        |receipt| measured_profile(receipt, backend, "cpu"),
+    )
+}
+
+fn measured_profile(
+    receipt: &Value,
+    backend: &str,
+    runtime_api: &str,
+) -> Result<Value, Box<dyn Error>> {
+    Ok(json!({
+        "backend": backend,
+        "runtime_api": runtime_api,
+        "status": "measured",
+        "selected_backend": str_at(receipt, "/selected_backend")?,
+        "kernel_id": str_at(receipt, "/kernel/kernel_id")?,
+        "kernel_implementation": str_at(receipt, "/kernel/implementation")?,
+        "total_ms": total_ms(receipt)?,
+        "first_token_ms": first_token_ms(receipt)?,
+        "tokens_per_second": tokens_per_second(receipt)?,
+        "prompt_tokens": execution_u64(receipt, "prompt_tokens")?,
+        "generated_tokens": execution_u64(receipt, "generated_tokens")?,
+        "fallback_used": bool_at(receipt, "/fallback_used")?
+    }))
+}
+
+fn total_ms(value: &Value) -> Result<f64, Box<dyn Error>> {
+    number_at(value, "/latency/total_ms").or_else(|_| number_at(value, "/timing/total_ms"))
+}
+
+fn first_token_ms(value: &Value) -> Result<f64, Box<dyn Error>> {
+    number_at(value, "/latency/decode_first_ms")
+        .or_else(|_| number_at(value, "/timing/first_token_ms"))
+}
+
+fn tokens_per_second(value: &Value) -> Result<f64, Box<dyn Error>> {
+    number_at(value, "/throughput/tokens_per_second")
+}
+
+fn execution_u64(value: &Value, field: &str) -> Result<u64, Box<dyn Error>> {
+    value
+        .get(field)
+        .and_then(Value::as_u64)
+        .or_else(|| value.pointer(&format!("/execution/{field}")).and_then(Value::as_u64))
+        .ok_or_else(|| format!("{field} must be an unsigned integer").into())
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Result<&'a str, Box<dyn Error>> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{pointer} must be a string").into())
+}
+
+fn bool_at(value: &Value, pointer: &str) -> Result<bool, Box<dyn Error>> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("{pointer} must be a boolean").into())
+}
+
+fn u64_at(value: &Value, pointer: &str) -> Result<u64, Box<dyn Error>> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("{pointer} must be an unsigned integer").into())
+}
+
+fn number_at(value: &Value, pointer: &str) -> Result<f64, Box<dyn Error>> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_f64)
+        .ok_or_else(|| format!("{pointer} must be a number").into())
+}
+
+fn timestamp_label() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn path_label(path: &Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}

--- a/crates/bitnet-bench-receipts/src/lib.rs
+++ b/crates/bitnet-bench-receipts/src/lib.rs
@@ -196,6 +196,134 @@ pub fn validate_rtx5070ti_cuda_benchmark_receipt_file(path: &Path) -> Result<(),
     validate_rtx5070ti_cuda_benchmark_receipt_json(&receipt)
 }
 
+/// Validate a strict BitNet CUDA benchmark receipt for the RTX 5070 Ti lane.
+///
+/// This receipt is distinct from the earlier tiny-kernel CUDA benchmark. It
+/// requires same-model strict BitNet decode evidence, selected RTX 5070 Ti CUDA
+/// identity, a measured AVX-512 CPU reference, explicit scalar/AVX2 profile
+/// disposition, CUDA kernel invocation counters, and no speedup claim.
+pub fn validate_strict_bitnet_cuda_benchmark_receipt_json(
+    receipt: &serde_json::Value,
+) -> Result<(), ReceiptError> {
+    require_u64_eq(receipt, "schema", 1)?;
+    require_string_eq(receipt, "artifact_kind", "strict_bitnet_cuda_benchmark")?;
+    require_string_eq(receipt, "machine_id", "windows-9950x3d-rtx5070ti")?;
+    require_string_eq(receipt, "hardware_lane", "nvidia_rtx_5070_ti_cuda")?;
+    require_string_eq(receipt, "requested_backend", "nvidia-rtx-5070-ti-cuda")?;
+    require_string_eq(receipt, "selected_backend", "nvidia-rtx-5070-ti-cuda")?;
+    require_string_eq(receipt, "reference_backend", "amd-9950x3d-cpu-avx512")?;
+    require_string_eq(receipt, "runtime_api", "cuda")?;
+    require_string_eq(receipt, "claim", "strict_bitnet_cuda_benchmark_baseline")?;
+    require_bool_eq(receipt, "fallback_used", false)?;
+    require_bool_eq(receipt, "speedup_claim", false)?;
+    require_null(receipt, "fallback_backend")?;
+    require_null(receipt, "fallback_reason")?;
+
+    let model = require_object(receipt, "model")?;
+    require_string_eq(model, "repo", "microsoft/bitnet-b1.58-2B-4T-gguf")?;
+    require_string_eq(model, "file", "ggml-model-i2_s.gguf")?;
+    require_non_empty_string(model, "sha256")?;
+    require_string_eq(model, "loader_mode", "strict")?;
+    require_bool_eq(model, "fallback_loader_used", false)?;
+
+    let tokenizer = require_object(receipt, "tokenizer")?;
+    require_string_eq(tokenizer, "source", "explicit")?;
+    require_bool_eq(tokenizer, "strict", true)?;
+
+    let bitnet = require_object(receipt, "bitnet")?;
+    require_string_eq(bitnet, "quantization", "W1.58A8")?;
+    require_non_empty_string(bitnet, "kernel_family")?;
+    require_non_empty_string(bitnet, "layout")?;
+    require_bool(bitnet, "weights_uploaded_once")?;
+    require_bool(bitnet, "per_token_weight_upload")?;
+
+    let workload = require_object(receipt, "workload")?;
+    require_string_eq(workload, "profile", "short_decode_8")?;
+    require_u64_at_least(workload, "prompt_tokens", 1)?;
+    require_u64_eq(workload, "generated_tokens", 8)?;
+    require_non_empty_string(workload, "prompt")?;
+    require_non_empty_string(workload, "generated_text")?;
+    require_bool_eq(workload, "cpu_cuda_output_match", true)?;
+
+    let contract = require_object(receipt, "comparison_contract")?;
+    for field in [
+        "same_model",
+        "same_tokenizer",
+        "same_prompt",
+        "same_generated_token_count",
+        "same_strict_loader_mode",
+        "same_sampling_policy",
+        "fallback_free",
+    ] {
+        require_bool_eq(contract, field, true)?;
+    }
+
+    let cuda = require_object(receipt, "cuda")?;
+    require_bool_eq(cuda, "available", true)?;
+    require_u64_at_least(cuda, "device_count", 1)?;
+    require_u64(cuda, "device_index")?;
+    let device_name = require_string(cuda, "device_name")?;
+    if !is_rtx5070ti_device_name(device_name) {
+        return Err(validation_error(format!(
+            "cuda.device_name must identify NVIDIA GeForce RTX 5070 Ti, got {device_name}"
+        )));
+    }
+    require_string_eq(cuda, "compute_capability", "12.0")?;
+    require_non_empty_string(cuda, "driver_version")?;
+    require_non_empty_string(cuda, "cuda_runtime_version")?;
+    require_non_empty_string(cuda, "cuda_toolkit_version")?;
+    require_non_empty_string(cuda, "nvrtc_version")?;
+    require_u64_at_least(cuda, "vram_bytes", 1)?;
+    require_u64_at_least(cuda, "memory_hwm_bytes", 1)?;
+    require_u64_at_least(cuda, "cuda_kernel_invocations", 1)?;
+
+    let benchmark = require_object(receipt, "benchmark")?;
+    require_string_eq(benchmark, "profile", "short_decode_8")?;
+    require_string_eq(benchmark, "cpu_reference_backend", "amd-9950x3d-cpu-avx512")?;
+    require_string_eq(benchmark, "cuda_backend", "nvidia-rtx-5070-ti-cuda")?;
+    require_non_negative_number(benchmark, "cpu_avx512_total_ms")?;
+    require_non_negative_number(benchmark, "cuda_total_ms")?;
+    require_non_negative_number(benchmark, "cpu_avx512_tokens_per_second")?;
+    require_non_negative_number(benchmark, "cuda_tokens_per_second")?;
+    require_non_negative_number(benchmark, "cpu_avx512_total_ms_div_cuda_total_ms")?;
+    require_u64_at_least(benchmark, "cuda_kernel_invocations", 1)?;
+    require_bool_eq(benchmark, "cpu_cuda_output_match", true)?;
+    require_bool_eq(benchmark, "speedup_claim", false)?;
+
+    let profiles = require_array(receipt, "profiles")?;
+    let cpu_scalar = require_backend_profile(profiles, "amd-9950x3d-cpu-scalar")?;
+    validate_bitnet_benchmark_profile(cpu_scalar, false)?;
+    let cpu_avx2 = require_backend_profile(profiles, "amd-9950x3d-cpu-avx2")?;
+    validate_bitnet_benchmark_profile(cpu_avx2, false)?;
+    let cpu_avx512 = require_backend_profile(profiles, "amd-9950x3d-cpu-avx512")?;
+    validate_bitnet_benchmark_profile(cpu_avx512, true)?;
+    let cuda_profile = require_backend_profile(profiles, "nvidia-rtx-5070-ti-cuda")?;
+    validate_bitnet_benchmark_profile(cuda_profile, true)?;
+
+    let stats = receipt
+        .get("kernel_stats")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|items| items.first())
+        .ok_or_else(|| validation_error("kernel_stats must contain at least one entry"))?;
+    require_string_eq(stats, "kernel_id", "qk256_gemv_cuda")?;
+    require_u64_at_least(stats, "invocations", 1)?;
+    require_u64_eq(stats, "fallback_invocations", 0)?;
+    require_u64_at_least(stats, "kernel_launches", 1)?;
+
+    let boundaries = require_array(receipt, "claim_boundaries")?;
+    if boundaries.is_empty() {
+        return Err(validation_error("claim_boundaries must not be empty"));
+    }
+
+    Ok(())
+}
+
+/// Validate a strict BitNet CUDA benchmark receipt file.
+pub fn validate_strict_bitnet_cuda_benchmark_receipt_file(path: &Path) -> Result<(), ReceiptError> {
+    let receipt = serde_json::from_slice(&std::fs::read(path)?)?;
+    validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt)
+}
+
 /// Validate a strict CPU BitNet benchmark receipt.
 ///
 /// This validator checks the benchmark evidence contract, not performance
@@ -340,6 +468,48 @@ fn expected_cpu_profile_phase(profile: &str) -> &'static str {
     }
 }
 
+fn require_backend_profile<'a>(
+    profiles: &'a [serde_json::Value],
+    backend: &str,
+) -> Result<&'a serde_json::Value, ReceiptError> {
+    profiles
+        .iter()
+        .find(|entry| entry.get("backend").and_then(serde_json::Value::as_str) == Some(backend))
+        .ok_or_else(|| validation_error(format!("profiles missing backend {backend}")))
+}
+
+fn validate_bitnet_benchmark_profile(
+    profile: &serde_json::Value,
+    must_be_measured: bool,
+) -> Result<(), ReceiptError> {
+    require_non_empty_string(profile, "backend")?;
+    require_non_empty_string(profile, "runtime_api")?;
+    let status = require_string(profile, "status")?;
+    match status {
+        "measured" => {
+            require_non_negative_number(profile, "total_ms")?;
+            require_non_negative_number(profile, "first_token_ms")?;
+            require_non_negative_number(profile, "tokens_per_second")?;
+            require_u64_at_least(profile, "prompt_tokens", 1)?;
+            require_u64_at_least(profile, "generated_tokens", 1)?;
+            require_bool_eq(profile, "fallback_used", false)?;
+        }
+        "not_run" => {
+            if must_be_measured {
+                let backend = require_string(profile, "backend")?;
+                return Err(validation_error(format!("profile {backend} must be measured")));
+            }
+            require_non_empty_string(profile, "reason")?;
+        }
+        other => {
+            return Err(validation_error(format!(
+                "profile status must be measured or not_run, got {other}"
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn require_object<'a>(
     value: &'a serde_json::Value,
     field: &str,
@@ -394,14 +564,18 @@ fn require_bool_eq(
     field: &str,
     expected: bool,
 ) -> Result<(), ReceiptError> {
-    let actual = value
-        .get(field)
-        .and_then(serde_json::Value::as_bool)
-        .ok_or_else(|| validation_error(format!("{field} must be a boolean")))?;
+    let actual = require_bool(value, field)?;
     if actual != expected {
         return Err(validation_error(format!("{field} must be {expected}, got {actual}")));
     }
     Ok(())
+}
+
+fn require_bool(value: &serde_json::Value, field: &str) -> Result<bool, ReceiptError> {
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_bool)
+        .ok_or_else(|| validation_error(format!("{field} must be a boolean")))
 }
 
 fn require_null(value: &serde_json::Value, field: &str) -> Result<(), ReceiptError> {
@@ -703,6 +877,74 @@ mod tests {
         validate_rtx5070ti_cuda_benchmark_receipt_file(&path).unwrap();
     }
 
+    #[test]
+    fn strict_bitnet_cuda_benchmark_receipt_validates() {
+        let receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap();
+    }
+
+    #[test]
+    fn strict_bitnet_cuda_benchmark_rejects_generic_cuda_backend() {
+        let mut receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        receipt["selected_backend"] = json!("cuda");
+
+        let err =
+            validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap_err().to_string();
+        assert!(err.contains("selected_backend"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn strict_bitnet_cuda_benchmark_rejects_fallback() {
+        let mut receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        receipt["fallback_used"] = json!(true);
+
+        let err =
+            validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap_err().to_string();
+        assert!(err.contains("fallback_used"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn strict_bitnet_cuda_benchmark_rejects_speedup_claim() {
+        let mut receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        receipt["speedup_claim"] = json!(true);
+
+        let err =
+            validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap_err().to_string();
+        assert!(err.contains("speedup_claim"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn strict_bitnet_cuda_benchmark_rejects_missing_cpu_profile() {
+        let mut receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        receipt["profiles"] = json!([
+            not_run_bitnet_profile("amd-9950x3d-cpu-scalar"),
+            measured_bitnet_profile("amd-9950x3d-cpu-avx512", "cpu"),
+            measured_bitnet_profile("nvidia-rtx-5070-ti-cuda", "cuda")
+        ]);
+
+        let err =
+            validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap_err().to_string();
+        assert!(err.contains("amd-9950x3d-cpu-avx2"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn strict_bitnet_cuda_benchmark_requires_measured_cuda_profile() {
+        let mut receipt = sample_strict_bitnet_cuda_benchmark_receipt();
+        receipt["profiles"][3] = not_run_bitnet_profile("nvidia-rtx-5070-ti-cuda");
+
+        let err =
+            validate_strict_bitnet_cuda_benchmark_receipt_json(&receipt).unwrap_err().to_string();
+        assert!(err.contains("must be measured"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn committed_strict_bitnet_cuda_benchmark_receipt_validates() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(
+            "../../ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json",
+        );
+        validate_strict_bitnet_cuda_benchmark_receipt_file(&path).unwrap();
+    }
+
     fn sample_cpu_benchmark_receipt() -> serde_json::Value {
         json!({
             "schema": 1,
@@ -866,6 +1108,130 @@ mod tests {
                 }
             ],
             "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/cuda-benchmark.json"
+        })
+    }
+
+    fn sample_strict_bitnet_cuda_benchmark_receipt() -> serde_json::Value {
+        json!({
+            "schema": 1,
+            "artifact_kind": "strict_bitnet_cuda_benchmark",
+            "machine_id": "windows-9950x3d-rtx5070ti",
+            "hardware_lane": "nvidia_rtx_5070_ti_cuda",
+            "timestamp_utc": "2026-05-07T00:00:00Z",
+            "requested_backend": "nvidia-rtx-5070-ti-cuda",
+            "selected_backend": "nvidia-rtx-5070-ti-cuda",
+            "reference_backend": "amd-9950x3d-cpu-avx512",
+            "runtime_api": "cuda",
+            "claim": "strict_bitnet_cuda_benchmark_baseline",
+            "speedup_claim": false,
+            "fallback_used": false,
+            "fallback_backend": null,
+            "fallback_reason": null,
+            "model": {
+                "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+                "file": "ggml-model-i2_s.gguf",
+                "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+                "loader_mode": "strict",
+                "fallback_loader_used": false
+            },
+            "tokenizer": {
+                "source": "explicit",
+                "strict": true
+            },
+            "bitnet": {
+                "quantization": "W1.58A8",
+                "kernel_family": "qk256",
+                "layout": "gguf_packed_i2_s",
+                "weights_uploaded_once": false,
+                "per_token_weight_upload": true
+            },
+            "workload": {
+                "profile": "short_decode_8",
+                "prompt": "fixture prompt",
+                "prompt_tokens": 37,
+                "generated_tokens": 8,
+                "generated_text": "'E'E'E'E'E'E'E'E",
+                "cpu_cuda_output_match": true
+            },
+            "comparison_contract": {
+                "same_model": true,
+                "same_tokenizer": true,
+                "same_prompt": true,
+                "same_generated_token_count": true,
+                "same_strict_loader_mode": true,
+                "same_sampling_policy": true,
+                "fallback_free": true
+            },
+            "cuda": {
+                "available": true,
+                "device_count": 1,
+                "device_index": 0,
+                "device_name": "NVIDIA GeForce RTX 5070 Ti",
+                "compute_capability": "12.0",
+                "driver_version": "591.86",
+                "cuda_runtime_version": "12.9",
+                "cuda_toolkit_version": "12.9",
+                "nvrtc_version": "12.9",
+                "vram_bytes": 17094475776u64,
+                "memory_hwm_bytes": 5949620224u64,
+                "cuda_kernel_invocations": 1680
+            },
+            "benchmark": {
+                "profile": "short_decode_8",
+                "cpu_reference_backend": "amd-9950x3d-cpu-avx512",
+                "cuda_backend": "nvidia-rtx-5070-ti-cuda",
+                "cpu_avx512_total_ms": 141559.0,
+                "cuda_total_ms": 190129.0,
+                "cpu_avx512_tokens_per_second": 0.0565,
+                "cuda_tokens_per_second": 0.0421,
+                "cpu_avx512_total_ms_div_cuda_total_ms": 0.7445,
+                "cuda_kernel_invocations": 1680,
+                "cpu_cuda_output_match": true,
+                "speedup_claim": false
+            },
+            "profiles": [
+                not_run_bitnet_profile("amd-9950x3d-cpu-scalar"),
+                not_run_bitnet_profile("amd-9950x3d-cpu-avx2"),
+                measured_bitnet_profile("amd-9950x3d-cpu-avx512", "cpu"),
+                measured_bitnet_profile("nvidia-rtx-5070-ti-cuda", "cuda")
+            ],
+            "kernel_stats": [
+                {
+                    "kernel_id": "qk256_gemv_cuda",
+                    "invocations": 1680,
+                    "fallback_invocations": 0,
+                    "kernel_launches": 1680,
+                    "kernel_time_ms": null
+                }
+            ],
+            "claim_boundaries": [
+                "speedup_claim=false; this receipt records a baseline only.",
+                "CPU scalar and AVX2 strict end-to-end profiles are explicitly present but not_run because this CLI path does not expose selectors for those modes."
+            ],
+            "artifact_path": "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json"
+        })
+    }
+
+    fn measured_bitnet_profile(backend: &str, runtime_api: &str) -> serde_json::Value {
+        json!({
+            "backend": backend,
+            "runtime_api": runtime_api,
+            "status": "measured",
+            "total_ms": 1.0,
+            "first_token_ms": 1.0,
+            "tokens_per_second": 1.0,
+            "prompt_tokens": 37,
+            "generated_tokens": 8,
+            "fallback_used": false
+        })
+    }
+
+    fn not_run_bitnet_profile(backend: &str) -> serde_json::Value {
+        json!({
+            "backend": backend,
+            "runtime_api": "cpu",
+            "status": "not_run",
+            "reason": "current CLI does not expose a strict end-to-end selector for this CPU SIMD mode"
         })
     }
 }

--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -459,7 +459,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CUDA-BITNET-008"
-status = "proposed"
+status = "pr_open"
 branch = "codex/cuda-bitnet-008-benchmark-baseline"
 stackable = false
 requires_human_merge = true
@@ -480,7 +480,9 @@ allowed_paths = [
 forbidden_paths = [
   "crates/bitnet-server/**",
 ]
-may_claim = []
+may_claim = [
+  "Strict BitNet CUDA same-model benchmark baseline evidence exists after strict-bitnet-cuda-benchmark.json validates, with speedup_claim=false.",
+]
 must_not_claim = [
   "CUDA speedup exists before same-model benchmark receipt proves it.",
 ]

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T020119Z-CUDA-BITNET-008-in-progress.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T020119Z-CUDA-BITNET-008-in-progress.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-07T02:01:19Z"
+campaign = "nvidia-5070ti"
+item = "CUDA-BITNET-008"
+event = "in_progress"
+previous_status = "proposed"
+new_status = "in_progress"
+actor = "codex"
+
+notes = [
+  "Started the strict BitNet CUDA benchmark baseline rung after CUDA-BITNET-007 merged.",
+  "Scope is limited to normalized same-model benchmark evidence, receipt validation, and tracker updates.",
+  "This rung keeps speedup_claim=false and records CPU scalar/AVX2 strict end-to-end profiles explicitly as not_run unless matching receipts are supplied.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T020410Z-CUDA-BITNET-008-pr-open.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T020410Z-CUDA-BITNET-008-pr-open.toml
@@ -1,0 +1,16 @@
+timestamp = "2026-05-07T02:04:10Z"
+campaign = "nvidia-5070ti"
+item = "CUDA-BITNET-008"
+event = "pr_open"
+previous_status = "in_progress"
+new_status = "pr_open"
+pr = 3823
+head_sha = "f40c4f948de505c71ec651fe121d4f6dcf7f81b3"
+actor = "codex"
+
+notes = [
+  "Opened the strict BitNet CUDA benchmark baseline PR.",
+  "The receipt records matching strict CUDA and AVX-512 CPU short-decode evidence for the same model, tokenizer, prompt profile, generated token count, and fallback-free loader mode.",
+  "CPU scalar and AVX2 strict end-to-end profiles are recorded as not_run because this CLI path does not expose selectors for those SIMD modes.",
+  "speedup_claim remains false.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -22,7 +22,7 @@
 | CUDA-BITNET-005 | merged | #3792 | `codex/cuda-bitnet-005-route-linear` | Route actual BitNetLinear transformer dispatch through the selected CUDA backend with coverage counters and strict CPU fallback rejection. |
 | CUDA-BITNET-006 | merged | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | CUDA-BITNET-007 | merged | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
-| CUDA-BITNET-008 | proposed | TBD | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
+| CUDA-BITNET-008 | pr_open | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
 | CUDA-DENSE-001 | proposed | TBD | `codex/cuda-dense-001-reference-lane` | Add regular LLM CUDA dense-kernel reference lane with dense_regular_llm receipt labels that cannot satisfy BitNet packed I2S or QK256 proof acceptance. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| nvidia-5070ti | CUDA-BITNET-008 | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -48,7 +48,7 @@
 | nvidia-5070ti | CUDA-BITNET-005 | CUDA-BITNET-004 | merged |
 | nvidia-5070ti | CUDA-BITNET-006 | CUDA-BITNET-005 | merged |
 | nvidia-5070ti | CUDA-BITNET-007 | CUDA-BITNET-006 | merged |
-| nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | proposed |
+| nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | pr_open |
 | nvidia-5070ti | CUDA-DENSE-001 | RTX5070TI-007 | proposed |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
 | tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-003 | #3739 | merged | none | Device-node detection is not inference. |
-| nvidia-5070ti | CUDA-BITNET-008 | TBD | proposed | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | CUDA-BITNET-008 | #3823 | pr_open | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- add a strict BitNet CUDA benchmark receipt validator and generator for the RTX 5070 Ti lane
- add `strict-bitnet-cuda-benchmark.json` derived from the matching strict CUDA short-decode proof and AVX-512 CPU reference run
- keep `speedup_claim=false`, preserve RTX 5070 Ti CUDA backend identity, and record CPU scalar/AVX2 strict end-to-end profiles as explicit `not_run` dispositions
- move `CUDA-BITNET-008` to `in_progress` and regenerate campaign dashboards

## Validation
- cargo run --locked -p bitnet-bench-receipts --no-default-features --bin strict_bitnet_cuda_benchmark_receipt -- --cuda-receipt ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-short-decode.json --cpu-avx512-receipt target/cuda-bitnet-008/strict-bitnet-cpu-short-decode.json --receipt-out ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json
- cargo fmt -p bitnet-bench-receipts -- --check
- cargo test --locked -p bitnet-bench-receipts --no-default-features
- cargo clippy --locked -p bitnet-bench-receipts --no-default-features --all-targets -- -D warnings
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Notes
- `cargo fmt --all -- --check` remains blocked locally by the known Windows path-length `os error 206`.
- No server, dense CUDA, QK256 kernel implementation, transformer routing, or new speedup claim is included.

Closes #3675