### PR TITLE
docs(tracking): mark KBL8250U-004 merged

### DIFF
--- a/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/CAMPAIGN.md
@@ -27,7 +27,7 @@ Move CPU BitNet work from strict proof surfaces into scalar, packed-layout, AVX2
 | Work item | Status | Notes |
 |---|---|---|
 | KBL8250U-003 | merged | Prove i5-8250U scalar and AVX2 dispatch. |
-| KBL8250U-004 | pr_open | Adds a strict real-GGUF CPU proof run on the i5-8250U lane, with raw CLI backend `cpu-rust`, hardware lane identity `intel-i5-8250u-cpu-avx2`, no fallback, model hash, first-token timing, and explicit thermal/frequency null context. |
+| KBL8250U-004 | merged | Added a strict real-GGUF CPU proof run on the i5-8250U lane, with raw CLI backend `cpu-rust`, hardware lane identity `intel-i5-8250u-cpu-avx2`, no fallback, model hash, first-token timing, and explicit thermal/frequency null context. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/cpu-qk256-performance/active.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/active.toml
@@ -54,7 +54,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "KBL8250U-004"
-status = "pr_open"
+status = "merged"
 branch = "codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T074100Z-KBL8250U-004-merged.toml
+++ b/docs/tracking/campaigns/cpu-qk256-performance/events/2026-05-07T074100Z-KBL8250U-004-merged.toml
@@ -1,0 +1,22 @@
+timestamp = "2026-05-07T07:41:00Z"
+campaign = "cpu-qk256-performance"
+item = "KBL8250U-004"
+event = "merged"
+previous_status = "pr_open"
+new_status = "merged"
+pr = 3839
+merge_sha = "4cc8fb6c7c27ff072762805757878a61a2fac725"
+actor = "codex"
+
+artifacts = [
+  "ci/intel-i5-8250u/2026-05-07/strict-bitnet-cpu-proof.json",
+  "ci/intel-i5-8250u/2026-05-07/cpu-phase-benchmark-receipt.json",
+  "ci/intel-i5-8250u/2026-05-07/strict-cpu-proof-hardware-context.json",
+]
+
+notes = [
+  "Merged the i5-8250U strict CPU proof artifact PR.",
+  "The strict proof uses real_gguf loading, GGUF metadata tokenizer authority, raw selected backend cpu-rust on the Kaby Lake AVX2 host, AVX2 I2_S kernel identity, no fallback, model hash, one generated token, and timing.",
+  "The companion phase benchmark receipt measures first_token only; micro, layer, prefill, and steady decode remain not_run and CPU-BITNET-008 remains open.",
+  "No sustained mobile performance, throughput superiority, GPU, OpenVINO, UHD 620, NPU, mock, fallback, or fixture-model claim is made.",
+]

--- a/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
+++ b/docs/tracking/campaigns/cpu-qk256-performance/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | KBL8250U-003 | merged | #3785 | `codex/cpu-qk256-performance/KBL8250U-003-avx2-proof-artifact` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Prove i5-8250U scalar and AVX2 dispatch with receipt-backed selected CPU kernel identity and no GPU/NPU fallback. |
-| KBL8250U-004 | pr_open | #3839 | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
+| KBL8250U-004 | merged | #3839 | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| cpu-qk256-performance | KBL8250U-004 | #3839 | `codex/cpu-qk256-performance/KBL8250U-004-strict-proof-run` | Add an i5-8250U strict CPU proof run with selected backend, no fallback, model hash, timing, and thermal context. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -35,7 +35,7 @@
 | cpu-proof | CPU-BITNET-006 | CPU-BITNET-005c | merged |
 | cpu-proof | CPU-BITNET-007 | CPU-BITNET-006 | merged |
 | cpu-proof | CPU-BITNET-008 | CPU-BITNET-007 | in_progress |
-| cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | pr_open |
+| cpu-qk256-performance | KBL8250U-004 | KBL8250U-003 | merged |
 | crate-collapse | LEAF-001 | INV-001 | proposed |
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -8,7 +8,7 @@
 | apple-m4-operational | M4-OP-002 | TBD | ready | M4-OP-003 | Do not reopen the completed apple-m4 proof campaign. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-BITNET-008 | #3833 | in_progress | none | No GPU or NPU claims. |
-| cpu-qk256-performance | KBL8250U-004 | #3839 | pr_open | none | Do not claim performance before strict proof receipts exist. |
+| cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
 | intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |


### PR DESCRIPTION
## Summary
- mark KBL8250U-004 merged after #3839
- record merge SHA `4cc8fb6c7c27ff072762805757878a61a2fac725`
- regenerate campaign dashboards so the i5-8250U proof lane is tracker-clean

## Claim boundary
- tracker-only sync
- does not claim CPU-BITNET-008 closeout
- does not add runtime, benchmark, server, GPU, NPU, or crate-collapse changes

## Validation
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`
- JSON parse for the three KBL8250U-004 artifacts on main