### PR TITLE
docs(readme): add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # bitnet-rs
 
 [![CI](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml)
+[![Codecov](https://codecov.io/gh/EffortlessMetrics/BitNet-rs/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/BitNet-rs)
 [![MSRV](https://img.shields.io/badge/MSRV-1.92.0-blue.svg)](./rust-toolchain.toml)
 [![Rust 2024](https://img.shields.io/badge/edition-2024-orange.svg)](./rust-toolchain.toml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](./LICENSE)


### PR DESCRIPTION
## Summary
Implements SRP step 3 of the BitNet-rs Codecov rollout: add public Codecov badge to README.

## Changes
- Add Codecov badge to README badges section
- Badge shows execution-surface coverage for Rust CPU path
- Links to Codecov dashboard for detailed trends and per-crate analysis

## CI economics
- **Failure mode caught:** none (docs-only)
- **Branch protection impact:** none
- **Cost:** none
- **Rollback:** remove badge line

## Claim boundary
Coverage is execution-surface evidence for the Rust CPU path. It does not prove GPU validation, hardware acceleration, model output quality, crossval parity, or mutation adequacy.

## Validation
- [x] `git diff --check` (no whitespace)
- [x] Markdown valid
- [ ] CI green before merge

---
_Implements https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc_

---
_Generated by [Claude Code](https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc)_