### PR TITLE
KBL8250U-004: add strict CPU proof artifacts

### DIFF
--- a/ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json
+++ b/ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json
@@ -1,0 +1,147 @@
+{
+  "artifact_kind": "cpu_benchmark",
+  "artifact_path": "ci\\intel-i5-8250u\\2026-05-07\\cpu-phase-benchmark-receipt.json",
+  "claim": "cpu_benchmark_receipt",
+  "claim_boundary": "Real phase profiles are measured only when backed by supplied strict CPU proof receipts; not_run profiles are explicit gaps, not performance evidence.",
+  "cpu": {
+    "arch": "x86_64",
+    "avx512": false,
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "frequency_mhz": null,
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "power_mode": "unknown",
+    "temperature_c": null,
+    "threads": 8
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "hardware_lane": "cpu-rust",
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "oracle_kernel": "qk256-scalar-gemv",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_kernel": "i2_s-avx2-reference"
+  },
+  "machine_id": "cpu-rust",
+  "model": {
+    "family": "bitnet",
+    "file": "ggml-model-i2_s.gguf",
+    "quant_format": "QK256/I2_S",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162"
+  },
+  "profile_order": [
+    "micro",
+    "layer",
+    "prefill",
+    "first_token",
+    "decode"
+  ],
+  "profiles": [
+    {
+      "execution_phase": "micro_kernel",
+      "fallback_reason": null,
+      "fallback_used": false,
+      "profile": "micro",
+      "reason": "micro is covered by canonical QK256 synthetic benchmark receipts, not this real phase receipt surface",
+      "requested_kernel": "i2_s-avx2-reference",
+      "selected_kernel": "i2_s-avx2-reference",
+      "shape": {
+        "cols": 1,
+        "iterations": 1,
+        "rows": 1
+      },
+      "status": "not_run"
+    },
+    {
+      "execution_phase": "layer_forward",
+      "fallback_reason": null,
+      "fallback_used": false,
+      "profile": "layer",
+      "reason": "layer phase harness is not yet wired to a real transformer block benchmark receipt",
+      "requested_kernel": "i2_s-avx2-reference",
+      "selected_kernel": "i2_s-avx2-reference",
+      "shape": {
+        "cols": 1,
+        "iterations": 1,
+        "rows": 1
+      },
+      "status": "not_run"
+    },
+    {
+      "execution_phase": "prefill",
+      "fallback_reason": null,
+      "fallback_used": false,
+      "profile": "prefill",
+      "reason": "no supplied strict CPU proof receipt measured prefill",
+      "requested_kernel": "i2_s-avx2-reference",
+      "selected_kernel": "i2_s-avx2-reference",
+      "shape": {
+        "cols": 1,
+        "iterations": 1,
+        "rows": 1
+      },
+      "status": "not_run"
+    },
+    {
+      "bandwidth_gbps": 0.0,
+      "execution_phase": "first_token",
+      "fallback_reason": null,
+      "fallback_used": false,
+      "median_ms": 3386602.0,
+      "p95_ms": 3386602.0,
+      "profile": "first_token",
+      "requested_kernel": "i2_s-avx2-reference",
+      "selected_kernel": "i2_s-avx2-reference",
+      "shape": {
+        "cols": 4096,
+        "iterations": 1,
+        "rows": 1
+      },
+      "status": "measured",
+      "tokens_per_second": 0.00029528122879511674,
+      "wall_time_ms": 3386602.0
+    },
+    {
+      "execution_phase": "decode_steady_state",
+      "fallback_reason": null,
+      "fallback_used": false,
+      "profile": "decode",
+      "reason": "no supplied strict CPU proof receipt measured steady-state decode with more than one generated token",
+      "requested_kernel": "i2_s-avx2-reference",
+      "selected_kernel": "i2_s-avx2-reference",
+      "shape": {
+        "cols": 1,
+        "iterations": 1,
+        "rows": 1
+      },
+      "status": "not_run"
+    }
+  ],
+  "receipt_inputs": [
+    "ci\\intel-i5-8250u\\2026-05-07\\strict-bitnet-cpu-proof.json"
+  ],
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema": 1,
+  "selected_backend": "cpu-rust",
+  "speedup_claim": false,
+  "timestamp_utc": "2026-05-07T06:51:21Z",
+  "tokenizer": {
+    "source": "gguf_metadata",
+    "strict": true
+  },
+  "workload": {
+    "batch_size": 1,
+    "generated_tokens": 1,
+    "prompt_tokens": 65
+  }
+}

--- a/ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json
+++ b/ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json
@@ -1,0 +1,401 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_profile",
+  "artifact_path": "ci\\intel-i5-8250u\\2026-05-07\\strict-bitnet-cpu-proof.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "threads": 8
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 1,
+    "phase": "decode",
+    "prompt_tokens": 65,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 8
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 13650,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": false,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 3386602,
+    "decode_first_ms": 3386602,
+    "total_ms": 3386603
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata"
+  },
+  "logits_dump": null,
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 1,
+        "max_ms": 0.07,
+        "mean_ms": 0.07,
+        "min_ms": 0.07,
+        "p50_ms": 0.07,
+        "p95_ms": 0.07,
+        "total_ms": 0.07
+      },
+      "first_token_decode_ms": 52328.725,
+      "forward_ms": {
+        "count": 1,
+        "max_ms": 51972.45,
+        "mean_ms": 51972.45,
+        "min_ms": 51972.45,
+        "p50_ms": 51972.45,
+        "p95_ms": 51972.45,
+        "total_ms": 51972.45
+      },
+      "generated_tokens": 1,
+      "logits_ms": {
+        "count": 1,
+        "max_ms": 345.043,
+        "mean_ms": 345.043,
+        "min_ms": 345.043,
+        "p50_ms": 345.043,
+        "p95_ms": 345.043,
+        "total_ms": 345.043
+      },
+      "per_token_ms": {
+        "count": 1,
+        "max_ms": 52328.725,
+        "mean_ms": 52328.725,
+        "min_ms": 52328.725,
+        "p50_ms": 52328.725,
+        "p95_ms": 52328.725,
+        "total_ms": 52328.725
+      },
+      "sample_ms": {
+        "count": 1,
+        "max_ms": 3.985,
+        "mean_ms": 3.985,
+        "min_ms": 3.985,
+        "p50_ms": 3.985,
+        "p95_ms": 3.985,
+        "total_ms": 3.985
+      },
+      "steady_per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "steady_state_tok_s": null,
+      "steady_state_tokens": 0,
+      "token_decode_ms": {
+        "count": 1,
+        "max_ms": 0.041,
+        "mean_ms": 0.041,
+        "min_ms": 0.041,
+        "p50_ms": 0.041,
+        "p95_ms": 0.041,
+        "total_ms": 0.041
+      },
+      "warmup_tokens": 1
+    },
+    "id": "kbl8250u_strict_first_token",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 119905.634,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": true,
+      "kv_cache_behavior": "prompt_prefix_prefilled_before_decode",
+      "ms": 3334274.255,
+      "per_token_ms": {
+        "count": 64,
+        "max_ms": 53199.902,
+        "mean_ms": 52098.03,
+        "min_ms": 51346.9,
+        "p50_ms": 52138.594,
+        "p95_ms": 52642.476,
+        "total_ms": 3334273.918
+      },
+      "tokens": 64
+    },
+    "prompt_tokenize_ms": 1.154,
+    "requested": true,
+    "tokenizer_load_ms": 1175.288
+  },
+  "prompt": "Answer with a single digit: 2+2=",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 142 Stepping 10, GenuineIntel",
+    "decode_tokens": 1,
+    "decode_tps": 0.0002952811416041384,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 65,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 8,
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true
+  },
+  "text": "-lived",
+  "throughput": {
+    "decoded_tokens": 1,
+    "tokens_per_second": 0.0002952811416041384
+  },
+  "timestamp": "2026-05-07T06:50:35.941059400+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": null,
+    "decode_total_ms": 52328.725,
+    "first_token_decode_ms": 52328.725,
+    "first_token_ms": 3386602,
+    "model_load_ms": 119905.634,
+    "prefill_ms": 3334274.255,
+    "sampling_ms_per_token": 3.985,
+    "tokenize_ms": 1.154,
+    "tokenizer_load_ms": 1175.288
+  },
+  "tokenizer": {
+    "bos": 128000,
+    "eos": 128001,
+    "origin": "embedded",
+    "source": "gguf_metadata",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 1,
+    "ids": [
+      62954
+    ],
+    "prompt": 65,
+    "total": 66
+  }
+}

--- a/ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json
+++ b/ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json
@@ -1,0 +1,92 @@
+{
+  "schema": 1,
+  "artifact_kind": "strict_cpu_proof_hardware_context",
+  "machine_id": "intel-i5-8250u-cpu-avx2",
+  "hardware_lane": "i5_8250u",
+  "timestamp_utc": "2026-05-07T06:50:26Z",
+  "work_item": "KBL8250U-004",
+  "strict_cpu_proof": {
+    "artifact_path": "ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+    "raw_receipt_path": "ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+    "artifact_kind": "strict_bitnet_cpu_profile",
+    "requested_backend": "cpu",
+    "selected_backend": "cpu-rust",
+    "hardware_lane_selected_backend": "intel-i5-8250u-cpu-avx2",
+    "runtime_api": "cpu",
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "tokenizer_source": "gguf_metadata",
+    "tokenizer_strict": true,
+    "model_sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "kernel_id": "i2_s-avx2-reference",
+    "dequantizes_before_compute": false,
+    "prompt_tokens": 65,
+    "generated_tokens": 1,
+    "total_ms": 3386603,
+    "first_token_ms": 3386602
+  },
+  "phase_benchmark_receipt": {
+    "artifact_path": "ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json",
+    "speedup_claim": false,
+    "profiles": [
+      {
+        "profile": "micro",
+        "status": "not_run"
+      },
+      {
+        "profile": "layer",
+        "status": "not_run"
+      },
+      {
+        "profile": "prefill",
+        "status": "not_run"
+      },
+      {
+        "profile": "first_token",
+        "status": "measured"
+      },
+      {
+        "profile": "decode",
+        "status": "not_run"
+      }
+    ]
+  },
+  "cpu": {
+    "model": "Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz",
+    "cores": 4,
+    "threads": 8,
+    "features": {
+      "avx2": true,
+      "fma": true,
+      "avx512": false
+    }
+  },
+  "system_context": {
+    "os": "Microsoft Windows",
+    "power_mode": "Balanced",
+    "memory_bytes": 34359738368,
+    "memory_speed_mhz": 2400,
+    "temperature_c": null,
+    "frequency_mhz": null,
+    "thermal_context": "Temperature sensor was not available through the collected Windows commands; field is intentionally null.",
+    "frequency_context": "Per-run frequency was not available through the collected Windows commands; field is intentionally null.",
+    "sustained_performance_claim": false
+  },
+  "validation": [
+    {
+      "command": "Get-FileHash models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf -Algorithm SHA256",
+      "result": "ok",
+      "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162"
+    },
+    {
+      "command": "BITNET_DISABLE_MINIMAL_LOADER=1 BITNET_STRICT_MODE=1 cargo run --locked -p bitnet-cli --no-default-features --features \"cpu,full-cli\" -- --device cpu run --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf --prompt \"Answer with a single digit: 2+2=\" --max-tokens 1 --temperature 0.0 --greedy --strict-loader --strict-tokenizer --threads 8 --profile-id kbl8250u_strict_first_token --json-out ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+      "result": "ok"
+    },
+    {
+      "command": "cargo run --locked -p bitnet-bench-receipts --bin cpu_phase_benchmark_receipt --no-default-features -- --strict-proof-receipt ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json --selected-backend cpu-rust --receipt-out ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json",
+      "result": "ok"
+    }
+  ],
+  "claim_boundary": "This artifact records a strict i5-8250U CPU proof run and a first-token phase receipt only. It does not claim sustained mobile performance, throughput superiority, GPU/OpenVINO/UHD 620/NPU execution, or complete CPU-BITNET-008 benchmark closeout.",
+  "artifact_path": "ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json"
+}

--- a/docs/hardware/intel-i5-8250u-validation.md
+++ b/docs/hardware/intel-i5-8250u-validation.md
@@ -175,6 +175,64 @@ The first useful receipt is a CPU feature and dispatch proof:
 
 This is not a performance claim. Sustained-load receipts come later.
 
+## Strict CPU Proof Run
+
+`KBL8250U-004` is the first i5-8250U lane item that may emit a strict CPU
+proof receipt. It requires the canonical BitNet GGUF and tokenizer authority to
+be present on the machine before the receipt can be created. Do not substitute
+`tests/models/mini.gguf`, tokenizer-only GGUF fixtures, mock tensors, or minimal
+loader fallback for this run.
+
+Required local input:
+
+```text
+models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf
+```
+
+Command shape:
+
+```powershell
+$env:BITNET_DISABLE_MINIMAL_LOADER = "1"
+$env:BITNET_STRICT_MODE = "1"
+cargo run --locked -p bitnet-cli --no-default-features --features "cpu,full-cli" -- `
+  run `
+  --model models\BitNet-b1.58-2B-4T\ggml-model-i2_s.gguf `
+  --prompt "Answer with a single digit: 2+2=" `
+  --max-tokens 1 `
+  --temperature 0.0 `
+  --greedy `
+  --strict-loader `
+  --strict-tokenizer `
+  --json-out ci\intel-i5-8250u\2026-05-07\strict-bitnet-cpu-proof.json
+```
+
+The proof receipt must record `loader.mode = real_gguf`, strict tokenizer
+authority, model SHA-256, selected backend, selected kernel, `fallback_used =
+false`, timing, power mode, and thermal context. If the canonical model is
+missing, emit a blocker artifact instead of a proof receipt.
+
+The 2026-05-07 Kaby Lake run emitted:
+
+```text
+ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json
+ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json
+ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json
+```
+
+The raw CLI receipt records `requested_backend = cpu`, `selected_backend =
+cpu-rust`, `fallback_used = false`, `loader.mode = real_gguf`,
+`tokenizer.source = gguf_metadata`, model SHA-256
+`4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162`, and
+kernel `i2_s-avx2-reference`. The hardware context maps that raw CPU execution
+onto the lane identity `intel-i5-8250u-cpu-avx2` and records temperature and
+frequency fields as `null` because those sensors were not available through the
+collected Windows commands.
+
+The companion phase benchmark receipt measures `first_token` only. `micro`,
+`layer`, `prefill`, and steady `decode` remain `not_run`, so this artifact is
+not a complete CPU-BITNET-008 benchmark closeout and is not a sustained
+performance claim.
+
 ## Sustained-Load Reporting
 
 Separate at least three phases when benchmarking:

--- a/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
@@ -27,7 +27,7 @@ Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2
 | Work item | Status | Notes |
 |---|---|---|
 | KBL8250U-003 | merged | Prove i5-8250U scalar and AVX2 dispatch. |
-| KBL8250U-004 | ready | Add strict CPU proof run on the i5-8250U lane. |
+| KBL8250U-004 | pr_open | Adds a strict real-GGUF CPU proof run on the i5-8250U lane, with raw CLI backend `cpu-rust`, hardware lane identity `intel-i5-8250u-cpu-avx2`, no fallback, model hash, first-token timing, and explicit thermal/frequency null context. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/cpu-qk256-performance/active.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/active.toml
@@ -54,7 +54,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "KBL8250U-004"
-status = "ready"
+status = "pr_open"
 branch = "codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T053417Z-KBL8250U-004-in-progress.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T053417Z-KBL8250U-004-in-progress.toml
@@ -1,0 +1,22 @@
+timestamp = "2026-05-07T05:34:17Z"
+campaign = "cpu-qk256-performance"
+item = "KBL8250U-004"
+event = "in_progress"
+previous_status = "ready"
+new_status = "in_progress"
+branch = "codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run"
+actor = "codex"
+
+artifacts = [
+  "ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+  "ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json",
+  "ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json",
+]
+
+notes = [
+  "Prepared the i5-8250U strict CPU proof lane and emitted a real-GGUF strict CPU proof receipt from the canonical BitNet GGUF.",
+  "The raw CLI backend identity is requested_backend=cpu and selected_backend=cpu-rust; the hardware lane context records the Kaby Lake proof host as intel-i5-8250u-cpu-avx2.",
+  "The strict proof records loader.mode=real_gguf, tokenizer.source=gguf_metadata, tokenizer.strict=true, model hash 4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162, kernel i2_s-avx2-reference, generated_tokens=1, fallback_used=false, and first-token timing.",
+  "The phase benchmark receipt consumes the strict proof and measures only first_token; micro, layer, prefill, and steady decode remain not_run and CPU-BITNET-008 is not closed by this lane artifact.",
+  "No throughput superiority, sustained-performance, GPU, OpenVINO, UHD 620, NPU, mock, fallback, or fixture-inference claim is made.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T065100Z-KBL8250U-004-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T065100Z-KBL8250U-004-pr-open.toml
@@ -1,0 +1,22 @@
+timestamp = "2026-05-07T06:51:00Z"
+campaign = "cpu-qk256-performance"
+item = "KBL8250U-004"
+event = "pr_open"
+previous_status = "in_progress"
+new_status = "pr_open"
+pr = 3839
+head_sha = "da266e01c3959a497e7d627db8247535862b170d"
+actor = "codex"
+
+artifacts = [
+  "ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+  "ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json",
+  "ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json",
+]
+
+notes = [
+  "Updated #3839 from blocked preflight documentation to a strict i5-8250U CPU proof artifact PR after downloading the canonical BitNet GGUF into the ignored local models directory.",
+  "The strict proof uses real_gguf loading, GGUF metadata tokenizer authority, selected raw backend cpu-rust, AVX2 I2_S kernel identity, no fallback, one generated token, model hash, and timing.",
+  "The companion phase benchmark receipt measures only first_token; micro, layer, prefill, and steady decode remain not_run.",
+  "No sustained mobile performance, throughput superiority, GPU, OpenVINO, UHD 620, NPU, mock, fallback, or fixture-model claim is made.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | KBL8250U-003 | merged | #3785 | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
-| KBL8250U-004 | ready | TBD | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
+| KBL8250U-004 | pr_open | #3839 | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| cpu-qk256-performance | KBL8250U-004 | #3839 | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -35,7 +35,7 @@
 | cpu-proof | CPU-BITNET-006 | CPU-BITNET-005c | merged |
 | cpu-proof | CPU-BITNET-007 | CPU-BITNET-006 | merged |
 | cpu-proof | CPU-BITNET-008 | CPU-BITNET-007 | in_progress |
-| cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | ready |
+| cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | pr_open |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -8,7 +8,7 @@
 | apple-m4-operational | M4-OP-002 | TBD | ready | M4-OP-003 | Do not reopen the completed apple-m4 proof campaign. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | #3833 | in_progress | none | No GPU or NPU claims. |
-| cpu-qk256-performance | KBL8250U-004 | TBD | ready | none | Do not claim performance before strict proof receipts exist. |
+| cpu-qk256-performance | KBL8250U-004 | #3839 | pr_open | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |


### PR DESCRIPTION
## Summary
KBL8250U-004 strict CPU proof artifact PR.

- replaces the blocked preflight with real i5-8250U strict CPU proof artifacts
- records raw CLI backend identity (`requested_backend=cpu`, `selected_backend=cpu-rust`) plus Kaby lane context (`intel-i5-8250u-cpu-avx2`)
- adds the first-token CPU phase benchmark receipt derived from the strict proof
- keeps CPU-BITNET-008 open: micro, layer, prefill, and steady decode remain `not_run`

## Artifacts
- `ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json`
- `ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json`
- `ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json`

## Claim boundary
- strict real-GGUF CPU proof only, one generated token
- no sustained mobile performance claim
- no throughput superiority claim
- no GPU, OpenVINO, UHD 620, NPU, mock, fallback, or fixture-model claim

## Validation
- `Get-FileHash models\BitNet-b1.58-2B-4T\ggml-model-i2_s.gguf -Algorithm SHA256`
- `BITNET_DISABLE_MINIMAL_LOADER=1 BITNET_STRICT_MODE=1 cargo run --locked -p bitnet-cli --no-default-features --features "cpu,full-cli" -- --device cpu run --model models\BitNet-b1.58-2B-4T\ggml-model-i2_s.gguf --prompt "Answer with a single digit: 2+2=" --max-tokens 1 --temperature 0.0 --greedy --strict-loader --strict-tokenizer --threads 8 --profile-id kbl8250u_strict_first_token --json-out ci\intel-i5-8250u\2026-05-07\strict-bitnet-cpu-proof.json`
- `cargo run --locked -p bitnet-bench-receipts --bin cpu_phase_benchmark_receipt --no-default-features -- --strict-proof-receipt ci\intel-i5-8250u\2026-05-07\strict-bitnet-cpu-proof.json --selected-backend cpu-rust --receipt-out ci\intel-i5-8250u\2026-05-07\cpu-phase-benchmark-receipt.json`
- JSON parse for all three artifacts
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

## Not run
- `cargo fmt --all -- --check` still fails on this Windows checkout with `The filename or extension is too long. (os error 206)` before formatting touched files