### PR TITLE
docs(cuda): define RTX 5070 Ti answer readiness

### DIFF
--- a/ci/hardware/_templates/bitnet-cuda-answer-receipt.json
+++ b/ci/hardware/_templates/bitnet-cuda-answer-receipt.json
@@ -1,0 +1,142 @@
+{
+  "schema": 1,
+  "artifact_kind": "bitnet_cuda_answer",
+  "machine_id": "windows-9950x3d-rtx5070ti",
+  "hardware_lane": "nvidia-rtx-5070-ti-cuda",
+  "timestamp_utc": "TBD",
+  "claim": "strict_cuda_answer_generation",
+  "speedup_claim": false,
+  "requested_backend": "nvidia-rtx-5070-ti-cuda",
+  "selected_backend": "nvidia-rtx-5070-ti-cuda",
+  "runtime_api": "cuda",
+  "reference_backend": "amd-9950x3d-cpu-avx512",
+  "fallback_used": false,
+  "fallback_backend": null,
+  "fallback_reason": null,
+  "question": "TBD",
+  "answer": "TBD",
+  "model": {
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "file": "ggml-model-i2_s.gguf",
+    "sha256": "TBD",
+    "format": "gguf",
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "loader_mode": "real_gguf",
+    "fallback_loader_used": false,
+    "tokenizer": "llama3",
+    "tokenizer_source": "explicit",
+    "tokenizer_path": "TBD",
+    "tokenizer_sha256": "TBD"
+  },
+  "backend": {
+    "requested_backend": "nvidia-rtx-5070-ti-cuda",
+    "selected_backend": "nvidia-rtx-5070-ti-cuda",
+    "runtime_api": "cuda",
+    "reference_backend": "amd-9950x3d-cpu-avx512",
+    "fallback_used": false,
+    "fallback_backend": null,
+    "fallback_reason": null,
+    "strict_cuda": true
+  },
+  "cuda": {
+    "device_index": 0,
+    "device_name": "NVIDIA GeForce RTX 5070 Ti",
+    "compute_capability": "12.0",
+    "driver_version": "TBD",
+    "cuda_runtime_version": "TBD",
+    "cuda_toolkit_version": "TBD",
+    "nvrtc_version": "TBD",
+    "vram_bytes": 17179869184,
+    "power_limit_watts": null,
+    "power_draw_watts": null,
+    "temperature_c": null
+  },
+  "prompt_template": {
+    "family": "llama3-chat",
+    "bos_inserted": true,
+    "system_prompt_present": false,
+    "assistant_prefix_inserted": true,
+    "stop_tokens": ["<|eot_id|>", "<|end_of_text|>"],
+    "special_tokens_skipped_on_decode": true
+  },
+  "prompt_prefill": {
+    "exercised": true,
+    "tokens": null,
+    "kv_cache_behavior": "prefill_then_incremental_decode",
+    "kv_cache_device": "cpu|cuda"
+  },
+  "generation": {
+    "mode": "greedy",
+    "max_new_tokens": 96,
+    "generated_tokens": null,
+    "temperature": 0.0,
+    "top_p": null,
+    "top_k": null,
+    "seed": 42,
+    "deterministic": true,
+    "stop_reason": "eos|stop_sequence|max_tokens"
+  },
+  "bitnet": {
+    "quantization": "W1.58A8",
+    "kernel_family": "qk256",
+    "layout": "gguf_packed_i2_s",
+    "layout_source": "gguf",
+    "weights_uploaded_once": true,
+    "per_token_weight_upload": false,
+    "kernel_id": "qk256_gemv_cuda"
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_total": null,
+    "bitnet_linear_layers_on_cuda": null,
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "unsupported_ops": []
+  },
+  "quality": {
+    "printable_utf8": true,
+    "non_empty_answer": true,
+    "stop_reason": "eos|stop_sequence|max_tokens",
+    "no_replacement_chars": true,
+    "no_raw_special_tokens": true,
+    "mostly_text": true,
+    "max_repeated_token_run": null,
+    "repeated_token_threshold": 8,
+    "garbage_filter_passed": true,
+    "failed_rules": []
+  },
+  "sequence_parity": {
+    "reference_backend": "amd-9950x3d-cpu-avx512",
+    "cpu_token_ids": [],
+    "cuda_token_ids": [],
+    "first_divergence_index": null,
+    "top1_agreement": null,
+    "max_abs_error": null,
+    "mean_abs_error": null,
+    "divergence_artifact_path": null
+  },
+  "timing": {
+    "load_ms": null,
+    "weight_upload_ms": null,
+    "prompt_prefill_ms": null,
+    "first_token_ms": null,
+    "decode_ms": null,
+    "total_ms": null,
+    "steady_state_tokens_per_second": null
+  },
+  "kernel_stats": [
+    {
+      "kernel_id": "qk256_gemv_cuda",
+      "invocations": null,
+      "fallback_invocations": 0,
+      "host_to_device_bytes": null,
+      "device_to_host_bytes": null,
+      "kernel_launches": null,
+      "kernel_time_ms": null,
+      "selected_device_index": 0,
+      "selected_device_name": "NVIDIA GeForce RTX 5070 Ti",
+      "compute_capability": "12.0"
+    }
+  ],
+  "cpu_fallback_ops": [],
+  "artifact_path": "target/bitnet/receipts/ask-rtx5070ti.json"
+}

--- a/docs/specs/nvidia-rtx-5070-ti-roadmap.md
+++ b/docs/specs/nvidia-rtx-5070-ti-roadmap.md
@@ -410,7 +410,9 @@ distinct proof stages into one implementation PR.
 - `docs/hardware/LANE_OWNERSHIP.md`
 - `docs/hardware/BENCHMARK_PROTOCOL.md`
 - `docs/hardware/windows-9950x3d-rtx5070ti-validation.md`
+- `docs/specs/rtx5070ti-cuda-answer-readiness.md`
 - `ci/hardware/_templates/cuda-probe-receipt.json`
 - `ci/hardware/_templates/cuda-smoke-receipt.json`
 - `ci/hardware/_templates/cuda-parity-receipt.json`
 - `ci/hardware/_templates/strict-bitnet-cuda-proof.json`
+- `ci/hardware/_templates/bitnet-cuda-answer-receipt.json`

--- a/docs/specs/rtx5070ti-cuda-answer-readiness.md
+++ b/docs/specs/rtx5070ti-cuda-answer-readiness.md
@@ -1,0 +1,338 @@
+# RTX 5070 Ti CUDA Answer Readiness
+
+## Purpose
+
+The RTX 5070 Ti CUDA lane has receipt-backed execution proof. The next product
+milestone is a normal user-answer path: one command, one question, a coherent
+answer, strict fallback rejection, and an answer receipt.
+
+The existing strict CUDA receipts prove that the official BitNet GGUF can route
+BitNet linear work through QK256 CUDA kernels with upload-once weights and zero
+BitNet linear CPU fallback. They do not by themselves prove that the command
+surface is a normal chat or ask flow. The answer-readiness lane must exercise
+the full user-visible generation stack:
+
+```text
+question
+-> prompt template
+-> tokenizer
+-> prompt prefill
+-> incremental decode
+-> stop criteria
+-> answer text
+-> receipt
+```
+
+## Target Command
+
+The intended user command is:
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features \
+  --features cpu,cuda,full-cli \
+  -- ask \
+  --device nvidia-rtx-5070-ti-cuda \
+  --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
+  --question "What is BitNet, in one sentence?" \
+  --max-new-tokens 96 \
+  --strict-cuda \
+  --receipt-out target/bitnet/receipts/ask-rtx5070ti.json
+```
+
+The exact answer text can vary once sampling is enabled. The first readiness
+gate must use deterministic greedy decode so failures are reproducible.
+
+## Current Boundary
+
+The completed NVIDIA proof lane supports these claims:
+
+- The selected backend is `nvidia-rtx-5070-ti-cuda`.
+- The runtime API is `cuda`.
+- The official BitNet GGUF and explicit tokenizer are recorded.
+- BitNet linear work routes through `qk256_gemv_cuda`.
+- QK256 CUDA kernel invocation counts are greater than zero.
+- Weights are uploaded once.
+- Per-token weight upload is false.
+- BitNet linear CPU fallback is zero.
+- `speedup_claim` remains false unless a later same-model benchmark upgrades it.
+
+That is CUDA execution proof. Answer readiness adds a stricter user-facing
+quality gate. A short proof decode whose output is valid CUDA evidence can still
+fail answer readiness if it has no real prompt prefill, emits raw special
+tokens, produces mostly punctuation, or returns unintelligible text.
+
+## Non-Goals
+
+- Do not make dense regular-LLM CUDA work satisfy this contract.
+- Do not use WGPU, Vulkan, D3D12, or generic `cuda` as RTX 5070 Ti CUDA proof.
+- Do not make speedup claims in answer receipts by default.
+- Do not weaken strict CUDA fallback behavior for user convenience.
+- Do not mutate the existing proof commands just to hide product gaps.
+
+## CPU-First Rule
+
+Before CUDA answer quality is debugged, the CPU reference path must answer the
+same prompt corpus with the official GGUF, strict loader, and explicit tokenizer.
+If CPU output is also garbage, the defect is not a CUDA-kernel defect.
+
+Initial CPU answer corpus:
+
+| ID | Prompt | Gate |
+|---|---|---|
+| `math_2_plus_2` | `What is 2+2? Answer with only the number.` | Exact constrained answer. |
+| `colors_four` | `Name four common colors.` | Readable list. |
+| `bitnet_one_sentence` | `Explain BitNet in one sentence.` | Readable one-sentence explanation. |
+| `python_add` | `Write a short Python function that adds two numbers.` | Contains a plausible function. |
+| `capital_france` | `What is the capital of France?` | Mentions Paris. |
+| `five_word_summary` | `Summarize this sentence in five words: BitNet uses very low-bit weights to reduce memory use.` | Non-empty, concise summary. |
+| `shapes_three` | `List three common shapes.` | Readable list. |
+| `yes_no_water` | `Answer yes or no: is water wet?` | Starts with yes or no. |
+
+CPU baseline acceptance:
+
+- Answer is non-empty after special-token trimming.
+- Answer is valid printable UTF-8.
+- No repeated raw special tokens are present.
+- No obvious tokenizer garbage is present.
+- Constrained prompts meet their exact gates.
+- Open prompts are readable enough to inspect manually.
+
+## Prompt Template Authority
+
+The answer path for the official BitNet GGUF must use an explicit Llama 3 chat
+template unless a future receipt records a different authoritative model
+template. The prompt envelope must control:
+
+- BOS handling.
+- `<|begin_of_text|>`.
+- `<|start_header_id|>system<|end_header_id|>` when a system prompt is present.
+- `<|start_header_id|>user<|end_header_id|>`.
+- `<|start_header_id|>assistant<|end_header_id|>`.
+- `<|eot_id|>` and `<|end_of_text|>` stop behavior.
+- Special-token skipping during answer decode.
+
+Answer receipts must include:
+
+```json
+{
+  "prompt_template": {
+    "family": "llama3-chat",
+    "bos_inserted": true,
+    "assistant_prefix_inserted": true,
+    "stop_tokens": ["<|eot_id|>", "<|end_of_text|>"],
+    "special_tokens_skipped_on_decode": true
+  }
+}
+```
+
+## Prompt Prefill Requirement
+
+Answer readiness requires real prompt prefill. The ask path must tokenize the
+full prompt, prefill all prompt tokens, populate the KV cache, then decode new
+tokens incrementally.
+
+Receipt requirement:
+
+```json
+{
+  "prompt_prefill": {
+    "exercised": true,
+    "tokens": 0,
+    "kv_cache_behavior": "prefill_then_incremental_decode",
+    "kv_cache_device": "cpu|cuda"
+  }
+}
+```
+
+CPU KV cache is acceptable for the first answer-readiness milestone if it is
+recorded honestly. Moving KV cache to CUDA is a later speed/productization
+improvement, not a prerequisite for initial coherent output.
+
+## Strict CUDA Behavior
+
+For `--device nvidia-rtx-5070-ti-cuda --strict-cuda`, these conditions must be
+hard failures:
+
+- CUDA unavailable.
+- Selected backend differs from `nvidia-rtx-5070-ti-cuda`.
+- CPU fallback is attempted.
+- BitNet linear layer fallback count is non-zero.
+- Unsupported op is encountered.
+- Minimal, mock, or fallback loader is used.
+- Tokenizer is missing or ambiguous.
+- QK256 CUDA kernel stats are missing or have zero invocations.
+- Weights are uploaded per token.
+
+Generic `cuda` remains distinct from the RTX 5070 Ti proof lane and must not be
+reported as `nvidia-rtx-5070-ti-cuda`.
+
+## Answer Receipt
+
+The answer receipt template lives at:
+
+```text
+ci/hardware/_templates/bitnet-cuda-answer-receipt.json
+```
+
+Required high-level invariants:
+
+- `artifact_kind == "bitnet_cuda_answer"`.
+- `requested_backend == selected_backend == "nvidia-rtx-5070-ti-cuda"`.
+- `runtime_api == "cuda"`.
+- `fallback_used == false`.
+- `speedup_claim == false` unless a same-model benchmark qualifies it.
+- `prompt_prefill.exercised == true`.
+- `bitnet.weights_uploaded_once == true`.
+- `bitnet.per_token_weight_upload == false`.
+- `kernel_stats` contains `qk256_gemv_cuda` with `invocations > 0`.
+- `execution_coverage.bitnet_linear_layers_cpu_fallback == 0`.
+- `quality.garbage_filter_passed == true`.
+
+## Garbage Filter
+
+The garbage filter is a readiness tripwire, not a model-quality evaluator. It
+must reject:
+
+- Empty answers after special-token trimming.
+- Invalid UTF-8 or replacement characters.
+- Mostly punctuation or control-character output.
+- Raw Llama special-token markers in visible answer text.
+- Repetition above the configured token or substring threshold.
+- Non-finite logits or invalid token IDs when those are recorded.
+
+The filter must be deterministic and receipt-visible. Failure should include the
+specific failed rule so the next debugging step is obvious.
+
+## CPU/CUDA Answer Parity
+
+After CPU answer quality is established, the CUDA ask path must compare against
+the CPU reference corpus:
+
+- CPU greedy token IDs.
+- CUDA greedy token IDs.
+- First divergence index.
+- Top-k logits at divergence when available.
+- Decoded CPU answer.
+- Decoded CUDA answer.
+- Prompt template and tokenizer authority for both lanes.
+
+Initial CUDA readiness requires exact token match for constrained prompts.
+Open prompts may diverge after an agreed prefix only if both outputs remain
+readable and the divergence artifact records the first differing token and
+logit context.
+
+## Speed Policy
+
+Answer receipts default to:
+
+```json
+{
+  "speedup_claim": false
+}
+```
+
+Speed claims can only be upgraded by a later same-model, same-tokenizer,
+same-prompt-profile, fallback-free CPU/CUDA benchmark receipt that records load
+time, weight upload time, prompt prefill, first-token latency, steady-state
+decode, kernel time, transfer time, VRAM high-water mark, power, temperature,
+driver, CUDA runtime, toolkit, and NVRTC versions.
+
+## Work Items
+
+### CUDA-ANSWER-001 - CPU Answer Corpus Baseline
+
+Add the fixed prompt corpus and prove the strict CPU path produces sane,
+deterministic greedy answers before debugging CUDA answer quality.
+
+### CUDA-ANSWER-002 - Prompt Template Authority
+
+Add or harden the strict Llama 3 BitNet chat template, including tokenized
+envelope tests and receipt fields for BOS, assistant prefix, stop tokens, and
+special-token decode policy.
+
+### CUDA-ANSWER-003 - CPU Ask Command
+
+Add `bitnet ask --device cpu` with real prompt prefill, normal decode loop,
+answer text, and answer receipt generation.
+
+### CUDA-ANSWER-004 - Strict RTX 5070 Ti CUDA Ask Command
+
+Route `bitnet ask --device nvidia-rtx-5070-ti-cuda --strict-cuda` through the
+proven CUDA backend with strict fallback rejection and answer receipts.
+
+### CUDA-ANSWER-005 - CPU/CUDA Answer Corpus Parity
+
+Record CPU and CUDA greedy token sequences, decoded answers, divergence
+artifacts, and quality-gate results for the fixed answer corpus.
+
+### CUDA-ANSWER-006 - Interactive CUDA Chat Session
+
+Add a session path that loads the model once, uploads weights once, reuses the
+CUDA BitNet context, and emits per-turn or session-summary receipts.
+
+### CUDA-ANSWER-007 - Answer Throughput Qualification
+
+Benchmark the user-facing ask/chat path only after answer quality passes. Keep
+`speedup_claim=false` until the benchmark policy explicitly qualifies it.
+
+## Diagnosis Commands
+
+Current `main` should be sanity-checked before implementation PRs that touch
+generation behavior. If command names differ, that mismatch is part of the
+product-surface gap.
+
+CPU sanity:
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features \
+  --features cpu,full-cli \
+  -- generate \
+  --device cpu \
+  --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
+  --prompt "What is 2+2? Answer with only the number." \
+  --max-new-tokens 16 \
+  --greedy
+```
+
+CUDA sanity:
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features \
+  --features cpu,cuda,full-cli \
+  -- generate \
+  --device nvidia-rtx-5070-ti-cuda \
+  --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
+  --prompt "What is 2+2? Answer with only the number." \
+  --max-new-tokens 16 \
+  --greedy \
+  --json-out target/bitnet/receipts/cuda-answer-smoke.json
+```
+
+## Debug Order
+
+If CPU is good and CUDA diverges early, debug in this order:
+
+1. QK256 unpack and scale handling.
+2. Projection weight name mapping.
+3. RMSNorm semantics.
+4. RoPE base and position handling.
+5. KV-cache append and read behavior.
+6. Logits extraction and output head.
+7. Greedy sampler tie-breaking.
+
+If CPU is also bad, debug in this order:
+
+1. Prompt envelope.
+2. Tokenizer authority and decode policy.
+3. BOS, EOS, and stop-token handling.
+4. Loader or weight mapping.
+5. RoPE and KV-cache behavior.
+6. Sampling and logits post-processing.
+
+## Related Docs
+
+- `docs/specs/nvidia-rtx-5070-ti-roadmap.md`
+- `docs/bitnet/BITNET_RUNTIME_PHASES.md`
+- `docs/bitnet/BITNET_RECEIPT_FIELDS.md`
+- `docs/explanation/architecture/adr-014-prompt-template-auto-detection.md`
+- `ci/hardware/_templates/strict-bitnet-cuda-proof.json`

--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -72,6 +72,26 @@ Not allowed:
 - Do not claim speedup unless a later same-model fallback-free receipt upgrades
   `speedup_claim` under the benchmark policy.
 
+## Productization Follow-Up
+
+The completed proof lane is not the same as a user-answer product path. The
+next productization track is defined in
+`docs/specs/rtx5070ti-cuda-answer-readiness.md` and starts from CPU answer
+quality, prompt template authority, real prompt prefill, and a normal
+`bitnet ask` command before adding strict RTX 5070 Ti CUDA answer receipts.
+
+Answer receipts must keep the completed proof invariants intact:
+
+- selected backend: `nvidia-rtx-5070-ti-cuda`
+- runtime API: `cuda`
+- `qk256_gemv_cuda` invocation count greater than zero
+- weights uploaded once: `true`
+- per-token weight upload: `false`
+- BitNet linear CPU fallback: `0`
+- prompt prefill exercised: `true`
+- answer quality gate passed: `true`
+- speedup claim: `false` unless later benchmark-qualified
+
 ## Work Items
 
 | Work item | Status | Notes |


### PR DESCRIPTION
## Summary
- define the RTX 5070 Ti CUDA answer-readiness contract for a normal `bitnet ask` user path
- add the answer receipt template with strict backend, prompt prefill, quality, parity, and QK256 CUDA evidence fields
- link the new answer-readiness spec and receipt template from the NVIDIA roadmap and completed campaign docs

## Validation
- `Get-Content -Raw ci\hardware\_templates\bitnet-cuda-answer-receipt.json | ConvertFrom-Json | Out-Null`
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`

## Scope
Docs/specs, docs/tracking, and receipt template only. No runtime code, kernels, transformer routing, committed proof receipts, or benchmark claims changed.