### PR TITLE
[codex][apple-m4] Polish Apple backend CLI surfaces (M4-018)

### DIFF
--- a/crates/bitnet-cli-config-core/src/lib.rs
+++ b/crates/bitnet-cli-config-core/src/lib.rs
@@ -5,6 +5,65 @@ use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use tracing::debug;
 
+/// Package-level device/backend labels accepted by CLI configuration.
+///
+/// These labels name proof lanes and requested backend identities. They do not
+/// imply that every subcommand can execute every backend on every host.
+pub const SUPPORTED_DEVICE_LABELS: &[&str] = &[
+    "cpu",
+    "cuda",
+    "gpu",
+    "vulkan",
+    "opencl",
+    "ocl",
+    "hip",
+    "rocm",
+    "oneapi",
+    "npu",
+    "npu:<index>",
+    "intel-npu",
+    "intel-npu:<index>",
+    "openvino-npu",
+    "intel-npu-openvino",
+    "nvidia-rtx-5070-ti-cuda",
+    "nvidia-rtx-5070-ti-wgpu",
+    "metal",
+    "mpsgraph",
+    "apple-m4-metal",
+    "apple-m4-mpsgraph",
+    "apple-m4-cpu-neon",
+    "auto",
+];
+
+/// Stable help text for supported package-level device/backend labels.
+pub const SUPPORTED_DEVICE_LABELS_TEXT: &str = "cpu, cuda, gpu, vulkan, opencl, ocl, hip, rocm, oneapi, npu, npu:<index>, intel-npu, intel-npu:<index>, openvino-npu, intel-npu-openvino, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto";
+
+/// Stable help text for Apple M4 proof-lane labels.
+pub const APPLE_M4_DEVICE_LABELS_TEXT: &str = "apple-m4-metal = native Metal proof lane, apple-m4-mpsgraph = MPSGraph graph/reference lane, apple-m4-cpu-neon = Apple CPU/NEON fallback/parity lane";
+
+/// Top-level `--device` help for package-level backend labels.
+pub const DEVICE_HELP: &str = "Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto). Apple M4 labels are distinct proof lanes";
+
+/// Help for legacy full-cli commands that do not emit Apple proof receipts.
+pub const LEGACY_RUNTIME_DEVICE_HELP: &str = "Device for this legacy command (cpu, cuda/gpu aliases, auto). Use `bitnet run` for receipt-backed Apple M4 labels";
+
+/// Runtime labels currently handled by legacy full-cli commands.
+pub const LEGACY_RUNTIME_DEVICE_LABELS_TEXT: &str = "cpu, cuda, gpu, vulkan, opencl, ocl, auto";
+
+/// Build a consistent invalid package-level device label error.
+pub fn invalid_device_message(device: &str) -> String {
+    format!(
+        "Invalid device: {device}. Must be one of: {SUPPORTED_DEVICE_LABELS_TEXT}. Apple M4 labels are distinct proof lanes: {APPLE_M4_DEVICE_LABELS_TEXT}. On unavailable or non-M4 hosts, strict mode fails and non-strict receipt paths must record fallback_used and fallback_reason."
+    )
+}
+
+/// Build a consistent error for legacy commands that do not support a proof lane.
+pub fn unsupported_legacy_command_device_message(command: &str, device: &str) -> String {
+    format!(
+        "{command} does not support device label '{device}'. This legacy command currently supports: {LEGACY_RUNTIME_DEVICE_LABELS_TEXT}. Use `bitnet run` for receipt-backed Apple M4 labels ({APPLE_M4_DEVICE_LABELS_TEXT}); CPU fallback cannot count as Metal execution."
+    )
+}
+
 /// CLI configuration structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliConfig {
@@ -136,10 +195,7 @@ impl CliConfig {
     /// Validate configuration
     pub fn validate(&self) -> Result<()> {
         if !is_supported_device_label(&self.default_device) {
-            anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, intel-npu, openvino-npu, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto",
-                self.default_device
-            );
+            anyhow::bail!("{}", invalid_device_message(&self.default_device));
         }
 
         match self.logging.level.as_str() {
@@ -166,16 +222,18 @@ impl CliConfig {
     }
 }
 
-fn is_supported_device_label(label: &str) -> bool {
-    let label = label.trim().to_ascii_lowercase();
+pub fn is_supported_device_label(label: &str) -> bool {
     matches!(
-        label.as_str(),
+        label,
         "cpu"
             | "cuda"
             | "gpu"
             | "vulkan"
             | "opencl"
             | "ocl"
+            | "hip"
+            | "rocm"
+            | "oneapi"
             | "npu"
             | "intel-npu"
             | "openvino-npu"
@@ -244,7 +302,22 @@ impl ConfigBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::{CliConfig, ConfigBuilder};
+    use super::{
+        APPLE_M4_DEVICE_LABELS_TEXT, CliConfig, ConfigBuilder, SUPPORTED_DEVICE_LABELS,
+        invalid_device_message,
+    };
+
+    #[test]
+    fn supported_device_labels_constant_matches_validation() {
+        for device in SUPPORTED_DEVICE_LABELS {
+            if device.contains("<index>") {
+                continue;
+            }
+            let config =
+                CliConfig { default_device: (*device).to_string(), ..CliConfig::default() };
+            config.validate().unwrap_or_else(|err| panic!("{device} should validate: {err}"));
+        }
+    }
 
     #[test]
     fn validates_intel_npu_labels_without_aliasing() {
@@ -266,5 +339,23 @@ mod tests {
     fn builder_preserves_intel_npu_device_label() {
         let config = ConfigBuilder::new().device(Some("intel-npu:2".to_string())).build().unwrap();
         assert_eq!(config.default_device, "intel-npu:2");
+    }
+
+    #[test]
+    fn validates_apple_m4_labels_without_aliasing() {
+        for device in ["apple-m4-metal", "apple-m4-mpsgraph", "apple-m4-cpu-neon"] {
+            let config = CliConfig { default_device: device.to_string(), ..CliConfig::default() };
+            config.validate().unwrap();
+        }
+    }
+
+    #[test]
+    fn invalid_device_message_describes_apple_m4_boundaries() {
+        let message = invalid_device_message("quantum");
+        assert!(message.contains("npu:<index>"), "got: {message}");
+        assert!(message.contains("intel-npu-openvino"), "got: {message}");
+        assert!(message.contains(APPLE_M4_DEVICE_LABELS_TEXT), "got: {message}");
+        assert!(message.contains("strict mode fails"), "got: {message}");
+        assert!(message.contains("fallback_used"), "got: {message}");
     }
 }

--- a/crates/bitnet-cli/src/commands/benchmark.rs
+++ b/crates/bitnet-cli/src/commands/benchmark.rs
@@ -16,7 +16,10 @@ use bitnet_models::ModelLoader;
 use bitnet_tokenizers::{Tokenizer, TokenizerBuilder};
 use candle_core::Device;
 
-use crate::config::CliConfig;
+use crate::config::{
+    CliConfig, LEGACY_RUNTIME_DEVICE_HELP, invalid_device_message, is_supported_device_label,
+    unsupported_legacy_command_device_message,
+};
 
 /// Benchmark command arguments
 #[derive(Args, Debug)]
@@ -25,8 +28,7 @@ pub struct BenchmarkCommand {
     #[arg(short, long, value_name = "PATH")]
     pub model: PathBuf,
 
-    /// Device to benchmark (cpu, cuda, auto)
-    #[arg(short, long, value_name = "DEVICE")]
+    #[arg(short, long, value_name = "DEVICE", help = LEGACY_RUNTIME_DEVICE_HELP)]
     pub device: Option<String>,
 
     /// Number of benchmark iterations
@@ -266,10 +268,13 @@ impl BenchmarkCommand {
                 warn!("CUDA support not yet implemented, falling back to CPU");
                 Ok(Device::Cpu)
             }
-            _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, auto",
-                device_str
-            ),
+            label if is_supported_device_label(label) => {
+                anyhow::bail!(
+                    "{}",
+                    unsupported_legacy_command_device_message("bitnet benchmark", label)
+                )
+            }
+            _ => anyhow::bail!("{}", invalid_device_message(device_str)),
         }
     }
 

--- a/crates/bitnet-cli/src/commands/eval.rs
+++ b/crates/bitnet-cli/src/commands/eval.rs
@@ -11,7 +11,10 @@ use bitnet_inference::InferenceEngine;
 use bitnet_models::ModelLoader;
 use bitnet_scoring_core::{NllStats, observe_target_nll, sanitize_logits_in_place};
 
-use crate::config::CliConfig;
+use crate::config::{
+    CliConfig, invalid_device_message, is_supported_device_label,
+    unsupported_legacy_command_device_message,
+};
 
 /// Evaluate model perplexity and performance
 #[derive(Debug, Args)]
@@ -32,7 +35,7 @@ pub struct EvalCommand {
     #[arg(long, value_name = "PATH")]
     pub tokenizer: Option<PathBuf>,
 
-    /// Device to use for inference
+    /// Device to use for eval; Apple M4 proof labels are receipt-backed in `bitnet run`
     #[arg(short, long, default_value = "auto")]
     pub device: String,
 
@@ -331,10 +334,10 @@ impl EvalCommand {
                     Ok(Device::Cpu)
                 }
             }
-            _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, metal, npu, auto",
-                self.device
-            ),
+            label if is_supported_device_label(label) => {
+                anyhow::bail!("{}", unsupported_legacy_command_device_message("bitnet eval", label))
+            }
+            _ => anyhow::bail!("{}", invalid_device_message(&self.device)),
         }
     }
 

--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -62,7 +62,10 @@ use bitnet_models::ModelLoader;
 use bitnet_tokenizers::Tokenizer;
 use candle_core::Device;
 
-use crate::config::CliConfig;
+use crate::config::{
+    CliConfig, LEGACY_RUNTIME_DEVICE_HELP, invalid_device_message, is_supported_device_label,
+    unsupported_legacy_command_device_message,
+};
 
 /// Generation configuration for inference
 #[derive(Debug, Clone)]
@@ -150,8 +153,7 @@ pub struct InferenceCommand {
     #[arg(short, long, value_name = "PATH")]
     pub output: Option<PathBuf>,
 
-    /// Device to use for inference (cpu, cuda, auto)
-    #[arg(short, long, value_name = "DEVICE")]
+    #[arg(short, long, value_name = "DEVICE", help = LEGACY_RUNTIME_DEVICE_HELP)]
     pub device: Option<String>,
 
     /// Quantization type (i2s, tl1, tl2, auto)
@@ -767,10 +769,13 @@ impl InferenceCommand {
                     Ok(Device::Cpu)
                 }
             }
-            _ => anyhow::bail!(
-                "Invalid device: {}. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, auto",
-                device_str
-            ),
+            label if is_supported_device_label(label) => {
+                anyhow::bail!(
+                    "{}",
+                    unsupported_legacy_command_device_message("bitnet inference", label)
+                )
+            }
+            _ => anyhow::bail!("{}", invalid_device_message(device_str)),
         }
     }
 

--- a/crates/bitnet-cli/src/commands/serve.rs
+++ b/crates/bitnet-cli/src/commands/serve.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use std::path::PathBuf;
 use tracing::{info, warn};
 
-use crate::config::CliConfig;
+use crate::config::{CliConfig, LEGACY_RUNTIME_DEVICE_HELP};
 
 /// Serve command arguments
 #[derive(Args, Debug)]
@@ -22,8 +22,7 @@ pub struct ServeCommand {
     #[arg(short, long, default_value = "8080", value_name = "PORT")]
     pub port: u16,
 
-    /// Device to use (cpu, cuda, auto)
-    #[arg(short, long, value_name = "DEVICE")]
+    #[arg(short, long, value_name = "DEVICE", help = LEGACY_RUNTIME_DEVICE_HELP)]
     pub device: Option<String>,
 
     /// Maximum concurrent requests

--- a/crates/bitnet-cli/src/config.rs
+++ b/crates/bitnet-cli/src/config.rs
@@ -4,4 +4,9 @@
 //! the existing `bitnet_cli::config::*` import path stable.
 
 #[allow(unused_imports)]
-pub use bitnet_cli_config_core::{CliConfig, ConfigBuilder, LoggingConfig, PerformanceConfig};
+pub use bitnet_cli_config_core::{
+    APPLE_M4_DEVICE_LABELS_TEXT, CliConfig, ConfigBuilder, DEVICE_HELP, LEGACY_RUNTIME_DEVICE_HELP,
+    LEGACY_RUNTIME_DEVICE_LABELS_TEXT, LoggingConfig, PerformanceConfig, SUPPORTED_DEVICE_LABELS,
+    SUPPORTED_DEVICE_LABELS_TEXT, invalid_device_message, is_supported_device_label,
+    unsupported_legacy_command_device_message,
+};

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -5,7 +5,7 @@
 
 // COMPILE-TIME FIREWALL: Prevent mock feature in production CLI
 #[cfg(feature = "mock")]
-compile_error!("The 'mock' feature must never be enabled for the CLI ΓÇô tests only.");
+compile_error!("The 'mock' feature must never be enabled for the CLI - tests only.");
 
 use anyhow::{Context, Result};
 use bitnet_common::Tensor;
@@ -119,13 +119,13 @@ fn bitnet_version() -> &'static str {
 use commands::BenchmarkCommand;
 #[cfg(feature = "full-cli")]
 use commands::{ConvertCommand, InferenceCommand, InspectCommand, ServeCommand};
-use config::{CliConfig, ConfigBuilder};
+use config::{CliConfig, ConfigBuilder, DEVICE_HELP};
 
 /// BitNet CLI - High-performance 1-bit LLM inference toolkit
 #[derive(Parser)]
 #[command(name = "bitnet")]
-#[command(about = "BitNet-rs ΓÇö 1-bit neural network inference with strict receipts")]
-#[command(long_about = r#"BitNet-rs CLI ΓÇö one-shot generation and chat with strict receipts
+#[command(about = "BitNet-rs - 1-bit neural network inference with strict receipts")]
+#[command(long_about = r#"BitNet-rs CLI - one-shot generation and chat with strict receipts
 
 QUICK EXAMPLES:
 
@@ -158,9 +158,9 @@ PERFORMANCE:
 
   QK256 Models (I2_S quantization):
     - Without AVX2: ~0.1 tok/s (scalar kernels, ~10s per token)
-    - With AVX2: ~1.2├ù faster (optimized kernels)
+    - With AVX2: ~1.2x faster (optimized kernels)
     - For quick validation: use --max-tokens 4-16
-    - SIMD optimizations (ΓëÑ3├ù faster) coming in v0.2.0
+    - SIMD optimizations (>=3x faster) coming in v0.2.0
 "#)]
 #[command(version = bitnet_version())]
 #[command(author = "BitNet Contributors")]
@@ -173,8 +173,7 @@ struct Cli {
     #[arg(short, long, value_name = "PATH", global = true)]
     config: Option<std::path::PathBuf>,
 
-    /// Device/backend to use (cpu, cuda, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, oneapi, gpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, npu, auto)
-    #[arg(short, long, value_name = "DEVICE", global = true)]
+    #[arg(short, long, value_name = "DEVICE", global = true, help = DEVICE_HELP)]
     device: Option<String>,
 
     /// Log level (trace, debug, info, warn, error)
@@ -636,8 +635,20 @@ async fn main() -> Result<()> {
             .unwrap_or(false);
         match select_backend(request, &caps) {
             Ok(result) => info!(backend_selection = %result.identity_summary(), "backend selected"),
-            Err(e) if strict_mode => return Err(e.into()),
-            Err(e) => warn!(error = %e, "backend selection warning"),
+            Err(e) if strict_mode => {
+                let message = backend_selection_error_message_with_note(
+                    &requested_backend_label,
+                    &e.to_string(),
+                );
+                return Err(anyhow::anyhow!(message));
+            }
+            Err(e) => {
+                let message = backend_selection_error_message_with_note(
+                    &requested_backend_label,
+                    &e.to_string(),
+                );
+                warn!(error = %message, "backend selection warning");
+            }
         }
     }
 
@@ -1772,13 +1783,20 @@ fn resolve_run_backend_identity(
             fallback_used: result.fallback_used(),
             fallback_reason: result.fallback_reason().map(str::to_string),
         }),
-        Err(err) if strict_backend => Err(err.into()),
+        Err(err) if strict_backend => {
+            let message =
+                backend_selection_error_message_with_note(&request.to_string(), &err.to_string());
+            Err(anyhow::anyhow!(message))
+        }
         Err(err) => Ok(RunBackendIdentity {
             requested_backend: request.to_string(),
             selected_backend: "cpu".to_string(),
             runtime_api: "cpu".to_string(),
             fallback_used: request != BackendRequest::Auto && request != BackendRequest::Cpu,
-            fallback_reason: Some(err.to_string()),
+            fallback_reason: Some(backend_selection_error_message_with_note(
+                &request.to_string(),
+                &err.to_string(),
+            )),
         }),
     }
 }
@@ -3864,6 +3882,28 @@ fn is_apple_m4_backend_label(label: &str) -> bool {
     label.trim().to_ascii_lowercase().starts_with("apple-m4-")
 }
 
+fn backend_selection_error_message_with_note(requested_backend_label: &str, error: &str) -> String {
+    match apple_backend_failure_note(requested_backend_label) {
+        Some(note) => format!("{error}. {note}"),
+        None => error.to_string(),
+    }
+}
+
+fn apple_backend_failure_note(requested_backend_label: &str) -> Option<&'static str> {
+    match requested_backend_label.trim().to_ascii_lowercase().as_str() {
+        "apple-m4-metal" => Some(
+            "apple-m4-metal is the native Metal proof lane; it does not imply MPSGraph or Neural Engine execution and must not silently fall back to CPU in strict mode. Run on native macOS Apple M4 with Metal visible, or request apple-m4-cpu-neon for the CPU/NEON reference lane.",
+        ),
+        "apple-m4-mpsgraph" => Some(
+            "apple-m4-mpsgraph is the graph/reference proof lane; it is not native Metal kernel proof and is not Neural Engine proof unless the resolved target is receipt-backed.",
+        ),
+        "apple-m4-cpu-neon" => Some(
+            "apple-m4-cpu-neon is the Apple ARM64 CPU/NEON fallback and parity lane; it is not Metal acceleration, and scalar fallback must be visible in receipts.",
+        ),
+        _ => None,
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct AppleCliMachineProbe {
     chip: Option<String>,
@@ -4025,6 +4065,31 @@ mod tests {
             assert!(identity.fallback_used);
             assert!(identity.fallback_reason.is_some());
         }
+    }
+
+    #[test]
+    fn strict_apple_metal_error_describes_non_fallback_proof_lane() {
+        let err = resolve_run_backend_identity("apple-m4-metal", true).unwrap_err().to_string();
+
+        assert!(err.contains("apple-m4-metal"), "got: {err}");
+        assert!(err.contains("native Metal proof lane"), "got: {err}");
+        assert!(err.contains("must not silently fall back to CPU"), "got: {err}");
+        assert!(err.contains("apple-m4-cpu-neon"), "got: {err}");
+    }
+
+    #[test]
+    fn non_strict_apple_mpsgraph_fallback_reason_keeps_graph_boundary() {
+        let identity = resolve_run_backend_identity("apple-m4-mpsgraph", false).unwrap();
+
+        assert_eq!(identity.requested_backend, "apple-m4-mpsgraph");
+        assert!(identity.fallback_used);
+        let fallback_reason = identity.fallback_reason.unwrap();
+        assert!(fallback_reason.contains("graph/reference proof lane"), "got: {fallback_reason}");
+        assert!(
+            fallback_reason.contains("not native Metal kernel proof"),
+            "got: {fallback_reason}"
+        );
+        assert!(fallback_reason.contains("not Neural Engine proof"), "got: {fallback_reason}");
     }
 
     #[test]

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -113,6 +113,47 @@ fn run_help_documents_greedy() {
         .stdout(predicate::str::contains("--greedy"));
 }
 
+#[test]
+fn top_level_help_documents_apple_backend_labels() {
+    bitnet()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apple-m4-metal"))
+        .stdout(predicate::str::contains("apple-m4-mpsgraph"))
+        .stdout(predicate::str::contains("apple-m4-cpu-neon"));
+}
+
+#[test]
+fn run_help_documents_apple_backend_labels() {
+    bitnet()
+        .args(["run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("apple-m4-metal"))
+        .stdout(predicate::str::contains("apple-m4-mpsgraph"))
+        .stdout(predicate::str::contains("apple-m4-cpu-neon"));
+}
+
+#[test]
+fn legacy_inference_apple_label_error_points_to_receipt_backed_run_path() {
+    bitnet()
+        .args([
+            "inference",
+            "--model",
+            "fake.gguf",
+            "--prompt",
+            "hello",
+            "--device",
+            "apple-m4-metal",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("does not support device label 'apple-m4-metal'"))
+        .stderr(predicate::str::contains("Use `bitnet run` for receipt-backed Apple M4 labels"))
+        .stderr(predicate::str::contains("CPU fallback cannot count as Metal execution"));
+}
+
 /// `run --help` documents the --deterministic flag.
 #[test]
 fn run_help_documents_deterministic() {

--- a/crates/bitnet-cli/tests/cli_config_edge_cases.rs
+++ b/crates/bitnet-cli/tests/cli_config_edge_cases.rs
@@ -2,7 +2,9 @@
 //! CliConfig, LoggingConfig, PerformanceConfig, ConfigBuilder, validation, and TOML serde.
 #![allow(clippy::field_reassign_with_default)]
 
-use bitnet_cli::config::{CliConfig, ConfigBuilder, LoggingConfig, PerformanceConfig};
+use bitnet_cli::config::{
+    APPLE_M4_DEVICE_LABELS_TEXT, CliConfig, ConfigBuilder, LoggingConfig, PerformanceConfig,
+};
 use std::path::PathBuf;
 
 // ---------------------------------------------------------------------------
@@ -94,6 +96,19 @@ fn validate_rejects_invalid_device() {
     let mut cfg = CliConfig::default();
     cfg.default_device = "tpu".to_string();
     assert!(cfg.validate().is_err());
+}
+
+#[test]
+fn validate_invalid_device_error_describes_apple_lane_boundaries() {
+    let mut cfg = CliConfig::default();
+    cfg.default_device = "tpu".to_string();
+    let err = cfg.validate().unwrap_err().to_string();
+
+    assert!(err.contains("npu:<index>"), "got: {err}");
+    assert!(err.contains("intel-npu-openvino"), "got: {err}");
+    assert!(err.contains(APPLE_M4_DEVICE_LABELS_TEXT), "got: {err}");
+    assert!(err.contains("strict mode fails"), "got: {err}");
+    assert!(err.contains("fallback_used"), "got: {err}");
 }
 
 #[test]

--- a/crates/bitnet-cli/tests/cli_snapshot_tests.rs
+++ b/crates/bitnet-cli/tests/cli_snapshot_tests.rs
@@ -25,7 +25,9 @@ use insta::assert_snapshot;
 /// Panics if the process exits with a non-zero code.
 fn bitnet_stdout(args: &[&str]) -> String {
     let output = cargo_bin_cmd!("bitnet").args(args).output().expect("failed to spawn bitnet");
-    String::from_utf8(output.stdout).expect("stdout is not valid UTF-8")
+    trim_trailing_line_whitespace(
+        String::from_utf8(output.stdout).expect("stdout is not valid UTF-8"),
+    )
 }
 
 /// Run `bitnet <args>` and return its stderr as a `String`.
@@ -34,6 +36,15 @@ fn bitnet_stderr_failure(args: &[&str]) -> String {
     let output = cargo_bin_cmd!("bitnet").args(args).output().expect("failed to spawn bitnet");
     assert!(!output.status.success(), "expected bitnet {:?} to fail, but it succeeded", args);
     String::from_utf8(output.stderr).expect("stderr is not valid UTF-8")
+}
+
+fn trim_trailing_line_whitespace(output: String) -> String {
+    let ends_with_newline = output.ends_with('\n');
+    let mut normalized = output.lines().map(str::trim_end).collect::<Vec<_>>().join("\n");
+    if ends_with_newline {
+        normalized.push('\n');
+    }
+    normalized
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__chat_help.snap
@@ -23,7 +23,7 @@ Options:
 
       --model-format <FORMAT>
           Model format (auto, gguf, safetensors)
-          
+
           [default: auto]
 
       --log-level <LEVEL>
@@ -39,20 +39,20 @@ Options:
           Output file for results
 
   -d, --device <DEVICE>
-          Device to use for inference (cpu, cuda, auto)
+          Device for this legacy command (cpu, cuda/gpu aliases, auto). Use `bitnet run` for receipt-backed Apple M4 labels
 
   -q, --quantization <TYPE>
           Quantization type (i2s, tl1, tl2, auto)
 
       --max-tokens <N>
           Maximum number of tokens to generate (aliases: --max-new-tokens, --n-predict)
-          
+
           [default: 512]
           [aliases: --max-new-tokens, --n-predict]
 
       --temperature <TEMP>
           Temperature for sampling (0.0 = greedy, higher = more random)
-          
+
           [default: 0.7]
 
       --top-k <K>
@@ -63,7 +63,7 @@ Options:
 
       --repetition-penalty <PENALTY>
           Repetition penalty
-          
+
           [default: 1.1]
 
       --seed <SEED>
@@ -83,7 +83,7 @@ Options:
 
       --batch-size <SIZE>
           Batch size for processing multiple prompts
-          
+
           [default: 1]
 
       --workers <N>
@@ -100,7 +100,7 @@ Options:
 
       --format <FORMAT>
           Output format (text, json, jsonl)
-          
+
           [default: text]
 
       --system-prompt <TEXT>
@@ -111,7 +111,7 @@ Options:
 
       --prompt-template <TEMPLATE>
           Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
-          
+
           [default: auto]
 
       --tokenizer <PATH>
@@ -125,7 +125,7 @@ Options:
 
       --stop <SEQ>
           Stop sequences (aliases: --stop-sequence, --stop_sequences)
-          
+
           [aliases: --stop-sequence, --stop_sequences]
 
       --stop-id <ID>
@@ -133,7 +133,7 @@ Options:
 
       --stop-string-window <N>
           Window size for tail-based stop string matching (default: 64) Only decode the last N tokens when checking stop sequences
-          
+
           [default: 64]
 
       --timeout <SECONDS>
@@ -144,7 +144,7 @@ Options:
 
       --logits-topk <K>
           Number of top logits to dump per step
-          
+
           [default: 10]
 
       --chat-history-limit <N>
@@ -160,7 +160,7 @@ Options:
           Q&A mode: bundle Q&A-friendly defaults (auto template, temp=0.7, top-p=0.95, top-k=50) Individual parameters can still be overridden (e.g., --qa --temperature 0.5)
 
       --strict-loader
-          Strict loader mode: fail-fast with enhanced loader (sets BITNET_DISABLE_MINIMAL_LOADER=1) Preferred for CI/parity testing. Unset to allow minimal loader fallback (reduced features)
+          Strict loader mode: fail-fast with authoritative real_gguf loading. Preferred for CI/parity testing; compatibility loaders are rejected
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
@@ -2,7 +2,7 @@
 source: crates/bitnet-cli/tests/cli_snapshot_tests.rs
 expression: help
 ---
-BitNet-rs CLI — one-shot generation and chat with strict receipts
+BitNet-rs CLI - one-shot generation and chat with strict receipts
 
 QUICK EXAMPLES:
 
@@ -35,34 +35,40 @@ PERFORMANCE:
 
   QK256 Models (I2_S quantization):
     - Without AVX2: ~0.1 tok/s (scalar kernels, ~10s per token)
-    - With AVX2: ~1.2× faster (optimized kernels)
+    - With AVX2: ~1.2x faster (optimized kernels)
     - For quick validation: use --max-tokens 4-16
-    - SIMD optimizations (≥3× faster) coming in v0.2.0
+    - SIMD optimizations (>=3x faster) coming in v0.2.0
 
 
 Usage: bitnet [OPTIONS] [COMMAND]
 
 Commands:
-  run           Run simple text generation
-  tokenize      Tokenize text and output token IDs as JSON
-  score         Calculate perplexity score for a model
-  inference     Run inference on a model
-  chat          Interactive chat mode (streaming)
-  convert       Convert between model formats
-  benchmark     Benchmark model performance
-  serve         Start inference server
-  config        Manage configuration
-  info          Show system information
-  inspect       Inspect model metadata and diagnostics
-  compat-check  Check GGUF file compatibility using header validation
-  help          Print this message or the help of the given subcommand(s)
+  run                 Run simple text generation
+  tokenize            Tokenize text and output token IDs as JSON
+  score               Calculate perplexity score for a model
+  inference           Run inference on a model
+  chat                Interactive chat mode (streaming)
+  convert             Convert between model formats
+  benchmark           Benchmark model performance
+  serve               Start inference server
+  config              Manage configuration
+  info                Show system information
+  device-smoke        Probe selected device identity without launching kernels
+  lunar-lake-probe    Probe Lunar Lake 258V platform visibility without launching kernels
+  validate            Run validation-only preflight checks
+  cuda-smoke          Compile and launch a tiny CUDA vector-add kernel
+  inspect             Inspect model metadata and diagnostics
+  compat-check        Check GGUF file compatibility using header validation
+  list-architectures  List all supported model architectures
+  list-templates      List all available prompt templates
+  help                Print this message or the help of the given subcommand(s)
 
 Options:
   -c, --config <PATH>
           Configuration file path
 
   -d, --device <DEVICE>
-          Device to use (cpu, cuda, auto)
+          Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto). Apple M4 labels are distinct proof lanes
 
       --log-level <LEVEL>
           Log level (trace, debug, info, warn, error)
@@ -75,7 +81,7 @@ Options:
 
       --completions <SHELL>
           Generate shell completions
-          
+
           [possible values: bash, elvish, fish, powershell, zsh]
 
       --save-config <PATH>

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__compat_check_help.snap
@@ -12,7 +12,7 @@ Arguments:
 Options:
   -c, --config <PATH>        Configuration file path
       --json                 Output JSON
-  -d, --device <DEVICE>      Device to use (cpu, cuda, auto)
+  -d, --device <DEVICE>      Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto). Apple M4 labels are distinct proof lanes
       --strict               Fail on unsupported version or suspicious counts
       --log-level <LEVEL>    Log level (trace, debug, info, warn, error)
       --show-kv              Show key-value metadata (limit with --kv-limit)

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__inspect_help.snap
@@ -12,7 +12,7 @@ Arguments:
 Options:
   -c, --config <PATH>            Configuration file path
       --ln-stats                 Compute and display LayerNorm gamma statistics
-  -d, --device <DEVICE>          Device to use (cpu, cuda, auto)
+  -d, --device <DEVICE>          Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto). Apple M4 labels are distinct proof lanes
       --gate <GATE>              Gate behavior: none|auto|policy [default: auto]
       --log-level <LEVEL>        Log level (trace, debug, info, warn, error)
       --policy <POLICY>          Policy file (YAML) for custom validation rules

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
@@ -23,47 +23,55 @@ Options:
           Configuration file path
 
   -m, --model <MODEL>
-          Model file path
+          Model file or directory path (.gguf file or HuggingFace model directory)
 
   -d, --device <DEVICE>
-          Device to use (cpu, cuda, auto)
+          Device/backend label (cpu, cuda/gpu, hip/rocm, oneapi, npu/openvino-npu, nvidia-rtx-5070-ti-cuda/wgpu, metal/mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto). Apple M4 labels are distinct proof lanes
+
+      --model-format <FORMAT>
+          Model format: auto (detect from path), gguf, safetensors
+
+          [default: auto]
+
+      --architecture <ARCH>
+          Model architecture override (e.g. bitnet, llama, phi3); auto-detected if omitted
+
+      --log-level <LEVEL>
+          Log level (trace, debug, info, warn, error)
 
       --tokenizer <TOKENIZER>
           Tokenizer file path (optional, will look for sibling file if not provided)
 
-      --log-level <LEVEL>
-          Log level (trace, debug, info, warn, error)
+      --batch-size <SIZE>
+          Batch size for processing
 
   -p, --prompt <PROMPT>
           Input prompt
 
       --max-new-tokens <MAX_NEW_TOKENS>
           Maximum new tokens to generate (aliases: --max-tokens, --n-predict)
-          
+
           [default: 32]
           [aliases: --max-tokens, --n-predict]
 
-      --batch-size <SIZE>
-          Batch size for processing
-
       --temperature <TEMPERATURE>
           Temperature for sampling (0 = greedy)
-          
+
           [default: 1]
 
       --top-k <TOP_K>
           Top-k sampling (0 = disabled)
-          
+
           [default: 0]
 
       --top-p <TOP_P>
           Top-p (nucleus) sampling
-          
+
           [default: 1]
 
       --repetition-penalty <REPETITION_PENALTY>
           Repetition penalty
-          
+
           [default: 1.1]
 
       --seed <SEED>
@@ -71,7 +79,7 @@ Options:
 
       --allow-mock
           Allow falling back to mock loader if real loader fails Also toggled by env BITNET_ALLOW_MOCK=1
-          
+
           [env: BITNET_ALLOW_MOCK=]
 
       --strict-mapping
@@ -100,12 +108,12 @@ Options:
 
       --threads <THREADS>
           Number of threads to use (0 = all cores)
-          
+
           [default: 0]
 
       --prompt-template <TEMPLATE>
           Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
-          
+
           [default: auto]
 
       --system-prompt <TEXT>
@@ -122,7 +130,7 @@ Options:
 
       --logits-topk <K>
           Top-k tokens to include in logit dump
-          
+
           [default: 10]
 
       --assert-greedy
@@ -130,6 +138,12 @@ Options:
 
       --no-warnings
           Suppress performance warnings
+
+      --profile-id <PROFILE>
+          Profile label to record in JSON receipts (for example: smoke_1, prefill_512, decode_128)
+
+      --allocation-audit
+          Measure scoped hot-loop allocation counter deltas in profile receipts
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
+++ b/crates/bitnet-cli/tests/snapshots/snapshot_wave10__cli_config_validate_invalid_device_error.snap
@@ -2,4 +2,4 @@
 source: crates/bitnet-cli/tests/snapshot_wave10.rs
 expression: err.to_string()
 ---
-Invalid device: quantum. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, npu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto
+Invalid device: quantum. Must be one of: cpu, cuda, gpu, vulkan, opencl, ocl, hip, rocm, oneapi, npu, npu:<index>, intel-npu, intel-npu:<index>, openvino-npu, intel-npu-openvino, nvidia-rtx-5070-ti-cuda, nvidia-rtx-5070-ti-wgpu, metal, mpsgraph, apple-m4-metal, apple-m4-mpsgraph, apple-m4-cpu-neon, auto. Apple M4 labels are distinct proof lanes: apple-m4-metal = native Metal proof lane, apple-m4-mpsgraph = MPSGraph graph/reference lane, apple-m4-cpu-neon = Apple CPU/NEON fallback/parity lane. On unavailable or non-M4 hosts, strict mode fails and non-strict receipt paths must record fallback_used and fallback_reason.

--- a/docs/hardware/apple-m4-mac-mini-validation.md
+++ b/docs/hardware/apple-m4-mac-mini-validation.md
@@ -614,6 +614,35 @@ reference parity with `fallback_used=false`. It must not claim full Metal
 inference, QK256 acceleration, Neural Engine execution, MPSGraph execution, or
 general M4 performance.
 
+## M4-018 CLI and Package Surface Polish
+
+The Apple backend labels exposed by the CLI are proof-lane labels, not generic
+accelerator aliases:
+
+| Label | Meaning | Must not imply |
+| --- | --- | --- |
+| `apple-m4-metal` | Native Apple M4 Metal proof lane | MPSGraph, Neural Engine, or CPU fallback proof |
+| `apple-m4-mpsgraph` | MPSGraph graph/reference proof lane | Native Metal kernel proof or Neural Engine proof without resolved-target evidence |
+| `apple-m4-cpu-neon` | Apple ARM64 CPU/NEON fallback and parity lane | Metal acceleration |
+
+CLI help and config validation should make these boundaries visible. Strict
+mode must fail when a requested Apple backend is unavailable; non-strict paths
+may fall back only when the receipt records `requested_backend`,
+`selected_backend`, `runtime_api`, `fallback_used`, and `fallback_reason`.
+
+Artifact path examples remain under the machine lane:
+
+```text
+ci/hardware/apple-m4-mac-mini/<date>/strict-bitnet-cpu-neon-proof.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-parity.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-prefill-contribution.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-projection-residual.json
+```
+
+Legacy CLI subcommands that do not emit Apple proof receipts should direct users
+to `bitnet run` for receipt-backed Apple M4 labels instead of silently aliasing
+those labels to `cpu`, `metal`, `mpsgraph`, or `auto`.
+
 ## Benchmark Notes
 
 Benchmarks must record:

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -627,6 +627,43 @@ reference parity with `fallback_used=false`. It must not claim full Metal
 inference, QK256 acceleration, Neural Engine execution, MPSGraph execution, or
 general M4 performance.
 
+### M4-018 - CLI and Package Surface Polish
+
+Polish the package-facing Apple backend labels and failure-mode text after the
+strict proof and kernel/subgraph expansion items. The CLI should present these
+as separate proof lanes:
+
+```text
+apple-m4-metal     native Metal proof lane
+apple-m4-mpsgraph  MPSGraph graph/reference proof lane
+apple-m4-cpu-neon  Apple ARM64 CPU/NEON fallback and parity lane
+```
+
+`apple-m4-metal` must not alias to MPSGraph, Neural Engine, CPU fallback, or
+generic `metal`. `apple-m4-mpsgraph` must not count as native Metal kernel
+proof or Neural Engine proof without resolved-target evidence.
+`apple-m4-cpu-neon` must not count as Metal acceleration.
+
+Strict-mode failures should explain that unavailable Apple labels fail rather
+than silently falling back. Non-strict fallback paths must remain receipt-backed
+with `requested_backend`, `selected_backend`, `runtime_api`, `fallback_used`,
+and `fallback_reason`.
+
+Legacy CLI subcommands that do not emit Apple proof receipts should point users
+to `bitnet run` for receipt-backed Apple M4 labels. The artifact path examples
+remain:
+
+```text
+ci/hardware/apple-m4-mac-mini/<date>/strict-bitnet-cpu-neon-proof.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-parity.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-prefill-contribution.json
+ci/hardware/apple-m4-mac-mini/<date>/metal-i2s-projection-residual.json
+```
+
+M4-018 may claim only that Apple backend CLI and package surfaces describe
+supported backend labels and failure modes accurately. It must not claim new
+Metal kernel execution, Neural Engine execution, or general M4 performance.
+
 ## Do Not
 
 - Do not start with Apple Neural Engine inference claims.

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -597,7 +597,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-018"
-status = "ready"
+status = "in_progress"
 branch = "codex/apple-m4/M4-018-cli-package-polish"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -597,11 +597,12 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-018"
-status = "in_progress"
+status = "pr_open"
 branch = "codex/apple-m4/M4-018-cli-package-polish"
 stackable = false
 requires_human_merge = true
 blocked_by = ["M4-017"]
+pr = 3826
 acceptance = "Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear."
 commands = [
   "cargo fmt --all -- --check",

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T030423Z-M4-018-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T030423Z-M4-018-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-07T03:04:23Z"
+campaign = "apple-m4"
+item = "M4-018"
+event = "in_progress"
+branch = "codex/apple-m4/M4-018-cli-package-polish"
+actor = "codex"
+
+notes = [
+  "Started Apple backend CLI and package surface polish.",
+  "Scope is help text, config validation, strict/fallback failure wording, docs, and campaign tracking only; no Metal kernels, QK256, server, Neural Engine, or general performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T031511Z-M4-018-pr-open.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T031511Z-M4-018-pr-open.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T03:15:11Z"
+campaign = "apple-m4"
+item = "M4-018"
+event = "pr_open"
+pr = 3826
+head_sha = "54ca72af3d355c5f053da532244c86a39c1d0b83"
+actor = "codex"
+
+notes = [
+  "Opened Apple backend CLI/package polish PR.",
+  "Scope remains CLI help/config/failure wording, docs, tests, and campaign tracking; no Metal kernels, QK256, server, Neural Engine, or general M4 performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -26,7 +26,7 @@
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | merged | #3818 | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
-| M4-018 | in_progress | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
+| M4-018 | pr_open | #3826 | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -26,7 +26,7 @@
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | merged | #3818 | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
-| M4-018 | ready | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
+| M4-018 | in_progress | TBD | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| apple-m4 | M4-018 | #3826 | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -19,7 +19,7 @@
 | apple-m4 | M4-015 | M4-014 | merged |
 | apple-m4 | M4-016 | M4-015 | merged |
 | apple-m4 | M4-017 | M4-016 | merged |
-| apple-m4 | M4-018 | M4-017 | in_progress |
+| apple-m4 | M4-018 | M4-017 | pr_open |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -19,7 +19,7 @@
 | apple-m4 | M4-015 | M4-014 | merged |
 | apple-m4 | M4-016 | M4-015 | merged |
 | apple-m4 | M4-017 | M4-016 | merged |
-| apple-m4 | M4-018 | M4-017 | ready |
+| apple-m4 | M4-018 | M4-017 | in_progress |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-018 | TBD | ready | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-018 | TBD | in_progress | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,7 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-018 | TBD | in_progress | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-018 | #3826 | pr_open | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | ready | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-018
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Centralize CLI device/backend label text in `bitnet-cli-config-core` and keep Apple M4 labels distinct from generic Metal, MPSGraph, CPU, and accelerator aliases.
- Improve strict and non-strict Apple backend failure wording so unavailable Apple proof lanes do not look like silent CPU fallback or Neural Engine/MPSGraph/native Metal proof.
- Update legacy full-cli command help/errors to point Apple proof labels at receipt-backed `bitnet run`, and refresh CLI snapshots with normalized help whitespace.
- Document M4-018 label boundaries and artifact path examples in the Apple validation/roadmap docs, then regenerate campaign dashboards.

## Claim Boundary
This PR only claims that Apple backend CLI and package surfaces describe supported backend labels and failure modes accurately. It does not add Metal kernels, QK256 work, server inference, Neural Engine execution, or general M4 performance claims.

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p bitnet-cli-config-core`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
