### PR TITLE
[codex][apple-m4-productization] Close out M4-PROD-005

### DIFF
--- a/docs/tracking/campaigns/apple-m4-productization/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-productization/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-productization`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -59,7 +59,7 @@ general M4 performance
 | M4-PROD-002 | merged | Add model fetch, verify, list, and prune commands for the supported SLM artifact cache. |
 | M4-PROD-003 | merged | Add Mac-oriented check, ask, validate, and receipts-check CLI wrappers. |
 | M4-PROD-004 | merged | Polish warm-session speed measurement and operator thresholds without broad performance claims. |
-| M4-PROD-005 | in_progress | Implement the first parity-gated Apple Metal prefill projection microphase handoff. |
+| M4-PROD-005 | merged | Implement the first parity-gated Apple Metal prefill projection microphase handoff. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-productization/active.toml
+++ b/docs/tracking/campaigns/apple-m4-productization/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-productization"
 title = "Apple M4 local answer productization"
-status = "active"
+status = "complete"
 
 objective = "Turn the completed Apple M4 SLM proof lane into a practical Mac user flow with documented baseline commands, model cache management, Mac-oriented CLI wrappers, warm-session speed polish, and a parity-gated Metal phase handoff."
 
@@ -200,13 +200,14 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-PROD-005"
-status = "pr_open"
+status = "merged"
 branch = "codex/apple-m4-productization/M4-PROD-005-metal-phase"
 stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
 pr = 4034
+merge_sha = "b7782f2c98f874d13a08bd9dfac9d5efc91d3dd8"
 blocked_by = ["M4-PROD-004"]
 acceptance = "Implement the first Apple Metal prefill linear projection microphase only with CPU-only versus CPU-plus-Metal greedy parity, Metal phase fallback_used=false, the rest of the pipeline recorded as CPU/NEON, layout handling recorded, and no full Metal inference claim."
 commands = [

--- a/docs/tracking/campaigns/apple-m4-productization/events/2026-05-08T105523Z-M4-PROD-005-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-productization/events/2026-05-08T105523Z-M4-PROD-005-merged.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-08T10:55:23Z"
+campaign = "apple-m4-productization"
+item = "M4-PROD-005"
+event = "merged"
+pr = 4034
+merge_sha = "b7782f2c98f874d13a08bd9dfac9d5efc91d3dd8"
+actor = "codex"
+
+notes = [
+  "M4-PROD-005 Apple Metal dense prefill linear phase proof merged.",
+  "The merged proof records Metal only as a named phase contribution with CPU/NEON remaining pipeline visibility and no full Metal inference, Neural Engine, MPSGraph, QK256, BitNet quality, or broad performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4-productization/events/2026-05-08T105524Z-M4-PROD-005-closeout.toml
+++ b/docs/tracking/campaigns/apple-m4-productization/events/2026-05-08T105524Z-M4-PROD-005-closeout.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-08T10:55:24Z"
+campaign = "apple-m4-productization"
+item = "M4-PROD-005"
+event = "closeout"
+pr = 4034
+merge_sha = "b7782f2c98f874d13a08bd9dfac9d5efc91d3dd8"
+actor = "codex"
+
+notes = [
+  "Closed the Apple M4 productization campaign after M4-PROD-001 through M4-PROD-005 merged.",
+  "The productized Mac path now covers documented CPU/NEON SLM answers, model cache management, Mac CLI wrappers, warm-session timing, and the first parity-gated Metal phase contribution.",
+]

--- a/docs/tracking/campaigns/apple-m4-productization/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-productization/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 local answer productization Campaign Status
 
 - Campaign: `apple-m4-productization`
-- State: `active`
+- State: `complete`
 - Objective: Turn the completed Apple M4 SLM proof lane into a practical Mac user flow with documented baseline commands, model cache management, Mac-oriented CLI wrappers, warm-session speed polish, and a parity-gated Metal phase handoff.
 
 ## Work Items
@@ -13,7 +13,7 @@
 | M4-PROD-002 | merged | #4020 | `codex/apple-m4-productization/M4-PROD-002-model-cache` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add storage-conscious model cache commands to fetch, verify, list, and prune supported SLM artifacts under the user cache, recording source, size, SHA256, and tokenizer metadata while warning on low disk and never committing binaries. |
 | M4-PROD-003 | merged | #4025 | `codex/apple-m4-productization/M4-PROD-003-mac-cli` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add Mac-oriented check, ask, validate, and receipts-check CLI wrappers that route the supported SLM path through apple-m4-cpu-neon with strict loader/tokenizer behavior and clear errors for missing models, wrong hashes, unsupported backends, hidden fallback, and premature full Metal requests. |
 | M4-PROD-004 | merged | #4029 | `codex/apple-m4-productization/M4-PROD-004-warm-speed-polish` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Polish warm-session timing and operator thresholds so 16, 32, and 64 token warm answers are measured with cold load separated, model/tokenizer reuse visible, and no broad performance claim. |
-| M4-PROD-005 | pr_open | #4034 | `codex/apple-m4-productization/M4-PROD-005-metal-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Implement the first Apple Metal prefill linear projection microphase only with CPU-only versus CPU-plus-Metal greedy parity, Metal phase fallback_used=false, the rest of the pipeline recorded as CPU/NEON, layout handling recorded, and no full Metal inference claim. |
+| M4-PROD-005 | merged | #4034 | `codex/apple-m4-productization/M4-PROD-005-metal-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Implement the first Apple Metal prefill linear projection microphase only with CPU-only versus CPU-plus-Metal greedy parity, Metal phase fallback_used=false, the rest of the pipeline recorded as CPU/NEON, layout handling recorded, and no full Metal inference claim. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4-productization | M4-PROD-005 | #4034 | `codex/apple-m4-productization/M4-PROD-005-metal-phase` | Implement the first Apple Metal prefill linear projection microphase only with CPU-only versus CPU-plus-Metal greedy parity, Metal phase fallback_used=false, the rest of the pipeline recorded as CPU/NEON, layout handling recorded, and no full Metal inference claim. |
 | intel-258v-platform | CPU258V-013 | #4036 | `codex/intel-258v-platform/CPU258V-013-warm-phase-artifacts` | Record release-built 258V warm-session strict CPU phase receipts for prefill_512 and decode_128 after the BitNet b1.58 mechanics correction, preserving real GGUF loading, explicit tokenizer resolution, selected i2_s-avx2-reference kernel, fallback=false, and phase timing claim boundaries. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -35,7 +35,7 @@
 | apple-m4-productization | M4-PROD-002 | M4-PROD-001 | merged |
 | apple-m4-productization | M4-PROD-003 | M4-PROD-002 | merged |
 | apple-m4-productization | M4-PROD-004 | M4-PROD-003 | merged |
-| apple-m4-productization | M4-PROD-005 | M4-PROD-004 | pr_open |
+| apple-m4-productization | M4-PROD-005 | M4-PROD-004 | merged |
 | apple-m4-slm-answer | SLM-M4-002 | SLM-M4-001 | merged |
 | apple-m4-slm-answer | SLM-M4-003 | SLM-M4-002 | merged |
 | apple-m4-slm-answer | SLM-M4-004 | SLM-M4-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -7,7 +7,7 @@
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-local-answer | M4-QA-001 | #3904 | blocked | M4-QA-MODEL-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
-| apple-m4-productization | M4-PROD-005 | #4034 | pr_open | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
+| apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |


### PR DESCRIPTION
Campaign: apple-m4-productization
Work item: M4-PROD-005 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Mark M4-PROD-005 merged with PR #4034 merge SHA `b7782f2c98f874d13a08bd9dfac9d5efc91d3dd8`.
- Add append-only merged and closeout events.
- Mark the apple-m4-productization campaign complete after M4-PROD-001 through M4-PROD-005 landed.
- Regenerate campaign and global dashboards.

## Claim Boundary
Tracker-only closeout. No runtime, kernel, QK256, server, model, dependency, or machine-local artifact changes.

## Verification
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-productization`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
