### PR TITLE
ci: Add workflow YAML linting to prevent duplicate keys

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,26 @@
+name: Lint Workflows
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+      - 'xtask/src/lint_workflows.rs'
+      - 'xtask/src/main.rs'
+      - 'xtask/Cargo.toml'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/*.yml'
+      - 'xtask/src/lint_workflows.rs'
+      - 'xtask/src/main.rs'
+      - 'xtask/Cargo.toml'
+
+jobs:
+  check-yaml:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4
+
+      - name: Check for duplicate YAML keys
+        run: cargo run --locked -p xtask --no-default-features -- lint-workflows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9977,6 +9977,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "serial_test",
  "sha2",
  "temp-env",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -21,6 +21,7 @@ fs2 = "0.4.3"
 is-terminal = "0.4.17"
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 toml = "0.9.8"
 httpdate = "1.0.3"
 tempfile = "3.23.0"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -7,6 +7,7 @@ pub mod build_helpers;
 pub mod cpp_setup_auto;
 pub mod crossval;
 pub mod ffi;
+pub mod lint_workflows;
 
 // Prompt template argument type for cross-validation
 // This mirrors the PromptTemplateArg in main.rs but is available to the library

--- a/xtask/src/lint_workflows.rs
+++ b/xtask/src/lint_workflows.rs
@@ -1,0 +1,199 @@
+use anyhow::{Result, anyhow};
+use std::{collections::HashSet, path::Path};
+use walkdir::WalkDir;
+
+pub fn lint_workflows() -> Result<()> {
+    let workflows_dir = Path::new(".github/workflows");
+
+    if !workflows_dir.exists() {
+        return Err(anyhow!(".github/workflows directory not found"));
+    }
+
+    let mut files: Vec<_> = WalkDir::new(workflows_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "yml"))
+        .map(|e| e.path().to_path_buf())
+        .collect();
+
+    files.sort();
+
+    let mut failed = false;
+
+    for path in files {
+        match check_file(&path) {
+            Ok(()) => println!("✓ {}", path.display()),
+            Err(e) => {
+                eprintln!("❌ {}: {}", path.display(), e);
+                failed = true;
+            }
+        }
+    }
+
+    if failed {
+        return Err(anyhow!("Some workflows have validation errors"));
+    }
+
+    println!("\n✓ All workflows valid (no duplicate keys)");
+    Ok(())
+}
+
+fn check_file(path: &Path) -> Result<()> {
+    let content = std::fs::read_to_string(path)?;
+    check_duplicate_keys(&content)?;
+    let _: serde_yaml::Value =
+        serde_yaml::from_str(&content).map_err(|e| anyhow!("YAML parse error: {}", e))?;
+    Ok(())
+}
+
+fn check_duplicate_keys(content: &str) -> Result<()> {
+    let mut frames = Vec::<MappingFrame>::new();
+    let mut block_scalar_indent = None;
+
+    for (line_index, raw_line) in content.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line = raw_line.trim_end_matches('\r');
+        let Some(indent) = line.find(|ch| ch != ' ') else {
+            continue;
+        };
+        let trimmed = &line[indent..];
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if let Some(block_indent) = block_scalar_indent {
+            if indent > block_indent {
+                continue;
+            }
+            block_scalar_indent = None;
+        }
+
+        let (key_indent, key_source, starts_sequence_item) =
+            if let Some(rest) = trimmed.strip_prefix("- ") {
+                (indent + 2, rest, true)
+            } else {
+                (indent, trimmed, false)
+            };
+
+        let Some((key, value)) = parse_mapping_key(key_source) else {
+            continue;
+        };
+
+        frames.retain(|frame| frame.indent <= key_indent);
+        if starts_sequence_item {
+            frames.retain(|frame| frame.indent < key_indent);
+        }
+
+        let frame_index = match frames.iter().position(|frame| frame.indent == key_indent) {
+            Some(index) => index,
+            None => {
+                frames.push(MappingFrame::new(key_indent));
+                frames.len() - 1
+            }
+        };
+
+        if !frames[frame_index].keys.insert(key.to_string()) {
+            return Err(anyhow!("duplicate key '{}' at line {}", key, line_number));
+        }
+
+        if value.trim_start().starts_with(['|', '>']) {
+            block_scalar_indent = Some(key_indent);
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_mapping_key(line: &str) -> Option<(&str, &str)> {
+    let colon_index = if line.starts_with('"') || line.starts_with('\'') {
+        quoted_key_end(line).and_then(|end| {
+            line[end..].char_indices().find_map(|(offset, ch)| (ch == ':').then_some(end + offset))
+        })?
+    } else {
+        line.find(':')?
+    };
+
+    let after_colon = &line[colon_index + 1..];
+    if !after_colon.is_empty()
+        && !after_colon.starts_with(char::is_whitespace)
+        && !after_colon.starts_with(['|', '>', '#'])
+    {
+        return None;
+    }
+
+    let key = line[..colon_index].trim().trim_matches(['"', '\'']);
+    (!key.is_empty()).then_some((key, after_colon))
+}
+
+fn quoted_key_end(line: &str) -> Option<usize> {
+    let mut chars = line.char_indices();
+    let (_, quote) = chars.next()?;
+    let mut escaped = false;
+
+    for (index, ch) in chars {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if quote == '"' && ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == quote {
+            return Some(index + ch.len_utf8());
+        }
+    }
+
+    None
+}
+
+struct MappingFrame {
+    indent: usize,
+    keys: HashSet<String>,
+}
+
+impl MappingFrame {
+    fn new(indent: usize) -> Self {
+        Self { indent, keys: HashSet::new() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_duplicate_keys;
+
+    #[test]
+    fn rejects_duplicate_top_level_keys() {
+        let err = check_duplicate_keys("name: CI\non: push\non: pull_request\n").unwrap_err();
+        assert!(err.to_string().contains("duplicate key 'on' at line 3"));
+    }
+
+    #[test]
+    fn rejects_duplicate_nested_keys() {
+        let err = check_duplicate_keys(
+            "jobs:\n  build:\n    runs-on: ubuntu-22.04\n    runs-on: ubuntu-24.04\n",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("duplicate key 'runs-on' at line 4"));
+    }
+
+    #[test]
+    fn allows_same_key_in_separate_sequence_items() {
+        check_duplicate_keys("steps:\n  - name: Checkout\n    uses: actions/checkout@v4\n  - name: Test\n    run: cargo test\n")
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_duplicate_key_in_same_sequence_item() {
+        let err =
+            check_duplicate_keys("steps:\n  - name: Checkout\n    name: Duplicate\n").unwrap_err();
+        assert!(err.to_string().contains("duplicate key 'name' at line 3"));
+    }
+
+    #[test]
+    fn ignores_mapping_like_lines_inside_block_scalars() {
+        check_duplicate_keys("jobs:\n  build:\n    steps:\n      - run: |\n          echo 'on: push'\n          echo 'on: pull_request'\n        shell: bash\n")
+            .unwrap();
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1100,6 +1100,10 @@ enum Cmd {
         #[command(subcommand)]
         command: CiCmd,
     },
+
+    /// Lint GitHub workflow files for YAML syntax issues (duplicate keys, etc).
+    #[command(name = "lint-workflows")]
+    LintWorkflows,
 }
 
 #[derive(Subcommand)]
@@ -1569,6 +1573,7 @@ fn real_main() -> Result<()> {
             policy::clippy::run(exceptions, report_dir, fail_on_error)
         }
         Cmd::PolicyReport { report_dir } => run_policy_report(report_dir),
+        Cmd::LintWorkflows => xtask::lint_workflows::lint_workflows(),
         Cmd::Ci { command } => match command {
             CiCmd::Actuals {
                 repo,


### PR DESCRIPTION
## Summary

Adds Rust-native workflow YAML linting to catch duplicate keys and YAML syntax errors before malformed workflow files can break CI triggers.

### Changes

- Adds `cargo run --locked -p xtask --no-default-features -- lint-workflows`.
- Adds a dedicated `Lint Workflows` GitHub Actions workflow for workflow-file changes.
- Validates every `.github/workflows/*.yml` file with duplicate-key detection before parsing with `serde_yaml`.
- Covers top-level duplicates, nested duplicates, sequence item isolation, and block scalar handling with unit tests.

## Test plan

- [x] `cargo fmt -p xtask -- --check`
- [x] `cargo test --locked -p xtask --no-default-features lint_workflows -- --nocapture`
- [x] `cargo run --locked -p xtask --no-default-features -- lint-workflows`
- [x] `cargo clippy --locked -p xtask --no-default-features -- -D warnings`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated GitHub Actions workflow validation that checks workflow YAML files for syntax errors and duplicate keys.
  * Introduced new command-line tool subcommand for local workflow file validation.

* **Chores**
  * Updated workspace dependencies to support workflow validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->