### PR TITLE
fix(cuda): align QK256 I2_S GEMV layout

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -999,6 +999,7 @@ async fn async_main() -> Result<()> {
 
     let requested_backend_label =
         cli.device.clone().unwrap_or_else(|| config.default_device.clone());
+    #[cfg(feature = "full-cli")]
     let explicit_device_label = cli.device.clone();
 
     // Report backend selection at startup so logs and receipts are deterministic.

--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -7360,6 +7360,7 @@ fn timing_samples_json(samples: &[f64]) -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "full-cli")]
 fn numeric_samples_json(samples: &[f64]) -> serde_json::Value {
     if samples.is_empty() {
         return serde_json::json!({
@@ -7386,6 +7387,7 @@ fn numeric_samples_json(samples: &[f64]) -> serde_json::Value {
     })
 }
 
+#[cfg(feature = "full-cli")]
 fn tokens_per_second_json(tokens: usize, elapsed_ms: f64) -> serde_json::Value {
     if tokens == 0 || elapsed_ms <= 0.0 {
         serde_json::Value::Null

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -17,6 +17,7 @@ use tokio::io::AsyncWriteExt;
 
 const DEFAULT_CACHE_RELATIVE: &[&str] = &["bitnet-rs", "models"];
 const LOW_DISK_HEADROOM_BYTES: u64 = 1_073_741_824;
+#[cfg(feature = "full-cli")]
 pub(crate) const M4_SLM_RUNTIME_MODEL_ID: &str = "qwen2.5-0.5b-instruct-q8_0";
 
 /// Manage supported local model artifacts.
@@ -145,6 +146,7 @@ struct VerifyResult {
     model: SupportedModel,
 }
 
+#[cfg(feature = "full-cli")]
 #[derive(Debug, Clone)]
 pub(crate) struct VerifiedCachedModel {
     pub id: String,
@@ -187,6 +189,7 @@ impl ModelCommand {
     }
 }
 
+#[cfg(feature = "full-cli")]
 pub(crate) fn verified_apple_m4_slm_model(
     id: &str,
     cache_dir: Option<PathBuf>,
@@ -232,6 +235,7 @@ pub(crate) fn verified_apple_m4_slm_model(
     })
 }
 
+#[cfg(feature = "full-cli")]
 pub(crate) fn apple_m4_slm_cache_status_json(
     id: &str,
     cache_dir: Option<PathBuf>,

--- a/crates/bitnet-ffi/src/config.rs
+++ b/crates/bitnet-ffi/src/config.rs
@@ -283,7 +283,7 @@ impl BitNetCInferenceConfig {
         config.repetition_penalty = self.repetition_penalty;
 
         if self.seed != 0 {
-            config = config.with_seed(self.seed);
+            config = config.with_seed(self.seed as u64);
         }
 
         config

--- a/crates/bitnet-ffi/src/config.rs
+++ b/crates/bitnet-ffi/src/config.rs
@@ -283,7 +283,7 @@ impl BitNetCInferenceConfig {
         config.repetition_penalty = self.repetition_penalty;
 
         if self.seed != 0 {
-            config = config.with_seed(u64::from(self.seed));
+            config = config.with_seed(self.seed);
         }
 
         config

--- a/crates/bitnet-ffi/src/config.rs
+++ b/crates/bitnet-ffi/src/config.rs
@@ -283,7 +283,7 @@ impl BitNetCInferenceConfig {
         config.repetition_penalty = self.repetition_penalty;
 
         if self.seed != 0 {
-            config = config.with_seed(self.seed);
+            config = config.with_seed(u64::from(self.seed));
         }
 
         config

--- a/crates/bitnet-kernels/src/cuda/qk256_gemv.rs
+++ b/crates/bitnet-kernels/src/cuda/qk256_gemv.rs
@@ -4,8 +4,9 @@
 //!
 //! Microsoft BitNet GGUF models in this repo use the GGML I2_S QK256 no-scale
 //! layout: each row is block-aligned, each block stores 256 two-bit codes in
-//! 64 bytes, and codes map directly through `[-2, -1, 1, 2]`. The fused
-//! dequant+GEMV kernel avoids materialising the full FP32 weight matrix by:
+//! two 128-value chunks of four 32-value bitplanes, and codes map through
+//! BitNet.cpp's `[-1, 0, 1, 0]` lookup table. The fused dequant+GEMV kernel
+//! avoids materialising the full FP32 weight matrix by:
 //!
 //! 1. Reading one packed row without expanding it to an intermediate tensor.
 //! 2. Unpacking two-bit codes with bit-shift/mask at the point of use.
@@ -59,17 +60,23 @@ void qk256_gemv_cuda(
     float acc = 0.0f;
 
     for (int col = 0; col < k; ++col) {
-        unsigned char packed = row[col >> 2];
-        unsigned int code = (packed >> ((col & 3) << 1)) & 0x3u;
+        int block_base = (col / 256) * 64;
+        int in_block = col % 256;
+        int chunk = in_block / 128;
+        int within_chunk = in_block % 128;
+        int lane = within_chunk / 32;
+        int group_pos = within_chunk % 32;
+        unsigned char packed = row[block_base + chunk * 32 + group_pos];
+        unsigned int code = (packed >> ((3 - lane) << 1)) & 0x3u;
         float weight;
         if (code == 0u) {
-            weight = -2.0f;
-        } else if (code == 1u) {
             weight = -1.0f;
+        } else if (code == 1u) {
+            weight = 0.0f;
         } else if (code == 2u) {
             weight = 1.0f;
         } else {
-            weight = 2.0f;
+            weight = 0.0f;
         }
         acc += weight * x[col];
     }
@@ -423,10 +430,10 @@ mod tests {
 
     fn code_to_f32(code: u8) -> f32 {
         match code & 0x03 {
-            0 => -2.0,
-            1 => -1.0,
+            0 => -1.0,
+            1 => 0.0,
             2 => 1.0,
-            _ => 2.0,
+            _ => 0.0,
         }
     }
 
@@ -435,7 +442,13 @@ mod tests {
         let mut packed = vec![0u8; row_stride_bytes];
         for (index, code) in codes.iter().copied().enumerate().take(cols) {
             assert!(code < 4, "test QK256 code must be 0..=3");
-            packed[index / 4] |= code << ((index % 4) * 2);
+            let block_base = (index / QK256_BLOCK_COLS) * QK256_PACKED_BYTES_PER_BLOCK;
+            let in_block = index % QK256_BLOCK_COLS;
+            let chunk = in_block / 128;
+            let within_chunk = in_block % 128;
+            let lane = within_chunk / 32;
+            let group_pos = within_chunk % 32;
+            packed[block_base + chunk * 32 + group_pos] |= code << ((3 - lane) * 2);
         }
         packed
     }
@@ -457,8 +470,14 @@ mod tests {
                 let row_bytes = &packed_weights[row_start..row_start + row_stride_bytes];
                 let mut acc = 0.0f32;
                 for col in 0..k {
-                    let packed = row_bytes[col / 4];
-                    let code = (packed >> ((col % 4) * 2)) & 0x03;
+                    let block_base = (col / QK256_BLOCK_COLS) * QK256_PACKED_BYTES_PER_BLOCK;
+                    let in_block = col % QK256_BLOCK_COLS;
+                    let chunk = in_block / 128;
+                    let within_chunk = in_block % 128;
+                    let lane = within_chunk / 32;
+                    let group_pos = within_chunk % 32;
+                    let packed = row_bytes[block_base + chunk * 32 + group_pos];
+                    let code = (packed >> ((3 - lane) * 2)) & 0x03;
                     acc += code_to_f32(code) * x[col];
                 }
                 output[token * n_out + row] = acc;
@@ -528,11 +547,11 @@ mod tests {
         let k = 300usize;
         let cfg = Qk256GemvConfig::for_shape(seq_len, n_out, k).unwrap();
         let row0_codes: Vec<u8> = (0..k).map(|i| (i % 4) as u8).collect();
-        let row1_codes: Vec<u8> = (0..k).map(|i| ((i + 1) % 4) as u8).collect();
+        let row1_codes: Vec<u8> = (0..k).map(|i| if i % 5 == 0 { 2 } else { 0 }).collect();
         let mut packed = Vec::new();
         packed.extend_from_slice(&pack_codes_for_cols(&row0_codes, k));
         packed.extend_from_slice(&pack_codes_for_cols(&row1_codes, k));
-        let input: Vec<f32> = (0..seq_len * k).map(|i| ((i % 13) as f32 - 6.0) * 0.125).collect();
+        let input: Vec<f32> = (0..seq_len * k).map(|i| (i % 31) as f32 + 1.0).collect();
 
         let expected = reference_qk256_gemv(&packed, &input, seq_len, n_out, k);
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3313,12 +3313,12 @@ fn resolve_fetch_cpp_bash() -> Result<PathBuf> {
             }
         }
 
-        return Err(anyhow!(
+        Err(anyhow!(
             "fetch-cpp requires Git Bash on Windows, but no Git Bash bash.exe was found. \
              Install Git for Windows or set BITNET_FETCH_CPP_BASH to the full path of bash.exe. \
              The Windows WSL launcher at C:\\Windows\\System32\\bash.exe is not used because it \
              can hang when WSL is unavailable or unconfigured."
-        ));
+        ))
     }
 
     #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
- align the CUDA QK256 GEMV unpacking with BitNet.cpp/GGML I2_S grouped bitplane layout
- use the canonical I2_S code map `[-1, 0, 1, 0]` instead of the stale contiguous `[-2, -1, 1, 2]` map
- update the CUDA QK256 test oracle/fixtures to match the CPU scalar oracle

## Validation
- cargo test --locked -p bitnet-kernels --no-default-features --features cuda --lib qk256 -- --nocapture
- $env:PATH="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.9\bin;$env:PATH"; $env:BITNET_RUN_CUDA_QK256_GEMV='1'; cargo test --locked -p bitnet-kernels --no-default-features --features cuda --lib cuda::qk256_gemv::tests::test_cuda_qk256_gemv_live_parity_opt_in -- --nocapture
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
- cargo run --locked --release -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- ask --device nvidia-rtx-5070-ti-cuda --model D:\Code\Rust\BitNet\models\microsoft-bitnet-b1.58-2B-4T-gguf\ggml-model-i2_s.gguf --tokenizer D:\Code\Rust\BitNet\models\microsoft-bitnet-b1.58-2B-4T\tokenizer.json --question "What is 2+2? Answer with only the number." --max-new-tokens 8 --temperature 0 --strict-cuda --receipt-out target\bitnet\receipts\cuda-answer-readiness\strict-cuda-ask-math-after-qk256-fix.json
- cargo run --locked --release -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- answer-corpus --device nvidia-rtx-5070-ti-cuda --model D:\Code\Rust\BitNet\models\microsoft-bitnet-b1.58-2B-4T-gguf\ggml-model-i2_s.gguf --tokenizer D:\Code\Rust\BitNet\models\microsoft-bitnet-b1.58-2B-4T\tokenizer.json --corpus ci\quality\bitnet-answer-corpus.yaml --per-prompt-timeout-seconds 300 --dump-logit-steps 1 --logits-topk 20 --fail-on-quality --json-out target\bitnet\receipts\cuda-answer-readiness\cuda-answer-corpus-after-qk256-fix.json
- cargo fmt -p bitnet-kernels -- --check
- git diff --check

## Result
- strict CUDA ask answers `4` with generated token IDs `220,19,128009`
- CUDA answer corpus passes all five deterministic cases with `selected_backend=nvidia-rtx-5070-ti-cuda`, `runtime_api=cuda`, `fallback_used=false`, and `selected_kernel=qk256_gemv_cuda`
- no speedup claim