### PR TITLE
fix(cuda): discover NVRTC for strict ask receipts

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -3774,6 +3774,12 @@ async fn run_ask_generation(
             "--strict-cuda requires --device {RTX_5070_TI_CUDA}; requested backend was {requested_backend_label}"
         );
     }
+    if strict_cuda && let Some(cuda_bin) = ensure_strict_cuda_ask_runtime_libraries_visible()? {
+        debug!(
+            "added CUDA Toolkit bin directory to process PATH for strict CUDA ask: {}",
+            cuda_bin.display()
+        );
+    }
 
     let question_for_receipt = question.clone();
     let system_prompt_for_receipt = system_prompt.clone();
@@ -3902,6 +3908,181 @@ fn validate_strict_cuda_ask_receipt(run_receipt: &serde_json::Value) -> Result<(
     Ok(())
 }
 
+fn ensure_strict_cuda_ask_runtime_libraries_visible() -> Result<Option<std::path::PathBuf>> {
+    #[cfg(all(feature = "cuda", target_os = "windows"))]
+    {
+        ensure_windows_cuda_toolkit_bin_on_path()
+    }
+
+    #[cfg(not(all(feature = "cuda", target_os = "windows")))]
+    {
+        Ok(None)
+    }
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn ensure_windows_cuda_toolkit_bin_on_path() -> Result<Option<std::path::PathBuf>> {
+    if windows_cuda_runtime_libraries_visible_on_path() {
+        return Ok(None);
+    }
+
+    let Some(cuda_bin) = discover_windows_cuda_toolkit_bin() else {
+        return Ok(None);
+    };
+    prepend_process_path(&cuda_bin).with_context(|| {
+        format!("failed to add CUDA Toolkit bin to PATH: {}", cuda_bin.display())
+    })?;
+    Ok(Some(cuda_bin))
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn discover_windows_cuda_toolkit_bin() -> Option<std::path::PathBuf> {
+    discover_cuda_toolkit_bin_from_roots(windows_cuda_toolkit_search_roots())
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn discover_cuda_toolkit_bin_from_roots<I, P>(roots: I) -> Option<std::path::PathBuf>
+where
+    I: IntoIterator<Item = P>,
+    P: AsRef<std::path::Path>,
+{
+    let mut candidates = Vec::new();
+    for root in roots {
+        collect_cuda_toolkit_bin_candidates(root.as_ref(), &mut candidates);
+    }
+    candidates.sort_by(|left, right| {
+        cuda_bin_version_key(right).cmp(&cuda_bin_version_key(left)).then_with(|| left.cmp(right))
+    });
+    candidates.into_iter().find(|candidate| cuda_toolkit_bin_has_runtime_libraries(candidate))
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn collect_cuda_toolkit_bin_candidates(
+    root: &std::path::Path,
+    candidates: &mut Vec<std::path::PathBuf>,
+) {
+    candidates.push(root.to_path_buf());
+    candidates.push(root.join("bin"));
+
+    let Ok(children) = std::fs::read_dir(root) else {
+        return;
+    };
+    for child in children.flatten() {
+        let path = child.path();
+        if path.is_dir()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with('v'))
+        {
+            candidates.push(path.join("bin"));
+        }
+    }
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn cuda_toolkit_bin_has_runtime_libraries(bin: &std::path::Path) -> bool {
+    cuda_toolkit_bin_has_any(bin, WINDOWS_NVRTC_LIBRARY_NAMES)
+        && cuda_toolkit_bin_has_any(bin, WINDOWS_CUDART_LIBRARY_NAMES)
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn cuda_toolkit_bin_has_any(bin: &std::path::Path, names: &[&str]) -> bool {
+    names.iter().any(|name| bin.join(name).is_file())
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn windows_cuda_runtime_libraries_visible_on_path() -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|entry| cuda_toolkit_bin_has_runtime_libraries(&entry))
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn windows_cuda_toolkit_search_roots() -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    for (key, value) in std::env::vars_os() {
+        if key.to_string_lossy().to_ascii_uppercase().starts_with("CUDA_PATH") && !value.is_empty()
+        {
+            roots.push(std::path::PathBuf::from(value));
+        }
+    }
+
+    for key in ["ProgramW6432", "ProgramFiles"] {
+        if let Some(program_files) = std::env::var_os(key) {
+            roots.push(
+                std::path::PathBuf::from(program_files)
+                    .join("NVIDIA GPU Computing Toolkit")
+                    .join("CUDA"),
+            );
+        }
+    }
+    roots.push(std::path::PathBuf::from(r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"));
+
+    dedupe_paths(roots)
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn dedupe_paths(paths: Vec<std::path::PathBuf>) -> Vec<std::path::PathBuf> {
+    let mut deduped = Vec::<std::path::PathBuf>::new();
+    for path in paths {
+        if !deduped.iter().any(|existing| paths_equal_for_process_path(existing, &path)) {
+            deduped.push(path);
+        }
+    }
+    deduped
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn prepend_process_path(path: &std::path::Path) -> Result<()> {
+    let current = std::env::var_os("PATH").unwrap_or_default();
+    let mut entries = Vec::from([path.to_path_buf()]);
+    entries.extend(
+        std::env::split_paths(&current).filter(|entry| !paths_equal_for_process_path(entry, path)),
+    );
+    let updated_path = std::env::join_paths(entries)?;
+    // SAFETY: Strict CUDA ask adjusts this process before CUDA/NVRTC loading
+    // starts, so cudarc can discover Toolkit DLLs installed in the standard
+    // Windows location. The CLI does not read PATH concurrently in this block.
+    unsafe {
+        std::env::set_var("PATH", updated_path);
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "cuda", target_os = "windows"))]
+fn paths_equal_for_process_path(left: &std::path::Path, right: &std::path::Path) -> bool {
+    left.to_string_lossy().eq_ignore_ascii_case(&right.to_string_lossy())
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn cuda_bin_version_key(path: &std::path::Path) -> (u32, u32, u32) {
+    let version_name =
+        path.parent().and_then(|parent| parent.file_name()).and_then(|name| name.to_str());
+    parse_cuda_version_name(version_name.unwrap_or_default())
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+fn parse_cuda_version_name(name: &str) -> (u32, u32, u32) {
+    let Some(rest) = name.strip_prefix('v') else {
+        return (0, 0, 0);
+    };
+    let mut parts = rest.split('.');
+    let major = parts.next().and_then(|value| value.parse().ok()).unwrap_or_default();
+    let minor = parts.next().and_then(|value| value.parse().ok()).unwrap_or_default();
+    let patch = parts.next().and_then(|value| value.parse().ok()).unwrap_or_default();
+    (major, minor, patch)
+}
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+const WINDOWS_NVRTC_LIBRARY_NAMES: &[&str] =
+    &["nvrtc64_120_0.dll", "nvrtc64_120.dll", "nvrtc64_12.dll", "nvrtc64.dll", "nvrtc.dll"];
+
+#[cfg(any(test, all(feature = "cuda", target_os = "windows")))]
+const WINDOWS_CUDART_LIBRARY_NAMES: &[&str] =
+    &["cudart64_120.dll", "cudart64_12.dll", "cudart64.dll", "cudart.dll"];
+
 fn answer_quality_receipt(
     answer: &str,
     run_receipt: &serde_json::Value,
@@ -3913,11 +4094,16 @@ fn answer_quality_receipt(
     let no_replacement_chars = !trimmed.contains('\u{FFFD}');
     let no_raw_special_tokens = !trimmed.contains("<|") && !trimmed.contains("|>");
     let mostly_text = answer_mostly_text(&trimmed);
+    let language_signal = answer_has_language_signal(&trimmed);
+    let suspicious_fragment_count = suspicious_answer_fragment_count(&trimmed);
+    let fragment_filter_passed = suspicious_fragment_count <= 1;
     let garbage_filter_passed = non_empty_answer
         && printable_utf8
         && no_replacement_chars
         && no_raw_special_tokens
-        && mostly_text;
+        && mostly_text
+        && language_signal
+        && fragment_filter_passed;
     let generated = run_receipt["tokens"]["generated"].as_u64().unwrap_or_default() as usize;
     serde_json::json!({
         "printable_utf8": printable_utf8,
@@ -3927,6 +4113,9 @@ fn answer_quality_receipt(
         "no_replacement_chars": no_replacement_chars,
         "no_raw_special_tokens": no_raw_special_tokens,
         "mostly_text": mostly_text,
+        "language_signal": language_signal,
+        "suspicious_fragment_count": suspicious_fragment_count,
+        "fragment_filter_passed": fragment_filter_passed,
     })
 }
 
@@ -3946,6 +4135,102 @@ fn answer_mostly_text(answer: &str) -> bool {
     }
     meaningful > 0 && punctuation_or_control <= meaningful.saturating_mul(2)
 }
+
+fn answer_has_language_signal(answer: &str) -> bool {
+    let compact: String = answer.chars().filter(|ch| !ch.is_whitespace()).collect();
+    let numeric_short_answer = compact.len() <= 8
+        && compact.chars().any(|ch| ch.is_ascii_digit())
+        && compact.chars().all(|ch| ch.is_ascii_digit() || matches!(ch, '.' | '-' | '+'));
+    if numeric_short_answer {
+        return true;
+    }
+
+    answer_word_tokens(answer).any(|word| ANSWER_QUALITY_LANGUAGE_WORDS.contains(&word.as_str()))
+}
+
+fn suspicious_answer_fragment_count(answer: &str) -> usize {
+    answer
+        .split_whitespace()
+        .filter(|token| {
+            let alphabetic = token.chars().filter(|ch| ch.is_alphabetic()).count();
+            if alphabetic == 0 {
+                return false;
+            }
+            let apostrophes = token.matches('\'').count();
+            let ascii_punctuation = token.chars().filter(|ch| ch.is_ascii_punctuation()).count();
+            let internal_period = token.contains('.')
+                && !token.ends_with('.')
+                && token.chars().any(|ch| ch.is_alphabetic());
+            (apostrophes > 1) || internal_period || (alphabetic >= 3 && ascii_punctuation >= 3)
+        })
+        .count()
+}
+
+fn answer_word_tokens(answer: &str) -> impl Iterator<Item = String> + '_ {
+    answer
+        .split(|ch: char| !ch.is_alphabetic())
+        .filter(|word| word.len() >= 2)
+        .map(str::to_ascii_lowercase)
+}
+
+const ANSWER_QUALITY_LANGUAGE_WORDS: &[&str] = &[
+    "a",
+    "about",
+    "add",
+    "adds",
+    "an",
+    "and",
+    "answer",
+    "are",
+    "architecture",
+    "blue",
+    "bit",
+    "bitnet",
+    "black",
+    "capital",
+    "color",
+    "colors",
+    "common",
+    "compute",
+    "data",
+    "efficient",
+    "explain",
+    "for",
+    "four",
+    "france",
+    "function",
+    "green",
+    "is",
+    "language",
+    "low",
+    "memory",
+    "model",
+    "number",
+    "numbers",
+    "of",
+    "one",
+    "paris",
+    "python",
+    "red",
+    "reduce",
+    "sentence",
+    "shape",
+    "shapes",
+    "the",
+    "that",
+    "three",
+    "to",
+    "uses",
+    "weight",
+    "weights",
+    "white",
+    "with",
+    "wet",
+    "water",
+    "yellow",
+    "yes",
+    "no",
+];
 
 fn ensure_non_empty_generation_context(
     tokens: &mut Vec<u32>,
@@ -4614,6 +4899,65 @@ mod tests {
 
         assert_eq!(quality["garbage_filter_passed"], true);
         assert_eq!(quality["stop_reason"], "max_tokens");
+    }
+
+    #[test]
+    fn answer_quality_rejects_observed_cuda_fragment_garbage() {
+        let run_receipt = serde_json::json!({
+            "tokens": {
+                "generated": 16,
+            }
+        });
+        let answer = "-lived'Elicence'E facts-livedConvert!\"\n\n Gab Clock Paperback,SIGNALIR realise.iOS rzd";
+        let quality = answer_quality_receipt(answer, &run_receipt, 16);
+
+        assert_eq!(quality["non_empty_answer"], true);
+        assert_eq!(quality["mostly_text"], true);
+        assert_eq!(quality["language_signal"], false);
+        assert_eq!(quality["fragment_filter_passed"], false);
+        assert_eq!(quality["garbage_filter_passed"], false);
+    }
+
+    #[test]
+    fn answer_quality_accepts_short_numeric_answer() {
+        let run_receipt = serde_json::json!({
+            "tokens": {
+                "generated": 1,
+            }
+        });
+        let quality = answer_quality_receipt("4", &run_receipt, 16);
+
+        assert_eq!(quality["language_signal"], true);
+        assert_eq!(quality["garbage_filter_passed"], true);
+    }
+
+    #[test]
+    fn cuda_toolkit_bin_discovery_prefers_highest_version_with_runtime_libraries() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cuda_root = temp_dir.path().join("CUDA");
+        let older_bin = cuda_root.join("v12.1").join("bin");
+        let newer_bin = cuda_root.join("v12.9").join("bin");
+        std::fs::create_dir_all(&older_bin).unwrap();
+        std::fs::create_dir_all(&newer_bin).unwrap();
+        std::fs::write(older_bin.join("nvrtc64_120_0.dll"), b"").unwrap();
+        std::fs::write(older_bin.join("cudart64_120.dll"), b"").unwrap();
+        std::fs::write(newer_bin.join("nvrtc64_120_0.dll"), b"").unwrap();
+        std::fs::write(newer_bin.join("cudart64_120.dll"), b"").unwrap();
+
+        let discovered = discover_cuda_toolkit_bin_from_roots([cuda_root]).unwrap();
+
+        assert_eq!(discovered, newer_bin);
+    }
+
+    #[test]
+    fn cuda_toolkit_bin_discovery_rejects_partial_toolkit_bin() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let cuda_root = temp_dir.path().join("CUDA");
+        let bin = cuda_root.join("v12.9").join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::write(bin.join("nvrtc64_120_0.dll"), b"").unwrap();
+
+        assert!(discover_cuda_toolkit_bin_from_roots([cuda_root]).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- auto-discover a standard Windows CUDA Toolkit `bin` directory for `ask --strict-cuda` before cudarc loads NVRTC
- keep strict `nvidia-rtx-5070-ti-cuda` ask commands from requiring manual PATH edits when the Toolkit is installed under Program Files
- strengthen answer receipt quality gates so the observed CUDA fragment output fails `garbage_filter_passed`

## Validation
- cargo fmt -p bitnet-cli -- --check
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_quality -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cuda_toolkit -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli ask_ -- --nocapture
- cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- -D warnings
- git diff --check

## Hardware smoke
Ran without manually prepending CUDA Toolkit to PATH:

```powershell
cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- --device nvidia-rtx-5070-ti-cuda ask --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --question "What is BitNet, in one sentence?" --max-new-tokens 16 --strict-cuda --receipt-out target/bitnet/receipts/ask-rtx5070ti-auto-nvrtc-smoke.json
```

Result: strict CUDA execution reached QK256 and wrote an answer receipt. The generated text is still not intelligible; the receipt now correctly reports `garbage_filter_passed=false`, `language_signal=false`, and `suspicious_fragment_count=3`.

## Notes
- This does not claim answer readiness or speedup.
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- -D warnings` is still blocked by pre-existing `bitnet-device-probe/src/nvidia_cuda.rs` clippy warnings.
- CPU answer sanity timed out locally after 7 minutes with no receipt; the timed-out process was stopped.