### PR TITLE
CPU258V-002: add scalar-vs-AVX2 answer parity

### DIFF
--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/capital_france.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/capital_france.json
@@ -1,0 +1,470 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\capital_france.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 8,
+    "phase": "decode",
+    "prompt_tokens": 23,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 1680,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16421,
+    "decode_first_ms": 16421,
+    "total_ms": 130693
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 8,
+        "max_ms": 0.033,
+        "mean_ms": 0.019,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.033,
+        "total_ms": 0.155
+      },
+      "first_token_decode_ms": 16421.298,
+      "forward_ms": {
+        "count": 8,
+        "max_ms": 16386.416,
+        "mean_ms": 16224.909,
+        "min_ms": 16110.528,
+        "p50_ms": 16205.61,
+        "p95_ms": 16386.416,
+        "total_ms": 129799.272
+      },
+      "generated_tokens": 8,
+      "logits_ms": {
+        "count": 8,
+        "max_ms": 99.129,
+        "mean_ms": 95.823,
+        "min_ms": 86.713,
+        "p50_ms": 96.522,
+        "p95_ms": 99.129,
+        "total_ms": 766.581
+      },
+      "per_token_ms": {
+        "count": 8,
+        "max_ms": 16490.943,
+        "mean_ms": 16336.616,
+        "min_ms": 16212.639,
+        "p50_ms": 16309.621,
+        "p95_ms": 16490.943,
+        "total_ms": 130692.93
+      },
+      "sample_ms": {
+        "count": 8,
+        "max_ms": 1.764,
+        "mean_ms": 1.699,
+        "min_ms": 1.638,
+        "p50_ms": 1.687,
+        "p95_ms": 1.764,
+        "total_ms": 13.591
+      },
+      "steady_per_token_ms": {
+        "count": 7,
+        "max_ms": 16490.943,
+        "mean_ms": 16324.519,
+        "min_ms": 16212.639,
+        "p50_ms": 16309.621,
+        "p95_ms": 16490.943,
+        "total_ms": 114271.633
+      },
+      "steady_state_tok_s": 0.061,
+      "steady_state_tokens": 7,
+      "token_decode_ms": {
+        "count": 8,
+        "max_ms": 0.042,
+        "mean_ms": 0.02,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.042,
+        "total_ms": 0.158
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 49309.92,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.304,
+    "requested": false,
+    "tokenizer_load_ms": 788.272
+  },
+  "prompt": "What is the capital of France? Answer with one word.",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 8,
+    "decode_tps": 0.061212153673111794,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 23,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+  "throughput": {
+    "decoded_tokens": 8,
+    "tokens_per_second": 0.061212153673111794
+  },
+  "timestamp": "2026-05-07T20:46:38.055214200+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.061,
+    "decode_total_ms": 130692.93,
+    "first_token_decode_ms": 16421.298,
+    "first_token_ms": 16421,
+    "model_load_ms": 49309.92,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.699,
+    "tokenize_ms": 0.304,
+    "tokenizer_load_ms": 788.272
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 8,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "prompt": 23,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      3923,
+      374,
+      279,
+      6864,
+      315,
+      9822,
+      30,
+      22559,
+      449,
+      832,
+      3492,
+      13,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 31
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/math_2_plus_2.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/math_2_plus_2.json
@@ -1,0 +1,463 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\math_2_plus_2.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 24,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16577,
+    "decode_first_ms": 16577,
+    "total_ms": 65996
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.031,
+        "mean_ms": 0.019,
+        "min_ms": 0.014,
+        "p50_ms": 0.014,
+        "p95_ms": 0.031,
+        "total_ms": 0.075
+      },
+      "first_token_decode_ms": 16577.679,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 16490.314,
+        "mean_ms": 16382.696,
+        "min_ms": 16226.742,
+        "p50_ms": 16384.474,
+        "p95_ms": 16490.314,
+        "total_ms": 65530.783
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 103.236,
+        "mean_ms": 89.965,
+        "min_ms": 84.615,
+        "p50_ms": 85.388,
+        "p95_ms": 103.236,
+        "total_ms": 359.858
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 16579.996,
+        "mean_ms": 16499.174,
+        "min_ms": 16319.092,
+        "p50_ms": 16519.929,
+        "p95_ms": 16579.996,
+        "total_ms": 65996.696
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.799,
+        "mean_ms": 1.71,
+        "min_ms": 1.589,
+        "p50_ms": 1.68,
+        "p95_ms": 1.799,
+        "total_ms": 6.842
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 16579.996,
+        "mean_ms": 16473.006,
+        "min_ms": 16319.092,
+        "p50_ms": 16519.929,
+        "p95_ms": 16579.996,
+        "total_ms": 49419.017
+      },
+      "steady_state_tok_s": 0.061,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.046,
+        "mean_ms": 0.024,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.046,
+        "total_ms": 0.094
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 48689.078,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.364,
+    "requested": false,
+    "tokenizer_load_ms": 805.448
+  },
+  "prompt": "What is 2+2? Answer with only the number.",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.06060973392326808,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 24,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.06060973392326808
+  },
+  "timestamp": "2026-05-07T20:43:35.983282400+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.061,
+    "decode_total_ms": 65996.696,
+    "first_token_decode_ms": 16577.679,
+    "first_token_ms": 16577,
+    "model_load_ms": 48689.078,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.71,
+    "tokenize_ms": 0.364,
+    "tokenizer_load_ms": 805.448
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 24,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      3923,
+      374,
+      220,
+      17,
+      10,
+      17,
+      30,
+      22559,
+      449,
+      1193,
+      279,
+      1396,
+      13,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 28
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/repeat_colors.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/repeat_colors.json
@@ -1,0 +1,464 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\repeat_colors.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 8,
+    "phase": "decode",
+    "prompt_tokens": 17,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 1680,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16590,
+    "decode_first_ms": 16590,
+    "total_ms": 131534
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 8,
+        "max_ms": 0.032,
+        "mean_ms": 0.018,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.032,
+        "total_ms": 0.141
+      },
+      "first_token_decode_ms": 16590.454,
+      "forward_ms": {
+        "count": 8,
+        "max_ms": 16727.483,
+        "mean_ms": 16336.121,
+        "min_ms": 16152.355,
+        "p50_ms": 16259.145,
+        "p95_ms": 16727.483,
+        "total_ms": 130688.972
+      },
+      "generated_tokens": 8,
+      "logits_ms": {
+        "count": 8,
+        "max_ms": 101.698,
+        "mean_ms": 89.968,
+        "min_ms": 83.984,
+        "p50_ms": 86.289,
+        "p95_ms": 101.698,
+        "total_ms": 719.747
+      },
+      "per_token_ms": {
+        "count": 8,
+        "max_ms": 16822.527,
+        "mean_ms": 16441.793,
+        "min_ms": 16243.899,
+        "p50_ms": 16350.757,
+        "p95_ms": 16822.527,
+        "total_ms": 131534.343
+      },
+      "sample_ms": {
+        "count": 8,
+        "max_ms": 1.913,
+        "mean_ms": 1.729,
+        "min_ms": 1.623,
+        "p50_ms": 1.668,
+        "p95_ms": 1.913,
+        "total_ms": 13.832
+      },
+      "steady_per_token_ms": {
+        "count": 7,
+        "max_ms": 16822.527,
+        "mean_ms": 16420.556,
+        "min_ms": 16243.899,
+        "p50_ms": 16350.757,
+        "p95_ms": 16822.527,
+        "total_ms": 114943.89
+      },
+      "steady_state_tok_s": 0.061,
+      "steady_state_tokens": 7,
+      "token_decode_ms": {
+        "count": 8,
+        "max_ms": 0.04,
+        "mean_ms": 0.019,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.04,
+        "total_ms": 0.153
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 48766.342,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.394,
+    "requested": false,
+    "tokenizer_load_ms": 868.982
+  },
+  "prompt": "Repeat exactly: red blue green",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 8,
+    "decode_tps": 0.06082077637721046,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 17,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+  "throughput": {
+    "decoded_tokens": 8,
+    "tokens_per_second": 0.06082077637721046
+  },
+  "timestamp": "2026-05-07T20:49:40.423312500+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.061,
+    "decode_total_ms": 131534.343,
+    "first_token_decode_ms": 16590.454,
+    "first_token_ms": 16590,
+    "model_load_ms": 48766.342,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.729,
+    "tokenize_ms": 0.394,
+    "tokenizer_load_ms": 868.982
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 8,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "prompt": 17,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      39818,
+      7041,
+      25,
+      2579,
+      6437,
+      6307,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 25
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/say_ok.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/say_ok.json
@@ -1,0 +1,454 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\say_ok.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 15,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16693,
+    "decode_first_ms": 16693,
+    "total_ms": 65727
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.032,
+        "mean_ms": 0.019,
+        "min_ms": 0.014,
+        "p50_ms": 0.015,
+        "p95_ms": 0.032,
+        "total_ms": 0.077
+      },
+      "first_token_decode_ms": 16693.42,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 16516.889,
+        "mean_ms": 16319.139,
+        "min_ms": 16231.203,
+        "p50_ms": 16255.876,
+        "p95_ms": 16516.889,
+        "total_ms": 65276.558
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 90.867,
+        "mean_ms": 87.193,
+        "min_ms": 82.974,
+        "p50_ms": 86.85,
+        "p95_ms": 90.867,
+        "total_ms": 348.774
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 16693.42,
+        "mean_ms": 16431.827,
+        "min_ms": 16323.513,
+        "p50_ms": 16344.009,
+        "p95_ms": 16693.42,
+        "total_ms": 65727.309
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.82,
+        "mean_ms": 1.693,
+        "min_ms": 1.588,
+        "p50_ms": 1.664,
+        "p95_ms": 1.82,
+        "total_ms": 6.773
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 16366.368,
+        "mean_ms": 16344.63,
+        "min_ms": 16323.513,
+        "p50_ms": 16344.009,
+        "p95_ms": 16366.368,
+        "total_ms": 49033.889
+      },
+      "steady_state_tok_s": 0.061,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.039,
+        "mean_ms": 0.021,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.039,
+        "total_ms": 0.085
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 48490.786,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.276,
+    "requested": false,
+    "tokenizer_load_ms": 804.092
+  },
+  "prompt": "Say exactly: OK",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.06085779055791379,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 15,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.06085779055791379
+  },
+  "timestamp": "2026-05-07T20:51:36.639647200+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.061,
+    "decode_total_ms": 65727.309,
+    "first_token_decode_ms": 16693.42,
+    "first_token_ms": 16693,
+    "model_load_ms": 48490.786,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.693,
+    "tokenize_ms": 0.276,
+    "tokenizer_load_ms": 804.092
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 15,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      46864,
+      7041,
+      25,
+      10619,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 19
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/yes_no_water.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2-runs/yes_no_water.json
@@ -1,0 +1,459 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\yes_no_water.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 20,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "avx2",
+    "kernel_id": "i2_s-avx2-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16478,
+    "decode_first_ms": 16478,
+    "total_ms": 65701
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.031,
+        "mean_ms": 0.02,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.031,
+        "total_ms": 0.079
+      },
+      "first_token_decode_ms": 16479.077,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 16374.001,
+        "mean_ms": 16312.614,
+        "min_ms": 16272.169,
+        "p50_ms": 16301.9,
+        "p95_ms": 16374.001,
+        "total_ms": 65250.455
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 91.324,
+        "mean_ms": 86.953,
+        "min_ms": 81.062,
+        "p50_ms": 86.89,
+        "p95_ms": 91.324,
+        "total_ms": 347.812
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 16479.077,
+        "mean_ms": 16425.319,
+        "min_ms": 16366.332,
+        "p50_ms": 16394.302,
+        "p95_ms": 16479.077,
+        "total_ms": 65701.274
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.794,
+        "mean_ms": 1.706,
+        "min_ms": 1.598,
+        "p50_ms": 1.696,
+        "p95_ms": 1.794,
+        "total_ms": 6.824
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 16461.564,
+        "mean_ms": 16407.399,
+        "min_ms": 16366.332,
+        "p50_ms": 16394.302,
+        "p95_ms": 16461.564,
+        "total_ms": 49222.197
+      },
+      "steady_state_tok_s": 0.061,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.066,
+        "mean_ms": 0.029,
+        "min_ms": 0.016,
+        "p50_ms": 0.016,
+        "p95_ms": 0.066,
+        "total_ms": 0.114
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 49143.485,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.572,
+    "requested": false,
+    "tokenizer_load_ms": 800.234
+  },
+  "prompt": "Answer yes or no: is water wet?",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.060881873944080005,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 20,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-avx2-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-avx2-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.060881873944080005
+  },
+  "timestamp": "2026-05-07T20:53:33.542475+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.061,
+    "decode_total_ms": 65701.274,
+    "first_token_decode_ms": 16479.077,
+    "first_token_ms": 16478,
+    "model_load_ms": 49143.485,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.706,
+    "tokenize_ms": 0.572,
+    "tokenizer_load_ms": 800.234
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 20,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      16533,
+      10035,
+      477,
+      912,
+      25,
+      374,
+      3090,
+      14739,
+      30,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 24
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2.json
@@ -1,0 +1,769 @@
+{
+  "artifact_kind": "bitnet_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu"
+  },
+  "cases": [
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "math_2_plus_2",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-avx2-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "gate_kind": "exact_trimmed",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "What is 2+2? Answer with only the number.",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\math_2_plus_2.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 24,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 28
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "capital_france",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-avx2-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [
+          "gate_contains_any"
+        ],
+        "gate_kind": "contains_any",
+        "generated_tokens": 8,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "What is the capital of France? Answer with one word.",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\capital_france.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 8,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": 23,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 31
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "repeat_colors",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-avx2-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [
+          "gate_contains_any"
+        ],
+        "gate_kind": "contains_any",
+        "generated_tokens": 8,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Repeat exactly: red blue green",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\repeat_colors.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 8,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": 17,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 25
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "say_ok",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-avx2-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "gate_kind": "exact_trimmed",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Say exactly: OK",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\say_ok.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 15,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 19
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "yes_no_water",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-avx2-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_starts_with_any"
+        ],
+        "gate_kind": "starts_with_any",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Answer yes or no: is water wet?",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-avx2-runs\\yes_no_water.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 20,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 24
+      }
+    }
+  ],
+  "claim_boundary": {
+    "broad_performance_claimed": false,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false
+  },
+  "corpus": {
+    "case_count": 5,
+    "description": "Fixed deterministic prompt set for answer-readiness baselines.",
+    "name": "strict-bitnet-answer-corpus-v1",
+    "path": "ci/quality/bitnet-answer-corpus.yaml"
+  },
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": 1,
+    "logits_topk": 5,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 360,
+    "requested_cpu_kernel": "avx2",
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "tokenizer": "llama3",
+    "tokenizer_path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\tokenizer.json"
+  },
+  "prompt_template": {
+    "family": "llama3-chat"
+  },
+  "quality_summary": {
+    "failed": 5,
+    "not_run": 0,
+    "passed": 0,
+    "timeout": 0,
+    "total": 5
+  },
+  "schema_version": "1.0.0",
+  "speedup_claim": false,
+  "timestamp": "2026-05-07T20:53:33.718314900+00:00"
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/capital_france.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/capital_france.json
@@ -1,0 +1,470 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\capital_france.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 8,
+    "phase": "decode",
+    "prompt_tokens": 23,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 1680,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "scalar",
+    "kernel_id": "i2_s-scalar-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 17244,
+    "decode_first_ms": 17244,
+    "total_ms": 138231
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 8,
+        "max_ms": 0.042,
+        "mean_ms": 0.021,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.042,
+        "total_ms": 0.164
+      },
+      "first_token_decode_ms": 17245.064,
+      "forward_ms": {
+        "count": 8,
+        "max_ms": 17223.197,
+        "mean_ms": 17155.436,
+        "min_ms": 17063.602,
+        "p50_ms": 17165.314,
+        "p95_ms": 17223.197,
+        "total_ms": 137243.492
+      },
+      "generated_tokens": 8,
+      "logits_ms": {
+        "count": 8,
+        "max_ms": 116.429,
+        "mean_ms": 107.464,
+        "min_ms": 94.835,
+        "p50_ms": 106.273,
+        "p95_ms": 116.429,
+        "total_ms": 859.709
+      },
+      "per_token_ms": {
+        "count": 8,
+        "max_ms": 17336.43,
+        "mean_ms": 17278.838,
+        "min_ms": 17194.729,
+        "p50_ms": 17284.466,
+        "p95_ms": 17336.43,
+        "total_ms": 138230.702
+      },
+      "sample_ms": {
+        "count": 8,
+        "max_ms": 2.057,
+        "mean_ms": 1.794,
+        "min_ms": 1.604,
+        "p50_ms": 1.741,
+        "p95_ms": 2.057,
+        "total_ms": 14.354
+      },
+      "steady_per_token_ms": {
+        "count": 7,
+        "max_ms": 17336.43,
+        "mean_ms": 17283.663,
+        "min_ms": 17194.729,
+        "p50_ms": 17300.824,
+        "p95_ms": 17336.43,
+        "total_ms": 120985.638
+      },
+      "steady_state_tok_s": 0.058,
+      "steady_state_tokens": 7,
+      "token_decode_ms": {
+        "count": 8,
+        "max_ms": 0.053,
+        "mean_ms": 0.023,
+        "min_ms": 0.016,
+        "p50_ms": 0.019,
+        "p95_ms": 0.053,
+        "total_ms": 0.181
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 46979.934,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.291,
+    "requested": false,
+    "tokenizer_load_ms": 912.148
+  },
+  "prompt": "What is the capital of France? Answer with one word.",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 8,
+    "decode_tps": 0.0578741382179106,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 23,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-scalar-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-scalar-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+  "throughput": {
+    "decoded_tokens": 8,
+    "tokens_per_second": 0.0578741382179106
+  },
+  "timestamp": "2026-05-07T20:34:04.472444700+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.058,
+    "decode_total_ms": 138230.702,
+    "first_token_decode_ms": 17245.064,
+    "first_token_ms": 17244,
+    "model_load_ms": 46979.934,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.794,
+    "tokenize_ms": 0.291,
+    "tokenizer_load_ms": 912.148
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 8,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "prompt": 23,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      3923,
+      374,
+      279,
+      6864,
+      315,
+      9822,
+      30,
+      22559,
+      449,
+      832,
+      3492,
+      13,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 31
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/math_2_plus_2.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/math_2_plus_2.json
@@ -1,0 +1,463 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\math_2_plus_2.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 24,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "scalar",
+    "kernel_id": "i2_s-scalar-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 17524,
+    "decode_first_ms": 17524,
+    "total_ms": 68812
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.049,
+        "mean_ms": 0.024,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.049,
+        "total_ms": 0.096
+      },
+      "first_token_decode_ms": 17524.602,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 17322.451,
+        "mean_ms": 17069.502,
+        "min_ms": 16713.178,
+        "p50_ms": 17062.153,
+        "p95_ms": 17322.451,
+        "total_ms": 68278.007
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 108.182,
+        "mean_ms": 105.793,
+        "min_ms": 101.731,
+        "p50_ms": 106.513,
+        "p95_ms": 108.182,
+        "total_ms": 423.171
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 17524.602,
+        "mean_ms": 17203.162,
+        "min_ms": 16826.603,
+        "p50_ms": 17174.261,
+        "p95_ms": 17524.602,
+        "total_ms": 68812.65
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.762,
+        "mean_ms": 1.627,
+        "min_ms": 1.511,
+        "p50_ms": 1.517,
+        "p95_ms": 1.762,
+        "total_ms": 6.508
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 17287.183,
+        "mean_ms": 17096.016,
+        "min_ms": 16826.603,
+        "p50_ms": 17174.261,
+        "p95_ms": 17287.183,
+        "total_ms": 51288.047
+      },
+      "steady_state_tok_s": 0.058,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.049,
+        "mean_ms": 0.028,
+        "min_ms": 0.016,
+        "p50_ms": 0.018,
+        "p95_ms": 0.049,
+        "total_ms": 0.113
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 52966.508,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.383,
+    "requested": false,
+    "tokenizer_load_ms": 883.585
+  },
+  "prompt": "What is 2+2? Answer with only the number.",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.058129396035575195,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 24,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-scalar-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-scalar-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.058129396035575195
+  },
+  "timestamp": "2026-05-07T20:30:57.062523+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.058,
+    "decode_total_ms": 68812.65,
+    "first_token_decode_ms": 17524.602,
+    "first_token_ms": 17524,
+    "model_load_ms": 52966.508,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.627,
+    "tokenize_ms": 0.383,
+    "tokenizer_load_ms": 883.585
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 24,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      3923,
+      374,
+      220,
+      17,
+      10,
+      17,
+      30,
+      22559,
+      449,
+      1193,
+      279,
+      1396,
+      13,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 28
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/repeat_colors.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/repeat_colors.json
@@ -1,0 +1,464 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\repeat_colors.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 8,
+    "phase": "decode",
+    "prompt_tokens": 17,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 1680,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "scalar",
+    "kernel_id": "i2_s-scalar-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16946,
+    "decode_first_ms": 16946,
+    "total_ms": 140643
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 8,
+        "max_ms": 0.034,
+        "mean_ms": 0.019,
+        "min_ms": 0.014,
+        "p50_ms": 0.015,
+        "p95_ms": 0.034,
+        "total_ms": 0.155
+      },
+      "first_token_decode_ms": 16947.131,
+      "forward_ms": {
+        "count": 8,
+        "max_ms": 20721.422,
+        "mean_ms": 17455.797,
+        "min_ms": 16752.792,
+        "p50_ms": 16814.473,
+        "p95_ms": 20721.422,
+        "total_ms": 139646.375
+      },
+      "generated_tokens": 8,
+      "logits_ms": {
+        "count": 8,
+        "max_ms": 120.146,
+        "mean_ms": 107.049,
+        "min_ms": 94.375,
+        "p50_ms": 106.077,
+        "p95_ms": 120.146,
+        "total_ms": 856.394
+      },
+      "per_token_ms": {
+        "count": 8,
+        "max_ms": 20831.809,
+        "mean_ms": 17580.432,
+        "min_ms": 16865.219,
+        "p50_ms": 16947.131,
+        "p95_ms": 20831.809,
+        "total_ms": 140643.459
+      },
+      "sample_ms": {
+        "count": 8,
+        "max_ms": 2.017,
+        "mean_ms": 1.772,
+        "min_ms": 1.597,
+        "p50_ms": 1.78,
+        "p95_ms": 2.017,
+        "total_ms": 14.178
+      },
+      "steady_per_token_ms": {
+        "count": 7,
+        "max_ms": 20831.809,
+        "mean_ms": 17670.904,
+        "min_ms": 16865.219,
+        "p50_ms": 16968.581,
+        "p95_ms": 20831.809,
+        "total_ms": 123696.328
+      },
+      "steady_state_tok_s": 0.057,
+      "steady_state_tokens": 7,
+      "token_decode_ms": {
+        "count": 8,
+        "max_ms": 0.08,
+        "mean_ms": 0.025,
+        "min_ms": 0.015,
+        "p50_ms": 0.016,
+        "p95_ms": 0.08,
+        "total_ms": 0.197
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 47662.15,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.28,
+    "requested": false,
+    "tokenizer_load_ms": 870.153
+  },
+  "prompt": "Repeat exactly: red blue green",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 8,
+    "decode_tps": 0.056881608043059376,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 17,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-scalar-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-scalar-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+  "throughput": {
+    "decoded_tokens": 8,
+    "tokens_per_second": 0.056881608043059376
+  },
+  "timestamp": "2026-05-07T20:37:14.999233700+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.057,
+    "decode_total_ms": 140643.459,
+    "first_token_decode_ms": 16947.131,
+    "first_token_ms": 16946,
+    "model_load_ms": 47662.15,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.772,
+    "tokenize_ms": 0.28,
+    "tokenizer_load_ms": 870.153
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 8,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281,
+      17642,
+      89048,
+      54616,
+      62954
+    ],
+    "prompt": 17,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      39818,
+      7041,
+      25,
+      2579,
+      6437,
+      6307,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 25
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/say_ok.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/say_ok.json
@@ -1,0 +1,454 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\say_ok.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 15,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "scalar",
+    "kernel_id": "i2_s-scalar-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 17075,
+    "decode_first_ms": 17075,
+    "total_ms": 67776
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.034,
+        "mean_ms": 0.02,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.034,
+        "total_ms": 0.081
+      },
+      "first_token_decode_ms": 17076.034,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 16899.768,
+        "mean_ms": 16822.669,
+        "min_ms": 16728.776,
+        "p50_ms": 16785.066,
+        "p95_ms": 16899.768,
+        "total_ms": 67290.677
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 100.842,
+        "mean_ms": 95.672,
+        "min_ms": 90.968,
+        "p50_ms": 95.142,
+        "p95_ms": 100.842,
+        "total_ms": 382.687
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 17076.034,
+        "mean_ms": 16943.978,
+        "min_ms": 16830.524,
+        "p50_ms": 16891.413,
+        "p95_ms": 17076.034,
+        "total_ms": 67775.91
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.86,
+        "mean_ms": 1.753,
+        "min_ms": 1.639,
+        "p50_ms": 1.725,
+        "p95_ms": 1.86,
+        "total_ms": 7.012
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 16977.94,
+        "mean_ms": 16899.959,
+        "min_ms": 16830.524,
+        "p50_ms": 16891.413,
+        "p95_ms": 16977.94,
+        "total_ms": 50699.877
+      },
+      "steady_state_tok_s": 0.059,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.095,
+        "mean_ms": 0.039,
+        "min_ms": 0.016,
+        "p50_ms": 0.018,
+        "p95_ms": 0.095,
+        "total_ms": 0.157
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 48559.814,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.328,
+    "requested": false,
+    "tokenizer_load_ms": 845.982
+  },
+  "prompt": "Say exactly: OK",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.05901794145420208,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 15,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-scalar-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-scalar-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.05901794145420208
+  },
+  "timestamp": "2026-05-07T20:39:13.509662800+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.059,
+    "decode_total_ms": 67775.91,
+    "first_token_decode_ms": 17076.034,
+    "first_token_ms": 17075,
+    "model_load_ms": 48559.814,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.753,
+    "tokenize_ms": 0.328,
+    "tokenizer_load_ms": 845.982
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 15,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      46864,
+      7041,
+      25,
+      10619,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 19
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/yes_no_water.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar-runs/yes_no_water.json
@@ -1,0 +1,459 @@
+{
+  "artifact_kind": "strict_bitnet_cpu_reference",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\yes_no_water.json",
+  "bitnet": {
+    "activation_quantization": "A8",
+    "execution_phase": "decode",
+    "fallback_layout": null,
+    "kernel_family": "i2_s",
+    "kernel_format": "i2_s",
+    "layout_source": "gguf_packed_i2_s_reference",
+    "per_token_weight_upload": false,
+    "quantization": "W1.58A8",
+    "weight_quantization": "W1.58",
+    "weights_uploaded_once": false
+  },
+  "counts": {
+    "n_kv": 24,
+    "n_tensors": 332,
+    "unmapped": 0
+  },
+  "cpu": {
+    "arch": "x86_64",
+    "features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "threads": 1
+  },
+  "execution": {
+    "batch_size": 1,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "generated_tokens": 4,
+    "phase": "decode",
+    "prompt_tokens": 20,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu-rust",
+    "thread_count": 1
+  },
+  "execution_coverage": {
+    "bitnet_linear_layers_cpu_fallback": 0,
+    "bitnet_linear_layers_on_cuda": 0,
+    "bitnet_linear_layers_total": 840,
+    "execution_claim": "cpu_reference",
+    "unsupported_ops": []
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "gen_policy": {
+    "bos": false,
+    "deterministic": true,
+    "greedy": true,
+    "seed": 0,
+    "temperature": 0.0
+  },
+  "kernel": {
+    "dequantizes_before_compute": false,
+    "family": "i2_s",
+    "implementation": "scalar",
+    "kernel_id": "i2_s-scalar-reference",
+    "layout": "gguf_packed_i2_s"
+  },
+  "latency": {
+    "cmd_to_first_ms": 16769,
+    "decode_first_ms": 16769,
+    "total_ms": 66983
+  },
+  "loader": {
+    "minimal_fallback_allowed": false,
+    "minimal_fallback_disabled": true,
+    "minimal_loader_fallback_used": false,
+    "mock_tensors_used": false,
+    "mode": "real_gguf",
+    "tokenizer_source": "explicit"
+  },
+  "logits_dump": [
+    {
+      "chosen_id": 89048,
+      "step": 0,
+      "top_logits": [
+        {
+          "logit": 9.742095947265625,
+          "token_id": 89048
+        },
+        {
+          "logit": 8.802050590515137,
+          "token_id": 12281
+        },
+        {
+          "logit": 8.758410453796387,
+          "token_id": 39256
+        },
+        {
+          "logit": 8.517449378967285,
+          "token_id": 87896
+        },
+        {
+          "logit": 8.477624893188477,
+          "token_id": 100952
+        }
+      ]
+    }
+  ],
+  "model": {
+    "architecture": "bitnet_b1_58",
+    "context_length": 4096,
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "format": "gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": "4221b252fdd5fd25e15847adfeb5ee88886506ba50b8a34548374492884c2162",
+    "tokenizer": "llama3",
+    "vocab_size": 128256
+  },
+  "profile": {
+    "allocation_audit": {
+      "claim_scope": "not_requested",
+      "decode": {
+        "embed": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "forward": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "logits": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "sample": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "steady_state": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "token_decode": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        },
+        "total": {
+          "alloc_bytes_total": 0,
+          "alloc_count_total": 0,
+          "count": 0,
+          "dealloc_bytes_total": 0,
+          "dealloc_count_total": 0,
+          "max_alloc_bytes_per_token": null,
+          "max_alloc_count_per_token": null,
+          "mean_alloc_bytes_per_token": null,
+          "mean_alloc_count_per_token": null,
+          "net_bytes_total": 0
+        }
+      },
+      "enabled": false,
+      "instrumentation_excluded": [
+        "model_load",
+        "tokenizer_load",
+        "prompt_tokenize",
+        "json_receipt_serialization",
+        "debug_logit_dump_topk_unless_enabled"
+      ],
+      "instrumentation_included": [
+        "prompt_prefill_step",
+        "decode_step_total",
+        "model.embed",
+        "model.forward",
+        "model.logits_and_extract",
+        "sampler.sample",
+        "tokenizer.decode",
+        "stdout_text_write",
+        "token_vector_updates",
+        "stop_tail_updates"
+      ],
+      "measured_tokens": 0,
+      "method": "not_requested",
+      "per_token_alloc_bytes_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "per_token_alloc_count_delta": {
+        "count": 0,
+        "max_per_token": null,
+        "mean_per_token": null,
+        "total": 0
+      },
+      "prompt_prefill": {
+        "alloc_bytes_total": 0,
+        "alloc_count_total": 0,
+        "count": 0,
+        "dealloc_bytes_total": 0,
+        "dealloc_count_total": 0,
+        "max_alloc_bytes_per_token": null,
+        "max_alloc_count_per_token": null,
+        "mean_alloc_bytes_per_token": null,
+        "mean_alloc_count_per_token": null,
+        "net_bytes_total": 0
+      },
+      "scope": "not_requested",
+      "steady_state_alloc_bytes_per_token": null,
+      "steady_state_alloc_count_per_token": null,
+      "warmup_tokens": 0
+    },
+    "backend": {
+      "fallback_reason": null,
+      "fallback_used": false,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "selected_backend": "cpu-rust"
+    },
+    "claim_scope": "selected CPU backend phase timing only",
+    "decode": {
+      "embed_ms": {
+        "count": 4,
+        "max_ms": 0.037,
+        "mean_ms": 0.021,
+        "min_ms": 0.015,
+        "p50_ms": 0.015,
+        "p95_ms": 0.037,
+        "total_ms": 0.084
+      },
+      "first_token_decode_ms": 16769.404,
+      "forward_ms": {
+        "count": 4,
+        "max_ms": 16693.528,
+        "mean_ms": 16630.029,
+        "min_ms": 16587.068,
+        "p50_ms": 16601.897,
+        "p95_ms": 16693.528,
+        "total_ms": 66520.117
+      },
+      "generated_tokens": 4,
+      "logits_ms": {
+        "count": 4,
+        "max_ms": 97.624,
+        "mean_ms": 90.141,
+        "min_ms": 82.397,
+        "p50_ms": 89.651,
+        "p95_ms": 97.624,
+        "total_ms": 360.566
+      },
+      "per_token_ms": {
+        "count": 4,
+        "max_ms": 16788.935,
+        "mean_ms": 16745.724,
+        "min_ms": 16690.288,
+        "p50_ms": 16734.268,
+        "p95_ms": 16788.935,
+        "total_ms": 66982.895
+      },
+      "sample_ms": {
+        "count": 4,
+        "max_ms": 1.741,
+        "mean_ms": 1.701,
+        "min_ms": 1.677,
+        "p50_ms": 1.687,
+        "p95_ms": 1.741,
+        "total_ms": 6.805
+      },
+      "steady_per_token_ms": {
+        "count": 3,
+        "max_ms": 16788.935,
+        "mean_ms": 16737.83,
+        "min_ms": 16690.288,
+        "p50_ms": 16734.268,
+        "p95_ms": 16788.935,
+        "total_ms": 50213.491
+      },
+      "steady_state_tok_s": 0.06,
+      "steady_state_tokens": 3,
+      "token_decode_ms": {
+        "count": 4,
+        "max_ms": 0.046,
+        "mean_ms": 0.024,
+        "min_ms": 0.016,
+        "p50_ms": 0.017,
+        "p95_ms": 0.046,
+        "total_ms": 0.096
+      },
+      "warmup_tokens": 1
+    },
+    "id": "default",
+    "kind": "steady_decode_prefill",
+    "machine_context_recorded": true,
+    "model_load_ms": 49801.536,
+    "phase": "decode",
+    "prompt_prefill": {
+      "exercised": false,
+      "kv_cache_behavior": "not_requested",
+      "ms": 0.0,
+      "per_token_ms": {
+        "count": 0,
+        "max_ms": null,
+        "mean_ms": null,
+        "min_ms": null,
+        "p50_ms": null,
+        "p95_ms": null,
+        "total_ms": 0.0
+      },
+      "tokens": 0
+    },
+    "prompt_tokenize_ms": 0.325,
+    "requested": false,
+    "tokenizer_load_ms": 979.957
+  },
+  "prompt": "Answer yes or no: is water wet?",
+  "requested_backend": "cpu",
+  "runtime_api": "cpu",
+  "schema_version": "1.0.0",
+  "selected_backend": "cpu-rust",
+  "strict_provenance": {
+    "cpu_features": [
+      "avx2",
+      "avx",
+      "fma",
+      "sse4.2",
+      "sse2"
+    ],
+    "cpu_model": "Intel64 Family 6 Model 189 Stepping 1, GenuineIntel",
+    "decode_tokens": 4,
+    "decode_tps": 0.05971664452174432,
+    "fallback_reason": null,
+    "fallback_used": false,
+    "loader_mode": "real_gguf",
+    "model_family": "bitnet",
+    "phase": "decode",
+    "prompt_tokens": 20,
+    "quant_format": "I2_S",
+    "requested_backend": "cpu",
+    "requested_kernel": "i2_s-scalar-reference",
+    "selected_backend": "cpu-rust",
+    "selected_kernel": "i2_s-scalar-reference",
+    "thread_count": 1,
+    "tokenizer_source": "explicit",
+    "tokenizer_strict": true
+  },
+  "text": "'E-lived,SIGNALConvert",
+  "throughput": {
+    "decoded_tokens": 4,
+    "tokens_per_second": 0.05971664452174432
+  },
+  "timestamp": "2026-05-07T20:41:12.551394600+00:00",
+  "timing": {
+    "decode_steady_state_tok_s": 0.06,
+    "decode_total_ms": 66982.895,
+    "first_token_decode_ms": 16769.404,
+    "first_token_ms": 16769,
+    "model_load_ms": 49801.536,
+    "prefill_ms": 0.0,
+    "sampling_ms_per_token": 1.701,
+    "tokenize_ms": 0.325,
+    "tokenizer_load_ms": 979.957
+  },
+  "tokenizer": {
+    "bos": 1,
+    "eos": 2,
+    "origin": "external",
+    "source": "explicit",
+    "strict": true,
+    "type": "llama3"
+  },
+  "tokens": {
+    "generated": 4,
+    "generated_ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "ids": [
+      89048,
+      62954,
+      87896,
+      12281
+    ],
+    "prompt": 20,
+    "prompt_ids": [
+      128000,
+      128000,
+      128006,
+      882,
+      128007,
+      271,
+      16533,
+      10035,
+      477,
+      912,
+      25,
+      374,
+      3090,
+      14739,
+      30,
+      128009,
+      128006,
+      78191,
+      128007,
+      271
+    ],
+    "total": 24
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar.json
@@ -1,0 +1,769 @@
+{
+  "artifact_kind": "bitnet_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu"
+  },
+  "cases": [
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "math_2_plus_2",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-scalar-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "gate_kind": "exact_trimmed",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "What is 2+2? Answer with only the number.",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\math_2_plus_2.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 24,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 28
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "capital_france",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-scalar-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [
+          "gate_contains_any"
+        ],
+        "gate_kind": "contains_any",
+        "generated_tokens": 8,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "What is the capital of France? Answer with one word.",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\capital_france.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 8,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": 23,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 31
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "repeat_colors",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-scalar-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 6,
+        "failed_rules": [
+          "gate_contains_any"
+        ],
+        "gate_kind": "contains_any",
+        "generated_tokens": 8,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Repeat exactly: red blue green",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\repeat_colors.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 8,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "prompt": 17,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 25
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "say_ok",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-scalar-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "gate_kind": "exact_trimmed",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Say exactly: OK",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\say_ok.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 15,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 19
+      }
+    },
+    {
+      "answer": "'E-lived,SIGNALConvert",
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu-rust"
+      },
+      "id": "yes_no_water",
+      "kernel": {
+        "family": "i2_s",
+        "selected_kernel": "i2_s-scalar-reference"
+      },
+      "loader": {
+        "mode": "real_gguf"
+      },
+      "logits_dump": [
+        {
+          "chosen_id": 89048,
+          "step": 0,
+          "top_logits": [
+            {
+              "logit": 9.742095947265623,
+              "token_id": 89048
+            },
+            {
+              "logit": 8.802050590515137,
+              "token_id": 12281
+            },
+            {
+              "logit": 8.758410453796387,
+              "token_id": 39256
+            },
+            {
+              "logit": 8.517449378967285,
+              "token_id": 87896
+            },
+            {
+              "logit": 8.477624893188477,
+              "token_id": 100952
+            }
+          ]
+        }
+      ],
+      "prompt_template": "llama3-chat",
+      "quality": {
+        "distinct_generated_tokens": 4,
+        "failed_rules": [
+          "gate_starts_with_any"
+        ],
+        "gate_kind": "starts_with_any",
+        "generated_tokens": 4,
+        "min_distinct_generated_tokens": null,
+        "min_generated_tokens": null,
+        "mostly_text": true,
+        "no_raw_special_tokens": true,
+        "no_replacement_chars": true,
+        "non_empty_answer": true,
+        "passed": false,
+        "printable_utf8": true
+      },
+      "question": "Answer yes or no: is water wet?",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-07\\cpu-answer-corpus-scalar-runs\\yes_no_water.json",
+      "status": "quality_failed",
+      "token_ids": {
+        "generated": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ]
+      },
+      "tokenizer": {
+        "source": "explicit",
+        "strict": true
+      },
+      "tokens": {
+        "generated": 4,
+        "generated_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "prompt": 20,
+        "prompt_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "total": 24
+      }
+    }
+  ],
+  "claim_boundary": {
+    "broad_performance_claimed": false,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false
+  },
+  "corpus": {
+    "case_count": 5,
+    "description": "Fixed deterministic prompt set for answer-readiness baselines.",
+    "name": "strict-bitnet-answer-corpus-v1",
+    "path": "ci/quality/bitnet-answer-corpus.yaml"
+  },
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": 1,
+    "logits_topk": 5,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 360,
+    "requested_cpu_kernel": "scalar",
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "fallback_loader_used": false,
+    "file": "ggml-model-i2_s.gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "tokenizer": "llama3",
+    "tokenizer_path": "C:\\Code\\Rust\\BitNet-rs-lnl258v-run001\\models\\BitNet-b1.58-2B-4T\\tokenizer.json"
+  },
+  "prompt_template": {
+    "family": "llama3-chat"
+  },
+  "quality_summary": {
+    "failed": 5,
+    "not_run": 0,
+    "passed": 0,
+    "timeout": 0,
+    "total": 5
+  },
+  "schema_version": "1.0.0",
+  "speedup_claim": false,
+  "timestamp": "2026-05-07T20:41:12.736637200+00:00"
+}

--- a/ci/hardware/intel-258v/2026-05-07/cpu-answer-parity.json
+++ b/ci/hardware/intel-258v/2026-05-07/cpu-answer-parity.json
@@ -1,0 +1,498 @@
+{
+  "artifact_kind": "bitnet_cpu_answer_parity",
+  "cases": [
+    {
+      "avx2": {
+        "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_contains_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-avx2-reference",
+        "status": "quality_failed"
+      },
+      "failed_rules": [],
+      "id": "capital_france",
+      "passed": true,
+      "scalar": {
+        "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          279,
+          6864,
+          315,
+          9822,
+          30,
+          22559,
+          449,
+          832,
+          3492,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_contains_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-scalar-reference",
+        "status": "quality_failed"
+      }
+    },
+    {
+      "avx2": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-avx2-reference",
+        "status": "quality_failed"
+      },
+      "failed_rules": [],
+      "id": "math_2_plus_2",
+      "passed": true,
+      "scalar": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          3923,
+          374,
+          220,
+          17,
+          10,
+          17,
+          30,
+          22559,
+          449,
+          1193,
+          279,
+          1396,
+          13,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-scalar-reference",
+        "status": "quality_failed"
+      }
+    },
+    {
+      "avx2": {
+        "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_contains_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-avx2-reference",
+        "status": "quality_failed"
+      },
+      "failed_rules": [],
+      "id": "repeat_colors",
+      "passed": true,
+      "scalar": {
+        "answer": "'E-lived,SIGNALConvert!\"\n\n'E$m-lived",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281,
+          17642,
+          89048,
+          54616,
+          62954
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          39818,
+          7041,
+          25,
+          2579,
+          6437,
+          6307,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_contains_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-scalar-reference",
+        "status": "quality_failed"
+      }
+    },
+    {
+      "avx2": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-avx2-reference",
+        "status": "quality_failed"
+      },
+      "failed_rules": [],
+      "id": "say_ok",
+      "passed": true,
+      "scalar": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          46864,
+          7041,
+          25,
+          10619,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_exact_trimmed"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-scalar-reference",
+        "status": "quality_failed"
+      }
+    },
+    {
+      "avx2": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_starts_with_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-avx2-reference",
+        "status": "quality_failed"
+      },
+      "failed_rules": [],
+      "id": "yes_no_water",
+      "passed": true,
+      "scalar": {
+        "answer": "'E-lived,SIGNALConvert",
+        "generated_token_ids": [
+          89048,
+          62954,
+          87896,
+          12281
+        ],
+        "logits_steps": 1,
+        "prompt_token_ids": [
+          128000,
+          128000,
+          128006,
+          882,
+          128007,
+          271,
+          16533,
+          10035,
+          477,
+          912,
+          25,
+          374,
+          3090,
+          14739,
+          30,
+          128009,
+          128006,
+          78191,
+          128007,
+          271
+        ],
+        "quality_failed_rules": [
+          "gate_starts_with_any"
+        ],
+        "quality_passed": false,
+        "selected_kernel": "i2_s-scalar-reference",
+        "status": "quality_failed"
+      }
+    }
+  ],
+  "claim": "scalar_avx2_full_decode_answer_parity",
+  "inputs": {
+    "avx2_receipt_path": "ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-avx2.json",
+    "scalar_receipt_path": "ci/hardware/intel-258v/2026-05-07/cpu-answer-corpus-scalar.json"
+  },
+  "machine": {
+    "cpu": {
+      "avx2_detected": true,
+      "avx512_detected": false,
+      "cores": 8,
+      "flags": [
+        "avx2",
+        "fma",
+        "sse4.2"
+      ],
+      "fma_detected": true,
+      "l2_cache_kib": 14336,
+      "l3_cache_kib": 12288,
+      "lp_e_core_count": 4,
+      "max_clock_mhz": 2200,
+      "model": "Intel(R) Core(TM) Ultra 7 258V",
+      "p_core_count": 4,
+      "requested_backend": "cpu",
+      "runtime_api": "cpu",
+      "scheduler_hint": "Lunar Lake validation should record P-core / low-power E-core and power context before benchmark claims.",
+      "selected_backend": "intel-258v-cpu-avx2",
+      "sse42_detected": true,
+      "threads": 8
+    },
+    "machine_id": "intel-258v",
+    "memory": {
+      "kind": "shared LPDDR-class system memory",
+      "reported_manufacturer": "Micron Technology",
+      "reported_module_bytes": 4294967296,
+      "reported_modules": 8,
+      "reported_speed_mt_s": 8533,
+      "shared_memory": true,
+      "total_bytes": 33873780736
+    },
+    "platform_artifact": "ci/hardware/intel-258v/2026-05-06/platform-probe.json",
+    "power": {
+      "mode": "Balanced",
+      "power_scheme_guid": "381b4222-f694-41f0-9685-ff5bb260df2e",
+      "sustained_run": false,
+      "thermal_profile": null
+    }
+  },
+  "may_claim": [
+    "Scalar versus AVX2 full-decode answer parity can be audited for the compared receipts.",
+    "First divergence evidence can separate AVX2 kernel issues from shared prompt, tokenizer, logits, sampler, or text decoding issues."
+  ],
+  "must_not_claim": [
+    "General chat quality is proven.",
+    "Sustained CPU throughput is proven.",
+    "Server inference is complete.",
+    "GPU or NPU execution is involved."
+  ],
+  "proof_stage": "full_decode_parity_compared",
+  "schema_version": "1.0.0",
+  "shared_contract": {
+    "failed_rules": [],
+    "same_greedy_settings": true,
+    "same_prompt_template": true,
+    "same_real_gguf": true,
+    "same_tokenizer": true
+  },
+  "speedup_claim": false,
+  "summary": {
+    "failed": 0,
+    "first_divergence": null,
+    "passed": 5,
+    "total": 5
+  },
+  "timestamp": "2026-05-07T20:53:47.385839500+00:00"
+}

--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -1,7 +1,7 @@
 //! Answer corpus runner for CPU-first and Apple M4 local-answer baselines.
 
 use anyhow::{Context, Result};
-use clap::Args;
+use clap::{Args, ValueEnum};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::{
@@ -60,6 +60,32 @@ pub struct AnswerCorpusCommand {
     /// Number of top logits to include when --dump-logit-steps is used.
     #[arg(long, default_value_t = 10, value_name = "K")]
     pub logits_topk: usize,
+
+    /// CPU kernel lane to request for child strict CPU runs.
+    #[arg(long, value_enum, value_name = "KERNEL")]
+    pub cpu_kernel: Option<AnswerCpuKernel>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum AnswerCpuKernel {
+    Scalar,
+    Avx2,
+}
+
+impl AnswerCpuKernel {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Scalar => "scalar",
+            Self::Avx2 => "avx2",
+        }
+    }
+
+    fn child_env(self) -> Vec<(&'static str, &'static str)> {
+        match self {
+            Self::Scalar => vec![("BITNET_CPU_KERNEL", "scalar"), ("BITNET_FORCE_SCALAR", "1")],
+            Self::Avx2 => vec![("BITNET_CPU_KERNEL", "avx2")],
+        }
+    }
 }
 
 impl AnswerCorpusCommand {
@@ -73,6 +99,12 @@ impl AnswerCorpusCommand {
                 "answer-corpus only accepts --device cpu or --device apple-m4-cpu-neon; got {device}"
             );
         }
+        if self.cpu_kernel.is_some() && device != "cpu" {
+            anyhow::bail!("--cpu-kernel is only valid with --device cpu");
+        }
+        if self.cpu_kernel == Some(AnswerCpuKernel::Avx2) && !cpu_avx2_available() {
+            anyhow::bail!("--cpu-kernel avx2 requested but AVX2 is unavailable on this host");
+        }
         let artifact_kind = answer_corpus_artifact_kind(&device);
         let default_timeout_seconds = effective_default_timeout_seconds(
             self.per_prompt_timeout_seconds,
@@ -84,7 +116,10 @@ impl AnswerCorpusCommand {
             .parent()
             .map(Path::to_path_buf)
             .unwrap_or_else(|| PathBuf::from("."))
-            .join("answer-corpus-runs");
+            .join(format!(
+                "{}-runs",
+                self.json_out.file_stem().and_then(|stem| stem.to_str()).unwrap_or("answer-corpus")
+            ));
         fs::create_dir_all(&receipt_dir)?;
 
         let exe = std::env::current_exe().context("failed to resolve current bitnet executable")?;
@@ -148,6 +183,7 @@ impl AnswerCorpusCommand {
                 } else {
                     None
                 },
+                "requested_cpu_kernel": self.cpu_kernel.map(AnswerCpuKernel::as_str),
             },
             "quality_summary": {
                 "total": total,
@@ -232,7 +268,9 @@ impl AnswerCorpusCommand {
                 args.push("--assert-greedy".into());
             }
         }
-        let run = run_child_with_timeout(exe, &args, Duration::from_secs(timeout_seconds))?;
+        let child_env = self.cpu_kernel.map(AnswerCpuKernel::child_env).unwrap_or_default();
+        let run =
+            run_child_with_timeout(exe, &args, &child_env, Duration::from_secs(timeout_seconds))?;
         if run.timed_out {
             return Ok(json!({
                 "id": case.id,
@@ -637,7 +675,12 @@ struct ChildRun {
     stderr: String,
 }
 
-fn run_child_with_timeout(exe: &Path, args: &[OsString], timeout: Duration) -> Result<ChildRun> {
+fn run_child_with_timeout(
+    exe: &Path,
+    args: &[OsString],
+    envs: &[(&'static str, &'static str)],
+    timeout: Duration,
+) -> Result<ChildRun> {
     let child_rust_log =
         std::env::var("BITNET_ANSWER_CORPUS_CHILD_RUST_LOG").unwrap_or_else(|_| "warn".into());
     let stdout_path = child_capture_path("stdout");
@@ -648,6 +691,7 @@ fn run_child_with_timeout(exe: &Path, args: &[OsString], timeout: Duration) -> R
         .with_context(|| format!("failed to create {}", stderr_path.display()))?;
     let mut child = Command::new(exe)
         .args(args)
+        .envs(envs.iter().copied())
         .env("RUST_LOG", child_rust_log)
         .stdout(Stdio::from(stdout_file))
         .stderr(Stdio::from(stderr_file))
@@ -684,6 +728,18 @@ fn run_child_with_timeout(exe: &Path, args: &[OsString], timeout: Duration) -> R
             });
         }
         thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn cpu_avx2_available() -> bool {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        std::is_x86_feature_detected!("avx2")
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
     }
 }
 

--- a/crates/bitnet-cli/src/commands/answer_parity.rs
+++ b/crates/bitnet-cli/src/commands/answer_parity.rs
@@ -27,6 +27,14 @@ pub struct AnswerParityCommand {
         default_value = "target/bitnet/receipts/cpu-answer-parity.json"
     )]
     pub json_out: PathBuf,
+
+    /// Machine identifier for hardware-scoped parity artifacts.
+    #[arg(long, value_name = "ID")]
+    pub machine: Option<String>,
+
+    /// Same-machine platform probe artifact to cross-link for CPU topology and power context.
+    #[arg(long, value_name = "PATH")]
+    pub platform_artifact: Option<PathBuf>,
 }
 
 impl AnswerParityCommand {
@@ -34,7 +42,19 @@ impl AnswerParityCommand {
     pub async fn execute(&self) -> Result<()> {
         let scalar = read_json(&self.scalar)?;
         let avx2 = read_json(&self.avx2)?;
-        let receipt = build_answer_parity_receipt(&self.scalar, &scalar, &self.avx2, &avx2);
+        let platform = match &self.platform_artifact {
+            Some(path) => Some(read_json(path)?),
+            None => None,
+        };
+        let receipt = build_answer_parity_receipt(
+            &self.scalar,
+            &scalar,
+            &self.avx2,
+            &avx2,
+            self.machine.as_deref(),
+            self.platform_artifact.as_deref(),
+            platform.as_ref(),
+        );
         let failed = receipt["summary"]["failed"].as_u64().unwrap_or(1);
 
         if let Some(parent) = self.json_out.parent()
@@ -67,6 +87,9 @@ fn build_answer_parity_receipt(
     scalar: &Value,
     avx2_path: &Path,
     avx2: &Value,
+    machine: Option<&str>,
+    platform_artifact: Option<&Path>,
+    platform: Option<&Value>,
 ) -> Value {
     let mut shared_failures = Vec::new();
     compare_top_level_contract(scalar, avx2, &mut shared_failures);
@@ -101,6 +124,13 @@ fn build_answer_parity_receipt(
         "inputs": {
             "scalar_receipt_path": scalar_path.display().to_string(),
             "avx2_receipt_path": avx2_path.display().to_string(),
+        },
+        "machine": {
+            "machine_id": machine,
+            "platform_artifact": platform_artifact.map(|path| path.display().to_string()),
+            "cpu": platform.and_then(|value| value.get("cpu")).cloned().unwrap_or(Value::Null),
+            "memory": platform.and_then(|value| value.get("memory")).cloned().unwrap_or(Value::Null),
+            "power": platform.and_then(|value| value.get("power")).cloned().unwrap_or(Value::Null),
         },
         "shared_contract": {
             "same_real_gguf": shared_failures.iter().all(|failure| *failure != "model_contract"),
@@ -300,12 +330,6 @@ fn check_case_contract(
     failures: &mut Vec<&'static str>,
     first_divergence: &mut Option<Value>,
 ) {
-    let status_rule = if lane == "scalar" { "scalar_case_passed" } else { "avx2_case_passed" };
-    if case["status"] != "passed" || case["quality"]["passed"] != true {
-        failures.push(status_rule);
-        set_first(first_divergence, id, status_rule, None, case["status"].clone(), json!("passed"));
-    }
-
     let backend_rule =
         if lane == "scalar" { "scalar_strict_cpu_backend" } else { "avx2_strict_cpu_backend" };
     if case["backend"]["requested_backend"] != "cpu"
@@ -428,6 +452,8 @@ fn compare_logits_dump(
 fn case_summary(case: &Value) -> Value {
     json!({
         "status": case["status"],
+        "quality_passed": case["quality"]["passed"],
+        "quality_failed_rules": case["quality"]["failed_rules"],
         "selected_kernel": case["kernel"]["selected_kernel"],
         "prompt_token_ids": case["token_ids"]["prompt"],
         "generated_token_ids": case["token_ids"]["generated"],
@@ -546,11 +572,46 @@ mod tests {
             &scalar,
             Path::new("avx2.json"),
             &avx2,
+            None,
+            None,
+            None,
         );
 
         assert_eq!(report["artifact_kind"], "bitnet_cpu_answer_parity");
         assert_eq!(report["summary"]["failed"], 0);
         assert_eq!(report["cases"][0]["passed"], true);
+        assert!(report["summary"]["first_divergence"].is_null());
+    }
+
+    #[test]
+    fn parity_receipt_passes_matching_shared_quality_failures() {
+        let mut scalar = receipt("i2_s-scalar-reference", &[999], "bad", logits());
+        let mut avx2 = receipt("i2_s-avx2-reference", &[999], "bad", logits());
+        scalar["cases"][0]["status"] = json!("quality_failed");
+        scalar["cases"][0]["quality"] = json!({
+            "passed": false,
+            "failed_rules": ["exact_trimmed"]
+        });
+        avx2["cases"][0]["status"] = json!("quality_failed");
+        avx2["cases"][0]["quality"] = json!({
+            "passed": false,
+            "failed_rules": ["exact_trimmed"]
+        });
+
+        let report = build_answer_parity_receipt(
+            Path::new("scalar.json"),
+            &scalar,
+            Path::new("avx2.json"),
+            &avx2,
+            Some("intel-258v"),
+            Some(Path::new("platform-probe.json")),
+            None,
+        );
+
+        assert_eq!(report["summary"]["failed"], 0);
+        assert_eq!(report["machine"]["machine_id"], "intel-258v");
+        assert_eq!(report["cases"][0]["passed"], true);
+        assert_eq!(report["cases"][0]["scalar"]["quality_passed"], false);
         assert!(report["summary"]["first_divergence"].is_null());
     }
 
@@ -564,6 +625,9 @@ mod tests {
             &scalar,
             Path::new("avx2.json"),
             &avx2,
+            None,
+            None,
+            None,
         );
 
         assert_eq!(report["summary"]["failed"], 1);
@@ -582,6 +646,9 @@ mod tests {
             &scalar,
             Path::new("avx2.json"),
             &avx2,
+            None,
+            None,
+            None,
         );
 
         let failed = report["cases"][0]["failed_rules"].as_array().unwrap();

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -690,8 +690,29 @@ enum ConfigAction {
     Path,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+#[cfg(windows)]
+fn main() -> Result<()> {
+    // The generated clap command tree is deep enough to overflow the default
+    // Windows main-thread stack before subcommands such as `answer-parity`
+    // can print help. Run the CLI body on an explicitly larger stack.
+    std::thread::Builder::new()
+        .name("bitnet-cli-main".to_string())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(run_main)?
+        .join()
+        .map_err(|_| anyhow::anyhow!("bitnet CLI worker thread panicked"))?
+}
+
+#[cfg(not(windows))]
+fn main() -> Result<()> {
+    run_main()
+}
+
+fn run_main() -> Result<()> {
+    tokio::runtime::Builder::new_multi_thread().enable_all().build()?.block_on(async_main())
+}
+
+async fn async_main() -> Result<()> {
     // RUNTIME GUARD: Forbid test shims in production
     if std::env::var_os("BITNET_GPU_FAKE").is_some() && std::env::var_os("CI").is_none() {
         eprintln!("Error: BITNET_GPU_FAKE is test-only and not allowed outside CI.");
@@ -1987,6 +2008,16 @@ fn detected_cpu_feature_labels() -> Vec<String> {
 }
 
 fn cpu_kernel_implementation(quantization: bitnet_common::QuantizationType) -> &'static str {
+    if std::env::var("BITNET_FORCE_SCALAR").as_deref() == Ok("1")
+        || std::env::var("BITNET_CPU_KERNEL").as_deref() == Ok("scalar")
+    {
+        return "scalar";
+    }
+    if std::env::var("BITNET_CPU_KERNEL").as_deref() == Ok("avx2")
+        && bitnet_common::runtime_diag::CpuFeatures::detect().avx2
+    {
+        return "avx2";
+    }
     if matches!(quantization, bitnet_common::QuantizationType::I2S) && cfg!(target_arch = "aarch64")
     {
         // The current Apple CPU proof path has NEON available, but the packed


### PR DESCRIPTION
## Summary
- add `answer-corpus --cpu-kernel scalar|avx2` so the 258V can emit explicit scalar and AVX2 strict CPU receipts
- keep `answer-parity` focused on scalar-vs-AVX2 divergence: shared answer-quality failures remain visible but do not count as parity failures
- attach machine/platform context to parity receipts and commit the 2026-05-07 258V scalar, AVX2, and parity artifacts

## Result
- scalar and AVX2 used the same GGUF/tokenizer/corpus/greedy settings
- scalar selected `i2_s-scalar-reference`; AVX2 selected `i2_s-avx2-reference`
- parity summary: `failed=0`, `first_divergence=null`, `passed=5/5`
- both lanes still fail answer quality with the same bad answers, so this does not prove answer quality

## Claim boundary
This proves scalar-vs-AVX2 agreement for the fixed 258V answer-corpus receipts. It does not prove general answer quality, sustained throughput, Arc 140V execution, Intel NPU execution, QK256 acceleration, or server inference.

## Verification
- rustfmt --check --config skip_children=true --edition 2024 crates/bitnet-cli/src/commands/answer_corpus.rs crates/bitnet-cli/src/commands/answer_parity.rs crates/bitnet-cli/src/main.rs
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_parity::tests -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_corpus::tests -- --nocapture
- cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings
- Parsed all ci/hardware/intel-258v/2026-05-07 JSON artifacts
- git diff --check

Note: the broader rustfmt command that also includes untouched `crates/bitnet-cli/src/commands/mod.rs` and `crates/bitnet-cli/tests/cli_arg_tests.rs` is blocked locally by pre-existing newline-style drift in those untouched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--cpu-kernel` CLI option to select CPU kernel implementation (scalar or AVX2) for answer corpus testing
  * Added environment variable overrides (`BITNET_CPU_KERNEL`, `BITNET_FORCE_SCALAR`) for CPU kernel selection

* **Tests**
  * Added Intel 258V CPU reference benchmark runs for AVX2 and scalar kernel implementations
  * Added CPU answer parity validation tests comparing kernel outputs

* **Chores**
  * Updated campaign tracking documentation for Intel 258V platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->