### PR TITLE
fix(bdd-grid): normalize feature label parsing

### DIFF
--- a/crates/bitnet-bdd-grid-core/src/lib.rs
+++ b/crates/bitnet-bdd-grid-core/src/lib.rs
@@ -7,6 +7,10 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::str::FromStr;
 
+fn normalize_label(input: &str) -> String {
+    input.trim().to_ascii_lowercase().replace(['_', ' '], "-")
+}
+
 /// Logical test scenario axis for BDD planning.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TestingScenario {
@@ -41,7 +45,7 @@ impl FromStr for TestingScenario {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_label(s).as_str() {
             "unit" => Ok(Self::Unit),
             "integration" => Ok(Self::Integration),
             "e2e" | "end-to-end" | "endtoend" => Ok(Self::EndToEnd),
@@ -80,7 +84,7 @@ impl FromStr for ExecutionEnvironment {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_label(s).as_str() {
             "local" | "dev" | "development" => Ok(Self::Local),
             "ci" | "ci/cd" | "cicd" => Ok(Self::Ci),
             "pre-prod" | "preprod" | "pre-production" | "preproduction" | "staging" => {
@@ -154,7 +158,7 @@ impl FromStr for BitnetFeature {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_ascii_lowercase().as_str() {
+        match normalize_label(s).as_str() {
             "cpu" => Ok(Self::Cpu),
             "gpu" => Ok(Self::Gpu),
             "cuda" => Ok(Self::Cuda),
@@ -224,6 +228,27 @@ impl FeatureSet {
             }
         }
         set
+    }
+
+    /// Create a set from a string list, returning unknown feature names.
+    pub fn try_from_names<I, S>(features: I) -> Result<Self, Vec<String>>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut set = Self::new();
+        let mut unknown = Vec::new();
+
+        for feature in features {
+            match feature.as_ref().parse() {
+                Ok(feature) => {
+                    set.insert(feature);
+                }
+                Err(_) => unknown.push(feature.as_ref().to_owned()),
+            }
+        }
+
+        if unknown.is_empty() { Ok(set) } else { Err(unknown) }
     }
 
     /// Human-readable representation for logs and diagnostics.
@@ -345,13 +370,12 @@ impl BddGrid {
 
 /// Canonical, reusable helper for mapping runtime feature selections to `FeatureSet`.
 pub fn feature_set_from_names(features: &[&str]) -> FeatureSet {
-    let mut set = FeatureSet::new();
-    for feature in features {
-        if let Ok(feature) = feature.parse() {
-            set.insert(feature);
-        }
-    }
-    set
+    FeatureSet::from_names(features.iter().copied())
+}
+
+/// Strict variant of [`feature_set_from_names`] that returns unknown feature names.
+pub fn try_feature_set_from_names(features: &[&str]) -> Result<FeatureSet, Vec<String>> {
+    FeatureSet::try_from_names(features.iter().copied())
 }
 
 #[cfg(test)]
@@ -389,5 +413,11 @@ mod tests {
         let grid = BddGrid::from_rows(rows);
         let found = grid.find(TestingScenario::Unit, ExecutionEnvironment::Local);
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn test_try_feature_set_from_names_rejects_unknown_features() {
+        let result = try_feature_set_from_names(&["inference", "unknown-feature"]);
+        assert_eq!(result, Err(vec!["unknown-feature".to_string()]));
     }
 }

--- a/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
+++ b/crates/bitnet-bdd-grid-core/tests/bdd_grid_core_edge_cases.rs
@@ -62,6 +62,12 @@ fn scenario_case_insensitive() {
 }
 
 #[test]
+fn scenario_normalizes_trimmed_underscored_and_spaced_values() {
+    assert_eq!(TestingScenario::from_str(" end_to_end "), Ok(TestingScenario::EndToEnd));
+    assert_eq!(TestingScenario::from_str("cross validation"), Ok(TestingScenario::CrossValidation));
+}
+
+#[test]
 fn scenario_display_roundtrip() {
     let scenarios = [
         TestingScenario::Unit,
@@ -164,6 +170,18 @@ fn env_case_insensitive() {
 }
 
 #[test]
+fn env_normalizes_trimmed_underscored_and_spaced_values() {
+    assert_eq!(
+        ExecutionEnvironment::from_str(" pre_production "),
+        Ok(ExecutionEnvironment::PreProduction)
+    );
+    assert_eq!(
+        ExecutionEnvironment::from_str("pre production"),
+        Ok(ExecutionEnvironment::PreProduction)
+    );
+}
+
+#[test]
 fn env_display_roundtrip() {
     let envs = [
         ExecutionEnvironment::Local,
@@ -248,6 +266,14 @@ fn feature_case_insensitive() {
 }
 
 #[test]
+fn feature_normalizes_trimmed_underscored_and_spaced_values() {
+    assert_eq!(BitnetFeature::from_str(" integration_tests "), Ok(BitnetFeature::IntegrationTests));
+    assert_eq!(BitnetFeature::from_str("cpp_ffi"), Ok(BitnetFeature::CppFfi));
+    assert_eq!(BitnetFeature::from_str("iq2s ffi"), Ok(BitnetFeature::Iq2sFfi));
+    assert_eq!(BitnetFeature::from_str("cross validation"), Ok(BitnetFeature::CrossValidation));
+}
+
+#[test]
 fn feature_display_roundtrip() {
     let features = [
         BitnetFeature::Cpu,
@@ -310,6 +336,20 @@ fn feature_set_from_names_skips_unknown() {
     assert!(set.contains(BitnetFeature::Cpu));
     assert!(set.contains(BitnetFeature::Gpu));
     assert!(!set.contains(BitnetFeature::Cuda));
+}
+
+#[test]
+fn feature_set_try_from_names_reports_unknowns() {
+    let result = FeatureSet::try_from_names(["cpu", "unknown-thing", "gpu", "also-unknown"]);
+    assert_eq!(result, Err(vec!["unknown-thing".to_string(), "also-unknown".to_string()]));
+}
+
+#[test]
+fn feature_set_from_names_normalizes_common_aliases() {
+    let set = FeatureSet::from_names([" cpu ", "integration_tests", "iq2s ffi"]);
+    assert!(set.contains(BitnetFeature::Cpu));
+    assert!(set.contains(BitnetFeature::IntegrationTests));
+    assert!(set.contains(BitnetFeature::Iq2sFfi));
 }
 
 #[test]

--- a/crates/bitnet-bdd-grid/src/lib.rs
+++ b/crates/bitnet-bdd-grid/src/lib.rs
@@ -8,70 +8,76 @@ use std::sync::LazyLock;
 
 pub use bitnet_bdd_grid_core::{
     BddCell, BddGrid, BitnetFeature, ExecutionEnvironment, FeatureSet, TestingScenario,
-    feature_set_from_names,
+    feature_set_from_names, try_feature_set_from_names,
 };
 
 static CURATED_ROWS: LazyLock<Box<[BddCell]>> = LazyLock::new(build_curated_rows);
+
+fn curated_features(features: &[&str]) -> FeatureSet {
+    try_feature_set_from_names(features).unwrap_or_else(|unknown| {
+        panic!("curated BDD grid contains unknown feature names: {}", unknown.join(", "))
+    })
+}
 
 fn build_curated_rows() -> Box<[BddCell]> {
     vec![
         BddCell {
             scenario: TestingScenario::Unit,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["reporting", "fixtures"]),
-            forbidden_features: feature_set_from_names(&["cpp-ffi"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["reporting", "fixtures"]),
+            forbidden_features: curated_features(&["cpp-ffi"]),
             intent: "Fast, isolated unit execution with core inference path",
         },
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["crossval", "reporting", "fixtures"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["crossval", "reporting", "fixtures"]),
             forbidden_features: FeatureSet::new(),
             intent: "Component and module interaction in local build",
         },
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "crossval",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting", "trend"]),
+            optional_features: curated_features(&["fixtures", "reporting", "trend"]),
             forbidden_features: FeatureSet::new(),
             intent: "Reference parity / regression surface with controlled fixtures",
         },
         BddCell {
             scenario: TestingScenario::Performance,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["gpu", "cuda", "reporting", "trend"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["gpu", "cuda", "reporting", "trend"]),
             forbidden_features: FeatureSet::new(),
             intent: "Throughput and latency-sensitive checks",
         },
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["tokenizers", "kernels", "crossval"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["tokenizers", "kernels", "crossval"]),
             forbidden_features: FeatureSet::new(),
             intent: "Minimum viable run for deployment safety",
         },
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["trace", "reporting"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["trace", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Detailed behavior introspection and diagnostics",
         },
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference"]),
+            required_features: curated_features(&["inference"]),
             optional_features: FeatureSet::new(),
             forbidden_features: FeatureSet::new(),
             intent: "Fastest-path execution with hard constraints",
@@ -79,14 +85,14 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "reporting",
                 "crossval",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "trend", "server"]),
+            optional_features: curated_features(&["fixtures", "trend", "server"]),
             forbidden_features: FeatureSet::new(),
             intent: "Full stack workflow checks spanning startup through response path",
         },
@@ -95,8 +101,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Unit,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["cpu", "inference", "kernels"]),
-            optional_features: feature_set_from_names(&["tokenizers", "reporting"]),
+            required_features: curated_features(&["cpu", "inference", "kernels"]),
+            optional_features: curated_features(&["tokenizers", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Deterministic CPU-only unit path with explicit kernel feature",
         },
@@ -105,13 +111,13 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&[
+            required_features: curated_features(&[
                 "inference",
                 "kernels",
                 "tokenizers",
                 "quantization",
             ]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting"]),
+            optional_features: curated_features(&["fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "GGUF model loading and quantization format integration (I2_S, QK256, TL1/TL2)",
         },
@@ -120,8 +126,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Performance,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["cpu", "gpu", "cuda", "reporting"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["cpu", "gpu", "cuda", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Local backend selection and kernel dispatch benchmarks",
         },
@@ -130,8 +136,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "kernels", "tokenizers"]),
-            optional_features: feature_set_from_names(&["reporting", "trace"]),
+            required_features: curated_features(&["inference", "kernels", "tokenizers"]),
+            optional_features: curated_features(&["reporting", "trace"]),
             forbidden_features: FeatureSet::new(),
             intent: "Sampling strategy development and greedy/top-p/top-k path exercising",
         },
@@ -140,8 +146,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Smoke path for receipt generation and schema v1.0.0 validation",
         },
@@ -152,8 +158,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference", "server", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "server", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Server health-check path (/health endpoint returns 200)",
         },
@@ -163,8 +169,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "tokenizers", "cli"]),
-            optional_features: feature_set_from_names(&["kernels", "reporting"]),
+            required_features: curated_features(&["inference", "tokenizers", "cli"]),
+            optional_features: curated_features(&["kernels", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Prompt-template auto-detection selects instruct for base models",
         },
@@ -174,8 +180,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["inference", "tokenizers"]),
-            optional_features: feature_set_from_names(&["fixtures", "reporting"]),
+            required_features: curated_features(&["inference", "tokenizers"]),
+            optional_features: curated_features(&["fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Tokenizer encode/decode round-trip preserves original token sequence",
         },
@@ -185,8 +191,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "reporting"]),
-            optional_features: feature_set_from_names(&["kernels", "tokenizers"]),
+            required_features: curated_features(&["inference", "reporting"]),
+            optional_features: curated_features(&["kernels", "tokenizers"]),
             forbidden_features: FeatureSet::new(),
             intent: "Receipt JSON validates against schema v1.0.0 with all required gates",
         },
@@ -197,7 +203,7 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::Ci,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
+            required_features: curated_features(&["inference", "kernels"]),
             optional_features: FeatureSet::new(),
             forbidden_features: FeatureSet::new(),
             intent: "Deterministic seed produces identical output across repeated runs",
@@ -209,9 +215,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Smoke,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["cpu", "inference"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["gpu", "cuda"]),
+            required_features: curated_features(&["cpu", "inference"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["gpu", "cuda"]),
             intent: "Device probe detects CPU features and reports available SIMD capabilities",
         },
         // Feature: logits — Scenario: "pure logits transforms pass numerical precision checks"
@@ -221,8 +227,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Integration,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "inference", "kernels"]),
-            optional_features: feature_set_from_names(&["reporting"]),
+            required_features: curated_features(&["cpu", "inference", "kernels"]),
+            optional_features: curated_features(&["reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Pure logits transforms (temperature, top-k, top-p) pass numerical precision checks",
         },
@@ -233,8 +239,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Debug,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference"]),
-            optional_features: feature_set_from_names(&["trace", "reporting"]),
+            required_features: curated_features(&["inference"]),
+            optional_features: curated_features(&["trace", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Generation stopping criteria (max-tokens, stop-id, stop-string) fire deterministically",
         },
@@ -246,8 +252,8 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::CrossValidation,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["inference", "kernels"]),
-            optional_features: feature_set_from_names(&["crossval", "fixtures", "reporting"]),
+            required_features: curated_features(&["inference", "kernels"]),
+            optional_features: curated_features(&["crossval", "fixtures", "reporting"]),
             forbidden_features: FeatureSet::new(),
             intent: "Engine-core session contracts match C++ reference for all decode-step invariants",
         },
@@ -258,9 +264,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::EndToEnd,
             environment: ExecutionEnvironment::Local,
-            required_features: feature_set_from_names(&["cpu", "metal"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "metal"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Metal backend feature gate compiles without errors (compile-only check)",
         },
         // Feature: vulkan — Scenario: "Vulkan backend compiles and probes availability"
@@ -269,9 +275,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Minimal,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "vulkan"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "vulkan"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Vulkan backend feature gate compiles and probe reports compiled=true",
         },
         // Feature: oneapi — Scenario: "Intel oneAPI backend compiles without errors"
@@ -280,9 +286,9 @@ fn build_curated_rows() -> Box<[BddCell]> {
         BddCell {
             scenario: TestingScenario::Development,
             environment: ExecutionEnvironment::PreProduction,
-            required_features: feature_set_from_names(&["cpu", "oneapi"]),
-            optional_features: feature_set_from_names(&["reporting"]),
-            forbidden_features: feature_set_from_names(&["cuda"]),
+            required_features: curated_features(&["cpu", "oneapi"]),
+            optional_features: curated_features(&["reporting"]),
+            forbidden_features: curated_features(&["cuda"]),
             intent: "Intel oneAPI backend feature gate compiles without errors (compile-only check)",
         },
     ]
@@ -304,7 +310,7 @@ mod tests {
         let cell = grid.find(TestingScenario::Unit, ExecutionEnvironment::Local);
         assert!(cell.is_some());
 
-        let active = feature_set_from_names(&["inference", "kernels", "tokenizers"]);
+        let active = curated_features(&["inference", "kernels", "tokenizers"]);
         let cell = cell.unwrap_or_else(|| panic!("unit/local row exists in curated grid"));
         assert!(cell.supports(&active));
         assert!(cell.violations(&active).0.is_empty());

--- a/crates/bitnet-bdd-grid/tests/grid_tests.rs
+++ b/crates/bitnet-bdd-grid/tests/grid_tests.rs
@@ -5,7 +5,7 @@
 
 use bitnet_bdd_grid::{
     BitnetFeature, ExecutionEnvironment, FeatureSet, TestingScenario, curated,
-    feature_set_from_names,
+    feature_set_from_names, try_feature_set_from_names,
 };
 
 // ── 1. Structural invariants ─────────────────────────────────────────────────
@@ -326,6 +326,12 @@ fn feature_set_from_names_silently_ignores_unknown_names() {
     assert!(set.contains(BitnetFeature::Kernels));
     // The unknown name must not be there (and no panic)
     assert_eq!(set.labels().len(), 2, "Unknown feature name should be silently dropped");
+}
+
+#[test]
+fn try_feature_set_from_names_rejects_unknown_names() {
+    let result = try_feature_set_from_names(&["inference", "not-a-real-feature", "kernels"]);
+    assert_eq!(result, Err(vec!["not-a-real-feature".to_string()]));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- normalize BDD scenario, environment, and feature labels by trimming and accepting underscore/space aliases
- add strict FeatureSet parsing for curated grid construction while preserving permissive runtime parsing
- wire curated BDD rows through the strict helper so policy typos fail fast

## Validation
- cargo fmt --check -p bitnet-bdd-grid-core -p bitnet-bdd-grid
- cargo test -p bitnet-bdd-grid-core
- cargo test -p bitnet-bdd-grid
- git diff --check

Supersedes #3562, #3564, #3565, #3567, #3568, #3570, #3573, and #3575 with a narrow current-main patch. Leaves #3574 separate because current curated-grid invariants require unique scenario/environment pairs.