### PR TITLE
fix(ffi): cast FFI seed to u64

### DIFF
--- a/crates/bitnet-ffi/src/config.rs
+++ b/crates/bitnet-ffi/src/config.rs
@@ -283,7 +283,7 @@ impl BitNetCInferenceConfig {
         config.repetition_penalty = self.repetition_penalty;
 
         if self.seed != 0 {
-            config = config.with_seed(self.seed);
+            config = config.with_seed(u64::from(self.seed));
         }
 
         config


### PR DESCRIPTION
## Summary
- Cast the C FFI `u32` seed to the `u64` expected by `InferenceConfig::with_seed`.
- Keep the fix scoped to the Feature CPU clippy/build blocker exposed while validating NPU-005.

## Verification
- `rustfmt --check crates/bitnet-ffi/src/config.rs --edition 2024`
- `$env:CMAKE_GENERATOR='Visual Studio 17 2022'; cargo clippy --locked --workspace --no-default-features --features cpu -- -D warnings`
- `git diff --check`