### PR TITLE
docs(lunar-lake): mark CPU258V-007 merged

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -39,7 +39,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-004 | merged | Require real token-count thresholds before promoting 258V `decode_128` or `prefill_512` phase evidence; merged in #3981. |
 | CPU258V-005 | merged | Record local strict CPU phase evidence attempts and keep `prefill_512`/`decode_128` blocked until a receipt-emitting phase runner exists; merged in #3999. |
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
-| CPU258V-007 | pr_open | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; open in #4006. |
+| CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -620,7 +620,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU258V-007"
-status = "pr_open"
+status = "merged"
 pr = 4006
 branch = "codex/intel-258v-platform/CPU258V-007-answer-template-refresh"
 stackable = false

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071023Z-CPU258V-007-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071023Z-CPU258V-007-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-08T07:10:23Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-007"
+event = "merged"
+pr = 4006
+branch = "codex/intel-258v-platform/CPU258V-007-answer-template-refresh"
+merge_sha = "2188b175629374073896c1f5f2c9234bee47a304"
+summary = "Merged #4006, recording 258V AVX2 timeout evidence under the BitNet.cpp answer-ready prompt envelope."
+
+details = [
+  "The committed artifact records five timeout rows and missing_child_receipt kernels for the refreshed answer-corpus attempt.",
+  "This remains blocker evidence only; it does not prove answer quality, scalar/AVX2 parity under the new prompt, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -23,7 +23,7 @@
 | CPU258V-005 | merged | #3999 | `codex/intel-258v-platform/CPU258V-005-phase-evidence` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record local strict CPU attempts to collect 258V prefill_512 and decode_128 phase evidence, preserve missing proof receipts as blocker evidence, and require a receipt-emitting warm phase runner or faster decode path before promoting these profiles. |
 | CPU258V-006 | merged | #4001 | `codex/intel-258v-platform/CPU258V-006-warm-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a strict CPU warm phase runner that loads the 258V BitNet GGUF model/tokenizer once, emits per-profile strict CPU receipts for prefill_512 and decode_128, preserves selected backend/kernel and fallback=false, and keeps phase evidence separate from speedup, Arc, or NPU claims. |
 
-| CPU258V-007 | pr_open | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-258v-platform | CPU258V-007 | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -65,7 +65,7 @@
 | intel-258v-platform | CPU258V-004 | CPU258V-003 | merged |
 | intel-258v-platform | CPU258V-005 | CPU258V-004 | merged |
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
-| intel-258v-platform | CPU258V-007 | CPU258V-006 | pr_open |
+| intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-007 | #4006 | pr_open | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-007 | #4006 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- mark CPU258V-007 merged after #4006
- add the merge event with merge SHA `2188b175629374073896c1f5f2c9234bee47a304`
- refresh generated tracker rows and remove CPU258V-007 from active PRs

## Verification
- parsed `docs/tracking/campaigns/intel-258v-platform/active.toml`
- parsed the CPU258V-007 merged event TOML
- verified generated rows for merged state and active-pr removal
- `git diff --check`

## Note
Local `xtask campaign generate --check` and `campaign doctor` continue to stack-overflow in this Windows checkout, so this is a narrow tracker closeout.