### PR TITLE
docs(model): close stock runner compatibility evidence

### DIFF
--- a/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
+++ b/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
@@ -36,7 +36,7 @@ GGUF that only proves structural validity or backend execution.
 |---|---|---|
 | MODEL-ARTIFACT-001 | merged | Shared answer-artifact gate merged in #3922; the current Microsoft BitNet I2_S GGUF is rejected for coherent local-answer claims. |
 | MODEL-ARTIFACT-002 | blocked | Shared search merged in #3928 and records no `answer_ready` BitNet artifact. Backend local-answer lanes remain blocked or diagnostic-only until a future artifact passes the reference prompt suite. |
-| MODEL-ARTIFACT-003 | PR open | PR #3932 records latest stock llama.cpp reference-runner compatibility for official-derived candidates. This is diagnostic-only and does not unblock backend answer claims. |
+| MODEL-ARTIFACT-003 | merged | PR #3932 records latest stock llama.cpp reference-runner compatibility for official-derived candidates. This is diagnostic-only and does not unblock backend answer claims. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/model-artifacts/active.toml
+++ b/docs/tracking/campaigns/model-artifacts/active.toml
@@ -112,7 +112,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "MODEL-ARTIFACT-003"
-status = "pr_open"
+status = "merged"
 pr = 3932
 branch = "codex/model-artifacts/MODEL-ARTIFACT-003-reference-runner-compat"
 stackable = false

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-07T221430Z-MODEL-ARTIFACT-003-merged.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-07T221430Z-MODEL-ARTIFACT-003-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-07T22:14:30Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-003"
+event = "merged"
+actor = "codex"
+pr = 3932
+merge_sha = "0fe12d4958ebe030c8b9aa530213cacf2ccd24ea"
+previous_status = "pr_open"
+new_status = "merged"
+
+notes = [
+  "PR #3932 merged the latest stock llama.cpp reference-runner compatibility evidence.",
+  "The tdh111 IQ2_BN_R4 candidate remains diagnostic-only because stock llama.cpp rejects it before prompt execution.",
+  "The shared artifact gate still has no answer_ready BitNet artifact; backend answer lanes remain blocked or diagnostic-only.",
+]

--- a/docs/tracking/campaigns/model-artifacts/generated/status.md
+++ b/docs/tracking/campaigns/model-artifacts/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | MODEL-ARTIFACT-001 | merged | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
 | MODEL-ARTIFACT-002 | blocked | #3928 | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
-| MODEL-ARTIFACT-003 | pr_open | #3932 | `codex/model-artifacts/MODEL-ARTIFACT-003-reference-runner-compat` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record reference-runner compatibility evidence for official-derived BitNet GGUF candidates, including the latest stock llama.cpp runner result, without claiming answer readiness or changing runtime behavior. |
+| MODEL-ARTIFACT-003 | merged | #3932 | `codex/model-artifacts/MODEL-ARTIFACT-003-reference-runner-compat` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record reference-runner compatibility evidence for official-derived BitNet GGUF candidates, including the latest stock llama.cpp runner result, without claiming answer readiness or changing runtime behavior. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| model-artifacts | MODEL-ARTIFACT-003 | #3932 | `codex/model-artifacts/MODEL-ARTIFACT-003-reference-runner-compat` | Record reference-runner compatibility evidence for official-derived BitNet GGUF candidates, including the latest stock llama.cpp runner result, without claiming answer readiness or changing runtime behavior. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -64,7 +64,7 @@
 | intel-npu | NPU-007 | NPU-006 | merged |
 | intel-npu | NPU-006 | NPU-005 | merged |
 | model-artifacts | MODEL-ARTIFACT-002 | MODEL-ARTIFACT-001 | blocked |
-| model-artifacts | MODEL-ARTIFACT-003 | MODEL-ARTIFACT-002 | pr_open |
+| model-artifacts | MODEL-ARTIFACT-003 | MODEL-ARTIFACT-002 | merged |
 | nvidia-5070ti | RTX5070TI-004 | RTX5070TI-003 | merged |
 | nvidia-5070ti | RTX5070TI-005 | RTX5070TI-004 | merged |
 | nvidia-5070ti | RTX5070TI-006 | RTX5070TI-005 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -15,7 +15,7 @@
 | intel-258v-platform | CPU258V-002 | TBD | ready | CPU258V-003 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
-| model-artifacts | MODEL-ARTIFACT-003 | #3932 | pr_open | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
+| model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-001 | TBD | proposed | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-003 | TBD | ready | SLM-CPU-004 | Do not edit BitNet QK256/I2_S kernels. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -15,7 +15,7 @@
 | intel-258v-platform | Intel 258V platform validation | CPU258V-002 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-006 | Device-node detection is not inference. |
-| model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-003 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
+| model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-001 | CUDA visibility is not kernel execution. |
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-003 | Do not edit BitNet QK256/I2_S kernels. |


### PR DESCRIPTION
## Work item
MODEL-ARTIFACT-003 closeout

## Summary
- mark MODEL-ARTIFACT-003 merged after #3932
- add the merge event with merge SHA
- regenerate campaign dashboards so model-artifacts no longer shows #3932 as active

## Boundaries
- tracker/docs only
- no runtime, tokenizer, model loader, CUDA, QK256, server, accelerator, or speed-claim changes
- no answer_ready artifact claim

## Validation
- parsed ci/model-artifacts/*.toml and model-artifacts event TOML with Python tomllib
- cargo run --release --locked -p xtask --no-default-features -- campaign check model-artifacts
- cargo run --release --locked -p xtask --no-default-features -- campaign doctor
- cargo run --release --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check
