### PR TITLE
docs(model): close artifact gate tracker

### DIFF
--- a/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
+++ b/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
@@ -34,8 +34,8 @@ GGUF that only proves structural validity or backend execution.
 
 | Work item | Status | Notes |
 |---|---|---|
-| MODEL-ARTIFACT-001 | in_progress | Define shared answer-artifact gate and record the current Microsoft BitNet I2_S GGUF as rejected for answer readiness. |
-| MODEL-ARTIFACT-002 | blocked | Acquire or regenerate a reference-good BitNet artifact that passes the deterministic prompt suite under a reference runner. |
+| MODEL-ARTIFACT-001 | merged | Shared answer-artifact gate merged in #3922; the current Microsoft BitNet I2_S GGUF is rejected for coherent local-answer claims. |
+| MODEL-ARTIFACT-002 | ready | Acquire or regenerate a reference-good BitNet artifact that passes the deterministic prompt suite under a reference runner. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/model-artifacts/active.toml
+++ b/docs/tracking/campaigns/model-artifacts/active.toml
@@ -21,7 +21,8 @@ hard_constraints = [
 
 [[work_item]]
 id = "MODEL-ARTIFACT-001"
-status = "pr_open"
+status = "merged"
+pr = 3922
 branch = "codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2"
 stackable = false
 review_mode = "codex_premerge"
@@ -67,7 +68,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "MODEL-ARTIFACT-002"
-status = "blocked"
+status = "ready"
 branch = "codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-07T201408Z-MODEL-ARTIFACT-001-merged.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-07T201408Z-MODEL-ARTIFACT-001-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-07T20:14:08Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-001"
+event = "merged"
+pr = 3922
+merge_sha = "7770e5236cc609f8c4af726f156177ea62fc9d95"
+actor = "codex"
+
+notes = [
+  "Merged #3922 to establish the shared answer-artifact gate.",
+  "The current Microsoft BitNet I2_S GGUF remains rejected for coherent local-answer claims; no CPU, CUDA, Apple, NPU, server, or speed claim is made by this closeout.",
+]

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-07T201410Z-MODEL-ARTIFACT-002-ready.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-07T201410Z-MODEL-ARTIFACT-002-ready.toml
@@ -1,0 +1,10 @@
+timestamp = "2026-05-07T20:14:10Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-002"
+event = "in_progress"
+actor = "codex"
+
+notes = [
+  "MODEL-ARTIFACT-002 is ready after the shared answer-artifact gate merged.",
+  "Next work must acquire or regenerate a reference-good BitNet answer artifact before backend lanes claim coherent local answers.",
+]

--- a/docs/tracking/campaigns/model-artifacts/generated/status.md
+++ b/docs/tracking/campaigns/model-artifacts/generated/status.md
@@ -9,8 +9,8 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| MODEL-ARTIFACT-001 | pr_open | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
-| MODEL-ARTIFACT-002 | blocked | TBD | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
+| MODEL-ARTIFACT-001 | merged | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
+| MODEL-ARTIFACT-002 | ready | TBD | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| model-artifacts | MODEL-ARTIFACT-001 | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -57,7 +57,7 @@
 | intel-npu | NPU-005 | NPU-004 | merged |
 | intel-npu | NPU-007 | NPU-006 | merged |
 | intel-npu | NPU-006 | NPU-005 | merged |
-| model-artifacts | MODEL-ARTIFACT-002 | MODEL-ARTIFACT-001 | blocked |
+| model-artifacts | MODEL-ARTIFACT-002 | MODEL-ARTIFACT-001 | ready |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -14,7 +14,7 @@
 | intel-258v-platform | CPU258V-002 | TBD | ready | CPU258V-003 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
-| model-artifacts | MODEL-ARTIFACT-001 | #3922 | pr_open | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
+| model-artifacts | MODEL-ARTIFACT-002 | TBD | ready | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-002B | TBD | ready | SLM-CPU-003 | Do not edit BitNet QK256/I2_S kernels. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -14,7 +14,7 @@
 | intel-258v-platform | Intel 258V platform validation | CPU258V-002 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-006 | Device-node detection is not inference. |
-| model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-001 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
+| model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-002B | Do not edit BitNet QK256/I2_S kernels. |


### PR DESCRIPTION
## Work item
MODEL-ARTIFACT-001 closeout

## Summary
- mark `MODEL-ARTIFACT-001` merged after #3922
- promote `MODEL-ARTIFACT-002` to ready so the reference-good artifact search is the next shared answer-readiness gate
- refresh generated campaign dashboards and add closeout/ready events

## Boundaries
- docs/tracking only
- no runtime, tokenizer, loader, CUDA, QK256, transformer, server, dense CUDA, or speed claim changes
- no claim that any backend local-answer lane is coherent

## Validation
- parsed model-artifact TOML files with Python/tomllib
- cargo run --release --locked -p xtask --no-default-features -- campaign check model-artifacts
- cargo run --release --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --release --locked -p xtask --no-default-features -- campaign doctor
- git diff --check