### PR TITLE
backlog A: security — drop hardcoded API-key fallback + UUID ids (#3500, #3533)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,6 +898,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/bitnet-gpu-hal/Cargo.toml
+++ b/crates/bitnet-gpu-hal/Cargo.toml
@@ -20,6 +20,7 @@ log.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/bitnet-gpu-hal/src/api_gateway.rs
+++ b/crates/bitnet-gpu-hal/src/api_gateway.rs
@@ -885,16 +885,19 @@ impl ApiGateway {
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/// Generate a short pseudo-random request id.
+/// Generate a request id from a v4 UUID. Uses cryptographic randomness so the
+/// id cannot be predicted from request timing.
 fn generate_request_id() -> String {
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-    format!("req-{ts:x}")
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    format!("req-{uuid}")
 }
 
-/// Generate a pseudo-random API key.
+/// Generate an API key from a v4 UUID. Time-based generation was previously
+/// vulnerable to brute-force prediction by an attacker who knew the
+/// approximate creation time.
 fn generate_api_key() -> String {
-    let ts = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-    format!("sk-bitnet-{ts:x}")
+    let uuid = uuid::Uuid::new_v4().simple().to_string();
+    format!("sk-bitnet-{uuid}")
 }
 
 /// Strip `"Bearer "` prefix from a header value.
@@ -1938,13 +1941,29 @@ mod tests {
     fn test_generate_request_id_format() {
         let id = generate_request_id();
         assert!(id.starts_with("req-"));
-        assert!(id.len() > 4);
+        // 32 hex chars (UUID v4 simple form) + "req-" prefix
+        assert_eq!(id.len(), 4 + 32);
+        assert!(id.chars().skip(4).all(|c| c.is_ascii_hexdigit()));
     }
 
     #[test]
     fn test_generate_api_key_format() {
         let key = generate_api_key();
         assert!(key.starts_with("sk-bitnet-"));
+        assert_eq!(key.len(), "sk-bitnet-".len() + 32);
+        assert!(key.chars().skip("sk-bitnet-".len()).all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_generate_ids_are_unique() {
+        // Two ids generated back-to-back must not collide. Under the previous
+        // timestamp-based implementation this was technically possible if both
+        // calls landed in the same nanosecond.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..256 {
+            assert!(seen.insert(generate_request_id()));
+            assert!(seen.insert(generate_api_key()));
+        }
     }
 
     // ── Debug impls ────────────────────────────────────────────────────

--- a/crates/bitnet-gpu-hal/src/lib.rs
+++ b/crates/bitnet-gpu-hal/src/lib.rs
@@ -207,3 +207,5 @@ pub mod memory_layout;
 pub mod api_server;
 pub mod ffi_safety;
 pub mod weight_loader;
+
+pub mod api_gateway;

--- a/examples/deployment/docker/docker-compose.yml
+++ b/examples/deployment/docker/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - RUST_LOG=info
       - BITNET_CONFIG_PATH=/app/config/bitnet.toml
       - BITNET_MODEL_PATH=/app/models/bitnet-1.58b.gguf
-      - BITNET_API_KEYS=demo-key-123,prod-key-456
+      - BITNET_API_KEYS=${BITNET_API_KEYS:?Set BITNET_API_KEYS before running docker compose}
     volumes:
       - ./models:/app/models:ro
       - ./config:/app/config:ro

--- a/examples/integrations/actix_server.rs
+++ b/examples/integrations/actix_server.rs
@@ -224,12 +224,19 @@ async fn initialize_app_state() -> Result<AppState> {
     // Create inference engine
     let inference_engine = InferenceEngine::new(model, tokenizer, device)?;
 
-    // Load API keys from environment
-    let api_keys = std::env::var("BITNET_API_KEYS")
-        .unwrap_or_else(|_| "demo-key-123,test-key-456".to_string())
+    // Load API keys from environment. No hardcoded fallback: an unset or empty
+    // BITNET_API_KEYS yields zero accepted keys, denying all bearer-token requests.
+    let api_keys: Vec<String> = std::env::var("BITNET_API_KEYS")
+        .unwrap_or_default()
         .split(',')
         .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .collect();
+    if api_keys.is_empty() {
+        warn!(
+            "BITNET_API_KEYS is unset or empty; authenticated endpoints will reject all requests"
+        );
+    }
 
     info!("Application state initialized successfully");
 
@@ -546,8 +553,8 @@ Model information (requires auth).
 ## Example Usage
 
 ```bash
-# Set your API key
-export API_KEY="demo-key-123"
+# Set your API key (must match a key configured via BITNET_API_KEYS on the server)
+export API_KEY="<your-api-key>"
 
 # Generate text
 curl -X POST http://localhost:3000/api/v1/generate \

--- a/examples/web/actix_server.rs
+++ b/examples/web/actix_server.rs
@@ -224,12 +224,19 @@ async fn initialize_app_state() -> Result<AppState> {
     // Create inference engine
     let inference_engine = InferenceEngine::new(model, tokenizer, device)?;
 
-    // Load API keys from environment
-    let api_keys = std::env::var("BITNET_API_KEYS")
-        .unwrap_or_else(|_| "demo-key-123,test-key-456".to_string())
+    // Load API keys from environment. No hardcoded fallback: an unset or empty
+    // BITNET_API_KEYS yields zero accepted keys, denying all bearer-token requests.
+    let api_keys: Vec<String> = std::env::var("BITNET_API_KEYS")
+        .unwrap_or_default()
         .split(',')
         .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
         .collect();
+    if api_keys.is_empty() {
+        warn!(
+            "BITNET_API_KEYS is unset or empty; authenticated endpoints will reject all requests"
+        );
+    }
 
     info!("Application state initialized successfully");
 
@@ -546,8 +553,8 @@ Model information (requires auth).
 ## Example Usage
 
 ```bash
-# Set your API key
-export API_KEY="demo-key-123"
+# Set your API key (must match a key configured via BITNET_API_KEYS on the server)
+export API_KEY="<your-api-key>"
 
 # Generate text
 curl -X POST http://localhost:3000/api/v1/generate \


### PR DESCRIPTION
## Summary

Focused security/correctness split from the stale #3838 consolidation branch.

### Changes

- Removed hardcoded Actix example API-key fallback values from `examples/{web,integrations}/actix_server.rs`. If `BITNET_API_KEYS` is unset or empty, no bearer tokens are accepted and the server logs a warning.
- Removed published demo API keys from `examples/deployment/docker/docker-compose.yml`; docker compose now requires `BITNET_API_KEYS` to be set by the caller.
- Switched `bitnet-gpu-hal::api_gateway` request IDs and generated API keys from timestamp-derived values to UUID v4 values.
- Exported `api_gateway` from `bitnet-gpu-hal` so the module compiles and its tests run through the crate.

### Relationship to #3838

This carries only the security/correctness subset that still applies cleanly on current `main`: #3500 hardcoded API-key fallback removal and #3533 UUID request/API-key IDs. Other #3838 items are either already on main or need separate focused PRs.

## Test plan

- [x] `rg "demo-key|test-key-456|prod-key-456" examples crates -g "*.rs" -g "*.yml" -g "*.yaml"` returns no matches
- [x] `cargo test --locked -p bitnet-gpu-hal --no-default-features --lib api_gateway::tests::test_generate -- --nocapture`
- [x] `cargo test --locked -p bitnet-gpu-hal --no-default-features --lib api_gateway -- --nocapture`
- [x] `cargo fmt -p bitnet-gpu-hal --all -- --check`
- [x] `cargo clippy --locked -p bitnet-gpu-hal --no-default-features -- -D warnings`
- [x] `git diff --check`