### PR TITLE
ci(coverage): add coverage receipt artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -120,6 +120,39 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Write coverage receipt
+        if: always()
+        run: |
+          mkdir -p target/bitnet/reports
+          python3 - <<'PYTHON'
+          import json
+          import pathlib
+          receipt = {
+              "schema_version": 1,
+              "repo": "bitnet-rs",
+              "lane": "coverage",
+              "flag": "rust-cpu",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "cpu_path_only",
+                  "not_gpu_validation",
+                  "not_model_quality",
+                  "not_crossval",
+                  "not_mutation_adequacy"
+              ],
+          }
+          pathlib.Path("target/bitnet/reports/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PYTHON
+
       - name: Upload coverage artifacts (always)
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
@@ -128,4 +161,6 @@ jobs:
           path: |
             coverage.json
             coverage.txt
+            lcov.info
+            target/bitnet/reports/coverage-receipt.json
           retention-days: 7


### PR DESCRIPTION
## Summary
Implements SRP step 5 of the BitNet-rs Codecov rollout: add coverage receipt artifact.

## Changes
- Add receipt generation step to produce `target/bitnet/reports/coverage-receipt.json`
- Receipt documents execution-surface evidence collection with schema version, lane, flag, and claim boundary
- Update artifact upload to include `lcov.info` and receipt file

## Receipt contents
- `schema_version`: 1
- `repo`: bitnet-rs
- `lane`: coverage
- `flag`: rust-cpu
- `workflow`: Coverage
- `artifacts`: existence booleans for coverage.json, coverage.txt, lcov.info
- `claim_boundary`: array of what coverage does and does not prove

## CI economics
- **Failure mode caught:** enables post-run evidence inspection and trend analysis
- **Branch protection impact:** none (evidence collection only)
- **Cost:** minimal (~10s Python execution)
- **Rollback:** remove receipt generation step and artifact inclusion

## Claim boundary
Coverage is execution-surface evidence for the Rust CPU path. It does not prove GPU validation, hardware acceleration, model output quality, crossval parity, or mutation adequacy.

## Validation
- [x] `git diff --check` (no whitespace)
- [x] Workflow syntax valid (Python snippet embedded)
- [ ] CI green before merge

---
_Implements https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc_

---
_Generated by [Claude Code](https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc)_