### PR TITLE
chore(guards): refresh MSRV guard wording

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -24,6 +24,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'Makefile'
 
       # Documentation tracked in CI policy
       - 'docs/tracking/**'
@@ -53,6 +54,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'Makefile'
       - '.github/workflows/ci-core.yml'
       - '.github/workflows/pr-plan.yml'
   workflow_dispatch:

--- a/Makefile
+++ b/Makefile
@@ -256,19 +256,28 @@ guards:
 	fi
 	@echo "$(GREEN)✅ All actions pinned to 40-hex SHAs$(NC)"
 	@echo ""
-	@# Check for wrong MSRV (1.90.0 or other non-1.89.0 hardcoded versions)
-	@echo "$(BLUE)Checking for wrong MSRV versions (should be 1.89.0 or dynamic)...$(NC)"
+	@# Check for stale MSRV references in workflow config
+	@echo "$(BLUE)Checking for stale MSRV versions (should be 1.93.0 or dynamic)...$(NC)"
 	@wrong_msrv=$$(rg --color=never --glob '!guards.yml' \
+	      -e 'toolchain:\s*"?1\.89\.0"?' \
 	      -e 'toolchain:\s*"?1\.90\.0"?' \
+	      -e 'toolchain:\s*"?1\.91\.0"?' \
+	      -e 'toolchain:\s*"?1\.92\.0"?' \
+	      -e 'rust-version\s*=\s*"1\.89\.0"' \
 	      -e 'rust-version\s*=\s*"1\.90\.0"' \
+	      -e 'rust-version\s*=\s*"1\.91\.0"' \
+	      -e 'rust-version\s*=\s*"1\.92\.0"' \
+	      -e '"RUST_VERSION"\s*:\s*"1\.89\.0"' \
 	      -e '"RUST_VERSION"\s*:\s*"1\.90\.0"' \
+	      -e '"RUST_VERSION"\s*:\s*"1\.91\.0"' \
+	      -e '"RUST_VERSION"\s*:\s*"1\.92\.0"' \
 	      .github/workflows 2>/dev/null || true); \
 	if [ -n "$$wrong_msrv" ]; then \
-	   echo "$(RED)❌ Found wrong MSRV (1.90.0) in workflows:$(NC)"; \
+	   echo "$(RED)❌ Found stale MSRV in workflows (expected 1.93.0 or dynamic):$(NC)"; \
 	   echo "$$wrong_msrv"; \
 	   exit 1; \
 	fi
-	@echo "$(GREEN)✅ No wrong MSRV versions found (1.89.0 or dynamic from rust-toolchain.toml)$(NC)"
+	@echo "$(GREEN)✅ No stale MSRV versions found (1.93.0 or dynamic from rust-toolchain.toml)$(NC)"
 	@echo ""
 	@# Check cargo/cross --locked flags
 	@echo "$(BLUE)Checking cargo/cross --locked flags...$(NC)"


### PR DESCRIPTION
## Summary
- update the local `make guards` MSRV messaging from the stale 1.89-era text to the current 1.93 policy
- flag hardcoded 1.89/1.90/1.91/1.92 workflow toolchain literals as stale
- add `Makefile` to CI Core path filters so required core contexts run for guard changes
- avoid taking the stale #3583 coverage workflow deletions, which are no longer appropriate after the CI policy rollout

## Validation
- make guards
- git diff --check
- rg -n "should be 1\\.89|1\\.89\\.0 or dynamic|wrong MSRV \\(1\\.90|No wrong MSRV|stale MSRV|1\\.92\\.0" Makefile rust-toolchain.toml Cargo.toml .github/workflows/guards.yml .github/workflows/guards-nightly.yml

Supersedes #3583 selectively on current main.