### PR TITLE
LNL258V-OWNERSHIP-001: make 258V BitNet CPU lead

### DIFF
--- a/.codex/bitnet-alignment.md
+++ b/.codex/bitnet-alignment.md
@@ -48,6 +48,16 @@ Rules:
 - Use `cargo run -p xtask --no-default-features -- campaign check <campaign>` before opening a tracker PR.
 - Use `cargo run -p xtask --no-default-features -- campaign generate` to refresh dashboards; do not hand-edit generated files.
 
+Lunar Lake platform priority:
+
+- Core Ultra 7 258V CPU is the BitNet CPU lead for strict CPU proof validation, scalar-vs-AVX2 answer parity, phase receipts, and same-machine CPU reference artifacts.
+- Intel NPU and Arc 140V are significant secondary lanes, but they must compare against 258V CPU reference receipts before BitNet-adjacent parity claims.
+- NPU work must not claim full BitNet inference, QK256 decode, acceleration, or CPU fallback as NPU proof.
+- Arc 140V work must prove native OpenCL execution before any BitNet kernel claim.
+- i5-8250U owns the SLM CPU lane and remains a legacy/low-power BitNet comparison lane; it must not block new BitNet CPU sequencing.
+- Ryzen 9 9950X3D may own AVX-512 BitNet CPU validation when needed, but its primary machine focus remains RTX 5070 Ti.
+- Ryzen 7 5700X may support AVX2 desktop validation when needed, but its primary machine focus remains A770.
+
 Transition note:
 
 `docs/tracking/bitnet-alignment/workstream-ledger.yaml` and `docs/tracking/bitnet-alignment/status.md` are transition surfaces. Normal item PRs should use campaign-local manifests and events once generated dashboards are available.

--- a/docs/hardware/HARDWARE_MATRIX.md
+++ b/docs/hardware/HARDWARE_MATRIX.md
@@ -19,11 +19,11 @@ Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or O
 
 | Machine | Proof label | Primary role | Must not claim |
 |---|---|---|---|
-| i5-8250U | `intel-i5-8250u-cpu-avx2` | CPU scalar/AVX2 proof, low-power sustained baseline | GPU/NPU acceleration |
-| Core Ultra 7 258V CPU | `intel-258v-cpu-avx2` | Parallel Lunar Lake AVX2 CPU validation and same-machine comparison | Replacing 8250U implementation ownership |
+| i5-8250U | `intel-i5-8250u-cpu-avx2` | SLM CPU lead plus legacy/low-power BitNet comparison baseline | GPU/NPU acceleration or blocking BitNet CPU leadership |
+| Core Ultra 7 258V CPU | `intel-258v-cpu-avx2` | BitNet CPU lead for strict real-GGUF validation, scalar/AVX2 answer parity, phase receipts, and same-machine CPU reference artifacts | GPU/NPU acceleration |
 | UHD 620 | `intel-uhd-620-openvino-gpu` | Optional/deferred OpenVINO GPU smoke on the 8250U box | CPU proof or primary GPU performance |
-| Ryzen 7 5700X | `amd-5700x-cpu-avx2` | Mainstream AM4 / DDR4 desktop CPU baseline | AVX-512 or accelerator proof |
-| Ryzen 9 9950X3D | `amd-9950x3d-cpu-avx512` | Modern AM5 / DDR5 / AVX-512 / cache-sensitive CPU lane | GPU/NPU acceleration |
+| Ryzen 7 5700X | `amd-5700x-cpu-avx2` | Mainstream AM4 / DDR4 desktop support validator; primary support around A770 work | AVX-512, accelerator proof, or BitNet CPU ownership |
+| Ryzen 9 9950X3D | `amd-9950x3d-cpu-avx512` | Modern AM5 / DDR5 / AVX-512 / cache-sensitive support validator; primary support around RTX 5070 Ti work | GPU/NPU acceleration or BitNet CPU ownership |
 | Arc A770 16GB | `intel-arc-a770-opencl` | Discrete GPU OpenCL kernel/perf lane | NPU support, generic GPU proof |
 | Arc A770 OpenVINO | `intel-arc-a770-openvino-gpu` | OpenVINO GPU reference lane | Native BitNet kernel proof |
 | Arc 140V | `intel-arc-140v-opencl` | Lunar Lake shared-memory iGPU comparison lane | A770-equivalent performance |
@@ -39,11 +39,11 @@ Do not merge CPU, Metal, MPSGraph, CUDA, WGPU, Intel Arc GPU, OpenVINO GPU, or O
 
 | Machine | Primary lane | Secondary lane | Notes |
 |---|---|---|---|
-| i5-8250U | `intel-i5-8250u-cpu-avx2` | `intel-uhd-620-openvino-gpu` | Active low-power AVX2 CPU implementation/proof |
-| Ryzen 7 5700X | `amd-5700x-cpu-avx2` | `amd-5700x-cpu-scalar` | Mainstream AM4 / DDR4 desktop CPU baseline |
-| Ryzen 9 9950X3D | `amd-9950x3d-cpu-avx512` | `amd-9950x3d-cpu-avx2`, `amd-9950x3d-cpu-scalar` | Modern AM5 / DDR5 / AVX-512 / cache-sensitive CPU lane |
+| i5-8250U | `intel-i5-8250u-cpu-avx2` | `intel-uhd-620-openvino-gpu` | SLM CPU lead; legacy/low-power BitNet comparison only |
+| Ryzen 7 5700X | `amd-5700x-cpu-avx2` | `amd-5700x-cpu-scalar` | Support validator; primary desktop support around A770 work |
+| Ryzen 9 9950X3D | `amd-9950x3d-cpu-avx512` | `amd-9950x3d-cpu-avx2`, `amd-9950x3d-cpu-scalar` | Support validator; primary desktop support around RTX 5070 Ti work |
 | A770 16GB | `intel-arc-a770-opencl` | `intel-arc-a770-openvino-gpu` | Intel discrete GPU kernel lane |
-| 258V | `intel-258v-cpu-avx2`, `intel-arc-140v-opencl`, `intel-npu-openvino` | `intel-arc-140v-openvino-gpu` | Lunar Lake tri-device box |
+| 258V | `intel-258v-cpu-avx2`, `intel-arc-140v-opencl`, `intel-npu-openvino` | `intel-arc-140v-openvino-gpu` | Lunar Lake tri-device box; BitNet CPU lead and same-machine CPU/NPU/Arc comparison plate |
 | M4 Mac mini | `apple-m4-metal` | `apple-m4-mpsgraph`, `apple-m4-cpu-neon` | Apple Silicon Metal lane |
 | RTX 5070 Ti | `nvidia-rtx-5070-ti-cuda` | `nvidia-rtx-5070-ti-wgpu` | Modern NVIDIA CUDA lane |
 

--- a/docs/hardware/LANE_OWNERSHIP.md
+++ b/docs/hardware/LANE_OWNERSHIP.md
@@ -8,10 +8,10 @@ Each hardware lane owns a narrow proof path. Ownership prevents CPU, GPU, OpenVI
 
 Owns:
 
-- i5-8250U `cpu-scalar` and `cpu-avx2` as the active AVX2 CPU implementation/proof lane.
-- 258V CPU `cpu-avx2` as a parallel Lunar Lake validation and same-machine comparison lane.
-- Ryzen 7 5700X `cpu-scalar` and `cpu-avx2`.
-- Ryzen 9 9950X3D `cpu-scalar`, `cpu-avx2`, and `cpu-avx512`.
+- 258V CPU `cpu-avx2` as the BitNet CPU lead for strict real-GGUF runs, scalar/AVX2 validation, answer parity, phase receipts, and same-machine comparison against Arc 140V and Intel NPU.
+- i5-8250U `cpu-scalar` and `cpu-avx2` as the SLM CPU lead plus legacy/low-power BitNet comparison lane.
+- Ryzen 7 5700X `cpu-scalar` and `cpu-avx2` as a BitNet support validation lane when it does not collide with A770 work.
+- Ryzen 9 9950X3D `cpu-scalar`, `cpu-avx2`, and `cpu-avx512` as a BitNet support validation lane when it does not collide with RTX 5070 Ti work.
 - CPU feature detection and selected CPU kernel-path receipts.
 - Strict CPU proof runs.
 - Sustained CPU baselines with power and thermal context.
@@ -27,20 +27,22 @@ Does not own:
 
 ## CPU No-Trample Rule
 
-The 8250U and 258V CPU lanes may both perform CPU work, but they must not edit the same runtime surface in overlapping PRs. The 8250U lane owns active AVX2 CPU implementation, scalar/AVX2 parity, strict CPU proof, and sustained low-power behavior. The 258V CPU lane owns Lunar Lake CPU validation and same-machine comparisons against Arc 140V and NPU artifacts.
+The 258V CPU lane owns BitNet CPU sequencing. It leads strict real-GGUF BitNet CPU runs, scalar/AVX2 answer parity, phase receipts, and same-machine comparison against Arc 140V and Intel NPU artifacts. The 8250U lane no longer blocks BitNet CPU work; it owns SLM CPU work and remains useful for legacy/low-power BitNet comparison artifacts.
 
-If a CPU change touches shared dispatch, QK256 CPU kernels, or inference hot paths, the ledger item must name the owning CPU lane and list the other CPU lane as a validation target, not a co-owner.
+The 8250U, 258V, 5700X, and 9950X3D CPU lanes may all perform CPU validation, but they must not edit the same runtime surface in overlapping PRs. 9950X3D may validate BitNet CPU changes when that does not collide with RTX 5070 Ti work. 5700X may validate BitNet CPU changes when that does not collide with A770 work.
+
+If a BitNet CPU change touches shared dispatch, QK256 CPU kernels, or inference hot paths, the ledger item must name the 258V lane as the owning BitNet CPU lane unless the item explicitly transfers ownership. Other CPU machines should be listed as validation targets, not co-owners.
 
 PR scoping:
 
 ```text
-8250U AVX2 PR:
-  may touch CPU detect, CPU kernels, scalar/AVX2 dispatch, CPU receipts
-  must not touch Arc 140V, A770, NPU, Metal, CUDA
+258V BitNet CPU PR:
+  may touch CPU detect, CPU kernels, scalar/AVX2 dispatch, answer parity, phase receipts
+  must not touch Arc 140V OpenCL, A770 OpenCL, Intel NPU execution, Metal, CUDA
 
-258V CPU validation PR:
-  may run/record CPU proof on 258V and compare artifacts
-  must not reshape shared CPU implementation unless the item explicitly says so
+8250U SLM CPU PR:
+  may touch SLM CPU proof, SLM receipts, and low-power comparison artifacts
+  must not block new BitNet CPU implementation leadership
 
 Accelerator PR:
   must not alter CPU dispatch or QK256 CPU kernels unless explicitly scoped

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -6,13 +6,13 @@ This file defines the validation bundle for the Core Ultra 7 258V Lunar Lake lap
 
 | Device | Proof lane |
 |---|---|
-| CPU | `intel-258v-cpu-avx2` / `cpu-avx2` Lunar Lake validation and fallback |
+| CPU | `intel-258v-cpu-avx2` / `cpu-avx2` BitNet CPU lead, strict validation, and fallback |
 | Integrated GPU | `intel-arc-140v-opencl` and `intel-arc-140v-openvino-gpu` |
 | NPU | `intel-npu-openvino` / `intel_258v_npu_openvino` |
 
 The 258V laptop should not be treated as a single generic Intel accelerator.
 
-The 258V CPU lane validates the same CPU path on Lunar Lake and provides same-machine comparison against Arc 140V and NPU results. It does not replace the i5-8250U active AVX2 implementation/proof lane.
+The 258V CPU lane is the BitNet CPU lead. It owns strict real-GGUF BitNet CPU validation, scalar-vs-AVX2 answer parity, phase receipts, and same-machine CPU reference artifacts used by the Arc 140V and Intel NPU lanes. The i5-8250U is now the SLM CPU lead and a legacy/low-power BitNet comparison lane; it does not block new BitNet CPU work.
 
 Platform roadmap:
 
@@ -76,7 +76,8 @@ Record these before moving any 258V hardware lane beyond `scaffold`:
 - OpenVINO `GPU.0` smoke does not prove BitNet OpenCL kernel acceleration.
 - OpenVINO `NPU` smoke does not prove full BitNet inference.
 - CPU or GPU fallback cannot count as NPU execution.
-- 258V CPU validation must record artifacts without reshaping shared CPU implementation unless explicitly scoped by a ledger item.
+- 258V CPU proof is the first priority on this platform; NPU and Arc proofs must compare against the 258V CPU reference when they make BitNet-adjacent parity claims.
+- 258V CPU changes may own BitNet CPU sequencing when explicitly scoped; accelerator PRs must not reshape CPU dispatch or QK256 CPU kernels.
 - Arc 140V visibility must preserve `requested_backend`, `selected_backend`, runtime API, exact device identity evidence, and `fallback_used=false`; generic Intel GPU visibility is not enough.
 
 ## Platform Probe Bundle Artifacts
@@ -147,8 +148,8 @@ lane-specific Arc 140V, NPU, CPU BitNet, parity, or benchmark artifacts.
 
 ### CPU BitNet Validation Preflight
 
-Use the CPU validation command to emit the Lunar Lake CPU lane artifact without
-taking ownership of CPU implementation internals:
+Use the CPU validation command to emit the Lunar Lake CPU lead artifact without
+touching unrelated accelerator surfaces:
 
 ```bash
 cargo run --locked -p bitnet-cli \

--- a/docs/specs/intel-lunar-lake-258v-buildout-plan.md
+++ b/docs/specs/intel-lunar-lake-258v-buildout-plan.md
@@ -2,20 +2,20 @@
 
 ## Purpose
 
-This document converts the Lunar Lake validation report into buildable work for BitNet-rs. The Core Ultra 7 258V laptop is a same-machine validation platform, not the owner of the shared CPU implementation sequence.
+This document converts the Lunar Lake validation report into buildable work for BitNet-rs. The Core Ultra 7 258V laptop is the BitNet CPU lead and the same-machine comparison platform for CPU, Arc 140V, and Intel NPU work.
 
 The highest-priority rule is:
 
 ```text
-Use the Core Ultra 7 258V to prove platform identity, backend identity, runtime visibility, strict receipts, and CPU validation artifacts. Keep core CPU loader/tokenizer/QK256 implementation ownership with the active CPU proof lane unless a ledger item explicitly transfers or stacks that work.
+Use the Core Ultra 7 258V CPU as the reference truth path for BitNet CPU proof: strict real-GGUF validation, scalar-vs-AVX2 answer parity, phase receipts, and same-machine CPU reference artifacts. NPU and Arc 140V proofs are secondary until they compare against the 258V CPU reference and must not claim full BitNet inference, QK256 decode, or acceleration without parity receipts.
 ```
 
 ## Lane Ownership
 
 | Lane | Proof label | Role | Editing boundary |
 |---|---|---|---|
-| i5-8250U CPU | `intel-i5-8250u-cpu-avx2` | Active low-power AVX2 CPU implementation and strict proof lane | Owns shared CPU implementation sequence unless a work item says otherwise. |
-| 258V CPU | `intel-258v-cpu-avx2` | Lunar Lake CPU validation and same-machine comparison lane | Records validation artifacts; must not reshape shared CPU hot paths by default. |
+| 258V CPU | `intel-258v-cpu-avx2` | BitNet CPU lead for strict validation, scalar/AVX2 answer parity, phase receipts, and CPU reference artifacts | Owns BitNet CPU sequencing when a work item touches shared BitNet CPU proof surfaces. |
+| i5-8250U CPU | `intel-i5-8250u-cpu-avx2` | SLM CPU lead plus legacy/low-power BitNet comparison lane | Does not block new BitNet CPU work. |
 | Arc 140V | `intel-arc-140v-opencl`, `intel-arc-140v-openvino-gpu` | Integrated GPU identity, smoke, parity, and benchmark lane | Must not count CPU fallback as GPU proof. |
 | Intel NPU | `intel-npu-openvino` | OpenVINO NPU identity, static-shape smoke, and subgraph lane | Must not be routed through Metal or generic GPU identities. |
 | 258V platform | `core-ultra-7-258v` | Machine fact collector tying CPU/GPU/NPU artifacts together | Does not merge CPU, GPU, and NPU claims. |
@@ -27,9 +27,11 @@ Do these identity and validation surfaces before claiming real BitNet performanc
 1. **NPU-002-lite**: preserve Intel NPU backend identity and stop mapping `npu` to Metal or generic GPU paths.
 2. **ARC140V-002**: prove Arc 140V runtime identity through PCI ID, OpenCL, Level Zero, and OpenVINO `GPU.0` evidence.
 3. **LNL258V-RUN-001**: add a visibility-only 258V platform probe receipt that records CPU, Arc 140V, OpenVINO GPU, and OpenVINO NPU facts without claiming inference.
-4. **CPU-BITNET-001 / CPU-BITNET-002**: land strict GGUF loader and tokenizer authority in the active 8250U-owned CPU proof lane.
-5. **CPU258V-001**: run the merged CPU path on the 258V laptop and emit strict validation receipts for scalar-vs-AVX2 parity, loader/tokenizer authority, kernel identity, and decode/prefill metrics.
-6. **Comparison work**: only after the lane receipts exist, compare CPU AVX2, Arc 140V, and OpenVINO NPU artifacts on the same shared-memory platform.
+4. **CPU258V-001**: run the merged CPU path on the 258V laptop and emit strict validation receipts for loader/tokenizer authority, kernel identity, and decode smoke.
+5. **CPU258V-002**: compare scalar and AVX2 strict CPU answer receipts on the 258V with the same model, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs/text, first divergence, logits/top-k evidence when available, fallback status, and power/topology context.
+6. **CPU258V-003**: emit 258V phase benchmark receipts for smoke, first token, decode, and prefill profiles as the CPU reference plate.
+7. **NPU-007 / ARC140V-003**: advance NPU selected RMSNorm subgraph parity and Arc 140V tiny OpenCL smoke against the 258V CPU-first priority order.
+8. **Comparison work**: only after the lane receipts exist, compare CPU AVX2, Arc 140V, and OpenVINO NPU artifacts on the same shared-memory platform.
 
 ## PR Contracts
 
@@ -38,7 +40,9 @@ Do these identity and validation surfaces before claiming real BitNet performanc
 | `NPU-002-lite` | Identity-before-runtime cleanup for Intel NPU. | Backend request parsing, device config, NPU backend selection, probe metadata, receipt identity fields. | OpenVINO graph execution, CPU QK256 kernels, transformer hot path. | `npu`, `intel-npu`, and `openvino-npu` preserve NPU identity; strict NPU requests fail cleanly when unavailable; receipts can represent requested and selected NPU backends. |
 | `ARC140V-002` | Exact Arc 140V runtime identity probe. | `bitnet-device-probe`, Arc 140V probe module, hardware docs, optional CLI/xtask probe command. | CPU kernels, NPU runtime, transformer hot path. | Probe records PCI ID when available, OpenCL device name/driver, Level Zero visibility, OpenVINO `GPU.0` full name, and never emits CPU fallback as Arc proof. |
 | `LNL258V-RUN-001` | Whole-laptop visibility receipt. | `bitnet-device-probe`, receipt schema, CLI/xtask platform probe command, 258V docs. | QK256 CPU kernels, shared transformer hot path. | JSON artifact records CPU AVX2 facts, Arc 140V visibility, Level Zero visibility, OpenVINO devices, NPU visibility, power/thermal context, and `status=runtime_detected` or a failure reason. |
-| `CPU258V-001` | 258V CPU validation harness. | CLI validation command, receipts, hardware/tracking docs, machine profile artifacts. | Shared CPU implementation logic unless stacked on the CPU proof lane. | Strict CPU receipt records loader mode, tokenizer source, mock/fallback status, requested/selected kernel, phase metrics, and same-machine platform link. |
+| `CPU258V-001` | 258V CPU validation harness. | CLI validation command, receipts, hardware/tracking docs, machine profile artifacts. | Accelerator code and unrelated model/tokenizer rewrites. | Strict CPU receipt records loader mode, tokenizer source, mock/fallback status, requested/selected kernel, phase metrics, and same-machine platform link. |
+| `CPU258V-002` | 258V scalar-vs-AVX2 strict answer parity. | CLI parity command, answer receipts, 258V CPU artifacts, hardware/tracking docs. | OpenCL, OpenVINO NPU execution, QK256 kernel rewrites unless explicitly scoped. | Receipt compares scalar and AVX2 output for the same model/tokenizer/prompt/greedy settings, records token IDs/text, first divergence, logits/top-k evidence, selected kernels, fallback=false, and power/topology context. |
+| `CPU258V-003` | 258V phase benchmark receipts. | Benchmark receipt generation, 258V artifacts, hardware/tracking docs. | Accelerator code, server inference, and thread pinning unless separately scoped. | Receipt records smoke, first-token, decode, and prefill phase timing when available with CPU feature, power, topology, selected backend/kernel, and fallback status. |
 
 ## Required Platform Probe Surface
 
@@ -187,7 +191,7 @@ Strict mode must fail before inference if Intel NPU is requested and no Intel NP
 
 ## Required 258V CPU Validation Receipt
 
-The 258V CPU harness should measure the merged CPU path without taking over the implementation surfaces. It should emit a receipt shaped like:
+The 258V CPU harness is the BitNet CPU lead surface. It should measure the merged CPU path and emit a receipt shaped like:
 
 ```rust
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -230,7 +234,7 @@ Strict 258V CPU validation is invalid if any of these are true:
 
 ## Downstream CPU Implementation Dependencies
 
-The 258V CPU lane depends on the CPU proof lane delivering these implementation surfaces:
+The 258V CPU lane now owns new BitNet CPU proof sequencing. These are the shared implementation surfaces it must preserve or consume deliberately:
 
 | Concern | Canonical authority | Required outcome |
 |---|---|---|

--- a/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
+++ b/docs/specs/intel-lunar-lake-258v-platform-roadmap.md
@@ -2,18 +2,18 @@
 
 ## Purpose
 
-This document defines the Core Ultra 7 258V Lunar Lake laptop as a tri-device validation platform for BitNet-rs. It does not merge CPU, GPU, and NPU claims.
+This document defines the Core Ultra 7 258V Lunar Lake laptop as the BitNet CPU lead and tri-device validation platform for BitNet-rs. It does not merge CPU, GPU, and NPU claims.
 
 Proof lanes:
 
 | Subdevice | Primary proof label | Owner |
 |---|---|---|
-| CPU | `intel-258v-cpu-avx2` / `cpu-avx2` | CPU runtime proof |
+| CPU | `intel-258v-cpu-avx2` / `cpu-avx2` | BitNet CPU lead |
 | Integrated GPU | `intel-arc-140v-opencl` | Intel Arc GPU validation |
 | Integrated GPU reference | `intel-arc-140v-openvino-gpu` | Intel Arc GPU validation |
 | NPU | `intel-npu-openvino` / `intel_258v_npu_openvino` | Intel NPU validation |
 
-The platform lane exists to collect machine facts and compare proof artifacts from those lanes on the same laptop. It does not replace the i5-8250U active AVX2 implementation lane.
+The platform lane exists to collect machine facts and compare proof artifacts from those lanes on the same laptop. The 258V CPU is the lead BitNet CPU reference path; the i5-8250U is the SLM CPU lead plus legacy/low-power BitNet comparison lane.
 
 ## Platform Baseline
 
@@ -61,7 +61,8 @@ NPU baseline:
 - GPU fallback cannot count as NPU execution.
 - Shared-memory laptop results must not be compared directly to A770 without memory, power, and thermal context.
 - WSL does not count as NPU-capable unless OpenVINO sees `NPU` inside WSL.
-- 258V CPU validation must not reshape shared CPU implementation unless the ledger item explicitly scopes that work.
+- 258V CPU proof is first priority; NPU and Arc proofs must compare against 258V CPU reference receipts before BitNet-adjacent parity claims.
+- Accelerator PRs must not reshape shared CPU dispatch or QK256 CPU kernels unless the ledger item explicitly scopes that work.
 
 ## Device Routing
 
@@ -175,9 +176,17 @@ Claim boundaries:
 - OpenVINO `NPU` visibility is not graph execution.
 - No BitNet inference, parity, benchmark, or accelerator contribution claim is allowed.
 
-### CPU258V-001 - Add CPU AVX2 Validation Lane
+### CPU258V-001 - Add CPU AVX2 Validation Harness
 
-Document 258V CPU as a parallel Lunar Lake validation lane for the same CPU path. The 8250U remains the active AVX2 implementation/proof lane; 258V CPU validates behavior on the Lunar Lake platform and supports same-machine comparison against Arc 140V and NPU artifacts.
+Document and run the 258V CPU validation harness as the first Lunar Lake CPU proof surface. The 258V CPU now leads BitNet CPU proof sequencing and supports same-machine comparison against Arc 140V and NPU artifacts.
+
+### CPU258V-002 - Add Scalar-vs-AVX2 Answer Parity
+
+Compare scalar and AVX2 strict CPU answer receipts on the 258V with the same real GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs/text, first-divergence evidence, logits/top-k evidence when available, fallback status, selected kernels, and power/topology context.
+
+### CPU258V-003 - Add Phase Benchmark Receipts
+
+Record 258V CPU phase receipts for smoke, first-token, decode, and prefill profiles with P-core / low-power E-core context, power mode, thread count, selected kernel, and fallback status. Do not claim sustained throughput until sustained benchmark receipts exist.
 
 ### ARC140V-001 - Add Integrated GPU Lane
 

--- a/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/cpu-proof/CAMPAIGN.md
@@ -42,8 +42,8 @@ Make real BitNet CPU inference strict, receipt-backed, and measurable. The campa
 | CPU-BITNET-008 | merged | CPU phase benchmark receipt profiles merged in #3856. |
 | CPU-PHASE-TIMING-001 | merged | Tightened Kaby phase timing receipt extraction in #3872 while leaving micro/layer gaps explicit. |
 | CPU-ANSWER-001 | merged | Strict CPU answer-readiness gates merged in #3898. |
-| CPU-ANSWER-002 | ready | Next: scalar-vs-AVX2 full-decode answer parity and first-divergence evidence. |
+| CPU-ANSWER-002 | ready | Next: scalar-vs-AVX2 full-decode answer parity and first-divergence evidence, with the 258V CPU as the lead BitNet CPU reference machine. |
 
 ## Review Policy
 
-CPU proof PRs are non-stackable when they touch loader, tokenizer, layout, dispatch, decode, or receipt authority. Hardware validation lanes can consume CPU proof artifacts but should not rewrite the same runtime surface concurrently.
+CPU proof PRs are non-stackable when they touch loader, tokenizer, layout, dispatch, decode, or receipt authority. New BitNet CPU proof leadership routes through the 258V CPU lane; other CPU machines are support validators unless a work item explicitly says otherwise. Hardware validation lanes can consume CPU proof artifacts but should not rewrite the same runtime surface concurrently.

--- a/docs/tracking/campaigns/cpu-proof/active.toml
+++ b/docs/tracking/campaigns/cpu-proof/active.toml
@@ -14,6 +14,7 @@ end_state = [
 ]
 
 hard_constraints = [
+  "258V CPU is the lead BitNet CPU reference; no GPU or NPU claims.",
   "No GPU or NPU claims.",
   "No silent GGUF fallback.",
   "No performance claim without receipt artifacts.",
@@ -530,7 +531,7 @@ review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 blocked_by = ["CPU-ANSWER-001"]
-acceptance = "Strict CPU answer runs can compare scalar and AVX2 full-decode outputs for the same real GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs, decoded text, and per-step logits/top-k evidence so AVX2 divergence is separated from shared decode correctness."
+acceptance = "Strict CPU answer runs can compare scalar and AVX2 full-decode outputs for the same real GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs, decoded text, and per-step logits/top-k evidence so AVX2 divergence is separated from shared decode correctness; the 258V CPU is the lead machine for new BitNet CPU answer parity artifacts."
 commands = [
   "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
   "cargo test --locked -p bitnet-inference --no-default-features --features cpu",
@@ -545,7 +546,7 @@ allowed_paths = [
   "crates/bitnet-receipts/**",
   "crates/bitnet-receipts-core/**",
   "ci/quality/**",
-  "ci/hardware/intel-i5-8250u-cpu-avx2/**",
+  "ci/hardware/intel-258v/**",
   "docs/bitnet/**",
   "docs/tracking/campaigns/cpu-proof/**",
   "tests/**",
@@ -558,10 +559,11 @@ forbidden_paths = [
 may_claim = [
   "Scalar versus AVX2 full-decode answer parity can be audited after merge.",
   "First divergence evidence can separate AVX2 kernel issues from shared decode, prompt, tokenizer, logits, or sampler issues after merge.",
+  "258V CPU answer parity artifacts can become the lead BitNet CPU reference for Arc 140V and Intel NPU comparison after merge.",
 ]
 must_not_claim = [
   "General chat quality is proven.",
-  "Sustained Kaby Lake throughput is proven.",
+  "258V sustained throughput is proven.",
   "Server inference is complete.",
   "GPU or NPU execution is involved.",
 ]

--- a/docs/tracking/campaigns/cpu-proof/generated/status.md
+++ b/docs/tracking/campaigns/cpu-proof/generated/status.md
@@ -22,10 +22,11 @@
 | CPU-BITNET-008 | merged | #3856 | `codex/cpu-bitnet-008-phase-benchmark-receipts` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | CPU proof benchmark profiles emit receipt-backed micro, layer, prefill, first-token, and decode measurements with selected backend/kernel, fallback status, workload shape, model identity, quant format, prompt/generated token counts, and hardware context. |
 | CPU-PHASE-TIMING-001 | merged | #3872 | `codex/cpu-bitnet-008-phase-timing-followup` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | CPU phase benchmark receipt generation prefers strict prompt-prefill, first-token decode, and steady-decode timing fields when present; regenerated Kaby Lake evidence records prefill, first_token, and decode as measured from strict proof timing while micro and layer remain explicit not_run gaps. |
 | CPU-ANSWER-001 | merged | #3898 | `codex/cpu-answer-001-strict-answer-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Strict real-model CPU runs prove answer readiness on a tiny deterministic corpus by recording prompt token IDs, generated token IDs, decoded text, selected backend/kernel, fallback=false, and pass/fail answer quality; scalar and AVX2 full-decode runs can be compared before blaming the AVX2 lane. |
-| CPU-ANSWER-002 | ready | TBD | `codex/cpu-answer-002-full-decode-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Strict CPU answer runs can compare scalar and AVX2 full-decode outputs for the same real GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs, decoded text, and per-step logits/top-k evidence so AVX2 divergence is separated from shared decode correctness. |
+| CPU-ANSWER-002 | ready | TBD | `codex/cpu-answer-002-full-decode-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Strict CPU answer runs can compare scalar and AVX2 full-decode outputs for the same real GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs, decoded text, and per-step logits/top-k evidence so AVX2 divergence is separated from shared decode correctness; the 258V CPU is the lead machine for new BitNet CPU answer parity artifacts. |
 
 ## Hard Constraints
 
+- 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims.
 - No GPU or NPU claims.
 - No silent GGUF fallback.
 - No performance claim without receipt artifacts.

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -6,16 +6,18 @@ Status: active
 
 ## Objective
 
-Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
+Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
 
 ## End State
 
 - Same-machine CPU, GPU, and NPU facts are captured.
+- 258V CPU strict real-GGUF validation, scalar/AVX2 answer parity, and phase receipts provide the CPU reference plate.
 - Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.
 - Receipts record OS, drivers, memory, power, thermal, and WSL/native visibility context.
 
 ## Hard Constraints
 
+- 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.
@@ -28,7 +30,10 @@ Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 
 | ARC140V-002 | merged | Add exact Arc 140V runtime identity probe logic. |
 | LNL258V-002 | merged | Add 258V probe bundle and same-machine comparison hooks. |
 | LNL258V-003 | merged | Add CLI platform probe emission for the current 258V machine. |
-| CPU258V-001 | ready | Add a validation-only CPU BitNet preflight harness for the 258V lane. |
+| CPU258V-001 | merged | Add a validation-only CPU BitNet preflight harness for the 258V lane. |
+| LNL258V-OWNERSHIP-001 | pr_open | Make the 258V CPU the BitNet CPU lead and set priority order: CPU, NPU, Arc 140V; open in #3914. |
+| CPU258V-002 | blocked | Add scalar-vs-AVX2 strict CPU answer parity on the 258V after ownership correction lands. |
+| CPU258V-003 | proposed | Add 258V CPU phase benchmark receipts for the CPU reference plate. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -2,15 +2,17 @@ id = "intel-258v-platform"
 title = "Intel 258V platform validation"
 status = "active"
 
-objective = "Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate."
+objective = "Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate."
 
 end_state = [
   "Same-machine CPU, GPU, and NPU facts are captured.",
+  "258V CPU strict real-GGUF validation, scalar/AVX2 answer parity, and phase receipts provide the CPU reference plate.",
   "Arc 140V OpenCL, OpenVINO GPU, and OpenVINO NPU evidence are not conflated.",
   "Receipts record OS, drivers, memory, power, thermal, and WSL/native visibility context.",
 ]
 
 hard_constraints = [
+  "258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.",
   "Arc 140V OpenCL proof is not NPU proof.",
   "OpenVINO GPU smoke is not packed BitNet kernel proof.",
   "WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.",
@@ -238,4 +240,132 @@ must_not_claim = [
   "QK256 or TL2 execution ran on 258V.",
   "BitNet inference works on 258V.",
   "258V CPU benchmark performance.",
+]
+
+[[work_item]]
+id = "LNL258V-OWNERSHIP-001"
+status = "pr_open"
+pr = 3914
+branch = "codex/docs/lnl-bitnet-cpu-lead"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU258V-001"]
+acceptance = "Update Lunar Lake ownership docs and trackers so the 258V CPU is the BitNet CPU lead, 8250U is the SLM CPU lead plus legacy/low-power BitNet comparison lane, 9950X3D and 5700X are support validators, and the priority order is 258V CPU first, Intel NPU second, Arc 140V third."
+commands = [
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".codex/bitnet-alignment.md",
+  "docs/hardware/LANE_OWNERSHIP.md",
+  "docs/hardware/HARDWARE_MATRIX.md",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-buildout-plan.md",
+  "docs/tracking/campaigns/cpu-proof/**",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+  "ci/hardware/**",
+]
+may_claim = [
+  "The ownership/control-plane docs route new BitNet CPU proof through the 258V CPU after merge.",
+  "CPU258V-002 and CPU258V-003 are discoverable as the next Lunar Lake CPU proof items after merge.",
+]
+must_not_claim = [
+  "New runtime proof was added.",
+  "258V CPU parity or phase benchmarks ran.",
+  "Intel NPU or Arc 140V execution changed.",
+]
+
+[[work_item]]
+id = "CPU258V-002"
+status = "blocked"
+branch = "codex/intel-258v-platform/CPU258V-002-answer-parity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["LNL258V-OWNERSHIP-001"]
+acceptance = "Run scalar-vs-AVX2 strict CPU answer parity on the 258V using the same GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs/text, first-divergence evidence, logits/top-k evidence when available, fallback=false, selected kernels, and P-core/LP-E/power context."
+commands = [
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_parity::tests -- --nocapture",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_corpus::tests -- --nocapture",
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-parity --scalar ci/hardware/intel-258v/<date>/cpu-answer-corpus-scalar.json --avx2 ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2.json --json-out ci/hardware/intel-258v/<date>/cpu-answer-parity.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "ci/hardware/intel-258v/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-buildout-plan.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/campaigns/cpu-proof/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "258V scalar-vs-AVX2 strict CPU answer parity can be audited after merge.",
+  "First-divergence evidence can separate AVX2-specific divergence from shared 258V decode, prompt, tokenizer, logits, or sampler issues after merge.",
+]
+must_not_claim = [
+  "General chat quality is proven.",
+  "258V sustained throughput is proven.",
+  "Arc 140V execution is involved.",
+  "Intel NPU execution is involved.",
+]
+
+[[work_item]]
+id = "CPU258V-003"
+status = "proposed"
+branch = "codex/intel-258v-platform/CPU258V-003-phase-receipts"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU258V-002"]
+acceptance = "Add 258V phase benchmark receipts for smoke_1, first_token, decode_128, and prefill_512 when available, recording selected backend/kernel, fallback status, CPU feature set, P-core/LP-E topology, power mode, memory context, and explicit not_run gaps for unavailable profiles."
+commands = [
+  "cargo test --locked -p bitnet-bench-receipts --no-default-features",
+  "Parse ci/hardware/intel-258v/<date>/cpu-phase-benchmark.json",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-bench-receipts/**",
+  "ci/hardware/intel-258v/**",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/specs/intel-lunar-lake-258v-buildout-plan.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-npu/**",
+]
+may_claim = [
+  "258V phase timing receipt fields are available for CPU reference comparison after merge.",
+]
+must_not_claim = [
+  "Sustained 258V throughput is proven unless a sustained receipt exists.",
+  "Arc 140V or Intel NPU performance is proven.",
+  "Full platform performance comparison is complete.",
 ]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-07T173836Z-LNL258V-OWNERSHIP-001-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-07T173836Z-LNL258V-OWNERSHIP-001-pr-open.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-07T17:38:36Z"
+campaign = "intel-258v-platform"
+item = "LNL258V-OWNERSHIP-001"
+event = "pr_open"
+from = "ready"
+to = "pr_open"
+pr = 3914
+branch = "codex/docs/lnl-bitnet-cpu-lead"
+head_sha = "faa02b447efd1b90affe8e01cccdfa167001ad74"
+actor = "codex"
+
+notes = [
+  "Opened ownership correction PR to make the 258V CPU the BitNet CPU lead.",
+  "The PR keeps runtime code untouched and prepares CPU258V-002 as the next Lunar Lake CPU proof item.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -3,7 +3,7 @@
 
 - Campaign: `intel-258v-platform`
 - State: `active`
-- Objective: Validate Core Ultra 7 258V as a tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
+- Objective: Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while keeping CPU AVX2, Arc 140V GPU, and Intel AI Boost NPU proof labels separate.
 
 ## Work Items
 
@@ -14,9 +14,13 @@
 | LNL258V-002 | merged | #3784 | `codex/intel-258v-platform/LNL258V-002-probe-bundle` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a 258V platform probe bundle that records CPU, Arc 140V GPU, Intel NPU, memory, OS, driver, OpenVINO, OpenCL, Level Zero, WSL, and power context without runtime claims. |
 | LNL258V-003 | merged | #3795 | `codex/intel-258v-platform/LNL258V-003-cli-platform-probe` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a CLI command that emits the Lunar Lake 258V visibility-only platform probe receipt from the current machine without launching kernels, compiling OpenVINO graphs, loading BitNet models, or making execution claims. |
 | CPU258V-001 | merged | #3802 | `codex/intel-258v-platform/CPU258V-001-validation-harness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a validation-only Core Ultra 7 258V CPU BitNet preflight command that emits structured blocked_preflight or preflight_ready artifacts without changing GGUF loader, tokenizer, QK256 layout, QK256 dispatch, CPU kernels, or transformer decode internals. |
+| LNL258V-OWNERSHIP-001 | pr_open | #3914 | `codex/docs/lnl-bitnet-cpu-lead` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Update Lunar Lake ownership docs and trackers so the 258V CPU is the BitNet CPU lead, 8250U is the SLM CPU lead plus legacy/low-power BitNet comparison lane, 9950X3D and 5700X are support validators, and the priority order is 258V CPU first, Intel NPU second, Arc 140V third. |
+| CPU258V-002 | blocked | TBD | `codex/intel-258v-platform/CPU258V-002-answer-parity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run scalar-vs-AVX2 strict CPU answer parity on the 258V using the same GGUF, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs/text, first-divergence evidence, logits/top-k evidence when available, fallback=false, selected kernels, and P-core/LP-E/power context. |
+| CPU258V-003 | proposed | TBD | `codex/intel-258v-platform/CPU258V-003-phase-receipts` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add 258V phase benchmark receipts for smoke_1, first_token, decode_128, and prefill_512 when available, recording selected backend/kernel, fallback status, CPU feature set, P-core/LP-E topology, power mode, memory context, and explicit not_run gaps for unavailable profiles. |
 
 ## Hard Constraints
 
+- 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims.
 - Arc 140V OpenCL proof is not NPU proof.
 - OpenVINO GPU smoke is not packed BitNet kernel proof.
 - WSL only counts for NPU validation if OpenVINO reports NPU inside WSL.

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-258v-platform | LNL258V-OWNERSHIP-001 | #3914 | `codex/docs/lnl-bitnet-cpu-lead` | Update Lunar Lake ownership docs and trackers so the 258V CPU is the BitNet CPU lead, 8250U is the SLM CPU lead plus legacy/low-power BitNet comparison lane, 9950X3D and 5700X are support validators, and the priority order is 258V CPU first, Intel NPU second, Arc 140V third. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -50,6 +50,9 @@
 | intel-258v-platform | ARC140V-002 | LNL258V-RUN-001 | merged |
 | intel-258v-platform | LNL258V-003 | LNL258V-002 | merged |
 | intel-258v-platform | CPU258V-001 | LNL258V-003 | merged |
+| intel-258v-platform | LNL258V-OWNERSHIP-001 | CPU258V-001 | pr_open |
+| intel-258v-platform | CPU258V-002 | LNL258V-OWNERSHIP-001 | blocked |
+| intel-258v-platform | CPU258V-003 | CPU258V-002 | proposed |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -8,10 +8,10 @@
 | apple-m4-local-answer | M4-QA-001 | #3904 | blocked | M4-QA-MODEL-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | CPU-ANSWER-002 | TBD | ready | none | No GPU or NPU claims. |
+| cpu-proof | CPU-ANSWER-002 | TBD | ready | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-001 | #3802 | merged | none | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | LNL258V-OWNERSHIP-001 | #3914 | pr_open | CPU258V-002 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -8,10 +8,10 @@
 | apple-m4-local-answer | Apple M4 local answer usability | M4-QA-001 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-operational | Apple M4 operational readiness | M4-OP-006 | Do not reopen the completed apple-m4 proof campaign. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
-| cpu-proof | BitNet CPU proof | CPU-ANSWER-002 | No GPU or NPU claims. |
+| cpu-proof | BitNet CPU proof | CPU-ANSWER-002 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | CPU258V-001 | Arc 140V OpenCL proof is not NPU proof. |
+| intel-258v-platform | Intel 258V platform validation | LNL258V-OWNERSHIP-001 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-006 | Device-node detection is not inference. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |


### PR DESCRIPTION
## Campaign item
LNL258V-OWNERSHIP-001

## Summary
- make the Core Ultra 7 258V CPU the BitNet CPU lead in hardware and Lunar Lake docs
- move i5-8250U wording to SLM CPU lead plus legacy/low-power BitNet comparison
- mark 9950X3D and 5700X as support validators around their primary 5070 Ti and A770 work
- add CPU258V-002 and CPU258V-003 as the next Lunar Lake CPU proof items before NPU/Arc comparison

## Claim boundary
- docs/tracker ownership only
- no runtime proof added
- no 258V CPU parity or phase benchmark run
- no Intel NPU or Arc 140V execution change

## Verification
- `python - tomllib parse for docs/tracking/campaigns/intel-258v-platform/active.toml and docs/tracking/campaigns/cpu-proof/active.toml`
- `rg` stale ownership scan for old 8250U/258V ownership language
- `git diff --check`

## Local note
- `cargo run --locked -p xtask --no-default-features -- campaign generate` timed out locally while compiling on Windows, so generated tracker files were updated mechanically from the manifest changes.
