### PR TITLE
docs(cpu258v): record single-case answer timeout

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json
+++ b/ci/hardware/intel-258v/2026-05-08/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json
@@ -1,0 +1,265 @@
+{
+  "artifact_kind": "bitnet_cpu_answer_corpus",
+  "backend": {
+    "fallback_used": false,
+    "requested_backend": "cpu",
+    "runtime_api": "cpu",
+    "selected_backend": "cpu"
+  },
+  "cases": [
+    {
+      "backend": {
+        "fallback_used": false,
+        "requested_backend": "cpu",
+        "runtime_api": "cpu",
+        "selected_backend": "cpu",
+        "source": "answer_corpus_launcher"
+      },
+      "child_invocation": {
+        "args": [
+          "--device",
+          "cpu",
+          "run",
+          "--model",
+          "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+          "--prompt",
+          "What is 2+2? Answer with only the number.",
+          "--max-new-tokens",
+          "4",
+          "--temperature",
+          "0",
+          "--prompt-template",
+          "bitnetcpp-answer",
+          "--json-out",
+          "ci/hardware/intel-258v/2026-05-08\\cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2-runs\\math_2_plus_2.json",
+          "--tokenizer",
+          "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\tokenizer.json",
+          "--greedy",
+          "--deterministic",
+          "--strict-loader",
+          "--strict-tokenizer",
+          "--dump-logit-steps",
+          "1",
+          "--logits-topk",
+          "5",
+          "--assert-greedy"
+        ],
+        "environment_overrides": {
+          "BITNET_CPU_KERNEL": "avx2",
+          "BITNET_FORCE_SCALAR": "0",
+          "RUST_LOG": "warn"
+        },
+        "executable": "C:\\Code\\Rust\\BitNet-rs-arc140v004-opencl-smoke\\target\\debug\\bitnet.exe",
+        "expected_receipt_path": "ci/hardware/intel-258v/2026-05-08\\cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2-runs\\math_2_plus_2.json",
+        "phase_path": "C:\\Users\\szim9\\AppData\\Local\\Temp\\bitnet-answer-corpus-25140-1778225309477049500-2-phases.log",
+        "timeout_seconds": 420
+      },
+      "child_process": {
+        "crash_class": "timeout",
+        "exit_code": 1,
+        "exit_code_hex": "0x00000001",
+        "last_observed_phase": "prompt_prefill_start",
+        "phase_events": [
+          {
+            "child_phase": "process_start",
+            "details": {
+              "command": "run"
+            },
+            "timestamp": "2026-05-08T07:28:29.545173800+00:00"
+          },
+          {
+            "child_phase": "args_parsed",
+            "details": {
+              "has_tokenizer_path": true,
+              "json_out": "ci/hardware/intel-258v/2026-05-08\\cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2-runs\\math_2_plus_2.json",
+              "max_new_tokens": 4,
+              "model_path": "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+              "prompt_template": "bitnetcpp-answer",
+              "requested_backend": "cpu"
+            },
+            "timestamp": "2026-05-08T07:28:29.546007800+00:00"
+          },
+          {
+            "child_phase": "backend_select_start",
+            "details": {
+              "requested_backend": "cpu",
+              "strict_backend": true
+            },
+            "timestamp": "2026-05-08T07:28:29.548994400+00:00"
+          },
+          {
+            "child_phase": "backend_select_complete",
+            "details": {
+              "fallback_reason": null,
+              "fallback_used": false,
+              "requested_backend": "cpu",
+              "runtime_api": "cpu",
+              "selected_backend": "cpu-rust"
+            },
+            "timestamp": "2026-05-08T07:28:29.549367300+00:00"
+          },
+          {
+            "child_phase": "model_load_start",
+            "details": {
+              "is_hf_directory": false,
+              "model_path": "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf"
+            },
+            "timestamp": "2026-05-08T07:28:30.055410300+00:00"
+          },
+          {
+            "child_phase": "model_load_complete",
+            "details": {
+              "loader_mode": "real_gguf",
+              "model_load_ms": 86602.028
+            },
+            "timestamp": "2026-05-08T07:29:56.658168700+00:00"
+          },
+          {
+            "child_phase": "tokenizer_load_start",
+            "details": {
+              "has_tokenizer_path": true,
+              "strict_tokenizer": true
+            },
+            "timestamp": "2026-05-08T07:29:56.660348500+00:00"
+          },
+          {
+            "child_phase": "tokenizer_load_complete",
+            "details": {
+              "tokenizer_load_ms": 2087.012,
+              "tokenizer_source": "explicit",
+              "tokenizer_strict": true
+            },
+            "timestamp": "2026-05-08T07:29:58.747437200+00:00"
+          },
+          {
+            "child_phase": "prompt_render_start",
+            "details": {
+              "has_system_prompt": false,
+              "template": "bitnetcpp-answer"
+            },
+            "timestamp": "2026-05-08T07:29:58.751464500+00:00"
+          },
+          {
+            "child_phase": "prompt_render_complete",
+            "details": {
+              "rendered_prompt_bytes": 67,
+              "rendered_prompt_sha256": "dee5b2fff5b96df948252b7a589ab7ea1a6b6a10ed1b2d9ed70a63ebbde554f3",
+              "template": "bitnetcpp-answer"
+            },
+            "timestamp": "2026-05-08T07:29:58.754198900+00:00"
+          },
+          {
+            "child_phase": "prompt_tokenize_start",
+            "details": {
+              "bos_policy": true,
+              "parse_special": true
+            },
+            "timestamp": "2026-05-08T07:29:58.910907700+00:00"
+          },
+          {
+            "child_phase": "prompt_tokenize_complete",
+            "details": {
+              "prompt_token_count": 19,
+              "prompt_tokenize_ms": 2.899
+            },
+            "timestamp": "2026-05-08T07:29:58.913798+00:00"
+          },
+          {
+            "child_phase": "prompt_prefill_start",
+            "details": {
+              "prefill_prefix_tokens": 18,
+              "prompt_token_count": 19,
+              "strict_cuda_backend_selected": false
+            },
+            "timestamp": "2026-05-08T07:29:58.917399100+00:00"
+          }
+        ],
+        "phase_path": "C:\\Users\\szim9\\AppData\\Local\\Temp\\bitnet-answer-corpus-25140-1778225309477049500-2-phases.log",
+        "receipt_observed": false,
+        "stderr_path": "C:\\Users\\szim9\\AppData\\Local\\Temp\\bitnet-answer-corpus-25140-1778225309477046400-1-stderr.log",
+        "stdout_path": "C:\\Users\\szim9\\AppData\\Local\\Temp\\bitnet-answer-corpus-25140-1778225309477018200-0-stdout.log",
+        "success": false,
+        "timed_out": true
+      },
+      "exit_code": 1,
+      "id": "math_2_plus_2",
+      "kernel": {
+        "family": null,
+        "requested_cpu_kernel": "avx2",
+        "selected_kernel": null,
+        "source": "missing_child_receipt"
+      },
+      "quality": {
+        "failed_rules": [
+          "timeout"
+        ],
+        "passed": false
+      },
+      "question": "What is 2+2? Answer with only the number.",
+      "run_receipt_path": "ci/hardware/intel-258v/2026-05-08\\cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2-runs\\math_2_plus_2.json",
+      "status": "timeout",
+      "stderr_tail": "answer_corpus_child_phase=process_start\nanswer_corpus_child_phase=args_parsed\nanswer_corpus_child_phase=backend_select_start\nanswer_corpus_child_phase=backend_select_complete\nΓä╣ Using QK256 quantization with AVX2 acceleration\nanswer_corpus_child_phase=model_load_start\nDEBUG from_gguf: Received config: hidden=2560, n_heads=20, n_kv_heads=5\nDEBUG from_gguf: Received 332 tensors, 210 raw QK256 tensors\nanswer_corpus_child_phase=model_load_complete\nanswer_corpus_child_phase=tokenizer_load_start\nanswer_corpus_child_phase=tokenizer_load_complete\nanswer_corpus_child_phase=prompt_render_start\nanswer_corpus_child_phase=prompt_render_complete\nanswer_corpus_child_phase=prompt_tokenize_start\nanswer_corpus_child_phase=prompt_tokenize_complete\nanswer_corpus_child_phase=prompt_prefill_start\n",
+      "stdout_tail": "Loading model from: C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf\nLoading tokenizer from: C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\tokenizer.json\nInput tokens (19): [128000, 1502, 25, 3639, 374, 220, 17, 10, 17, 30]\nGenerating: User: What is 2+2? Answer with only the number.<|eot_id|>Assistant:",
+      "timeout_seconds": 420
+    }
+  ],
+  "claim_boundary": {
+    "broad_performance_claimed": false,
+    "coherent_answer_claimed": false,
+    "cuda_answer_corpus": false,
+    "diagnostic_only_until_answer_ready_artifact": true,
+    "full_metal_inference_claimed": false,
+    "local_answer_path": false,
+    "neural_engine_claimed": false,
+    "qk256_apple_claimed": false,
+    "slm_answer_path": false,
+    "strict_cuda_answer_claimed": false
+  },
+  "corpus": {
+    "case_count": 5,
+    "description": "Fixed deterministic prompt set for answer-readiness baselines.",
+    "name": "strict-bitnet-answer-corpus-v1",
+    "path": "ci/quality/bitnet-answer-corpus.yaml",
+    "selected_case_count": 1,
+    "selected_case_ids": [
+      "math_2_plus_2"
+    ]
+  },
+  "generation": {
+    "default_max_new_tokens": 8,
+    "deterministic": true,
+    "logits_dump_steps": 1,
+    "logits_topk": 5,
+    "mode": "greedy",
+    "per_prompt_timeout_seconds": 420,
+    "requested_cpu_kernel": "avx2",
+    "strict_loader": true,
+    "temperature": 0.0
+  },
+  "model": {
+    "architecture": null,
+    "fallback_loader_used": false,
+    "family": null,
+    "file": "ggml-model-i2_s.gguf",
+    "loader_mode": "real_gguf",
+    "path": "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\ggml-model-i2_s.gguf",
+    "quant_format": null,
+    "repo": "microsoft/bitnet-b1.58-2B-4T-gguf",
+    "sha256": null,
+    "tokenizer": "externally_supplied_llama_bpe",
+    "tokenizer_path": "C:\\Code\\Rust\\BitNet-rs-lnl258v002\\models\\BitNet-b1.58-2B-4T\\tokenizer.json"
+  },
+  "prompt_template": {
+    "family": "bitnetcpp-answer"
+  },
+  "quality_summary": {
+    "failed": 0,
+    "not_run": 0,
+    "passed": 0,
+    "timeout": 1,
+    "total": 1
+  },
+  "schema_version": "1.0.0",
+  "speedup_claim": false,
+  "timestamp": "2026-05-08T07:35:29.604262200+00:00"
+}

--- a/ci/hardware/intel-258v/README.md
+++ b/ci/hardware/intel-258v/README.md
@@ -13,6 +13,7 @@ ci/hardware/intel-258v/<date>/cpu-phase-evidence-attempts.json
 ci/hardware/intel-258v/<date>/cpu-phase-warm-session.json
 ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2-bitnetcpp-template.json
 ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2-bitnetcpp-template-case.json
+ci/hardware/intel-258v/<date>/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json
 ```
 
 `platform-probe.json` is visibility-only. It may record CPU AVX2 facts, Arc
@@ -44,3 +45,7 @@ bounded single-case follow-up attempts using `answer-corpus --case-id`. It must
 preserve the full corpus identity while recording `selected_case_count` and
 `selected_case_ids`, and it remains diagnostic blocker evidence until a real
 child receipt is emitted.
+
+`cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json` records the
+first 258V AVX2 single-case follow-up. The selected `math_2_plus_2` case still
+timed out within the bounded child-run window, so it is blocker evidence only.

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -308,6 +308,18 @@ it narrows timeout evidence collection and does not prove selected-case
 completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V
 execution, or Intel NPU execution.
 
+CPU258V-009 records the first bounded single-case attempt:
+
+```text
+ci/hardware/intel-258v/2026-05-08/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json
+```
+
+The selected `math_2_plus_2` case timed out within the same 420-second child-run
+window and emitted no child receipt. This confirms that at least one individual
+BitNet.cpp-template case is blocked independently of full-corpus fanout. It does
+not prove answer quality, scalar/AVX2 parity under the new prompt, sustained
+throughput, Arc 140V execution, or Intel NPU execution.
+
 ## Windows PowerShell Bundle
 
 ```powershell

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -41,6 +41,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
 | CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
 | CPU258V-008 | merged | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims; merged in #4008. |
+| CPU258V-009 | ready | Record a bounded single-case 258V AVX2 answer-corpus attempt for `math_2_plus_2`, preserving timeout/blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
+++ b/docs/tracking/campaigns/intel-258v-platform/CAMPAIGN.md
@@ -41,7 +41,7 @@ Validate Core Ultra 7 258V as the BitNet CPU lead and tri-device platform while 
 | CPU258V-006 | merged | Add a strict CPU warm phase runner that emits receipt-converter inputs for `prefill_512` and `decode_128` without speedup, Arc, or NPU claims; merged in #4001. |
 | CPU258V-007 | merged | Record the 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope as timeout/blocker evidence; merged in #4006. |
 | CPU258V-008 | merged | Add bounded `answer-corpus --case-id` diagnostics so the 258V answer-template refresh can run one corpus case at a time without answer-quality, parity, speed, Arc, or NPU claims; merged in #4008. |
-| CPU258V-009 | ready | Record a bounded single-case 258V AVX2 answer-corpus attempt for `math_2_plus_2`, preserving timeout/blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-009 | pr_open | Record a bounded single-case 258V AVX2 answer-corpus attempt for `math_2_plus_2`, preserving timeout/blocker evidence without answer-quality, parity, speed, Arc, or NPU claims; open in #4010. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -708,7 +708,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "CPU258V-009"
-status = "ready"
+status = "pr_open"
+pr = 4010
 branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/intel-258v-platform/active.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/active.toml
@@ -705,3 +705,41 @@ must_not_claim = [
   "Sustained throughput is proven.",
   "Arc 140V or Intel NPU execution is proven.",
 ]
+
+[[work_item]]
+id = "CPU258V-009"
+status = "ready"
+branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["CPU258V-008"]
+acceptance = "Record a bounded 258V AVX2 answer-corpus attempt for a single BitNet.cpp-template case selected with --case-id, preserving the timeout row and missing child receipt as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims."
+commands = [
+  "Parse ci/hardware/intel-258v/2026-05-08/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json",
+  "Parse docs/tracking/campaigns/intel-258v-platform/active.toml",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/intel-258v/**",
+  "ci/hardware/intel-258v/README.md",
+  "docs/hardware/intel-258v-validation.md",
+  "docs/tracking/campaigns/intel-258v-platform/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "tests/**",
+]
+may_claim = [
+  "The selected 258V AVX2 math_2_plus_2 BitNet.cpp-template answer-corpus case timed out within the bounded local child-run window.",
+  "The aggregate receipt preserves full corpus identity and selected_case_ids for the single-case attempt.",
+]
+must_not_claim = [
+  "The selected case completed on the local 258V.",
+  "The BitNet.cpp answer-ready prompt envelope improves 258V answer quality.",
+  "Scalar/AVX2 parity under the new prompt is proven.",
+  "Sustained throughput is proven.",
+  "Arc 140V or Intel NPU execution is proven.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073609Z-CPU258V-009-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073609Z-CPU258V-009-ready.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-08T07:36:09Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-009"
+event = "ready"
+branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
+base_sha = "0039a42b3072dbde905f02b157642bfc94847346"
+summary = "Readied CPU258V-009 to record a bounded single-case 258V AVX2 answer-corpus attempt."
+
+details = [
+  "CPU258V-008 made answer-corpus case selection available after the full BitNet.cpp-template AVX2 answer refresh timed out.",
+  "The selected math_2_plus_2 case still timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",
+  "This is blocker evidence only and does not prove selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073902Z-CPU258V-009-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073902Z-CPU258V-009-pr-open.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-08T07:39:02Z"
+campaign = "intel-258v-platform"
+item = "CPU258V-009"
+event = "pr_open"
+pr = 4010
+branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
+head_sha = "9575a61aa07c5616cb03b3718283abd0ea98f8d9"
+summary = "Opened CPU258V-009 to record a bounded single-case 258V AVX2 answer-corpus timeout."
+
+details = [
+  "The selected math_2_plus_2 case timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",
+  "The aggregate receipt preserves full corpus identity with selected_case_count=1 and selected_case_ids=[math_2_plus_2].",
+  "This PR does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -25,6 +25,7 @@
 
 | CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 | CPU258V-008 | merged | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-009 | ready | TBD | `codex/intel-258v-platform/CPU258V-009-single-case-answer` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record a bounded 258V AVX2 answer-corpus attempt for a single BitNet.cpp-template case selected with --case-id, preserving the timeout row and missing child receipt as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/intel-258v-platform/generated/status.md
+++ b/docs/tracking/campaigns/intel-258v-platform/generated/status.md
@@ -25,7 +25,7 @@
 
 | CPU258V-007 | merged | #4006 | `codex/intel-258v-platform/CPU258V-007-answer-template-refresh` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the first 258V AVX2 answer-corpus refresh using the BitNet.cpp answer-ready prompt envelope, preserving timeout rows and missing child receipts as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 | CPU258V-008 | merged | #4008 | `codex/intel-258v-platform/CPU258V-008-answer-case-filter` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an answer-corpus case-id filter so 258V answer-template refreshes can run one bounded corpus case at a time, preserving full corpus identity plus selected case IDs in the aggregate receipt without answer-quality, parity, speed, Arc, or NPU claims. |
-| CPU258V-009 | ready | TBD | `codex/intel-258v-platform/CPU258V-009-single-case-answer` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record a bounded 258V AVX2 answer-corpus attempt for a single BitNet.cpp-template case selected with --case-id, preserving the timeout row and missing child receipt as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
+| CPU258V-009 | pr_open | #4010 | `codex/intel-258v-platform/CPU258V-009-single-case-answer` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record a bounded 258V AVX2 answer-corpus attempt for a single BitNet.cpp-template case selected with --case-id, preserving the timeout row and missing child receipt as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| intel-258v-platform | CPU258V-009 | #4010 | `codex/intel-258v-platform/CPU258V-009-single-case-answer` | Record a bounded 258V AVX2 answer-corpus attempt for a single BitNet.cpp-template case selected with --case-id, preserving the timeout row and missing child receipt as blocker evidence without answer-quality, parity, speed, Arc, or NPU claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -67,7 +67,7 @@
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
 | intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
 | intel-258v-platform | CPU258V-008 | CPU258V-007 | merged |
-| intel-258v-platform | CPU258V-009 | CPU258V-008 | ready |
+| intel-258v-platform | CPU258V-009 | CPU258V-008 | pr_open |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -67,6 +67,7 @@
 | intel-258v-platform | CPU258V-006 | CPU258V-005 | merged |
 | intel-258v-platform | CPU258V-007 | CPU258V-006 | merged |
 | intel-258v-platform | CPU258V-008 | CPU258V-007 | merged |
+| intel-258v-platform | CPU258V-009 | CPU258V-008 | ready |
 | intel-npu | NPU-003 | NPU-002 | merged |
 | intel-npu | NPU-004 | NPU-003 | merged |
 | intel-npu | NPU-005 | NPU-004 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-008 | #4008 | merged | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-009 | TBD | ready | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | CPU-ANSWER-005 | #4003 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | LEAF-001 | TBD | proposed | none | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | CPU258V-009 | TBD | ready | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | CPU258V-009 | #4010 | pr_open | none | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | A770-003 | TBD | ready | none | OpenCL-first for native A770 proof. |
 | intel-npu | NPU-006 | #3860 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,7 +12,7 @@
 | cpu-proof | BitNet CPU proof | CPU-ANSWER-005 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |
 | crate-collapse | Crate collapse | LEAF-001 | Do not combine crate movement with runtime proof. |
-| intel-258v-platform | Intel 258V platform validation | CPU258V-008 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
+| intel-258v-platform | Intel 258V platform validation | CPU258V-009 | 258V CPU proof is first priority; NPU and Arc proofs must compare against the 258V CPU reference before BitNet-adjacent parity claims. |
 | intel-a770 | Intel Arc A770 validation | A770-003 | OpenCL-first for native A770 proof. |
 | intel-npu | Intel NPU validation | NPU-006 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |


### PR DESCRIPTION
## Summary
- record the first bounded 258V AVX2 answer-corpus attempt using `answer-corpus --case-id math_2_plus_2`
- add the single-case receipt under `ci/hardware/intel-258v/2026-05-08/`
- update the 258V docs/tracker to mark CPU258V-009 ready and describe the claim boundary

## Result
The selected `math_2_plus_2` case still timed out within the 420-second child-run window. The aggregate receipt preserves `case_count=5`, `selected_case_count=1`, and `selected_case_ids=["math_2_plus_2"]`; the case row records `status=timeout`, requested `avx2`, and `source=missing_child_receipt`.

## Claim Boundary
This is blocker evidence only. It does not prove selected-case completion, answer quality, scalar/AVX2 parity under the BitNet.cpp prompt envelope, sustained throughput, Arc 140V execution, or Intel NPU execution.

## Verification
- ran `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- --device cpu answer-corpus --model C:\Code\Rust\BitNet-rs-lnl258v002\models\BitNet-b1.58-2B-4T\ggml-model-i2_s.gguf --tokenizer C:\Code\Rust\BitNet-rs-lnl258v002\models\BitNet-b1.58-2B-4T\tokenizer.json --cpu-kernel avx2 --case-id math_2_plus_2 --dump-logit-steps 1 --logits-topk 5 --per-prompt-timeout-seconds 420 --json-out ci/hardware/intel-258v/2026-05-08/cpu-answer-corpus-avx2-bitnetcpp-template-math_2_plus_2.json`
- parsed artifact for selected case fields, timeout status, requested AVX2, and missing child receipt source
- parsed `docs/tracking/campaigns/intel-258v-platform/active.toml`
- `git diff --check`