### PR TITLE
fix(xtask): satisfy campaign clippy map_or lint

### DIFF
--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -1192,15 +1192,15 @@ fn body_line_claims_item(line: &str, item_id: &str) -> bool {
 
 fn text_starts_with_item_token(text: &str, item_id: &str) -> bool {
     text.strip_prefix(item_id)
-        .is_some_and(|rest| rest.chars().next().map_or(true, |ch| !is_item_token_char(ch)))
+        .is_some_and(|rest| rest.chars().next().is_none_or(|ch| !is_item_token_char(ch)))
 }
 
 fn text_contains_item_token(text: &str, item_id: &str) -> bool {
     text.match_indices(item_id).any(|(start, matched)| {
         let before = text[..start].chars().next_back();
         let after = text[start + matched.len()..].chars().next();
-        before.map_or(true, |ch| !is_item_token_char(ch))
-            && after.map_or(true, |ch| !is_item_token_char(ch))
+        before.is_none_or(|ch| !is_item_token_char(ch))
+            && after.is_none_or(|ch| !is_item_token_char(ch))
     })
 }
 


### PR DESCRIPTION
## Summary
- replace campaign item-token boundary `map_or(true, ...)` checks with `is_none_or(...)`
- unblock the current `Feature cpu` Clippy gate seen on Lunar Lake tracker/Arc PRs

## Verification
- `rustfmt --check --edition 2024 xtask/src/campaign.rs`
- `cargo clippy --locked -p xtask --no-default-features -- -D warnings`
- `git diff --check`

## Claim boundary
This is a narrow CI hygiene fix only. It does not change campaign semantics or Lunar Lake CPU/NPU/Arc proof behavior.