### PR TITLE
docs(cpu258v): mark CPU258V-008 merged

### DIFF
--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -40,7 +40,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-005 | merged | Record local strict CPU phase evidence attempts and keep `prefill_512`/`decode_128` blocked until a receipt-emitting phase runner exists; merged in #3999. |
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
 | CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
-| CPU258V-008 | pr_open | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims; open in #4008. |
+| CPU258V-008 | merged | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims; merged in #4008. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -658,7 +658,7 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU258V-008"
-status = "pr_open"
+status = "merged"
 pr = 4008
 branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
 stackable = false

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072640Z-CPU258V-008-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072640Z-CPU258V-008-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-08T07:26:40Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-008"
+event = "merged"
+pr = 4008
+merge_sha = "d4979be17c107200a723bbc8d5c24553983c04e3"
+summary = "Merged CPU258V-008, adding bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
+
+details = [
+  "The merged command can run selected answer-corpus case IDs and records selected_case_count plus selected_case_ids in the aggregate receipt.",
+  "The claim boundary remains diagnostic only: no selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution is claimed.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -24,7 +24,7 @@
 | CPU258V-006 | merged | #4001 | `codex/intel-258v-platform/CPU258V-006-warm-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a strict CPU warm phase runner that loads the 258V BitNet GGUF model/tokenizer once, emits per-profile strict CPU receipts for prefill_512 and decode_128, preserves selected backend/kernel and fallback=false, and keeps phase evidence separate from speedup, Arc, or NPU claims. |
 
 | CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
-| CPU258V-008 | pr_open | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-008 | merged | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-258v-platform | CPU258V-008 | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -66,7 +66,7 @@
 | intel-258v-platform | CPU258V-005 | CPU258V-004 | merged |
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
 | intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
-| intel-258v-platform | CPU258V-008 | CPU258V-007 | pr_open |
+| intel-258v-platform | CPU258V-008 | CPU258V-007 | merged |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-008 | #4008 | pr_open | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-008 | #4008 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- mark CPU258V-008 merged after #4008
- add the CPU258V-008 merge event with merge SHA `d4979be17c107200a723bbc8d5c24553983c04e3`
- remove CPU258V-008 from active PRs and refresh the 258V generated status/dashboard rows

## Verification
- parsed `docs/tracking/campaigns/intel-258v-platform/active.toml`
- checked generated rows for CPU258V-008 merged state and active-pr removal
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal campaign tracking documentation to record completion of a development work item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->