### PR TITLE
fix(cuda): fail strict ask on answer quality gate

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -3861,6 +3861,7 @@ async fn run_ask_generation(
     } else {
         "bitnet_cpu_answer"
     };
+    let quality = answer_quality_receipt(answer, &run_receipt, max_new_tokens);
     let answer_receipt = serde_json::json!({
         "schema_version": "1.0.0",
         "artifact_kind": artifact_kind,
@@ -3902,11 +3903,14 @@ async fn run_ask_generation(
             "per_token_weight_upload": run_receipt["bitnet"]["per_token_weight_upload"].clone(),
         },
         "execution_coverage": run_receipt["execution_coverage"].clone(),
-        "quality": answer_quality_receipt(answer, &run_receipt, max_new_tokens),
+        "quality": quality,
         "speedup_claim": false,
         "source_receipt": run_receipt,
     });
     write_json_output(Some(&receipt_path), &answer_receipt)?;
+    if strict_cuda {
+        validate_strict_cuda_answer_quality(&answer_receipt)?;
+    }
     Ok(())
 }
 
@@ -3927,6 +3931,19 @@ fn validate_strict_cuda_ask_receipt(run_receipt: &serde_json::Value) -> Result<(
         anyhow::bail!("strict CUDA ask recorded {cpu_fallback} BitNet linear CPU fallback layers");
     }
     Ok(())
+}
+
+fn validate_strict_cuda_answer_quality(answer_receipt: &serde_json::Value) -> Result<()> {
+    let quality = &answer_receipt["quality"];
+    if quality["garbage_filter_passed"].as_bool().unwrap_or(false) {
+        return Ok(());
+    }
+
+    let quality_summary = serde_json::to_string(quality)
+        .unwrap_or_else(|_| "<unprintable quality receipt>".to_string());
+    anyhow::bail!(
+        "strict CUDA ask failed answer quality gate after writing receipt: {quality_summary}"
+    )
 }
 
 fn ensure_strict_cuda_ask_runtime_libraries_visible() -> Result<Option<std::path::PathBuf>> {
@@ -4950,6 +4967,33 @@ mod tests {
 
         assert_eq!(quality["language_signal"], true);
         assert_eq!(quality["garbage_filter_passed"], true);
+    }
+
+    #[test]
+    fn strict_cuda_answer_quality_gate_rejects_failed_receipt() {
+        let answer_receipt = serde_json::json!({
+            "quality": {
+                "garbage_filter_passed": false,
+                "language_signal": false,
+                "suspicious_fragment_count": 3,
+            }
+        });
+
+        let err = validate_strict_cuda_answer_quality(&answer_receipt).unwrap_err().to_string();
+
+        assert!(err.contains("strict CUDA ask failed answer quality gate"), "got: {err}");
+        assert!(err.contains("\"garbage_filter_passed\":false"), "got: {err}");
+    }
+
+    #[test]
+    fn strict_cuda_answer_quality_gate_accepts_passed_receipt() {
+        let answer_receipt = serde_json::json!({
+            "quality": {
+                "garbage_filter_passed": true,
+            }
+        });
+
+        validate_strict_cuda_answer_quality(&answer_receipt).unwrap();
     }
 
     #[test]

--- a/docs/specs/rtx5070ti-cuda-answer-readiness.md
+++ b/docs/specs/rtx5070ti-cuda-answer-readiness.md
@@ -162,6 +162,7 @@ hard failures:
 - Tokenizer is missing or ambiguous.
 - QK256 CUDA kernel stats are missing or have zero invocations.
 - Weights are uploaded per token.
+- Answer quality gate fails after the answer receipt is written.
 
 Generic `cuda` remains distinct from the RTX 5070 Ti proof lane and must not be
 reported as `nvidia-rtx-5070-ti-cuda`.
@@ -201,7 +202,10 @@ must reject:
 - Non-finite logits or invalid token IDs when those are recorded.
 
 The filter must be deterministic and receipt-visible. Failure should include the
-specific failed rule so the next debugging step is obvious.
+specific failed rule so the next debugging step is obvious. Strict CUDA ask
+runs must still write the answer receipt before exiting non-zero on a failed
+quality gate, so the artifact records the backend proof and the quality failure
+in the same place.
 
 ## CPU/CUDA Answer Parity
 


### PR DESCRIPTION
## Summary
- make `ask --strict-cuda` fail when the answer receipt quality gate fails
- still write the answer receipt before returning the error, so the CUDA proof and quality failure are preserved together
- document the strict answer-readiness behavior in the RTX 5070 Ti answer-readiness spec

## Validation
- cargo fmt -p bitnet-cli -- --check
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_quality -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli strict_cuda_answer_quality -- --nocapture
- cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- -D warnings
- git diff --check

## Hardware smoke
Ran:

```powershell
cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- ask --device nvidia-rtx-5070-ti-cuda --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --question "What is 2+2? Answer with only the number." --max-new-tokens 1 --strict-cuda --receipt-out target/bitnet/receipts/ask-rtx5070ti-strict-quality-fail-smoke.json
```

Expected result for the current model/path: command exits nonzero after writing the receipt because `quality.garbage_filter_passed=false`. The receipt still preserves `selected_backend=nvidia-rtx-5070-ti-cuda`, `runtime_api=cuda`, and `fallback_used=false`.

## Notes
- This does not claim answer readiness; it prevents strict CUDA answer runs from looking successful when the answer gate fails.
- The generated receipt stays in `target/` and is not committed.