### PR TITLE
fix(cli): satisfy tokenizer source clippy

### DIFF
--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -1555,8 +1555,7 @@ impl InferenceCommand {
     /// Get tokenizer information
     fn get_tokenizer_info(&self, tokenizer: &dyn bitnet_tokenizers::Tokenizer) -> TokenizerInfo {
         // Determine source from tokenizer type or path
-        let source = if self.tokenizer.is_some() {
-            let path = self.tokenizer.as_ref().unwrap();
+        let source = if let Some(path) = &self.tokenizer {
             if path.extension().is_some_and(|e| e == "json") {
                 "hf_json".to_string()
             } else if path.extension().is_some_and(|e| e == "model") {


### PR DESCRIPTION
## Summary
- replace tokenizer presence check plus unwrap with `if let Some(path)` in the inference command
- unblocks `bitnet-cli` cpu/full-cli clippy with `-D warnings`

## Verification
- `cargo clippy --locked -p bitnet-cli --bin bitnet --no-default-features --features cpu,full-cli -- -D warnings`
- `git diff --check`