### PR TITLE
feat(npu): add Intel NPU runtime probe command

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -464,6 +464,17 @@ enum Commands {
         json_out: Option<std::path::PathBuf>,
     },
 
+    /// Probe Intel NPU OpenVINO runtime visibility without compiling graphs
+    IntelNpuProbe {
+        /// Require OpenVINO to report an NPU runtime device
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+
+        /// Output JSON probe receipt to file
+        #[arg(long)]
+        json_out: Option<std::path::PathBuf>,
+    },
+
     /// Run validation-only preflight checks
     Validate {
         #[command(subcommand)]
@@ -743,6 +754,9 @@ async fn main() -> Result<()> {
         }
         Some(Commands::LunarLakeProbe { json_out }) => {
             handle_lunar_lake_probe_command(json_out).await
+        }
+        Some(Commands::IntelNpuProbe { strict, json_out }) => {
+            handle_intel_npu_probe_command(strict, json_out).await
         }
         Some(Commands::Validate { action }) => handle_validate_command(action).await,
         Some(Commands::CudaSmoke { device_index, json_out }) => {
@@ -1111,6 +1125,79 @@ async fn handle_lunar_lake_probe_command(json_out: Option<std::path::PathBuf>) -
     let receipt = build_lunar_lake_probe_receipt(probe, timestamp_utc, artifact_path);
 
     write_json_output(json_out.as_ref(), &receipt)?;
+
+    Ok(())
+}
+
+fn build_intel_npu_probe_receipt(
+    probe: bitnet_device_probe::IntelNpuProbe,
+    strict: bool,
+    timestamp_utc: String,
+    artifact_path: Option<String>,
+) -> serde_json::Value {
+    let claim = if probe.openvino_npu_visible {
+        "openvino_npu_runtime_visibility_recorded"
+    } else if probe.available {
+        "intel_npu_os_visibility_recorded"
+    } else {
+        "intel_npu_unavailable"
+    };
+    let error =
+        if strict && !probe.openvino_npu_visible {
+            Some(probe.failure_reason.clone().unwrap_or_else(|| {
+                "strict Intel NPU probe requires OpenVINO to report NPU".to_owned()
+            }))
+        } else {
+            None
+        };
+
+    serde_json::json!({
+        "schema": 1,
+        "artifact_kind": "intel_npu_runtime_probe",
+        "machine_id": "intel-258v",
+        "hardware_lane": "intel-npu-openvino",
+        "proof_stage": probe.proof_stage.clone(),
+        "timestamp_utc": timestamp_utc,
+        "requested_backend": probe.requested_backend.clone(),
+        "selected_backend": probe.selected_backend.clone(),
+        "runtime_api": probe.runtime_api.clone(),
+        "runtime_device": probe.runtime_device.clone(),
+        "shape_mode": "static",
+        "strict_mode": strict,
+        "fallback_used": probe.fallback_used,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "kernel_execution": false,
+        "graph_execution": false,
+        "bitnet_inference": false,
+        "npu": probe,
+        "claim": claim,
+        "must_not_claim": [
+            "OpenVINO NPU graph execution works",
+            "Intel NPU accelerates BitNet",
+            "BitNet inference works on Intel NPU",
+            "CPU fallback satisfies NPU proof"
+        ],
+        "artifact_path": artifact_path,
+        "error": error,
+    })
+}
+
+async fn handle_intel_npu_probe_command(
+    strict: bool,
+    json_out: Option<std::path::PathBuf>,
+) -> Result<()> {
+    let openvino = bitnet_device_probe::runtimes::openvino::probe_openvino();
+    let npu = bitnet_device_probe::intel::lunar_lake::probe_intel_npu(&openvino);
+    let timestamp_utc = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let artifact_path = json_out.as_ref().map(|path| path.display().to_string());
+    let receipt = build_intel_npu_probe_receipt(npu, strict, timestamp_utc, artifact_path);
+
+    write_json_output(json_out.as_ref(), &receipt)?;
+
+    if let Some(error) = receipt.get("error").and_then(serde_json::Value::as_str) {
+        anyhow::bail!("{error}");
+    }
 
     Ok(())
 }
@@ -4344,6 +4431,101 @@ mod tests {
         assert_eq!(receipt["bitnet_inference"], false);
         assert_eq!(receipt["fallback_used"], false);
         assert!(receipt["platform"]["cpu"]["has_avx512"].is_boolean());
+    }
+
+    #[test]
+    fn intel_npu_probe_receipt_is_visibility_only() {
+        let probe = bitnet_device_probe::IntelNpuProbe {
+            proof_stage: "runtime_detected".to_string(),
+            requested_backend: "intel-npu".to_string(),
+            selected_backend: Some("intel-npu-openvino".to_string()),
+            runtime_api: Some("openvino".to_string()),
+            runtime_device: Some("NPU".to_string()),
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            available: true,
+            accel_device_present: false,
+            accel_devices: Vec::new(),
+            intel_vpu_driver_seen: true,
+            driver_hint: Some("intel_vpu/ivpu evidence".to_string()),
+            openvino_runtime_available: true,
+            openvino_version: Some("2026.1".to_string()),
+            openvino_available_devices: vec![
+                "CPU".to_string(),
+                "GPU.0".to_string(),
+                "NPU".to_string(),
+            ],
+            openvino_npu_visible: true,
+            openvino_npu_full_name: Some("Intel(R) AI Boost".to_string()),
+            supported_properties: vec!["FULL_DEVICE_NAME".to_string()],
+            driver_version: Some("1.2.3".to_string()),
+            compiler_version: Some("4.5.6".to_string()),
+            total_mem_size: Some(1024),
+            alloc_mem_size: Some(128),
+            max_tiles: Some(1),
+            fallback_used: false,
+            failure_reason: None,
+        };
+        let receipt = build_intel_npu_probe_receipt(
+            probe,
+            true,
+            "2026-05-06T00:00:00Z".to_string(),
+            Some("ci/hardware/intel-258v/2026-05-06/npu-openvino-runtime-probe.json".to_string()),
+        );
+
+        assert_eq!(receipt["artifact_kind"], "intel_npu_runtime_probe");
+        assert_eq!(receipt["requested_backend"], "intel-npu");
+        assert_eq!(receipt["selected_backend"], "intel-npu-openvino");
+        assert_eq!(receipt["runtime_api"], "openvino");
+        assert_eq!(receipt["runtime_device"], "NPU");
+        assert_eq!(receipt["strict_mode"], true);
+        assert_eq!(receipt["shape_mode"], "static");
+        assert_eq!(receipt["fallback_used"], false);
+        assert_eq!(receipt["kernel_execution"], false);
+        assert_eq!(receipt["graph_execution"], false);
+        assert_eq!(receipt["bitnet_inference"], false);
+        assert!(receipt["error"].is_null());
+    }
+
+    #[test]
+    fn strict_intel_npu_probe_records_error_without_fallback() {
+        let probe = bitnet_device_probe::IntelNpuProbe {
+            proof_stage: "runtime_detected".to_string(),
+            requested_backend: "intel-npu".to_string(),
+            selected_backend: None,
+            runtime_api: None,
+            runtime_device: None,
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            available: true,
+            accel_device_present: false,
+            accel_devices: Vec::new(),
+            intel_vpu_driver_seen: true,
+            driver_hint: Some("intel_vpu/ivpu evidence".to_string()),
+            openvino_runtime_available: false,
+            openvino_version: None,
+            openvino_available_devices: Vec::new(),
+            openvino_npu_visible: false,
+            openvino_npu_full_name: None,
+            supported_properties: Vec::new(),
+            driver_version: None,
+            compiler_version: None,
+            total_mem_size: None,
+            alloc_mem_size: None,
+            max_tiles: None,
+            fallback_used: false,
+            failure_reason: Some("OpenVINO NPU was not visible".to_string()),
+        };
+        let receipt =
+            build_intel_npu_probe_receipt(probe, true, "2026-05-06T00:00:00Z".to_string(), None);
+
+        assert_eq!(receipt["requested_backend"], "intel-npu");
+        assert!(receipt["selected_backend"].is_null());
+        assert!(receipt["runtime_api"].is_null());
+        assert_eq!(receipt["fallback_used"], false);
+        assert_eq!(receipt["graph_execution"], false);
+        assert_eq!(receipt["claim"], "intel_npu_os_visibility_recorded");
+        assert_eq!(receipt["error"], "OpenVINO NPU was not visible");
     }
 
     #[test]

--- a/docs/specs/intel-lunar-lake-npu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-npu-roadmap.md
@@ -517,6 +517,19 @@ Native Windows and native Linux artifacts should both be valid probe inputs. WSL
 
 Add a CLI or xtask command that writes machine-readable output without running model inference.
 
+CLI shape:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- intel-npu-probe \
+  --json-out ci/hardware/intel-258v/<date>/npu-openvino-runtime-probe.json
+```
+
+Use `--strict` when the caller requires OpenVINO to report `NPU`; strict mode
+writes the receipt and then fails if OpenVINO NPU visibility is absent.
+
 Example artifact shape:
 
 ```json

--- a/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
@@ -28,7 +28,7 @@ Validate Intel Lunar Lake NPU through OpenVINO static-shape detection, smoke, pa
 |---|---|---|
 | NPU-002 | merged | Preserve Intel NPU backend identity. |
 | NPU-003 | merged | Add runtime detection. |
-| NPU-004 | proposed | Add smoke probe command. |
+| NPU-004 | in_progress | Add smoke probe command. |
 | NPU-005 | proposed | Run tiny OpenVINO NPU graph smoke. |
 | NPU-006 | proposed | Add receipt fields. |
 

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -103,3 +103,45 @@ must_not_claim = [
   "BitNet inference works on Intel NPU.",
   "Intel NPU accelerates BitNet.",
 ]
+
+[[work_item]]
+id = "NPU-004"
+status = "in_progress"
+branch = "codex/intel-npu/NPU-004-smoke-probe-command"
+stackable = false
+requires_human_merge = true
+blocked_by = ["NPU-003"]
+acceptance = "Add an Intel NPU smoke probe command that writes a machine-readable OpenVINO NPU runtime visibility receipt with requested/selected backend identity, runtime API/device, strict mode, proof_stage=runtime_detected, fallback_used=false, and no graph, kernel, or BitNet inference claims."
+commands = [
+  "rustfmt --check --config skip_children=true crates/bitnet-cli/src/main.rs --edition 2024",
+  "cargo test --locked -p bitnet-cli --bin bitnet tests::intel_npu_probe_receipt_is_visibility_only -- --exact --nocapture",
+  "cargo test --locked -p bitnet-cli --bin bitnet tests::strict_intel_npu_probe_records_error_without_fallback -- --exact --nocapture",
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- intel-npu-probe --json-out target/intel-npu-runtime-probe.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/main.rs",
+  "docs/specs/intel-lunar-lake-npu-roadmap.md",
+  "docs/tracking/campaigns/intel-npu/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "The CLI can emit an Intel NPU OpenVINO runtime visibility receipt after merge.",
+]
+must_not_claim = [
+  "OpenVINO NPU graph execution works.",
+  "Intel NPU accelerates BitNet.",
+  "BitNet inference works on Intel NPU.",
+]

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-07T034459Z-NPU-004-in-progress.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-07T034459Z-NPU-004-in-progress.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-07T03:44:59Z"
+campaign = "intel-npu"
+item = "NPU-004"
+event = "in_progress"
+branch = "codex/intel-npu/NPU-004-smoke-probe-command"
+actor = "codex"
+
+notes = [
+  "Started Intel NPU smoke probe command work.",
+  "Scope is CLI receipt emission for OpenVINO NPU runtime visibility only; graph execution and BitNet inference remain out of scope.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -11,6 +11,7 @@
 |---|---|---:|---|---|
 | NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | NPU-003 | merged | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
+| NPU-004 | in_progress | TBD | `codex/intel-npu/NPU-004-smoke-probe-command` | Add an Intel NPU smoke probe command that writes a machine-readable OpenVINO NPU runtime visibility receipt with requested/selected backend identity, runtime API/device, strict mode, proof_stage=runtime_detected, fallback_used=false, and no graph, kernel, or BitNet inference claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -36,6 +36,7 @@
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
 | intel-258v-platform | CPU258V-001 | LNL258V-003 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
+| intel-npu | NPU-004 | NPU-003 | in_progress |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -11,7 +11,7 @@
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-003 | #3739 | merged | none | Device-node detection is not inference. |
+| intel-npu | NPU-004 | TBD | in_progress | none | Device-node detection is not inference. |
 | nvidia-5070ti | CUDA-BITNET-009 | TBD | ready | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -11,7 +11,7 @@
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
-| intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
+| intel-npu | Intel NPU validation | NPU-004 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-009 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- Add `bitnet intel-npu-probe` to emit an Intel NPU OpenVINO runtime visibility receipt without compiling graphs or running BitNet.
- Preserve requested/selected backend identity, runtime API/device, strict mode, fallback status, and claim boundaries in the receipt.
- Keep the command NPU-only by probing OpenVINO plus Intel NPU identity directly, not the full Lunar Lake platform probe.
- Mark NPU-004 in progress and regenerate tracker dashboards.

## Claim Boundary
This is visibility/probe only. It does not claim OpenVINO NPU graph execution, NPU acceleration, BitNet inference, or CPU fallback as NPU proof.

## Verification
- `rustfmt --check --config skip_children=true crates/bitnet-cli/src/main.rs --edition 2024`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo test --locked -p bitnet-cli --bin bitnet tests::intel_npu_probe_receipt_is_visibility_only -- --exact --nocapture`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo test --locked -p bitnet-cli --bin bitnet tests::strict_intel_npu_probe_records_error_without_fallback -- --exact --nocapture`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- intel-npu-probe --json-out target/intel-npu-runtime-probe.json`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`