### PR TITLE
ci(coverage): harden workflow triggers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/coverage.yml'
+      - 'codecov.yml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches: [ main ]
@@ -20,6 +21,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/coverage.yml'
+      - 'codecov.yml'
   workflow_dispatch:
 
 concurrency:
@@ -38,11 +40,12 @@ jobs:
       contents: read
       packages: read
 
-    # PRs: only run when explicitly labeled "coverage"
+    # PRs: only run when explicitly labeled "coverage" or "full-ci"
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'coverage')
+      contains(github.event.pull_request.labels.*.name, 'coverage') ||
+      contains(github.event.pull_request.labels.*.name, 'full-ci')
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
## Summary
- run the coverage workflow when `codecov.yml` changes
- allow the documented `full-ci` label to trigger coverage PR runs alongside `coverage`

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/coverage.yml")'
- git diff --check

Supersedes the still-relevant trigger pieces of #3887/#3876 on current main; the upload hardening and quiet Codecov configuration are already present.