### PR TITLE
ci(codecov): quiet PR reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -20,10 +20,7 @@ coverage:
         flags:
           - rust-cpu
 
-comment:
-  layout: "reach,diff,flags,tree"
-  behavior: default
-  require_changes: false
+comment: false
 
 github_checks:
   annotations: false


### PR DESCRIPTION
## Summary
Disable Codecov PR comments for cleaner rollout.

All passing CI. Ready to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_011s3LDg95tjHfRJhXYSkBwc)_