### PR TITLE
ci: implement Codecov reporting for CPU execution-surface coverage

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -11,22 +11,34 @@ name: CI (Core)
 # (rationale for the well-below-$1-per-PR target and the verification ladder).
 
 on:
+on:
   pull_request:
     branches: [ main ]
     paths:
+      # Rust code and build files - always trigger core checks
       - 'crates/**'
       - 'crossval/**'
       - 'tests/**'
       - 'tools/bitnet-task/**'
       - 'xtask/**'
-      - 'docs/tracking/**'
-      - '.codex/campaigns/**'
       - 'fuzz/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+
+      # Documentation tracked in CI policy
+      - 'docs/tracking/**'
+
+      # CI/Codex campaign definitions
+      - '.codex/campaigns/**'
+
+      # Workflow files - core and related CI workflows
       - '.github/workflows/ci-core.yml'
       - '.github/workflows/coverage.yml'
+      - '.github/workflows/ci-reporting.yml'
+
+      # CI configuration - codecov config affects verification signal
+      - 'codecov.yml'
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -26,6 +26,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/ci-core.yml'
+      - '.github/workflows/coverage.yml'
   push:
     branches: [ main ]
     paths:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -11,7 +11,6 @@ name: CI (Core)
 # (rationale for the well-below-$1-per-PR target and the verification ladder).
 
 on:
-on:
   pull_request:
     branches: [ main ]
     paths:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -133,8 +133,8 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload coverage reports to Codecov
-        if: ${{ always() && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+      - name: Upload coverage reports to Codecov (main)
+        if: ${{ github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -142,6 +142,16 @@ jobs:
           flags: rust-cpu
           name: bitnet-rs-rust-cpu
           fail_ci_if_error: true
+
+      - name: Upload coverage reports to Codecov (advisory PR)
+        if: ${{ github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: false
 
       - name: Upload coverage artifacts (always)
         if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -134,7 +134,7 @@ jobs:
           fi
 
       - name: Upload coverage reports to Codecov (main)
-        if: ${{ github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -709,6 +709,87 @@ gh pr edit 123 --remove-label quant,perf,crossval
 
 **See also:** `.github/workflows/` for individual workflow definitions and trigger conditions.
 
+### CI Workflow Path Filters
+
+**Important:** BitNet-rs uses **path filters** in GitHub Actions workflows to prevent unnecessary CI runs and keep costs low. When adding or modifying CI configuration files, you must ensure the appropriate workflows are triggered—otherwise PRs can hang waiting for required checks that never start.
+
+#### Understanding Path Filters
+
+Path filters determine which workflows run based on what files changed in a PR:
+
+- **ci-core.yml**: Required for all PR merges. Runs only when specific paths change (Rust code, config files, CI workflows)
+- **coverage.yml**: Label-gated. Runs on `main` push and PRs labeled `coverage` or `full-ci`
+- **Other workflows**: Scoped to their domain (GPU, quantization, fuzz, etc.)
+
+If your PR changes a file but the workflow that validates those changes has a path filter that **doesn't include that file**, the workflow won't run—and if it's a required check, your PR will hang waiting for it.
+
+#### Path Filter Checklist
+
+When adding a new workflow or CI config file, update **both**:
+
+1. **ci-core.yml path filters** — Include if the file affects Rust compilation, test execution, or core verification:
+   - ✅ Workflow files (`.github/workflows/*.yml`) → Add to `ci-core.yml` paths
+   - ✅ Config files that affect verification (`codecov.yml`, `.rustfmt.toml`, etc.) → Add to `ci-core.yml` paths
+   - ✅ Rust source code, Cargo.toml, etc. → Already included
+   - ❌ Docs-only changes → Use existing doc workflow filters instead
+
+2. **Any new workflow's path filters** — If you create a new workflow, define its path filters to avoid running on unrelated changes
+
+#### Example: Adding a New Verification Workflow
+
+If you create a new workflow file (e.g., `quality-gates.yml`) that validates CI configuration:
+
+```yaml
+name: Quality Gates
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'  # Run when any workflow changes
+      - 'codecov.yml'           # Run when coverage config changes
+      - '.rustfmt.toml'         # Run when formatter config changes
+```
+
+Then add this workflow file to **ci-core.yml** path filters (if it's a required check):
+
+```yaml
+paths:
+  - '.github/workflows/ci-core.yml'
+  - '.github/workflows/quality-gates.yml'  # ← Add new workflow here
+```
+
+#### Troubleshooting: "4 of 5 required checks expected"
+
+If your PR shows this error on GitHub:
+- ✓ 4 required checks passed
+- ✗ 1 required check not yet reported
+
+**Likely cause**: A required workflow (usually `ci-core`) has path filters that don't match your changed files.
+
+**Solution**:
+1. Check what you changed (files in the PR)
+2. Look at the required workflow's path filters in `.github/workflows/ci-core.yml`
+3. If your changed files aren't in the path filters, add them
+4. Commit and push the updated workflow file
+5. The workflow should now trigger and complete
+
+**Example PR flow:**
+```bash
+# 1. Change codecov.yml (CI config)
+# 2. Push PR → ci-core doesn't run (codecov.yml not in path filters)
+# 3. PR hangs: "4 of 5 required checks"
+# 4. Update ci-core.yml to include codecov.yml in paths
+# 5. Push update → ci-core now triggers
+# 6. After ci-core passes, PR merges
+```
+
+**See also:**
+- [CI Cost and Verification Policy](docs/ci/cost-and-verification-policy.md) — Design rationale for path filters and CI lanes
+- `.github/workflows/ci-core.yml` — Current path filter definitions (search for "paths:")
+
+---
+
 ## GPU Backend Development
 
 If you're contributing GPU backend code (kernels, new backends, device selection),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # bitnet-rs
 
 [![CI](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml)
-[![MSRV: 1.93.0-blue.svg)](./rust-toolchain.toml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/BitNet-rs/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/BitNet-rs)
+[![MSRV](https://img.shields.io/badge/MSRV-1.92.0-blue.svg)](./rust-toolchain.toml)
 [![Rust 2024](https://img.shields.io/badge/edition-2024-orange.svg)](./rust-toolchain.toml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](./LICENSE)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,10 +20,7 @@ coverage:
         flags:
           - rust-cpu
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: false
+comment: false
 
 github_checks:
   annotations: false

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -163,6 +163,67 @@ spend scale linearly with PR volume. The goal is more proof per CI minute —
 enough verification for the agentic age, paid for by changing the cost curve
 of verification.
 
+## Coverage reporting (Codecov)
+
+Coverage is one signal on the verification ladder: it measures **execution
+surface**, not test adequacy or model quality.
+
+### What coverage answers
+
+Coverage tells us: _Did tests exercise this Rust code?_
+
+It does **not** tell us:
+
+- whether tests would catch the wrong behavior (see `ripr`, property tests)
+- whether the inference engine produces correct output (see crossval, hardware validation)
+- whether GPU backends are correct (see GPU scaffolding status in README)
+- whether model predictions are sound (see model validation in `docs/howto/`)
+
+### Coverage in BitNet-rs
+
+Coverage runs are **gated by label or main branch**:
+
+- **PR runs:** only when explicitly labeled `coverage` or `full-ci`
+- **Main runs:** automatic after every merge (cost: ~45 LEM, included in
+  release validation)
+- **Flag:** `rust-cpu` — CPU path execution surface only
+- **Threshold policy:** currently informational; will ratchet after baseline
+  collection
+
+Coverage artifacts (`coverage.json`, `coverage.txt`, `lcov.info`, `coverage-report`) are stored on every run, enabling trend analysis and per-crate surface inspection.
+
+### Codecov configuration
+
+Codecov integration is configured in `codecov.yml` with:
+
+- **Project status:** tracks overall coverage %
+- **Patch status:** tracks changes in PR diffs
+- **Comments:** disabled — the GitHub check and Codecov dashboard are the
+  primary signals
+- **Flags:** scoped to `rust-cpu` for now; GPU flags deferred until backend
+  validation is real
+
+### Coverage is not
+
+Coverage is explicitly **not** responsible for:
+
+- CUDA, Metal, OpenCL, ROCm validation (GPU backends are still scaffold)
+- model quality or inference correctness (see crossval, hardware receipts)
+- test design adequacy (see `ripr` and property tests)
+- production inference performance (see hardware validation, runtime receipts)
+
+### Future: baseline and ratchet
+
+After 10–20 runs with real project coverage, we will review:
+
+1. Coverage % distribution across crate types
+2. Lowest-covered core paths
+3. Runtime cost and flake rate
+4. Whether `--ignore-run-fail` is masking relevant failures
+
+Then we will decide whether to tighten thresholds and move from informational
+to enforced status. Decisions will be based on observed data, not aspiration.
+
 ## Why verification needs to increase
 
 Agentic development changes the shape of risk.


### PR DESCRIPTION
## Summary

Complete Codecov integration as a CPU-first, advisory coverage signal that fits the repo's CI economics model.

**Key changes:**

1. **README badge** — Add Codecov badge beside CI badge for public visibility
2. **Workflow hardening** — Split coverage.yml upload into two steps:
   - Main: strict (`fail_ci_if_error: true`)
   - PR: advisory (`fail_ci_if_error: false`)
3. **Quiet comments** — Set `comment: false` in codecov.yml for cleaner rollout
4. **Policy documentation** — Add coverage section to cost-and-verification-policy.md explaining:
   - Coverage measures **execution surface**, not test adequacy or model quality
   - No GPU validation claims (backends are scaffolded)
   - Label/main gating keeps cost reasonable
   - Thresholds informational during baseline (will ratchet after data)

## Verification

- [x] No whitespace issues (`git diff --check`)
- [x] Cargo format check
- [x] Codecov badge URL verified
- [x] Workflow syntax valid

## Coverage gating

- **PR runs:** explicit `coverage` or `full-ci` label only
- **Main runs:** automatic (cost: ~45 LEM)
- **Flag:** `rust-cpu` (CPU path only)
- **Threshold:** informational until baseline established

## Next steps (PR 5)

After 10–20 runs with real data, review:
1. Coverage % distribution
2. Lowest-covered core paths
3. Runtime cost and flake rate
4. Whether `--ignore-run-fail` is masking failures

Then decide on tightening thresholds to enforced status.

https://claude.ai/code/session_017CTuEMQyfvgGjpxjwo7PC4

---
_Generated by [Claude Code](https://claude.ai/code/session_017CTuEMQyfvgGjpxjwo7PC4)_