### PR TITLE
docs(cuda): track upload-once routed proof gap

### DIFF
--- a/docs/tracking/campaigns/nvidia-5070ti/active.toml
+++ b/docs/tracking/campaigns/nvidia-5070ti/active.toml
@@ -488,6 +488,45 @@ must_not_claim = [
 ]
 
 [[work_item]]
+id = "CUDA-BITNET-009"
+status = "ready"
+branch = "codex/cuda-bitnet-009-upload-once-routed-proof"
+stackable = false
+requires_human_merge = true
+blocked_by = ["CUDA-BITNET-008"]
+acceptance = "Route the strict RTX 5070 Ti CUDA inference proof through persistent CUDA BitNet weight handles so receipts prove weights_uploaded_once=true, per_token_weight_upload=false, qk256_gemv_cuda invocations greater than zero, and zero CPU fallback."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features cuda",
+  "cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cuda",
+  "cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli",
+  "Manual RTX 5070 Ti strict one-token and short-decode BitNet CUDA proofs with upload-once receipt fields.",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/src/cuda/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-cli/**",
+  "crates/bitnet-bench-receipts/**",
+  "crates/bitnet-receipts/**",
+  "crates/bitnet-receipts-core/**",
+  "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-proof.json",
+  "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-short-decode.json",
+  "ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json",
+  "docs/tracking/campaigns/nvidia-5070ti/**",
+]
+forbidden_paths = [
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "Strict RTX 5070 Ti BitNet CUDA inference uses upload-once CUDA weight handles only after strict proof receipts record weights_uploaded_once=true and per_token_weight_upload=false.",
+]
+must_not_claim = [
+  "CUDA speedup exists before a refreshed same-model benchmark receipt proves it.",
+  "The current CUDA-BITNET-008 benchmark is upload-once optimized; it explicitly records per_token_weight_upload=true.",
+]
+
+[[work_item]]
 id = "CUDA-DENSE-001"
 status = "proposed"
 branch = "codex/cuda-dense-001-reference-lane"

--- a/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/generated/status.md
@@ -23,6 +23,7 @@
 | CUDA-BITNET-006 | merged | #3801 | `codex/cuda-bitnet-006-one-token-proof` | Add strict one-token BitNet CUDA proof with official GGUF, real tokenizer, CUDA kernel invocations greater than zero, zero CPU fallback, CPU/CUDA greedy or top-1 agreement, fallback_used=false, and speedup_claim=false. |
 | CUDA-BITNET-007 | merged | #3806 | `codex/cuda-bitnet-007-short-decode-proof` | Add short greedy BitNet CUDA decode proof with timing, kernel invocation growth, memory high-water mark, and fallback_used=false. |
 | CUDA-BITNET-008 | merged | #3823 | `codex/cuda-bitnet-008-benchmark-baseline` | Add RTX 5070 Ti full BitNet CUDA benchmark baseline comparing 9950X3D CPU scalar, AVX2, AVX-512, and CUDA with matching model, tokenizer, prompt profile, strict loader mode, fallback_used=false, and runtime context. |
+| CUDA-BITNET-009 | ready | TBD | `codex/cuda-bitnet-009-upload-once-routed-proof` | Route the strict RTX 5070 Ti CUDA inference proof through persistent CUDA BitNet weight handles so receipts prove weights_uploaded_once=true, per_token_weight_upload=false, qk256_gemv_cuda invocations greater than zero, and zero CPU fallback. |
 | CUDA-DENSE-001 | proposed | TBD | `codex/cuda-dense-001-reference-lane` | Add regular LLM CUDA dense-kernel reference lane with dense_regular_llm receipt labels that cannot satisfy BitNet packed I2S or QK256 proof acceptance. |
 
 ## Hard Constraints

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -49,6 +49,7 @@
 | nvidia-5070ti | CUDA-BITNET-006 | CUDA-BITNET-005 | merged |
 | nvidia-5070ti | CUDA-BITNET-007 | CUDA-BITNET-006 | merged |
 | nvidia-5070ti | CUDA-BITNET-008 | CUDA-BITNET-007 | merged |
+| nvidia-5070ti | CUDA-BITNET-009 | CUDA-BITNET-008 | ready |
 | nvidia-5070ti | CUDA-DENSE-001 | RTX5070TI-007 | proposed |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
 | tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-003 | #3739 | merged | none | Device-node detection is not inference. |
-| nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | CUDA-BITNET-009 | TBD | ready | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,6 +12,6 @@
 | intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-003 | Device-node detection is not inference. |
-| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
+| nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-BITNET-009 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- add `CUDA-BITNET-009` as the next ready NVIDIA item for routed upload-once CUDA proof
- update the alignment status to reflect the actual current receipts: QK256 CUDA dispatch exists, but strict CUDA proofs still record `weights_uploaded_once=false` and `per_token_weight_upload=true`
- regenerate campaign dashboards so the NVIDIA lane points at `CUDA-BITNET-009` instead of dense CUDA

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Notes
- Tracker/docs only.
- No CUDA kernels, transformer routing, server, dense CUDA, or receipt artifacts are changed.
- This PR does not claim upload-once optimized inference; it records that the current CUDA benchmark explicitly does not prove it.