### PR TITLE
Convert Python migration example to native Rust

### DIFF
--- a/examples/migration/python-to-rust/README.md
+++ b/examples/migration/python-to-rust/README.md
@@ -1,284 +1,165 @@
 # Python to Rust Migration Example
 
-This example demonstrates migrating from Python BitNet usage to bitnet-rs with Python bindings.
+This example demonstrates converting a Python BitNet-style inference script into a native Rust implementation.
 
 ## Overview
 
-This migration shows how to:
-- Replace Python-only BitNet usage with bitnet-rs Python bindings
-- Improve performance while maintaining Python API compatibility
-- Handle model loading and inference migration
-- Optimize memory usage and error handling
+The migration shows how to replace common Python patterns with Rust equivalents:
+
+- Dynamic dictionaries become typed Rust structs.
+- Runtime exceptions become `Result<T, E>` with an explicit error enum.
+- A Python decode loop becomes an owned Rust inference type.
+- Ad-hoc timing fields become typed `Duration` and throughput metrics.
+- A Python benchmark script becomes a dependency-free Rust benchmark smoke test.
+
+## Layout
+
+```text
+python-to-rust/
+├── before/
+│   ├── inference.py   # Legacy Python inference wrapper
+│   └── benchmark.py   # Legacy Python benchmark harness
+├── after/
+│   ├── Cargo.toml
+│   └── src/
+│       ├── main.rs      # Converted Rust inference wrapper
+│       └── benchmark.rs # Converted Rust benchmark harness
+└── README.md
+```
 
 ## Before: Python Implementation
 
-The original implementation uses pure Python with slower inference:
+The original Python code stores model state in a dynamic class and returns dictionary-shaped generation results:
 
 ```python
-# before/inference.py
-import bitnet_python  # Legacy Python implementation
-import numpy as np
-import time
-
 class BitNetInference:
-    def __init__(self, model_path):
-        self.model = bitnet_python.load_model(model_path)
+    def __init__(self, model_path: str):
+        self.model = load_model(model_path)
 
-    def generate(self, prompt, max_tokens=100):
-        start_time = time.time()
+    def generate(self, prompt: str, max_tokens: int = 100) -> dict[str, Any]:
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be positive")
+
+        start_time = time.perf_counter()
         tokens = self.model.tokenize(prompt)
-        output_tokens = []
+        output_tokens: list[int] = []
 
         for _ in range(max_tokens):
             logits = self.model.forward(tokens)
-            next_token = np.argmax(logits[-1])
+            next_token = max(range(len(logits[-1])), key=logits[-1].__getitem__)
             output_tokens.append(next_token)
             tokens.append(next_token)
 
             if next_token == self.model.eos_token:
                 break
 
-        result = self.model.detokenize(output_tokens)
-        inference_time = time.time() - start_time
+        inference_time = time.perf_counter() - start_time
+        token_count = len(output_tokens)
 
         return {
-            'text': result,
-            'tokens': len(output_tokens),
-            'time': inference_time,
-            'tokens_per_second': len(output_tokens) / inference_time
+            "text": self.model.detokenize(output_tokens),
+            "tokens": token_count,
+            "time": inference_time,
+            "tokens_per_second": token_count / inference_time if inference_time else 0.0,
         }
-
-# Usage
-if __name__ == "__main__":
-    model = BitNetInference("model.gguf")
-    result = model.generate("The future of AI is")
-    print(f"Generated: {result['text']}")
-    print(f"Speed: {result['tokens_per_second']:.1f} tok/s")
 ```
 
-## After: bitnet-rs Python Bindings
+See `before/inference.py` for the complete legacy example.
 
-The migrated implementation uses bitnet-rs Python bindings for better performance:
+## After: Rust Implementation
 
-```python
-# after/inference.py
-import bitnet_py  # bitnet-rs Python bindings
-import time
-from typing import Dict, Optional
+The Rust version makes model loading, generation configuration, output metrics, and errors explicit:
 
-class BitNetInference:
-    def __init__(self, model_path: str):
-        # bitnet-rs handles model loading more efficiently
-        self.model = bitnet_py.Model.load(model_path)
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GenerationConfig {
+    pub max_tokens: usize,
+}
 
-    def generate(self, prompt: str, max_tokens: int = 100) -> Dict[str, any]:
-        start_time = time.time()
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenerationStats {
+    pub text: String,
+    pub tokens: usize,
+    pub elapsed: Duration,
+    pub tokens_per_second: f64,
+}
 
-        # bitnet-rs provides streaming generation
-        result = self.model.generate(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=0.7,
-            top_p=0.9
-        )
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InferenceError {
+    EmptyModelPath,
+    EmptyPrompt,
+    InvalidMaxTokens,
+}
 
-        inference_time = time.time() - start_time
-
-        return {
-            'text': result.text,
-            'tokens': result.token_count,
-            'time': inference_time,
-            'tokens_per_second': result.token_count / inference_time,
-            'finish_reason': result.finish_reason
+impl BitNetInference {
+    pub fn generate(
+        &self,
+        prompt: &str,
+        config: GenerationConfig,
+    ) -> Result<GenerationStats, InferenceError> {
+        if prompt.trim().is_empty() {
+            return Err(InferenceError::EmptyPrompt);
+        }
+        if config.max_tokens == 0 {
+            return Err(InferenceError::InvalidMaxTokens);
         }
 
-    def generate_stream(self, prompt: str, max_tokens: int = 100):
-        """Streaming generation for real-time applications"""
-        for chunk in self.model.generate_stream(
-            prompt=prompt,
-            max_tokens=max_tokens
-        ):
-            yield {
-                'text': chunk.text,
-                'is_complete': chunk.is_complete,
-                'token_count': chunk.token_count
-            }
-
-# Usage with error handling
-if __name__ == "__main__":
-    try:
-        model = BitNetInference("model.gguf")
-
-        # Batch generation
-        result = model.generate("The future of AI is")
-        print(f"Generated: {result['text']}")
-        print(f"Speed: {result['tokens_per_second']:.1f} tok/s")
-
-        # Streaming generation
-        print("\nStreaming generation:")
-        for chunk in model.generate_stream("Rust programming is"):
-            if chunk['text']:
-                print(chunk['text'], end='', flush=True)
-        print()
-
-    except bitnet_py.ModelError as e:
-        print(f"Model error: {e}")
-    except Exception as e:
-        print(f"Unexpected error: {e}")
-```
-
-## Performance Comparison
-
-```python
-# benchmark.py
-import time
-import statistics
-from before.inference import BitNetInference as OldInference
-from after.inference import BitNetInference as NewInference
-
-def benchmark_inference(model_class, model_path, prompts, runs=5):
-    model = model_class(model_path)
-    times = []
-    token_counts = []
-
-    for _ in range(runs):
-        for prompt in prompts:
-            start = time.time()
-            result = model.generate(prompt, max_tokens=50)
-            end = time.time()
-
-            times.append(end - start)
-            token_counts.append(result['tokens'])
-
-    avg_time = statistics.mean(times)
-    total_tokens = sum(token_counts)
-    tokens_per_second = total_tokens / sum(times)
-
-    return {
-        'avg_time': avg_time,
-        'tokens_per_second': tokens_per_second,
-        'total_tokens': total_tokens
+        // Decode loop omitted here; see after/src/main.rs.
+        // The full implementation returns GenerationStats on success.
     }
-
-if __name__ == "__main__":
-    prompts = [
-        "The future of AI is",
-        "Rust programming language",
-        "Machine learning models",
-        "High performance computing"
-    ]
-
-    print("Benchmarking Python implementations...")
-
-    # Benchmark old implementation
-    old_results = benchmark_inference(OldInference, "model.gguf", prompts)
-    print(f"Legacy Python: {old_results['tokens_per_second']:.1f} tok/s")
-
-    # Benchmark new implementation
-    new_results = benchmark_inference(NewInference, "model.gguf", prompts)
-    print(f"bitnet-rs Python: {new_results['tokens_per_second']:.1f} tok/s")
-
-    # Calculate improvement
-    improvement = new_results['tokens_per_second'] / old_results['tokens_per_second']
-    print(f"Performance improvement: {improvement:.1f}x faster")
+}
 ```
 
-## Migration Steps
+See `after/src/main.rs` for the complete converted implementation.
 
-### 1. Install bitnet-rs Python Bindings
+## Migration Map
+
+| Python pattern | Rust replacement |
+| --- | --- |
+| `dict[str, Any]` generation result | `GenerationStats` struct |
+| `ValueError` for validation | `InferenceError` enum implementing `std::error::Error` |
+| `max_tokens: int = 100` | `GenerationConfig::default()` |
+| Mutable Python list token buffers | Owned `Vec<u32>` buffers |
+| `time.perf_counter()` float seconds | `Instant` and `Duration` |
+| Script-level benchmark | `src/benchmark.rs` binary with tests |
+
+## Running the Examples
+
+Run the legacy Python example:
 
 ```bash
-# Remove old dependencies
-pip uninstall bitnet-python
-
-# Install bitnet-rs Python bindings
-pip install bitnet-py
+python examples/migration/python-to-rust/before/inference.py
 ```
 
-### 2. Update Import Statements
+Run the converted Rust inference example:
 
-```python
-# Before
-import bitnet_python
-
-# After
-import bitnet_py
+```bash
+cargo run --manifest-path examples/migration/python-to-rust/after/Cargo.toml --bin inference
 ```
 
-### 3. Update Model Loading
+Run the converted Rust benchmark smoke test:
 
-```python
-# Before
-model = bitnet_python.load_model(path)
-
-# After
-model = bitnet_py.Model.load(path)
+```bash
+cargo run --manifest-path examples/migration/python-to-rust/after/Cargo.toml --bin benchmark
 ```
 
-### 4. Update Generation API
+Run the Rust tests:
 
-```python
-# Before
-tokens = model.tokenize(prompt)
-logits = model.forward(tokens)
-result = model.detokenize(output_tokens)
-
-# After
-result = model.generate(prompt=prompt, max_tokens=100)
-```
-
-### 5. Add Error Handling
-
-```python
-try:
-    result = model.generate(prompt)
-except bitnet_py.ModelError as e:
-    print(f"Model error: {e}")
+```bash
+cargo test --manifest-path examples/migration/python-to-rust/after/Cargo.toml
 ```
 
 ## Key Benefits
 
-- **3.2x faster inference** - Rust implementation with optimized kernels
-- **Better memory management** - Automatic memory cleanup
-- **Type safety** - Python type hints with Rust backing
-- **Streaming support** - Real-time token generation
-- **Error handling** - Proper exception handling
-- **Thread safety** - Safe concurrent usage
+- **Type safety:** Callers receive `GenerationStats` instead of a dictionary with string keys.
+- **Explicit failures:** Validation errors are exhaustively represented by `InferenceError`.
+- **Ownership:** Model state is owned by `BitNetInference`, so cleanup happens automatically.
+- **No runtime dependencies:** The converted sample uses only the Rust standard library.
+- **Migration validation:** Unit tests cover model loading validation, prompt validation, generation limits, and benchmark output.
 
-## Common Issues and Solutions
+## Next Steps for a Real Model
 
-### Issue: Import Error
-```python
-# Error: ModuleNotFoundError: No module named 'bitnet_py'
-# Solution: Install bitnet-rs Python bindings
-pip install bitnet-py
-```
-
-### Issue: Model Loading Fails
-```python
-# Error: Model file not found or corrupted
-# Solution: Verify model path and format
-try:
-    model = bitnet_py.Model.load("model.gguf")
-except bitnet_py.ModelError as e:
-    print(f"Failed to load model: {e}")
-```
-
-### Issue: Performance Not Improved
-```python
-# Solution: Ensure you're using the right model format
-# bitnet-rs works best with GGUF models
-model = bitnet_py.Model.load("model.gguf")  # Preferred
-```
-
-## Next Steps
-
-1. **Test thoroughly** - Run your existing test suite
-2. **Benchmark performance** - Measure actual improvements
-3. **Update documentation** - Document API changes
-4. **Consider streaming** - Use streaming APIs for better UX
-5. **Add monitoring** - Track performance metrics
-
----
-
-**Migration complete!** Your Python code now benefits from Rust performance while maintaining familiar Python APIs.
+1. Replace the placeholder `BitNetModel::tokenize`, `forward_next_token`, and `detokenize` methods with the production bitnet-rs APIs.
+2. Extend `GenerationConfig` with sampling parameters such as temperature, top-p, and top-k.
+3. Add integration tests that compare Python and Rust output on fixed prompts.
+4. Promote the smoke benchmark to Criterion once the production inference path is wired in.

--- a/examples/migration/python-to-rust/after/.gitignore
+++ b/examples/migration/python-to-rust/after/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/Cargo.lock

--- a/examples/migration/python-to-rust/after/Cargo.toml
+++ b/examples/migration/python-to-rust/after/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bitnet-python-to-rust-example"
+version = "0.1.0"
+edition = "2024"
+description = "BitNet migration example converted from Python to Rust"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[[bin]]
+name = "inference"
+path = "src/main.rs"
+
+[[bin]]
+name = "benchmark"
+path = "src/benchmark.rs"
+
+[workspace]

--- a/examples/migration/python-to-rust/after/src/benchmark.rs
+++ b/examples/migration/python-to-rust/after/src/benchmark.rs
@@ -1,0 +1,80 @@
+//! Rust benchmark companion for the Python-to-Rust migration example.
+//!
+//! This is a dependency-free smoke benchmark intended for documentation and
+//! migration validation, not a statistically rigorous Criterion benchmark.
+
+use std::error::Error;
+use std::time::{Duration, Instant};
+
+#[path = "main.rs"]
+mod inference;
+
+use inference::{BitNetInference, GenerationConfig};
+
+const PROMPTS: &[&str] = &[
+    "The future of AI is",
+    "Rust programming language",
+    "Machine learning models",
+    "High performance computing",
+];
+
+#[derive(Debug, Clone, PartialEq)]
+struct BenchmarkSummary {
+    avg_time: Duration,
+    tokens_per_second: f64,
+    total_tokens: usize,
+}
+
+fn benchmark_inference(
+    model_path: &str,
+    prompts: &[&str],
+    runs: usize,
+) -> Result<BenchmarkSummary, Box<dyn Error>> {
+    let model = BitNetInference::new(model_path)?;
+    let mut total_time = Duration::ZERO;
+    let mut total_tokens = 0;
+    let mut samples = 0;
+
+    for _ in 0..runs {
+        for prompt in prompts {
+            let started_at = Instant::now();
+            let result = model.generate(prompt, GenerationConfig { max_tokens: 50 })?;
+            total_time += started_at.elapsed();
+            total_tokens += result.tokens;
+            samples += 1;
+        }
+    }
+
+    let avg_time = if samples == 0 {
+        Duration::ZERO
+    } else {
+        Duration::from_secs_f64(total_time.as_secs_f64() / samples as f64)
+    };
+    let tokens_per_second =
+        if total_time.is_zero() { 0.0 } else { total_tokens as f64 / total_time.as_secs_f64() };
+
+    Ok(BenchmarkSummary { avg_time, tokens_per_second, total_tokens })
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let results = benchmark_inference("model.gguf", PROMPTS, 5)?;
+
+    println!("Rust implementation: {:.1} tok/s", results.tokens_per_second);
+    println!("Average request time: {:.3} ms", results.avg_time.as_secs_f64() * 1000.0);
+    println!("Total tokens: {}", results.total_tokens);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_produces_summary() {
+        let results = benchmark_inference("model.gguf", PROMPTS, 1).unwrap();
+
+        assert_eq!(results.total_tokens, PROMPTS.len() * 50);
+        assert!(results.tokens_per_second >= 0.0);
+    }
+}

--- a/examples/migration/python-to-rust/after/src/main.rs
+++ b/examples/migration/python-to-rust/after/src/main.rs
@@ -1,0 +1,175 @@
+//! Python-to-Rust BitNet inference migration example.
+//!
+//! The legacy Python version returned untyped dictionaries and performed the
+//! decode loop with runtime checks. This Rust version keeps the same observable
+//! shape while using typed configuration, typed results, ownership-based model
+//! lifetime management, and `Result`-based errors.
+
+use std::error::Error;
+use std::fmt;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BitNetModel {
+    model_path: String,
+    eos_token: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GenerationConfig {
+    pub max_tokens: usize,
+}
+
+impl Default for GenerationConfig {
+    fn default() -> Self {
+        Self { max_tokens: 100 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenerationStats {
+    pub text: String,
+    pub tokens: usize,
+    pub elapsed: Duration,
+    pub tokens_per_second: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InferenceError {
+    EmptyModelPath,
+    EmptyPrompt,
+    InvalidMaxTokens,
+}
+
+impl fmt::Display for InferenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyModelPath => formatter.write_str("model_path cannot be empty"),
+            Self::EmptyPrompt => formatter.write_str("prompt cannot be empty"),
+            Self::InvalidMaxTokens => formatter.write_str("max_tokens must be positive"),
+        }
+    }
+}
+
+impl Error for InferenceError {}
+
+impl BitNetModel {
+    pub fn load(model_path: impl Into<String>) -> Result<Self, InferenceError> {
+        let model_path = model_path.into();
+        if model_path.trim().is_empty() {
+            return Err(InferenceError::EmptyModelPath);
+        }
+
+        Ok(Self { model_path, eos_token: 0 })
+    }
+
+    fn tokenize(&self, prompt: &str) -> Vec<u32> {
+        prompt.split_whitespace().map(|part| part.len() as u32).collect()
+    }
+
+    fn forward_next_token(&self, tokens: &[u32]) -> u32 {
+        tokens.iter().sum::<u32>() % 31 + 1
+    }
+
+    fn detokenize(&self, tokens: &[u32]) -> String {
+        tokens.iter().map(|token| format!("token_{token}")).collect::<Vec<_>>().join(" ")
+    }
+}
+
+#[derive(Debug)]
+pub struct BitNetInference {
+    model: BitNetModel,
+}
+
+impl BitNetInference {
+    pub fn new(model_path: impl Into<String>) -> Result<Self, InferenceError> {
+        Ok(Self { model: BitNetModel::load(model_path)? })
+    }
+
+    pub fn generate(
+        &self,
+        prompt: &str,
+        config: GenerationConfig,
+    ) -> Result<GenerationStats, InferenceError> {
+        if prompt.trim().is_empty() {
+            return Err(InferenceError::EmptyPrompt);
+        }
+        if config.max_tokens == 0 {
+            return Err(InferenceError::InvalidMaxTokens);
+        }
+
+        let started_at = Instant::now();
+        let mut context_tokens = self.model.tokenize(prompt);
+        let mut output_tokens = Vec::with_capacity(config.max_tokens);
+
+        for _ in 0..config.max_tokens {
+            let next_token = self.model.forward_next_token(&context_tokens);
+            output_tokens.push(next_token);
+            context_tokens.push(next_token);
+
+            if next_token == self.model.eos_token {
+                break;
+            }
+        }
+
+        let elapsed = started_at.elapsed();
+        let tokens = output_tokens.len();
+        let tokens_per_second =
+            if elapsed.is_zero() { 0.0 } else { tokens as f64 / elapsed.as_secs_f64() };
+
+        Ok(GenerationStats {
+            text: self.model.detokenize(&output_tokens),
+            tokens,
+            elapsed,
+            tokens_per_second,
+        })
+    }
+}
+
+#[allow(dead_code)]
+fn main() -> Result<(), Box<dyn Error>> {
+    let model = BitNetInference::new("model.gguf")?;
+    let result = model.generate("The future of AI is", GenerationConfig::default())?;
+
+    println!("Generated: {}", result.text);
+    println!("Tokens: {}", result.tokens);
+    println!("Speed: {:.1} tok/s", result.tokens_per_second);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_empty_model_path() {
+        let error = BitNetInference::new("   ").unwrap_err();
+        assert_eq!(error, InferenceError::EmptyModelPath);
+    }
+
+    #[test]
+    fn rejects_empty_prompt() {
+        let model = BitNetInference::new("model.gguf").unwrap();
+        let error = model.generate(" ", GenerationConfig::default()).unwrap_err();
+        assert_eq!(error, InferenceError::EmptyPrompt);
+    }
+
+    #[test]
+    fn rejects_zero_max_tokens() {
+        let model = BitNetInference::new("model.gguf").unwrap();
+        let error = model.generate("hello", GenerationConfig { max_tokens: 0 }).unwrap_err();
+        assert_eq!(error, InferenceError::InvalidMaxTokens);
+    }
+
+    #[test]
+    fn generates_typed_stats() {
+        let model = BitNetInference::new("model.gguf").unwrap();
+        let result =
+            model.generate("The future of AI is", GenerationConfig { max_tokens: 4 }).unwrap();
+
+        assert_eq!(result.tokens, 4);
+        assert!(!result.text.is_empty());
+        assert!(result.text.split_whitespace().all(|part| part.starts_with("token_")));
+    }
+}

--- a/examples/migration/python-to-rust/before/benchmark.py
+++ b/examples/migration/python-to-rust/before/benchmark.py
@@ -1,0 +1,49 @@
+"""Benchmark harness for the legacy Python example."""
+
+from __future__ import annotations
+
+import statistics
+import time
+from collections.abc import Sequence
+
+from inference import BitNetInference
+
+
+PROMPTS = (
+    "The future of AI is",
+    "Rust programming language",
+    "Machine learning models",
+    "High performance computing",
+)
+
+
+def benchmark_inference(
+    model_path: str,
+    prompts: Sequence[str] = PROMPTS,
+    runs: int = 5,
+) -> dict[str, float]:
+    model = BitNetInference(model_path)
+    times: list[float] = []
+    token_counts: list[int] = []
+
+    for _ in range(runs):
+        for prompt in prompts:
+            start = time.perf_counter()
+            result = model.generate(prompt, max_tokens=50)
+            elapsed = time.perf_counter() - start
+
+            times.append(elapsed)
+            token_counts.append(int(result["tokens"]))
+
+    total_time = sum(times)
+    total_tokens = sum(token_counts)
+    return {
+        "avg_time": statistics.mean(times),
+        "tokens_per_second": total_tokens / total_time if total_time else 0.0,
+        "total_tokens": float(total_tokens),
+    }
+
+
+if __name__ == "__main__":
+    results = benchmark_inference("model.gguf")
+    print(f"Legacy Python: {results['tokens_per_second']:.1f} tok/s")

--- a/examples/migration/python-to-rust/before/inference.py
+++ b/examples/migration/python-to-rust/before/inference.py
@@ -1,0 +1,79 @@
+"""Legacy pure-Python BitNet-style inference example.
+
+This intentionally small example mirrors common Python migration pain points:
+manual decode loops, dict-shaped results, dynamic runtime validation, and
+benchmark timing code mixed into the inference path.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class LegacyBitNetModel:
+    """Tiny stand-in for a Python-only model implementation."""
+
+    model_path: str
+    eos_token: int = 0
+
+    def tokenize(self, prompt: str) -> list[int]:
+        return [len(part) for part in prompt.split()]
+
+    def forward(self, tokens: list[int]) -> list[list[float]]:
+        # A real implementation would run Python/Numpy kernels here. The last
+        # row is shaped so argmax selects a deterministic next token.
+        next_token = (sum(tokens) % 31) + 1 if tokens else 1
+        row = [0.0] * 32
+        row[next_token] = 1.0
+        return [row]
+
+    def detokenize(self, tokens: list[int]) -> str:
+        return " ".join(f"token_{token}" for token in tokens)
+
+
+def load_model(model_path: str) -> LegacyBitNetModel:
+    if not model_path:
+        raise ValueError("model_path cannot be empty")
+    return LegacyBitNetModel(model_path=model_path)
+
+
+class BitNetInference:
+    def __init__(self, model_path: str):
+        self.model = load_model(model_path)
+
+    def generate(self, prompt: str, max_tokens: int = 100) -> dict[str, Any]:
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be positive")
+
+        start_time = time.perf_counter()
+        tokens = self.model.tokenize(prompt)
+        output_tokens: list[int] = []
+
+        for _ in range(max_tokens):
+            logits = self.model.forward(tokens)
+            next_token = max(range(len(logits[-1])), key=logits[-1].__getitem__)
+            output_tokens.append(next_token)
+            tokens.append(next_token)
+
+            if next_token == self.model.eos_token:
+                break
+
+        inference_time = time.perf_counter() - start_time
+        token_count = len(output_tokens)
+
+        return {
+            "text": self.model.detokenize(output_tokens),
+            "tokens": token_count,
+            "time": inference_time,
+            "tokens_per_second": token_count / inference_time if inference_time else 0.0,
+        }
+
+
+if __name__ == "__main__":
+    model = BitNetInference("model.gguf")
+    result = model.generate("The future of AI is")
+    print(f"Generated: {result['text']}")
+    print(f"Speed: {result['tokens_per_second']:.1f} tok/s")


### PR DESCRIPTION
### Motivation

- Provide a native Rust version of the Python-to-Rust migration example so readers can follow a direct conversion instead of pretending to keep Python bindings. 
- Show concrete, minimal-before and after artifacts that illustrate how dynamic Python patterns map to typed Rust equivalents and safer ownership/error handling. 

### Description

- Rewrote `examples/migration/python-to-rust/README.md` to document a native Rust conversion and migration map instead of a Python-binding migration. 
- Added legacy Python artifacts under `examples/migration/python-to-rust/before/` (`inference.py`, `benchmark.py`) to preserve the original example. 
- Added a standalone Rust example crate under `examples/migration/python-to-rust/after/` with `Cargo.toml`, `.gitignore`, `src/main.rs` (typed inference, `InferenceError`, decode loop), `src/benchmark.rs` (smoke benchmark), and unit tests. 

### Testing

- Ran the legacy example with `python examples/migration/python-to-rust/before/inference.py` and observed expected output. 
- Built and executed the Rust example with `cargo run --manifest-path examples/migration/python-to-rust/after/Cargo.toml --bin inference` and observed expected output. 
- Verified formatting with `cargo fmt --check --manifest-path examples/migration/python-to-rust/after/Cargo.toml` and fixed minor warnings. 
- Ran `cargo test --manifest-path examples/migration/python-to-rust/after/Cargo.toml` and all unit tests passed (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcb97221c83338bfd62e35ba5c094)