### PR TITLE
[codex][apple-m4] Close out M4-018

### DIFF
--- a/docs/tracking/campaigns/apple-m4/active.toml
+++ b/docs/tracking/campaigns/apple-m4/active.toml
@@ -597,7 +597,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-018"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4/M4-018-cli-package-polish"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/apple-m4/events/2026-05-07T034359Z-M4-018-merged.toml
+++ b/docs/tracking/campaigns/apple-m4/events/2026-05-07T034359Z-M4-018-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T03:43:59Z"
+campaign = "apple-m4"
+item = "M4-018"
+event = "merged"
+pr = 3826
+merge_sha = "b5ea2d245ae94a5fc8388f7b0a9a7f19fdfdd648"
+actor = "codex"
+
+notes = [
+  "Merged Apple backend CLI/package polish.",
+  "Clarified Apple backend labels, strict-mode errors, artifact paths, and non-M4 failure modes without adding Metal kernels, QK256, server inference, MPSGraph execution, or Neural Engine claims.",
+]

--- a/docs/tracking/campaigns/apple-m4/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4/generated/status.md
@@ -26,7 +26,7 @@
 | M4-015 | merged | #3804 | `codex/apple-m4/M4-015-steady-decode-profile` | Add steady decode and prefill timing profiles for the selected Apple backend with strict model, tokenizer, phase, fallback, and machine context recorded. |
 | M4-016 | merged | #3811 | `codex/apple-m4/M4-016-hot-loop-allocation-audit` | Measure or bound hot-loop allocations for the Apple BitNet path and distinguish compute timing from allocation overhead. |
 | M4-017 | merged | #3818 | `codex/apple-m4/M4-017-metal-kernel-family-expansion` | Expand Apple Metal BitNet kernel or subgraph coverage only where CPU reference parity, fallback=false receipts, phase labels, and claim boundaries are present. |
-| M4-018 | pr_open | #3826 | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
+| M4-018 | merged | #3826 | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4 | M4-018 | #3826 | `codex/apple-m4/M4-018-cli-package-polish` | Polish Apple backend CLI and package surfaces so backend labels, strict-mode errors, artifact paths, and non-M4 failure modes are clear. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -19,7 +19,7 @@
 | apple-m4 | M4-015 | M4-014 | merged |
 | apple-m4 | M4-016 | M4-015 | merged |
 | apple-m4 | M4-017 | M4-016 | merged |
-| apple-m4 | M4-018 | M4-017 | pr_open |
+| apple-m4 | M4-018 | M4-017 | merged |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,14 +4,14 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
-| apple-m4 | M4-018 | #3826 | pr_open | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
+| apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | TBD | in_progress | none | No GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | LNL258V-RUN-001 | #3714 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-002 | #3722 | merged | none | Device-node detection is not inference. |
+| intel-npu | NPU-003 | #3739 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | CUDA-BITNET-008 | TBD | proposed | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,9 +9,9 @@
 | cpu-proof | BitNet CPU proof | CPU-BITNET-008 | No GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | LNL258V-RUN-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
-| intel-npu | Intel NPU validation | NPU-002 | Device-node detection is not inference. |
+| intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-008 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -629,7 +629,7 @@ fn current_item(manifest: &CampaignManifest) -> Option<&WorkItem> {
             return Some(item);
         }
     }
-    manifest.work_items.iter().find(|item| item.status == "merged")
+    manifest.work_items.iter().rev().find(|item| item.status == "merged")
 }
 
 fn latest_pr(events: &[Event], item_id: &str) -> Option<u64> {


### PR DESCRIPTION
Campaign: apple-m4
Work item: M4-018 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Mark M4-018 merged with PR #3826 merge SHA b5ea2d245ae94a5fc8388f7b0a9a7f19fdfdd648.
- Add the append-only M4-018 merged event.
- Regenerate campaign/global dashboards.
- Fix campaign dashboard selection so fully merged campaigns show the latest merged item instead of the first scaffold item.

## Claim boundary
Tracker closeout only. No runtime code, kernels, QK256, server inference, MPSGraph execution, Neural Engine claim, or performance claim.

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check
