### PR TITLE
docs(npu): mark NPU-004 merged

### DIFF
--- a/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-npu/CAMPAIGN.md
@@ -28,7 +28,7 @@ Validate Intel Lunar Lake NPU through OpenVINO static-shape detection, smoke, pa
 |---|---|---|
 | NPU-002 | merged | Preserve Intel NPU backend identity. |
 | NPU-003 | merged | Add runtime detection. |
-| NPU-004 | in_progress | Add smoke probe command. |
+| NPU-004 | merged | Add smoke probe command. |
 | NPU-005 | proposed | Run tiny OpenVINO NPU graph smoke. |
 | NPU-006 | proposed | Add receipt fields. |
 

--- a/docs/tracking/campaigns/intel-npu/active.toml
+++ b/docs/tracking/campaigns/intel-npu/active.toml
@@ -110,7 +110,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "NPU-004"
-status = "in_progress"
+status = "merged"
 branch = "codex/intel-npu/NPU-004-smoke-probe-command"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-07T054422Z-NPU-004-merged.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-07T054422Z-NPU-004-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T05:44:22Z"
+campaign = "intel-npu"
+item = "NPU-004"
+event = "merged"
+pr = 3830
+merge_sha = "9ae037bad83ee9c1320689fc931932862a213c6b"
+actor = "maintainer"
+
+notes = [
+  "Intel NPU runtime visibility probe command merged.",
+  "The command emits machine-readable visibility receipts only; graph execution, BitNet inference, and NPU acceleration remain follow-up work.",
+]

--- a/docs/tracking/campaigns/intel-npu/generated/status.md
+++ b/docs/tracking/campaigns/intel-npu/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | NPU-002 | merged | #3722 | `codex/intel-npu/NPU-002-lite-backend-identity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Preserve Intel NPU requested and selected backend identity without mapping it to Metal, CUDA, generic GPU, or CPU fallback. |
 | NPU-003 | merged | #3739 | `codex/intel-npu/NPU-003-openvino-runtime-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add Intel NPU runtime detection fields that keep OS accelerator evidence separate from OpenVINO NPU visibility and record OpenVINO NPU full name, driver/compiler/memory properties, runtime device, proof_stage=runtime_detected, and fallback_used=false without graph execution claims. |
-| NPU-004 | in_progress | TBD | `codex/intel-npu/NPU-004-smoke-probe-command` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an Intel NPU smoke probe command that writes a machine-readable OpenVINO NPU runtime visibility receipt with requested/selected backend identity, runtime API/device, strict mode, proof_stage=runtime_detected, fallback_used=false, and no graph, kernel, or BitNet inference claims. |
+| NPU-004 | merged | #3830 | `codex/intel-npu/NPU-004-smoke-probe-command` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an Intel NPU smoke probe command that writes a machine-readable OpenVINO NPU runtime visibility receipt with requested/selected backend identity, runtime API/device, strict mode, proof_stage=runtime_detected, fallback_used=false, and no graph, kernel, or BitNet inference claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -41,7 +41,7 @@
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
 | intel-258v-platform | CPU258V-001 | LNL258V-003 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
-| intel-npu | NPU-004 | NPU-003 | in_progress |
+| intel-npu | NPU-004 | NPU-003 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
-| intel-npu | NPU-004 | TBD | in_progress | none | Device-node detection is not inference. |
+| intel-npu | NPU-004 | #3830 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | CUDA-BITNET-009 | TBD | ready | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |


### PR DESCRIPTION
## Summary
- Mark NPU-004 merged after #3830.
- Add the NPU-004 merge event with the squash merge SHA.
- Regenerate the NPU and global tracking dashboards.

## Verification
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --cached --check`