### PR TITLE
ci(coverage): harden Codecov upload behavior

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/coverage.yml'
+      - 'codecov.yml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches: [ main ]
@@ -20,6 +21,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/coverage.yml'
+      - 'codecov.yml'
   workflow_dispatch:
 
 concurrency:
@@ -38,11 +40,12 @@ jobs:
       contents: read
       packages: read
 
-    # PRs: only run when explicitly labeled "coverage"
+    # PRs: only run when explicitly labeled "coverage" or "full-ci"
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'coverage')
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -133,8 +136,8 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload coverage reports to Codecov
-        if: ${{ always() && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+      - name: Upload coverage reports to Codecov (main)
+        if: ${{ always() && github.event_name == 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -142,6 +145,16 @@ jobs:
           flags: rust-cpu
           name: bitnet-rs-rust-cpu
           fail_ci_if_error: true
+
+      - name: Upload coverage reports to Codecov (advisory PR)
+        if: ${{ always() && github.event_name != 'push' && hashFiles('lcov.info') != '' && steps.codecov-token.outputs.present == 'true' }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe  # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          flags: rust-cpu
+          name: bitnet-rs-rust-cpu
+          fail_ci_if_error: false
 
       - name: Upload coverage artifacts (always)
         if: always()


### PR DESCRIPTION
## Summary
Split Codecov upload into main (strict) and PR (advisory) steps.

## Changes
- Main: fail_ci_if_error=true
- PR/manual: fail_ci_if_error=false
- Add full-ci label support
- Include codecov.yml in path filters

All passing CI. Ready to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc)_