### PR TITLE
docs(model): close blocked artifact search

### DIFF
--- a/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
+++ b/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
@@ -35,7 +35,7 @@ GGUF that only proves structural validity or backend execution.
 | Work item | Status | Notes |
 |---|---|---|
 | MODEL-ARTIFACT-001 | merged | Shared answer-artifact gate merged in #3922; the current Microsoft BitNet I2_S GGUF is rejected for coherent local-answer claims. |
-| MODEL-ARTIFACT-002 | blocked | Shared search records no `answer_ready` BitNet artifact. Backend local-answer lanes remain blocked or diagnostic-only until a future artifact passes the reference prompt suite. |
+| MODEL-ARTIFACT-002 | blocked | Shared search merged in #3928 and records no `answer_ready` BitNet artifact. Backend local-answer lanes remain blocked or diagnostic-only until a future artifact passes the reference prompt suite. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/model-artifacts/active.toml
+++ b/docs/tracking/campaigns/model-artifacts/active.toml
@@ -68,7 +68,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "MODEL-ARTIFACT-002"
-status = "pr_open"
+status = "blocked"
 pr = 3928
 branch = "codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet"
 stackable = false

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-07T210305Z-MODEL-ARTIFACT-002-blocked-closeout.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-07T210305Z-MODEL-ARTIFACT-002-blocked-closeout.toml
@@ -1,0 +1,11 @@
+timestamp = "2026-05-07T21:03:05Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-002"
+event = "blocked"
+actor = "codex"
+
+notes = [
+  "PR #3928 merged the shared candidate manifest and reference-good search report.",
+  "MODEL-ARTIFACT-002 remains blocked because no recorded BitNet artifact reached answer_ready.",
+  "Next work should acquire or regenerate a new candidate artifact; backend local-answer lanes remain diagnostic-only until then.",
+]

--- a/docs/tracking/campaigns/model-artifacts/generated/status.md
+++ b/docs/tracking/campaigns/model-artifacts/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | MODEL-ARTIFACT-001 | merged | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
-| MODEL-ARTIFACT-002 | pr_open | #3928 | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
+| MODEL-ARTIFACT-002 | blocked | #3928 | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| model-artifacts | MODEL-ARTIFACT-002 | #3928 | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -63,7 +63,7 @@
 | intel-npu | NPU-005 | NPU-004 | merged |
 | intel-npu | NPU-007 | NPU-006 | merged |
 | intel-npu | NPU-006 | NPU-005 | merged |
-| model-artifacts | MODEL-ARTIFACT-002 | MODEL-ARTIFACT-001 | pr_open |
+| model-artifacts | MODEL-ARTIFACT-002 | MODEL-ARTIFACT-001 | blocked |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -15,7 +15,7 @@
 | intel-258v-platform | CPU258V-002 | TBD | ready | CPU258V-003 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
-| model-artifacts | MODEL-ARTIFACT-002 | #3928 | pr_open | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
+| model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-002B | TBD | ready | SLM-CPU-003 | Do not edit BitNet QK256/I2_S kernels. |


### PR DESCRIPTION
## Summary
- mark `MODEL-ARTIFACT-002` blocked after #3928 merged the shared search evidence
- add the post-merge blocked closeout event
- regenerate campaign dashboards so model-artifacts no longer appears as an active PR

## Validation
- parsed model-artifacts event TOML with Python `tomllib`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check model-artifacts`
- `cargo run --release --locked -p xtask --no-default-features -- campaign doctor` (passes with pre-existing `CPU-PHASE-TIMING-001` missing `head_sha` warning)
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `cargo fmt --all -- --check` remains blocked locally by Windows `os error 206`; this PR only changes docs/tracker files.
- This PR does not claim an answer-ready artifact exists.