### PR TITLE
ci(coverage): raise workflow timeout budget

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary
- raises the Code Coverage job timeout from 40 to 60 minutes
- keeps the change scoped to the timeout budget on current main

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/coverage.yml")'
- git diff --check

Supersedes #3450, whose branch also carries stale unrelated workflow and repository changes.