### PR TITLE
feat(cpu258v): add answer-corpus case filter

### DIFF
--- a/ci/hardware/intel-258v/README.md
+++ b/ci/hardware/intel-258v/README.md
@@ -12,6 +12,7 @@ ci/hardware/intel-258v/<date>/cpu-phase-benchmark.json
 ci/hardware/intel-258v/<date>/cpu-phase-evidence-attempts.json
 ci/hardware/intel-258v/<date>/cpu-phase-warm-session.json
 ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2-bitnetcpp-template.json
+ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2-bitnetcpp-template-case.json
 ```
 
 `platform-probe.json` is visibility-only. It may record CPU AVX2 facts, Arc
@@ -37,3 +38,9 @@ converted by `cpu_phase_benchmark_receipt`.
 attempt to refresh answer-corpus evidence with the BitNet.cpp answer-ready
 prompt envelope. Timeout rows and `missing_child_receipt` kernels are blocker
 evidence only; they do not prove answer quality or AVX2 correctness.
+
+`cpu-answer-corpus-avx2-bitnetcpp-template-case.json` is the expected shape for
+bounded single-case follow-up attempts using `answer-corpus --case-id`. It must
+preserve the full corpus identity while recording `selected_case_count` and
+`selected_case_ids`, and it remains diagnostic blocker evidence until a real
+child receipt is emitted.

--- a/crates/bitnet-cli/src/commands/answer_corpus.rs
+++ b/crates/bitnet-cli/src/commands/answer_corpus.rs
@@ -5,6 +5,7 @@ use clap::{Args, ValueEnum};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::{
+    collections::BTreeSet,
     ffi::OsString,
     fs::{self, File},
     path::{Path, PathBuf},
@@ -66,6 +67,10 @@ pub struct AnswerCorpusCommand {
     /// CPU kernel lane to request for child strict CPU runs.
     #[arg(long, value_enum, value_name = "KERNEL")]
     pub cpu_kernel: Option<AnswerCpuKernel>,
+
+    /// Run only matching corpus case IDs. Repeat to run multiple cases.
+    #[arg(long = "case-id", value_name = "ID")]
+    pub case_ids: Vec<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -130,9 +135,13 @@ impl AnswerCorpusCommand {
             ));
         fs::create_dir_all(&receipt_dir)?;
 
+        let selected_cases = self.selected_cases(&corpus)?;
+        let selected_case_ids: Vec<String> =
+            selected_cases.iter().map(|case| case.id.clone()).collect();
+
         let exe = std::env::current_exe().context("failed to resolve current bitnet executable")?;
-        let mut rows = Vec::with_capacity(corpus.cases.len());
-        for case in &corpus.cases {
+        let mut rows = Vec::with_capacity(selected_cases.len());
+        for case in selected_cases {
             let row = if self.dry_run {
                 self.not_run_row(case, "dry_run_requested")
             } else {
@@ -165,6 +174,8 @@ impl AnswerCorpusCommand {
                 "name": corpus.name,
                 "description": corpus.description,
                 "case_count": corpus.cases.len(),
+                "selected_case_count": selected_case_ids.len(),
+                "selected_case_ids": selected_case_ids,
             },
             "model": {
                 "repo": corpus.model.repo,
@@ -236,6 +247,22 @@ impl AnswerCorpusCommand {
             anyhow::bail!("answer corpus quality failed: {failed} failed, {timed_out} timed out");
         }
         Ok(())
+    }
+
+    fn selected_cases<'a>(&self, corpus: &'a AnswerCorpus) -> Result<Vec<&'a AnswerCase>> {
+        if self.case_ids.is_empty() {
+            return Ok(corpus.cases.iter().collect());
+        }
+
+        let requested: BTreeSet<&str> = self.case_ids.iter().map(String::as_str).collect();
+        let selected: Vec<&AnswerCase> =
+            corpus.cases.iter().filter(|case| requested.contains(case.id.as_str())).collect();
+        let found: BTreeSet<&str> = selected.iter().map(|case| case.id.as_str()).collect();
+        let missing: Vec<&str> = requested.difference(&found).copied().collect();
+        if !missing.is_empty() {
+            anyhow::bail!("answer-corpus --case-id not found: {}", missing.join(", "));
+        }
+        Ok(selected)
     }
 
     fn run_case(

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -4798,8 +4798,9 @@ async fn run_cpu_phase_warm_session(
     let tokenizer_strict = tokenizer_resolution.strict;
     let tokenizer: Arc<dyn Tokenizer + Send + Sync> = tokenizer_resolution.tokenizer;
     let tokenizer_source_str = tokenizer_source.as_str();
-    let pretokenizer_authority = tokenizer_pretokenizer_authority(tokenizer_source);
     let tokenizer_label = infer_tokenizer_label(tokenizer.as_ref(), tokenizer_source);
+    let pretokenizer_authority =
+        tokenizer_pretokenizer_authority(tokenizer_source, &tokenizer_label);
     let tokenizer_type = tokenizer_type_for_receipt(&tokenizer_label, tokenizer_source);
     let gguf_metadata = gguf_header_counts_for_receipt(&model_path, is_hf_directory);
     let (n_kv, n_tensors) = gguf_metadata.unwrap_or((0, 0));

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -668,6 +668,7 @@ fn answer_corpus_subcommand_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("--corpus"))
+        .stdout(predicate::str::contains("--case-id"))
         .stdout(predicate::str::contains("--dry-run"))
         .stdout(predicate::str::contains("--dump-logit-steps"));
 }
@@ -768,6 +769,119 @@ cases:
     assert_eq!(receipt["artifact_kind"], "bitnet_cpu_answer_corpus");
     assert_eq!(receipt["quality_summary"]["not_run"], 1);
     assert_eq!(receipt["cases"][0]["status"], "not_run");
+}
+
+/// `answer-corpus --case-id` limits a diagnostic run without changing corpus identity.
+#[cfg(feature = "full-cli")]
+#[test]
+fn answer_corpus_case_id_dry_run_selects_one_case() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let corpus = dir.path().join("corpus.yaml");
+    let out = dir.path().join("receipt.json");
+    std::fs::write(
+        &corpus,
+        r#"schema: 1
+artifact_kind: bitnet_answer_corpus
+name: test-corpus
+description: test
+model:
+  repo: microsoft/bitnet-b1.58-2B-4T-gguf
+  file: ggml-model-i2_s.gguf
+defaults:
+  prompt_template: llama3-chat
+  max_new_tokens: 4
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+cases:
+  - id: math
+    question: "What is 2+2?"
+    gate:
+      kind: exact_trimmed
+      expected: "4"
+  - id: word
+    question: "Answer with one word."
+    gate:
+      kind: contains_any
+      contains_any: ["yes", "no"]
+"#,
+    )
+    .expect("write corpus");
+
+    bitnet()
+        .args([
+            "answer-corpus",
+            "--dry-run",
+            "--case-id",
+            "word",
+            "--model",
+            "missing.gguf",
+            "--corpus",
+            corpus.to_str().unwrap(),
+            "--json-out",
+            out.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let receipt: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(out).expect("read receipt")).expect("json receipt");
+    assert_eq!(receipt["corpus"]["case_count"], 2);
+    assert_eq!(receipt["corpus"]["selected_case_count"], 1);
+    assert_eq!(receipt["corpus"]["selected_case_ids"][0], "word");
+    assert_eq!(receipt["quality_summary"]["total"], 1);
+    assert_eq!(receipt["quality_summary"]["not_run"], 1);
+    assert_eq!(receipt["cases"][0]["id"], "word");
+    assert_eq!(receipt["cases"][0]["status"], "not_run");
+}
+
+/// `answer-corpus --case-id` fails early for unknown case IDs.
+#[cfg(feature = "full-cli")]
+#[test]
+fn answer_corpus_case_id_rejects_missing_case() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let corpus = dir.path().join("corpus.yaml");
+    std::fs::write(
+        &corpus,
+        r#"schema: 1
+artifact_kind: bitnet_answer_corpus
+name: test-corpus
+description: test
+model:
+  repo: microsoft/bitnet-b1.58-2B-4T-gguf
+  file: ggml-model-i2_s.gguf
+defaults:
+  prompt_template: llama3-chat
+  max_new_tokens: 4
+  greedy: true
+  deterministic: true
+  strict_loader: true
+  temperature: 0.0
+cases:
+  - id: math
+    question: "What is 2+2?"
+    gate:
+      kind: exact_trimmed
+      expected: "4"
+"#,
+    )
+    .expect("write corpus");
+
+    bitnet()
+        .args([
+            "answer-corpus",
+            "--dry-run",
+            "--case-id",
+            "missing",
+            "--model",
+            "missing.gguf",
+            "--corpus",
+            corpus.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("answer-corpus --case-id not found: missing"));
 }
 
 /// `answer-corpus --dry-run` accepts the SLM corpus and preserves model identity.

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -282,6 +282,32 @@ did not complete within the bounded local child-run window. It does not prove
 answer quality, scalar/AVX2 parity under the new prompt, sustained throughput,
 Arc 140V execution, or Intel NPU execution.
 
+CPU258V-008 adds a bounded answer-corpus case filter so the next 258V refresh
+can isolate a single prompt before spending a full-corpus local decode window:
+
+```bash
+cargo run --locked -p bitnet-cli \
+  --no-default-features \
+  --features cpu,full-cli \
+  -- \
+  --device cpu \
+  answer-corpus \
+  --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --tokenizer models/BitNet-b1.58-2B-4T/tokenizer.json \
+  --cpu-kernel avx2 \
+  --case-id arithmetic-single-digit \
+  --dump-logit-steps 1 \
+  --logits-topk 5 \
+  --per-prompt-timeout-seconds 420 \
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/cpu-answer-corpus-avx2-bitnetcpp-template-case.json
+```
+
+The aggregate receipt preserves the full corpus `case_count` and records
+`selected_case_count` plus `selected_case_ids`. This is diagnostic scope only:
+it narrows timeout evidence collection and does not prove selected-case
+completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V
+execution, or Intel NPU execution.
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -40,7 +40,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-005 | merged | Record local strict CPU phase evidence attempts and keep `prefill_512`/`decode_128` blocked until a receipt-emitting phase runner exists; merged in #3999. |
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
 | CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
-| CPU258V-008 | ready | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-008 | pr_open | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims; open in #4008. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -40,6 +40,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-005 | merged | Record local strict CPU phase evidence attempts and keep `prefill_512`/`decode_128` blocked until a receipt-emitting phase runner exists; merged in #3999. |
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
 | CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
+| CPU258V-008 | ready | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -655,3 +655,52 @@ must_not_claim = [
   "Sustained throughput is proven.",
   "Arc 140V or Intel NPU execution is proven.",
 ]
+
+[[work_item]]
+id = "CPU258V-008"
+status = "ready"
+branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU258V-007"]
+acceptance = "Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims."
+commands = [
+  "rustfmt --check --config skip_children=true,newline_style=Unix crates/bitnet-cli/src/commands/answer_corpus.rs crates/bitnet-cli/tests/cli_arg_tests.rs crates/bitnet-cli/src/main.rs --edition 2024",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus_case -- --nocapture",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus_subcommand_help -- --exact --nocapture",
+  "cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings",
+  "Parse docs/tracking/campaigns/intel-258v-platform/active.toml",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/src/commands/answer_corpus.rs",
+  "crates/bitnet-cli/src/main.rs",
+  "crates/bitnet-cli/tests/cli_arg_tests.rs",
+  "ci/hardware/intel-258v/README.md",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-models/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-quantization/**",
+  "crates/bitnet-qk256-layout-core/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-server/**",
+]
+may_claim = [
+  "answer-corpus can run selected case IDs and records selected_case_count plus selected_case_ids in the aggregate receipt.",
+  "258V answer-template refresh diagnostics can be narrowed to one corpus case at a time after merge.",
+]
+must_not_claim = [
+  "The selected case completed on the local 258V.",
+  "The BitNet.cpp answer-ready prompt envelope improves 258V answer quality.",
+  "Scalar/AVX2 parity under the new prompt is proven.",
+  "Sustained throughput is proven.",
+  "Arc 140V or Intel NPU execution is proven.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -658,7 +658,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU258V-008"
-status = "ready"
+status = "pr_open"
+pr = 4008
 branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071910Z-CPU258V-008-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071910Z-CPU258V-008-ready.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-08T07:19:10Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-008"
+event = "ready"
+branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
+base_sha = "832e7c846d8c4e66310f3771b65b63539b8543ba"
+summary = "Readied CPU258V-008 to add bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
+
+details = [
+  "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",
+  "CPU258V-008 narrows follow-up runs with repeatable --case-id filters while preserving full corpus identity and selected case IDs in the aggregate receipt.",
+  "This is diagnostic scope only and does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072300Z-CPU258V-008-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072300Z-CPU258V-008-pr-open.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-08T07:23:00Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-008"
+event = "pr_open"
+pr = 4008
+branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
+head_sha = "1ac4d98ff73ee9531d2e47022d193412bea5db3a"
+summary = "Opened CPU258V-008 to add bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
+
+details = [
+  "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",
+  "CPU258V-008 adds repeatable --case-id filters while preserving full corpus identity and selected case IDs in the aggregate receipt.",
+  "This PR does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -24,7 +24,7 @@
 | CPU258V-006 | merged | #4001 | `codex/intel-258v-platform/CPU258V-006-warm-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a strict CPU warm phase runner that loads the 258V BitNet GGUF model/tokenizer once, emits per-profile strict CPU receipts for prefill_512 and decode_128, preserves selected backend/kernel and fallback=false, and keeps phase evidence separate from speedup, Arc, or NPU claims. |
 
 | CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
-| CPU258V-008 | ready | TBD | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-008 | pr_open | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -24,6 +24,7 @@
 | CPU258V-006 | merged | #4001 | `codex/intel-258v-platform/CPU258V-006-warm-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a strict CPU warm phase runner that loads the 258V BitNet GGUF model/tokenizer once, emits per-profile strict CPU receipts for prefill_512 and decode_128, preserves selected backend/kernel and fallback=false, and keeps phase evidence separate from speedup, Arc, or NPU claims. |
 
 | CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-008 | ready | TBD | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-258v-platform | CPU258V-008 | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -66,6 +66,7 @@
 | intel-258v-platform | CPU258V-005 | CPU258V-004 | merged |
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
 | intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
+| intel-258v-platform | CPU258V-008 | CPU258V-007 | ready |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -66,7 +66,7 @@
 | intel-258v-platform | CPU258V-005 | CPU258V-004 | merged |
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
 | intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
-| intel-258v-platform | CPU258V-008 | CPU258V-007 | ready |
+| intel-258v-platform | CPU258V-008 | CPU258V-007 | pr_open |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-008 | TBD | ready | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-008 | #4008 | pr_open | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-007 | #4006 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-008 | TBD | ready | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | BitNet CPU proof | CPU-ANSWER-005 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | CPU258V-007 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | Intel 258V platform validation | CPU258V-008 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-006 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- add repeatable `answer-corpus --case-id <ID>` filtering so the 258V BitNet.cpp-template answer refresh can run one bounded corpus case at a time
- preserve full corpus identity in aggregate receipts while recording `selected_case_count` and `selected_case_ids`
- add dry-run coverage for selected-case receipts, missing case-id rejection, and help text
- fix the existing `cpu-phase-warm-session` tokenizer authority call so `bitnet-cli` compiles with the current helper signature
- track CPU258V-008 as a diagnostic timeout-isolation step, not an answer-quality or parity claim

## Claim Boundary
This proves only that answer-corpus can select specific case IDs and record that selection in receipts. It does not prove selected-case completion on the 258V, answer quality, scalar/AVX2 parity under the BitNet.cpp prompt envelope, sustained throughput, Arc 140V execution, or Intel NPU execution.

## Verification
- `rustfmt --check --config skip_children=true,newline_style=Unix crates/bitnet-cli/src/commands/answer_corpus.rs crates/bitnet-cli/tests/cli_arg_tests.rs crates/bitnet-cli/src/main.rs --edition 2024`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus_case -- --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus_subcommand_help -- --exact --nocapture`
- `cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests answer_corpus -- --nocapture`
- `cargo clippy --locked -p bitnet-cli --no-default-features --features cpu,full-cli --bin bitnet -- -D warnings`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- answer-corpus --dry-run --case-id math_2_plus_2 --model missing.gguf --corpus ci/quality/bitnet-answer-corpus.yaml --json-out target/cpu258v008-case-filter-dry-run.json`
- parsed `target/cpu258v008-case-filter-dry-run.json` for `case_count=5`, `selected_case_count=1`, and `selected_case_ids=["math_2_plus_2"]`
- parsed `docs/tracking/campaigns/intel-258v-platform/active.toml` and generated dashboard rows for CPU258V-008
- `git diff --check`