### PR TITLE
docs(model): MODEL-ARTIFACT-005 split artifact authority dimensions

### DIFF
--- a/ci/model-artifacts/artifact-manifest.toml
+++ b/ci/model-artifacts/artifact-manifest.toml
@@ -1,6 +1,6 @@
-schema = 1
+schema = 2
 artifact_kind = "model_answer_artifact_manifest"
-updated = "2026-05-07"
+updated = "2026-05-08"
 
 [gate]
 doc = "docs/model-artifacts/ANSWER_ARTIFACT_GATE.md"
@@ -9,10 +9,49 @@ candidate_artifacts = "ci/model-artifacts/candidate-artifacts.toml"
 rejected_artifacts = "ci/model-artifacts/rejected-artifacts.toml"
 reference_runner_compatibility_report = "docs/reports/MODEL_ARTIFACT_003_REFERENCE_RUNNER_COMPAT.md"
 intended_runner_report = "docs/reports/MODEL_ARTIFACT_004_IKLLAMA_INTENDED_RUNNER.md"
+authority_dimensions_report = "docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md"
 reference_runner_coherent_output_required = true
 sha256_required = true
 tokenizer_metadata_required = true
 pretokenizer_metadata_required = true
+
+# Authority dimension schema added in MODEL-ARTIFACT-005.
+# Each artifact record must carry these fields.
+[gate.authority_dimensions]
+answer_readiness_scope_values = [
+  "official_target",
+  "alternate_quant_control",
+  "diagnostic_only",
+]
+target_alignment_values = [
+  "official_i2s_cuda_target",
+  "official_derived_alt_quant",
+  "unrelated",
+]
+runner_authority_values = [
+  "stock_llama_cpp",
+  "ik_llama_cpp",
+  "microsoft_bitnet",
+  "unknown",
+]
+tokenizer_authority_values = [
+  "present",
+  "missing",
+  "defaulted",
+  "externally_supplied",
+]
+pretokenizer_authority_values = [
+  "present",
+  "missing",
+  "defaulted",
+  "externally_supplied",
+]
+prompt_suite_result_values = [
+  "passed",
+  "failed",
+  "blocked",
+  "not_run",
+]
 
 states = [
   "unknown",
@@ -29,7 +68,7 @@ structural_validity_is_not_answer_readiness = true
 backend_execution_is_not_answer_readiness = true
 speedup_requires_answer_ready_artifact = true
 answer_ready_artifact_available = false
-current_blocker = "MODEL-ARTIFACT-002 did not find a BitNet GGUF/tokenizer artifact that passes the full shared answer gate. MODEL-ARTIFACT-003 records that latest stock llama.cpp cannot load the official I2_S or tdh111 IQ2_BN_R4 candidates before prompt execution. MODEL-ARTIFACT-004 records that tdh111 IQ2_BN_R4 passes the tiny prompt suite under its intended ik_llama.cpp runner but is still not answer_ready because pre-tokenizer authority is missing and it does not unblock the official Microsoft I2_S CUDA target; the official Microsoft I2_S artifact still fails the prompt suite under ik_llama.cpp."
+current_blocker = "Official Microsoft I2_S is structurally valid but fails the prompt suite under both stock llama.cpp and ik_llama.cpp; missing pre-tokenizer authority is the concrete blocker. tdh111 IQ2_BN_R4 passes the tiny prompt suite under its intended ik_llama.cpp runner but is an alternate-quant control artifact, not the official I2_S CUDA target, and also lacks pre-tokenizer authority. MODEL-ARTIFACT-006 (tokenizer/pre-tokenizer authority audit) is the next unblocker."
 
 allowed_before_answer_ready = [
   "structural GGUF validity",
@@ -66,3 +105,12 @@ tokenizer_authority = "missing_pretokenizer_authority"
 reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "Structurally valid GGUF, but missing tokenizer pre-tokenizer authority and failing reference prompt-suite output quality."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "official_target"
+target_alignment = "official_i2s_cuda_target"
+runner_authority = "ik_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false

--- a/ci/model-artifacts/candidate-artifacts.toml
+++ b/ci/model-artifacts/candidate-artifacts.toml
@@ -1,8 +1,8 @@
-schema = 1
+schema = 2
 artifact_kind = "model_answer_candidate_artifacts"
 campaign = "model-artifacts"
 work_item = "MODEL-ARTIFACT-002"
-updated = "2026-05-07"
+updated = "2026-05-08"
 
 [search]
 status = "blocked"
@@ -13,6 +13,7 @@ legacy_search_report = "docs/reports/M4_QA_MODEL_002_ARTIFACT_SEARCH.md"
 shared_search_report = "docs/reports/MODEL_ARTIFACT_002_REFERENCE_GOOD_SEARCH.md"
 reference_runner_compatibility_report = "docs/reports/MODEL_ARTIFACT_003_REFERENCE_RUNNER_COMPAT.md"
 intended_runner_report = "docs/reports/MODEL_ARTIFACT_004_IKLLAMA_INTENDED_RUNNER.md"
+authority_dimensions_report = "docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md"
 claim_boundary = "All candidates below are diagnostic-only until a later artifact passes the shared answer artifact gate."
 
 [local_environment]
@@ -69,6 +70,15 @@ notes = [
 intended_runner = "ik_llama.cpp llama-cli"
 intended_runner_version = "1 (9a26522), commit 9a26522af234f8db079ae3735f35ab6c20fe2c66"
 intended_runner_prompt_suite = "failed"
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "official_target"
+target_alignment = "official_i2s_cuda_target"
+runner_authority = "ik_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "jpacifico_aramis_2b_i2s"
@@ -87,6 +97,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "Published artifact and a local tokenizer.ggml.pre metadata repair both produced non-coherent reference output.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "richarderkhov_bitnet_b158_large_q8_0"
@@ -105,6 +124,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "France and Rust continuations were plausible, but the math gate repeated the prompt instead of answering with 4 or four.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "imi2_bitnet_b158_large_instruct_tq2_0"
@@ -123,6 +151,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "France and Rust continuations were plausible, but the math gate answered incoherently.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "bosco_bessie_bitnet_instruct_100k_published"
@@ -141,6 +178,15 @@ status = "rejected_reference_runner_failed"
 notes = [
   "The local reference runner aborted while loading the published GGUF with a tensor dimension assertion.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "blocked"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "greensky_bitnet_b158_3b_q2_q1"
@@ -159,6 +205,15 @@ status = "rejected_reference_runner_failed"
 notes = [
   "Published checksums matched, but the reference loader reported tensor data outside file bounds.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "blocked"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "larenspear_bitnet_b158_large_q4_k_m"
@@ -177,6 +232,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "Raw, instruct, and LLaMA-3 chat prompt shapes all failed the math gate; LLaMA-3 chat also failed France.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "bifrost_sol_2b_i2s"
@@ -195,6 +259,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "Loads with a missing pre-tokenizer warning, but raw and LLaMA-3 chat prompt shapes failed all gates.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "bosco_bitnet_instruct_100k_regenerated_q8_0"
@@ -213,6 +286,15 @@ status = "rejected_prompt_suite_failed"
 notes = [
   "Local regeneration fixed loader compatibility enough to run, but raw, instruct, and Human:/BITNETAssistant: prompt shapes all produced non-coherent output.",
 ]
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "present"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[candidate]]
 id = "tdh111_bitnet_b158_2b_4t_iq2_bn_r4"
@@ -242,3 +324,12 @@ stock_reference_runner = "stock llama.cpp b9061 llama-completion"
 stock_reference_runner_version = "9061 (deab41ec6)"
 stock_reference_runner_result = "rejected_reference_runner_failed"
 stock_reference_runner_error = "gguf_init_from_file_ptr: tensor 'blk.0.ffn_down.weight' has invalid ggml type 335. should be in [0, 42)"
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "alternate_quant_control"
+target_alignment = "official_derived_alt_quant"
+runner_authority = "ik_llama_cpp"
+tokenizer_authority_dim = "present"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "passed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = true

--- a/ci/model-artifacts/rejected-artifacts.toml
+++ b/ci/model-artifacts/rejected-artifacts.toml
@@ -1,6 +1,6 @@
-schema = 1
+schema = 2
 artifact_kind = "model_answer_rejected_artifacts"
-updated = "2026-05-07"
+updated = "2026-05-08"
 
 [[artifact]]
 id = "microsoft_bitnet_b158_2b_4t_gguf_i2s_current"
@@ -28,6 +28,15 @@ intended_runner_version = "1 (9a26522), commit 9a26522af234f8db079ae3735f35ab6c2
 intended_runner_result = "failed_prompt_suite"
 intended_runner_rejection_reason = "The artifact loads under ik_llama.cpp but emits repeated colon output for every deterministic prompt-suite row."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "official_target"
+target_alignment = "official_i2s_cuda_target"
+runner_authority = "ik_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
   [[artifact.prompt_result]]
   id = "math_sentence"
@@ -65,6 +74,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The published artifact and a local tokenizer.ggml.pre metadata repair both produced non-coherent reference output."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "richarderkhov_bitnet_b158_large_q8_0"
@@ -84,6 +102,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The reference runner produced plausible France and Rust continuations, but the math prompt repeated the prompt instead of answering with 4 or four."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "imi2_bitnet_b158_large_instruct_tq2_0"
@@ -103,6 +130,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The reference runner produced plausible France and Rust continuations, but the math prompt produced '2+2 is the answer to the question' rather than the required answer."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "bosco_bessie_bitnet_instruct_100k_published"
@@ -122,6 +158,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The local reference runner aborts while loading the published GGUF with GGML_ASSERT(n_dims >= 1 && n_dims <= GGML_MAX_DIMS)."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "blocked"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "greensky_bitnet_b158_3b_q2_q1"
@@ -139,6 +184,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "All tested Green-Sky 3B variants match their published checksums, but the reference loader reports tensor data outside file bounds."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "blocked"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "larenspear_bitnet_b158_large_q4_k_m"
@@ -158,6 +212,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The artifact loads, but raw, instruct, and LLaMA-3 chat prompt shapes all fail the math gate; LLaMA-3 chat also fails France."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "bifrost_sol_2b_i2s"
@@ -177,6 +240,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "The artifact loads with a missing pre-tokenizer warning, but raw and LLaMA-3 chat prompt shapes fail all local-answer gates."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "bosco_bitnet_instruct_100k_regenerated_q8_0"
@@ -197,6 +269,15 @@ reference_runner = "llama-cli via local BitNet.cpp checkout"
 legacy_evidence = "ci/quality/apple-m4-local-answer-model-artifacts.toml"
 rejection_reason = "A locally regenerated GGUF loads after conversion fixes, but raw, instruct, and Human:/BITNETAssistant: prompt shapes all produce non-coherent output."
 claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "diagnostic_only"
+target_alignment = "unrelated"
+runner_authority = "stock_llama_cpp"
+tokenizer_authority_dim = "present"
+pretokenizer_authority_dim = "defaulted"
+prompt_suite_result = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
 
 [[artifact]]
 id = "tdh111_bitnet_b158_2b_4t_iq2_bn_r4"
@@ -226,7 +307,16 @@ stock_reference_runner_error = "gguf_init_from_file_ptr: tensor 'blk.0.ffn_down.
 evidence = "docs/reports/MODEL_ARTIFACT_004_IKLLAMA_INTENDED_RUNNER.md"
 prior_evidence = "docs/reports/MODEL_ARTIFACT_003_REFERENCE_RUNNER_COMPAT.md"
 rejection_reason = "The intended ik_llama.cpp runner loads the GGUF and passes the tiny deterministic prompt suite, but the artifact still lacks required pre-tokenizer authority and is an alternate IQ2_BN_R4 artifact rather than the official Microsoft I2_S CUDA target."
-claim_boundary = "May be used for diagnostic-only receipts; must not be used for coherent local-answer claims."
+claim_boundary = "May be used for diagnostic-only receipts and as an alternate-quant control; must not be used for official I2_S CUDA answer claims."
+# Authority dimensions (MODEL-ARTIFACT-005)
+answer_readiness_scope = "alternate_quant_control"
+target_alignment = "official_derived_alt_quant"
+runner_authority = "ik_llama_cpp"
+tokenizer_authority_dim = "present"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result = "passed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = true
 
   [[artifact.prompt_result]]
   id = "math_2_plus_2"

--- a/docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md
+++ b/docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md
@@ -1,0 +1,204 @@
+# MODEL-ARTIFACT-005 Authority Dimensions
+
+**Date:** 2026-05-08
+**Campaign:** `model-artifacts`
+**Status:** manifest refinement only; no artifact is promoted to `answer_ready`; no runtime changes
+
+## Purpose
+
+This report documents the authority-dimension split introduced in MODEL-ARTIFACT-005.
+Prior work items (001–004) used a coarse binary:
+
+```
+answer_ready = true | false
+```
+
+That binary hid important distinctions:
+
+- **Target alignment** — is this artifact the one our CUDA product path is built around?
+- **Runner authority** — which runner is authoritative for this artifact?
+- **Tokenizer authority** — is the tokenizer model present and identified?
+- **Pre-tokenizer authority** — is the pre-tokenizer rule present or only defaulted?
+- **Prompt-suite result** — did the artifact pass the tiny deterministic suite under its intended runner?
+- **Unblock scope** — what, if anything, can this artifact unblock?
+
+MODEL-ARTIFACT-005 adds these dimensions as machine-readable fields on every artifact
+record in `ci/model-artifacts/*.toml` without changing any gate thresholds, runtime
+behavior, or answer-readiness claims.
+
+## Authority Dimension Definitions
+
+| Dimension | Values | Meaning |
+|---|---|---|
+| `answer_readiness_scope` | `official_target` | This is the artifact the official I2_S CUDA lane is built around. |
+| | `alternate_quant_control` | Useful as a control lane; not the official I2_S CUDA target. |
+| | `diagnostic_only` | Diagnostic evidence only; cannot unblock any answer lane. |
+| `target_alignment` | `official_i2s_cuda_target` | The official Microsoft I2_S GGUF for the RTX 5070 Ti CUDA path. |
+| | `official_derived_alt_quant` | Derived from the same base model but in a different quantization. |
+| | `unrelated` | Different architecture, size, or training lineage. |
+| `runner_authority` | `stock_llama_cpp` | Stock llama.cpp; cannot load all BitNet-specific quant types. |
+| | `ik_llama_cpp` | ik_llama.cpp; intended runner for IQ2_BN family artifacts. |
+| | `microsoft_bitnet` | Official Microsoft BitNet reference runner. |
+| | `unknown` | Runner not identified or not tested. |
+| `tokenizer_authority_dim` | `present` | GGUF contains a recognized tokenizer model. |
+| | `missing` | No tokenizer model field or unrecognized value. |
+| `pretokenizer_authority_dim` | `present` | `tokenizer.ggml.pre` is present in the GGUF. |
+| | `missing` | `tokenizer.ggml.pre` is absent; runner used default behavior. |
+| | `defaulted` | A default pre-tokenizer was applied and the artifact still failed. |
+| | `externally_supplied` | Pre-tokenizer authority comes from an external tokenizer.json. |
+| `prompt_suite_result` | `passed` | Tiny deterministic suite passed under intended runner. |
+| | `failed` | One or more suite rows failed. |
+| | `blocked` | Runner could not load the artifact to run the suite. |
+| | `not_run` | Suite not yet executed for this artifact. |
+| `can_unblock_official_i2s_cuda` | `true` / `false` | Whether this artifact can unblock the RTX 5070 Ti I2_S CUDA answer path. |
+| `can_unblock_alt_quant_control` | `true` / `false` | Whether this artifact can serve as an alternate-quant control lane. |
+
+## Current Artifact Decisions
+
+### Official Microsoft I2_S (`ggml-model-i2_s.gguf`)
+
+```toml
+answer_readiness_scope = "official_target"
+target_alignment       = "official_i2s_cuda_target"
+runner_authority       = "ik_llama_cpp"
+tokenizer_authority_dim    = "missing"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result    = "failed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = false
+```
+
+**Evidence:** Loads under ik_llama.cpp (commit 9a26522) with warning
+`load: missing pre-tokenizer type, using: 'default'`, then emits repeated colon
+output (`::::`) for every deterministic prompt-suite row.
+
+**Decision:** Remains `rejected_prompt_suite_failed`. The artifact is structurally
+valid, but pre-tokenizer authority is absent and output is non-coherent. This is
+the exact artifact the RTX 5070 Ti QK256/I2_S CUDA answer path requires. Until it
+passes the prompt suite under a reference runner, the CUDA answer lane remains
+blocked.
+
+**Next action:** MODEL-ARTIFACT-006 (tokenizer/pre-tokenizer authority audit)
+must determine whether an external `tokenizer.json` can supply the missing
+pre-tokenizer authority, or whether artifact regeneration is required.
+
+---
+
+### tdh111 IQ2_BN_R4 (`bitnet1582b4t-iq2_bn_r4.gguf`)
+
+```toml
+answer_readiness_scope = "alternate_quant_control"
+target_alignment       = "official_derived_alt_quant"
+runner_authority       = "ik_llama_cpp"
+tokenizer_authority_dim    = "present"
+pretokenizer_authority_dim = "missing"
+prompt_suite_result    = "passed"
+can_unblock_official_i2s_cuda = false
+can_unblock_alt_quant_control = true
+```
+
+**Evidence:** Under ik_llama.cpp (commit 9a26522), loads and passes the five-row
+deterministic tiny prompt suite:
+
+| Prompt | Expected | Output | Pass |
+|---|---|---|---|
+| `math_2_plus_2` | `4` or starts with `4` | `4` | yes |
+| `capital_france` | mentions Paris | `The capital of France is Paris.` | yes |
+| `yes_no_water` | starts yes/no | `Yes.` | yes |
+| `colors_four` | readable color list | `1. Red 2. Blue 3. Green 4. Yellow` | yes |
+| `bitnet_one_sentence` | readable one sentence | `BitNet is a computer network protocol...` | yes (readability only) |
+
+The runner still reports `load: missing pre-tokenizer type, using: 'default'`.
+
+**Decision:** Remains `rejected_missing_tokenizer_authority` for shared answer
+readiness, but is now explicitly recorded as an `alternate_quant_control` artifact
+that `can_unblock_alt_quant_control = true`.
+
+**What this means:** tdh111 IQ2_BN_R4 is useful evidence that the general ik_llama.cpp
+runner pipeline can produce coherent BitNet-derived answers. It does **not** prove
+that the official Microsoft I2_S artifact works, and it does **not** unblock the RTX
+5070 Ti official I2_S CUDA answer path. The quantization format (IQ2_BN_R4) is
+runner-specific and not the I2_S format targeted by the Rust CUDA kernel path.
+
+**What this does NOT mean:**
+- It does not prove the Rust CPU or CUDA tokenizer is correct.
+- It does not prove the Rust QK256/I2_S kernel path is correct.
+- It does not constitute a speed or quality claim for any hardware lane.
+
+---
+
+### All Other Candidates
+
+All remaining candidates in `ci/model-artifacts/candidate-artifacts.toml` and
+`ci/model-artifacts/rejected-artifacts.toml` are classified as `diagnostic_only`
+with `target_alignment = "unrelated"` and both `can_unblock_*` flags set to
+`false`. Their existing rejection state and rejection reasons are unchanged.
+
+## Why This Split Matters
+
+Before MODEL-ARTIFACT-005, both artifacts were described with `answer_ready = false`.
+That coarse binary obscured two different situations:
+
+1. **Official Microsoft I2_S** — the artifact we *need* to work, under the runner
+   where it *should* work, producing non-coherent output. The blocking dimension is
+   pre-tokenizer authority + prompt-suite failure.
+
+2. **tdh111 IQ2_BN_R4** — a *different quant* of the same model, under its *intended*
+   runner, producing coherent output. Its blocking dimension is only pre-tokenizer
+   authority. If that is resolved, it could provide a useful alternate-quant control
+   lane — but not the official I2_S CUDA lane.
+
+The authority dimensions make these distinctions machine-readable so that:
+- CI and gate tooling can enforce that `can_unblock_official_i2s_cuda = false` for
+  all current artifacts.
+- Future promotion of the official I2_S artifact can be done by flipping
+  `can_unblock_official_i2s_cuda` to `true` and `answer_ready_artifact_available`
+  to `true` — but only after all gate requirements are actually met.
+- The alternate-quant control lane has a defined promotion path separate from the
+  official I2_S CUDA lane.
+
+## Claim Boundary
+
+This report does **not** change any of the following:
+- Gate thresholds for `answer_ready`.
+- State of `answer_ready_artifact_available` (remains `false`).
+- Runtime tokenizer behavior.
+- Model loader behavior.
+- CPU or CUDA kernel behavior.
+- Any backend answer-readiness claim.
+- Any speedup claim.
+
+## Next Unblocker: MODEL-ARTIFACT-006
+
+The concrete next step is a tokenizer/pre-tokenizer authority audit for both key artifacts.
+
+For each artifact, MODEL-ARTIFACT-006 must record:
+- Whether `tokenizer.ggml.pre` is absent in the GGUF or present but not parsed.
+- Whether the Hugging Face repo ships a `tokenizer.json` beside the GGUF.
+- Whether `tokenizer.json` defines the missing pre-tokenizer behavior.
+- Whether ik_llama.cpp uses a default pre-tokenizer that differs from the Rust
+  tokenizer pipeline.
+- Whether a documented compatibility decision can supply `tokenizer.json` as
+  external pre-tokenizer authority without changing the GGUF SHA256.
+
+Deliverables:
+- `ci/model-artifacts/tokenizer-authority.toml` — machine-readable per-artifact
+  tokenizer/pre-tokenizer authority records.
+- `docs/reports/MODEL_ARTIFACT_006_TOKENIZER_AUTHORITY.md` — findings and
+  classification of each artifact.
+
+**MODEL-ARTIFACT-006 does not change runtime behavior.** It only records whether
+a valid authority source exists. If it does, MODEL-ARTIFACT-008 (Path A) can then
+promote the official I2_S artifact with documented external tokenizer authority. If
+it does not, MODEL-ARTIFACT-008B (Path B) initiates artifact regeneration.
+
+## Decision Matrix
+
+| Finding after MODEL-ARTIFACT-006 | Next action |
+|---|---|
+| Official I2_S passes with external tokenizer authority (Path A) | MODEL-ARTIFACT-008: promote official I2_S with external tokenizer authority; run 9950X3D / RTX 5070 Ti parity. |
+| Official I2_S cannot pass under any valid runner (Path B) | MODEL-ARTIFACT-008B: regenerate official-target I2_S GGUF with required metadata; run parity. |
+| tdh111 remains the only coherent candidate (Path C) | MODEL-ARTIFACT-008C: add alternate-quant BitNet answer control lane; do **not** claim official I2_S CUDA readiness. |
+| Rust token IDs differ from reference runner | Fix tokenizer/template authority in a separate tracker item. |
+| Rust token IDs match but logits differ | Fix model math / output head / quantization in a separate tracker item. |
+| CPU passes, CUDA diverges | Fix CUDA/QK256 path in the RTX 5070 Ti lane. |

--- a/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
+++ b/docs/tracking/campaigns/model-artifacts/CAMPAIGN.md
@@ -37,7 +37,8 @@ GGUF that only proves structural validity or backend execution.
 | MODEL-ARTIFACT-001 | merged | Shared answer-artifact gate merged in #3922; the current Microsoft BitNet I2_S GGUF is rejected for coherent local-answer claims. |
 | MODEL-ARTIFACT-002 | blocked | Shared search merged in #3928 and records no `answer_ready` BitNet artifact. Backend local-answer lanes remain blocked or diagnostic-only until a future artifact passes the reference prompt suite. |
 | MODEL-ARTIFACT-003 | merged | PR #3932 records latest stock llama.cpp reference-runner compatibility for official-derived candidates. This is diagnostic-only and does not unblock backend answer claims. |
-| MODEL-ARTIFACT-004 | pr open | PR #3939 records intended `ik_llama.cpp` runner evidence for `tdh111` IQ2_BN_R4 and the official Microsoft I2_S artifact. This is diagnostic-only and does not promote an `answer_ready` artifact. |
+| MODEL-ARTIFACT-004 | merged | PR #3939 (merge SHA `1c06b33`) records intended `ik_llama.cpp` runner evidence for `tdh111` IQ2_BN_R4 and the official Microsoft I2_S artifact. This is diagnostic-only and does not promote an `answer_ready` artifact. |
+| MODEL-ARTIFACT-005 | in_progress | Split artifact authority into explicit machine-readable dimensions: `target_alignment`, `runner_authority`, `tokenizer_authority`, `pretokenizer_authority`, `prompt_suite_result`, `can_unblock_official_i2s_cuda`, `can_unblock_alt_quant_control`. No artifact promoted; no runtime changes. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/model-artifacts/active.toml
+++ b/docs/tracking/campaigns/model-artifacts/active.toml
@@ -160,8 +160,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "MODEL-ARTIFACT-004"
-status = "pr_open"
+status = "merged"
 pr = 3939
+merge_sha = "1c06b3367d7d49b3c44a37dec29bc2d69687bd66"
 branch = "codex/model-artifacts/MODEL-ARTIFACT-004-ikllama-intended-runner"
 stackable = false
 review_mode = "codex_premerge"
@@ -202,6 +203,47 @@ may_claim = [
 must_not_claim = [
   "A shared answer_ready BitNet artifact has been acquired.",
   "tdh111 IQ2_BN_R4 satisfies the official Microsoft I2_S CUDA answer target.",
+  "CPU or CUDA local-answer generation is coherent in Rust.",
+  "Any backend speedup is proven.",
+]
+
+[[work_item]]
+id = "MODEL-ARTIFACT-005"
+status = "ready"
+branch = "claude/untangle-authority-gates-5oPxH"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MODEL-ARTIFACT-004"]
+acceptance = "Split artifact authority into explicit machine-readable dimensions (target_alignment, runner_authority, tokenizer_authority, pretokenizer_authority, prompt_suite_result, can_unblock_official_i2s_cuda, can_unblock_alt_quant_control) across all manifest files. Produce MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md report. Preserve current claim boundary: official I2_S remains rejected, tdh111 remains rejected for official target; no artifact is promoted to answer_ready."
+commands = [
+  "python3 -c \"import tomllib; [tomllib.loads(open(f).read()) for f in ['ci/model-artifacts/artifact-manifest.toml','ci/model-artifacts/candidate-artifacts.toml','ci/model-artifacts/rejected-artifacts.toml']]\"",
+  "cargo run --locked -p xtask --no-default-features -- campaign check model-artifacts",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/model-artifacts/**",
+  "ci/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/model-artifacts/**",
+  "docs/specs/rtx5070ti-cuda-answer-readiness.md",
+]
+forbidden_paths = [
+  "crates/**",
+  "src/**",
+]
+may_claim = [
+  "Artifact authority is now split into target_alignment, runner_authority, tokenizer_authority, pretokenizer_authority, prompt_suite_result, can_unblock_official_i2s_cuda, and can_unblock_alt_quant_control dimensions.",
+  "Official Microsoft I2_S is recorded as official_i2s_cuda_target with prompt_suite_result=failed and can_unblock_official_i2s_cuda=false.",
+  "tdh111 IQ2_BN_R4 is recorded as official_derived_alt_quant with can_unblock_alt_quant_control=true and can_unblock_official_i2s_cuda=false.",
+  "Missing pre-tokenizer authority is the concrete next blocker for both artifacts.",
+]
+must_not_claim = [
+  "Any artifact is answer_ready for the official I2_S CUDA target.",
+  "tdh111 IQ2_BN_R4 unblocks the RTX 5070 Ti official I2_S CUDA answer path.",
   "CPU or CUDA local-answer generation is coherent in Rust.",
   "Any backend speedup is proven.",
 ]

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-07T231841Z-MODEL-ARTIFACT-004-merged.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-07T231841Z-MODEL-ARTIFACT-004-merged.toml
@@ -1,0 +1,18 @@
+timestamp = "2026-05-07T23:18:41Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-004"
+event = "merged"
+actor = "github"
+pr = 3939
+merge_sha = "1c06b3367d7d49b3c44a37dec29bc2d69687bd66"
+previous_status = "pr_open"
+new_status = "merged"
+
+notes = [
+  "PR #3939 merged at 1c06b3367d7d49b3c44a37dec29bc2d69687bd66.",
+  "Records intended ik_llama.cpp runner evidence for tdh111 IQ2_BN_R4 and official Microsoft I2_S.",
+  "tdh111 IQ2_BN_R4 passes the tiny deterministic prompt suite under ik_llama.cpp but remains rejected for answer readiness.",
+  "Official Microsoft I2_S still fails the prompt suite under ik_llama.cpp with repeated colon output.",
+  "No artifact promoted to answer_ready; no runtime changes.",
+  "Pre-tokenizer authority is the identified concrete next blocker.",
+]

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-08T000000Z-MODEL-ARTIFACT-005-ready.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-08T000000Z-MODEL-ARTIFACT-005-ready.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-08T00:00:00Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-005"
+event = "ready"
+actor = "codex"
+previous_status = "none"
+new_status = "ready"
+
+notes = [
+  "MODEL-ARTIFACT-005 unblocked after MODEL-ARTIFACT-004 merged.",
+  "Goal: split artifact authority into explicit machine-readable dimensions.",
+  "New dimensions: target_alignment, runner_authority, tokenizer_authority, pretokenizer_authority, prompt_suite_result, can_unblock_official_i2s_cuda, can_unblock_alt_quant_control.",
+  "Implements the authority-split described in docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md.",
+  "No artifact is promoted to answer_ready; no runtime changes.",
+]

--- a/docs/tracking/campaigns/model-artifacts/events/2026-05-08T000100Z-MODEL-ARTIFACT-005-in-progress.toml
+++ b/docs/tracking/campaigns/model-artifacts/events/2026-05-08T000100Z-MODEL-ARTIFACT-005-in-progress.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-08T00:01:00Z"
+campaign = "model-artifacts"
+item = "MODEL-ARTIFACT-005"
+event = "in_progress"
+actor = "codex"
+branch = "claude/untangle-authority-gates-5oPxH"
+previous_status = "ready"
+new_status = "in_progress"
+
+notes = [
+  "Starting work on MODEL-ARTIFACT-005: split target, runner, and tokenizer authority dimensions.",
+  "Extending ci/model-artifacts/*.toml with explicit authority dimension fields.",
+  "Adding docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md.",
+  "No runtime code changes; docs and manifests only.",
+]

--- a/docs/tracking/campaigns/model-artifacts/generated/status.md
+++ b/docs/tracking/campaigns/model-artifacts/generated/status.md
@@ -12,7 +12,18 @@
 | MODEL-ARTIFACT-001 | merged | #3922 | `codex/model-artifacts/MODEL-ARTIFACT-001-shared-answer-gate-v2` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the shared reference-good answer artifact gate, record artifact states, and list the current Microsoft BitNet I2_S GGUF as rejected for answer-readiness claims without changing runtime behavior. |
 | MODEL-ARTIFACT-002 | blocked | #3928 | `codex/model-artifacts/MODEL-ARTIFACT-002-reference-good-bitnet` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Acquire or regenerate a reference-good BitNet GGUF/tokenizer artifact that passes the deterministic answer prompt suite under a reference runner, records exact SHA256 and tokenizer/pre-tokenizer authority, and can unblock backend answer-readiness lanes. |
 | MODEL-ARTIFACT-003 | merged | #3932 | `codex/model-artifacts/MODEL-ARTIFACT-003-reference-runner-compat` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record reference-runner compatibility evidence for official-derived BitNet GGUF candidates, including the latest stock llama.cpp runner result, without claiming answer readiness or changing runtime behavior. |
-| MODEL-ARTIFACT-004 | pr_open | #3939 | `codex/model-artifacts/MODEL-ARTIFACT-004-ikllama-intended-runner` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record intended ik_llama.cpp runner evidence for official-derived BitNet GGUF candidates, including tdh111 IQ2_BN_R4 prompt-suite output and official Microsoft I2_S prompt-suite output, without promoting an answer_ready artifact or changing runtime behavior. |
+| MODEL-ARTIFACT-004 | merged | #3939 | `codex/model-artifacts/MODEL-ARTIFACT-004-ikllama-intended-runner` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record intended ik_llama.cpp runner evidence for official-derived BitNet GGUF candidates, including tdh111 IQ2_BN_R4 prompt-suite output and official Microsoft I2_S prompt-suite output, without promoting an answer_ready artifact or changing runtime behavior. |
+| MODEL-ARTIFACT-005 | in_progress | — | `claude/untangle-authority-gates-5oPxH` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Split artifact authority into explicit machine-readable dimensions (target_alignment, runner_authority, tokenizer_authority, pretokenizer_authority, prompt_suite_result, can_unblock_official_i2s_cuda, can_unblock_alt_quant_control) across all manifest files. Produce MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md. Preserve claim boundary: official I2_S remains rejected; no artifact promoted to answer_ready. |
+
+## Current Claim Boundary
+
+`answer_ready_artifact_available = false`
+
+Official Microsoft I2_S (`ggml-model-i2_s.gguf`) is the official CUDA target and remains `rejected_prompt_suite_failed`. It loads under ik_llama.cpp but emits non-coherent output. Pre-tokenizer authority is missing.
+
+`tdh111` IQ2_BN_R4 passes the tiny prompt suite under its intended ik_llama.cpp runner. It is recorded as `alternate_quant_control` with `can_unblock_alt_quant_control = true`, but `can_unblock_official_i2s_cuda = false`. It does not satisfy the official I2_S CUDA answer target.
+
+Next unblocker: MODEL-ARTIFACT-006 — tokenizer/pre-tokenizer authority audit.
 
 ## Hard Constraints
 


### PR DESCRIPTION
## Summary

- Marks MODEL-ARTIFACT-004 as merged (PR #3939, merge SHA `1c06b33`) and closes out its `pr_open` tracker state.
- Adds MODEL-ARTIFACT-005 to the campaign tracker as `in_progress`.
- Extends all `ci/model-artifacts/*.toml` manifests with seven new authority-dimension fields on every artifact record:
  - `answer_readiness_scope` — `official_target | alternate_quant_control | diagnostic_only`
  - `target_alignment` — `official_i2s_cuda_target | official_derived_alt_quant | unrelated`
  - `runner_authority` — `stock_llama_cpp | ik_llama_cpp | microsoft_bitnet | unknown`
  - `tokenizer_authority_dim` — `present | missing | defaulted | externally_supplied`
  - `pretokenizer_authority_dim` — `present | missing | defaulted | externally_supplied`
  - `prompt_suite_result` — `passed | failed | blocked | not_run`
  - `can_unblock_official_i2s_cuda` / `can_unblock_alt_quant_control` — `true | false`
- Official Microsoft I2_S records: `official_target`, `prompt_suite_result = failed`, `can_unblock_official_i2s_cuda = false`.
- tdh111 IQ2_BN_R4 records: `alternate_quant_control`, `prompt_suite_result = passed`, `can_unblock_alt_quant_control = true`, `can_unblock_official_i2s_cuda = false`.
- Adds `docs/reports/MODEL_ARTIFACT_005_AUTHORITY_DIMENSIONS.md` with dimension definitions, per-artifact decisions, and the MODEL-ARTIFACT-006 decision matrix.
- Updates `CAMPAIGN.md` and `generated/status.md` dashboards.

## No-change invariants

- `answer_ready_artifact_available = false` — unchanged.
- Official Microsoft I2_S state — remains `rejected_prompt_suite_failed`.
- tdh111 IQ2_BN_R4 state — remains `rejected_missing_tokenizer_authority`.
- No runtime code, tokenizer behavior, model loader behavior, CUDA, or kernel changes.
- No artifact is promoted to `answer_ready`. No speed or quality claims added.

## Test plan

- [ ] All `ci/model-artifacts/*.toml` files parse with `python3 -c "import tomllib; ..."` — validated in CI.
- [ ] `git diff --check` — no trailing whitespace.
- [ ] `cargo run --locked -p xtask --no-default-features -- campaign check model-artifacts` — passes.
- [ ] `cargo run --locked -p xtask --no-default-features -- campaign generate --check` — passes.
- [ ] `cargo run --locked -p xtask --no-default-features -- campaign doctor` — passes.

https://claude.ai/code/session_01Cy1AWAUQ8mpwJJNiNqSwp7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cy1AWAUQ8mpwJJNiNqSwp7)_