### PR TITLE
AVX512-ANSWER-001: add AVX512 answer-corpus receipts and divergence metadata

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -70,6 +70,7 @@ pub struct AnswerCorpusCommand {
 pub enum AnswerCpuKernel {
     Scalar,
     Avx2,
+    Avx512,
 }
 
 impl AnswerCpuKernel {
@@ -77,13 +78,15 @@ impl AnswerCpuKernel {
         match self {
             Self::Scalar => "scalar",
             Self::Avx2 => "avx2",
+            Self::Avx512 => "avx512",
         }
     }
 
     fn child_env(self) -> Vec<(&'static str, &'static str)> {
         match self {
             Self::Scalar => vec![("BITNET_CPU_KERNEL", "scalar"), ("BITNET_FORCE_SCALAR", "1")],
-            Self::Avx2 => vec![("BITNET_CPU_KERNEL", "avx2")],
+            Self::Avx2 => vec![("BITNET_CPU_KERNEL", "avx2"), ("BITNET_FORCE_SCALAR", "0")],
+            Self::Avx512 => vec![("BITNET_CPU_KERNEL", "avx512"), ("BITNET_FORCE_SCALAR", "0")],
         }
     }
 }
@@ -104,6 +107,9 @@ impl AnswerCorpusCommand {
         }
         if self.cpu_kernel == Some(AnswerCpuKernel::Avx2) && !cpu_avx2_available() {
             anyhow::bail!("--cpu-kernel avx2 requested but AVX2 is unavailable on this host");
+        }
+        if self.cpu_kernel == Some(AnswerCpuKernel::Avx512) && !cpu_avx512_available() {
+            anyhow::bail!("--cpu-kernel avx512 requested but AVX512 is unavailable on this host");
         }
         let artifact_kind = answer_corpus_artifact_kind(&device);
         let default_timeout_seconds = effective_default_timeout_seconds(
@@ -194,6 +200,8 @@ impl AnswerCorpusCommand {
             },
             "claim_boundary": {
                 "local_answer_path": device.as_str() == "apple-m4-cpu-neon",
+                "diagnostic_only_until_answer_ready_artifact": true,
+                "coherent_answer_claimed": false,
                 "full_metal_inference_claimed": false,
                 "qk256_apple_claimed": false,
                 "neural_engine_claimed": false,
@@ -308,6 +316,7 @@ impl AnswerCorpusCommand {
         .with_context(|| format!("invalid run receipt {}", case_receipt.display()))?;
         let answer = run_receipt["text"].as_str().unwrap_or_default().to_string();
         let token_ids = generated_token_ids(&run_receipt);
+        let prompt_prefill = prompt_prefill_receipt(&run_receipt);
         let generated_token_count = run_receipt["tokens"]["generated"]
             .as_u64()
             .and_then(|value| usize::try_from(value).ok())
@@ -339,7 +348,18 @@ impl AnswerCorpusCommand {
                 "generated": run_receipt["tokens"]["generated_ids"].clone(),
             },
             "logits_dump": run_receipt.get("logits_dump").cloned().unwrap_or(Value::Null),
+            "prompt": {
+                "rendered_text": run_receipt["prompt"].clone(),
+                "template_family": corpus.defaults.prompt_template,
+                "add_bos": run_receipt["gen_policy"]["bos"].clone(),
+                "add_special": run_receipt["tokenizer"]["bos"].is_number()
+                    || run_receipt["tokenizer"]["eos"].is_number(),
+            },
             "prompt_template": corpus.defaults.prompt_template,
+            "prompt_prefill": prompt_prefill,
+            "position": {
+                "next_decode_position": run_receipt["tokens"]["prompt"].clone(),
+            },
             "quality": {
                 "passed": quality.passed,
                 "printable_utf8": quality.printable_utf8,
@@ -370,6 +390,16 @@ impl AnswerCorpusCommand {
             "tokenizer": {
                 "source": run_receipt["tokenizer"]["source"].clone(),
                 "strict": run_receipt["tokenizer"]["strict"].clone(),
+                "model_family": run_receipt["tokenizer"]["type"].clone(),
+                "pretokenizer_authority": run_receipt["tokenizer"]["pretokenizer_authority"]
+                    .as_str()
+                    .map(Value::from)
+                    .unwrap_or_else(|| Value::from("unknown")),
+            },
+            "model": {
+                "vocab_size": run_receipt["model"]["vocab_size"].clone(),
+                "tie_word_embeddings": run_receipt["model"]["tie_word_embeddings"].clone(),
+                "output_head_tensor": run_receipt["model"]["output_head_tensor"].clone(),
             }
         }))
     }
@@ -480,6 +510,29 @@ fn answer_corpus_artifact_kind(device: &str) -> &'static str {
         "apple-m4-cpu-neon" => "bitnet_apple_m4_local_answer_corpus",
         _ => "bitnet_cpu_answer_corpus",
     }
+}
+
+fn prompt_prefill_receipt(run_receipt: &Value) -> Value {
+    let prompt_token_count = run_receipt["tokens"]["prompt"].as_u64().unwrap_or_else(|| {
+        run_receipt["tokens"]["prompt_ids"]
+            .as_array()
+            .map(|tokens| tokens.len() as u64)
+            .unwrap_or_default()
+    });
+    let profile_prefill = &run_receipt["profile"]["prompt_prefill"];
+    let exercised = profile_prefill["exercised"].as_bool().unwrap_or(prompt_token_count > 0);
+    json!({
+        "executed": exercised,
+        "exercised": exercised,
+        "prompt_token_count": prompt_token_count,
+        "decode_start_position": prompt_token_count,
+        "kv_cache_behavior": profile_prefill["kv_cache_behavior"].clone(),
+        "source": if profile_prefill.is_object() {
+            "run_receipt_profile"
+        } else {
+            "tokens_prompt_count"
+        },
+    })
 }
 
 fn effective_default_timeout_seconds(cli: Option<u64>, corpus: Option<u64>) -> u64 {
@@ -743,6 +796,18 @@ fn cpu_avx2_available() -> bool {
     }
 }
 
+fn cpu_avx512_available() -> bool {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        std::is_x86_feature_detected!("avx512f")
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        false
+    }
+}
+
 fn child_capture_path(kind: &str) -> PathBuf {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -844,6 +909,37 @@ mod tests {
         });
 
         assert!(answer_receipt_failed_rules(&receipt, "cpu").is_empty());
+    }
+
+    #[test]
+    fn avx512_cpu_kernel_selector_sets_child_env() {
+        assert_eq!(AnswerCpuKernel::Avx512.as_str(), "avx512");
+        assert_eq!(
+            AnswerCpuKernel::Avx512.child_env(),
+            vec![("BITNET_CPU_KERNEL", "avx512"), ("BITNET_FORCE_SCALAR", "0")]
+        );
+    }
+
+    #[test]
+    fn prompt_prefill_receipt_prefers_profile_data() {
+        let receipt = json!({
+            "tokens": {
+                "prompt": 7,
+                "prompt_ids": [1, 2, 3, 4, 5, 6, 7]
+            },
+            "profile": {
+                "prompt_prefill": {
+                    "exercised": true,
+                    "kv_cache_behavior": "prompt_prefix_prefilled_before_decode"
+                }
+            }
+        });
+
+        let prefill = prompt_prefill_receipt(&receipt);
+        assert_eq!(prefill["executed"], true);
+        assert_eq!(prefill["prompt_token_count"], 7);
+        assert_eq!(prefill["decode_start_position"], 7);
+        assert_eq!(prefill["source"], "run_receipt_profile");
     }
 
     #[test]

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -2018,6 +2018,11 @@ fn cpu_kernel_implementation(quantization: bitnet_common::QuantizationType) -> &
     {
         return "avx2";
     }
+    if std::env::var("BITNET_CPU_KERNEL").as_deref() == Ok("avx512")
+        && bitnet_common::runtime_diag::CpuFeatures::detect().avx512f
+    {
+        return "avx512";
+    }
     if matches!(quantization, bitnet_common::QuantizationType::I2S) && cfg!(target_arch = "aarch64")
     {
         // The current Apple CPU proof path has NEON available, but the packed
@@ -2981,6 +2986,7 @@ async fn run_simple_generation(
         let tokenizer_type = tokenizer_type_for_receipt(&tokenizer_label, tokenizer_source);
         let tokenizer_info = serde_json::json!({
             "type": tokenizer_type,
+            "model_family": tokenizer_type,
             "origin": if tokenizer_source == bitnet_tokenizers::auto::TokenizerSource::GgufMetadata {
                 "embedded"
             } else {
@@ -2988,6 +2994,7 @@ async fn run_simple_generation(
             },
             "source": tokenizer_source_str,
             "strict": tokenizer_strict,
+            "pretokenizer_authority": "unknown",
             "bos": tokenizer.bos_token_id().unwrap_or(1),
             "eos": tokenizer.eos_token_id().unwrap_or(2),
         });
@@ -3285,6 +3292,8 @@ async fn run_simple_generation(
                 "context_length": config.model.max_position_embeddings,
                 "tokenizer": tokenizer_label,
                 "vocab_size": tokenizer.vocab_size(),
+                "tie_word_embeddings": serde_json::Value::Null,
+                "output_head_tensor": "output.weight",
                 "loader_mode": loader_mode,
                 "fallback_loader_used": loader_mode != bitnet_models::GgufLoaderMode::RealGguf.as_str(),
             },


### PR DESCRIPTION
## Summary

Implements AVX512-ANSWER-001 diagnostic infrastructure for the answer-corpus path. This PR does not touch CUDA kernels, QK256 dispatch, transformer math, or artifact readiness gates.

## Changes

- Adds `--cpu-kernel avx512` support to `bitnet answer-corpus`, with an AVX512 host capability guard and child-run selector env.
- Enriches answer-corpus case receipts with rendered prompt metadata, prompt prefill/position evidence, tokenizer authority fields, model vocab/output-head metadata, token IDs, decoded text, backend/kernel identity, and optional logit dumps.
- Marks aggregate answer-corpus receipts as diagnostic-only until a shared `answer_ready` model artifact exists.
- Exposes AVX512-selected kernel identity in the child run receipt when `BITNET_CPU_KERNEL=avx512` is requested on a capable host.

## Local validation

- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_corpus::tests -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer -- --nocapture`
- `cargo fmt -p bitnet-cli -- --check`
- `git diff --check`
- `cargo run --locked -p xtask --release --no-default-features -- campaign check nvidia-5070ti`
- `cargo run --locked -p xtask --release --no-default-features -- campaign doctor` (passes with pre-existing `CPU-PHASE-TIMING-001` missing `head_sha` warning)
- `cargo run --locked -p xtask --release --no-default-features -- campaign generate --check`

## Diagnostic smoke

Ran release AVX512 answer-corpus against the local Microsoft I2_S GGUF using `--dump-logit-steps 4 --logits-topk 10`. The receipt selected `i2_s-avx512-reference`, recorded prompt IDs/generated IDs/logits/prefill evidence, and remained diagnostic-only. Quality still failed against the current non-answer-ready artifact, as expected.

## Boundaries

- No coherent answer-readiness claim.
- No speedup claim.
- No CUDA/kernel/transformer changes.