### PR TITLE
feat(lunar-lake): add Arc 140V OpenVINO GPU smoke

### DIFF
--- a/crates/bitnet-cli/src/intel_arc.rs
+++ b/crates/bitnet-cli/src/intel_arc.rs
@@ -1,0 +1,241 @@
+use anyhow::Result;
+use std::path::PathBuf;
+
+fn build_openvino_gpu_smoke_receipt(
+    smoke: bitnet_device_probe::runtimes::OpenVinoGpuTinyGraphSmoke,
+    strict: bool,
+    timestamp_utc: String,
+    artifact_path: Option<String>,
+) -> serde_json::Value {
+    let backend_runtime = serde_json::json!({
+        "name": "openvino",
+        "version": smoke.openvino_version.clone(),
+        "device": smoke.runtime_device.clone(),
+        "device_name": smoke.openvino_gpu_full_name.clone(),
+    });
+    let shape_contract = serde_json::json!({
+        "shape_mode": smoke.shape_mode.clone(),
+        "input_shape": smoke.input_shape.clone(),
+        "output_shape": smoke.output_shape.clone(),
+    });
+    let fallback_policy = serde_json::json!({
+        "fallback_used": smoke.fallback_used,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "cpu_fallback_allowed": smoke.cpu_fallback_allowed,
+    });
+    let error = if strict && !smoke.passed {
+        Some(smoke.error.clone().unwrap_or_else(|| {
+            "strict Arc 140V OpenVINO GPU smoke requires tiny graph pass".to_owned()
+        }))
+    } else {
+        smoke.error.clone()
+    };
+    let claim = if smoke.passed {
+        "openvino_gpu_arc140v_tiny_graph_smoke_passed"
+    } else if smoke.graph_execution {
+        "openvino_gpu_tiny_graph_executed_without_arc140v_identity"
+    } else {
+        "openvino_gpu_arc140v_smoke_not_proven"
+    };
+
+    serde_json::json!({
+        "schema": 1,
+        "artifact_kind": "intel_arc_140v_openvino_gpu_smoke",
+        "machine_id": "intel-258v",
+        "hardware_lane": "intel-arc-140v-openvino-gpu",
+        "proof_stage": smoke.proof_stage.clone(),
+        "timestamp_utc": timestamp_utc,
+        "requested_backend": smoke.requested_backend.clone(),
+        "selected_backend": smoke.selected_backend.clone(),
+        "runtime_api": smoke.runtime_api.clone(),
+        "runtime_device": smoke.runtime_device.clone(),
+        "backend_runtime": backend_runtime,
+        "shape_contract": shape_contract,
+        "shape_mode": smoke.shape_mode.clone(),
+        "strict_mode": strict,
+        "fallback_used": smoke.fallback_used,
+        "fallback_backend": null,
+        "fallback_reason": null,
+        "fallback_policy": fallback_policy,
+        "cpu_fallback_allowed": smoke.cpu_fallback_allowed,
+        "kernel_execution": false,
+        "graph_execution": smoke.graph_execution,
+        "bitnet_inference": smoke.bitnet_inference,
+        "qk256_decode": smoke.qk256_decode,
+        "arc140v_identity_matched": smoke.arc140v_identity_matched,
+        "graph": {
+            "name": smoke.graph_name.clone(),
+            "precision": smoke.precision.clone(),
+            "cache_dir": null,
+            "input_shape": smoke.input_shape.clone(),
+            "output_shape": smoke.output_shape.clone(),
+            "max_abs_error": smoke.max_abs_error,
+            "mean_abs_error": smoke.mean_abs_error,
+            "tolerance": smoke.tolerance,
+            "result": if smoke.passed { "pass" } else { "fail" },
+        },
+        "timing": {
+            "first_ever_compile_and_infer_ms": null,
+            "cached_compile_ms": smoke.compile_ms,
+            "steady_state_infer_ms": null,
+            "compile_ms": smoke.compile_ms,
+            "first_infer_ms": smoke.first_infer_ms,
+        },
+        "kernels_or_graphs": [
+            "tiny_matmul_openvino_gpu"
+        ],
+        "openvino_gpu_smoke": smoke,
+        "claim": claim,
+        "must_not_claim": [
+            "Native OpenCL kernels work on Arc 140V",
+            "BitNet inference works on Arc 140V",
+            "Arc 140V accelerates BitNet",
+            "Packed BitNet QK256 decode works on Arc 140V",
+            "CPU fallback satisfies Arc 140V proof"
+        ],
+        "artifact_path": artifact_path,
+        "error": error,
+    })
+}
+
+pub(crate) async fn handle_openvino_gpu_smoke_command(
+    strict: bool,
+    json_out: Option<PathBuf>,
+) -> Result<()> {
+    let smoke = bitnet_device_probe::runtimes::run_openvino_gpu_tiny_graph_smoke();
+    let timestamp_utc = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let artifact_path = json_out.as_ref().map(|path| path.display().to_string());
+    let receipt = build_openvino_gpu_smoke_receipt(smoke, strict, timestamp_utc, artifact_path);
+
+    crate::write_json_output(json_out.as_ref(), &receipt)?;
+
+    if strict && let Some(error) = receipt.get("error").and_then(serde_json::Value::as_str) {
+        anyhow::bail!("{error}");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_openvino_gpu_smoke_receipt;
+
+    #[test]
+    fn intel_arc_openvino_gpu_smoke_receipt_records_graph_execution_only() {
+        let smoke = bitnet_device_probe::runtimes::OpenVinoGpuTinyGraphSmoke {
+            passed: true,
+            proof_stage: "kernel_smoke_tested".to_string(),
+            requested_backend: "intel-arc-140v".to_string(),
+            selected_backend: Some("intel-arc-140v-openvino-gpu".to_string()),
+            runtime_api: Some("openvino".to_string()),
+            runtime_device: Some("GPU.0".to_string()),
+            openvino_gpu_full_name: Some("Intel(R) Arc(TM) 140V Graphics".to_string()),
+            arc140v_identity_matched: true,
+            openvino_version: Some("2026.1".to_string()),
+            openvino_available_devices: vec!["CPU".to_string(), "GPU.0".to_string()],
+            graph_name: "tiny_matmul_add_f16_1x16".to_string(),
+            shape_mode: "static".to_string(),
+            input_shape: vec![1, 16],
+            output_shape: Some(vec![1, 16]),
+            precision: "F16".to_string(),
+            tolerance: 0.001,
+            max_abs_error: Some(0.0),
+            mean_abs_error: Some(0.0),
+            compile_ms: Some(7.5),
+            first_infer_ms: Some(0.75),
+            fallback_used: false,
+            cpu_fallback_allowed: false,
+            graph_execution: true,
+            bitnet_inference: false,
+            qk256_decode: false,
+            error: None,
+        };
+
+        let receipt = build_openvino_gpu_smoke_receipt(
+            smoke,
+            true,
+            "2026-05-07T00:00:00Z".to_string(),
+            Some("ci/hardware/intel-258v/2026-05-07/arc-140v-openvino-gpu-smoke.json".to_string()),
+        );
+
+        assert_eq!(receipt["artifact_kind"], "intel_arc_140v_openvino_gpu_smoke");
+        assert_eq!(receipt["proof_stage"], "kernel_smoke_tested");
+        assert_eq!(receipt["requested_backend"], "intel-arc-140v");
+        assert_eq!(receipt["selected_backend"], "intel-arc-140v-openvino-gpu");
+        assert_eq!(receipt["runtime_api"], "openvino");
+        assert_eq!(receipt["runtime_device"], "GPU.0");
+        assert_eq!(receipt["backend_runtime"]["name"], "openvino");
+        assert_eq!(receipt["backend_runtime"]["version"], "2026.1");
+        assert_eq!(receipt["backend_runtime"]["device"], "GPU.0");
+        assert_eq!(receipt["backend_runtime"]["device_name"], "Intel(R) Arc(TM) 140V Graphics");
+        assert_eq!(receipt["shape_mode"], "static");
+        assert_eq!(receipt["shape_contract"]["input_shape"], serde_json::json!([1, 16]));
+        assert_eq!(receipt["shape_contract"]["output_shape"], serde_json::json!([1, 16]));
+        assert_eq!(receipt["fallback_used"], false);
+        assert_eq!(receipt["fallback_policy"]["cpu_fallback_allowed"], false);
+        assert_eq!(receipt["graph_execution"], true);
+        assert_eq!(receipt["kernel_execution"], false);
+        assert_eq!(receipt["bitnet_inference"], false);
+        assert_eq!(receipt["qk256_decode"], false);
+        assert_eq!(receipt["arc140v_identity_matched"], true);
+        assert_eq!(receipt["graph"]["name"], "tiny_matmul_add_f16_1x16");
+        assert_eq!(receipt["graph"]["result"], "pass");
+        assert_eq!(receipt["timing"]["cached_compile_ms"], 7.5);
+        assert_eq!(receipt["timing"]["first_infer_ms"], 0.75);
+        assert_eq!(receipt["kernels_or_graphs"], serde_json::json!(["tiny_matmul_openvino_gpu"]));
+        assert_eq!(receipt["claim"], "openvino_gpu_arc140v_tiny_graph_smoke_passed");
+        assert!(receipt["error"].is_null());
+    }
+
+    #[test]
+    fn strict_intel_arc_openvino_gpu_smoke_records_error_without_fallback() {
+        let smoke = bitnet_device_probe::runtimes::OpenVinoGpuTinyGraphSmoke {
+            passed: false,
+            proof_stage: "runtime_detected".to_string(),
+            requested_backend: "intel-arc-140v".to_string(),
+            selected_backend: None,
+            runtime_api: Some("openvino".to_string()),
+            runtime_device: Some("GPU.0".to_string()),
+            openvino_gpu_full_name: Some("Intel(R) UHD Graphics".to_string()),
+            arc140v_identity_matched: false,
+            openvino_version: Some("2026.1".to_string()),
+            openvino_available_devices: vec!["CPU".to_string(), "GPU.0".to_string()],
+            graph_name: "tiny_matmul_add_f16_1x16".to_string(),
+            shape_mode: "static".to_string(),
+            input_shape: vec![1, 16],
+            output_shape: Some(vec![1, 16]),
+            precision: "F16".to_string(),
+            tolerance: 0.001,
+            max_abs_error: Some(0.0),
+            mean_abs_error: Some(0.0),
+            compile_ms: Some(7.5),
+            first_infer_ms: Some(0.75),
+            fallback_used: false,
+            cpu_fallback_allowed: false,
+            graph_execution: true,
+            bitnet_inference: false,
+            qk256_decode: false,
+            error: Some("OpenVINO GPU full name did not identify Arc 140V".to_string()),
+        };
+
+        let receipt =
+            build_openvino_gpu_smoke_receipt(smoke, true, "2026-05-07T00:00:00Z".to_string(), None);
+
+        assert_eq!(receipt["artifact_kind"], "intel_arc_140v_openvino_gpu_smoke");
+        assert_eq!(receipt["proof_stage"], "runtime_detected");
+        assert!(receipt["selected_backend"].is_null());
+        assert_eq!(receipt["runtime_api"], "openvino");
+        assert_eq!(receipt["runtime_device"], "GPU.0");
+        assert_eq!(receipt["fallback_used"], false);
+        assert_eq!(receipt["fallback_policy"]["fallback_used"], false);
+        assert_eq!(receipt["fallback_policy"]["cpu_fallback_allowed"], false);
+        assert_eq!(receipt["graph_execution"], true);
+        assert_eq!(receipt["kernel_execution"], false);
+        assert_eq!(receipt["bitnet_inference"], false);
+        assert_eq!(receipt["qk256_decode"], false);
+        assert_eq!(receipt["arc140v_identity_matched"], false);
+        assert_eq!(receipt["claim"], "openvino_gpu_tiny_graph_executed_without_arc140v_identity");
+        assert_eq!(receipt["error"], "OpenVINO GPU full name did not identify Arc 140V");
+    }
+}

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -80,6 +80,7 @@ fn record_allocation_audit_dealloc(size: usize) {
 mod commands;
 mod config;
 mod exit;
+mod intel_arc;
 mod intel_npu;
 #[cfg(feature = "full-cli")]
 mod ln_rules;
@@ -577,6 +578,18 @@ enum Commands {
         json_out: Option<std::path::PathBuf>,
     },
 
+    /// Run a tiny static OpenVINO GPU.0 graph smoke for Arc 140V
+    #[command(name = "intel-arc-140v-openvino-gpu-smoke")]
+    IntelArc140vOpenvinoGpuSmoke {
+        /// Require Arc 140V identity and tiny graph execution to pass
+        #[arg(long, default_value_t = false)]
+        strict: bool,
+
+        /// Output JSON smoke receipt to file
+        #[arg(long)]
+        json_out: Option<std::path::PathBuf>,
+    },
+
     /// Run validation-only preflight checks
     Validate {
         #[command(subcommand)]
@@ -919,6 +932,9 @@ async fn async_main() -> Result<()> {
         }
         Some(Commands::IntelNpuBitnetSubgraph { strict, json_out }) => {
             intel_npu::handle_bitnet_subgraph_command(strict, json_out).await
+        }
+        Some(Commands::IntelArc140vOpenvinoGpuSmoke { strict, json_out }) => {
+            intel_arc::handle_openvino_gpu_smoke_command(strict, json_out).await
         }
         Some(Commands::Validate { action }) => handle_validate_command(action).await,
         Some(Commands::CudaSmoke { device_index, json_out }) => {

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__cli_help.snap
@@ -57,30 +57,32 @@ PERFORMANCE:
 Usage: bitnet [OPTIONS] [COMMAND]
 
 Commands:
-  run                 Run simple text generation
-  ask                 Ask one question using the answer-readiness generation path
-  tokenize            Tokenize text and output token IDs as JSON
-  score               Calculate perplexity score for a model
-  inference           Run inference on a model
-  chat                Interactive chat mode (streaming)
-  answer-corpus       Run the fixed CPU answer-readiness corpus through the `run` surface
-  answer-parity       Compare scalar and AVX2 strict CPU answer-corpus receipts
-  convert             Convert between model formats
-  benchmark           Benchmark model performance
-  serve               Start inference server
-  config              Manage configuration
-  info                Show system information
-  device-smoke        Probe selected device identity without launching kernels
-  lunar-lake-probe    Probe Lunar Lake 258V platform visibility without launching kernels
-  intel-npu-probe     Probe Intel NPU OpenVINO runtime visibility without compiling graphs
-  intel-npu-smoke     Run a tiny static OpenVINO NPU graph smoke without BitNet inference
-  validate            Run validation-only preflight checks
-  cuda-smoke          Compile and launch a tiny CUDA vector-add kernel
-  inspect             Inspect model metadata and diagnostics
-  compat-check        Check GGUF file compatibility using header validation
-  list-architectures  List all supported model architectures
-  list-templates      List all available prompt templates
-  help                Print this message or the help of the given subcommand(s)
+  run                                Run simple text generation
+  ask                                Ask one question using the answer-readiness generation path
+  tokenize                           Tokenize text and output token IDs as JSON
+  score                              Calculate perplexity score for a model
+  inference                          Run inference on a model
+  chat                               Interactive chat mode (streaming)
+  answer-corpus                      Run the fixed CPU answer-readiness corpus through the `run` surface
+  answer-parity                      Compare scalar and AVX2 strict CPU answer-corpus receipts
+  convert                            Convert between model formats
+  benchmark                          Benchmark model performance
+  serve                              Start inference server
+  config                             Manage configuration
+  info                               Show system information
+  device-smoke                       Probe selected device identity without launching kernels
+  lunar-lake-probe                   Probe Lunar Lake 258V platform visibility without launching kernels
+  intel-npu-probe                    Probe Intel NPU OpenVINO runtime visibility without compiling graphs
+  intel-npu-smoke                    Run a tiny static OpenVINO NPU graph smoke without BitNet inference
+  intel-npu-bitnet-subgraph          Run selected static BitNet subgraph parity on OpenVINO NPU
+  intel-arc-140v-openvino-gpu-smoke  Run a tiny static OpenVINO GPU.0 graph smoke for Arc 140V
+  validate                           Run validation-only preflight checks
+  cuda-smoke                         Compile and launch a tiny CUDA vector-add kernel
+  inspect                            Inspect model metadata and diagnostics
+  compat-check                       Check GGUF file compatibility using header validation
+  list-architectures                 List all supported model architectures
+  list-templates                     List all available prompt templates
+  help                               Print this message or the help of the given subcommand(s)
 
 Options:
   -c, --config <PATH>

--- a/crates/bitnet-device-probe/src/runtimes/mod.rs
+++ b/crates/bitnet-device-probe/src/runtimes/mod.rs
@@ -12,8 +12,9 @@ pub mod openvino;
 pub use level_zero::LevelZeroProbe;
 pub use opencl::{OpenClRuntimeDevice, OpenClRuntimeProbe};
 pub use openvino::{
-    OpenVinoDeviceProbe, OpenVinoNpuBitnetSubgraphParity, OpenVinoNpuTinyGraphSmoke, OpenVinoProbe,
-    OpenVinoPropertyProbe, run_openvino_npu_bitnet_subgraph_parity,
+    OpenVinoDeviceProbe, OpenVinoGpuTinyGraphSmoke, OpenVinoNpuBitnetSubgraphParity,
+    OpenVinoNpuTinyGraphSmoke, OpenVinoProbe, OpenVinoPropertyProbe,
+    run_openvino_gpu_tiny_graph_smoke, run_openvino_npu_bitnet_subgraph_parity,
     run_openvino_npu_tiny_graph_smoke,
 };
 

--- a/crates/bitnet-device-probe/src/runtimes/openvino.rs
+++ b/crates/bitnet-device-probe/src/runtimes/openvino.rs
@@ -94,6 +94,64 @@ pub struct OpenVinoNpuTinyGraphSmoke {
     pub error: Option<String>,
 }
 
+/// Tiny static OpenVINO GPU graph smoke result for the Arc 140V reference lane.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct OpenVinoGpuTinyGraphSmoke {
+    /// Whether the tiny graph executed on an Arc 140V GPU device and matched CPU expected output.
+    pub passed: bool,
+    /// Proof stage reached by this smoke result.
+    pub proof_stage: String,
+    /// Requested backend identity for the Arc 140V lane.
+    pub requested_backend: String,
+    /// Selected backend when OpenVINO reports or uses an Arc 140V GPU device.
+    pub selected_backend: Option<String>,
+    /// Runtime API used by the smoke.
+    pub runtime_api: Option<String>,
+    /// Concrete OpenVINO runtime device token, normally `GPU.0`.
+    pub runtime_device: Option<String>,
+    /// OpenVINO `FULL_DEVICE_NAME` for the selected GPU token when available.
+    pub openvino_gpu_full_name: Option<String>,
+    /// Whether the selected GPU full name identifies Arc 140V.
+    pub arc140v_identity_matched: bool,
+    /// OpenVINO Python package version when available.
+    pub openvino_version: Option<String>,
+    /// OpenVINO available device tokens observed by the smoke script.
+    pub openvino_available_devices: Vec<String>,
+    /// Tiny static graph identifier.
+    pub graph_name: String,
+    /// Static shape mode expected by the OpenVINO GPU reference lane.
+    pub shape_mode: String,
+    /// Input shape used by the tiny graph.
+    pub input_shape: Vec<usize>,
+    /// Output shape returned by the tiny graph when available.
+    pub output_shape: Option<Vec<usize>>,
+    /// Graph precision label.
+    pub precision: String,
+    /// Absolute/mean tolerance used for the CPU expected-output comparison.
+    pub tolerance: f32,
+    /// Maximum absolute error versus CPU expected output.
+    pub max_abs_error: Option<f32>,
+    /// Mean absolute error versus CPU expected output.
+    pub mean_abs_error: Option<f32>,
+    /// Compile time to OpenVINO `GPU.0` when measured.
+    pub compile_ms: Option<f64>,
+    /// First inference time when measured.
+    pub first_infer_ms: Option<f64>,
+    /// Always false: this smoke never substitutes CPU fallback.
+    pub fallback_used: bool,
+    /// Always false: CPU fallback is not allowed for Arc 140V OpenVINO proof.
+    pub cpu_fallback_allowed: bool,
+    /// Whether graph execution occurred.
+    pub graph_execution: bool,
+    /// Always false: this is a tiny graph smoke, not BitNet inference.
+    pub bitnet_inference: bool,
+    /// Always false: this graph smoke does not prove packed QK256 decode.
+    pub qk256_decode: bool,
+    /// Non-fatal error for unavailable runtime, missing GPU, identity mismatch, compile, infer, or parity failure.
+    pub error: Option<String>,
+}
+
 /// Selected static BitNet subgraph parity result on OpenVINO NPU.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::struct_excessive_bools)]
@@ -179,6 +237,39 @@ impl OpenVinoNpuTinyGraphSmoke {
             cpu_fallback_allowed: false,
             graph_execution: false,
             bitnet_inference: false,
+            error: Some(reason.into()),
+        }
+    }
+}
+
+impl OpenVinoGpuTinyGraphSmoke {
+    fn unavailable(reason: impl Into<String>) -> Self {
+        Self {
+            passed: false,
+            proof_stage: "runtime_detected".to_owned(),
+            requested_backend: "intel-arc-140v".to_owned(),
+            selected_backend: None,
+            runtime_api: None,
+            runtime_device: None,
+            openvino_gpu_full_name: None,
+            arc140v_identity_matched: false,
+            openvino_version: None,
+            openvino_available_devices: Vec::new(),
+            graph_name: "tiny_matmul_add_f16_1x16".to_owned(),
+            shape_mode: "static".to_owned(),
+            input_shape: vec![1, 16],
+            output_shape: None,
+            precision: "F16".to_owned(),
+            tolerance: 0.001,
+            max_abs_error: None,
+            mean_abs_error: None,
+            compile_ms: None,
+            first_infer_ms: None,
+            fallback_used: false,
+            cpu_fallback_allowed: false,
+            graph_execution: false,
+            bitnet_inference: false,
+            qk256_decode: false,
             error: Some(reason.into()),
         }
     }
@@ -385,6 +476,94 @@ except Exception as exc:
     OpenVinoNpuTinyGraphSmoke::unavailable("python openvino smoke unavailable")
 }
 
+/// Run a tiny static OpenVINO graph on `GPU.0` through Python, without linking OpenVINO.
+pub fn run_openvino_gpu_tiny_graph_smoke() -> OpenVinoGpuTinyGraphSmoke {
+    let script = r#"
+import time
+
+def matches_arc_140v(value):
+    lower = str(value).lower()
+    return ("arc" in lower and "140v" in lower) or "64a0" in lower
+
+try:
+    import openvino as ov
+    import numpy as np
+    from openvino import opset8 as opset
+
+    core = ov.Core()
+    print("OPENVINO_VERSION=" + str(ov.__version__))
+    for dev in core.available_devices:
+        print("AVAILABLE_DEVICE=" + str(dev))
+
+    gpu_devices = [str(dev) for dev in core.available_devices if str(dev) == "GPU.0" or str(dev).startswith("GPU")]
+    if not gpu_devices:
+        print("RESULT=fail")
+        print("ERROR=OpenVINO did not report GPU")
+    else:
+        device = "GPU.0" if "GPU.0" in gpu_devices else gpu_devices[0]
+        try:
+            full_name = str(core.get_property(device, "FULL_DEVICE_NAME"))
+        except Exception as exc:
+            full_name = "ERR: " + repr(exc)
+        identity_matched = matches_arc_140v(full_name)
+
+        input_data = np.arange(16, dtype=np.float16).reshape(1, 16)
+        expected = input_data + np.ones((1, 16), dtype=np.float16)
+
+        param = opset.parameter([1, 16], dtype=np.float16, name="input")
+        weights = opset.constant(np.eye(16, dtype=np.float16))
+        bias = opset.constant(np.ones((1, 16), dtype=np.float16))
+        matmul = opset.matmul(param, weights, False, False)
+        output = opset.add(matmul, bias)
+        model = ov.Model([output], [param], "tiny_matmul_add_f16_1x16")
+
+        compile_start = time.perf_counter()
+        compiled = core.compile_model(model, device)
+        compile_ms = (time.perf_counter() - compile_start) * 1000.0
+
+        infer_start = time.perf_counter()
+        result = compiled([input_data])
+        first_infer_ms = (time.perf_counter() - infer_start) * 1000.0
+        actual = np.asarray(next(iter(result.values())))
+
+        diff = np.abs(actual.astype(np.float32) - expected.astype(np.float32))
+        max_abs = float(np.max(diff))
+        mean_abs = float(np.mean(diff))
+        graph_passed = bool(max_abs <= 0.001)
+        lane_passed = bool(graph_passed and identity_matched)
+
+        print("SELECTED_DEVICE=" + device)
+        print("FULL_DEVICE_NAME=" + full_name)
+        print("ARC140V_IDENTITY_MATCHED=" + ("true" if identity_matched else "false"))
+        print("GRAPH_NAME=tiny_matmul_add_f16_1x16")
+        print("SHAPE_MODE=static")
+        print("PRECISION=F16")
+        print("INPUT_SHAPE=1,16")
+        print("OUTPUT_SHAPE=" + ",".join(str(dim) for dim in actual.shape))
+        print("COMPILE_MS=" + str(compile_ms))
+        print("FIRST_INFER_MS=" + str(first_infer_ms))
+        print("MAX_ABS_ERROR=" + str(max_abs))
+        print("MEAN_ABS_ERROR=" + str(mean_abs))
+        print("GRAPH_EXECUTION=" + ("true" if graph_passed else "false"))
+        print("RESULT=" + ("pass" if lane_passed else "fail"))
+        if not identity_matched:
+            print("ERROR=OpenVINO GPU full name did not identify Arc 140V")
+        elif not graph_passed:
+            print("ERROR=Output mismatch versus CPU expected output")
+except Exception as exc:
+    print("RESULT=fail")
+    print("ERROR=" + repr(exc))
+"#;
+
+    for python in ["python3", "python"] {
+        if let Ok(stdout) = command_output(python, ["-c", script]) {
+            return parse_openvino_gpu_tiny_graph_smoke_output(&stdout);
+        }
+    }
+
+    OpenVinoGpuTinyGraphSmoke::unavailable("python openvino GPU smoke unavailable")
+}
+
 /// Run selected static BitNet subgraph parity on `NPU` through Python, without linking OpenVINO.
 pub fn run_openvino_npu_bitnet_subgraph_parity() -> OpenVinoNpuBitnetSubgraphParity {
     let script = r#"
@@ -559,6 +738,73 @@ pub(crate) fn parse_openvino_npu_tiny_graph_smoke_output(
     smoke
 }
 
+pub(crate) fn parse_openvino_gpu_tiny_graph_smoke_output(
+    output: &str,
+) -> OpenVinoGpuTinyGraphSmoke {
+    let mut smoke =
+        OpenVinoGpuTinyGraphSmoke::unavailable("OpenVINO GPU smoke did not pass for Arc 140V");
+    smoke.openvino_available_devices.clear();
+
+    for line in output.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        if let Some(value) = line.strip_prefix("RESULT=") {
+            smoke.passed = value == "pass";
+        } else if let Some(value) = line.strip_prefix("ERROR=") {
+            smoke.error = Some(value.to_owned());
+        } else if let Some(value) = line.strip_prefix("OPENVINO_VERSION=") {
+            smoke.openvino_version = Some(value.to_owned());
+            smoke.runtime_api = Some("openvino".to_owned());
+        } else if let Some(value) = line.strip_prefix("AVAILABLE_DEVICE=") {
+            smoke.openvino_available_devices.push(value.to_owned());
+            if value == "GPU.0" || value.starts_with("GPU") {
+                smoke.runtime_api = Some("openvino".to_owned());
+                smoke.runtime_device.get_or_insert_with(|| value.to_owned());
+            }
+        } else if let Some(value) = line.strip_prefix("SELECTED_DEVICE=") {
+            smoke.runtime_api = Some("openvino".to_owned());
+            smoke.runtime_device = Some(value.to_owned());
+        } else if let Some(value) = line.strip_prefix("FULL_DEVICE_NAME=") {
+            smoke.openvino_gpu_full_name = Some(value.to_owned());
+        } else if let Some(value) = line.strip_prefix("ARC140V_IDENTITY_MATCHED=") {
+            smoke.arc140v_identity_matched = value == "true";
+        } else if let Some(value) = line.strip_prefix("GRAPH_NAME=") {
+            value.clone_into(&mut smoke.graph_name);
+        } else if let Some(value) = line.strip_prefix("SHAPE_MODE=") {
+            value.clone_into(&mut smoke.shape_mode);
+        } else if let Some(value) = line.strip_prefix("PRECISION=") {
+            value.clone_into(&mut smoke.precision);
+        } else if let Some(value) = line.strip_prefix("INPUT_SHAPE=") {
+            smoke.input_shape = parse_usize_list(value);
+        } else if let Some(value) = line.strip_prefix("OUTPUT_SHAPE=") {
+            smoke.output_shape = Some(parse_usize_list(value));
+        } else if let Some(value) = line.strip_prefix("COMPILE_MS=") {
+            smoke.compile_ms = value.parse().ok();
+        } else if let Some(value) = line.strip_prefix("FIRST_INFER_MS=") {
+            smoke.first_infer_ms = value.parse().ok();
+        } else if let Some(value) = line.strip_prefix("MAX_ABS_ERROR=") {
+            smoke.max_abs_error = value.parse().ok();
+        } else if let Some(value) = line.strip_prefix("MEAN_ABS_ERROR=") {
+            smoke.mean_abs_error = value.parse().ok();
+        } else if let Some(value) = line.strip_prefix("GRAPH_EXECUTION=") {
+            smoke.graph_execution = value == "true";
+        }
+    }
+
+    if smoke.arc140v_identity_matched {
+        smoke.selected_backend = Some("intel-arc-140v-openvino-gpu".to_owned());
+    }
+    smoke.proof_stage = if smoke.passed {
+        smoke.error = None;
+        "kernel_smoke_tested".to_owned()
+    } else {
+        "runtime_detected".to_owned()
+    };
+    smoke.fallback_used = false;
+    smoke.cpu_fallback_allowed = false;
+    smoke.bitnet_inference = false;
+    smoke.qk256_decode = false;
+    smoke
+}
+
 pub(crate) fn parse_openvino_npu_bitnet_subgraph_parity_output(
     output: &str,
 ) -> OpenVinoNpuBitnetSubgraphParity {
@@ -696,7 +942,8 @@ fn upsert_property_value(device: &mut OpenVinoDeviceProbe, property: &str, value
 #[cfg(test)]
 mod tests {
     use super::{
-        parse_openvino_line_output, parse_openvino_npu_bitnet_subgraph_parity_output,
+        parse_openvino_gpu_tiny_graph_smoke_output, parse_openvino_line_output,
+        parse_openvino_npu_bitnet_subgraph_parity_output,
         parse_openvino_npu_tiny_graph_smoke_output,
     };
 
@@ -784,6 +1031,115 @@ ERROR=OpenVINO did not report NPU
         assert!(!smoke.graph_execution);
         assert!(!smoke.fallback_used);
         assert_eq!(smoke.error.as_deref(), Some("OpenVINO did not report NPU"));
+    }
+
+    #[test]
+    fn parses_openvino_gpu_tiny_graph_smoke_pass() {
+        let output = r"
+OPENVINO_VERSION=2026.1
+AVAILABLE_DEVICE=CPU
+AVAILABLE_DEVICE=GPU.0
+SELECTED_DEVICE=GPU.0
+FULL_DEVICE_NAME=Intel(R) Arc(TM) 140V Graphics
+ARC140V_IDENTITY_MATCHED=true
+GRAPH_NAME=tiny_matmul_add_f16_1x16
+SHAPE_MODE=static
+PRECISION=F16
+INPUT_SHAPE=1,16
+OUTPUT_SHAPE=1,16
+COMPILE_MS=7.5
+FIRST_INFER_MS=0.75
+MAX_ABS_ERROR=0.0
+MEAN_ABS_ERROR=0.0
+GRAPH_EXECUTION=true
+RESULT=pass
+";
+
+        let smoke = parse_openvino_gpu_tiny_graph_smoke_output(output);
+
+        assert!(smoke.passed);
+        assert_eq!(smoke.proof_stage, "kernel_smoke_tested");
+        assert_eq!(smoke.selected_backend.as_deref(), Some("intel-arc-140v-openvino-gpu"));
+        assert_eq!(smoke.runtime_api.as_deref(), Some("openvino"));
+        assert_eq!(smoke.runtime_device.as_deref(), Some("GPU.0"));
+        assert_eq!(smoke.openvino_gpu_full_name.as_deref(), Some("Intel(R) Arc(TM) 140V Graphics"));
+        assert!(smoke.arc140v_identity_matched);
+        assert_eq!(smoke.input_shape, [1, 16]);
+        assert_eq!(smoke.output_shape.as_deref(), Some(&[1, 16][..]));
+        assert_eq!(smoke.precision, "F16");
+        assert_eq!(smoke.max_abs_error, Some(0.0));
+        assert!(!smoke.fallback_used);
+        assert!(!smoke.cpu_fallback_allowed);
+        assert!(smoke.graph_execution);
+        assert!(!smoke.bitnet_inference);
+        assert!(!smoke.qk256_decode);
+        assert!(smoke.error.is_none());
+    }
+
+    #[test]
+    fn parses_openvino_gpu_tiny_graph_missing_gpu_as_runtime_only() {
+        let output = r"
+OPENVINO_VERSION=2026.1
+AVAILABLE_DEVICE=CPU
+RESULT=fail
+ERROR=OpenVINO did not report GPU
+";
+
+        let smoke = parse_openvino_gpu_tiny_graph_smoke_output(output);
+
+        assert!(!smoke.passed);
+        assert_eq!(smoke.proof_stage, "runtime_detected");
+        assert_eq!(smoke.runtime_api.as_deref(), Some("openvino"));
+        assert!(smoke.runtime_device.is_none());
+        assert!(smoke.selected_backend.is_none());
+        assert!(!smoke.arc140v_identity_matched);
+        assert!(!smoke.graph_execution);
+        assert!(!smoke.fallback_used);
+        assert!(!smoke.bitnet_inference);
+        assert!(!smoke.qk256_decode);
+        assert_eq!(smoke.error.as_deref(), Some("OpenVINO did not report GPU"));
+    }
+
+    #[test]
+    fn parses_openvino_gpu_tiny_graph_rejects_generic_gpu_identity() {
+        let output = r"
+OPENVINO_VERSION=2026.1
+AVAILABLE_DEVICE=CPU
+AVAILABLE_DEVICE=GPU.0
+SELECTED_DEVICE=GPU.0
+FULL_DEVICE_NAME=Intel(R) UHD Graphics
+ARC140V_IDENTITY_MATCHED=false
+GRAPH_NAME=tiny_matmul_add_f16_1x16
+SHAPE_MODE=static
+PRECISION=F16
+INPUT_SHAPE=1,16
+OUTPUT_SHAPE=1,16
+COMPILE_MS=7.5
+FIRST_INFER_MS=0.75
+MAX_ABS_ERROR=0.0
+MEAN_ABS_ERROR=0.0
+GRAPH_EXECUTION=true
+RESULT=fail
+ERROR=OpenVINO GPU full name did not identify Arc 140V
+";
+
+        let smoke = parse_openvino_gpu_tiny_graph_smoke_output(output);
+
+        assert!(!smoke.passed);
+        assert_eq!(smoke.proof_stage, "runtime_detected");
+        assert_eq!(smoke.runtime_api.as_deref(), Some("openvino"));
+        assert_eq!(smoke.runtime_device.as_deref(), Some("GPU.0"));
+        assert_eq!(smoke.openvino_gpu_full_name.as_deref(), Some("Intel(R) UHD Graphics"));
+        assert!(smoke.selected_backend.is_none());
+        assert!(!smoke.arc140v_identity_matched);
+        assert!(smoke.graph_execution);
+        assert!(!smoke.fallback_used);
+        assert!(!smoke.bitnet_inference);
+        assert!(!smoke.qk256_decode);
+        assert_eq!(
+            smoke.error.as_deref(),
+            Some("OpenVINO GPU full name did not identify Arc 140V")
+        );
     }
 
     #[test]

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -90,6 +90,7 @@ real machine artifact and does not prove runtime execution.
 ```text
 ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json
 ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-runtime-probe.json
+ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-openvino-gpu-smoke.json
 ci/hardware/intel-258v/YYYY-MM-DD/npu-openvino-runtime-probe.json
 ci/hardware/intel-258v/YYYY-MM-DD/platform-comparison-index.json
 ```
@@ -100,6 +101,7 @@ The bundle must keep each lane independently addressable:
 |---|---|---|---|
 | `platform-probe.json` | `runtime_detected` | OS, CPU, memory, power, OpenVINO device list, shared platform context | Machine visibility only |
 | `arc-140v-runtime-probe.json` | `runtime_detected` | Arc 140V OpenCL, Level Zero, OpenVINO `GPU.0`, exact device identity | No OpenCL kernel execution claim |
+| `arc-140v-openvino-gpu-smoke.json` | `kernel_smoke_tested` | Tiny static OpenVINO `GPU.0` graph execution with Arc 140V identity and CPU expected-output comparison | No native OpenCL, BitNet, QK256, or acceleration claim |
 | `npu-openvino-runtime-probe.json` | `runtime_detected` | OS NPU evidence, OpenVINO `NPU`, driver/compiler/memory properties | No graph execution claim |
 | `platform-comparison-index.json` | index only | Links CPU, Arc 140V, and NPU artifacts from the same machine/date | No independent proof claim |
 
@@ -114,6 +116,7 @@ CPU, GPU, and NPU receipts can be compared without inferring cross-lane proof:
   "artifacts": {
     "platform": "ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json",
     "arc140v": "ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-runtime-probe.json",
+    "arc140v_openvino_gpu": "ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-openvino-gpu-smoke.json",
     "npu": "ci/hardware/intel-258v/YYYY-MM-DD/npu-openvino-runtime-probe.json"
   },
   "lanes": {
@@ -145,6 +148,25 @@ cargo run --locked -p bitnet-cli \
 The command records `proof_stage=runtime_detected`, `runtime_api=platform_probe`,
 `fallback_used=false`, and a `must_not_claim` list. It does not replace the
 lane-specific Arc 140V, NPU, CPU BitNet, parity, or benchmark artifacts.
+
+### Arc 140V OpenVINO GPU Smoke
+
+Use the Arc 140V OpenVINO GPU smoke command to emit a tiny fixed-shape graph
+receipt from `GPU.0` without loading BitNet models or running native OpenCL:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- intel-arc-140v-openvino-gpu-smoke \
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-openvino-gpu-smoke.json
+```
+
+The command records `proof_stage=kernel_smoke_tested` only when OpenVINO reports
+an Arc 140V `GPU.0`, compiles the tiny static graph to that device, and matches
+the CPU expected output. It keeps `fallback_used=false`,
+`cpu_fallback_allowed=false`, `bitnet_inference=false`, and `qk256_decode=false`.
+It does not prove native OpenCL kernels, BitNet inference, or Arc acceleration.
 
 ### CPU BitNet Validation Preflight
 

--- a/docs/specs/intel-lunar-lake-258v-buildout-plan.md
+++ b/docs/specs/intel-lunar-lake-258v-buildout-plan.md
@@ -30,8 +30,9 @@ Do these identity and validation surfaces before claiming real BitNet performanc
 4. **CPU258V-001**: run the merged CPU path on the 258V laptop and emit strict validation receipts for loader/tokenizer authority, kernel identity, and decode smoke.
 5. **CPU258V-002**: compare scalar and AVX2 strict CPU answer receipts on the 258V with the same model, tokenizer, prompt, greedy settings, prompt token IDs, generated token IDs/text, first divergence, logits/top-k evidence when available, fallback status, and power/topology context.
 6. **CPU258V-003**: emit 258V phase benchmark receipts for smoke, first token, decode, and prefill profiles as the CPU reference plate.
-7. **NPU-007 / ARC140V-003**: advance NPU selected RMSNorm subgraph parity and Arc 140V tiny OpenCL smoke against the 258V CPU-first priority order.
-8. **Comparison work**: only after the lane receipts exist, compare CPU AVX2, Arc 140V, and OpenVINO NPU artifacts on the same shared-memory platform.
+7. **NPU-007 / ARC140V-003**: advance NPU selected RMSNorm subgraph parity and Arc 140V OpenVINO `GPU.0` smoke against the 258V CPU-first priority order.
+8. **ARC140V-004**: only after OpenVINO GPU smoke, advance Arc 140V to tiny native OpenCL execution.
+9. **Comparison work**: only after the lane receipts exist, compare CPU AVX2, Arc 140V, and OpenVINO NPU artifacts on the same shared-memory platform.
 
 ## PR Contracts
 
@@ -43,6 +44,7 @@ Do these identity and validation surfaces before claiming real BitNet performanc
 | `CPU258V-001` | 258V CPU validation harness. | CLI validation command, receipts, hardware/tracking docs, machine profile artifacts. | Accelerator code and unrelated model/tokenizer rewrites. | Strict CPU receipt records loader mode, tokenizer source, mock/fallback status, requested/selected kernel, phase metrics, and same-machine platform link. |
 | `CPU258V-002` | 258V scalar-vs-AVX2 strict answer parity. | CLI parity command, answer receipts, 258V CPU artifacts, hardware/tracking docs. | OpenCL, OpenVINO NPU execution, QK256 kernel rewrites unless explicitly scoped. | Receipt compares scalar and AVX2 output for the same model/tokenizer/prompt/greedy settings, records token IDs/text, first divergence, logits/top-k evidence, selected kernels, fallback=false, and power/topology context. |
 | `CPU258V-003` | 258V phase benchmark receipts. | Benchmark receipt generation, 258V artifacts, hardware/tracking docs. | Accelerator code, server inference, and thread pinning unless separately scoped. | Receipt records smoke, first-token, decode, and prefill phase timing when available with CPU feature, power, topology, selected backend/kernel, and fallback status. |
+| `ARC140V-003` | Tiny OpenVINO `GPU.0` graph smoke for the Arc 140V reference lane. | OpenVINO runtime probe, CLI smoke receipt, Arc 140V hardware docs. | Native OpenCL kernels, BitNet model/tokenizer/QK256/inference code. | Receipt records Arc 140V OpenVINO GPU identity, static tiny graph execution, shape/timing/tolerance fields, fallback=false, and no BitNet/QK256/native OpenCL claims. |
 
 ## Required Platform Probe Surface
 

--- a/docs/specs/intel-lunar-lake-gpu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-gpu-roadmap.md
@@ -67,8 +67,8 @@ memory_kind = "shared-system-memory"
 OpenVINO GPU reference:
 
 ```text
-requested_backend = "intel-arc-140v-openvino-gpu"
-selected_backend = "openvino-gpu"
+requested_backend = "intel-arc-140v"
+selected_backend = "intel-arc-140v-openvino-gpu"
 openvino_device = "GPU.0"
 ```
 
@@ -208,6 +208,25 @@ Detect Arc 140V by device name or PCI ID 0x64A0, and record OpenCL, Level Zero, 
 ### ARC140V-003 - OpenVINO GPU Smoke
 
 Compile and run a tiny fixed-shape graph on OpenVINO `GPU.0`.
+
+Command shape:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- intel-arc-140v-openvino-gpu-smoke \
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/arc-140v-openvino-gpu-smoke.json
+```
+
+The receipt must keep `requested_backend=intel-arc-140v`,
+`selected_backend=intel-arc-140v-openvino-gpu`, `runtime_api=openvino`,
+`runtime_device=GPU.0`, `fallback_used=false`, `bitnet_inference=false`, and
+`qk256_decode=false`. It may claim tiny OpenVINO GPU graph smoke only when the
+selected `GPU.0` full device name identifies Arc 140V and the graph output
+matches the CPU expected output.
+
+This is not native OpenCL execution. Native OpenCL starts at `ARC140V-004`.
 
 ### ARC140V-004 - OpenCL Kernel Smoke
 


### PR DESCRIPTION
## Summary
- add an Arc 140V OpenVINO `GPU.0` tiny static graph smoke probe and JSON-ready result struct
- add `bitnet intel-arc-140v-openvino-gpu-smoke` to emit receipt-backed OpenVINO GPU smoke artifacts
- document ARC140V-003 as OpenVINO GPU smoke and keep native OpenCL execution reserved for ARC140V-004

## Claim Boundary
This proves only a tiny static OpenVINO GPU graph smoke when `GPU.0` identifies Arc 140V and output matches the CPU expected output. It does not claim native OpenCL kernels, BitNet inference, Arc 140V acceleration, packed QK256 decode, or CPU fallback as Arc proof.

## Verification
- `rustfmt --check --config skip_children=true --edition 2024 crates/bitnet-device-probe/src/runtimes/openvino.rs crates/bitnet-device-probe/src/runtimes/mod.rs crates/bitnet-cli/src/intel_arc.rs crates/bitnet-cli/src/main.rs`
- `cargo test --locked -p bitnet-device-probe --no-default-features`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet intel_arc::tests -- --nocapture`
- `cargo clippy --locked -p bitnet-device-probe --no-default-features -- -D warnings`
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- intel-arc-140v-openvino-gpu-smoke --json-out target/arc140v-openvino-gpu-smoke.json` (local host recorded OpenVINO unavailable with `fallback_used=false`, `graph_execution=false`)
- `git diff --check`

## Local Note
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_snapshot_tests cli_help -- --exact --nocapture` fails locally on Windows only because clap renders `Usage: bitnet.exe ...` while the committed snapshot uses the cross-platform `Usage: bitnet ...` string.