### PR TITLE
ci: extend PR Plan timeout

### DIFF
--- a/.github/workflows/campaign-tracker.yml
+++ b/.github/workflows/campaign-tracker.yml
@@ -9,6 +9,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/campaign-tracker.yml'
+      - '.github/workflows/pr-plan.yml'
   push:
     branches: [main]
     paths:
@@ -18,6 +19,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/campaign-tracker.yml'
+      - '.github/workflows/pr-plan.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -33,6 +33,7 @@ on:
 
       # Workflow files - core and related CI workflows
       - '.github/workflows/ci-core.yml'
+      - '.github/workflows/pr-plan.yml'
       - '.github/workflows/coverage.yml'
       - '.github/workflows/ci-reporting.yml'
 
@@ -53,6 +54,7 @@ on:
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/ci-core.yml'
+      - '.github/workflows/pr-plan.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -26,7 +26,7 @@ jobs:
   plan:
     name: PR Plan
     runs-on: ubuntu-22.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4


### PR DESCRIPTION
## Summary
- extend the advisory PR Plan job timeout from 5 to 10 minutes
- unblock cold `xtask ci plan` builds that currently cancel mid-compile before producing plan output

## Verification
- `git diff --check`

This is a CI hygiene unblocker for tracker-only PRs; it does not change runtime code.