### PR TITLE
test(answer): record child failure diagnostics

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -291,32 +291,33 @@ impl AnswerCorpusCommand {
         let run =
             run_child_with_timeout(exe, &args, &child_env, Duration::from_secs(timeout_seconds))?;
         if run.timed_out {
-            return Ok(json!({
-                "id": case.id,
-                "question": case.question,
-                "status": "timeout",
-                "timeout_seconds": timeout_seconds,
-                "run_receipt_path": case_receipt.display().to_string(),
-                "quality": {
-                    "passed": false,
-                    "failed_rules": ["timeout"],
-                },
-                "stderr_tail": tail_string(&run.stderr, 4096),
+            return Ok(child_failure_row(ChildFailureRowInput {
+                case,
+                status: "timeout",
+                failed_rule: "timeout",
+                exe,
+                args: &args,
+                child_env: &child_env,
+                run: &run,
+                case_receipt: &case_receipt,
+                device,
+                timeout_seconds,
+                cpu_kernel: self.cpu_kernel,
             }));
         }
         if !run.success {
-            return Ok(json!({
-                "id": case.id,
-                "question": case.question,
-                "status": "command_failed",
-                "exit_code": run.exit_code,
-                "run_receipt_path": case_receipt.display().to_string(),
-                "quality": {
-                    "passed": false,
-                    "failed_rules": ["command_failed"],
-                },
-                "stdout_tail": tail_string(&run.stdout, 4096),
-                "stderr_tail": tail_string(&run.stderr, 4096),
+            return Ok(child_failure_row(ChildFailureRowInput {
+                case,
+                status: "command_failed",
+                failed_rule: "command_failed",
+                exe,
+                args: &args,
+                child_env: &child_env,
+                run: &run,
+                case_receipt: &case_receipt,
+                device,
+                timeout_seconds,
+                cpu_kernel: self.cpu_kernel,
             }));
         }
 
@@ -537,7 +538,7 @@ fn normalize_answer_corpus_device(device: &str) -> String {
 fn answer_corpus_artifact_kind(device: &str, corpus_artifact_kind: &str) -> &'static str {
     match (device, corpus_artifact_kind) {
         ("apple-m4-cpu-neon", _) => "bitnet_apple_m4_local_answer_corpus",
-        ("cuda" | RTX_5070_TI_CUDA, _) => "bitnet_cuda_answer_corpus",
+        ("cuda" | RTX_5070_TI_CUDA, _) => "bitnet_cuda_answer_diagnostic_corpus",
         (_, "slm_answer_corpus") => "slm_cpu_answer_corpus",
         _ => "bitnet_cpu_answer_corpus",
     }
@@ -788,14 +789,120 @@ struct ChildRun {
     stderr: String,
 }
 
+struct ChildFailureRowInput<'a> {
+    case: &'a AnswerCase,
+    status: &'static str,
+    failed_rule: &'static str,
+    exe: &'a Path,
+    args: &'a [OsString],
+    child_env: &'a [(&'static str, &'static str)],
+    run: &'a ChildRun,
+    case_receipt: &'a Path,
+    device: &'a str,
+    timeout_seconds: u64,
+    cpu_kernel: Option<AnswerCpuKernel>,
+}
+
+fn child_failure_row(input: ChildFailureRowInput<'_>) -> Value {
+    json!({
+        "id": input.case.id,
+        "question": input.case.question,
+        "status": input.status,
+        "exit_code": input.run.exit_code,
+        "timeout_seconds": input.timeout_seconds,
+        "run_receipt_path": input.case_receipt.display().to_string(),
+        "quality": {
+            "passed": false,
+            "failed_rules": [input.failed_rule],
+        },
+        "backend": {
+            "requested_backend": input.device,
+            "selected_backend": input.device,
+            "runtime_api": answer_corpus_runtime_api(input.device),
+            "fallback_used": false,
+            "source": "answer_corpus_launcher",
+        },
+        "kernel": {
+            "requested_cpu_kernel": input.cpu_kernel.map(AnswerCpuKernel::as_str),
+            "selected_kernel": Value::Null,
+            "family": Value::Null,
+            "source": "missing_child_receipt",
+        },
+        "child_invocation": {
+            "executable": input.exe.display().to_string(),
+            "args": os_args_json(input.args),
+            "environment_overrides": child_environment_json(input.child_env),
+            "timeout_seconds": input.timeout_seconds,
+            "expected_receipt_path": input.case_receipt.display().to_string(),
+        },
+        "child_process": {
+            "success": input.run.success,
+            "timed_out": input.run.timed_out,
+            "exit_code": input.run.exit_code,
+            "exit_code_hex": input.run.exit_code.map(exit_code_hex),
+            "crash_class": classify_child_exit(input.run),
+            "receipt_observed": input.case_receipt.exists(),
+        },
+        "stdout_tail": tail_string(&input.run.stdout, 4096),
+        "stderr_tail": tail_string(&input.run.stderr, 4096),
+    })
+}
+
+fn os_args_json(args: &[OsString]) -> Value {
+    Value::Array(args.iter().map(|arg| Value::String(arg.to_string_lossy().into_owned())).collect())
+}
+
+fn child_environment_json(child_env: &[(&'static str, &'static str)]) -> Value {
+    let mut env = serde_json::Map::new();
+    for (key, value) in child_env {
+        env.insert((*key).to_string(), Value::String((*value).to_string()));
+    }
+    env.insert("RUST_LOG".to_string(), Value::String(child_rust_log_value()));
+    Value::Object(env)
+}
+
+fn classify_child_exit(run: &ChildRun) -> &'static str {
+    if run.timed_out {
+        return "timeout";
+    }
+    match run.exit_code {
+        None => "terminated_without_exit_code",
+        Some(0) if run.success => "success",
+        Some(code) if is_windows_native_status(code) => classify_windows_status(code),
+        Some(_) => "nonzero_exit",
+    }
+}
+
+fn is_windows_native_status(code: i32) -> bool {
+    (code as u32) & 0xC000_0000 == 0xC000_0000
+}
+
+fn classify_windows_status(code: i32) -> &'static str {
+    match code as u32 {
+        0xC000_0005 => "windows_access_violation",
+        0xC000_001D => "windows_illegal_instruction",
+        0xC000_00FD => "windows_stack_overflow",
+        0xC000_0374 => "windows_heap_corruption",
+        0xC000_0409 => "windows_stack_buffer_overrun_or_fast_fail",
+        _ => "windows_native_status",
+    }
+}
+
+fn exit_code_hex(code: i32) -> String {
+    format!("0x{:08X}", code as u32)
+}
+
+fn child_rust_log_value() -> String {
+    std::env::var("BITNET_ANSWER_CORPUS_CHILD_RUST_LOG").unwrap_or_else(|_| "warn".into())
+}
+
 fn run_child_with_timeout(
     exe: &Path,
     args: &[OsString],
     envs: &[(&'static str, &'static str)],
     timeout: Duration,
 ) -> Result<ChildRun> {
-    let child_rust_log =
-        std::env::var("BITNET_ANSWER_CORPUS_CHILD_RUST_LOG").unwrap_or_else(|_| "warn".into());
+    let child_rust_log = child_rust_log_value();
     let stdout_path = child_capture_path("stdout");
     let stderr_path = child_capture_path("stderr");
     let stdout_file = File::create(&stdout_path)
@@ -1012,6 +1119,98 @@ mod tests {
         assert_eq!(prefill["prompt_token_count"], 7);
         assert_eq!(prefill["decode_start_position"], 7);
         assert_eq!(prefill["source"], "run_receipt_profile");
+    }
+
+    #[test]
+    fn child_failure_row_records_cuda_crash_diagnostics() {
+        let case = AnswerCase {
+            id: "math_2_plus_2".to_string(),
+            question: "What is 2+2? Answer with only the number.".to_string(),
+            max_new_tokens: Some(4),
+            timeout_seconds: None,
+            min_generated_tokens: None,
+            min_distinct_generated_tokens: None,
+            gate: gate("exact_trimmed"),
+        };
+        let run = ChildRun {
+            success: false,
+            timed_out: false,
+            exit_code: Some(-1_073_740_791),
+            stdout: "selected_backend=nvidia-rtx-5070-ti-cuda".to_string(),
+            stderr: "child terminated before receipt".to_string(),
+        };
+        let args = vec![
+            "--device".into(),
+            RTX_5070_TI_CUDA.into(),
+            "run".into(),
+            "--json-out".into(),
+            "target/bitnet/receipts/math.json".into(),
+        ];
+        let row = child_failure_row(ChildFailureRowInput {
+            case: &case,
+            status: "command_failed",
+            failed_rule: "command_failed",
+            exe: Path::new("bitnet.exe"),
+            args: &args,
+            child_env: &[],
+            run: &run,
+            case_receipt: Path::new("target/bitnet/receipts/math.json"),
+            device: RTX_5070_TI_CUDA,
+            timeout_seconds: 120,
+            cpu_kernel: None,
+        });
+
+        assert_eq!(row["status"], "command_failed");
+        assert_eq!(row["backend"]["runtime_api"], "cuda");
+        assert_eq!(row["child_process"]["exit_code_hex"], "0xC0000409");
+        assert_eq!(
+            row["child_process"]["crash_class"],
+            "windows_stack_buffer_overrun_or_fast_fail"
+        );
+        assert_eq!(row["child_process"]["receipt_observed"], false);
+        assert_eq!(row["child_invocation"]["timeout_seconds"], 120);
+        assert_eq!(row["quality"]["failed_rules"], json!(["command_failed"]));
+    }
+
+    #[test]
+    fn child_failure_row_records_requested_cpu_kernel_env() {
+        let case = AnswerCase {
+            id: "math_2_plus_2".to_string(),
+            question: "What is 2+2? Answer with only the number.".to_string(),
+            max_new_tokens: Some(4),
+            timeout_seconds: None,
+            min_generated_tokens: None,
+            min_distinct_generated_tokens: None,
+            gate: gate("exact_trimmed"),
+        };
+        let run = ChildRun {
+            success: false,
+            timed_out: true,
+            exit_code: None,
+            stdout: String::new(),
+            stderr: "timeout".to_string(),
+        };
+        let env = AnswerCpuKernel::Avx512.child_env();
+        let args = vec!["--device".into(), "cpu".into(), "run".into()];
+        let row = child_failure_row(ChildFailureRowInput {
+            case: &case,
+            status: "timeout",
+            failed_rule: "timeout",
+            exe: Path::new("bitnet.exe"),
+            args: &args,
+            child_env: &env,
+            run: &run,
+            case_receipt: Path::new("target/bitnet/receipts/math.json"),
+            device: "cpu",
+            timeout_seconds: 1,
+            cpu_kernel: Some(AnswerCpuKernel::Avx512),
+        });
+
+        assert_eq!(row["status"], "timeout");
+        assert_eq!(row["child_process"]["crash_class"], "timeout");
+        assert_eq!(row["kernel"]["requested_cpu_kernel"], "avx512");
+        assert_eq!(row["child_invocation"]["environment_overrides"]["BITNET_CPU_KERNEL"], "avx512");
+        assert_eq!(row["child_invocation"]["environment_overrides"]["BITNET_FORCE_SCALAR"], "0");
     }
 
     #[test]

--- a/crates/bitnet-cli/src/commands/answer_parity.rs
+++ b/crates/bitnet-cli/src/commands/answer_parity.rs
@@ -352,6 +352,7 @@ fn answer_corpus_artifact_kind_allowed(kind: Option<&str>) -> bool {
         Some(
             "bitnet_cpu_answer_corpus"
                 | "bitnet_cuda_answer_corpus"
+                | "bitnet_cuda_answer_diagnostic_corpus"
                 | "bitnet_apple_m4_local_answer_corpus"
         )
     )
@@ -442,6 +443,17 @@ fn compare_case(
 
     let mut failures = Vec::new();
     if !case_has_execution_evidence(left) || !case_has_execution_evidence(right) {
+        set_first(
+            first_divergence,
+            id,
+            "execution_evidence_recorded",
+            None,
+            case_status_summary(left),
+            case_status_summary(right),
+            left_label,
+            right_label,
+            legacy_scalar_avx2,
+        );
         check_equal(
             id,
             "question",
@@ -479,17 +491,6 @@ fn compare_case(
             first_divergence,
         );
         failures.push("execution_evidence_recorded");
-        set_first(
-            first_divergence,
-            id,
-            "execution_evidence_recorded",
-            None,
-            case_status_summary(left),
-            case_status_summary(right),
-            left_label,
-            right_label,
-            legacy_scalar_avx2,
-        );
         return case_comparison_row(
             id,
             failures,
@@ -963,6 +964,11 @@ fn case_status_summary(case: &Value) -> Value {
         "quality_failed_rules": case["quality"]["failed_rules"],
         "run_receipt_path": case["run_receipt_path"],
         "exit_code": case["exit_code"],
+        "child_process": case["child_process"],
+        "child_invocation": {
+            "expected_receipt_path": case["child_invocation"]["expected_receipt_path"],
+            "timeout_seconds": case["child_invocation"]["timeout_seconds"],
+        },
         "reason": case["reason"],
     })
 }
@@ -1086,7 +1092,7 @@ mod tests {
 
     fn cuda_receipt(generated: &[u64], answer: &str, logits: Value) -> Value {
         let mut receipt = receipt("qk256_gemv_cuda", generated, answer, logits);
-        receipt["artifact_kind"] = json!("bitnet_cuda_answer_corpus");
+        receipt["artifact_kind"] = json!("bitnet_cuda_answer_diagnostic_corpus");
         receipt["backend"] = json!({
             "requested_backend": "nvidia-rtx-5070-ti-cuda",
             "selected_backend": "nvidia-rtx-5070-ti-cuda",
@@ -1274,5 +1280,46 @@ mod tests {
         assert!(failed.iter().any(|rule| rule == "execution_evidence_recorded"));
         assert!(!failed.iter().any(|rule| rule == "left_backend_contract"));
         assert!(!failed.iter().any(|rule| rule == "right_backend_contract"));
+    }
+
+    #[test]
+    fn generic_parity_prioritizes_missing_child_receipt_over_status_difference() {
+        let scalar = receipt("i2_s-scalar-reference", &[4], "4", logits());
+        let mut cuda = cuda_receipt(&[4], "4", logits());
+        cuda["cases"][0] = json!({
+            "id": "math",
+            "question": "Answer with a single digit: 2+2=",
+            "status": "command_failed",
+            "exit_code": -1_073_740_791,
+            "run_receipt_path": "target/bitnet/receipts/math.json",
+            "quality": {
+                "passed": false,
+                "failed_rules": ["command_failed"]
+            },
+            "child_process": {
+                "success": false,
+                "timed_out": false,
+                "exit_code": -1_073_740_791,
+                "exit_code_hex": "0xC0000409",
+                "crash_class": "windows_stack_buffer_overrun_or_fast_fail",
+                "receipt_observed": false
+            },
+            "child_invocation": {
+                "expected_receipt_path": "target/bitnet/receipts/math.json",
+                "timeout_seconds": 120
+            }
+        });
+
+        let report = build_generic_report(&scalar, &cuda);
+
+        assert_eq!(report["summary"]["failed"], 1);
+        assert_eq!(report["summary"]["first_divergence"]["kind"], "execution_evidence_recorded");
+        assert_eq!(
+            report["summary"]["first_divergence"]["right"]["child_process"]["crash_class"],
+            "windows_stack_buffer_overrun_or_fast_fail"
+        );
+        let failed = report["cases"][0]["failed_rules"].as_array().unwrap();
+        assert!(failed.iter().any(|rule| rule == "status"));
+        assert!(failed.iter().any(|rule| rule == "execution_evidence_recorded"));
     }
 }

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -595,7 +595,7 @@ fn answer_corpus_dry_run_accepts_rtx5070ti_cuda_lane() {
 
     let receipt: serde_json::Value =
         serde_json::from_slice(&std::fs::read(out).expect("read receipt")).expect("json receipt");
-    assert_eq!(receipt["artifact_kind"], "bitnet_cuda_answer_corpus");
+    assert_eq!(receipt["artifact_kind"], "bitnet_cuda_answer_diagnostic_corpus");
     assert_eq!(receipt["backend"]["requested_backend"], "nvidia-rtx-5070-ti-cuda");
     assert_eq!(receipt["backend"]["selected_backend"], "nvidia-rtx-5070-ti-cuda");
     assert_eq!(receipt["backend"]["runtime_api"], "cuda");


### PR DESCRIPTION
## Summary
- enrich answer-corpus `command_failed` and timeout rows with structured `child_process` and `child_invocation` diagnostics
- classify Windows native child exits, including the observed CUDA child `0xC0000409` fast-fail/status case
- rename new CUDA answer-corpus output to `bitnet_cuda_answer_diagnostic_corpus` while keeping the parity comparator backward-compatible with existing `bitnet_cuda_answer_corpus` receipts
- carry child-process summary into generic answer-parity first-divergence evidence

## Boundaries
- diagnostic-only receipt/CLI observability change
- no CUDA kernel, QK256 dispatch, transformer math, loader, tokenizer, server, artifact, or speed-claim changes
- does not claim answer readiness; failed child runs remain failed evidence

## Validation
- `cargo fmt -p bitnet-cli -- --check`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_corpus::tests -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet commands::answer_parity::tests -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli`
- `git diff --check`

## Result
This makes CUDA answer-corpus failures receipt-grade even when the child exits before writing its own run receipt. The current known CUDA child failure can now be represented as missing child execution evidence with a Windows native crash class instead of looking like a kernel/logit divergence.