### PR TITLE
Add model-family foundation docs, schemas, receipt templates, and tracker

### DIFF
--- a/ci/model-receipts/_templates/external-reference-proof.json
+++ b/ci/model-receipts/_templates/external-reference-proof.json
@@ -1,0 +1,19 @@
+{
+  "schema": 1,
+  "claim": "external_reference",
+  "model_family": "",
+  "variant": "",
+  "task": "external_reference",
+  "external_runtime": {
+    "name": "",
+    "version": "",
+    "host": "",
+    "command": "",
+    "artifact_hash": "TBD"
+  },
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "native_kernel_claim": false,
+  "speedup_claim": false,
+  "notes": "External reference does not prove native bitnet-rs support."
+}

--- a/ci/model-receipts/_templates/generative-design-only.json
+++ b/ci/model-receipts/_templates/generative-design-only.json
@@ -1,0 +1,11 @@
+{
+  "schema": 1,
+  "claim": "design_only",
+  "model_family": "",
+  "variant": "",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false,
+  "reason": "Model exceeds local hardware or implementation is not started."
+}

--- a/ci/model-receipts/_templates/generative-one-token-proof.json
+++ b/ci/model-receipts/_templates/generative-one-token-proof.json
@@ -1,0 +1,40 @@
+{
+  "schema": 1,
+  "claim": "strict_model_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "text_generation",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "gguf|safetensors|openvino_ir|onnx",
+    "hash": "TBD"
+  },
+  "tokenizer": {
+    "source": "explicit|model|sibling|unknown",
+    "fallback_used": false
+  },
+  "prompt_template": {
+    "id": "",
+    "thinking_enabled": false,
+    "developer_role_used": false,
+    "tool_calling_used": false
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "greedy": true
+  }
+}

--- a/ci/model-receipts/_templates/moe-router-smoke.json
+++ b/ci/model-receipts/_templates/moe-router-smoke.json
@@ -1,0 +1,31 @@
+{
+  "schema": 1,
+  "claim": "moe_router_smoke",
+  "model_family": "",
+  "variant": "",
+  "task": "moe_router_smoke",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "gguf|safetensors|openvino_ir|onnx",
+    "hash": "TBD"
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "moe": {
+    "router_logits_shape": [],
+    "top_k": 0,
+    "shared_expert_present": false,
+    "active_parameters": "TBD",
+    "total_parameters": "TBD",
+    "per_token_expert_coverage_recorded": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "moe_claim": true,
+    "speedup_claim": false
+  }
+}

--- a/ci/model-receipts/_templates/multimodal-text-only-proof.json
+++ b/ci/model-receipts/_templates/multimodal-text-only-proof.json
@@ -1,0 +1,32 @@
+{
+  "schema": 1,
+  "claim": "multimodal_family_text_only_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "multimodal_text_only",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "gguf|safetensors|openvino_ir|onnx",
+    "hash": "TBD"
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "text_only_claim": true,
+    "multimodal_claim": false,
+    "image_claim": false,
+    "audio_claim": false,
+    "video_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "greedy": true
+  }
+}

--- a/ci/model-receipts/_templates/token-classification-proof.json
+++ b/ci/model-receipts/_templates/token-classification-proof.json
@@ -1,0 +1,33 @@
+{
+  "schema": 1,
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "variant": "",
+  "task": "token_classification",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "onnx|safetensors",
+    "hash": "TBD"
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "classification": {
+    "input_tokens": 12,
+    "output_shape": [12, 33],
+    "span_decoder": "bioes_viterbi",
+    "labels": [
+      "private_person",
+      "private_email",
+      "private_phone"
+    ]
+  },
+  "coverage": {
+    "generation_claim": false,
+    "full_inference_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
+++ b/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
@@ -1,0 +1,37 @@
+# Architecture feature glossary
+
+Features in this glossary are shared vocabulary for family docs. Anything not source-backed must be marked `TBD`, not inferred.
+
+- `dense_decoder`: autoregressive decoder with dense feed-forward layers.
+- `moe_decoder`: autoregressive decoder with routed expert feed-forward layers.
+- `effective_parameters`: parameters materially used for a task or configuration; must be source-backed or receipt-backed.
+- `active_parameters`: per-token or per-forward routed parameters in MoE models; not the same as total parameters.
+- `hybrid_thinking`: model family supports both reasoning/thinking and direct-answer modes.
+- `thinking_mode`: prompt/runtime mode that exposes or controls model reasoning behavior.
+- `reasoning_effort`: request-level control over amount of reasoning, such as `none` or `high`.
+- `developer_role`: chat role distinct from system/user/assistant for coding or agentic instructions.
+- `tool_calling`: structured tool invocation support.
+- `structured_outputs`: constrained JSON/schema output behavior.
+- `multimodal_text_image`: accepts text and image input.
+- `multimodal_audio`: accepts audio input.
+- `video_as_frames`: represents video as extracted image frames; preprocessing details are TBD unless source-backed.
+- `vision_encoder`: image encoder or projector path for multimodal models.
+- `audio_encoder`: audio encoder path for multimodal models.
+- `per_layer_embeddings`: layer-specific embedding behavior such as PLE.
+- `shared_kv_cache`: shared or unified K/V behavior across attention layers.
+- `sliding_window_attention`: local attention window rather than full attention at every layer.
+- `global_attention`: full-context/global attention layer.
+- `p_rope`: positional RoPE variant named by source notes.
+- `yarn`: YaRN context-extension mechanism; runtime support is TBD until proven.
+- `long_context`: context lengths above ordinary local smoke sizes; runtime support requires receipt.
+- `compressed_sparse_attention`: CSA-style sparse attention; implementation details are TBD until source and parity proof exist.
+- `heavily_compressed_attention`: HCA-style compressed attention; implementation details are TBD until source and parity proof exist.
+- `mamba_or_hybrid_state_space_tbd`: possible state-space/hybrid feature that must remain TBD unless source-backed.
+- `mtp_drafter`: multi-token prediction draft model for speculative decoding.
+- `eagle_drafter`: EAGLE draft model for speculative decoding.
+- `gguf_dynamic_quant`: GGUF dynamic quantization reference; not a native kernel claim.
+- `mxfp4`: 4-bit floating-point format; kernel support must be separately proven.
+- `fp4_fp8_mixed`: mixed FP4/FP8 precision; kernel support must be separately proven.
+- `token_classification`: per-token labeling task, not autoregressive generation.
+- `bioes_labels`: begin/inside/outside/end/single span labeling taxonomy.
+- `viterbi_span_decoder`: constrained decoding over token labels to produce coherent spans.

--- a/docs/models/DESIGN_ONLY_POLICY.md
+++ b/docs/models/DESIGN_ONLY_POLICY.md
@@ -1,0 +1,5 @@
+# Design-only policy
+
+`design_only` is an explicit positive state for models that are too large for local proof or whose implementation has not started.
+
+Design-only artifacts may include source notes, architecture terminology, prompt-template notes, loader plans, external-reference commands, and receipt shapes. They must not claim local loading, local inference, quality, speed, multimodal support, long-context support, or kernel support.

--- a/docs/models/LONG_CONTEXT_POLICY.md
+++ b/docs/models/LONG_CONTEXT_POLICY.md
@@ -1,0 +1,5 @@
+# Long-context policy
+
+Published context length is a source-backed model capability, not a bitnet-rs runtime claim.
+
+A one-token or reduced-context receipt must set `long_context_claim=false`. Full-context claims require explicit prompt length, KV/cache settings, rope/yarn settings, backend, memory behavior, fallback status, and receipt artifact.

--- a/docs/models/MODEL_HARDWARE_FIT_5070TI.md
+++ b/docs/models/MODEL_HARDWARE_FIT_5070TI.md
@@ -1,0 +1,27 @@
+# Hardware fit policy: 5070 Ti-class 16 GB GPU
+
+This policy assumes the largest local accelerator is a 5070 Ti-class GPU with 16 GB VRAM. Memory estimates are planning inputs, not benchmarks.
+
+## Tier A: locally testable soon
+
+- Gemma 4 E2B/E4B text-only quantized proof targets.
+- Qwen3.5 0.8B, 2B, 4B, and 9B text-only quantized proof targets.
+- OpenAI privacy-filter CPU/ONNX/safetensors token-classification smoke.
+
+## Tier B: partial/offload possible
+
+- Qwen3.6 27B text-only reduced-context/offload design target.
+- Qwen3.5 27B and 35B-A3B quantized/offload targets.
+- Gemma 4 31B and 26B-A4B quantized/offload targets.
+- Mistral Medium 3.5 only as external or offload reference unless a future receipt proves otherwise.
+
+## Tier C: design-only locally
+
+- Kimi K2.6.
+- GLM-5.1.
+- DeepSeek V4 Flash/Pro.
+- Mistral Medium 3.5 128B full path.
+
+## Hard boundary
+
+Tier membership is not runtime proof. Design-only docs must not be converted into local execution, speed, quality, long-context, multimodal, or MoE support claims without receipts.

--- a/docs/models/MODEL_IMPLEMENTATION_TIERS.md
+++ b/docs/models/MODEL_IMPLEMENTATION_TIERS.md
@@ -1,0 +1,11 @@
+# Model implementation tiers
+
+The current local planning target is a 5070 Ti-class 16 GB GPU. Tiers describe what can be planned locally without over-claiming.
+
+| Tier | Meaning | Families |
+| --- | --- | --- |
+| Tier A: locally testable soon | Reasonable to smoke locally with small/quantized models or CPU/GPU offload. | Gemma 4 E2B/E4B text-only; Qwen3.5 0.8B/2B/4B/9B; OpenAI privacy-filter. |
+| Tier B: partial/offload possible | May run with quantization, CPU/RAM offload, reduced context, or single-token proof only. | Qwen3.6 27B; Qwen3.5 27B/35B-A3B; Gemma 4 26B-A4B/31B quantized; Mistral Medium 3.5 only if external/offload reference exists. |
+| Tier C: design-only locally | Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands. | Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, Mistral Medium 3.5 128B full path. |
+
+Design-only is a positive state: it records rails for future agents while explicitly refusing local inference claims.

--- a/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
+++ b/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
@@ -1,0 +1,11 @@
+# Model receipt requirements
+
+Receipts are the only basis for working model-family claims.
+
+## Required fields
+
+Generative receipts must record model id, variant id, model hash or `TBD`, tokenizer source, prompt template id, requested backend, selected backend, fallback flag, task, generated token count, and explicit booleans for full-inference, multimodal, MoE, long-context, and speedup claims.
+
+Token-classification receipts must record input token count, output shape, label taxonomy, span decoder, fallback flag, and `generation_claim=false`.
+
+External-reference receipts must record the external runtime, host, command, artifact hash or `TBD`, and must set `local_execution_claim=false` unless the local repo executed the path.

--- a/docs/models/MODEL_STATUS_VALUES.md
+++ b/docs/models/MODEL_STATUS_VALUES.md
@@ -1,0 +1,28 @@
+# Model status values
+
+Model-family statuses mirror the backend tracker style: each status has a narrow claim boundary and must not imply later proof stages.
+
+## Values
+
+- `not_present`: no repository artifact exists.
+- `documented`: source-backed notes exist; no implementation claim.
+- `design_scaffold`: architecture and implementation plan are recorded; no compile/load/run claim.
+- `catalog_scaffold`: registry/catalog shape is planned or present; no loader claim.
+- `tokenizer_scaffold`: tokenizer policy or mapping is planned; no tokenization parity claim.
+- `prompt_template_scaffold`: prompt template policy is planned; no chat parity claim.
+- `loader_scaffold`: intended loader/tensor mapping exists; no inference claim.
+- `synthetic_shape_tested`: synthetic shape-only checks ran; no real model claim.
+- `runtime_detected`: runtime/backend was detected; no inference claim.
+- `one_token_smoke_tested`: one deterministic generation/classification smoke ran; no quality, speed, modality, or long-context claim.
+- `parity_tested`: parity was checked for the named path only.
+- `receipt_backed`: the named model/variant/backend/task claim is proven by receipt.
+- `benchmarked`: benchmark data exists for the receipt-backed path only.
+- `design_only`: intentionally documented for future work or external reference; no local execution claim.
+
+## Claim boundaries
+
+- `documented` may claim source-backed implementation notes exist, but must not claim the model loads or runs.
+- `design_scaffold` may claim the architecture plan is recorded, but must not claim the implementation compiles, loads, or runs.
+- `loader_scaffold` may claim the intended loader/tensor mapping exists, but must not claim inference works.
+- `one_token_smoke_tested` may claim one strict deterministic smoke ran, but must not claim quality, speed, long context, or full feature support.
+- `receipt_backed` may claim the named model/variant/backend/task is proven by receipt, but must not claim other variants, backends, modalities, or quantizations work.

--- a/docs/models/MODEL_SUPPORT_POLICY.md
+++ b/docs/models/MODEL_SUPPORT_POLICY.md
@@ -1,0 +1,20 @@
+# Model support policy
+
+Support is evidence-based and scoped. The repository must not describe a model family as supported unless the exact support claim is backed by a status value and, for working claims, a receipt.
+
+## Required dimensions
+
+Every support claim must name:
+
+- model family and variant;
+- weight format and quantization;
+- tokenizer source;
+- prompt template id;
+- requested and selected backend;
+- task shape such as text generation or token classification;
+- whether fallback was used;
+- whether multimodal, MoE, long-context, full-inference, or speedup support is claimed.
+
+## Non-BitNet boundary
+
+Non-BitNet dense and MoE families must not use BitNet W1.58, QK256, or BitNet-specific kernel receipts as proof. If a non-BitNet path falls back to CPU, a reference graph, or an external runtime, the receipt must say so.

--- a/docs/models/MOE_SUPPORT_POLICY.md
+++ b/docs/models/MOE_SUPPORT_POLICY.md
@@ -1,0 +1,5 @@
+# MoE support policy
+
+MoE support requires more than loading dense decoder weights. A receipt-backed MoE claim must prove router logits, top-k expert selection, expert weight loading, shared expert handling when present, active/total parameter accounting, and per-token expert coverage metrics.
+
+A dense variant proof does not prove MoE variants in the same family. A source-backed active-parameter number is not a runtime routing claim.

--- a/docs/models/MULTIMODAL_SUPPORT_POLICY.md
+++ b/docs/models/MULTIMODAL_SUPPORT_POLICY.md
@@ -1,0 +1,7 @@
+# Multimodal support policy
+
+Multimodal facts in family docs are architecture and source notes until receipt-backed.
+
+A text-only proof for a multimodal model proves only text-only behavior. It must not imply image, audio, video, projector, vision encoder, audio encoder, or multimodal prompt-template support.
+
+Separate projector files, encoder weights, preprocessing, and modality-specific prompt fields require separate loader contracts and receipts.

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,19 @@
+# Model-family foundation
+
+This directory is a documentation and control-plane layer for future non-BitNet model support. It records source-backed facts, implementation contracts, local hardware fit, receipt requirements, and explicit non-claims before runtime code is added.
+
+The model-family lane is intentionally separate from the BitNet hardware/backend tracker. Backend proof for CPU, CUDA, OpenCL, OpenVINO, Metal, or NPU paths remains in `docs/tracking/bitnet-alignment/`; model-family readiness lives in `docs/tracking/model-family-foundation/`.
+
+## Claim rule
+
+A family document is not a support claim. Claims advance only through named statuses such as `documented`, `design_scaffold`, `loader_scaffold`, `one_token_smoke_tested`, and `receipt_backed`. A claim applies only to the exact family, variant, backend, format, modality, task, and receipt that proved it.
+
+## First practical targets
+
+- Qwen3.5 small text-only GGUF path.
+- Gemma 4 E2B/E4B text-only quantized path.
+- OpenAI privacy-filter token classification path.
+
+## Design-only rails
+
+Kimi K2.6, GLM-5.1, DeepSeek V4, and the full Mistral Medium 3.5 path are documented as design-only or external-reference targets on a 5070 Ti-class 16 GB local GPU.

--- a/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
+++ b/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
@@ -1,0 +1,9 @@
+# Tokenizer and prompt template policy
+
+Tokenizer and prompt template behavior is model-family-specific and must be explicit.
+
+- Tokenizer source must be `explicit`, `model`, `sibling`, or `unknown`.
+- Prompt template ids must be versioned and recorded in receipts.
+- Thinking modes, developer roles, tool-calling blocks, reasoning effort, and multimodal placeholders must not be inferred from another family.
+- If a model requires chat-template kwargs to enable or disable thinking, the family doc must record the default and receipt setting.
+- Tokenizer or prompt-template scaffolds are not inference claims.

--- a/docs/models/families/deepseek-v4.md
+++ b/docs/models/families/deepseek-v4.md
@@ -1,0 +1,56 @@
+# DeepSeek V4
+
+## Status
+- Repo status: design_only.
+- First target: design_only_architecture_notes.
+- Local test tier: tier_c_design_only.
+- Implementation owner lane: moe_decoder_design, long_context_design, mixed_precision_design.
+- Design-only? yes.
+
+## Source-backed facts
+- Model variants: DeepSeek V4 Flash and DeepSeek V4 Pro, with Base and instruct variants.
+- Context: 1M context.
+- Modalities: text focus in supplied notes; multimodal TBD.
+- Tokenizer/prompt: TBD from model cards.
+- Architecture features: MoE, compressed_sparse_attention, heavily_compressed_attention, manifold-constrained hyper-connections, million-token context, and fp4_fp8_mixed precision.
+- Quantization/runtime notes: Flash has 284B total and 13B active; Pro has 1.6T total and 49B active. Base uses FP8 mixed; instruct uses FP4 + FP8 mixed, with MoE experts in FP4 and most other parameters in FP8 according to supplied notes.
+- License: TBD from model card.
+- Known tool support: TBD.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| V4 Flash Base/Instruct | 284B | 13B | 1M | text TBD | design-only architecture notes | tier_c_design_only |
+| V4 Pro Base/Instruct | 1.6T | 49B | 1M | text TBD | design-only architecture notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only for huge MoE and mixed precision.
+### Tokenizer
+TBD from model cards.
+### Prompt template
+TBD from instruct cards.
+### Architecture module
+CSA/HCA/mHC are terminology notes until implemented and parity-tested.
+### Kernels/backend
+FP4/FP8 mixed kernels do not exist until separately implemented and receipt-backed.
+### Receipts
+Use design-only receipt only in first pass.
+### Tests
+No local inference test is planned in first pass.
+
+## Explicit non-claims
+- DeepSeek V4 Flash/Pro docs do not mean FP4/FP8 mixed kernels exist.
+- 1M context is a source-backed model capability, not a bitnet-rs runtime claim.
+- CSA/HCA/mHC are architecture notes until implemented and parity-tested.
+
+## First proof target
+Design-only receipt with architecture notes and no local execution claim.
+
+## Work items
+- DSV4-DOC-001: Add DeepSeek V4 family doc.
+- DSV4-DOC-002: Add Flash vs Pro variant table.
+- DSV4-DOC-003: Add CSA/HCA/mHC terminology and implementation unknowns.
+- DSV4-DOC-004: Add FP4/FP8 mixed precision future-gate.
+- DSV4-DOC-005: Add design-only local hardware warning.

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,60 @@
+# Gemma 4
+
+## Status
+- Repo status: design_scaffold.
+- First target: gemma4-e2b-it-q4-text-only.
+- Local test tier: tier_a_local for E2B/E4B text-only; tier_b_partial for 31B and 26B-A4B quantized/offload.
+- Implementation owner lane: dense_decoder, gguf_dense_quant, moe_decoder_future, multimodal_future.
+- Design-only? no for text-only E2B/E4B planning; yes for multimodal, MTP, and MoE until receipts exist.
+
+## Source-backed facts
+- Model variants: E2B, E4B, 31B dense, and 26B A4B MoE.
+- Context: E2B/E4B have 128K context; 31B and 26B-A4B have 256K context.
+- Modalities: E2B/E4B support text/image/audio; 31B and 26B-A4B support text/image.
+- Tokenizer/prompt: vocabulary is 262K; thinking mode uses `<|think|>` and thought-channel delimiters.
+- Architecture features: hybrid local/global attention, final layer global attention, unified K/V and p-RoPE on global layers, PLE on small models, and MTP draft models.
+- Quantization/runtime notes: Q4 estimates are E2B ~3.2 GB, E4B ~5 GB, 31B ~17.4 GB, and 26B-A4B ~15.6 GB, not including KV/software overhead.
+- License: TBD from model card.
+- Known tool support: TBD; do not overload existing Gemma 2 catalog entries.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| E2B | ~2B effective | dense | 128K | text/image/audio | text-only Q4 smoke | tier_a_local |
+| E4B | ~4B effective | dense | 128K | text/image/audio | text-only Q4 smoke | tier_a_local |
+| 31B | 31B | dense | 256K | text/image | offload/design | tier_b_partial |
+| 26B-A4B | 26B total | 4B active; 8 active / 128 total experts plus shared expert | 256K | text/image | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Create a separate Gemma 4 catalog/loader mapping; generic `ModelArchitecture::Gemma` and Gemma 2 defaults are not Gemma 4 support.
+### Tokenizer
+Record 262K vocabulary source and tokenizer hash before proof.
+### Prompt template
+Record thinking delimiters and whether thinking is enabled.
+### Architecture module
+Plan dense E2B/E4B/31B separately from 26B-A4B MoE; PLE/shared-KV/p-RoPE are future implementation notes.
+### Kernels/backend
+Do not route through BitNet QK256 kernels as evidence.
+### Receipts
+First receipt must be text-only, one-token, no multimodal, no MoE, no MTP, no speed claim.
+### Tests
+Start with strict deterministic one-token text generation at reduced context.
+
+## Explicit non-claims
+- Gemma 4 documented does not mean Gemma 4 loads.
+- E2B/E4B text-only proof does not mean image/audio works.
+- MTP draft support is future-gated.
+- 26B-A4B MoE support is future-gated.
+
+## First proof target
+Use `ci/model-receipts/_templates/generative-one-token-proof.json` with `model_family=gemma4`, `variant=e2b`, `multimodal_claim=false`, `moe_claim=false`, and `speedup_claim=false`.
+
+## Work items
+- GEMMA4-DOC-001: Add Gemma 4 family doc and variant table.
+- GEMMA4-DOC-002: Add Gemma 4 prompt/template contract.
+- GEMMA4-DOC-003: Add Gemma 4 text-only E2B proof plan.
+- GEMMA4-DOC-004: Add PLE/shared-KV/sliding-global attention implementation notes.
+- GEMMA4-DOC-005: Add MoE 26B-A4B future gate.
+- GEMMA4-DOC-006: Add multimodal future gate.

--- a/docs/models/families/glm-5.1.md
+++ b/docs/models/families/glm-5.1.md
@@ -1,0 +1,54 @@
+# GLM 5.1
+
+## Status
+- Repo status: design_only.
+- First target: design_only_prompt_template_and_moe_notes.
+- Local test tier: tier_c_design_only.
+- Implementation owner lane: moe_decoder_design, prompt_template, tool_calling, external_reference.
+- Design-only? yes.
+
+## Source-backed facts
+- Model variants: GLM-5.1 full model.
+- Context: 200K.
+- Modalities: text/tooling focus in supplied notes; multimodal TBD.
+- Tokenizer/prompt: thinking enabled by default and disabled with chat-template kwargs; `chat_template.jinja` changes focus on tool exposure, reasoning-history reconstruction, and tool-message rendering.
+- Architecture features: same architecture as GLM-5 in supplied notes, huge_moe, tool_calling, long_context.
+- Quantization/runtime notes: 744B total parameters, 40B active; full disk size around 1.65 TB; dynamic 2-bit around 220 GB, dynamic 1-bit around 200 GB, and `UD-IQ2_M` around 236 GB.
+- License: TBD from model card.
+- Known tool support: future OpenVINO/llama.cpp reference receipt plan.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| GLM-5.1 | 744B | 40B | 200K | text/tools TBD | design-only prompt/MoE notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+External-reference or future graph loader notes only.
+### Tokenizer
+Tokenizer and template source must be recorded before any proof.
+### Prompt template
+Record thinking default and disable kwargs.
+### Architecture module
+Huge MoE details are design-only until source and routing proofs exist.
+### Kernels/backend
+No local full-model kernel claim.
+### Receipts
+Use design-only or external-reference receipt.
+### Tests
+No local inference test is planned in first pass.
+
+## Explicit non-claims
+- GLM-5.1 docs do not imply local loading or inference.
+- Thinking/tool template notes do not imply prompt parity.
+- Quantized disk sizes are not VRAM fit or performance claims.
+
+## First proof target
+Design-only receipt for prompt-template and MoE notes; future external reference may cite OpenVINO or llama.cpp.
+
+## Work items
+- GLM51-DOC-001: Add GLM-5.1 design-only family doc.
+- GLM51-DOC-002: Add thinking/tool/chat-template behavior notes.
+- GLM51-DOC-003: Add model-size/hardware non-claim policy.
+- GLM51-DOC-004: Add future OpenVINO/llama.cpp reference receipt plan.

--- a/docs/models/families/kimi-k2.6.md
+++ b/docs/models/families/kimi-k2.6.md
@@ -1,0 +1,55 @@
+# Kimi K2.6
+
+## Status
+- Repo status: design_only.
+- First target: design_only_prompt_tokenizer_loader_notes.
+- Local test tier: tier_c_design_only.
+- Implementation owner lane: moe_decoder_design, prompt_template, gguf_dynamic_quant_design.
+- Design-only? yes.
+
+## Source-backed facts
+- Model variants: Kimi K2.6 hybrid-thinking 1T-parameter family.
+- Context: 256K.
+- Modalities: vision support appears in supplied Unsloth GGUF notes.
+- Tokenizer/prompt: Kimi chat template uses `<|im_system|>`, `<|im_user|>`, `<|im_assistant|>`, and `<think>` in supplied notes.
+- Architecture features: hybrid_thinking, long_context, vision, extreme_model_size, dynamic_quant_reference.
+- Quantization/runtime notes: full precision disk footprint around 610 GB; dynamic 2-bit around 340-350 GB; Q4 around 584 GB; Q8 around 595 GB.
+- License: TBD from model card.
+- Known tool support: external/offload/reference only for current local hardware.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| K2.6 | 1T | TBD | 256K | text/vision in supplied notes | design-only prompt/loader notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Record huge-model and dynamic-quant loader notes only.
+### Tokenizer
+Record tokenizer source and chat-template source before any external receipt.
+### Prompt template
+Capture Kimi-specific role tokens and thinking marker.
+### Architecture module
+MoE and huge-model details remain design-only until source-backed enough to implement.
+### Kernels/backend
+No local kernel claim on 16 GB hardware.
+### Receipts
+Use design-only or external-reference receipts.
+### Tests
+No local inference test is planned in first pass.
+
+## Explicit non-claims
+- Kimi K2.6 is design-only on current hardware.
+- Any future local artifact is offload/reference unless receipt-backed.
+- No speed, quality, long-context, or full-inference claim is allowed from docs.
+
+## First proof target
+Use `generative-design-only.json` or `external-reference-proof.json` with `local_execution_claim=false`.
+
+## Work items
+- KIMI26-DOC-001: Add Kimi K2.6 design-only family doc.
+- KIMI26-DOC-002: Add chat template and thinking-mode notes.
+- KIMI26-DOC-003: Add hardware infeasibility/local non-claim section.
+- KIMI26-DOC-004: Add future MoE/huge-model loader design notes.
+- KIMI26-DOC-005: Add external-reference receipt template.

--- a/docs/models/families/mistral-medium-3.5.md
+++ b/docs/models/families/mistral-medium-3.5.md
@@ -1,0 +1,55 @@
+# Mistral Medium 3.5
+
+## Status
+- Repo status: design_only.
+- First target: design_only_prompt_reasoning_effort_contract.
+- Local test tier: tier_c_design_only for full path; tier_b_partial only if external/offload reference exists.
+- Implementation owner lane: dense_decoder_design, prompt_template, tool_calling, speculative_decoding_future.
+- Design-only? yes for full local path.
+
+## Source-backed facts
+- Model variants: Mistral Medium 3.5 dense 128B.
+- Context: 256K.
+- Modalities: text + image input, text output.
+- Tokenizer/prompt: reasoning effort configurable per request as `none` or `high`; function calls / JSON / agentic use.
+- Architecture features: dense_decoder, reasoning_effort, multimodal_text_image, function_calling, long_context, eagle_drafter_future.
+- Quantization/runtime notes: vLLM recommended with tensor parallelism; local full path is beyond current hardware.
+- License: Modified MIT, not plain MIT.
+- Known tool support: EAGLE draft model exists for speculative decoding.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| Medium 3.5 | 128B dense | dense | 256K | text+image input, text output | design-only reasoning contract | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only unless an external/offload reference is added.
+### Tokenizer
+TBD from model card.
+### Prompt template
+Record reasoning_effort values and tool/function-call structure.
+### Architecture module
+Dense decoder full path is beyond local 16 GB proof.
+### Kernels/backend
+No vLLM/tensor-parallel external result counts as native bitnet-rs proof.
+### Receipts
+Use external-reference receipt for external vLLM runs.
+### Tests
+No local full-path test is planned in first pass.
+
+## Explicit non-claims
+- Mistral Medium 3.5 full local inference is not claimed.
+- Modified MIT is not plain MIT.
+- EAGLE draft existence is not speculative decoding support.
+
+## First proof target
+Design-only prompt/API receipt with `local_execution_claim=false`.
+
+## Work items
+- MM35-DOC-001: Add Mistral Medium 3.5 design-only family doc.
+- MM35-DOC-002: Add reasoning_effort prompt/API contract.
+- MM35-DOC-003: Add EAGLE speculative decoding future-gate.
+- MM35-DOC-004: Add license caveat.
+- MM35-DOC-005: Add external-reference receipt plan.

--- a/docs/models/families/openai-privacy-filter.md
+++ b/docs/models/families/openai-privacy-filter.md
@@ -1,0 +1,68 @@
+# OpenAI privacy-filter
+
+## Status
+- Repo status: design_scaffold.
+- First target: token_classification_cpu_or_onnx_smoke.
+- Local test tier: tier_a_local.
+- Implementation owner lane: token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference.
+- Design-only? no for planning a CPU/ONNX smoke; yes for calibration and production masking until receipts exist.
+
+## Source-backed facts
+- Model variants: OpenAI privacy-filter token-classification model.
+- Context: 128K.
+- Modalities: text tokens for PII detection/masking.
+- Tokenizer/prompt: not an autoregressive chat/generate template.
+- Architecture features: bidirectional token-classification model, pre-norm transformer encoder-style stack, 8 transformer blocks, GQA with 14 query heads and 2 KV heads, sparse MoE FFN with 128 experts and top-4 routing, `d_model=640`, banded attention with band size 128 and effective window 257.
+- Quantization/runtime notes: ONNX, safetensors, and Transformers.js surfaces exist in supplied card.
+- License: Apache 2.0.
+- Known tool support: token classification, not generation.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| privacy-filter | 1.5B | 50M active | 128K | text token classification | CPU/ONNX smoke | tier_a_local |
+
+## Implementation contract
+### Loader
+Start with ONNX or safetensors path planning; do not force through autoregressive decoder loaders.
+### Tokenizer
+Tokenizer must align input tokens to output labels.
+### Prompt template
+No generate/chat template; use token-classification input policy.
+### Architecture module
+Requires encoder/bidirectional attention, classification head, per-token logits, and MoE routing if native.
+### Kernels/backend
+ONNX/reference backend may be first; native support requires receipts.
+### Receipts
+Receipt must include output shape `[tokens, 33]`, BIOES taxonomy, and Viterbi decoder.
+### Tests
+First smoke labels a short deterministic input and checks shape/classes.
+
+## Explicit non-claims
+- OpenAI privacy-filter is not an autoregressive decoder.
+- A token-classification smoke is not a generation claim.
+- Calibration, masking quality, and operating points are future-gated.
+
+## First proof target
+```json
+{
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "task": "token_classification",
+  "input_tokens": 12,
+  "output_shape": [12, 33],
+  "span_decoder": "bioes_viterbi",
+  "labels": ["private_person", "private_email", "private_phone"],
+  "generation_claim": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- PRIVACY-DOC-001: Add privacy-filter family doc.
+- PRIVACY-DOC-002: Add token-classification lane doc.
+- PRIVACY-DOC-003: Add BIOES/Viterbi receipt schema.
+- PRIVACY-DOC-004: Add local CPU/ONNX smoke proof plan.
+- PRIVACY-DOC-005: Add calibration/operating-point future-gate.

--- a/docs/models/families/qwen-3.5.md
+++ b/docs/models/families/qwen-3.5.md
@@ -1,0 +1,76 @@
+# Qwen 3.5
+
+## Status
+- Repo status: design_scaffold.
+- First target: qwen3.5-0.8b-or-2b-text-only-gguf.
+- Local test tier: tier_a_local for 0.8B/2B/4B/9B; tier_b_partial for 27B/35B-A3B; tier_c_design_only for 122B/397B.
+- Implementation owner lane: dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future.
+- Design-only? no for small text-only targets; yes for projector, larger MoE, and full context until receipts exist.
+
+## Source-backed facts
+- Model variants: 0.8B, 2B, 4B, 9B, 27B, 35B-A3B, 122B-A10B, and 397B-A17B.
+- Context: 256K context and 201 languages.
+- Modalities: causal LM with vision encoder notes in fine-tuning context; projector compatibility is future-gated.
+- Tokenizer/prompt: hybrid reasoning; small-model reasoning disabled by default, and enabling thinking requires chat-template kwargs.
+- Architecture features: hybrid_thinking, thinking_disabled_by_default_for_small, tool_calling, long_context, multimodal_projector_external.
+- Quantization/runtime notes: 0.8B/2B 4-bit around 3.5 GB, 4B around 5.5 GB, 9B around 6.5 GB, 27B around 17 GB, and 35B-A3B around 22 GB.
+- License: TBD from model card.
+- Known tool support: separate multimodal projector files may be required for GGUF compatibility.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| 0.8B | 0.8B | dense | 256K source capability | text-first | first local proof | tier_a_local |
+| 2B | 2B | dense | 256K source capability | text-first | first local proof | tier_a_local |
+| 4B | 4B | dense | 256K source capability | text-first | follow-up local proof | tier_a_local |
+| 9B | 9B | dense | 256K source capability | text-first | follow-up local proof | tier_a_local |
+| 27B | 27B | dense | 256K source capability | text/projector TBD | offload future gate | tier_b_partial |
+| 35B-A3B | 35B | 3B active | 256K source capability | text/projector TBD | MoE future gate | tier_b_partial |
+| 122B-A10B | 122B | 10B active | 256K source capability | TBD | design gate | tier_c_design_only |
+| 397B-A17B | 397B | 17B active | 256K source capability | TBD | design gate | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Prioritize small dense GGUF variants before any large/MoE path.
+### Tokenizer
+Tokenizer source and hash must be explicit before proof.
+### Prompt template
+Small-model receipts must record `thinking_enabled=false` unless kwargs explicitly enable it.
+### Architecture module
+Dense small models are first; MoE variants are future-gated.
+### Kernels/backend
+Non-BitNet dense path must not use QK256 proof.
+### Receipts
+Small proof uses one-token text generation with no speed, multimodal, or full-context claim.
+### Tests
+Use deterministic greedy generation at context 2048 first.
+
+## Explicit non-claims
+- Qwen3.5 small proof does not prove 27B, 35B-A3B, 122B, or 397B.
+- 256K context is not a bitnet-rs runtime claim.
+- Multimodal projector support is not implemented until receipt-backed.
+
+## First proof target
+```json
+{
+  "claim": "qwen3.5_small_text_only_one_token",
+  "model_family": "qwen3.5",
+  "variant": "0.8b_or_2b",
+  "task": "text_generation",
+  "context_requested": 2048,
+  "full_context_claim": false,
+  "multimodal_claim": false,
+  "thinking_enabled": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- QWEN35-DOC-001: Add Qwen3.5 family doc.
+- QWEN35-DOC-002: Add small-model-first implementation plan for 0.8B/2B/4B/9B.
+- QWEN35-DOC-003: Add thinking-mode prompt contract with small-model default disabled.
+- QWEN35-DOC-004: Add 27B/35B-A3B future-gated plan.
+- QWEN35-DOC-005: Add multimodal projector future gate.
+- QWEN35-DOC-006: Add first local proof template for 0.8B or 2B.

--- a/docs/models/families/qwen-3.6.md
+++ b/docs/models/families/qwen-3.6.md
@@ -1,0 +1,56 @@
+# Qwen 3.6
+
+## Status
+- Repo status: design_scaffold.
+- First target: qwen3.6-27b-text-only-gguf-design.
+- Local test tier: tier_b_partial.
+- Implementation owner lane: dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling.
+- Design-only? no for planning; yes for full 256K/1M, multimodal projector, and 35B-A3B MoE until receipts exist.
+
+## Source-backed facts
+- Model variants: 27B and 35B-A3B.
+- Context: 256K context; maximum context 262,144 and extendable to 1M via YaRN in supplied notes.
+- Modalities: multimodal hybrid-thinking.
+- Tokenizer/prompt: thinking and non-thinking modes have different recommended sampling; developer role is supported for agentic coding tools.
+- Architecture features: hybrid_thinking, tool_calling, developer_role, long_context, yarn_future, multimodal_projector_external.
+- Quantization/runtime notes: 27B 4-bit around 18 GB total memory; 35B-A3B 4-bit around 23 GB total memory; some GGUF flows require separate multimodal projector files.
+- License: TBD from model card.
+- Known tool support: do not assume Ollama compatibility when projector files are separate.
+- Source links: Source links are tracked in `docs/tracking/model-family-foundation/source-index.yaml`; supplied notes must be verified against model cards before implementation claims advance.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+| --- | --- | --- | --- | --- | --- | --- |
+| 27B | 27B | dense | 256K / YaRN to 1M in notes | multimodal text/image TBD | reduced-context text-only design | tier_b_partial |
+| 35B-A3B | 35B | 3B active | 256K / YaRN to 1M in notes | multimodal text/image TBD | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Start with text-only GGUF design; projector files are separate future-gated artifacts.
+### Tokenizer
+Verify tokenizer and chat template from model card before scaffolding.
+### Prompt template
+Record thinking/non-thinking sampling settings and developer role behavior.
+### Architecture module
+Dense 27B and MoE 35B-A3B must be separate contracts.
+### Kernels/backend
+No full-residency or 256K claim on 16 GB hardware without receipt.
+### Receipts
+Reduced-context receipt must set `long_context_claim=false` and `multimodal_claim=false`.
+### Tests
+First proof is one-token text-only if memory/offload plan is available.
+
+## Explicit non-claims
+- Qwen3.6 docs do not imply 256K context works in bitnet-rs.
+- 27B offload/design does not imply full 5070Ti residency.
+- 35B-A3B MoE is not implemented until expert routing is receipt-backed.
+
+## First proof target
+Use generative one-token receipt with `context_requested` reduced, `full_context_claim=false`, and `fallback_used` recorded.
+
+## Work items
+- QWEN36-DOC-001: Add Qwen3.6 family doc.
+- QWEN36-DOC-002: Add Qwen3.6 prompt/template settings for thinking and non-thinking.
+- QWEN36-DOC-003: Add 27B text-only reduced-context proof plan.
+- QWEN36-DOC-004: Add 35B-A3B MoE future gate.
+- QWEN36-DOC-005: Add multimodal projector future gate.

--- a/docs/models/implementation/dense-decoder-lane.md
+++ b/docs/models/implementation/dense-decoder-lane.md
@@ -1,0 +1,23 @@
+# Dense decoder lane
+
+This lane covers non-BitNet dense autoregressive decoders.
+
+It must not use QK256 or BitNet W1.58 kernel proof as evidence.
+
+## First supported formats
+
+- GGUF dense quantized CPU/GPU path.
+- safetensors path later.
+- OpenVINO graph/reference path later.
+
+## Receipt requirements
+
+Receipts must record:
+
+- `dense_regular_llm=true`
+- `bitnet_kernel_used=false`
+- `qk256_used=false` unless the model actually uses QK256
+- requested backend, selected backend, and fallback status
+- full-inference, long-context, multimodal, MoE, and speedup claim booleans
+
+This boundary exists because the current BitNet transformer path has QK256-specific dispatch in linear calls; non-BitNet models must not be silently routed through that path and called supported.

--- a/docs/models/implementation/gguf-dense-quant-lane.md
+++ b/docs/models/implementation/gguf-dense-quant-lane.md
@@ -1,0 +1,14 @@
+# GGUF dense quant lane
+
+This lane covers dense quantized GGUF artifacts for regular non-BitNet LLMs.
+
+## Required gates
+
+- GGUF metadata and tensor map inspection.
+- Tokenizer source and hash.
+- Prompt template id.
+- Quantization type and model hash.
+- Requested/selected backend and fallback status.
+- One-token deterministic proof before broader claims.
+
+GGUF compatibility is per artifact. A GGUF text-only receipt does not prove safetensors, ONNX, OpenVINO IR, multimodal projectors, MoE routing, full context, or speed.

--- a/docs/models/implementation/moe-decoder-lane.md
+++ b/docs/models/implementation/moe-decoder-lane.md
@@ -1,0 +1,12 @@
+# MoE decoder lane
+
+MoE support requires:
+
+- router logits;
+- top-k expert selection;
+- shared expert handling if present;
+- expert weight loading;
+- active vs total parameter receipts;
+- per-token expert coverage metrics.
+
+A dense decoder smoke does not prove MoE support. A source-backed active-parameter count does not prove runtime routing. MoE claims advance only when routing, expert loading, and per-token coverage are receipt-backed for the named model and variant.

--- a/docs/models/implementation/multimodal-lane.md
+++ b/docs/models/implementation/multimodal-lane.md
@@ -1,0 +1,13 @@
+# Multimodal lane
+
+This lane covers models with text plus image, audio, or video/frame inputs.
+
+## Required gates
+
+- Modality-specific tokenizer or processor source.
+- Vision/audio/projector weight loading.
+- Prompt-template placeholders and role rules.
+- Text-only receipts that explicitly set `multimodal_claim=false`.
+- Modality receipts that record preprocessing, encoder/projector artifacts, and fallback status.
+
+A text-only proof for a multimodal family does not prove image, audio, video, projector, or encoder support.

--- a/docs/models/implementation/openvino-graph-lane.md
+++ b/docs/models/implementation/openvino-graph-lane.md
@@ -1,0 +1,5 @@
+# OpenVINO graph/reference lane
+
+This lane is for graph or reference execution through OpenVINO IR or OpenVINO-supported imported graphs.
+
+OpenVINO graph execution is a backend/reference claim only for the exact graph, device, precision, and task in the receipt. It does not prove native bitnet-rs kernels, BitNet QK256 dispatch, CUDA, or full model-family support.

--- a/docs/models/implementation/safetensors-loader-lane.md
+++ b/docs/models/implementation/safetensors-loader-lane.md
@@ -1,0 +1,14 @@
+# safetensors loader lane
+
+This lane covers future safetensors loading for model families that publish Hugging Face-style artifacts.
+
+## Required gates
+
+- Config-to-architecture mapping.
+- Tensor name map.
+- Tokenizer and chat-template source.
+- Weight dtype and quantization policy.
+- Hashes for config, tokenizer, and shards.
+- Shape-only checks before inference claims.
+
+A safetensors loader scaffold is not inference support. Remote code requirements must be marked `remote_code_tbd` until audited.

--- a/docs/models/implementation/token-classification-lane.md
+++ b/docs/models/implementation/token-classification-lane.md
@@ -1,0 +1,14 @@
+# Token classification lane
+
+Token classification is not generation.
+
+## Required
+
+- encoder/bidirectional attention support;
+- token classification head;
+- per-token logits;
+- label taxonomy;
+- constrained decoder if required;
+- span output receipt.
+
+OpenAI privacy-filter uses this lane. Receipts must include token count, output shape, label set, span decoder, `generation_claim=false`, fallback status, and speedup claim status.

--- a/docs/models/schemas/hardware-fit.schema.yaml
+++ b/docs/models/schemas/hardware-fit.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [family_id, variant_id, local_test_tier, fit_reason, non_claims]
+fields:
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]
+  memory_estimate: {type: string, optional: true}
+  fit_reason: {type: string}
+  proof_target: {type: string}
+  non_claims: {type: list_string}

--- a/docs/models/schemas/model-capability.schema.yaml
+++ b/docs/models/schemas/model-capability.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [capability_id, source_status, runtime_claim, receipt_required]
+fields:
+  capability_id: {type: string}
+  source_status:
+    enum: [source_backed, source_backed_partial, needs_model_card_verification, design_only]
+  runtime_claim: {type: boolean}
+  receipt_required: {type: boolean}
+  non_claims: {type: list_string}

--- a/docs/models/schemas/model-family.schema.yaml
+++ b/docs/models/schemas/model-family.schema.yaml
@@ -1,0 +1,70 @@
+schema: 1
+required:
+  - id
+  - display_name
+  - source_status
+  - implementation_status
+  - first_target
+  - local_test_tier
+  - architecture
+  - variants
+  - tokenizer
+  - prompt_template
+  - loader
+  - receipts
+  - non_claims
+fields:
+  id:
+    type: string
+    example: gemma4
+  source_status:
+    enum:
+      - source_backed
+      - source_backed_partial
+      - needs_model_card_verification
+      - design_only
+  implementation_status:
+    enum:
+      - not_present
+      - documented
+      - design_scaffold
+      - catalog_scaffold
+      - loader_scaffold
+      - one_token_smoke_tested
+      - receipt_backed
+  local_test_tier:
+    enum:
+      - tier_a_local
+      - tier_b_partial
+      - tier_c_design_only
+  architecture.kind:
+    enum:
+      - dense_decoder
+      - moe_decoder
+      - hybrid_dense_moe
+      - multimodal_decoder
+      - token_classifier
+      - graph_reference
+      - unknown_tbd
+  loader.formats:
+    list_enum:
+      - gguf
+      - safetensors
+      - onnx
+      - openvino_ir
+      - tokenizer_json
+      - remote_code_tbd
+  receipts.required_fields:
+    list:
+      - model_id
+      - variant_id
+      - model_hash_or_tbd
+      - tokenizer_source
+      - prompt_template
+      - requested_backend
+      - selected_backend
+      - fallback_used
+      - task
+      - generated_tokens_or_labeled_tokens
+      - full_inference_claim
+      - speedup_claim

--- a/docs/models/schemas/model-receipt.schema.yaml
+++ b/docs/models/schemas/model-receipt.schema.yaml
@@ -1,0 +1,18 @@
+schema: 1
+required:
+  - schema
+  - claim
+  - model_family
+  - variant
+  - task
+  - runtime
+  - coverage
+fields:
+  schema: {const: 1}
+  claim: {type: string}
+  model_family: {type: string}
+  variant: {type: string}
+  task:
+    enum: [text_generation, token_classification, multimodal_text_only, moe_router_smoke, external_reference, design_only]
+  runtime.required: [requested_backend, selected_backend, fallback_used]
+  coverage.required: [full_inference_claim, speedup_claim]

--- a/docs/models/schemas/model-variant.schema.yaml
+++ b/docs/models/schemas/model-variant.schema.yaml
@@ -1,0 +1,14 @@
+schema: 1
+required: [family_id, variant_id, params, active_params, context, modalities, local_test_tier, status]
+fields:
+  family_id: {type: string}
+  variant_id: {type: string}
+  params: {type: string}
+  active_params: {type: string, nullable: true}
+  context: {type: string}
+  modalities: {type: list_string}
+  first_repo_target: {type: string}
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]
+  status:
+    enum: [not_present, documented, design_scaffold, catalog_scaffold, tokenizer_scaffold, prompt_template_scaffold, loader_scaffold, synthetic_shape_tested, runtime_detected, one_token_smoke_tested, parity_tested, receipt_backed, benchmarked, design_only]

--- a/docs/models/schemas/prompt-template.schema.yaml
+++ b/docs/models/schemas/prompt-template.schema.yaml
@@ -1,0 +1,12 @@
+schema: 1
+required: [id, family_id, roles, thinking_controls, tool_calling, non_claims]
+fields:
+  id: {type: string}
+  family_id: {type: string}
+  roles: {type: list_string}
+  thinking_controls: {type: list_string}
+  reasoning_effort: {type: list_string, optional: true}
+  developer_role_supported: {type: boolean}
+  tool_calling: {type: boolean}
+  multimodal_placeholders: {type: list_string}
+  non_claims: {type: list_string}

--- a/docs/models/schemas/tokenizer-policy.schema.yaml
+++ b/docs/models/schemas/tokenizer-policy.schema.yaml
@@ -1,0 +1,10 @@
+schema: 1
+required: [family_id, tokenizer_source, vocab_size_or_tbd, fallback_allowed, receipt_fields]
+fields:
+  family_id: {type: string}
+  tokenizer_source:
+    enum: [explicit, model, sibling, unknown]
+  vocab_size_or_tbd: {type: string}
+  fallback_allowed: {type: boolean}
+  receipt_fields:
+    list: [tokenizer_source, tokenizer_hash_or_tbd, fallback_used]

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -178,3 +178,7 @@ HW-002 remains proposed. #3625 added `ci/hardware/README.md` with artifact namin
 
 | Item/PR | Superseded by | Reason |
 |---|---|---|
+
+## Related model-family planning tracker
+
+Non-BitNet model-family documentation, schemas, and receipt rails are tracked separately in `docs/tracking/model-family-foundation/status.md`; this BitNet alignment tracker remains the source of truth for backend and hardware proof status.

--- a/docs/tracking/model-family-foundation/hardware-fit.yaml
+++ b/docs/tracking/model-family-foundation/hardware-fit.yaml
@@ -1,0 +1,19 @@
+schema: 1
+updated: 2026-05-07
+local_hardware_profile:
+  largest_local_gpu: 5070 Ti-class
+  vram_gb: 16
+tiers:
+  tier_a_local:
+    meaning: Reasonable to smoke locally with small/quantized models or CPU/GPU offload.
+    families: [gemma4_e2b_e4b_text_only, qwen35_0_8b_2b_4b_9b, openai_privacy_filter]
+  tier_b_partial:
+    meaning: May run with quantization, CPU/RAM offload, reduced context, or single-token proof only.
+    families: [qwen36_27b, qwen35_27b_35b_a3b, gemma4_31b_26b_a4b, mistral_medium_35_external_or_offload]
+  tier_c_design_only:
+    meaning: Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands.
+    families: [kimi_k26, glm51, deepseek_v4, mistral_medium_35_full]
+hard_rules:
+  - Tier membership is not a runtime claim.
+  - Design-only documentation must not become a local execution claim.
+  - Memory estimates are not benchmarks.

--- a/docs/tracking/model-family-foundation/implementation-lanes.yaml
+++ b/docs/tracking/model-family-foundation/implementation-lanes.yaml
@@ -1,0 +1,24 @@
+schema: 1
+updated: 2026-05-07
+lanes:
+  dense_decoder:
+    doc: docs/models/implementation/dense-decoder-lane.md
+    claim_boundary: Non-BitNet dense decoders must not use BitNet QK256 proof.
+  moe_decoder:
+    doc: docs/models/implementation/moe-decoder-lane.md
+    claim_boundary: MoE requires router/expert receipts.
+  multimodal:
+    doc: docs/models/implementation/multimodal-lane.md
+    claim_boundary: Text-only proof is not multimodal proof.
+  token_classification:
+    doc: docs/models/implementation/token-classification-lane.md
+    claim_boundary: Token classification is not generation.
+  openvino_graph:
+    doc: docs/models/implementation/openvino-graph-lane.md
+    claim_boundary: Reference graph proof is not native kernel proof.
+  gguf_dense_quant:
+    doc: docs/models/implementation/gguf-dense-quant-lane.md
+    claim_boundary: GGUF proof is per artifact.
+  safetensors_loader:
+    doc: docs/models/implementation/safetensors-loader-lane.md
+    claim_boundary: Loader scaffold is not inference.

--- a/docs/tracking/model-family-foundation/model-status.yaml
+++ b/docs/tracking/model-family-foundation/model-status.yaml
@@ -1,0 +1,129 @@
+schema: 1
+project: bitnet-rs-model-family-foundation
+updated: 2026-05-07
+status_values:
+  - not_present
+  - documented
+  - design_scaffold
+  - catalog_scaffold
+  - tokenizer_scaffold
+  - prompt_template_scaffold
+  - loader_scaffold
+  - synthetic_shape_tested
+  - runtime_detected
+  - one_token_smoke_tested
+  - parity_tested
+  - receipt_backed
+  - benchmarked
+  - design_only
+claim_boundaries:
+  documented:
+    may_claim:
+      - "The repo contains source-backed implementation notes."
+    must_not_claim:
+      - "The model loads or runs."
+  design_scaffold:
+    may_claim:
+      - "The architecture plan is recorded."
+    must_not_claim:
+      - "The implementation compiles, loads, or runs."
+  loader_scaffold:
+    may_claim:
+      - "The intended loader/tensor mapping exists."
+    must_not_claim:
+      - "Inference works."
+  one_token_smoke_tested:
+    may_claim:
+      - "One strict deterministic generation/classification smoke ran."
+    must_not_claim:
+      - "Quality, speed, long context, or full feature support."
+  receipt_backed:
+    may_claim:
+      - "The named model/variant/backend/task is proven by receipt."
+    must_not_claim:
+      - "Other variants, backends, modalities, or quantizations work."
+families:
+  gemma4:
+    display_name: Gemma 4
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: gemma4-e2b-it-q4-text-only
+    local_test_tier: tier_a_local
+    architecture:
+      kind: multimodal_decoder
+      decoder: dense_for_e2b_e4b_31b
+      moe_variant: gemma4-26b-a4b
+      features: [per_layer_embeddings, sliding_window_attention, global_attention, shared_kv_cache, p_rope, thinking_mode, mtp_drafter_future]
+    implementation_lanes: [dense_decoder, moe_decoder_future, multimodal_future, gguf_dense_quant]
+  qwen36:
+    display_name: Qwen 3.6
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: qwen3.6-27b-text-only-gguf-design
+    local_test_tier: tier_b_partial
+    architecture:
+      kind: multimodal_decoder
+      features: [hybrid_thinking, tool_calling, developer_role, long_context, yarn_future, multimodal_projector_external]
+    implementation_lanes: [dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling]
+  qwen35:
+    display_name: Qwen 3.5
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: qwen3.5-0.8b-or-2b-text-only-gguf
+    local_test_tier: tier_a_local
+    small_model_priority: true
+    architecture:
+      kind: multimodal_decoder
+      features: [hybrid_thinking, thinking_disabled_by_default_for_small, tool_calling, long_context, multimodal_projector_external]
+    implementation_lanes: [dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future]
+  kimi_k26:
+    display_name: Kimi K2.6
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_tokenizer_loader_notes
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: moe_decoder
+      features: [hybrid_thinking, long_context, vision, extreme_model_size, dynamic_quant_reference]
+    implementation_lanes: [moe_decoder_design, prompt_template, gguf_dynamic_quant_design]
+  glm51:
+    display_name: GLM 5.1
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_template_and_moe_notes
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: moe_decoder
+      features: [thinking_enabled_by_default, long_context, tool_calling, huge_moe]
+    implementation_lanes: [moe_decoder_design, prompt_template, tool_calling, external_reference]
+  deepseek_v4:
+    display_name: DeepSeek V4
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_architecture_notes
+    local_test_tier: tier_c_design_only
+    variants: [deepseek-v4-flash, deepseek-v4-pro]
+    architecture:
+      kind: moe_decoder
+      features: [compressed_sparse_attention, heavily_compressed_attention, manifold_constrained_hyper_connections, million_token_context, fp4_fp8_mixed, huge_moe]
+    implementation_lanes: [moe_decoder_design, long_context_design, mixed_precision_design]
+  mistral_medium_35:
+    display_name: Mistral Medium 3.5
+    source_status: source_backed_partial
+    implementation_status: design_only
+    first_target: design_only_prompt_reasoning_effort_contract
+    local_test_tier: tier_c_design_only
+    architecture:
+      kind: dense_decoder
+      features: [reasoning_effort, multimodal_text_image, function_calling, long_context, eagle_drafter_future]
+    implementation_lanes: [dense_decoder_design, prompt_template, tool_calling, speculative_decoding_future]
+  openai_privacy_filter:
+    display_name: OpenAI privacy-filter
+    source_status: source_backed_partial
+    implementation_status: design_scaffold
+    first_target: token_classification_cpu_or_onnx_smoke
+    local_test_tier: tier_a_local
+    architecture:
+      kind: token_classifier
+      features: [bidirectional_encoder, banded_attention, sparse_moe, bioes_labels, viterbi_span_decoder, pii_detection]
+    implementation_lanes: [token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference]

--- a/docs/tracking/model-family-foundation/source-index.yaml
+++ b/docs/tracking/model-family-foundation/source-index.yaml
@@ -1,0 +1,39 @@
+schema: 1
+updated: 2026-05-07
+policy:
+  - Supplied notes are captured as source-backed planning facts for this foundation pass.
+  - Before runtime implementation, each fact must be re-verified against primary model cards or official documentation.
+  - Unknown or unverified fields must remain TBD.
+sources:
+  gemma4:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/gemma-4.md
+  qwen36:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/qwen-3.6.md
+  qwen35:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/qwen-3.5.md
+  kimi_k26:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/kimi-k2.6.md
+  glm51:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/glm-5.1.md
+  deepseek_v4:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/deepseek-v4.md
+  mistral_medium_35:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/mistral-medium-3.5.md
+  openai_privacy_filter:
+    fact_source: supplied_notes
+    verification_needed: true
+    doc: docs/models/families/openai-privacy-filter.md

--- a/docs/tracking/model-family-foundation/status.md
+++ b/docs/tracking/model-family-foundation/status.md
@@ -1,0 +1,19 @@
+# Model-family foundation status
+
+This tracker is separate from `docs/tracking/bitnet-alignment/` so model-family planning does not become mixed with CPU, GPU, NPU, or BitNet backend proof items.
+
+## Current state
+
+- MF-001 is ready: the documentation structure, schemas, status values, source index, and receipt templates are in place.
+- MF-002 is proposed: architecture glossary and implementation lanes define shared vocabulary and claim boundaries.
+- MF-003 is proposed: 5070 Ti-class hardware-fit tiers separate locally testable, partial/offload, and design-only targets.
+
+## First practical model-family targets
+
+1. Qwen3.5 0.8B or 2B text-only GGUF one-token proof.
+2. Gemma 4 E2B/E4B text-only quantized one-token proof.
+3. OpenAI privacy-filter token-classification CPU/ONNX smoke.
+
+## Design-only targets
+
+Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, and the full Mistral Medium 3.5 path are design-only on current local hardware until external or local receipts prove a narrower claim.

--- a/docs/tracking/model-family-foundation/workstream-ledger.yaml
+++ b/docs/tracking/model-family-foundation/workstream-ledger.yaml
@@ -1,0 +1,231 @@
+schema: 1
+project: bitnet-rs-model-family-foundation
+updated: 2026-05-07
+states: [proposed, ready, in_progress, pr_open, blocked, merged, superseded]
+item_schema:
+  required:
+    - id
+    - title
+    - state
+    - priority
+    - workstream
+    - depends_on
+    - scope.allowed_paths
+    - scope.forbidden_paths
+    - acceptance
+    - verification
+    - notes
+    - followups
+state_transition_rules:
+  - proposed -> ready only when scope, acceptance, and verification are clear.
+  - ready -> in_progress when a branch starts work.
+  - in_progress -> pr_open when a PR is opened.
+  - pr_open -> merged only after merge.
+  - A PR must not mark itself merged.
+workstreams:
+  model_foundation:
+    title: Model-family foundation
+    objective: Add source-backed docs, schemas, status values, and receipt templates without runtime code.
+  model_family_docs:
+    title: Model-family docs
+    objective: Record family-specific facts, implementation contracts, non-claims, and first proof targets.
+items:
+  - id: MF-001
+    title: Add model-family documentation structure
+    state: ready
+    priority: P0
+    workstream: model_foundation
+    depends_on: []
+    scope:
+      allowed_paths:
+        - docs/models/**
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+        - tests/**
+        - .github/**
+    acceptance:
+      - Adds model docs tree.
+      - Adds status values and claim boundaries.
+      - Adds schemas for model family, variant, prompt template, hardware fit, and receipts.
+      - Adds source-index.yaml for source-backed facts.
+      - Does not add runtime code.
+    verification:
+      - cargo fmt --all -- --check
+      - Parse YAML files.
+      - Parse JSON receipt templates.
+    notes:
+      - This pass is docs, schemas, tracker, and receipt templates only.
+    followups: []
+  - id: MF-002
+    title: Add architecture feature glossary
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths:
+        - docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
+        - docs/models/implementation/**
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Defines dense, MoE, multimodal, token-classification, long-context, and speculative-decoding features.
+      - Unknowns are marked TBD.
+      - No implementation claims are made.
+    verification:
+      - cargo fmt --all -- --check
+    notes:
+      - Shared terms prevent family docs from inventing unsupported implementation claims.
+    followups: []
+  - id: MF-003
+    title: Add local hardware fit policy for 5070Ti
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths:
+        - docs/models/MODEL_HARDWARE_FIT_5070TI.md
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Splits models into tier_a_local, tier_b_partial, and tier_c_design_only.
+      - Explicitly states that design-only docs are not local inference claims.
+      - Does not invent benchmarks.
+    verification:
+      - cargo fmt --all -- --check
+    notes:
+      - Hardware fit is planning metadata, not proof.
+    followups: []
+  - id: GEMMA4-DOC-001
+    title: Add Gemma 4 model-family foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths:
+        - docs/models/families/gemma-4.md
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Documents E2B, E4B, 31B, and 26B-A4B variants.
+      - Separates text-only, multimodal, MoE, and MTP claims.
+      - First target is E2B text-only Q4/quantized proof.
+      - Explicitly says generic Gemma support is not Gemma 4 support.
+    verification:
+      - cargo fmt --all -- --check
+    notes: []
+    followups: [GEMMA4-DOC-002, GEMMA4-DOC-003, GEMMA4-DOC-004, GEMMA4-DOC-005, GEMMA4-DOC-006]
+  - id: QWEN35-DOC-001
+    title: Add Qwen3.5 small-model-first foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths:
+        - docs/models/families/qwen-3.5.md
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Documents 0.8B, 2B, 4B, 9B as first local targets.
+      - Documents thinking disabled by default for small models.
+      - Separates 27B/35B/122B/397B as larger or design-gated targets.
+    verification:
+      - cargo fmt --all -- --check
+    notes: []
+    followups: [QWEN35-DOC-002, QWEN35-DOC-003, QWEN35-DOC-004, QWEN35-DOC-005, QWEN35-DOC-006]
+  - id: PRIVACY-DOC-001
+    title: Add OpenAI privacy-filter token-classification foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths:
+        - docs/models/families/openai-privacy-filter.md
+        - docs/models/implementation/token-classification-lane.md
+        - ci/model-receipts/_templates/token-classification-proof.json
+        - docs/tracking/model-family-foundation/**
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Documents token-classification pipeline separately from generation.
+      - Documents 33 BIOES labels and Viterbi span decoder.
+      - Adds receipt requirements for span classification.
+    verification:
+      - cargo fmt --all -- --check
+      - Parse JSON receipt template
+    notes: []
+    followups: [PRIVACY-DOC-002, PRIVACY-DOC-003, PRIVACY-DOC-004, PRIVACY-DOC-005]
+  - id: QWEN36-DOC-001
+    title: Add Qwen3.6 family doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/qwen-3.6.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance: [Documents 27B and 35B-A3B, Separates 27B text-only design from 35B-A3B MoE future gate]
+    verification: [cargo fmt --all -- --check]
+    notes: []
+    followups: [QWEN36-DOC-002, QWEN36-DOC-003, QWEN36-DOC-004, QWEN36-DOC-005]
+  - id: KIMI26-DOC-001
+    title: Add Kimi K2.6 design-only family doc
+    state: proposed
+    priority: P1
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/kimi-k2.6.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance: [Documents design-only status, Adds hardware infeasibility non-claims]
+    verification: [cargo fmt --all -- --check]
+    notes: []
+    followups: [KIMI26-DOC-002, KIMI26-DOC-003, KIMI26-DOC-004, KIMI26-DOC-005]
+  - id: GLM51-DOC-001
+    title: Add GLM-5.1 design-only family doc
+    state: proposed
+    priority: P1
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/glm-5.1.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance: [Documents design-only status, Adds future OpenVINO/llama.cpp reference receipt plan]
+    verification: [cargo fmt --all -- --check]
+    notes: []
+    followups: [GLM51-DOC-002, GLM51-DOC-003, GLM51-DOC-004]
+  - id: DSV4-DOC-001
+    title: Add DeepSeek V4 family doc
+    state: proposed
+    priority: P1
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/deepseek-v4.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance: [Documents Flash vs Pro variants, Adds FP4/FP8 and CSA/HCA future gates]
+    verification: [cargo fmt --all -- --check]
+    notes: []
+    followups: [DSV4-DOC-002, DSV4-DOC-003, DSV4-DOC-004, DSV4-DOC-005]
+  - id: MM35-DOC-001
+    title: Add Mistral Medium 3.5 design-only family doc
+    state: proposed
+    priority: P1
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope:
+      allowed_paths: [docs/models/families/mistral-medium-3.5.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance: [Documents dense 128B design-only path, Adds reasoning_effort and license caveats]
+    verification: [cargo fmt --all -- --check]
+    notes: []
+    followups: [MM35-DOC-002, MM35-DOC-003, MM35-DOC-004, MM35-DOC-005]


### PR DESCRIPTION
### Motivation

- Provide a source-backed documentation and planning layer for non-BitNet model families so future agents can implement loaders, prompts, kernels, receipts, and tests “on rails” without making accidental runtime claims.
- Mirror the repo’s existing backend tracker pattern so model-family claims advance only through explicit statuses and receipt-backed proofs rather than informal checklists.
- Make small/local targets, partial/offload targets, and design-only rails explicit for a 5070 Ti-class 16 GB GPU host so implementers know what can be proved locally versus what must remain design-only.
- Capture shared vocabulary (architecture features), schemas, and implementation lanes so family pages remain consistent and avoid inferring non-source-backed facts.

### Description

- Added a new docs area under `docs/models/` containing `README.md`, policy docs (`MODEL_*`), `ARCHITECTURE_FEATURE_GLOSSARY.md`, family pages for Gemma 4, Qwen 3.6, Qwen 3.5, Kimi K2.6, GLM-5.1, DeepSeek V4, Mistral Medium 3.5, and OpenAI privacy-filter, and implementation lane docs under `docs/models/implementation/`.
- Added machine-readable schemas under `docs/models/schemas/` (including `model-family.schema.yaml`, `model-variant.schema.yaml`, `model-receipt.schema.yaml`, `prompt-template.schema.yaml`, and tokenizer/hardware-fit schemas) and a model-family catalog `docs/tracking/model-family-foundation/model-status.yaml` expressing first targets, tiers, and claim boundaries.
- Introduced a separate model-family tracker under `docs/tracking/model-family-foundation/` with `workstream-ledger.yaml`, `status.md`, `source-index.yaml`, `implementation-lanes.yaml`, and `hardware-fit.yaml`, and added short cross-reference from the existing BitNet alignment tracker to keep proof lanes separate.
- Added standardized receipt templates under `ci/model-receipts/_templates/` for `generative-one-token-proof.json`, `generative-design-only.json`, `moe-router-smoke.json`, `multimodal-text-only-proof.json`, `token-classification-proof.json`, and `external-reference-proof.json` and defined lanes for `gguf`, `safetensors`, `onnx`, and `openvino_ir` flows.

### Testing

- Ran `cargo fmt --all -- --check`, which completed successfully.
- Parsed all new YAML schema and tracker files via a Python YAML loader and parsed all JSON receipt templates with `json.loads`, both of which succeeded without errors. 
- Ran `git diff --check` to surface whitespace/check issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1f02e3b083339674e40ca3e577ad)