### PR TITLE
fix(cli): expose CUDA toolkit DLLs for strict run

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -2816,6 +2816,28 @@ async fn run_simple_generation(
         && backend_identity.selected_backend.as_str() == "nvidia-rtx-5070-ti-cuda"
         && backend_identity.runtime_api.as_str() == "cuda"
         && !backend_identity.fallback_used;
+    if strict_cuda_backend_selected {
+        answer_corpus_child_phase(
+            "cuda_runtime_libraries_start",
+            serde_json::json!({
+                "selected_backend": backend_identity.selected_backend.as_str(),
+                "runtime_api": backend_identity.runtime_api.as_str(),
+            }),
+        );
+        let cuda_bin = ensure_strict_cuda_runtime_libraries_visible()?;
+        answer_corpus_child_phase(
+            "cuda_runtime_libraries_complete",
+            serde_json::json!({
+                "added_cuda_toolkit_bin": cuda_bin.as_ref().map(|path| path.display().to_string()),
+            }),
+        );
+        if let Some(cuda_bin) = cuda_bin {
+            debug!(
+                "added CUDA Toolkit bin directory to process PATH for strict CUDA run: {}",
+                cuda_bin.display()
+            );
+        }
+    }
     let cuda_memory_before_bytes =
         strict_cuda_backend_selected.then(|| nvidia_smi_memory_used_bytes(Some(0))).flatten();
     unsafe {
@@ -4939,7 +4961,7 @@ async fn run_ask_generation(
             "--strict-cpu requires --device cpu; requested backend was {requested_backend_label}"
         );
     }
-    if strict_cuda && let Some(cuda_bin) = ensure_strict_cuda_ask_runtime_libraries_visible()? {
+    if strict_cuda && let Some(cuda_bin) = ensure_strict_cuda_runtime_libraries_visible()? {
         debug!(
             "added CUDA Toolkit bin directory to process PATH for strict CUDA ask: {}",
             cuda_bin.display()
@@ -5152,7 +5174,7 @@ fn validate_strict_cpu_answer_quality(answer_receipt: &serde_json::Value) -> Res
     )
 }
 
-fn ensure_strict_cuda_ask_runtime_libraries_visible() -> Result<Option<std::path::PathBuf>> {
+fn ensure_strict_cuda_runtime_libraries_visible() -> Result<Option<std::path::PathBuf>> {
     #[cfg(all(feature = "cuda", target_os = "windows"))]
     {
         ensure_windows_cuda_toolkit_bin_on_path()


### PR DESCRIPTION
## Summary
- reuse the existing Windows CUDA Toolkit PATH repair for strict CUDA `bitnet run`, not only strict `bitnet ask`
- emit child phase breadcrumbs around CUDA runtime-library discovery in answer-corpus child runs
- preserves strict no-fallback routing and does not touch CUDA kernels, QK256 dispatch, transformer math, loader behavior, tokenizer behavior, or quality gates

## Evidence
Before this change, the local CUDA answer-corpus child reached `weight_upload_start` and failed before a child receipt because NVRTC could not load `nvrtc64_120_0.dll`.

After this change, the same one-prompt diagnostic emitted a normal child receipt:
- selected_backend = `nvidia-rtx-5070-ti-cuda`
- runtime_api = `cuda`
- fallback_used = false
- selected_kernel = `qk256_gemv_cuda`
- prompt_prefill.exercised = true
- quality failed only `gate_exact_trimmed` with generated text `sparkCheap spheresplier`

That moves the current blocker from child execution/NVRTC discovery back to the known answer-quality/artifact gate.

## Validation
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli --bin bitnet cuda_toolkit_bin -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo fmt -p bitnet-cli -- --check
- git diff --check
- local diagnostic: `answer-corpus --device nvidia-rtx-5070-ti-cuda` on `math_2_plus_2` with explicit tokenizer wrote a normal CUDA child receipt and failed only the answer quality gate
