### PR TITLE
Add model-family foundation docs, schemas, tracker, and receipt templates

### DIFF
--- a/ci/model-receipts/_templates/external-reference-proof.json
+++ b/ci/model-receipts/_templates/external-reference-proof.json
@@ -1,0 +1,25 @@
+{
+  "schema": 1,
+  "claim": "external_reference",
+  "model_family": "",
+  "variant": "",
+  "task": "external_reference",
+  "external_tool": "",
+  "external_version": "",
+  "command": "",
+  "artifact_hash": "TBD",
+  "native_bitnet_rs_loader_claim": false,
+  "native_bitnet_rs_inference_claim": false,
+  "runtime": {
+    "requested_backend": "external",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/ci/model-receipts/_templates/generative-design-only.json
+++ b/ci/model-receipts/_templates/generative-design-only.json
@@ -1,0 +1,11 @@
+{
+  "schema": 1,
+  "claim": "design_only",
+  "model_family": "",
+  "variant": "",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false,
+  "reason": "Model exceeds local hardware or implementation is not started."
+}

--- a/ci/model-receipts/_templates/generative-one-token-proof.json
+++ b/ci/model-receipts/_templates/generative-one-token-proof.json
@@ -1,0 +1,40 @@
+{
+  "schema": 1,
+  "claim": "strict_model_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "text_generation",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "gguf|safetensors|openvino_ir|onnx",
+    "hash": "TBD"
+  },
+  "tokenizer": {
+    "source": "explicit|model|sibling|unknown",
+    "fallback_used": false
+  },
+  "prompt_template": {
+    "id": "",
+    "thinking_enabled": false,
+    "developer_role_used": false,
+    "tool_calling_used": false
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "greedy": true
+  }
+}

--- a/ci/model-receipts/_templates/moe-router-smoke.json
+++ b/ci/model-receipts/_templates/moe-router-smoke.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "claim": "moe_router_smoke",
+  "model_family": "",
+  "variant": "",
+  "task": "moe_router_smoke",
+  "router_logits_shape": [],
+  "top_k": 0,
+  "shared_expert_present": "TBD",
+  "tokens_checked": 0,
+  "expert_coverage": {},
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": true,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/ci/model-receipts/_templates/multimodal-text-only-proof.json
+++ b/ci/model-receipts/_templates/multimodal-text-only-proof.json
@@ -1,0 +1,30 @@
+{
+  "schema": 1,
+  "claim": "multimodal_model_text_only_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "multimodal_text_only",
+  "modalities_requested": [
+    "text"
+  ],
+  "projector_loaded": false,
+  "vision_encoder_loaded": false,
+  "audio_encoder_loaded": false,
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "greedy": true
+  }
+}

--- a/ci/model-receipts/_templates/token-classification-proof.json
+++ b/ci/model-receipts/_templates/token-classification-proof.json
@@ -1,0 +1,31 @@
+{
+  "schema": 1,
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "variant": "",
+  "task": "token_classification",
+  "input_tokens": 12,
+  "output_shape": [
+    12,
+    33
+  ],
+  "span_decoder": "bioes_viterbi",
+  "labels": [
+    "private_person",
+    "private_email",
+    "private_phone"
+  ],
+  "generation_claim": false,
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
+++ b/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
@@ -1,0 +1,39 @@
+# Architecture feature glossary
+
+Unknowns must be marked `TBD`, not inferred. Family docs should link concepts to these terms and state whether the fact is source-backed, partial, or design-only.
+
+| Term | Meaning |
+|---|---|
+| `dense_decoder` | Autoregressive decoder with dense feed-forward blocks. |
+| `moe_decoder` | Autoregressive decoder with router-selected expert feed-forward blocks. |
+| `effective_parameters` | Parameters used for planning footprint or runtime; definition must be source-specific. |
+| `active_parameters` | Parameters active per token in MoE or sparse models. |
+| `hybrid_thinking` | Model supports thinking and non-thinking modes. |
+| `thinking_mode` | Prompt/template mode that exposes or controls hidden/visible reasoning behavior. |
+| `reasoning_effort` | Request-level reasoning control such as none/high. |
+| `developer_role` | Prompt role distinct from system/user/assistant for coding or agent tools. |
+| `tool_calling` | Model/template supports function or tool call syntax. |
+| `structured_outputs` | Model/template supports JSON or constrained structured output. |
+| `multimodal_text_image` | Text plus image input with text output unless otherwise stated. |
+| `multimodal_audio` | Audio input support; preprocessing and encoder are separate proof items. |
+| `video_as_frames` | Video handled as sampled image frames, not native video unless proven. |
+| `vision_encoder` | Vision tower/projector path; not implied by text decoder support. |
+| `audio_encoder` | Audio encoder path; not implied by text decoder support. |
+| `per_layer_embeddings` | Layer-specific embeddings such as Gemma small-model PLE. |
+| `shared_kv_cache` | K/V sharing mechanism for attention layers; implementation details are source-specific. |
+| `sliding_window_attention` | Attention constrained to a moving local window. |
+| `global_attention` | Attention layer with broader/global token reach. |
+| `p_rope` | Positional RoPE variant; exact math is model-specific until source-backed. |
+| `yarn` | YaRN context extension; source config and receipt required. |
+| `long_context` | Context claims beyond ordinary smoke sizes. |
+| `compressed_sparse_attention` | CSA; design note until implemented and parity-tested. |
+| `heavily_compressed_attention` | HCA; design note until implemented and parity-tested. |
+| `mamba_or_hybrid_state_space_tbd` | Possible state-space/hybrid feature; always TBD unless source-backed. |
+| `mtp_drafter` | Multi-token prediction draft model for speculative decoding. |
+| `eagle_drafter` | EAGLE draft model for speculative decoding. |
+| `gguf_dynamic_quant` | Dynamic GGUF quantization requiring exact quant recipe and receipt. |
+| `mxfp4` | MXFP4 precision; kernel/storage support must be proven separately. |
+| `fp4_fp8_mixed` | Mixed FP4/FP8 precision; loader and kernel support are future-gated. |
+| `token_classification` | Per-token labeling task; not generation. |
+| `bioes_labels` | Begin/Inside/Outside/End/Singleton span-label scheme. |
+| `viterbi_span_decoder` | Constrained decoding for coherent token spans. |

--- a/docs/models/DESIGN_ONLY_POLICY.md
+++ b/docs/models/DESIGN_ONLY_POLICY.md
@@ -1,0 +1,5 @@
+# Design-only policy
+
+`design_only` is a positive repo state for models that are useful to document but unsafe to claim locally.
+
+Design-only docs may include source-backed facts, prompt contracts, tokenizer notes, loader mappings, hardware-fit reasoning, future receipt templates, and external-reference commands. They must not claim local execution, native loader support, quality, speed, long-context support, or full inference.

--- a/docs/models/LONG_CONTEXT_POLICY.md
+++ b/docs/models/LONG_CONTEXT_POLICY.md
@@ -1,0 +1,5 @@
+# Long-context policy
+
+Model-card context length is not a bitnet-rs runtime claim.
+
+Any context claim must state requested context, actual prompt length, generated/labeled tokens, KV/cache strategy, backend, fallback state, and whether the run used YaRN, sliding windows, global attention, compression, or another long-context mechanism. One-token smoke receipts at short context must set `long_context_claim=false`.

--- a/docs/models/MODEL_HARDWARE_FIT_5070TI.md
+++ b/docs/models/MODEL_HARDWARE_FIT_5070TI.md
@@ -1,0 +1,25 @@
+# 5070 Ti-class hardware fit
+
+This policy assumes the largest local accelerator is a 5070 Ti-class 16 GB GPU. Memory estimates are planning inputs and exclude KV cache, allocator overhead, runtime buffers, multimodal projector memory, and software overhead unless explicitly stated.
+
+## Tier A: locally testable soon
+
+- Gemma 4 E2B/E4B text-only quantized proof plans.
+- Qwen3.5 0.8B/2B/4B/9B text-only GGUF proof plans.
+- OpenAI privacy-filter CPU/ONNX token-classification smoke plans.
+
+## Tier B: partial/offload possible
+
+- Qwen3.6 27B text-only reduced-context/offload design.
+- Qwen3.5 27B/35B-A3B offload or one-token proof only.
+- Gemma 4 31B and 26B-A4B quantized/offload plans.
+- Mistral Medium 3.5 only with external/offload reference receipts.
+
+## Tier C: design-only locally
+
+- Kimi K2.6.
+- GLM-5.1.
+- DeepSeek V4 Flash/Pro.
+- Full local Mistral Medium 3.5 128B.
+
+No tier implies quality, speed, long-context, multimodal, or full-inference support. Those claims require receipts.

--- a/docs/models/MODEL_IMPLEMENTATION_TIERS.md
+++ b/docs/models/MODEL_IMPLEMENTATION_TIERS.md
@@ -1,0 +1,11 @@
+# Model implementation tiers
+
+The current largest local device target is a 5070 Ti-class 16 GB GPU. Tiers describe local proof feasibility, not product quality.
+
+| Tier | Meaning | Families |
+|---|---|---|
+| Tier A: locally testable soon | Reasonable to smoke locally with small/quantized models or CPU/GPU offload. | Gemma 4 E2B/E4B text-only; Qwen3.5 0.8B/2B/4B/9B; OpenAI privacy-filter. |
+| Tier B: partial/offload possible | May run with quantization, CPU/RAM offload, reduced context, or single-token proof only. | Qwen3.6 27B; Qwen3.5 27B/35B-A3B; Gemma 4 26B-A4B/31B quantized; Mistral Medium 3.5 only if external/offload reference exists. |
+| Tier C: design-only locally | Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands. | Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, Mistral Medium 3.5 128B full path. |
+
+Design-only is not failure. It is the safe state for preserving implementation knowledge without pretending local hardware has proven the target.

--- a/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
+++ b/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
@@ -1,0 +1,19 @@
+# Model receipt requirements
+
+Receipts are the only way to advance a model-family claim past documentation/scaffold states.
+
+## Common fields
+
+Receipts must record `model_id`, `variant_id`, `model_hash_or_tbd`, `tokenizer_source`, `prompt_template`, `requested_backend`, `selected_backend`, `fallback_used`, `task`, `generated_tokens_or_labeled_tokens`, `full_inference_claim`, and `speedup_claim`.
+
+## Coverage booleans
+
+Every receipt must explicitly set false for unsupported coverage: multimodal, MoE, long-context, full inference, and speedup claims. Absence is not proof.
+
+## Task-specific receipts
+
+- Generative one-token receipts prove only deterministic one-token generation.
+- Multimodal text-only receipts prove the text path only.
+- MoE router receipts must include expert routing evidence.
+- Token-classification receipts must include logits shape, label taxonomy, span decoder, and generation_claim=false.
+- External-reference receipts must identify the external tool/backend and must not imply native bitnet-rs runtime support.

--- a/docs/models/MODEL_STATUS_VALUES.md
+++ b/docs/models/MODEL_STATUS_VALUES.md
@@ -1,0 +1,32 @@
+# Model status values
+
+Model-family status values mirror the backend tracker style: each status has a narrow claim boundary, and later statuses do not generalize beyond the named model, variant, backend, task, modality, and quantization in the receipt.
+
+## Values
+
+- `not_present`
+- `documented`
+- `design_scaffold`
+- `catalog_scaffold`
+- `tokenizer_scaffold`
+- `prompt_template_scaffold`
+- `loader_scaffold`
+- `synthetic_shape_tested`
+- `runtime_detected`
+- `one_token_smoke_tested`
+- `parity_tested`
+- `receipt_backed`
+- `benchmarked`
+- `design_only`
+
+## Claim boundaries
+
+| Status | May claim | Must not claim |
+|---|---|---|
+| `documented` | The repo contains source-backed implementation notes. | The model loads or runs. |
+| `design_scaffold` | The architecture plan is recorded. | The implementation compiles, loads, or runs. |
+| `loader_scaffold` | The intended loader/tensor mapping exists. | Inference works. |
+| `one_token_smoke_tested` | One strict deterministic generation/classification smoke ran. | Quality, speed, long context, or full feature support. |
+| `receipt_backed` | The named model/variant/backend/task is proven by receipt. | Other variants, backends, modalities, or quantizations work. |
+
+`design_only` is a positive planning state. It means the repo has useful architecture, prompt, loader, receipt, or external-reference rails without claiming local execution.

--- a/docs/models/MODEL_SUPPORT_POLICY.md
+++ b/docs/models/MODEL_SUPPORT_POLICY.md
@@ -1,0 +1,17 @@
+# Model support policy
+
+bitnet-rs must not claim support for a model family until proof exists for the exact family, variant, task, backend, modality, quantization, tokenizer, prompt template, and fallback state.
+
+## Required support dimensions
+
+- Family and variant ID.
+- Architecture kind and unsupported feature gates.
+- Tokenizer source and prompt-template ID.
+- Loader format and tensor mapping status.
+- Requested backend, selected backend, and fallback status.
+- Task shape: generation, multimodal text-only, MoE router smoke, graph reference, or token classification.
+- Receipt path and hash/TBD status.
+
+## Non-BitNet boundary
+
+Non-BitNet dense and MoE models must not use BitNet W1.58, QK256, or hardware-kernel receipts as model support evidence unless that exact model actually uses those kernels and the receipt says so.

--- a/docs/models/MOE_SUPPORT_POLICY.md
+++ b/docs/models/MOE_SUPPORT_POLICY.md
@@ -1,0 +1,5 @@
+# MoE support policy
+
+MoE support is not implied by dense decoder support.
+
+A MoE claim requires router logits, top-k expert selection, expert weight loading, shared expert handling when present, active-vs-total parameter accounting, and per-token expert coverage metrics in receipts. Dense one-token receipts must set `moe_claim=false`.

--- a/docs/models/MULTIMODAL_SUPPORT_POLICY.md
+++ b/docs/models/MULTIMODAL_SUPPORT_POLICY.md
@@ -1,0 +1,10 @@
+# Multimodal support policy
+
+Multimodal model-family facts are architecture notes until a receipt proves a named modality path.
+
+## Claim boundaries
+
+- Text-only proof does not prove image, audio, or video support.
+- A multimodal projector file requirement must be recorded separately from base model weights.
+- Video-as-frames is not native video support unless the model card and receipt say so.
+- Vision/audio encoder loading, preprocessing, tensor shapes, and prompt wiring each require implementation notes and receipts.

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,19 @@
+# Model-family foundation
+
+This area is the documentation and control-plane layer for future model-family support in bitnet-rs. It records architecture facts, prompt and tokenizer contracts, implementation lanes, receipt requirements, and explicit non-claims before any runtime behavior is added.
+
+The model-family tracker is intentionally separate from the BitNet/hardware tracker. Hardware lanes prove CPU, CUDA, OpenCL, Metal, NPU, and fallback identity; this area proves named model families, variants, modalities, tokenizers, prompt templates, loaders, and receipts.
+
+## Claim rule
+
+A family document is not a support claim. Claims advance only through named statuses in `MODEL_STATUS_VALUES.md` and the machine-readable catalog in `docs/tracking/model-family-foundation/model-status.yaml`.
+
+## First practical lanes
+
+- Qwen3.5 small text-only GGUF models.
+- Gemma 4 E2B/E4B text-only quantized proofs.
+- OpenAI privacy-filter token classification.
+
+## Design-only lanes
+
+Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, and the full Mistral Medium 3.5 path are documented as design-only rails for current 5070 Ti-class local hardware.

--- a/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
+++ b/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
@@ -1,0 +1,16 @@
+# Tokenizer and prompt-template policy
+
+Tokenizer and prompt-template compatibility are separate proof dimensions. A model must not be considered supported when only weights load or when a generic family template happens to produce tokens.
+
+## Tokenizer rules
+
+- Record tokenizer source: explicit, model, sibling, or unknown.
+- Treat tokenizer fallback as a claim boundary.
+- Do not infer vocabulary size or special tokens unless source-backed.
+
+## Prompt-template rules
+
+- Record prompt-template ID and source.
+- Record thinking mode, developer role, reasoning effort, tool calling, and structured-output switches.
+- Small-model defaults must be explicit, especially when thinking is disabled by default.
+- Template-only docs do not imply loader or inference support.

--- a/docs/models/families/deepseek-v4.md
+++ b/docs/models/families/deepseek-v4.md
@@ -1,0 +1,72 @@
+# DeepSeek V4
+
+## Status
+- Repo status: design_only
+- First target: deepseek-v4_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: design lanes and external_reference
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: DeepSeek V4 Flash and DeepSeek V4 Pro, each with Base and instruct variants.
+- Context: 1M source capability for Flash and Pro.
+- Modalities: text source facts only in supplied notes; other modalities TBD.
+- Tokenizer/prompt: instruct/base prompt specifics TBD pending model-card verification.
+- Architecture features: MoE, CSA/HCA hybrid attention, mHC residual/hyper-connection, Muon optimizer during training.
+- Quantization/runtime notes: Flash 284B total/13B active; Pro 1.6T total/49B active; Base uses FP8 mixed; instruct uses FP4 + FP8 mixed with MoE experts in FP4 and most other params in FP8.
+- License: source card verification required.
+- Known tool support: mixed precision and long-context support are future-gated.
+- Source links: supplied DeepSeek V4 notes; source-index `deepseek-v4-model-card`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| DeepSeek V4 Flash Base/Instruct | 284B | 13B | 1M | text TBD | design-only architecture notes | tier_c_design_only |
+| DeepSeek V4 Pro Base/Instruct | 1.6T | 49B | 1M | text TBD | design-only architecture notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- This family is design-only on current hardware.
+- Docs do not imply local loader, inference, speed, quality, long-context, multimodal, or kernel support.
+- Any future local/offload/reference artifact must be receipt-backed.
+
+## First proof target
+
+```json
+{
+  "claim": "design_only",
+  "model_family": "deepseek-v4",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- DSV4-DOC-001: Add DeepSeek V4 family doc.
+- DSV4-DOC-002: Add Flash vs Pro variant table.
+- DSV4-DOC-003: Add CSA/HCA/mHC terminology and implementation unknowns.
+- DSV4-DOC-004: Add FP4/FP8 mixed precision future-gate.
+- DSV4-DOC-005: Add design-only local hardware warning.

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,76 @@
+# Gemma 4
+
+## Status
+- Repo status: design_scaffold
+- First target: gemma4-e2b-it-q4-text-only
+- Local test tier: tier_a_local
+- Implementation owner lane: dense_decoder, moe_decoder_future, multimodal_future, gguf_dense_quant
+- Design-only? no
+
+## Source-backed facts
+- Model variants: E2B, E4B, 31B dense, 26B A4B MoE.
+- Context: E2B/E4B 128K; 31B and 26B-A4B 256K.
+- Modalities: E2B/E4B text/image/audio; 31B and 26B-A4B text/image.
+- Tokenizer/prompt: vocabulary 262K; thinking mode uses `<|think|>` and thought-channel delimiters.
+- Architecture features: hybrid local/global attention, final layer global, unified K/V and p-RoPE in global layers, PLE in small models.
+- Quantization/runtime notes: Q4 estimates E2B ~3.2 GB, E4B ~5 GB, 31B ~17.4 GB, 26B-A4B ~15.6 GB, excluding KV/software overhead.
+- License: source card verification required before redistribution claims.
+- Known tool support: MTP draft models are noted by Google overview and remain future-gated.
+- Source links: supplied model-family notes; source-index entries `gemma4-google-overview` and `gemma4-memory-notes`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| E2B | E2B | TBD | 128K | text/image/audio | text-only Q4 proof | tier_a_local |
+| E4B | E4B | TBD | 128K | text/image/audio | text-only Q4 proof | tier_a_local |
+| 31B dense | 31B | 31B | 256K | text/image | quantized/offload design | tier_b_partial |
+| 26B-A4B | 26B total | A4B; 8 active / 128 total experts plus shared expert | 256K | text/image | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- Gemma 4 documented does not mean Gemma 4 loads.
+- Generic `ModelArchitecture::Gemma` support and Gemma 2 catalog entries are not Gemma 4 support.
+- E2B/E4B text-only proof does not mean image/audio works.
+- MTP draft support is future-gated.
+- 26B-A4B MoE support is future-gated.
+
+## First proof target
+
+```json
+{
+  "claim": "gemma4_e2b_text_only_one_token_plan",
+  "full_inference_claim": false,
+  "multimodal_claim": false,
+  "moe_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- GEMMA4-DOC-001: Add Gemma 4 family doc and variant table.
+- GEMMA4-DOC-002: Add Gemma 4 prompt/template contract.
+- GEMMA4-DOC-003: Add Gemma 4 text-only E2B proof plan.
+- GEMMA4-DOC-004: Add PLE/shared-KV/sliding-global attention implementation notes.
+- GEMMA4-DOC-005: Add MoE 26B-A4B future gate.
+- GEMMA4-DOC-006: Add multimodal future gate.

--- a/docs/models/families/glm-5.1.md
+++ b/docs/models/families/glm-5.1.md
@@ -1,0 +1,70 @@
+# GLM-5.1
+
+## Status
+- Repo status: design_only
+- First target: glm-5.1_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: design lanes and external_reference
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: GLM-5.1 full model.
+- Context: 200K.
+- Modalities: text/tooling per supplied notes; other modalities TBD.
+- Tokenizer/prompt: thinking enabled by default; disable with chat-template kwargs; `chat_template.jinja` changes focus on tool exposure, reasoning-history reconstruction, and tool-message rendering.
+- Architecture features: same architecture as GLM-5 per supplied notes, huge MoE, tool calling, long context.
+- Quantization/runtime notes: 744B parameters, 40B active, full disk around 1.65 TB; dynamic 2-bit around 220 GB, dynamic 1-bit around 200 GB, `UD-IQ2_M` around 236 GB.
+- License: source card verification required.
+- Known tool support: future OpenVINO/llama.cpp reference receipt plan only.
+- Source links: supplied GLM-5.1 notes; source-index `glm51-model-notes`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| GLM-5.1 | 744B | 40B | 200K | text/tool TBD | design-only prompt/template and MoE notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- This family is design-only on current hardware.
+- Docs do not imply local loader, inference, speed, quality, long-context, multimodal, or kernel support.
+- Any future local/offload/reference artifact must be receipt-backed.
+
+## First proof target
+
+```json
+{
+  "claim": "design_only",
+  "model_family": "glm-5.1",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- GLM51-DOC-001: Add GLM-5.1 design-only family doc.
+- GLM51-DOC-002: Add thinking/tool/chat-template behavior notes.
+- GLM51-DOC-003: Add model-size/hardware non-claim policy.
+- GLM51-DOC-004: Add future OpenVINO/llama.cpp reference receipt plan.

--- a/docs/models/families/kimi-k2.6.md
+++ b/docs/models/families/kimi-k2.6.md
@@ -1,0 +1,71 @@
+# Kimi K2.6
+
+## Status
+- Repo status: design_only
+- First target: kimi-k2.6_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: design lanes and external_reference
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: Kimi K2.6.
+- Context: 256K.
+- Modalities: vision support in Unsloth GGUF notes.
+- Tokenizer/prompt: Kimi-specific chat template uses `<|im_system|>`, `<|im_user|>`, `<|im_assistant|>`, and `<think>`.
+- Architecture features: 1T-parameter hybrid-thinking MoE-scale model, long context, extreme model size, dynamic quant reference.
+- Quantization/runtime notes: full precision disk footprint around 610 GB; dynamic 2-bit around 340-350 GB; Q4 around 584 GB; Q8 around 595 GB.
+- License: source card verification required.
+- Known tool support: GGUF dynamic quant references are external/design-only locally.
+- Source links: supplied Kimi K2.6 notes; source-index `kimi26-unsloth-notes`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| Kimi K2.6 | 1T | TBD | 256K | text/vision | design-only prompt/tokenizer/loader notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- This family is design-only on current hardware.
+- Docs do not imply local loader, inference, speed, quality, long-context, multimodal, or kernel support.
+- Any future local/offload/reference artifact must be receipt-backed.
+
+## First proof target
+
+```json
+{
+  "claim": "design_only",
+  "model_family": "kimi-k2.6",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- KIMI26-DOC-001: Add Kimi K2.6 design-only family doc.
+- KIMI26-DOC-002: Add chat template and thinking-mode notes.
+- KIMI26-DOC-003: Add hardware infeasibility/local non-claim section.
+- KIMI26-DOC-004: Add future MoE/huge-model loader design notes.
+- KIMI26-DOC-005: Add external-reference receipt template.

--- a/docs/models/families/mistral-medium-3.5.md
+++ b/docs/models/families/mistral-medium-3.5.md
@@ -1,0 +1,71 @@
+# Mistral Medium 3.5
+
+## Status
+- Repo status: design_only
+- First target: mistral-medium-3.5_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: design lanes and external_reference
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: dense 128B.
+- Context: 256K.
+- Modalities: text + image input, text output.
+- Tokenizer/prompt: reasoning effort configurable per request as `none` or `high`; function calls, JSON, and agentic use.
+- Architecture features: dense decoder, multimodal text-image, reasoning effort, function calling, long context, EAGLE drafter future.
+- Quantization/runtime notes: vLLM recommended with tensor parallelism; local full path is beyond current hardware.
+- License: Modified MIT, not plain MIT.
+- Known tool support: EAGLE draft model exists for speculative decoding.
+- Source links: supplied Mistral Medium 3.5 notes; source-index `mistral-medium-35-card`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| Mistral Medium 3.5 | 128B | 128B | 256K | text/image in, text out | design-only prompt reasoning-effort contract | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- This family is design-only on current hardware.
+- Docs do not imply local loader, inference, speed, quality, long-context, multimodal, or kernel support.
+- Any future local/offload/reference artifact must be receipt-backed.
+
+## First proof target
+
+```json
+{
+  "claim": "design_only",
+  "model_family": "mistral-medium-3.5",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- MM35-DOC-001: Add Mistral Medium 3.5 design-only family doc.
+- MM35-DOC-002: Add reasoning_effort prompt/API contract.
+- MM35-DOC-003: Add EAGLE speculative decoding future-gate.
+- MM35-DOC-004: Add license caveat.
+- MM35-DOC-005: Add external-reference receipt plan.

--- a/docs/models/families/openai-privacy-filter.md
+++ b/docs/models/families/openai-privacy-filter.md
@@ -1,0 +1,83 @@
+# OpenAI privacy-filter
+
+## Status
+- Repo status: design_scaffold
+- First target: token_classification_cpu_or_onnx_smoke
+- Local test tier: tier_a_local
+- Implementation owner lane: token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference
+- Design-only? no
+
+## Source-backed facts
+- Model type: bidirectional token-classification model for PII detection/masking.
+- Context: 128K.
+- Modalities: token labels, not autoregressive generation.
+- Tokenizer/prompt: tokenizer policy TBD from model card; no chat-template generation contract.
+- Architecture features: pre-norm encoder-style stack, 8 transformer blocks, GQA with 14 query heads and 2 KV heads, sparse MoE FFN with 128 experts and top-4 routing, d_model=640, banded attention size 128 and effective window 257 tokens.
+- Quantization/runtime notes: ONNX, safetensors, and Transformers.js surfaces exist in supplied card.
+- License: Apache 2.0.
+- Known tool support: constrained Viterbi decoding produces coherent spans.
+- Source links: supplied OpenAI privacy-filter card; source-index `openai-privacy-filter-card`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| privacy-filter | 1.5B total | 50M active | 128K | token labels | CPU/ONNX token-classification smoke | tier_a_local |
+
+## Implementation contract
+### Loader
+ONNX and safetensors surfaces are tracked separately; loader scaffold is not classification proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+No `generate()` prompt template. Record tokenization and label-head contract instead.
+
+### Architecture module
+Implement as token_classifier with bidirectional encoder attention, banded attention, sparse MoE, BIOES labels, and Viterbi span decoding.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use token-classification proof with output shape and labels; generation_claim must be false.
+
+### Tests
+First test is CPU/ONNX per-token logits plus constrained span decoder smoke.
+
+## Explicit non-claims
+- OpenAI privacy-filter is token classification, not generation.
+- It must not be forced into `generate()`.
+- BIOES/Viterbi documentation does not imply calibrated PII quality.
+- ONNX/safetensors surfaces do not imply native bitnet-rs loader support.
+
+## First proof target
+
+```json
+{
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "task": "token_classification",
+  "input_tokens": 12,
+  "output_shape": [
+    12,
+    33
+  ],
+  "span_decoder": "bioes_viterbi",
+  "labels": [
+    "private_person",
+    "private_email",
+    "private_phone"
+  ],
+  "generation_claim": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- PRIVACY-DOC-001: Add privacy-filter family doc.
+- PRIVACY-DOC-002: Add token-classification lane doc.
+- PRIVACY-DOC-003: Add BIOES/Viterbi receipt schema.
+- PRIVACY-DOC-004: Add local CPU/ONNX smoke proof plan.
+- PRIVACY-DOC-005: Add calibration/operating-point future-gate.

--- a/docs/models/families/qwen-3.5.md
+++ b/docs/models/families/qwen-3.5.md
@@ -1,0 +1,84 @@
+# Qwen 3.5
+
+## Status
+- Repo status: design_scaffold
+- First target: qwen3.5-0.8b-or-2b-text-only-gguf
+- Local test tier: tier_a_local
+- Implementation owner lane: dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future
+- Design-only? no
+
+## Source-backed facts
+- Model variants: 0.8B, 2B, 4B, 9B, 27B, 35B-A3B, 122B-A10B, and 397B-A17B.
+- Context: 256K and 201 languages.
+- Modalities: supplied notes describe a causal LM with a vision encoder in fine-tuning context.
+- Tokenizer/prompt: hybrid reasoning with thinking and non-thinking modes; small models disable reasoning by default and require chat-template kwargs to enable thinking.
+- Architecture features: hybrid thinking, tool calling, long context, multimodal projector external.
+- Quantization/runtime notes: 0.8B/2B 4-bit around 3.5 GB, 4B around 5.5 GB, 9B around 6.5 GB; 27B around 17 GB and 35B-A3B around 22 GB.
+- License: source card verification required.
+- Known tool support: Separate multimodal projector files may be required for GGUF compatibility.
+- Source links: supplied Qwen3.5 notes; source-index entries `qwen35-model-notes` and `qwen35-hardware-table`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| 0.8B | 0.8B | 0.8B | 256K source capability | text | first local GGUF proof | tier_a_local |
+| 2B | 2B | 2B | 256K source capability | text | first local GGUF proof | tier_a_local |
+| 4B | 4B | 4B | 256K source capability | text | local GGUF proof after 0.8B/2B | tier_a_local |
+| 9B | 9B | 9B | 256K source capability | text | local GGUF proof after smaller models | tier_a_local |
+| 27B | 27B | 27B | 256K source capability | text/image TBD | offload/future gate | tier_b_partial |
+| 35B-A3B | 35B | A3B | 256K source capability | text/image TBD | MoE future gate | tier_b_partial |
+| 122B-A10B | 122B | A10B | 256K source capability | TBD | design-gated | tier_c_design_only |
+| 397B-A17B | 397B | A17B | 256K source capability | TBD | design-gated | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- Qwen3.5 small-model text-only proof does not imply 256K context works.
+- Thinking remains disabled by default for small-model proof unless the receipt explicitly enables it.
+- Multimodal projector support is future-gated.
+- 27B/35B/122B/397B are larger or design-gated targets.
+
+## First proof target
+
+```json
+{
+  "claim": "qwen3.5_small_text_only_one_token",
+  "model_family": "qwen3.5",
+  "variant": "0.8b_or_2b",
+  "task": "text_generation",
+  "context_requested": 2048,
+  "full_context_claim": false,
+  "multimodal_claim": false,
+  "thinking_enabled": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- QWEN35-DOC-001: Add Qwen3.5 family doc.
+- QWEN35-DOC-002: Add small-model-first implementation plan for 0.8B/2B/4B/9B.
+- QWEN35-DOC-003: Add thinking-mode prompt contract with small-model default disabled.
+- QWEN35-DOC-004: Add 27B/35B-A3B future-gated plan.
+- QWEN35-DOC-005: Add multimodal projector future gate.
+- QWEN35-DOC-006: Add first local proof template for 0.8B or 2B.

--- a/docs/models/families/qwen-3.6.md
+++ b/docs/models/families/qwen-3.6.md
@@ -1,0 +1,72 @@
+# Qwen 3.6
+
+## Status
+- Repo status: design_scaffold
+- First target: qwen3.6-27b-text-only-gguf-design
+- Local test tier: tier_b_partial
+- Implementation owner lane: dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling
+- Design-only? no
+
+## Source-backed facts
+- Model variants: 27B and 35B-A3B.
+- Context: 256K maximum 262,144, extendable to 1M via YaRN in supplied notes.
+- Modalities: multimodal hybrid-thinking.
+- Tokenizer/prompt: developer role for agentic coding tools; thinking and non-thinking modes have different recommended sampling settings.
+- Architecture features: tool calling, improved nested tool-call parsing, long context, multimodal projector external flows.
+- Quantization/runtime notes: Unsloth notes 27B 4-bit around 18 GB total memory and 35B-A3B around 23 GB.
+- License: source card verification required.
+- Known tool support: Some GGUF flows require separate multimodal projector files; do not assume Ollama compatibility.
+- Source links: supplied Qwen3.6 notes; source-index entries `qwen36-model-notes` and `qwen36-unsloth-memory`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---|---|---|---|---|---|
+| 27B | 27B | 27B | 262,144 / YaRN to 1M design | text/image TBD | text-only reduced-context design | tier_b_partial |
+| 35B-A3B | 35B | A3B | 262,144 / YaRN to 1M design | text/image TBD | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Document intended GGUF/safetensors/projector inputs before adding runtime code. Loader notes are not inference proof.
+
+### Tokenizer
+Record tokenizer source explicitly; unknown or sibling fallback must remain a non-claim until receipt-backed.
+
+### Prompt template
+Record family-specific chat template switches separately from tokenizer loading.
+
+### Architecture module
+Map features to `ARCHITECTURE_FEATURE_GLOSSARY.md`; mark unknowns TBD.
+
+### Kernels/backend
+Do not route through BitNet QK256/W1.58 kernels and call the family supported.
+
+### Receipts
+Use templates under `ci/model-receipts/_templates`; coverage booleans must be explicit.
+
+### Tests
+First tests are future one-token, shape, router, or token-classification smokes only.
+
+## Explicit non-claims
+- Qwen3.6 docs do not imply 256K context works in bitnet-rs.
+- 27B offload/design does not imply full 5070Ti residency.
+- 35B-A3B MoE is not implemented until expert routing is receipt-backed.
+
+## First proof target
+
+```json
+{
+  "claim": "qwen3.6_27b_text_only_design",
+  "context_requested": 2048,
+  "full_context_claim": false,
+  "multimodal_claim": false,
+  "moe_claim": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- QWEN36-DOC-001: Add Qwen3.6 family doc.
+- QWEN36-DOC-002: Add Qwen3.6 prompt/template settings for thinking and non-thinking.
+- QWEN36-DOC-003: Add 27B text-only reduced-context proof plan.
+- QWEN36-DOC-004: Add 35B-A3B MoE future gate.
+- QWEN36-DOC-005: Add multimodal projector future gate.

--- a/docs/models/implementation/dense-decoder-lane.md
+++ b/docs/models/implementation/dense-decoder-lane.md
@@ -1,0 +1,21 @@
+# Dense decoder lane
+
+This lane covers non-BitNet dense autoregressive decoders.
+
+It must not use QK256 or BitNet W1.58 kernel proof as evidence.
+
+## First supported formats
+
+- GGUF dense quantized CPU/GPU path.
+- safetensors path later.
+- OpenVINO graph/reference path later.
+
+## Receipt requirements
+
+Receipts must record:
+
+- `dense_regular_llm=true`
+- `bitnet_kernel_used=false`
+- `qk256_used=false` unless the model actually uses QK256
+
+This boundary exists because the current BitNet transformer path has QK256-specific dispatch in linear calls; non-BitNet models must not be silently routed through that and called supported.

--- a/docs/models/implementation/gguf-dense-quant-lane.md
+++ b/docs/models/implementation/gguf-dense-quant-lane.md
@@ -1,0 +1,5 @@
+# GGUF dense quant lane
+
+This lane is the first practical path for small non-BitNet local decoder proofs.
+
+Required rails include GGUF metadata inspection, tokenizer source, chat-template source, quantization type, backend selection, deterministic one-token command, and receipt coverage booleans. Dynamic quantization recipes must be recorded and cannot be inferred from file names alone.

--- a/docs/models/implementation/moe-decoder-lane.md
+++ b/docs/models/implementation/moe-decoder-lane.md
@@ -1,0 +1,12 @@
+# MoE decoder lane
+
+MoE support requires:
+
+- router logits
+- top-k expert selection
+- shared expert handling if present
+- expert weight loading
+- active vs total parameter receipts
+- per-token expert coverage metrics
+
+Dense decoder receipts do not prove MoE routing. MoE families stay `design_scaffold` or `design_only` until routing, expert loading, and token coverage are smoke-tested and receipt-backed for the named variant.

--- a/docs/models/implementation/multimodal-lane.md
+++ b/docs/models/implementation/multimodal-lane.md
@@ -1,0 +1,5 @@
+# Multimodal lane
+
+Multimodal support is split by modality and preprocessing path. A text-only decoder proof is not image, audio, or video proof.
+
+Required gates include projector/encoder file discovery, preprocessing shape contract, prompt wiring, backend selection, fallback recording, and modality-specific receipts. Separate projector files must be tracked as first-class model artifacts.

--- a/docs/models/implementation/openvino-graph-lane.md
+++ b/docs/models/implementation/openvino-graph-lane.md
@@ -1,0 +1,5 @@
+# OpenVINO graph/reference lane
+
+This lane records external or graph-reference execution plans. OpenVINO IR or runtime detection is not native bitnet-rs model support unless the receipt names the OpenVINO backend, selected device, graph hash, shapes, task, and fallback status.
+
+External-reference proofs must not be promoted into native loader claims.

--- a/docs/models/implementation/safetensors-loader-lane.md
+++ b/docs/models/implementation/safetensors-loader-lane.md
@@ -1,0 +1,5 @@
+# safetensors loader lane
+
+This lane records future native tensor loading for non-BitNet model families.
+
+A loader scaffold must include tensor-name mapping, dtype/quantization expectations, sharding policy, tokenizer/prompt location, architecture module target, unsupported tensor policy, and receipt requirements. It must not claim inference until runtime execution is smoke-tested and receipt-backed.

--- a/docs/models/implementation/token-classification-lane.md
+++ b/docs/models/implementation/token-classification-lane.md
@@ -1,0 +1,14 @@
+# Token-classification lane
+
+Token classification is not generation.
+
+Required:
+
+- encoder/bidirectional attention support
+- token classification head
+- per-token logits
+- label taxonomy
+- constrained decoder if required
+- span output receipt
+
+Receipts must set `generation_claim=false` and include output shape, label names or taxonomy hash, span decoder, fallback status, and speedup_claim=false unless benchmarked separately.

--- a/docs/models/schemas/hardware-fit.schema.yaml
+++ b/docs/models/schemas/hardware-fit.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [family_id, variant_id, local_test_tier, device_assumption, memory_notes, non_claims]
+fields:
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]
+  device_assumption:
+    example: 5070 Ti-class 16 GB GPU
+  memory_notes:
+    type: string

--- a/docs/models/schemas/model-capability.schema.yaml
+++ b/docs/models/schemas/model-capability.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [id, family_id, status, source_status, receipt_required, non_claims]
+fields:
+  status:
+    enum: [documented, design_scaffold, synthetic_shape_tested, runtime_detected, one_token_smoke_tested, parity_tested, receipt_backed, design_only]
+  source_status:
+    enum: [source_backed, source_backed_partial, needs_model_card_verification, design_only]
+  receipt_required:
+    type: boolean

--- a/docs/models/schemas/model-family.schema.yaml
+++ b/docs/models/schemas/model-family.schema.yaml
@@ -1,0 +1,43 @@
+schema: 1
+required:
+  - id
+  - display_name
+  - source_status
+  - implementation_status
+  - first_target
+  - local_test_tier
+  - architecture
+  - variants
+  - tokenizer
+  - prompt_template
+  - loader
+  - receipts
+  - non_claims
+fields:
+  id:
+    type: string
+    example: gemma4
+  source_status:
+    enum: [source_backed, source_backed_partial, needs_model_card_verification, design_only]
+  implementation_status:
+    enum: [not_present, documented, design_scaffold, catalog_scaffold, loader_scaffold, one_token_smoke_tested, receipt_backed]
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]
+  architecture.kind:
+    enum: [dense_decoder, moe_decoder, hybrid_dense_moe, multimodal_decoder, token_classifier, graph_reference, unknown_tbd]
+  loader.formats:
+    list_enum: [gguf, safetensors, onnx, openvino_ir, tokenizer_json, remote_code_tbd]
+  receipts.required_fields:
+    list:
+      - model_id
+      - variant_id
+      - model_hash_or_tbd
+      - tokenizer_source
+      - prompt_template
+      - requested_backend
+      - selected_backend
+      - fallback_used
+      - task
+      - generated_tokens_or_labeled_tokens
+      - full_inference_claim
+      - speedup_claim

--- a/docs/models/schemas/model-receipt.schema.yaml
+++ b/docs/models/schemas/model-receipt.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [schema, claim, model_family, variant, task, runtime, coverage]
+fields:
+  claim:
+    type: string
+  task:
+    enum: [text_generation, multimodal_text_only, moe_router_smoke, token_classification, external_reference, design_only]
+  runtime.required: [requested_backend, selected_backend, fallback_used]
+  coverage.required: [full_inference_claim, multimodal_claim, moe_claim, long_context_claim, speedup_claim]

--- a/docs/models/schemas/model-variant.schema.yaml
+++ b/docs/models/schemas/model-variant.schema.yaml
@@ -1,0 +1,18 @@
+schema: 1
+required: [family_id, variant_id, params, active_params, context, modalities, local_test_tier, first_repo_target, non_claims]
+fields:
+  params:
+    type: string
+    examples: [0.8B, 26B-A4B, 1T]
+  active_params:
+    type: string
+    notes: Use TBD when not source-backed.
+  context:
+    type: string
+    notes: Model-card context is not runtime proof.
+  modalities:
+    list_enum: [text, image, audio, video_as_frames, token_labels, tbd]
+  first_repo_target:
+    type: string
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]

--- a/docs/models/schemas/prompt-template.schema.yaml
+++ b/docs/models/schemas/prompt-template.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [id, family_id, source, thinking_enabled_default, roles, tool_calling, non_claims]
+fields:
+  roles:
+    list_enum: [system, developer, user, assistant, tool, im_system, im_user, im_assistant]
+  thinking_enabled_default:
+    enum: [true, false, tbd]
+  reasoning_effort:
+    list_enum: [none, low, medium, high, tbd]

--- a/docs/models/schemas/tokenizer-policy.schema.yaml
+++ b/docs/models/schemas/tokenizer-policy.schema.yaml
@@ -1,0 +1,10 @@
+schema: 1
+required: [family_id, tokenizer_source, vocab_size, special_tokens_status, fallback_policy]
+fields:
+  tokenizer_source:
+    enum: [explicit, model, sibling, unknown]
+  vocab_size:
+    type: string
+    notes: May be numeric or TBD.
+  fallback_policy:
+    enum: [forbidden_without_receipt, allowed_for_docs_only, tbd]

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -8,6 +8,8 @@ Real BitNet CPU path sequencing remains active, Apple Silicon M4-003 backend ide
 
 Transition note: campaign-local `active.toml` files and append-only `events/*.toml` files are now the active tracker model. This legacy global status file remains a transition view; normal item PRs should use campaign-local tracking plus generated dashboards instead of hand-editing this table.
 
+Model-family planning for non-BitNet targets lives separately in `docs/tracking/model-family-foundation/status.md` so model support states do not mix with CPU/A770/NPU/CUDA hardware proof lanes.
+
 ## Active / Coordination Queue
 
 | Item | PR | State | Notes |

--- a/docs/tracking/model-family-foundation/hardware-fit.yaml
+++ b/docs/tracking/model-family-foundation/hardware-fit.yaml
@@ -1,0 +1,17 @@
+schema: 1
+updated: 2026-05-07
+device_assumption: 5070 Ti-class 16 GB GPU
+tiers:
+  tier_a_local:
+    meaning: Reasonable to smoke locally with small/quantized models or CPU/GPU offload.
+    families: [gemma4-e2b-e4b-text-only, qwen3.5-0.8b-2b-4b-9b, openai-privacy-filter]
+  tier_b_partial:
+    meaning: May run with quantization, CPU/RAM offload, reduced context, or single-token proof only.
+    families: [qwen3.6-27b, qwen3.5-27b-35b-a3b, gemma4-31b-26b-a4b, mistral-medium-3.5-external-offload]
+  tier_c_design_only:
+    meaning: Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands.
+    families: [kimi-k2.6, glm-5.1, deepseek-v4-flash-pro, mistral-medium-3.5-full]
+non_claims:
+  - Hardware fit tiers do not imply runtime support.
+  - Design-only docs do not imply local inference.
+  - Memory estimates exclude KV/software overhead unless stated.

--- a/docs/tracking/model-family-foundation/implementation-lanes.yaml
+++ b/docs/tracking/model-family-foundation/implementation-lanes.yaml
@@ -1,0 +1,10 @@
+schema: 1
+updated: 2026-05-07
+lanes:
+  dense_decoder: {doc: docs/models/implementation/dense-decoder-lane.md, first_targets: [qwen35, gemma4], bitnet_kernel_proof_allowed: false}
+  moe_decoder: {doc: docs/models/implementation/moe-decoder-lane.md, requires: [router_logits, top_k_experts, expert_weights, active_vs_total_receipts]}
+  multimodal: {doc: docs/models/implementation/multimodal-lane.md, text_only_is_multimodal_claim: false}
+  token_classification: {doc: docs/models/implementation/token-classification-lane.md, generation_api_allowed: false}
+  openvino_graph: {doc: docs/models/implementation/openvino-graph-lane.md, native_support_claim: false}
+  gguf_dense_quant: {doc: docs/models/implementation/gguf-dense-quant-lane.md, first_targets: [qwen35, gemma4]}
+  safetensors_loader: {doc: docs/models/implementation/safetensors-loader-lane.md, inference_claim_from_loader: false}

--- a/docs/tracking/model-family-foundation/model-status.yaml
+++ b/docs/tracking/model-family-foundation/model-status.yaml
@@ -1,0 +1,136 @@
+schema: 1
+updated: 2026-05-07
+status_values:
+  - not_present
+  - documented
+  - design_scaffold
+  - catalog_scaffold
+  - tokenizer_scaffold
+  - prompt_template_scaffold
+  - loader_scaffold
+  - synthetic_shape_tested
+  - runtime_detected
+  - one_token_smoke_tested
+  - parity_tested
+  - receipt_backed
+  - benchmarked
+  - design_only
+claim_boundaries:
+  documented:
+    may_claim:
+      - "The repo contains source-backed implementation notes."
+    must_not_claim:
+      - "The model loads or runs."
+  design_scaffold:
+    may_claim:
+      - "The architecture plan is recorded."
+    must_not_claim:
+      - "The implementation compiles, loads, or runs."
+  loader_scaffold:
+    may_claim:
+      - "The intended loader/tensor mapping exists."
+    must_not_claim:
+      - "Inference works."
+  one_token_smoke_tested:
+    may_claim:
+      - "One strict deterministic generation/classification smoke ran."
+    must_not_claim:
+      - "Quality, speed, long context, or full feature support."
+  receipt_backed:
+    may_claim:
+      - "The named model/variant/backend/task is proven by receipt."
+    must_not_claim:
+      - "Other variants, backends, modalities, or quantizations work."
+families:
+  gemma4:
+    display_name: Gemma 4
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: gemma4-e2b-it-q4-text-only
+    local_test_tier: tier_a_local
+    architecture:
+      kind: multimodal_decoder
+      decoder: dense_for_e2b_e4b_31b
+      moe_variant: gemma4-26b-a4b
+      features: [per_layer_embeddings, sliding_window_attention, global_attention, shared_kv_cache, p_rope, thinking_mode, mtp_drafter_future]
+    implementation_lanes: [dense_decoder, moe_decoder_future, multimodal_future, gguf_dense_quant]
+    non_claims: [no_loader, no_multimodal_runtime, no_moe_runtime, no_mtp_runtime]
+  qwen36:
+    display_name: Qwen 3.6
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: qwen3.6-27b-text-only-gguf-design
+    local_test_tier: tier_b_partial
+    architecture:
+      kind: multimodal_decoder
+      features: [hybrid_thinking, tool_calling, developer_role, long_context, yarn_future, multimodal_projector_external]
+    implementation_lanes: [dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling]
+    non_claims: [no_256k_runtime, no_full_gpu_residency, no_moe_runtime]
+  qwen35:
+    display_name: Qwen 3.5
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: qwen3.5-0.8b-or-2b-text-only-gguf
+    local_test_tier: tier_a_local
+    small_model_priority: true
+    architecture:
+      kind: multimodal_decoder
+      features: [hybrid_thinking, thinking_disabled_by_default_for_small, tool_calling, long_context, multimodal_projector_external]
+    implementation_lanes: [dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future]
+    non_claims: [no_256k_runtime, no_multimodal_runtime, no_large_variant_runtime]
+  kimi_k26:
+    display_name: Kimi K2.6
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_tokenizer_loader_notes
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: moe_decoder
+      features: [hybrid_thinking, long_context, vision, extreme_model_size, dynamic_quant_reference]
+    implementation_lanes: [moe_decoder_design, prompt_template, gguf_dynamic_quant_design]
+    non_claims: [no_local_execution, no_loader, no_inference]
+  glm51:
+    display_name: GLM-5.1
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_template_and_moe_notes
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: moe_decoder
+      features: [thinking_enabled_by_default, long_context, tool_calling, huge_moe]
+    implementation_lanes: [moe_decoder_design, prompt_template, tool_calling, external_reference]
+    non_claims: [no_local_execution, no_loader, no_inference]
+  deepseek_v4:
+    display_name: DeepSeek V4
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_architecture_notes
+    local_test_tier: tier_c_design_only
+    variants: [deepseek-v4-flash, deepseek-v4-pro]
+    architecture:
+      kind: moe_decoder
+      features: [compressed_sparse_attention, heavily_compressed_attention, manifold_constrained_hyper_connections, million_token_context, fp4_fp8_mixed, huge_moe]
+    implementation_lanes: [moe_decoder_design, long_context_design, mixed_precision_design]
+    non_claims: [no_fp4_fp8_kernels, no_1m_runtime, no_csa_hca_mhc_runtime]
+  mistral_medium_35:
+    display_name: Mistral Medium 3.5
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_reasoning_effort_contract
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: dense_decoder
+      features: [reasoning_effort, multimodal_text_image, function_calling, long_context, eagle_drafter_future]
+    implementation_lanes: [dense_decoder_design, prompt_template, tool_calling, speculative_decoding_future]
+    non_claims: [no_local_full_path, no_eagle_runtime]
+  openai_privacy_filter:
+    display_name: OpenAI privacy-filter
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: token_classification_cpu_or_onnx_smoke
+    local_test_tier: tier_a_local
+    architecture:
+      kind: token_classifier
+      features: [bidirectional_encoder, banded_attention, sparse_moe, bioes_labels, viterbi_span_decoder, pii_detection]
+    implementation_lanes: [token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference]
+    non_claims: [not_generation, no_calibration_claim, no_native_loader]

--- a/docs/tracking/model-family-foundation/source-index.yaml
+++ b/docs/tracking/model-family-foundation/source-index.yaml
@@ -1,0 +1,15 @@
+schema: 1
+updated: 2026-05-07
+policy: Supplied notes are recorded as planning sources; external URLs and license terms must be verified before runtime, distribution, or benchmark claims.
+sources:
+  gemma4-google-overview: {family: gemma4, source_type: supplied_notes, verification_status: needs_url_verification}
+  gemma4-memory-notes: {family: gemma4, source_type: supplied_notes, verification_status: needs_url_verification}
+  qwen36-model-notes: {family: qwen36, source_type: supplied_notes, verification_status: needs_url_verification}
+  qwen36-unsloth-memory: {family: qwen36, source_type: supplied_notes, verification_status: needs_url_verification}
+  qwen35-model-notes: {family: qwen35, source_type: supplied_notes, verification_status: needs_url_verification}
+  qwen35-hardware-table: {family: qwen35, source_type: supplied_notes, verification_status: needs_url_verification}
+  kimi26-unsloth-notes: {family: kimi_k26, source_type: supplied_notes, verification_status: needs_url_verification}
+  glm51-model-notes: {family: glm51, source_type: supplied_notes, verification_status: needs_url_verification}
+  deepseek-v4-model-card: {family: deepseek_v4, source_type: supplied_notes, verification_status: needs_url_verification}
+  mistral-medium-35-card: {family: mistral_medium_35, source_type: supplied_notes, verification_status: needs_url_verification}
+  openai-privacy-filter-card: {family: openai_privacy_filter, source_type: supplied_notes, verification_status: needs_url_verification}

--- a/docs/tracking/model-family-foundation/status.md
+++ b/docs/tracking/model-family-foundation/status.md
@@ -1,0 +1,25 @@
+# Model-family foundation status
+
+Updated: 2026-05-07
+
+This tracker is separate from the BitNet/hardware alignment tracker. It records model-family documentation, implementation lanes, status values, hardware-fit tiers, and receipt requirements without changing runtime behavior.
+
+## Current queue
+
+| Item | State | Notes |
+|---|---|---|
+| MF-001 | ready | Add model docs tree, schemas, source index, statuses, and receipt templates. |
+| MF-002 | proposed | Add shared architecture glossary and lane docs. |
+| MF-003 | proposed | Add 5070 Ti-class local hardware fit policy. |
+| GEMMA4-DOC-001 | proposed | Gemma 4 plan; no Gemma 4 loader claim. |
+| QWEN35-DOC-001 | proposed | Qwen3.5 small-model-first plan. |
+| PRIVACY-DOC-001 | proposed | Token-classification plan separate from generation. |
+| QWEN36-DOC-001 | proposed | Qwen3.6 partial/offload design. |
+| KIMI26-DOC-001 | proposed | Design-only huge-model rails. |
+| GLM51-DOC-001 | proposed | Design-only huge MoE rails. |
+| DSV4-DOC-001 | proposed | Design-only DeepSeek V4 rails. |
+| MM35-DOC-001 | proposed | Design-only Mistral Medium 3.5 full path. |
+
+## Claim boundary
+
+Docs do not mean loaders exist; loader scaffold does not mean inference works; one-token proof does not mean multimodal, long-context, MoE, speed, or quality support; design-only families remain explicit non-claims.

--- a/docs/tracking/model-family-foundation/workstream-ledger.yaml
+++ b/docs/tracking/model-family-foundation/workstream-ledger.yaml
@@ -1,0 +1,174 @@
+schema: 1
+project: bitnet-rs-model-family-foundation
+updated: 2026-05-07
+states: [proposed, ready, in_progress, pr_open, blocked, merged, superseded]
+item_schema:
+  required: [id, title, state, priority, workstream, depends_on, scope.allowed_paths, scope.forbidden_paths, acceptance, verification, notes, followups]
+state_transition_rules:
+  - proposed -> ready only when scope, acceptance, and verification are clear.
+  - ready -> in_progress when a branch starts work.
+  - in_progress -> pr_open when a PR is opened.
+  - pr_open -> merged only after merge.
+  - A PR must not mark itself merged.
+workstreams:
+  model_foundation:
+    title: Model-family foundation
+    objective: Add documentation, schemas, status values, and receipts without runtime behavior.
+  model_family_docs:
+    title: Model-family docs
+    objective: Add family-specific implementation plans and non-claims.
+items:
+  - id: MF-001
+    title: Add model-family documentation structure
+    state: ready
+    priority: P0
+    workstream: model_foundation
+    depends_on: []
+    scope:
+      allowed_paths: [docs/models/**, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**, tests/**, .github/**]
+    acceptance:
+      - Adds model docs tree.
+      - Adds status values and claim boundaries.
+      - Adds schemas for model family, variant, prompt template, hardware fit, and receipts.
+      - Adds source-index.yaml for source-backed facts.
+      - Does not add runtime code.
+    verification: [cargo fmt --all -- --check, Parse YAML files, Parse JSON receipt templates]
+    notes: First pass only; no runtime behavior.
+    followups: [MF-002, MF-003]
+  - id: MF-002
+    title: Add architecture feature glossary
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths: [docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md, docs/models/implementation/**, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Defines dense, MoE, multimodal, token-classification, long-context, and speculative-decoding features.
+      - Unknowns are marked TBD.
+      - No implementation claims are made.
+    verification: [cargo fmt --all -- --check]
+    notes: Glossary terms are shared rails, not runtime support.
+    followups: []
+  - id: MF-003
+    title: Add local hardware fit policy for 5070Ti
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths: [docs/models/MODEL_HARDWARE_FIT_5070TI.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Splits models into tier_a_local, tier_b_partial, and tier_c_design_only.
+      - Explicitly states that design-only docs are not local inference claims.
+      - Does not invent benchmarks.
+    verification: [cargo fmt --all -- --check]
+    notes: 5070 Ti-class 16 GB is a planning assumption.
+    followups: []
+  - id: GEMMA4-DOC-001
+    title: Add Gemma 4 model-family foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/gemma-4.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Documents E2B, E4B, 31B, and 26B-A4B variants.
+      - Separates text-only, multimodal, MoE, and MTP claims.
+      - First target is E2B text-only Q4/quantized proof.
+      - Explicitly says generic Gemma support is not Gemma 4 support.
+    verification: [cargo fmt --all -- --check]
+    notes: No Gemma 4 loader or runtime claim.
+    followups: [GEMMA4-DOC-002, GEMMA4-DOC-003, GEMMA4-DOC-004, GEMMA4-DOC-005, GEMMA4-DOC-006]
+  - id: QWEN35-DOC-001
+    title: Add Qwen3.5 small-model-first foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/qwen-3.5.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Documents 0.8B, 2B, 4B, 9B as first local targets.
+      - Documents thinking disabled by default for small models.
+      - Separates 27B/35B/122B/397B as larger or design-gated targets.
+    verification: [cargo fmt --all -- --check]
+    notes: Best early non-BitNet local decoder target.
+    followups: [QWEN35-DOC-002, QWEN35-DOC-003, QWEN35-DOC-004, QWEN35-DOC-005, QWEN35-DOC-006]
+  - id: PRIVACY-DOC-001
+    title: Add OpenAI privacy-filter token-classification foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/openai-privacy-filter.md, docs/models/implementation/token-classification-lane.md, ci/model-receipts/_templates/token-classification-proof.json, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Documents token-classification pipeline separately from generation.
+      - Documents 33 BIOES labels and Viterbi span decoder.
+      - Adds receipt requirements for span classification.
+    verification: [cargo fmt --all -- --check, Parse JSON receipt template]
+    notes: Not an autoregressive generation lane.
+    followups: [PRIVACY-DOC-002, PRIVACY-DOC-003, PRIVACY-DOC-004, PRIVACY-DOC-005]
+  - id: QWEN36-DOC-001
+    title: Add Qwen3.6 family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/qwen-3.6.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents Qwen3.6 variants and future gates.]
+    verification: [cargo fmt --all -- --check]
+    notes: Tier B partial/offload design.
+    followups: []
+  - id: KIMI26-DOC-001
+    title: Add Kimi K2.6 design-only family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/kimi-k2.6.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents design-only huge-model rails.]
+    verification: [cargo fmt --all -- --check]
+    notes: Tier C design-only.
+    followups: []
+  - id: GLM51-DOC-001
+    title: Add GLM-5.1 design-only family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/glm-5.1.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents design-only GLM-5.1 MoE rails.]
+    verification: [cargo fmt --all -- --check]
+    notes: Tier C design-only.
+    followups: []
+  - id: DSV4-DOC-001
+    title: Add DeepSeek V4 family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/deepseek-v4.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents DeepSeek V4 Flash and Pro design-only rails.]
+    verification: [cargo fmt --all -- --check]
+    notes: Tier C design-only.
+    followups: []
+  - id: MM35-DOC-001
+    title: Add Mistral Medium 3.5 design-only family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/mistral-medium-3.5.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents Mistral Medium 3.5 prompt and external-reference rails.]
+    verification: [cargo fmt --all -- --check]
+    notes: Tier C full-path design-only.
+    followups: []


### PR DESCRIPTION
### Motivation

- Establish a safe, source-backed control plane for future non-BitNet model-family work that separates documentation/scaffold claims from runtime/receipt-backed claims. 
- Encode strict status stages, claim boundaries, and hardware-fit tiers so model-family progress can be advanced only with explicit proofs and receipts. 
- Provide common schemas, shared glossary, and implementation-lane contracts so later agents can implement loaders, prompt templates, kernels, and receipts “on rails.”
- Surface prioritized first local proof targets (Qwen3.5 small, Gemma 4 E2B/E4B text-only, OpenAI privacy-filter) while marking very large models as design-only.

### Description

- Added comprehensive docs under `docs/models/` including `README.md`, support policies, status values, implementation tiers, receipt requirements, tokenizer/prompt policy, multimodal and MoE policies, long-context and design-only policies, and an architecture feature glossary. 
- Added machine-readable schemas under `docs/models/schemas/` for model families, variants, capabilities, receipts, prompt templates, tokenizer policy, and hardware-fit. 
- Added family-level documents in `docs/models/families/` for Gemma 4, Qwen 3.6, Qwen 3.5, Kimi K2.6, GLM-5.1, DeepSeek V4, Mistral Medium 3.5, and OpenAI privacy-filter with standardized templates, non-claims, and work items. 
- Added implementation-lane docs under `docs/models/implementation/` and a parallel model-family tracker in `docs/tracking/model-family-foundation/` containing `model-status.yaml`, `workstream-ledger.yaml`, `status.md`, `source-index.yaml`, `implementation-lanes.yaml`, and `hardware-fit.yaml`. 
- Added receipt templates under `ci/model-receipts/_templates/` for generative one-token proofs, design-only, MoE router smoke, multimodal text-only, token-classification, and external-reference proofs. 
- Added a single-line cross-reference in the existing BitNet alignment status to point maintainers to the separate model-family tracker so hardware and model-family states do not mix.

### Testing

- Ran `cargo fmt --all -- --check` as part of verification and it completed successfully. 
- Parsed all new YAML and JSON artifacts with a Python loader (`yaml.safe_load` and `json.loads`) and the files parsed without error. 
- Ran repository checks including `git diff --check` style verification steps as part of the PR creation flow and no check failures were reported. 
- All automated verification steps recorded in the change (format and parse checks) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1f02e3b083339674e40ca3e577ad)