### PR TITLE
Add model-family foundation docs, schemas, tracker, and receipt templates

### DIFF
--- a/ci/model-receipts/_templates/external-reference-proof.json
+++ b/ci/model-receipts/_templates/external-reference-proof.json
@@ -1,0 +1,24 @@
+{
+  "schema": 1,
+  "claim": "external_reference",
+  "model_family": "",
+  "variant": "",
+  "task": "external_reference",
+  "reference_tool": "",
+  "reference_command": "",
+  "artifact_hash_or_tbd": "TBD",
+  "local_execution_claim": false,
+  "repo_native_claim": false,
+  "runtime": {
+    "requested_backend": "external",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/ci/model-receipts/_templates/generative-design-only.json
+++ b/ci/model-receipts/_templates/generative-design-only.json
@@ -1,0 +1,11 @@
+{
+  "schema": 1,
+  "claim": "design_only",
+  "model_family": "",
+  "variant": "",
+  "local_execution_claim": false,
+  "loader_claim": false,
+  "inference_claim": false,
+  "speedup_claim": false,
+  "reason": "Model exceeds local hardware or implementation is not started."
+}

--- a/ci/model-receipts/_templates/generative-one-token-proof.json
+++ b/ci/model-receipts/_templates/generative-one-token-proof.json
@@ -1,0 +1,40 @@
+{
+  "schema": 1,
+  "claim": "strict_model_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "text_generation",
+  "model_source": {
+    "repo": "",
+    "file": "",
+    "format": "gguf|safetensors|openvino_ir|onnx",
+    "hash": "TBD"
+  },
+  "tokenizer": {
+    "source": "explicit|model|sibling|unknown",
+    "fallback_used": false
+  },
+  "prompt_template": {
+    "id": "",
+    "thinking_enabled": false,
+    "developer_role_used": false,
+    "tool_calling_used": false
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "prompt_tokens": 0,
+    "generated_tokens": 0,
+    "greedy": true
+  }
+}

--- a/ci/model-receipts/_templates/moe-router-smoke.json
+++ b/ci/model-receipts/_templates/moe-router-smoke.json
@@ -1,0 +1,25 @@
+{
+  "schema": 1,
+  "claim": "moe_router_smoke",
+  "model_family": "",
+  "variant": "",
+  "task": "moe_router_smoke",
+  "router_logits_shape": [],
+  "top_k": 0,
+  "active_parameters": "TBD",
+  "total_parameters": "TBD",
+  "shared_expert_used": "TBD",
+  "expert_coverage": [],
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": true,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/ci/model-receipts/_templates/multimodal-text-only-proof.json
+++ b/ci/model-receipts/_templates/multimodal-text-only-proof.json
@@ -1,0 +1,28 @@
+{
+  "schema": 1,
+  "claim": "multimodal_family_text_only_one_token",
+  "model_family": "",
+  "variant": "",
+  "task": "multimodal_text_only",
+  "inputs": {
+    "text_tokens": 0,
+    "image_inputs": 0,
+    "audio_inputs": 0,
+    "video_frames": 0
+  },
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  },
+  "output": {
+    "generated_tokens": 1
+  }
+}

--- a/ci/model-receipts/_templates/token-classification-proof.json
+++ b/ci/model-receipts/_templates/token-classification-proof.json
@@ -1,0 +1,31 @@
+{
+  "schema": 1,
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "variant": "",
+  "task": "token_classification",
+  "input_tokens": 12,
+  "output_shape": [
+    12,
+    33
+  ],
+  "span_decoder": "bioes_viterbi",
+  "labels": [
+    "private_person",
+    "private_email",
+    "private_phone"
+  ],
+  "generation_claim": false,
+  "runtime": {
+    "requested_backend": "",
+    "selected_backend": "",
+    "fallback_used": false
+  },
+  "coverage": {
+    "full_inference_claim": false,
+    "multimodal_claim": false,
+    "moe_claim": false,
+    "long_context_claim": false,
+    "speedup_claim": false
+  }
+}

--- a/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
+++ b/docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md
@@ -1,0 +1,39 @@
+# Architecture Feature Glossary
+
+Terms in family docs should refer back here. Anything not source-backed must be marked `TBD`, not inferred.
+
+| Term | Definition |
+|---|---|
+| `dense_decoder` | Autoregressive decoder with dense feed-forward blocks. |
+| `moe_decoder` | Autoregressive decoder with routed mixture-of-experts feed-forward blocks. |
+| `effective_parameters` | Parameter count represented by a model artifact or quantized form. |
+| `active_parameters` | Parameters used per token in sparse/MoE execution. |
+| `hybrid_thinking` | Family exposes thinking and non-thinking behavior. |
+| `thinking_mode` | Prompt/template mode that requests explicit hidden/reasoning-style output when supported. |
+| `reasoning_effort` | Request-level control over reasoning budget or style. |
+| `developer_role` | Chat role distinct from system/user/assistant for agentic instruction layering. |
+| `tool_calling` | Template/API support for tool or function calls. |
+| `structured_outputs` | Output constrained to JSON/schema-like formats. |
+| `multimodal_text_image` | Text and image input, generally text output unless otherwise receipt-backed. |
+| `multimodal_audio` | Audio input support; requires separate encoder/receipt proof. |
+| `video_as_frames` | Video handled through sampled image frames; TBD unless source-backed. |
+| `vision_encoder` | Visual feature encoder or projector path. |
+| `audio_encoder` | Audio feature encoder path. |
+| `per_layer_embeddings` | PLE; layer-specific embedding behavior noted by the model family. |
+| `shared_kv_cache` | Global layers share or unify K/V cache behavior. |
+| `sliding_window_attention` | Local-window attention over a bounded neighborhood. |
+| `global_attention` | Attention layers that can see broader/global context. |
+| `p_rope` | p-RoPE positional encoding variant. |
+| `yarn` | YaRN context extension; runtime support is future-gated unless receipted. |
+| `long_context` | Context beyond normal small smoke lengths; not a runtime claim by itself. |
+| `compressed_sparse_attention` | CSA architecture note; implementation details TBD until source and parity backed. |
+| `heavily_compressed_attention` | HCA architecture note; implementation details TBD until source and parity backed. |
+| `mamba_or_hybrid_state_space_tbd` | Placeholder for state-space/hybrid blocks; must remain TBD until source-backed. |
+| `mtp_drafter` | Multi-token prediction draft model for speculative decoding. |
+| `eagle_drafter` | EAGLE draft model for speculative decoding. |
+| `gguf_dynamic_quant` | Dynamic GGUF quantization reference; not a kernel or quality claim. |
+| `mxfp4` | MXFP4 precision format; kernel support TBD unless receipted. |
+| `fp4_fp8_mixed` | Mixed FP4/FP8 precision; kernel support TBD unless receipted. |
+| `token_classification` | Per-token labeling task, not generation. |
+| `bioes_labels` | Begin/Inside/Outside/End/Singleton span tag taxonomy. |
+| `viterbi_span_decoder` | Constrained decoding over token labels to coherent spans. |

--- a/docs/models/DESIGN_ONLY_POLICY.md
+++ b/docs/models/DESIGN_ONLY_POLICY.md
@@ -1,0 +1,3 @@
+# Design-Only Policy
+
+`design_only` is an explicit positive status for models that are too large for local proof or whose implementation has not started. It permits architecture, prompt, tokenizer, loader, receipt, and external-reference planning while forbidding loader, inference, speed, quality, and local execution claims.

--- a/docs/models/LONG_CONTEXT_POLICY.md
+++ b/docs/models/LONG_CONTEXT_POLICY.md
@@ -1,0 +1,3 @@
+# Long Context Policy
+
+A source-backed context length is a model capability note, not a bitnet-rs runtime claim. Long-context support requires receipts that record requested context, actual context, memory mode, fallback status, and whether YaRN, sliding window, global attention, or other mechanisms were used.

--- a/docs/models/MODEL_HARDWARE_FIT_5070TI.md
+++ b/docs/models/MODEL_HARDWARE_FIT_5070TI.md
@@ -1,0 +1,11 @@
+# Model Hardware Fit for 5070 Ti-Class 16 GB GPU
+
+The current largest local device class is treated as a 5070 Ti-class 16 GB GPU. This policy prevents large-model documentation from becoming local execution claims.
+
+| Local tier | Expected proof shape | Families |
+|---|---|---|
+| `tier_a_local` | Small/quantized local smoke or CPU/GPU offload. | Qwen3.5 0.8B/2B/4B/9B; Gemma 4 E2B/E4B text-only; OpenAI privacy-filter. |
+| `tier_b_partial` | Reduced-context, offload, quantized, or one-token proof only. | Qwen3.6 27B; Qwen3.5 27B/35B-A3B; Gemma 4 31B/26B-A4B quantized; Mistral Medium 3.5 external/offload reference only. |
+| `tier_c_design_only` | Documentation, prompt/tokenizer/loader notes, and external-reference receipt shapes only. | Kimi K2.6; GLM-5.1; DeepSeek V4; Mistral Medium 3.5 full path. |
+
+No document in this tree claims full local inference, full context, performance, or quality on this GPU unless a named receipt backs that exact claim.

--- a/docs/models/MODEL_IMPLEMENTATION_TIERS.md
+++ b/docs/models/MODEL_IMPLEMENTATION_TIERS.md
@@ -1,0 +1,9 @@
+# Model Implementation Tiers
+
+| Tier | Meaning | Families |
+|---|---|---|
+| **Tier A: locally testable soon** | Reasonable to smoke locally with small/quantized models or CPU/GPU offload. | Gemma 4 E2B/E4B text-only; Qwen3.5 0.8B/2B/4B/9B; OpenAI privacy-filter. |
+| **Tier B: partial/offload possible** | May run with quantization, CPU/RAM offload, reduced context, or single-token proof only. | Qwen3.6 27B; Qwen3.5 27B/35B-A3B; Gemma 4 26B-A4B/31B quantized; Mistral Medium 3.5 only if external/offload reference exists. |
+| **Tier C: design-only locally** | Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands. | Kimi K2.6; GLM-5.1; DeepSeek V4 Flash/Pro; Mistral Medium 3.5 128B full path. |
+
+Design-only is a positive state for safe planning, not a failed implementation.

--- a/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
+++ b/docs/models/MODEL_RECEIPT_REQUIREMENTS.md
@@ -1,0 +1,5 @@
+# Model Receipt Requirements
+
+Every model receipt must record model family, variant, model hash or `TBD`, tokenizer source, prompt template, requested backend, selected backend, fallback status, task, output evidence, full-inference claim flag, speedup claim flag, and feature coverage flags.
+
+Receipts must be narrow. A text-only one-token receipt does not prove multimodal input, MoE routing, long context, quality, speed, other variants, or other quantizations.

--- a/docs/models/MODEL_STATUS_VALUES.md
+++ b/docs/models/MODEL_STATUS_VALUES.md
@@ -1,0 +1,28 @@
+# Model Status Values
+
+Model-family claims advance only through named statuses. Each status is narrow and must not be upgraded by implication from docs, hardware visibility, generic architecture detection, or fallback execution.
+
+| Status | Meaning |
+|---|---|
+| `not_present` | No tracked model-family plan exists. |
+| `documented` | Source-backed notes exist, but no implementation is claimed. |
+| `design_scaffold` | Architecture and lane plans exist, but no runtime behavior is claimed. |
+| `catalog_scaffold` | Catalog metadata can be drafted, but loading is not claimed. |
+| `tokenizer_scaffold` | Tokenizer policy or intended source is recorded, not proven. |
+| `prompt_template_scaffold` | Prompt/template contract is recorded, not proven. |
+| `loader_scaffold` | Intended format/tensor mapping exists, but inference is not claimed. |
+| `synthetic_shape_tested` | Synthetic shape checks ran without model-quality or real-weight claims. |
+| `runtime_detected` | Runtime/backend surfaced, but execution is not a model claim. |
+| `one_token_smoke_tested` | One strict deterministic generation/classification smoke ran. |
+| `parity_tested` | A named reference comparison passed for a narrow variant/task/backend. |
+| `receipt_backed` | The named model/variant/backend/task claim has a receipt. |
+| `benchmarked` | A receipt-backed benchmark exists; no broader capability is implied. |
+| `design_only` | Positive planning state for targets too large or unimplemented locally. |
+
+## Claim boundaries
+
+- `documented` may claim that repo notes exist; it must not claim the model loads or runs.
+- `design_scaffold` may claim the architecture plan is recorded; it must not claim implementation compiles, loads, or runs.
+- `loader_scaffold` may claim intended loader/tensor mapping exists; it must not claim inference works.
+- `one_token_smoke_tested` may claim one deterministic smoke ran; it must not claim quality, speed, long context, or full feature support.
+- `receipt_backed` may claim only the named model/variant/backend/task proven by receipt; it must not claim other variants, backends, modalities, or quantizations.

--- a/docs/models/MODEL_SUPPORT_POLICY.md
+++ b/docs/models/MODEL_SUPPORT_POLICY.md
@@ -1,0 +1,5 @@
+# Model Support Policy
+
+Model support is a receipt-backed, variant-specific claim. A family doc is not support. Generic architecture detection is not family support. Backend visibility is not model execution.
+
+Support statements must name model family, variant, format, tokenizer source, prompt template, backend, task, fallback status, and receipt path. Non-BitNet dense and MoE models must not use BitNet QK256 or W1.58 kernel proof as evidence.

--- a/docs/models/MOE_SUPPORT_POLICY.md
+++ b/docs/models/MOE_SUPPORT_POLICY.md
@@ -1,0 +1,5 @@
+# MoE Support Policy
+
+MoE support requires router logits, top-k expert selection, expert weight loading, shared expert handling where present, active/total parameter receipts, and per-token expert coverage metrics.
+
+Dense decoder proof cannot be reused as MoE proof. A family with both dense and MoE variants must keep those claims separate.

--- a/docs/models/MULTIMODAL_SUPPORT_POLICY.md
+++ b/docs/models/MULTIMODAL_SUPPORT_POLICY.md
@@ -1,0 +1,5 @@
+# Multimodal Support Policy
+
+Text-only proof is not multimodal proof. Image, audio, video-as-frames, projector, vision encoder, and audio encoder paths require separate loader contracts and receipts.
+
+A multimodal family may begin with a text-only first target only when receipts set `multimodal_claim=false` and family docs list multimodal support as future-gated.

--- a/docs/models/README.md
+++ b/docs/models/README.md
@@ -1,0 +1,19 @@
+# Model Family Foundation
+
+This directory is a documentation and planning control plane for future non-BitNet model-family support. It records architecture facts, prompt/tokenizer contracts, local hardware fit, implementation lanes, receipt requirements, and explicit non-claims before runtime code exists.
+
+The model-family lane is intentionally separate from the BitNet/hardware alignment tracker. Hardware tracker receipts prove devices and BitNet kernels; this area proves named model family, variant, backend, task, tokenizer, prompt template, fallback status, and receipt coverage.
+
+## First practical targets
+
+- Qwen3.5 small models as regular dense local LLM targets.
+- Gemma 4 E2B/E4B text-only as newer hybrid/multimodal decoder targets with multimodal future-gated.
+- OpenAI privacy-filter as a non-generative token-classification target.
+
+## Design-only targets
+
+Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, and the full Mistral Medium 3.5 path are design-only locally until external/offload receipts or future hardware prove narrower claims.
+
+## Claim rule
+
+Docs do not mean loaders exist; loaders do not mean inference works; one-token proof does not mean multimodal, long-context, MoE, quality, speed, or broad variant support.

--- a/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
+++ b/docs/models/TOKENIZER_AND_PROMPT_TEMPLATE_POLICY.md
@@ -1,0 +1,5 @@
+# Tokenizer and Prompt Template Policy
+
+Tokenizer and prompt templates are part of the model claim. A loader cannot silently choose a fallback tokenizer or generic chat template and claim family support.
+
+Receipts must record tokenizer source, prompt-template id, thinking-mode flag, developer-role usage, tool-calling usage, and fallback status. Thinking and non-thinking modes require separate template settings where model cards distinguish them.

--- a/docs/models/families/deepseek-v4.md
+++ b/docs/models/families/deepseek-v4.md
@@ -1,0 +1,61 @@
+# DeepSeek V4
+
+## Status
+- Repo status: design_only
+- First target: design_only_architecture_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: prompt_template, external_reference, design lane
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: Flash 284B total / 13B active; Pro 1.6T total / 49B active; Base and instruct variants.
+- Context: 1M.
+- Modalities: Text; other modalities TBD.
+- Tokenizer/prompt: Prompt template TBD from model cards before implementation.
+- Architecture features: compressed_sparse_attention, heavily_compressed_attention, manifold_constrained_hyper_connections, million_token_context, fp4_fp8_mixed, huge_moe.
+- Quantization/runtime notes: Base uses FP8 mixed; instruct versions use FP4 + FP8 mixed, with MoE experts in FP4 and most other params in FP8 according to supplied notes.
+- License: TBD from model card.
+- Known tool support: External/offload/reference only until receipt-backed.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| V4 Flash Base/Instruct | 284B | 13B | 1M | text | design-only notes | tier_c_design_only |
+| V4 Pro Base/Instruct | 1.6T | 49B | 1M | text | design-only notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only loader notes. No local loader, inference, or speed claim is allowed.
+
+### Tokenizer
+Record tokenizer source and template source before any support claim.
+
+### Prompt template
+Record family-specific prompt controls and disable unsupported fallbacks.
+
+### Architecture module
+Architecture notes only; implementation details remain TBD until source-backed and parity-tested.
+
+### Kernels/backend
+No local kernel claim. Non-BitNet QK256/BitNet evidence is invalid.
+
+### Receipts
+Use `generative-design-only.json` or `external-reference-proof.json` until narrow execution receipts exist.
+
+### Tests
+YAML/JSON parse only now; future external reference command receipts.
+
+## Explicit non-claims
+- DeepSeek V4 is design-only on current hardware.
+- Any future local artifact is offload/reference unless receipt-backed.
+- No speed, quality, long-context, or full-inference claim is allowed from docs.
+
+## First proof target
+Design-only receipt with local execution, loader, inference, and speedup claims all false.
+
+## Work items
+- DSV4-DOC-001: Add DeepSeek V4 family doc.
+- DSV4-DOC-002: Add prompt/template and architecture notes.
+- DSV4-DOC-003: Add hardware infeasibility/local non-claim section.
+- DSV4-DOC-004: Add external-reference receipt plan.

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,66 @@
+# Gemma 4
+
+## Status
+- Repo status: design_scaffold
+- First target: gemma4-e2b-it-q4-text-only
+- Local test tier: tier_a_local
+- Implementation owner lane: dense_decoder, gguf_dense_quant, moe_decoder_future, multimodal_future
+- Design-only? no for E2B/E4B text-only planning; yes for unproven multimodal/MoE/MTP claims
+
+## Source-backed facts
+- Model variants: E2B, E4B, 31B dense, 26B A4B MoE.
+- Context: E2B/E4B 128K; 31B/26B-A4B 256K.
+- Modalities: E2B/E4B text/image/audio; 31B/26B-A4B text/image.
+- Tokenizer/prompt: Vocabulary 262K; thinking mode uses `<|think|>` and thought-channel delimiters.
+- Architecture features: PLE on small models; hybrid local/global attention; final layer global; global layers use unified K/V and p-RoPE; 26B A4B has 8 active / 128 total experts plus shared expert; all models have MTP draft models in supplied overview.
+- Quantization/runtime notes: Q4 estimates: E2B ~3.2 GB, E4B ~5 GB, 31B ~17.4 GB, 26B-A4B ~15.6 GB, excluding KV/software overhead.
+- License: TBD from model card before support claims.
+- Known tool support: Generic `ModelArchitecture::Gemma` detector and Gemma-family defaults exist, but they are not Gemma 4 support; Gemma 2 catalog entries must remain separate.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| E2B | 2B effective | N/A | 128K | text/image/audio | text-only Q4 smoke | tier_a_local |
+| E4B | 4B effective | N/A | 128K | text/image/audio | text-only Q4 smoke | tier_a_local |
+| 31B dense | 31B | N/A | 256K | text/image | quantized/offload design | tier_b_partial |
+| 26B-A4B | 26B | 4B active / 8 experts active | 256K | text/image | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Start with text-only GGUF dense quant for E2B/E4B. MoE, multimodal, and MTP artifacts require separate loader contracts.
+
+### Tokenizer
+Use explicit Gemma 4 tokenizer source; no fallback tokenizer can support a claim.
+
+### Prompt template
+Record `<|think|>` and thought-channel delimiter behavior. Text-only smoke should set thinking according to receipt.
+
+### Architecture module
+Plan multimodal decoder with dense E2B/E4B/31B path and future 26B-A4B MoE gate.
+
+### Kernels/backend
+Non-BitNet dense path; no QK256 or BitNet W1.58 proof may count.
+
+### Receipts
+First receipt must set multimodal, MoE, long-context, MTP, speedup, and full-inference claims false.
+
+### Tests
+Future: tokenizer/template parse, one-token deterministic text smoke, then parity.
+
+## Explicit non-claims
+- Gemma 4 documented does not mean Gemma 4 loads.
+- E2B/E4B text-only proof does not mean image/audio works.
+- MTP draft support is future-gated.
+- 26B-A4B MoE support is future-gated.
+
+## First proof target
+`generative-one-token-proof.json` with `model_family=gemma4`, `variant=gemma4-e2b-it-q4`, `task=text_generation`, `generated_tokens=1`, and feature claims false.
+
+## Work items
+- GEMMA4-DOC-001: Add Gemma 4 family doc and variant table.
+- GEMMA4-DOC-002: Add Gemma 4 prompt/template contract.
+- GEMMA4-DOC-003: Add Gemma 4 text-only E2B proof plan.
+- GEMMA4-DOC-004: Add PLE/shared-KV/sliding-global attention implementation notes.
+- GEMMA4-DOC-005: Add MoE 26B-A4B future gate.
+- GEMMA4-DOC-006: Add multimodal future gate.

--- a/docs/models/families/glm-5.1.md
+++ b/docs/models/families/glm-5.1.md
@@ -1,0 +1,60 @@
+# GLM-5.1
+
+## Status
+- Repo status: design_only
+- First target: design_only_prompt_template_and_moe_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: prompt_template, external_reference, design lane
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: Full model is 744B parameters with 40B active.
+- Context: 200K.
+- Modalities: Text/tools; other modalities TBD.
+- Tokenizer/prompt: Thinking enabled by default; disable with chat-template kwargs; GLM-5.1 uses same architecture as GLM-5 with `chat_template.jinja` changes for tool exposure, reasoning-history reconstruction, and tool-message rendering.
+- Architecture features: thinking_enabled_by_default, long_context, tool_calling, huge_moe.
+- Quantization/runtime notes: Full disk ~1.65 TB; dynamic 2-bit ~220 GB; dynamic 1-bit ~200 GB; `UD-IQ2_M` ~236 GB.
+- License: TBD from model card.
+- Known tool support: External/offload/reference only until receipt-backed.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| GLM-5.1 | 744B | 40B | 200K | text/tools | design-only notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only loader notes. No local loader, inference, or speed claim is allowed.
+
+### Tokenizer
+Record tokenizer source and template source before any support claim.
+
+### Prompt template
+Record family-specific prompt controls and disable unsupported fallbacks.
+
+### Architecture module
+Architecture notes only; implementation details remain TBD until source-backed and parity-tested.
+
+### Kernels/backend
+No local kernel claim. Non-BitNet QK256/BitNet evidence is invalid.
+
+### Receipts
+Use `generative-design-only.json` or `external-reference-proof.json` until narrow execution receipts exist.
+
+### Tests
+YAML/JSON parse only now; future external reference command receipts.
+
+## Explicit non-claims
+- GLM-5.1 is design-only on current hardware.
+- Any future local artifact is offload/reference unless receipt-backed.
+- No speed, quality, long-context, or full-inference claim is allowed from docs.
+
+## First proof target
+Design-only receipt with local execution, loader, inference, and speedup claims all false.
+
+## Work items
+- GLM51-DOC-001: Add GLM-5.1 family doc.
+- GLM51-DOC-002: Add prompt/template and architecture notes.
+- GLM51-DOC-003: Add hardware infeasibility/local non-claim section.
+- GLM51-DOC-004: Add external-reference receipt plan.

--- a/docs/models/families/kimi-k2.6.md
+++ b/docs/models/families/kimi-k2.6.md
@@ -1,0 +1,60 @@
+# Kimi K2.6
+
+## Status
+- Repo status: design_only
+- First target: design_only_prompt_tokenizer_loader_notes
+- Local test tier: tier_c_design_only
+- Implementation owner lane: prompt_template, external_reference, design lane
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: Kimi K2.6 is a 1T-parameter hybrid-thinking model.
+- Context: 256K.
+- Modalities: Vision support in Unsloth GGUF notes.
+- Tokenizer/prompt: Kimi-specific chat template uses `<|im_system|>`, `<|im_user|>`, `<|im_assistant|>`, and `<think>`.
+- Architecture features: hybrid_thinking, long_context, vision, extreme_model_size, dynamic_quant_reference.
+- Quantization/runtime notes: Full precision ~610 GB; dynamic 2-bit ~340-350 GB; Q4 ~584 GB; Q8 ~595 GB.
+- License: TBD from model card.
+- Known tool support: External/offload/reference only until receipt-backed.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| K2.6 | 1T | TBD | 256K | text/vision | design-only notes | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only loader notes. No local loader, inference, or speed claim is allowed.
+
+### Tokenizer
+Record tokenizer source and template source before any support claim.
+
+### Prompt template
+Record family-specific prompt controls and disable unsupported fallbacks.
+
+### Architecture module
+Architecture notes only; implementation details remain TBD until source-backed and parity-tested.
+
+### Kernels/backend
+No local kernel claim. Non-BitNet QK256/BitNet evidence is invalid.
+
+### Receipts
+Use `generative-design-only.json` or `external-reference-proof.json` until narrow execution receipts exist.
+
+### Tests
+YAML/JSON parse only now; future external reference command receipts.
+
+## Explicit non-claims
+- Kimi K2.6 is design-only on current hardware.
+- Any future local artifact is offload/reference unless receipt-backed.
+- No speed, quality, long-context, or full-inference claim is allowed from docs.
+
+## First proof target
+Design-only receipt with local execution, loader, inference, and speedup claims all false.
+
+## Work items
+- KIMI26-DOC-001: Add Kimi K2.6 family doc.
+- KIMI26-DOC-002: Add prompt/template and architecture notes.
+- KIMI26-DOC-003: Add hardware infeasibility/local non-claim section.
+- KIMI26-DOC-004: Add external-reference receipt plan.

--- a/docs/models/families/mistral-medium-3.5.md
+++ b/docs/models/families/mistral-medium-3.5.md
@@ -1,0 +1,60 @@
+# Mistral Medium 3.5
+
+## Status
+- Repo status: design_only
+- First target: design_only_prompt_reasoning_effort_contract
+- Local test tier: tier_c_design_only
+- Implementation owner lane: prompt_template, external_reference, design lane
+- Design-only? yes
+
+## Source-backed facts
+- Model variants: Dense 128B.
+- Context: 256K.
+- Modalities: Multimodal text + image input, text output.
+- Tokenizer/prompt: Reasoning effort configurable per request: `none` or `high`; function calls / JSON / agentic use.
+- Architecture features: reasoning_effort, multimodal_text_image, function_calling, long_context, eagle_drafter_future.
+- Quantization/runtime notes: vLLM recommended with tensor parallelism; local full path is beyond current hardware; EAGLE draft model exists.
+- License: TBD from model card; Mistral Medium 3.5 notes say Modified MIT, not plain MIT.
+- Known tool support: External/offload/reference only until receipt-backed.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| Medium 3.5 | 128B | N/A | 256K | text+image input, text output | external/design-only | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Design-only loader notes. No local loader, inference, or speed claim is allowed.
+
+### Tokenizer
+Record tokenizer source and template source before any support claim.
+
+### Prompt template
+Record family-specific prompt controls and disable unsupported fallbacks.
+
+### Architecture module
+Architecture notes only; implementation details remain TBD until source-backed and parity-tested.
+
+### Kernels/backend
+No local kernel claim. Non-BitNet QK256/BitNet evidence is invalid.
+
+### Receipts
+Use `generative-design-only.json` or `external-reference-proof.json` until narrow execution receipts exist.
+
+### Tests
+YAML/JSON parse only now; future external reference command receipts.
+
+## Explicit non-claims
+- Mistral Medium 3.5 is design-only on current hardware.
+- Any future local artifact is offload/reference unless receipt-backed.
+- No speed, quality, long-context, or full-inference claim is allowed from docs.
+
+## First proof target
+Design-only receipt with local execution, loader, inference, and speedup claims all false.
+
+## Work items
+- MM35-DOC-001: Add Mistral Medium 3.5 family doc.
+- MM35-DOC-002: Add prompt/template and architecture notes.
+- MM35-DOC-003: Add hardware infeasibility/local non-claim section.
+- MM35-DOC-004: Add external-reference receipt plan.

--- a/docs/models/families/openai-privacy-filter.md
+++ b/docs/models/families/openai-privacy-filter.md
@@ -1,0 +1,74 @@
+# OpenAI Privacy Filter
+
+## Status
+- Repo status: design_scaffold
+- First target: token_classification_cpu_or_onnx_smoke
+- Local test tier: tier_a_local
+- Implementation owner lane: token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference
+- Design-only? no for token-classification smoke planning
+
+## Source-backed facts
+- Model variants: Bidirectional token-classification model for PII detection/masking.
+- Context: 128K.
+- Modalities: Text token classification.
+- Tokenizer/prompt: Not an autoregressive decoder and must not be forced into `generate()`.
+- Architecture features: pre-norm encoder-style stack; 8 blocks; GQA 14 query heads and 2 KV heads; sparse MoE FFN with 128 experts, top-4 routing; d_model=640; banded attention size 128/effective 257 tokens; BIOES labels; constrained Viterbi span decoder.
+- Quantization/runtime notes: ONNX, safetensors, and Transformers.js surfaces exist in supplied card.
+- License: Apache 2.0.
+- Known tool support: Token-classification lane; ONNX/runtime and safetensors future gates.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| privacy-filter | 1.5B | 50M active | 128K | text token labels | CPU/ONNX token smoke | tier_a_local |
+
+## Implementation contract
+### Loader
+ONNX or safetensors design path; must expose encoder outputs and classification head, not generation logits.
+
+### Tokenizer
+Tokenizer source must align token labels to input tokens.
+
+### Prompt template
+No chat template required for generation; task input is classification text/token sequence.
+
+### Architecture module
+Token classifier with bidirectional encoder, banded attention, sparse MoE FFN, BIOES label head, Viterbi span decoder.
+
+### Kernels/backend
+Token classification path; generation kernels and QK256 proof do not apply.
+
+### Receipts
+Receipt records output shape `[tokens, 33]`, label taxonomy, span decoder, `generation_claim=false`, fallback, and speedup flags.
+
+### Tests
+Future local CPU/ONNX smoke: 12-token input, 33-class output shape, selected labels, coherent spans.
+
+## Explicit non-claims
+- Privacy-filter docs do not mean ONNX or safetensors loading works.
+- Token classification is not generation and must not be exposed as `generate()` support.
+- BIOES/Viterbi notes do not prove calibration, recall, precision, masking quality, or operating point.
+
+## First proof target
+```json
+{
+  "claim": "privacy_filter_token_classification_smoke",
+  "model_family": "openai-privacy-filter",
+  "task": "token_classification",
+  "input_tokens": 12,
+  "output_shape": [12, 33],
+  "span_decoder": "bioes_viterbi",
+  "labels": ["private_person", "private_email", "private_phone"],
+  "generation_claim": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- PRIVACY-DOC-001: Add privacy-filter family doc.
+- PRIVACY-DOC-002: Add token-classification lane doc.
+- PRIVACY-DOC-003: Add BIOES/Viterbi receipt schema.
+- PRIVACY-DOC-004: Add local CPU/ONNX smoke proof plan.
+- PRIVACY-DOC-005: Add calibration/operating-point future-gate.

--- a/docs/models/families/qwen-3.5.md
+++ b/docs/models/families/qwen-3.5.md
@@ -1,0 +1,83 @@
+# Qwen 3.5
+
+## Status
+- Repo status: design_scaffold
+- First target: qwen3.5-0.8b-or-2b-text-only-gguf
+- Local test tier: tier_a_local
+- Implementation owner lane: dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future
+- Design-only? no for small text-only targets; yes for very large variants locally
+
+## Source-backed facts
+- Model variants: 0.8B, 2B, 4B, 9B, 27B, 35B-A3B, 122B-A10B, 397B-A17B.
+- Context: 256K context and 201 languages in supplied notes.
+- Modalities: Causal LM with vision encoder in fine-tuning context; GGUF multimodal projector files may be separate.
+- Tokenizer/prompt: Hybrid reasoning; small models have reasoning disabled by default and require chat-template kwargs to enable thinking.
+- Architecture features: hybrid_thinking, thinking_disabled_by_default_for_small, tool_calling, long_context, multimodal_projector_external.
+- Quantization/runtime notes: 4-bit estimates: 0.8B/2B ~3.5 GB, 4B ~5.5 GB, 9B ~6.5 GB, 27B ~17 GB, 35B-A3B ~22 GB.
+- License: TBD from model card.
+- Known tool support: Best early non-BitNet local target because small models fit the local tier.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| 0.8B | 0.8B | N/A | 256K source note | text; multimodal TBD | first local text-only | tier_a_local |
+| 2B | 2B | N/A | 256K source note | text; multimodal TBD | first local text-only | tier_a_local |
+| 4B | 4B | N/A | 256K source note | text; multimodal TBD | local text-only | tier_a_local |
+| 9B | 9B | N/A | 256K source note | text; multimodal TBD | local text-only | tier_a_local |
+| 27B | 27B | N/A | 256K | text/multimodal TBD | offload/future | tier_b_partial |
+| 35B-A3B | 35B | 3B active TBD | 256K | text/multimodal TBD | MoE future gate | tier_b_partial |
+| 122B-A10B | 122B | 10B active TBD | 256K | text/multimodal TBD | design gate | tier_c_design_only |
+| 397B-A17B | 397B | 17B active TBD | 256K | text/multimodal TBD | design gate | tier_c_design_only |
+
+## Implementation contract
+### Loader
+Start with GGUF dense quant for 0.8B or 2B text-only. Projector and MoE artifacts are future-gated.
+
+### Tokenizer
+Explicit Qwen3.5 tokenizer. No fallback for support claims.
+
+### Prompt template
+Small-model receipts default `thinking_enabled=false`; enabling thinking must record chat-template kwargs.
+
+### Architecture module
+Multimodal decoder family with dense small models and future MoE gates.
+
+### Kernels/backend
+Non-BitNet dense path; QK256 proof is not evidence.
+
+### Receipts
+Use one-token proof with 2048 context request and no full-context/multimodal/speedup claim.
+
+### Tests
+Future: tokenizer/template tests and deterministic one-token smoke for 0.8B or 2B.
+
+## Explicit non-claims
+- Qwen3.5 docs do not mean models load.
+- Small-model one-token proof does not prove 256K context.
+- Thinking mode remains disabled unless a receipt explicitly enables it.
+- Multimodal projector and MoE support are future-gated.
+
+## First proof target
+```json
+{
+  "claim": "qwen3.5_small_text_only_one_token",
+  "model_family": "qwen3.5",
+  "variant": "0.8b_or_2b",
+  "task": "text_generation",
+  "context_requested": 2048,
+  "full_context_claim": false,
+  "multimodal_claim": false,
+  "thinking_enabled": false,
+  "fallback_used": false,
+  "speedup_claim": false
+}
+```
+
+## Work items
+- QWEN35-DOC-001: Add Qwen3.5 family doc.
+- QWEN35-DOC-002: Add small-model-first implementation plan for 0.8B/2B/4B/9B.
+- QWEN35-DOC-003: Add thinking-mode prompt contract with small-model default disabled.
+- QWEN35-DOC-004: Add 27B/35B-A3B future-gated plan.
+- QWEN35-DOC-005: Add multimodal projector future gate.
+- QWEN35-DOC-006: Add first local proof template for 0.8B or 2B.

--- a/docs/models/families/qwen-3.6.md
+++ b/docs/models/families/qwen-3.6.md
@@ -1,0 +1,62 @@
+# Qwen 3.6
+
+## Status
+- Repo status: design_scaffold
+- First target: qwen3.6-27b-text-only-gguf-design
+- Local test tier: tier_b_partial
+- Implementation owner lane: dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling
+- Design-only? no for reduced-context design; local proof remains partial/offload only
+
+## Source-backed facts
+- Model variants: 27B and 35B-A3B.
+- Context: 256K context / 262,144 tokens, extendable to 1M via YaRN in supplied notes.
+- Modalities: Multimodal hybrid-thinking.
+- Tokenizer/prompt: Developer role for agentic coding tools; improved nested tool-calling parsing; thinking and non-thinking modes have different recommended sampling settings.
+- Architecture features: hybrid_thinking, developer_role, tool_calling, long_context, yarn_future, multimodal_projector_external.
+- Quantization/runtime notes: Unsloth notes 27B 4-bit around 18 GB total memory and 35B-A3B 4-bit around 23 GB.
+- License: TBD from model card.
+- Known tool support: Some GGUF flows require separate multimodal projector files; do not assume Ollama compatibility.
+- Source links: Supplied planning notes in this change; model-card URLs must be verified before advancing beyond `documented` or `design_scaffold`.
+
+## Variants
+| Variant | Params | Active params | Context | Modalities | First repo target | Local test tier |
+|---|---:|---:|---|---|---|---|
+| 27B | 27B | N/A | 256K | multimodal | text-only reduced-context design | tier_b_partial |
+| 35B-A3B | 35B | 3B active TBD | 256K | multimodal | MoE future gate | tier_b_partial |
+
+## Implementation contract
+### Loader
+Text-only GGUF design first; projector and 35B-A3B expert routing are future-gated.
+
+### Tokenizer
+Tokenizer source must be explicit and variant-compatible.
+
+### Prompt template
+Separate thinking and non-thinking template settings; developer role and nested tools are opt-in receipt fields.
+
+### Architecture module
+Multimodal decoder with dense 27B plan and MoE gate for 35B-A3B.
+
+### Kernels/backend
+Non-BitNet dense/MoE lanes; QK256 proof is not evidence.
+
+### Receipts
+Reduced-context receipts must record context requested and `full_context_claim=false`.
+
+### Tests
+Future: prompt rendering tests, one-token text-only smoke with reduced context.
+
+## Explicit non-claims
+- Qwen3.6 docs do not imply 256K context works in bitnet-rs.
+- 27B offload/design does not imply full 5070Ti residency.
+- 35B-A3B MoE is not implemented until expert routing is receipt-backed.
+
+## First proof target
+Design receipt or future one-token receipt with reduced context, text-only, no speedup claim.
+
+## Work items
+- QWEN36-DOC-001: Add Qwen3.6 family doc.
+- QWEN36-DOC-002: Add Qwen3.6 prompt/template settings for thinking and non-thinking.
+- QWEN36-DOC-003: Add 27B text-only reduced-context proof plan.
+- QWEN36-DOC-004: Add 35B-A3B MoE future gate.
+- QWEN36-DOC-005: Add multimodal projector future gate.

--- a/docs/models/implementation/dense-decoder-lane.md
+++ b/docs/models/implementation/dense-decoder-lane.md
@@ -1,0 +1,17 @@
+# Dense Decoder Lane
+
+This lane covers non-BitNet dense autoregressive decoders.
+
+It must not use QK256 or BitNet W1.58 kernel proof as evidence.
+
+First supported formats:
+- GGUF dense quantized CPU/GPU path.
+- safetensors path later.
+- OpenVINO graph/reference path later.
+
+Receipts must record:
+- `dense_regular_llm=true`
+- `bitnet_kernel_used=false`
+- `qk256_used=false` unless the model actually uses QK256
+
+Current scope is planning only. Do not route non-BitNet models through QK256-specific dispatch and call them supported without receipts.

--- a/docs/models/implementation/gguf-dense-quant-lane.md
+++ b/docs/models/implementation/gguf-dense-quant-lane.md
@@ -1,0 +1,5 @@
+# GGUF Dense Quant Lane
+
+This lane tracks GGUF dense quantized artifacts for non-BitNet models. GGUF metadata, tokenizer availability, and quantization type must be recorded before a loader claim.
+
+A GGUF text-only receipt does not prove safetensors loading, multimodal projector loading, MoE expert routing, or long-context execution.

--- a/docs/models/implementation/moe-decoder-lane.md
+++ b/docs/models/implementation/moe-decoder-lane.md
@@ -1,0 +1,11 @@
+# MoE Decoder Lane
+
+MoE support requires:
+- router logits
+- top-k expert selection
+- shared expert handling if present
+- expert weight loading
+- active vs total parameter receipts
+- per-token expert coverage metrics
+
+Dense receipts are not MoE receipts. Expert routing, expert loading, and shared-expert behavior must be proven separately for every claimed family/variant/backend.

--- a/docs/models/implementation/multimodal-lane.md
+++ b/docs/models/implementation/multimodal-lane.md
@@ -1,0 +1,5 @@
+# Multimodal Lane
+
+Multimodal support requires explicit vision/audio/projector contracts and receipts. Text-only smoke tests for multimodal families must set `multimodal_claim=false`.
+
+Future receipts must record modality inputs, encoder/projector artifact source, preprocessing parameters, context interaction, selected backend, and fallback status.

--- a/docs/models/implementation/openvino-graph-lane.md
+++ b/docs/models/implementation/openvino-graph-lane.md
@@ -1,0 +1,5 @@
+# OpenVINO Graph Reference Lane
+
+OpenVINO graph support is a graph/reference lane unless native integration is receipt-backed. Runtime detection is not inference. A graph smoke is not a full model claim.
+
+Receipts must record IR/ONNX source, OpenVINO device, selected device, fallback status, input/output shapes, and whether the result is external reference or repo-native execution.

--- a/docs/models/implementation/safetensors-loader-lane.md
+++ b/docs/models/implementation/safetensors-loader-lane.md
@@ -1,0 +1,3 @@
+# Safetensors Loader Lane
+
+The safetensors lane records tensor naming, sharding, dtype, tokenizer sibling files, config source, and architecture mapping. A tensor map is `loader_scaffold`; it is not inference until one-token or task-specific receipts exist.

--- a/docs/models/implementation/token-classification-lane.md
+++ b/docs/models/implementation/token-classification-lane.md
@@ -1,0 +1,13 @@
+# Token Classification Lane
+
+Token classification is not generation.
+
+Required:
+- encoder/bidirectional attention support
+- token classification head
+- per-token logits
+- label taxonomy
+- constrained decoder if required
+- span output receipt
+
+Receipts should record input token count, output shape, label taxonomy, span decoder, fallback status, and `generation_claim=false`.

--- a/docs/models/schemas/hardware-fit.schema.yaml
+++ b/docs/models/schemas/hardware-fit.schema.yaml
@@ -1,0 +1,7 @@
+schema: 1
+required: [family_id, variant_id, local_test_tier, memory_note, proof_shape, non_claims]
+fields:
+  local_test_tier: {enum: [tier_a_local, tier_b_partial, tier_c_design_only]}
+  proof_shape: {enum: [local_one_token, reduced_context_offload, external_reference, design_only]}
+  full_context_claim: {type: boolean}
+  speedup_claim: {type: boolean}

--- a/docs/models/schemas/model-capability.schema.yaml
+++ b/docs/models/schemas/model-capability.schema.yaml
@@ -1,0 +1,8 @@
+schema: 1
+required: [id, family_id, source_status, runtime_claim, receipt_required]
+fields:
+  id: {type: string}
+  family_id: {type: string}
+  source_status: {enum: [source_backed, source_backed_partial, needs_model_card_verification, design_only, tbd]}
+  runtime_claim: {type: boolean}
+  receipt_required: {type: boolean}

--- a/docs/models/schemas/model-family.schema.yaml
+++ b/docs/models/schemas/model-family.schema.yaml
@@ -1,0 +1,45 @@
+schema: 1
+required:
+  - id
+  - display_name
+  - source_status
+  - implementation_status
+  - first_target
+  - local_test_tier
+  - architecture
+  - variants
+  - tokenizer
+  - prompt_template
+  - loader
+  - receipts
+  - non_claims
+fields:
+  id:
+    type: string
+    example: gemma4
+  display_name:
+    type: string
+  source_status:
+    enum: [source_backed, source_backed_partial, needs_model_card_verification, design_only]
+  implementation_status:
+    enum: [not_present, documented, design_scaffold, catalog_scaffold, loader_scaffold, one_token_smoke_tested, receipt_backed]
+  local_test_tier:
+    enum: [tier_a_local, tier_b_partial, tier_c_design_only]
+  architecture.kind:
+    enum: [dense_decoder, moe_decoder, hybrid_dense_moe, multimodal_decoder, token_classifier, graph_reference, unknown_tbd]
+  loader.formats:
+    list_enum: [gguf, safetensors, onnx, openvino_ir, tokenizer_json, remote_code_tbd]
+  receipts.required_fields:
+    list:
+      - model_id
+      - variant_id
+      - model_hash_or_tbd
+      - tokenizer_source
+      - prompt_template
+      - requested_backend
+      - selected_backend
+      - fallback_used
+      - task
+      - generated_tokens_or_labeled_tokens
+      - full_inference_claim
+      - speedup_claim

--- a/docs/models/schemas/model-receipt.schema.yaml
+++ b/docs/models/schemas/model-receipt.schema.yaml
@@ -1,0 +1,9 @@
+schema: 1
+required: [schema, claim, model_family, variant, task, runtime, coverage]
+fields:
+  claim: {type: string}
+  model_family: {type: string}
+  variant: {type: string}
+  task: {enum: [text_generation, token_classification, multimodal_text_only, moe_router_smoke, external_reference, design_only]}
+  runtime.required: [requested_backend, selected_backend, fallback_used]
+  coverage.required: [full_inference_claim, multimodal_claim, moe_claim, long_context_claim, speedup_claim]

--- a/docs/models/schemas/model-variant.schema.yaml
+++ b/docs/models/schemas/model-variant.schema.yaml
@@ -1,0 +1,11 @@
+schema: 1
+required: [id, family_id, params, active_params, context, modalities, local_test_tier, first_repo_target]
+fields:
+  id: {type: string}
+  family_id: {type: string}
+  params: {type: string}
+  active_params: {type: string_or_null}
+  context: {type: string}
+  modalities: {type: list_string}
+  local_test_tier: {enum: [tier_a_local, tier_b_partial, tier_c_design_only]}
+  first_repo_target: {type: string}

--- a/docs/models/schemas/prompt-template.schema.yaml
+++ b/docs/models/schemas/prompt-template.schema.yaml
@@ -1,0 +1,10 @@
+schema: 1
+required: [id, family_id, variant_scope, tokenizer_source, thinking_modes, roles, fallback_allowed]
+fields:
+  id: {type: string}
+  family_id: {type: string}
+  variant_scope: {type: list_string}
+  tokenizer_source: {enum: [explicit, model, sibling, unknown]}
+  thinking_modes: {type: list_string}
+  roles: {type: list_string}
+  fallback_allowed: {type: boolean}

--- a/docs/models/schemas/tokenizer-policy.schema.yaml
+++ b/docs/models/schemas/tokenizer-policy.schema.yaml
@@ -1,0 +1,8 @@
+schema: 1
+required: [family_id, tokenizer_source, vocab_size_or_tbd, fallback_policy, receipt_fields]
+fields:
+  family_id: {type: string}
+  tokenizer_source: {enum: [explicit, model, sibling, unknown]}
+  vocab_size_or_tbd: {type: string_or_integer}
+  fallback_policy: {enum: [forbidden_for_support_claims, allowed_only_with_non_claim_receipt]}
+  receipt_fields: {list: [tokenizer_source, fallback_used, hash_or_tbd]}

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -8,6 +8,10 @@ Real BitNet CPU path sequencing remains active, Apple Silicon M4-003 backend ide
 
 Transition note: campaign-local `active.toml` files and append-only `events/*.toml` files are now the active tracker model. This legacy global status file remains a transition view; normal item PRs should use campaign-local tracking plus generated dashboards instead of hand-editing this table.
 
+## Model Family Cross-Reference
+
+Model-family planning for non-BitNet targets is tracked separately in `docs/tracking/model-family-foundation/status.md`.
+
 ## Active / Coordination Queue
 
 | Item | PR | State | Notes |

--- a/docs/tracking/model-family-foundation/hardware-fit.yaml
+++ b/docs/tracking/model-family-foundation/hardware-fit.yaml
@@ -1,0 +1,15 @@
+schema: 1
+local_device_class: nvidia_5070_ti_class_16gb
+tiers:
+  tier_a_local:
+    meaning: Reasonable to smoke locally with small/quantized models or CPU/GPU offload.
+    families: [gemma4_e2b_e4b_text_only, qwen35_0_8b_2b_4b_9b, openai_privacy_filter]
+  tier_b_partial:
+    meaning: May run with quantization, CPU/RAM offload, reduced context, or single-token proof only.
+    families: [qwen36_27b, qwen35_27b_35b_a3b, gemma4_31b_26b_a4b_quantized, mistral_medium_35_external_offload]
+  tier_c_design_only:
+    meaning: Too large for direct local proof; document architecture, prompt, loader, receipts, and reference commands.
+    families: [kimi_k26, glm51, deepseek_v4, mistral_medium_35_full]
+non_claims:
+  - Source-backed context length is not local long-context proof.
+  - Design-only is not loader, inference, speed, quality, or local execution proof.

--- a/docs/tracking/model-family-foundation/implementation-lanes.yaml
+++ b/docs/tracking/model-family-foundation/implementation-lanes.yaml
@@ -1,0 +1,20 @@
+schema: 1
+lanes:
+  dense_decoder:
+    doc: docs/models/implementation/dense-decoder-lane.md
+    qk256_proof_allowed: false
+  moe_decoder:
+    doc: docs/models/implementation/moe-decoder-lane.md
+    required_receipt_fields: [router_logits, top_k, active_parameters, total_parameters, expert_coverage]
+  multimodal:
+    doc: docs/models/implementation/multimodal-lane.md
+    text_only_is_multimodal_claim: false
+  token_classification:
+    doc: docs/models/implementation/token-classification-lane.md
+    generation_claim_allowed: false
+  openvino_graph:
+    doc: docs/models/implementation/openvino-graph-lane.md
+  gguf_dense_quant:
+    doc: docs/models/implementation/gguf-dense-quant-lane.md
+  safetensors_loader:
+    doc: docs/models/implementation/safetensors-loader-lane.md

--- a/docs/tracking/model-family-foundation/model-status.yaml
+++ b/docs/tracking/model-family-foundation/model-status.yaml
@@ -1,0 +1,51 @@
+schema: 1
+status_values:
+  - not_present
+  - documented
+  - design_scaffold
+  - catalog_scaffold
+  - tokenizer_scaffold
+  - prompt_template_scaffold
+  - loader_scaffold
+  - synthetic_shape_tested
+  - runtime_detected
+  - one_token_smoke_tested
+  - parity_tested
+  - receipt_backed
+  - benchmarked
+  - design_only
+claim_boundaries:
+  documented:
+    may_claim:
+      - "The repo contains source-backed implementation notes."
+    must_not_claim:
+      - "The model loads or runs."
+  design_scaffold:
+    may_claim:
+      - "The architecture plan is recorded."
+    must_not_claim:
+      - "The implementation compiles, loads, or runs."
+  loader_scaffold:
+    may_claim:
+      - "The intended loader/tensor mapping exists."
+    must_not_claim:
+      - "Inference works."
+  one_token_smoke_tested:
+    may_claim:
+      - "One strict deterministic generation/classification smoke ran."
+    must_not_claim:
+      - "Quality, speed, long context, or full feature support."
+  receipt_backed:
+    may_claim:
+      - "The named model/variant/backend/task is proven by receipt."
+    must_not_claim:
+      - "Other variants, backends, modalities, or quantizations work."
+families:
+  gemma4: {display_name: Gemma 4, implementation_status: design_scaffold, first_target: gemma4-e2b-it-q4-text-only, local_test_tier: tier_a_local, owner_lanes: [dense_decoder, gguf_dense_quant, moe_decoder_future, multimodal_future]}
+  qwen36: {display_name: Qwen 3.6, implementation_status: design_scaffold, first_target: qwen3.6-27b-text-only-gguf-design, local_test_tier: tier_b_partial, owner_lanes: [dense_decoder, moe_decoder_for_35b_a3b, prompt_template, tool_calling]}
+  qwen35: {display_name: Qwen 3.5, implementation_status: design_scaffold, first_target: qwen3.5-0.8b-or-2b-text-only-gguf, local_test_tier: tier_a_local, small_model_priority: true, owner_lanes: [dense_decoder, prompt_template, tokenizer, gguf_dense_quant, moe_decoder_future]}
+  kimi_k26: {display_name: Kimi K2.6, implementation_status: design_only, first_target: design_only_prompt_tokenizer_loader_notes, local_test_tier: tier_c_design_only, owner_lanes: [moe_decoder_design, prompt_template, gguf_dynamic_quant_design]}
+  glm51: {display_name: GLM-5.1, implementation_status: design_only, first_target: design_only_prompt_template_and_moe_notes, local_test_tier: tier_c_design_only, owner_lanes: [moe_decoder_design, prompt_template, tool_calling, external_reference]}
+  deepseek_v4: {display_name: DeepSeek V4, implementation_status: design_only, first_target: design_only_architecture_notes, local_test_tier: tier_c_design_only, owner_lanes: [moe_decoder_design, long_context_design, mixed_precision_design]}
+  mistral_medium_35: {display_name: Mistral Medium 3.5, implementation_status: design_only, first_target: design_only_prompt_reasoning_effort_contract, local_test_tier: tier_c_design_only, owner_lanes: [dense_decoder_design, prompt_template, tool_calling, speculative_decoding_future]}
+  openai_privacy_filter: {display_name: OpenAI privacy-filter, implementation_status: design_scaffold, first_target: token_classification_cpu_or_onnx_smoke, local_test_tier: tier_a_local, owner_lanes: [token_classification, onnx_runtime_future, safetensors_loader, transformersjs_reference]}

--- a/docs/tracking/model-family-foundation/source-index.yaml
+++ b/docs/tracking/model-family-foundation/source-index.yaml
@@ -1,0 +1,13 @@
+schema: 1
+source_policy:
+  supplied_notes: The initial facts in this foundation are transcribed from maintainer-supplied planning notes in the task prompt.
+  before_claim_advancement: Replace or augment supplied-note entries with model-card, release-note, or artifact URLs before advancing to loader, smoke, parity, receipt, or benchmark claims.
+families:
+  gemma4: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  qwen36: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  qwen35: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  kimi_k26: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  glm51: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  deepseek_v4: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  mistral_medium_35: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}
+  openai_privacy_filter: {source_status: source_backed_partial, primary_source: supplied_planning_notes, verification_required_before_runtime_claim: true}

--- a/docs/tracking/model-family-foundation/status.md
+++ b/docs/tracking/model-family-foundation/status.md
@@ -1,0 +1,15 @@
+# Model Family Foundation Status
+
+Updated: 2026-05-07
+
+This tracker is separate from the BitNet/hardware alignment tracker. It records model-family planning, status values, hardware fit, implementation lanes, source index, and receipt requirements without adding runtime behavior.
+
+## Current state
+
+- `MF-001` is ready with docs, schemas, receipt templates, and machine-readable status/catalog scaffolding.
+- First local priorities: Qwen3.5 small models, Gemma 4 E2B/E4B text-only, and OpenAI privacy-filter token classification.
+- Design-only locally: Kimi K2.6, GLM-5.1, DeepSeek V4 Flash/Pro, and Mistral Medium 3.5 full path.
+
+## Non-claim boundary
+
+No family listed here loads, runs, accelerates, supports full context, supports multimodal input, supports MoE routing, or has quality/performance claims until a narrow receipt backs that exact model/variant/backend/task claim.

--- a/docs/tracking/model-family-foundation/workstream-ledger.yaml
+++ b/docs/tracking/model-family-foundation/workstream-ledger.yaml
@@ -1,0 +1,84 @@
+schema: 1
+states: [proposed, ready, pr_open, merged, blocked, superseded]
+required_fields: [id, title, state, priority, workstream, depends_on, scope, acceptance, verification]
+transition_rules:
+  - proposed_to_ready_requires_dependencies_clear
+  - pr_open_requires_allowed_paths_only
+  - merged_requires_acceptance_and_verification_notes
+items:
+  - id: MF-001
+    title: Add model-family documentation structure
+    state: ready
+    priority: P0
+    workstream: model_foundation
+    depends_on: []
+    scope:
+      allowed_paths: [docs/models/**, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**, tests/**, .github/**]
+    acceptance:
+      - Adds model docs tree.
+      - Adds status values and claim boundaries.
+      - Adds schemas for model family, variant, prompt template, hardware fit, and receipts.
+      - Adds source-index.yaml for source-backed facts.
+      - Does not add runtime code.
+    verification: [cargo fmt --all -- --check, Parse YAML files, Parse JSON receipt templates]
+  - id: MF-002
+    title: Add architecture feature glossary
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths: [docs/models/ARCHITECTURE_FEATURE_GLOSSARY.md, docs/models/implementation/**, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Defines dense, MoE, multimodal, token-classification, long-context, and speculative-decoding features.
+      - Unknowns are marked TBD.
+      - No implementation claims are made.
+    verification: [cargo fmt --all -- --check]
+  - id: MF-003
+    title: Add local hardware fit policy for 5070Ti
+    state: proposed
+    priority: P0
+    workstream: model_foundation
+    depends_on: [MF-001]
+    scope:
+      allowed_paths: [docs/models/MODEL_HARDWARE_FIT_5070TI.md, docs/tracking/model-family-foundation/**]
+      forbidden_paths: [crates/**]
+    acceptance:
+      - Splits models into tier_a_local, tier_b_partial, and tier_c_design_only.
+      - Explicitly states that design-only docs are not local inference claims.
+      - Does not invent benchmarks.
+    verification: [cargo fmt --all -- --check]
+  - id: GEMMA4-DOC-001
+    title: Add Gemma 4 model-family foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/gemma-4.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents E2B E4B 31B and 26B-A4B variants., Separates text-only multimodal MoE and MTP claims., First target is E2B text-only Q4 quantized proof., Explicitly says generic Gemma support is not Gemma 4 support.]
+    verification: [cargo fmt --all -- --check]
+  - id: QWEN35-DOC-001
+    title: Add Qwen3.5 small-model-first foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/qwen-3.5.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents 0.8B 2B 4B 9B as first local targets., Documents thinking disabled by default for small models., Separates 27B 35B 122B 397B as larger or design-gated targets.]
+    verification: [cargo fmt --all -- --check]
+  - id: PRIVACY-DOC-001
+    title: Add OpenAI privacy-filter token-classification foundation doc
+    state: proposed
+    priority: P0
+    workstream: model_family_docs
+    depends_on: [MF-001, MF-002]
+    scope: {allowed_paths: [docs/models/families/openai-privacy-filter.md, docs/models/implementation/token-classification-lane.md, ci/model-receipts/_templates/token-classification-proof.json, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}
+    acceptance: [Documents token-classification pipeline separately from generation., Documents 33 BIOES labels and Viterbi span decoder., Adds receipt requirements for span classification.]
+    verification: [cargo fmt --all -- --check, Parse JSON receipt template]
+  - {id: QWEN36-DOC-001, title: Add Qwen3.6 family doc, state: proposed, priority: P0, workstream: model_family_docs, depends_on: [MF-001, MF-002], scope: {allowed_paths: [docs/models/families/qwen-3.6.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}, acceptance: [Adds Qwen3.6 design scaffold and future gates.], verification: [cargo fmt --all -- --check]}
+  - {id: KIMI26-DOC-001, title: Add Kimi K2.6 design-only family doc, state: proposed, priority: P0, workstream: model_family_docs, depends_on: [MF-001, MF-002], scope: {allowed_paths: [docs/models/families/kimi-k2.6.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}, acceptance: [Adds Kimi K2.6 design-only rails and non-claims.], verification: [cargo fmt --all -- --check]}
+  - {id: GLM51-DOC-001, title: Add GLM-5.1 design-only family doc, state: proposed, priority: P0, workstream: model_family_docs, depends_on: [MF-001, MF-002], scope: {allowed_paths: [docs/models/families/glm-5.1.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}, acceptance: [Adds GLM-5.1 design-only rails and non-claims.], verification: [cargo fmt --all -- --check]}
+  - {id: DSV4-DOC-001, title: Add DeepSeek V4 family doc, state: proposed, priority: P0, workstream: model_family_docs, depends_on: [MF-001, MF-002], scope: {allowed_paths: [docs/models/families/deepseek-v4.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}, acceptance: [Adds DeepSeek V4 Flash Pro design-only rails and non-claims.], verification: [cargo fmt --all -- --check]}
+  - {id: MM35-DOC-001, title: Add Mistral Medium 3.5 design-only family doc, state: proposed, priority: P0, workstream: model_family_docs, depends_on: [MF-001, MF-002], scope: {allowed_paths: [docs/models/families/mistral-medium-3.5.md, docs/tracking/model-family-foundation/**], forbidden_paths: [crates/**]}, acceptance: [Adds Mistral Medium 3.5 design-only rails and non-claims.], verification: [cargo fmt --all -- --check]}


### PR DESCRIPTION
### Motivation
- Establish a separate model-family documentation and planning control plane so model claims are advanced through narrow, receipt-backed stages rather than being inferred from hardware or generic architecture detection.
- Encode strict claim boundaries and staged statuses (e.g., `design_scaffold`, `one_token_smoke_tested`, `receipt_backed`, `design_only`) to prevent documentation from becoming accidental support claims.
- Preserve a safe first-pass surface that records architecture facts, tokenizer/prompt contracts, implementation lanes, and receipt shapes while marking very large models as positive `design_only` items and prioritizing Qwen3.5 small, Gemma 4 E2B/E4B text-only, and OpenAI privacy-filter for early local work.

### Description
- Add a new `docs/models/` tree containing `README.md`, policy docs (`MODEL_*`), `ARCHITECTURE_FEATURE_GLOSSARY.md`, tokenizer/prompt policies, implementation-lane docs, family templates under `docs/models/families/`, and machine-readable schemas under `docs/models/schemas/` to standardize metadata and contracts.
- Add a parallel tracker at `docs/tracking/model-family-foundation/` with `model-status.yaml`, `workstream-ledger.yaml`, `status.md`, `source-index.yaml`, `implementation-lanes.yaml`, and `hardware-fit.yaml` to drive future work and enforce allowed/forbidden paths for PRs.
- Add receipt templates in `ci/model-receipts/_templates/` (generative one-token, design-only, MoE-router smoke, multimodal text-only, token-classification, external-reference) to standardize narrow proof artifacts and coverage flags.
- Update implementation lane docs to explicitly forbid using BitNet QK256/W1.58 kernel evidence for non-BitNet models and to separate token-classification (non-generative) lanes, and add a one-line cross-reference in `docs/tracking/bitnet-alignment/status.md` pointing to the new model-family tracker.

### Testing
- Ran `cargo fmt --all -- --check` to validate formatting, which passed. 
- Parsed YAML and JSON artifacts with a Python check (`yaml.safe_load` / `json.loads`) to ensure machine-readable files are syntactically valid, which succeeded. 
- Ran `git diff --check` as part of verification which produced no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1f02e3b083339674e40ca3e577ad)