### PR TITLE
fix(ffi): remove redundant seed cast

### DIFF
--- a/crates/bitnet-ffi/src/config.rs
+++ b/crates/bitnet-ffi/src/config.rs
@@ -283,7 +283,7 @@ impl BitNetCInferenceConfig {
         config.repetition_penalty = self.repetition_penalty;
 
         if self.seed != 0 {
-            config = config.with_seed(self.seed as u64);
+            config = config.with_seed(self.seed);
         }
 
         config


### PR DESCRIPTION
## Summary
- Remove the redundant `as u64` cast from the FFI generation config seed path.
- This fixes the current `cargo clippy --locked --workspace --no-default-features --features cpu -- -D warnings` failure on CI.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --no-default-features --features cpu -- -D warnings`
- `git diff --check`
