### PR TITLE
docs: close CUDA-BITNET-008 tracker

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -459,7 +459,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CUDA-BITNET-008"
-status = "pr_open"
+status = "merged"
 branch = "codex/cuda-bitnet-008-benchmark-baseline"
 stackable = false
 requires_human_merge = true

--- a/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T042414Z-CUDA-BITNET-008-merged.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/events/2026-05-07T042414Z-CUDA-BITNET-008-merged.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-07T04:24:14Z"
+campaign = "nvidia-5070ti"
+item = "CUDA-BITNET-008"
+event = "merged"
+previous_status = "pr_open"
+new_status = "merged"
+pr = 3823
+merge_sha = "c2b4d904ad00c4e31450c79a60bb3b787daabae2"
+actor = "codex"
+
+notes = [
+  "Merged the strict BitNet CUDA benchmark baseline.",
+  "The benchmark receipt compares the RTX 5070 Ti CUDA short-decode proof with the 9950X3D AVX-512 CPU reference, records scalar and AVX2 profiles as not_run, preserves fallback_used=false, and keeps speedup_claim=false.",
+]

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -22,7 +22,7 @@
 | CUDA-BITNET-005 | merged | #3792 | `codex/cuda-bitnet-005-route-linear` | Route actual BitNetLinear transformer dispatch through the selected CUDA backend with coverage counters and strict CPU fallback rejection. |
 | CUDA-BITNET-006 | merged | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | CUDA-BITNET-007 | merged | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
-| CUDA-BITNET-008 | pr_open | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
+| CUDA-BITNET-008 | merged | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
 | CUDA-DENSE-001 | proposed | TBD | `codex/cuda-dense-001-reference-lane` | Add regular LLM CUDA dense-kernel reference lane with dense_regular_llm receipt labels that cannot satisfy BitNet packed I2S or QK256 proof acceptance. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| nvidia-5070ti | CUDA-BITNET-008 | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -48,7 +48,7 @@
 | nvidia-5070ti | CUDA-BITNET-005 | CUDA-BITNET-004 | merged |
 | nvidia-5070ti | CUDA-BITNET-006 | CUDA-BITNET-005 | merged |
 | nvidia-5070ti | CUDA-BITNET-007 | CUDA-BITNET-006 | merged |
-| nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | pr_open |
+| nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | merged |
 | nvidia-5070ti | CUDA-DENSE-001 | RTX5070TI-007 | proposed |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
 | tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-003 | #3739 | merged | none | Device-node detection is not inference. |
-| nvidia-5070ti | CUDA-BITNET-008 | #3823 | pr_open | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-008 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- mark `CUDA-BITNET-008` merged in the NVIDIA 5070 Ti campaign tracker
- add the merge event for #3823 with squash merge SHA `c2b4d904ad00c4e31450c79a60bb3b787daabae2`
- regenerate campaign dashboards

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Notes
- Tracker-only closeout after #3823 merged.
- No CUDA kernels, inference routing, QK256, server, dense CUDA, or receipt semantics changed.