### PR TITLE
feat(cli): align ask prompt receipts with BitNet.cpp authority

### DIFF
--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -150,7 +150,11 @@ impl AnswerCorpusCommand {
         let timed_out = rows.iter().filter(|row| row["status"] == "timeout").count();
         let not_run = rows.iter().filter(|row| row["status"] == "not_run").count();
         let aggregate_tokenizer =
-            if corpus.model.family.as_deref() == Some("qwen") { "gguf_metadata" } else { "llama3" };
+            match (corpus.model.family.as_deref(), corpus.defaults.prompt_template.as_str()) {
+                (_, "bitnetcpp-answer") => "externally_supplied_llama_bpe",
+                (Some("qwen"), _) => "gguf_metadata",
+                _ => "llama3",
+            };
 
         let receipt = json!({
             "schema_version": "1.0.0",
@@ -361,11 +365,25 @@ impl AnswerCorpusCommand {
             },
             "logits_dump": run_receipt.get("logits_dump").cloned().unwrap_or(Value::Null),
             "prompt": {
-                "rendered_text": run_receipt["prompt"].clone(),
+                "rendered_text": run_receipt["prompt_render"]["rendered_text"]
+                    .as_str()
+                    .map(Value::from)
+                    .unwrap_or_else(|| run_receipt["prompt"].clone()),
+                "rendered_sha256": run_receipt["prompt_render"]["rendered_sha256"].clone(),
                 "template_family": corpus.defaults.prompt_template,
-                "add_bos": run_receipt["gen_policy"]["bos"].clone(),
-                "add_special": run_receipt["tokenizer"]["bos"].is_number()
-                    || run_receipt["tokenizer"]["eos"].is_number(),
+                "add_bos": run_receipt["prompt_render"]["add_bos"]
+                    .as_bool()
+                    .map(Value::from)
+                    .unwrap_or_else(|| run_receipt["gen_policy"]["bos"].clone()),
+                "add_special": run_receipt["prompt_render"]["parse_special"]
+                    .as_bool()
+                    .map(Value::from)
+                    .unwrap_or_else(|| {
+                        Value::from(
+                            run_receipt["tokenizer"]["bos"].is_number()
+                                || run_receipt["tokenizer"]["eos"].is_number(),
+                        )
+                    }),
             },
             "prompt_template": corpus.defaults.prompt_template,
             "prompt_prefill": prompt_prefill,

--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -237,7 +237,7 @@ pub struct InferenceCommand {
     #[arg(long, value_name = "TEMPLATE")]
     pub chat_template: Option<String>,
 
-    /// Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
+    /// Prompt template: auto (detect), raw, instruct, llama3-chat, bitnetcpp-answer
     #[arg(long, value_name = "TEMPLATE", default_value = "auto")]
     pub prompt_template: String,
 

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 //! BitNet CLI application
 //!
 //! A comprehensive command-line interface for BitNet 1-bit LLM inference.
@@ -342,7 +344,7 @@ enum Commands {
         #[arg(long, default_value_t = 0)]
         threads: usize,
 
-        /// Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
+        /// Prompt template: auto (detect), raw, instruct, llama3-chat, bitnetcpp-answer
         #[arg(long, value_name = "TEMPLATE", default_value = "auto")]
         prompt_template: String,
 
@@ -2469,6 +2471,14 @@ fn compute_model_sha256(path: &std::path::Path) -> Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+fn compute_sha256_bytes(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("{:x}", hasher.finalize())
+}
+
 fn greedy_top1_token_id(logits: &[f32]) -> Option<u32> {
     logits
         .iter()
@@ -2895,7 +2905,7 @@ async fn run_simple_generation(
     } else {
         prompt_template.parse().with_context(|| {
             format!(
-                "Invalid prompt template '{}'. Supported: raw, instruct, llama3-chat",
+                "Invalid prompt template '{}'. Supported: raw, instruct, llama3-chat, bitnetcpp-answer",
                 prompt_template
             )
         })?
@@ -3123,8 +3133,12 @@ async fn run_simple_generation(
 
     // Auto-detect template if needed
     let template_type = if prompt_template == "auto" {
-        // Check if tokenizer has special tokens for LLaMA-3
-        if tokenizer.token_to_id("<|eot_id|>").is_some() {
+        let path_template =
+            TemplateType::detect_from_paths(Some(&model_path), tokenizer_path.as_deref());
+        if matches!(path_template, TemplateType::BitnetCppAnswer) {
+            debug!("Auto-detected bitnetcpp-answer template (model path matches BitNet)");
+            TemplateType::BitnetCppAnswer
+        } else if tokenizer.token_to_id("<|eot_id|>").is_some() {
             debug!("Auto-detected llama3-chat template (tokenizer has <|eot_id|>)");
             TemplateType::Llama3Chat
         } else {
@@ -3144,11 +3158,13 @@ async fn run_simple_generation(
         }),
     );
     let formatted_prompt = template_type.apply(&prompt, system_prompt.as_deref());
+    let rendered_prompt_sha256 = compute_sha256_bytes(formatted_prompt.as_bytes());
     answer_corpus_child_phase(
         "prompt_render_complete",
         serde_json::json!({
             "template": template_type.to_string(),
             "rendered_prompt_bytes": formatted_prompt.len(),
+            "rendered_prompt_sha256": rendered_prompt_sha256.clone(),
         }),
     );
 
@@ -3773,6 +3789,7 @@ async fn run_simple_generation(
         let tokenizer_source_str = tokenizer_source.as_str();
         let tokenizer_label = infer_tokenizer_label(tokenizer.as_ref(), tokenizer_source);
         let tokenizer_type = tokenizer_type_for_receipt(&tokenizer_label, tokenizer_source);
+        let pretokenizer_authority = tokenizer_pretokenizer_authority(tokenizer_source);
         let tokenizer_info = serde_json::json!({
             "type": tokenizer_type,
             "model_family": tokenizer_type,
@@ -3783,7 +3800,7 @@ async fn run_simple_generation(
             },
             "source": tokenizer_source_str,
             "strict": tokenizer_strict,
-            "pretokenizer_authority": "unknown",
+            "pretokenizer_authority": pretokenizer_authority,
             "bos": tokenizer.bos_token_id().unwrap_or(1),
             "eos": tokenizer.eos_token_id().unwrap_or(2),
         });
@@ -3797,11 +3814,22 @@ async fn run_simple_generation(
         });
 
         let gen_policy = serde_json::json!({
-            "bos": bos,
+            "bos": bos_policy,
+            "explicit_bos_requested": bos,
+            "parse_special": parse_special,
             "temperature": temperature,
             "seed": seed.unwrap_or(0),
             "greedy": greedy,
             "deterministic": deterministic,
+        });
+        let prompt_render_receipt = serde_json::json!({
+            "template_family": template_type.to_string(),
+            "rendered_text": formatted_prompt,
+            "rendered_sha256": rendered_prompt_sha256,
+            "add_bos": bos_policy,
+            "parse_special": parse_special,
+            "stop_sequences": all_stop_sequences,
+            "stop_token_ids": all_stop_ids,
         });
         let loader_info = serde_json::json!({
             "mode": loader_mode,
@@ -4042,6 +4070,7 @@ async fn run_simple_generation(
             "fallback_used": backend_identity.fallback_used,
             "fallback_reason": fallback_reason,
             "prompt": prompt,
+            "prompt_render": prompt_render_receipt,
             "text": generated_text,
             "tokens": {
                 "prompt": prompt_tokens_len,
@@ -4451,10 +4480,10 @@ fn tokenizer_pretokenizer_authority(
     source: bitnet_tokenizers::auto::TokenizerSource,
 ) -> &'static str {
     match source {
-        bitnet_tokenizers::auto::TokenizerSource::Explicit => "explicit_tokenizer",
-        bitnet_tokenizers::auto::TokenizerSource::GgufMetadata => "gguf_metadata",
-        bitnet_tokenizers::auto::TokenizerSource::Sibling => "sibling_tokenizer",
-        bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback => "compatibility_fallback",
+        bitnet_tokenizers::auto::TokenizerSource::Explicit => "externally_supplied",
+        bitnet_tokenizers::auto::TokenizerSource::GgufMetadata => "present",
+        bitnet_tokenizers::auto::TokenizerSource::Sibling => "externally_supplied",
+        bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback => "defaulted",
     }
 }
 
@@ -5555,6 +5584,7 @@ async fn run_ask_generation(
     receipt_out: Option<std::path::PathBuf>,
 ) -> Result<()> {
     const RTX_5070_TI_CUDA: &str = "nvidia-rtx-5070-ti-cuda";
+    const BITNET_CPP_ANSWER_TEMPLATE: &str = "bitnetcpp-answer";
     if strict_cuda && strict_cpu {
         anyhow::bail!("--strict-cuda and --strict-cpu are mutually exclusive");
     }
@@ -5600,7 +5630,7 @@ async fn run_ask_generation(
         true,
         true,
         0,
-        "llama3-chat".to_string(),
+        BITNET_CPP_ANSWER_TEMPLATE.to_string(),
         system_prompt,
         vec!["<|eot_id|>".to_string(), "<|end_of_text|>".to_string()],
         Vec::new(),
@@ -5660,11 +5690,15 @@ async fn run_ask_generation(
             "fallback_reason": run_receipt["fallback_reason"].clone(),
         },
         "prompt_template": {
-            "family": "llama3-chat",
+            "family": BITNET_CPP_ANSWER_TEMPLATE,
             "system_prompt_present": system_prompt_for_receipt.as_ref().is_some_and(|value| !value.is_empty()),
-            "bos_inserted": true,
+            "bos_inserted": run_receipt["prompt_render"]["add_bos"].clone(),
             "assistant_prefix_inserted": true,
+            "rendered_sha256": run_receipt["prompt_render"]["rendered_sha256"].clone(),
+            "rendered_text": run_receipt["prompt_render"]["rendered_text"].clone(),
+            "parse_special": run_receipt["prompt_render"]["parse_special"].clone(),
             "stop_tokens": ["<|eot_id|>", "<|end_of_text|>"],
+            "stop_token_ids": run_receipt["prompt_render"]["stop_token_ids"].clone(),
         },
         "prompt_prefill": {
             "exercised": run_receipt["profile"]["prompt_prefill"]["exercised"].clone(),

--- a/crates/bitnet-cli/tests/cli_arg_validation_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_validation_tests.rs
@@ -110,6 +110,14 @@ mod inference_cmd {
         assert_eq!(cmd.prompt_template, "llama3-chat");
     }
 
+    /// `--prompt-template bitnetcpp-answer` is accepted.
+    #[test]
+    fn test_prompt_template_bitnetcpp_answer_accepted() {
+        let cmd = parse(&["test-cli", "--prompt-template", "bitnetcpp-answer"])
+            .expect("--prompt-template bitnetcpp-answer must be accepted");
+        assert_eq!(cmd.prompt_template, "bitnetcpp-answer");
+    }
+
     // ── system-prompt ─────────────────────────────────────────────────────────
 
     /// `--system-prompt` is optional and defaults to `None`.

--- a/crates/bitnet-cli/tests/cli_extended_tests.rs
+++ b/crates/bitnet-cli/tests/cli_extended_tests.rs
@@ -196,6 +196,7 @@ mod prompt_template_parsing {
             ("raw", TemplateType::Raw),
             ("instruct", TemplateType::Instruct),
             ("llama3-chat", TemplateType::Llama3Chat),
+            ("bitnetcpp-answer", TemplateType::BitnetCppAnswer),
         ];
         for (name, expected) in &cases {
             let got: TemplateType = name.parse().unwrap_or_else(|e| {

--- a/crates/bitnet-cli/tests/property_tests.rs
+++ b/crates/bitnet-cli/tests/property_tests.rs
@@ -157,7 +157,7 @@ proptest! {
 
 // ── Deterministic unit tests ─────────────────────────────────────────────────
 
-/// --prompt-template raw/instruct/llama3-chat each parse to the correct TemplateType.
+/// Supported explicit prompt templates parse to the correct TemplateType.
 #[test]
 fn test_explicit_prompt_templates_parse_to_correct_type() {
     use bitnet_inference::TemplateType;
@@ -166,6 +166,7 @@ fn test_explicit_prompt_templates_parse_to_correct_type() {
         ("raw", TemplateType::Raw),
         ("instruct", TemplateType::Instruct),
         ("llama3-chat", TemplateType::Llama3Chat),
+        ("bitnetcpp-answer", TemplateType::BitnetCppAnswer),
     ];
 
     for (value, expected) in cases {

--- a/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
+++ b/crates/bitnet-cli/tests/snapshots/cli_snapshot_tests__run_help.snap
@@ -114,7 +114,7 @@ Options:
           [default: 0]
 
       --prompt-template <TEMPLATE>
-          Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format)
+          Prompt template: auto (detect), raw, instruct, llama3-chat, bitnetcpp-answer
 
           [default: auto]
 

--- a/crates/bitnet-cli/tests/snapshots/snapshot_tests__help_prompt_template_section.snap
+++ b/crates/bitnet-cli/tests/snapshots/snapshot_tests__help_prompt_template_section.snap
@@ -4,4 +4,4 @@ expression: relevant
 ---
       --system-prompt <TEXT>          System prompt for chat models
       --chat-template <TEMPLATE>      Chat template to use (deprecated - use --prompt-template)
-      --prompt-template <TEMPLATE>    Prompt template: auto (detect), raw (no formatting), instruct (Q&A format), llama3-chat (LLaMA-3 format) [default: auto]
+      --prompt-template <TEMPLATE>    Prompt template: auto (detect), raw, instruct, llama3-chat, bitnetcpp-answer [default: auto]

--- a/crates/bitnet-prompt-templates-core/src/lib.rs
+++ b/crates/bitnet-prompt-templates-core/src/lib.rs
@@ -416,7 +416,7 @@ impl TemplateType {
                 || path_str.contains("1_58b")
                 || (path_str.contains("bitnet") && !path_str.contains("instruct"))
             {
-                return Self::Instruct;
+                return Self::BitnetCppAnswer;
             }
 
             if path_str.contains("instruct") || path_str.contains("chat") {
@@ -456,6 +456,17 @@ impl TemplateType {
                     "auto-detected prompt template"
                 );
                 return Self::Llama3Chat;
+            }
+            if jinja.contains("<|eot_id|>")
+                && (jinja.contains("Assistant:") || jinja.contains("BITNETAssistant"))
+                && (jinja.contains("User:") || jinja.contains("Human:"))
+            {
+                tracing::debug!(
+                    template = "BitnetCppAnswer",
+                    source = "gguf_chat_template",
+                    "auto-detected prompt template"
+                );
+                return Self::BitnetCppAnswer;
             }
             // Fill-in-the-middle signature
             if jinja.contains("<fim_prefix>") {
@@ -3523,7 +3534,7 @@ mod tests {
             Some(Path::new("models/microsoft-bitnet-b1.58-2B-4T.gguf")),
             None,
         );
-        assert_eq!(detected, TemplateType::Instruct);
+        assert_eq!(detected, TemplateType::BitnetCppAnswer);
     }
 
     #[test]
@@ -3827,6 +3838,15 @@ mod tests {
             result,
             "System: Keep answers short.<|eot_id|>User: Say exactly: OK<|eot_id|>Assistant:"
         );
+    }
+
+    #[test]
+    fn detects_bitnetcpp_answer_from_reference_template_shape() {
+        let detected = TemplateType::detect(
+            Some("gpt2"),
+            Some("{{ 'User: ' + messages[0]['content'] + '<|eot_id|>Assistant:' }}"),
+        );
+        assert_eq!(detected, TemplateType::BitnetCppAnswer);
     }
 
     #[test]

--- a/docs/specs/rtx5070ti-cuda-answer-readiness.md
+++ b/docs/specs/rtx5070ti-cuda-answer-readiness.md
@@ -110,20 +110,17 @@ CPU baseline acceptance:
 
 ## Prompt Template Authority
 
-The answer path for the official BitNet GGUF must use an explicit Llama 3 chat
-template unless a future receipt records a different authoritative model
-template. The model-artifact gate is the authority for changing that template:
-if GGUF metadata, reference-runner evidence, or tokenizer metadata contradicts
-the Llama 3 assumption, a new answer-ready artifact record must capture the
-accepted template family before the CUDA answer lane can claim coherent output.
+The answer path for the official BitNet GGUF must use the BitNet.cpp answer
+template recorded by the CPU/reference evidence. The model-artifact gate remains
+the authority for promoting any template to answer-ready status: if GGUF
+metadata, reference-runner evidence, or tokenizer metadata changes the accepted
+template family, the answer artifact record must capture that before the CUDA
+answer lane can claim coherent output.
 
 The prompt envelope must control:
 
 - BOS handling.
-- `<|begin_of_text|>`.
-- `<|start_header_id|>system<|end_header_id|>` when a system prompt is present.
-- `<|start_header_id|>user<|end_header_id|>`.
-- `<|start_header_id|>assistant<|end_header_id|>`.
+- `User:` / `Assistant:` envelope text.
 - `<|eot_id|>` and `<|end_of_text|>` stop behavior.
 - Special-token skipping during answer decode.
 
@@ -132,9 +129,10 @@ Answer receipts must include:
 ```json
 {
   "prompt_template": {
-    "family": "llama3-chat",
+    "family": "bitnetcpp-answer",
     "bos_inserted": true,
     "assistant_prefix_inserted": true,
+    "rendered_sha256": "...",
     "stop_tokens": ["<|eot_id|>", "<|end_of_text|>"],
     "special_tokens_skipped_on_decode": true
   }
@@ -266,7 +264,7 @@ deterministic greedy answers before debugging CUDA answer quality.
 
 ### CUDA-ANSWER-002 - Prompt Template Authority
 
-Add or harden the strict Llama 3 BitNet chat template, including tokenized
+Add or harden the strict BitNet.cpp answer template, including tokenized
 envelope tests and receipt fields for BOS, assistant prefix, stop tokens, and
 special-token decode policy.
 

--- a/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
+++ b/docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md
@@ -38,7 +38,7 @@ RTX 5070 Ti CUDA BitNet proof state:
 - strict selected backend: `nvidia-rtx-5070-ti-cuda`
 - runtime API: `cuda`
 - model: `microsoft/bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf`
-- tokenizer: explicit, strict `llama3`
+- tokenizer: explicit external Llama BPE with BitNet.cpp answer template
 - quantization/layout: `W1.58A8`, `gguf_packed_i2_s`
 - CUDA kernel family: `qk256`
 - weights uploaded once: `true`


### PR DESCRIPTION
## Summary
- switch normal `bitnet ask` receipts for the official BitNet path from the stale `llama3-chat` assumption to the `bitnetcpp-answer` template
- record rendered prompt text/hash, BOS/special-token policy, stop token IDs, and tokenizer pre-tokenizer authority in run/ask receipts
- update answer-corpus prompt extraction and prompt-template help/tests so diagnostics consume the rendered prompt receipt shape
- align the RTX 5070 Ti answer-readiness spec/ledger with the BitNet.cpp template authority without claiming answer readiness

## Claim Boundary
- no CUDA kernel, QK256 dispatch, transformer, tokenizer behavior, or loader behavior changes
- no coherent answer-readiness claim; the local CPU smoke still generated bad text from the blocked official artifact
- no speed claim

## Validation
- `cargo fmt -p bitnet-cli -p bitnet-prompt-templates-core -- --check`
- `cargo test --locked -p bitnet-prompt-templates-core --no-default-features bitnet -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli ask -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli prompt_template -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli answer_corpus -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli snapshot -- --nocapture`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check nvidia-5070ti`
- `cargo run --release --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Local receipt smoke
Ran non-strict CPU `ask` against the official Microsoft I2_S GGUF with the external tokenizer. Receipt showed:
- `prompt_template.family = bitnetcpp-answer`
- rendered prompt `User: What is 2+2? Answer with only the number.<|eot_id|>Assistant:`
- prompt IDs `128000,1502,25,3639,374,220,17,10,17,30,22559,449,1193,279,1396,13,128009,72803,25`
- generated ID `89048`
- answer `'E`

That smoke proves receipt/template alignment only; it preserves the existing artifact-quality failure.