### PR TITLE
test(cpu): add BitNet answer corpus baseline

### DIFF
--- a/ci/quality/bitnet-answer-corpus.yaml
+++ b/ci/quality/bitnet-answer-corpus.yaml
@@ -1,0 +1,80 @@
+schema: 1
+artifact_kind: bitnet_answer_corpus
+name: strict-bitnet-answer-corpus-v1
+description: Fixed deterministic prompt set for answer-readiness baselines.
+model:
+  repo: microsoft/bitnet-b1.58-2B-4T-gguf
+  file: ggml-model-i2_s.gguf
+defaults:
+  prompt_template: llama3-chat
+  max_new_tokens: 96
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+  per_prompt_timeout_seconds: 300
+cases:
+  - id: math_2_plus_2
+    question: "What is 2+2? Answer with only the number."
+    max_new_tokens: 16
+    gate:
+      kind: exact_trimmed
+      expected: "4"
+
+  - id: colors_four
+    question: "Name four common colors."
+    max_new_tokens: 48
+    gate:
+      kind: readable
+      min_words: 4
+
+  - id: bitnet_one_sentence
+    question: "Explain BitNet in one sentence."
+    max_new_tokens: 96
+    gate:
+      kind: contains_any
+      contains_any:
+        - "bit"
+        - "weight"
+        - "model"
+
+  - id: python_add
+    question: "Write a short Python function that adds two numbers."
+    max_new_tokens: 96
+    gate:
+      kind: contains_any
+      contains_any:
+        - "def "
+        - "return"
+
+  - id: capital_france
+    question: "What is the capital of France?"
+    max_new_tokens: 32
+    gate:
+      kind: contains_any
+      contains_any:
+        - "Paris"
+        - "paris"
+
+  - id: five_word_summary
+    question: "Summarize this sentence in five words: BitNet uses very low-bit weights to reduce memory use."
+    max_new_tokens: 32
+    gate:
+      kind: readable
+      min_words: 3
+
+  - id: shapes_three
+    question: "List three common shapes."
+    max_new_tokens: 48
+    gate:
+      kind: readable
+      min_words: 3
+
+  - id: yes_no_water
+    question: "Answer yes or no: is water wet?"
+    max_new_tokens: 16
+    gate:
+      kind: starts_with_any
+      starts_with_any:
+        - "yes"
+        - "no"

--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -1,0 +1,553 @@
+//! Answer corpus runner for CPU-first answer-readiness baselines.
+
+use anyhow::{Context, Result};
+use clap::Args;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+/// Run the fixed answer corpus through the existing `bitnet run` surface.
+#[derive(Args, Debug)]
+pub struct AnswerCorpusCommand {
+    /// Path to the answer corpus YAML.
+    #[arg(long, default_value = "ci/quality/bitnet-answer-corpus.yaml", value_name = "PATH")]
+    pub corpus: PathBuf,
+
+    /// Official BitNet GGUF model path.
+    #[arg(long, value_name = "PATH")]
+    pub model: PathBuf,
+
+    /// Explicit tokenizer path. If omitted, the run path must resolve one strictly.
+    #[arg(long, value_name = "PATH")]
+    pub tokenizer: Option<PathBuf>,
+
+    /// Backend label for this baseline. CUDA-ANSWER-001 is CPU-only.
+    #[arg(long, value_name = "BACKEND")]
+    pub device: Option<String>,
+
+    /// Output aggregate answer-corpus receipt.
+    #[arg(
+        long,
+        value_name = "PATH",
+        default_value = "target/bitnet/receipts/cpu-answer-corpus.json"
+    )]
+    pub json_out: PathBuf,
+
+    /// Do not invoke model generation; validate corpus shape and emit not_run rows.
+    #[arg(long, default_value_t = false)]
+    pub dry_run: bool,
+
+    /// Per-prompt timeout for child `bitnet run` invocations.
+    #[arg(long, value_name = "SECONDS")]
+    pub per_prompt_timeout_seconds: Option<u64>,
+
+    /// Fail the command if any executed prompt fails its quality gate.
+    #[arg(long, default_value_t = false)]
+    pub fail_on_quality: bool,
+}
+
+impl AnswerCorpusCommand {
+    /// Execute the answer corpus runner.
+    pub async fn execute(&self, default_device: &str) -> Result<()> {
+        let corpus = AnswerCorpus::load(&self.corpus)?;
+        let device =
+            normalize_cpu_baseline_device(self.device.as_deref().unwrap_or(default_device));
+        if device != "cpu" {
+            anyhow::bail!(
+                "answer-corpus is the CUDA-ANSWER-001 CPU baseline and only accepts --device cpu; got {device}"
+            );
+        }
+        let default_timeout_seconds = effective_default_timeout_seconds(
+            self.per_prompt_timeout_seconds,
+            corpus.defaults.per_prompt_timeout_seconds,
+        );
+
+        let receipt_dir = self
+            .json_out
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("answer-corpus-runs");
+        fs::create_dir_all(&receipt_dir)?;
+
+        let exe = std::env::current_exe().context("failed to resolve current bitnet executable")?;
+        let mut rows = Vec::with_capacity(corpus.cases.len());
+        for case in &corpus.cases {
+            let row = if self.dry_run {
+                self.not_run_row(case, "dry_run_requested")
+            } else {
+                self.run_case(&exe, &receipt_dir, &corpus, case, device, default_timeout_seconds)?
+            };
+            rows.push(row);
+        }
+
+        let total = rows.len();
+        let passed = rows.iter().filter(|row| row["quality"]["passed"] == true).count();
+        let failed = rows
+            .iter()
+            .filter(|row| row["status"] == "quality_failed" || row["status"] == "command_failed")
+            .count();
+        let timed_out = rows.iter().filter(|row| row["status"] == "timeout").count();
+        let not_run = rows.iter().filter(|row| row["status"] == "not_run").count();
+
+        let receipt = json!({
+            "schema_version": "1.0.0",
+            "artifact_kind": "bitnet_cpu_answer_corpus",
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+            "corpus": {
+                "path": self.corpus.display().to_string(),
+                "name": corpus.name,
+                "description": corpus.description,
+                "case_count": corpus.cases.len(),
+            },
+            "model": {
+                "repo": corpus.model.repo,
+                "file": corpus.model.file,
+                "path": self.model.display().to_string(),
+                "loader_mode": "real_gguf",
+                "fallback_loader_used": false,
+                "tokenizer": "llama3",
+                "tokenizer_path": self.tokenizer.as_ref().map(|path| path.display().to_string()),
+            },
+            "backend": {
+                "requested_backend": "cpu",
+                "selected_backend": "cpu",
+                "runtime_api": "cpu",
+                "fallback_used": false,
+            },
+            "prompt_template": {
+                "family": corpus.defaults.prompt_template,
+            },
+            "generation": {
+                "mode": if corpus.defaults.greedy { "greedy" } else { "sampling" },
+                "temperature": corpus.defaults.temperature,
+                "deterministic": corpus.defaults.deterministic,
+                "strict_loader": corpus.defaults.strict_loader,
+                "default_max_new_tokens": corpus.defaults.max_new_tokens,
+                "per_prompt_timeout_seconds": default_timeout_seconds,
+            },
+            "quality_summary": {
+                "total": total,
+                "passed": passed,
+                "failed": failed,
+                "timeout": timed_out,
+                "not_run": not_run,
+            },
+            "cases": rows,
+            "speedup_claim": false,
+        });
+
+        if let Some(parent) = self.json_out.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&self.json_out, serde_json::to_vec_pretty(&receipt)?)?;
+        println!("answer corpus receipt written to {}", self.json_out.display());
+
+        if self.fail_on_quality && (failed > 0 || timed_out > 0) {
+            anyhow::bail!("answer corpus quality failed: {failed} failed, {timed_out} timed out");
+        }
+        Ok(())
+    }
+
+    fn run_case(
+        &self,
+        exe: &Path,
+        receipt_dir: &Path,
+        corpus: &AnswerCorpus,
+        case: &AnswerCase,
+        device: &str,
+        default_timeout_seconds: u64,
+    ) -> Result<Value> {
+        let case_receipt = receipt_dir.join(format!("{}.json", sanitize_file_stem(&case.id)));
+        let max_new_tokens = case.max_new_tokens.unwrap_or(corpus.defaults.max_new_tokens);
+        let timeout_seconds = case.timeout_seconds.unwrap_or(default_timeout_seconds).max(1);
+
+        let mut args: Vec<OsString> = vec![
+            "--device".into(),
+            device.into(),
+            "run".into(),
+            "--model".into(),
+            self.model.as_os_str().to_owned(),
+            "--prompt".into(),
+            case.question.clone().into(),
+            "--max-new-tokens".into(),
+            max_new_tokens.to_string().into(),
+            "--temperature".into(),
+            corpus.defaults.temperature.to_string().into(),
+            "--prompt-template".into(),
+            corpus.defaults.prompt_template.clone().into(),
+            "--json-out".into(),
+            case_receipt.as_os_str().to_owned(),
+        ];
+        if let Some(tokenizer) = &self.tokenizer {
+            args.push("--tokenizer".into());
+            args.push(tokenizer.as_os_str().to_owned());
+        }
+        if corpus.defaults.greedy {
+            args.push("--greedy".into());
+        }
+        if corpus.defaults.deterministic {
+            args.push("--deterministic".into());
+        }
+        if corpus.defaults.strict_loader {
+            args.push("--strict-loader".into());
+            args.push("--strict-tokenizer".into());
+        }
+
+        let run = run_child_with_timeout(exe, &args, Duration::from_secs(timeout_seconds))?;
+        if run.timed_out {
+            return Ok(json!({
+                "id": case.id,
+                "question": case.question,
+                "status": "timeout",
+                "timeout_seconds": timeout_seconds,
+                "run_receipt_path": case_receipt.display().to_string(),
+                "quality": {
+                    "passed": false,
+                    "failed_rules": ["timeout"],
+                },
+                "stderr_tail": tail_string(&run.stderr, 4096),
+            }));
+        }
+        if !run.success {
+            return Ok(json!({
+                "id": case.id,
+                "question": case.question,
+                "status": "command_failed",
+                "exit_code": run.exit_code,
+                "run_receipt_path": case_receipt.display().to_string(),
+                "quality": {
+                    "passed": false,
+                    "failed_rules": ["command_failed"],
+                },
+                "stdout_tail": tail_string(&run.stdout, 4096),
+                "stderr_tail": tail_string(&run.stderr, 4096),
+            }));
+        }
+
+        let run_receipt: Value = serde_json::from_slice(
+            &fs::read(&case_receipt)
+                .with_context(|| format!("missing run receipt {}", case_receipt.display()))?,
+        )
+        .with_context(|| format!("invalid run receipt {}", case_receipt.display()))?;
+        let answer = run_receipt["text"].as_str().unwrap_or_default().to_string();
+        let quality = evaluate_quality(&answer, &case.gate);
+        let status = if quality.passed { "passed" } else { "quality_failed" };
+
+        Ok(json!({
+            "id": case.id,
+            "question": case.question,
+            "status": status,
+            "run_receipt_path": case_receipt.display().to_string(),
+            "answer": answer,
+            "tokens": run_receipt.get("tokens").cloned().unwrap_or(Value::Null),
+            "prompt_template": corpus.defaults.prompt_template,
+            "quality": {
+                "passed": quality.passed,
+                "printable_utf8": quality.printable_utf8,
+                "non_empty_answer": quality.non_empty_answer,
+                "no_replacement_chars": quality.no_replacement_chars,
+                "no_raw_special_tokens": quality.no_raw_special_tokens,
+                "mostly_text": quality.mostly_text,
+                "gate_kind": case.gate.kind,
+                "failed_rules": quality.failed_rules,
+            },
+            "backend": {
+                "requested_backend": run_receipt["requested_backend"].clone(),
+                "selected_backend": run_receipt["selected_backend"].clone(),
+                "runtime_api": run_receipt["runtime_api"].clone(),
+                "fallback_used": run_receipt["fallback_used"].clone(),
+            }
+        }))
+    }
+
+    fn not_run_row(&self, case: &AnswerCase, reason: &str) -> Value {
+        json!({
+            "id": case.id,
+            "question": case.question,
+            "status": "not_run",
+            "reason": reason,
+            "quality": {
+                "passed": false,
+                "failed_rules": ["not_run"],
+            }
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AnswerCorpus {
+    schema: u32,
+    artifact_kind: String,
+    name: String,
+    description: String,
+    model: CorpusModel,
+    defaults: CorpusDefaults,
+    cases: Vec<AnswerCase>,
+}
+
+impl AnswerCorpus {
+    fn load(path: &Path) -> Result<Self> {
+        let corpus: Self = serde_yaml::from_slice(
+            &fs::read(path).with_context(|| format!("failed to read {}", path.display()))?,
+        )
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+        if corpus.schema != 1 {
+            anyhow::bail!("unsupported answer corpus schema {}", corpus.schema);
+        }
+        if corpus.artifact_kind != "bitnet_answer_corpus" {
+            anyhow::bail!("unexpected answer corpus artifact_kind {}", corpus.artifact_kind);
+        }
+        if corpus.cases.is_empty() {
+            anyhow::bail!("answer corpus must contain at least one case");
+        }
+        Ok(corpus)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusModel {
+    repo: String,
+    file: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CorpusDefaults {
+    prompt_template: String,
+    max_new_tokens: usize,
+    greedy: bool,
+    deterministic: bool,
+    strict_loader: bool,
+    temperature: f32,
+    per_prompt_timeout_seconds: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnswerCase {
+    id: String,
+    question: String,
+    max_new_tokens: Option<usize>,
+    timeout_seconds: Option<u64>,
+    gate: AnswerGate,
+}
+
+#[derive(Debug, Deserialize)]
+struct AnswerGate {
+    kind: String,
+    expected: Option<String>,
+    contains_any: Option<Vec<String>>,
+    starts_with_any: Option<Vec<String>>,
+    min_words: Option<usize>,
+}
+
+struct QualityResult {
+    passed: bool,
+    printable_utf8: bool,
+    non_empty_answer: bool,
+    no_replacement_chars: bool,
+    no_raw_special_tokens: bool,
+    mostly_text: bool,
+    failed_rules: Vec<String>,
+}
+
+fn normalize_cpu_baseline_device(device: &str) -> &str {
+    if device == "auto" { "cpu" } else { device }
+}
+
+fn effective_default_timeout_seconds(cli: Option<u64>, corpus: Option<u64>) -> u64 {
+    cli.or(corpus).unwrap_or(300).max(1)
+}
+
+fn evaluate_quality(answer: &str, gate: &AnswerGate) -> QualityResult {
+    let normalized = strip_special_markers(answer).trim().to_string();
+    let non_empty_answer = !normalized.is_empty();
+    let no_replacement_chars = !normalized.contains('\u{FFFD}');
+    let no_raw_special_tokens = !contains_raw_special_token(&normalized);
+    let mostly_text = mostly_text(&normalized);
+    let printable_utf8 = normalized.chars().all(|ch| ch == '\n' || ch == '\t' || !ch.is_control());
+
+    let mut failed_rules = Vec::new();
+    if !non_empty_answer {
+        failed_rules.push("empty_answer".to_string());
+    }
+    if !no_replacement_chars {
+        failed_rules.push("replacement_chars".to_string());
+    }
+    if !no_raw_special_tokens {
+        failed_rules.push("raw_special_tokens".to_string());
+    }
+    if !mostly_text {
+        failed_rules.push("mostly_text".to_string());
+    }
+    if !printable_utf8 {
+        failed_rules.push("printable_utf8".to_string());
+    }
+
+    if !gate_passed(&normalized, gate) {
+        failed_rules.push(format!("gate_{}", gate.kind));
+    }
+
+    QualityResult {
+        passed: failed_rules.is_empty(),
+        printable_utf8,
+        non_empty_answer,
+        no_replacement_chars,
+        no_raw_special_tokens,
+        mostly_text,
+        failed_rules,
+    }
+}
+
+fn gate_passed(answer: &str, gate: &AnswerGate) -> bool {
+    match gate.kind.as_str() {
+        "exact_trimmed" => {
+            let Some(expected) = &gate.expected else {
+                return false;
+            };
+            answer.trim().eq_ignore_ascii_case(expected.trim())
+        }
+        "contains_any" => {
+            let lower = answer.to_ascii_lowercase();
+            gate.contains_any.as_ref().is_some_and(|items| {
+                items.iter().any(|needle| lower.contains(&needle.to_ascii_lowercase()))
+            })
+        }
+        "starts_with_any" => {
+            let lower = answer.trim_start().to_ascii_lowercase();
+            gate.starts_with_any.as_ref().is_some_and(|items| {
+                items.iter().any(|needle| lower.starts_with(&needle.to_ascii_lowercase()))
+            })
+        }
+        "readable" => word_count(answer) >= gate.min_words.unwrap_or(1),
+        _ => false,
+    }
+}
+
+fn strip_special_markers(answer: &str) -> String {
+    answer.replace("<|begin_of_text|>", "").replace("<|end_of_text|>", "").replace("<|eot_id|>", "")
+}
+
+fn contains_raw_special_token(answer: &str) -> bool {
+    answer.contains("<|") || answer.contains("|>")
+}
+
+fn mostly_text(answer: &str) -> bool {
+    let mut meaningful = 0usize;
+    let mut punctuation_or_control = 0usize;
+    for ch in answer.chars() {
+        if ch.is_alphanumeric() || ch.is_whitespace() {
+            meaningful += 1;
+        } else if ch.is_ascii_punctuation() || ch.is_control() {
+            punctuation_or_control += 1;
+        }
+    }
+    meaningful > 0 && punctuation_or_control <= meaningful.saturating_mul(2)
+}
+
+fn word_count(answer: &str) -> usize {
+    answer.split_whitespace().filter(|word| word.chars().any(char::is_alphanumeric)).count()
+}
+
+struct ChildRun {
+    success: bool,
+    timed_out: bool,
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_child_with_timeout(exe: &Path, args: &[OsString], timeout: Duration) -> Result<ChildRun> {
+    let mut child = Command::new(exe)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to spawn {}", exe.display()))?;
+    let start = Instant::now();
+    loop {
+        if child.try_wait()?.is_some() {
+            let output = child.wait_with_output()?;
+            return Ok(ChildRun {
+                success: output.status.success(),
+                timed_out: false,
+                exit_code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let output = child.wait_with_output()?;
+            return Ok(ChildRun {
+                success: false,
+                timed_out: true,
+                exit_code: output.status.code(),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            });
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn tail_string(value: &str, max_chars: usize) -> String {
+    let len = value.chars().count();
+    if len <= max_chars { value.to_string() } else { value.chars().skip(len - max_chars).collect() }
+}
+
+fn sanitize_file_stem(id: &str) -> String {
+    id.chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' { ch } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gate(kind: &str) -> AnswerGate {
+        AnswerGate {
+            kind: kind.to_string(),
+            expected: None,
+            contains_any: None,
+            starts_with_any: None,
+            min_words: None,
+        }
+    }
+
+    #[test]
+    fn exact_gate_accepts_trimmed_answer() {
+        let gate = AnswerGate { expected: Some("4".to_string()), ..gate("exact_trimmed") };
+        let quality = evaluate_quality(" 4\n", &gate);
+        assert!(quality.passed);
+    }
+
+    #[test]
+    fn quality_rejects_raw_special_tokens() {
+        let quality = evaluate_quality("<|start_header_id|>assistant", &gate("readable"));
+        assert!(!quality.passed);
+        assert!(quality.failed_rules.contains(&"raw_special_tokens".to_string()));
+    }
+
+    #[test]
+    fn quality_rejects_punctuation_noise() {
+        let quality = evaluate_quality("!!!,,,!!!", &gate("readable"));
+        assert!(!quality.passed);
+        assert!(quality.failed_rules.contains(&"mostly_text".to_string()));
+    }
+
+    #[test]
+    fn cli_timeout_overrides_corpus_default() {
+        assert_eq!(effective_default_timeout_seconds(Some(1), Some(300)), 1);
+        assert_eq!(effective_default_timeout_seconds(None, Some(120)), 120);
+        assert_eq!(effective_default_timeout_seconds(None, None), 300);
+        assert_eq!(effective_default_timeout_seconds(Some(0), Some(300)), 1);
+    }
+}

--- a/crates/bitnet-cli/src/commands/mod.rs
+++ b/crates/bitnet-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! CLI command implementations
 
+pub mod answer_corpus;
 #[cfg(feature = "cli-bench")]
 pub mod benchmark;
 pub mod chat;
@@ -11,6 +12,7 @@ pub mod inspect;
 pub mod serve;
 pub mod template_util;
 
+pub use answer_corpus::AnswerCorpusCommand;
 #[cfg(feature = "cli-bench")]
 pub use benchmark::BenchmarkCommand;
 pub use convert::ConvertCommand;

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -118,7 +118,9 @@ fn bitnet_version() -> &'static str {
 #[cfg(feature = "cli-bench")]
 use commands::BenchmarkCommand;
 #[cfg(feature = "full-cli")]
-use commands::{ConvertCommand, InferenceCommand, InspectCommand, ServeCommand};
+use commands::{
+    AnswerCorpusCommand, ConvertCommand, InferenceCommand, InspectCommand, ServeCommand,
+};
 use config::{CliConfig, ConfigBuilder, DEVICE_HELP};
 
 /// BitNet CLI - High-performance 1-bit LLM inference toolkit
@@ -425,6 +427,10 @@ enum Commands {
     /// Creative chat with nucleus sampling:
     ///   bitnet chat --model model.gguf --temperature 0.8 --top-p 0.95
     Chat(Box<InferenceCommand>),
+
+    #[cfg(feature = "full-cli")]
+    /// Run the fixed CPU answer-readiness corpus through the `run` surface
+    AnswerCorpus(Box<AnswerCorpusCommand>),
 
     #[cfg(feature = "full-cli")]
     /// Convert between model formats
@@ -748,6 +754,8 @@ async fn main() -> Result<()> {
         Some(Commands::Inference(cmd)) => (*cmd).execute(&config).await,
         #[cfg(feature = "full-cli")]
         Some(Commands::Chat(cmd)) => (*cmd).run_chat(&config).await,
+        #[cfg(feature = "full-cli")]
+        Some(Commands::AnswerCorpus(cmd)) => (*cmd).execute(&requested_backend_label).await,
         #[cfg(feature = "full-cli")]
         Some(Commands::Convert(cmd)) => cmd.execute(&config).await,
         #[cfg(feature = "cli-bench")]

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -358,6 +358,72 @@ fn chat_subcommand_help() {
         .stdout(predicate::str::contains("--model"));
 }
 
+/// `answer-corpus --help` is recognized (requires full-cli).
+#[cfg(feature = "full-cli")]
+#[test]
+fn answer_corpus_subcommand_help() {
+    bitnet()
+        .args(["answer-corpus", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--corpus"))
+        .stdout(predicate::str::contains("--dry-run"));
+}
+
+/// `answer-corpus --dry-run` validates corpus shape without requiring a model load.
+#[cfg(feature = "full-cli")]
+#[test]
+fn answer_corpus_dry_run_writes_not_run_receipt() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let corpus = dir.path().join("corpus.yaml");
+    let out = dir.path().join("receipt.json");
+    std::fs::write(
+        &corpus,
+        r#"schema: 1
+artifact_kind: bitnet_answer_corpus
+name: test-corpus
+description: test
+model:
+  repo: microsoft/bitnet-b1.58-2B-4T-gguf
+  file: ggml-model-i2_s.gguf
+defaults:
+  prompt_template: llama3-chat
+  max_new_tokens: 4
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+cases:
+  - id: math
+    question: "What is 2+2?"
+    gate:
+      kind: exact_trimmed
+      expected: "4"
+"#,
+    )
+    .expect("write corpus");
+
+    bitnet()
+        .args([
+            "answer-corpus",
+            "--dry-run",
+            "--model",
+            "missing.gguf",
+            "--corpus",
+            corpus.to_str().unwrap(),
+            "--json-out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out).expect("read receipt")).expect("json receipt");
+    assert_eq!(receipt["artifact_kind"], "bitnet_cpu_answer_corpus");
+    assert_eq!(receipt["quality_summary"]["not_run"], 1);
+    assert_eq!(receipt["cases"][0]["status"], "not_run");
+}
+
 /// `inference --help` is recognized (requires full-cli).
 #[cfg(feature = "full-cli")]
 #[test]

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
@@ -48,6 +48,7 @@ Commands:
   score               Calculate perplexity score for a model
   inference           Run inference on a model
   chat                Interactive chat mode (streaming)
+  answer-corpus       Run the fixed CPU answer-readiness corpus through the `run` surface
   convert             Convert between model formats
   benchmark           Benchmark model performance
   serve               Start inference server


### PR DESCRIPTION
## Summary
- add a fixed deterministic BitNet answer-readiness corpus for CPU-first quality baselining
- add `bitnet answer-corpus` to run the corpus through the existing `run` surface and emit aggregate receipts
- include dry-run, timeout, quality-gate, and CPU-only backend guard coverage

## Validation
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --dry-run --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --corpus ci/quality/bitnet-answer-corpus.yaml --json-out target/bitnet/receipts/cpu-answer-corpus-dry-run.json
- cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --corpus ci/quality/bitnet-answer-corpus.yaml --json-out target/bitnet/receipts/cpu-answer-corpus-timeout-smoke.json --per-prompt-timeout-seconds 1
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus -- --nocapture
- cargo fmt -p bitnet-cli -- --check
- git diff --check

## Notes
- This does not claim CPU answer quality yet; it adds the corpus runner and honest receipt surface for that baseline.
- This does not touch CUDA routing, QK256 kernels, transformer routing, server inference, or speed claims.