### PR TITLE
ci(codecov): quiet PR reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        informational: true
+        flags:
+          - rust-cpu
+
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        flags:
+          - rust-cpu
+
+comment: false
+
+github_checks:
+  annotations: false


### PR DESCRIPTION
## Summary
Implements SRP step 2 of the BitNet-rs Codecov rollout: disable Codecov PR comments.

## Changes
- Set `comment: false` in codecov.yml
- Keep project/patch statuses as informational for now

## CI economics
- **Failure mode caught:** reduces notification fatigue from redundant Codecov comments
- **Branch protection impact:** none
- **Cost:** none (config-only)
- **Rollback:** restore comment layout and behavior settings

## Claim boundary
Coverage is execution-surface evidence for the Rust CPU path. It does not prove GPU validation, hardware acceleration, model output quality, crossval parity, or mutation adequacy.

## Validation
- [x] `git diff --check` (no whitespace)
- [x] Config syntax valid
- [ ] CI green before merge

---
_Implements https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc_

---
_Generated by [Claude Code](https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc)_