### PR TITLE
Convert preflight shell logic to bitnet-task

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,58 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
+ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# BitNet-rs preflight script - Resource monitoring and concurrency caps
-# This script sets conservative defaults to prevent fork/PID/file-descriptor storms
-# and ensures stable test execution across different machines
-
-# Show current system pressure
-pids_used=$(ps -e --no-headers | wc -l | xargs)
-pid_max=$(cat /proc/sys/kernel/pid_max)
-files_used=$(awk '{print $2}' /proc/sys/fs/file-nr)
-files_max=$(cat /proc/sys/fs/file-max)
-load_avg=$(uptime | awk -F'load average:' '{ print $2 }' | awk '{ print $1 }' | sed 's/,//')
-
-echo "=== BitNet-rs System Resource Check ==="
-echo "PIDs: $pids_used / $pid_max ($(echo "$pids_used * 100 / $pid_max" | bc)%)"
-echo "Open files: $files_used / $files_max ($(echo "$files_used * 100 / $files_max" | bc)%)"
-echo "Load average: $load_avg"
-
-# Conservative defaults (overridable via env in CI/local)
-export RUST_TEST_THREADS="${RUST_TEST_THREADS:-2}"
-export RAYON_NUM_THREADS="${RAYON_NUM_THREADS:-2}"
-export CROSSVAL_WORKERS="${CROSSVAL_WORKERS:-2}"
-
-# BLAS/NumPy thread limits (for Python validation scripts)
-export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
-export OPENBLAS_NUM_THREADS="${OPENBLAS_NUM_THREADS:-1}"
-export MKL_NUM_THREADS="${MKL_NUM_THREADS:-1}"
-export NUMEXPR_NUM_THREADS="${NUMEXPR_NUM_THREADS:-1}"
-
-# BitNet-specific environment
-export BITNET_DETERMINISTIC="${BITNET_DETERMINISTIC:-1}"
-export BITNET_SEED="${BITNET_SEED:-42}"
-
-# If near PID limit, drop to ultra-safe mode
-pid_usage_pct=$((pids_used * 100 / pid_max))
-if [ "$pid_usage_pct" -gt 85 ]; then
-    export RUST_TEST_THREADS=1
-    export RAYON_NUM_THREADS=1
-    export CROSSVAL_WORKERS=1
-    export OMP_NUM_THREADS=1
-    export OPENBLAS_NUM_THREADS=1
-    export MKL_NUM_THREADS=1
-    export NUMEXPR_NUM_THREADS=1
-    echo "⚠️  System hot (${pid_usage_pct}% PID usage) → auto-degraded to single-threaded mode"
-else
-    echo "✅ System resources OK → using capped concurrency (RUST_TEST_THREADS=$RUST_TEST_THREADS, RAYON=$RAYON_NUM_THREADS)"
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    eval "$(cargo run --quiet --locked --manifest-path "$ROOT/Cargo.toml" -p bitnet-task -- preflight --emit-env)"
+    return $?
 fi
 
-# Show final configuration
-echo "=== BitNet-rs Concurrency Configuration ==="
-echo "RUST_TEST_THREADS=$RUST_TEST_THREADS"
-echo "RAYON_NUM_THREADS=$RAYON_NUM_THREADS"
-echo "CROSSVAL_WORKERS=$CROSSVAL_WORKERS"
-echo "BITNET_DETERMINISTIC=$BITNET_DETERMINISTIC"
-echo "BITNET_SEED=$BITNET_SEED"
-echo "BLAS threads: OMP=$OMP_NUM_THREADS, OPENBLAS=$OPENBLAS_NUM_THREADS, MKL=$MKL_NUM_THREADS"
-echo "========================================"
+exec cargo run --quiet --locked --manifest-path "$ROOT/Cargo.toml" -p bitnet-task -- preflight "$@"

--- a/tools/bitnet-task/src/ci.rs
+++ b/tools/bitnet-task/src/ci.rs
@@ -56,7 +56,7 @@ pub(crate) fn cmd_quality_gate(root: &Path) -> Result<()> {
 pub(crate) fn cmd_verify_tests(root: &Path) -> Result<()> {
     println!("=== BitNet-rs Verification Tests ===");
 
-    let preflight = collect_preflight_env()?;
+    let preflight = collect_preflight_env(false)?;
     let preflight_refs = env_refs_from_pairs(&preflight);
 
     println!("== Pre-flight test discovery ==");

--- a/tools/bitnet-task/src/main.rs
+++ b/tools/bitnet-task/src/main.rs
@@ -59,6 +59,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Task {
+    /// Equivalent of scripts/preflight.sh
+    Preflight {
+        /// Print shell exports for callers that source scripts/preflight.sh.
+        #[arg(long)]
+        emit_env: bool,
+    },
     /// Equivalent of scripts/bitnet_accept.sh
     BitnetAccept {
         #[arg(default_value = DEFAULT_MODEL)]
@@ -249,6 +255,7 @@ fn main() -> Result<()> {
     let root = workspace_root()?;
 
     match cli.command {
+        Task::Preflight { emit_env } => cmd_preflight(emit_env),
         Task::BitnetAccept { model, tokenizer } => cmd_bitnet_accept(&root, &model, &tokenizer),
         Task::BuildCppStatic { cpp_dir } => cmd_build_cpp_static(&root, cpp_dir.as_deref()),
         Task::CheckIgnoreAnnotations => cmd_check_ignore_annotations(&root),
@@ -469,7 +476,29 @@ fn run_xtask_binary<S: AsRef<str>>(
     run_capture(root, program, args, &[], allow_failure)
 }
 
-fn collect_preflight_env() -> Result<Vec<(String, String)>> {
+fn cmd_preflight(emit_env: bool) -> Result<()> {
+    let envs = collect_preflight_env(emit_env)?;
+    if emit_env {
+        for (name, value) in envs {
+            println!("export {name}={}", shell_quote(&value));
+        }
+    }
+    Ok(())
+}
+
+fn preflight_line(diagnostics_to_stderr: bool, message: impl AsRef<str>) {
+    if diagnostics_to_stderr {
+        eprintln!("{}", message.as_ref());
+    } else {
+        println!("{}", message.as_ref());
+    }
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace("'", "'\''"))
+}
+
+fn collect_preflight_env(diagnostics_to_stderr: bool) -> Result<Vec<(String, String)>> {
     let pids_used = if command_available("ps") {
         let output = run_capture(Path::new("."), "ps", &["-e"], &[], true)?;
         if output.status.success() {
@@ -502,10 +531,13 @@ fn collect_preflight_env() -> Result<Vec<(String, String)>> {
     let pids_pct = if pid_max > 0 { pids_used.saturating_mul(100) / pid_max } else { 0 };
     let files_pct = if files_max > 0 { files_used.saturating_mul(100) / files_max } else { 0 };
 
-    println!("=== BitNet-rs System Resource Check ===");
-    println!("PIDs: {pids_used} / {pid_max} ({pids_pct}%)");
-    println!("Open files: {files_used} / {files_max} ({files_pct}%)");
-    println!("Load average: {load_avg}");
+    preflight_line(diagnostics_to_stderr, "=== BitNet-rs System Resource Check ===");
+    preflight_line(diagnostics_to_stderr, format!("PIDs: {pids_used} / {pid_max} ({pids_pct}%)"));
+    preflight_line(
+        diagnostics_to_stderr,
+        format!("Open files: {files_used} / {files_max} ({files_pct}%)"),
+    );
+    preflight_line(diagnostics_to_stderr, format!("Load average: {load_avg}"));
 
     let mut envs = vec![
         (
@@ -559,19 +591,27 @@ fn collect_preflight_env() -> Result<Vec<(String, String)>> {
                 }
             }
         }
-        println!("⚠️  System hot ({pids_pct}% PID usage) → auto-degraded to single-threaded mode");
+        preflight_line(
+            diagnostics_to_stderr,
+            format!(
+                "⚠️  System hot ({pids_pct}% PID usage) → auto-degraded to single-threaded mode"
+            ),
+        );
     } else {
-        println!(
-            "✅ System resources OK → using capped concurrency (RUST_TEST_THREADS={}, RAYON={} )",
-            envs[0].1, envs[1].1,
+        preflight_line(
+            diagnostics_to_stderr,
+            format!(
+                "✅ System resources OK → using capped concurrency (RUST_TEST_THREADS={}, RAYON={} )",
+                envs[0].1, envs[1].1,
+            ),
         );
     }
 
-    println!("=== BitNet-rs Concurrency Configuration ===");
+    preflight_line(diagnostics_to_stderr, "=== BitNet-rs Concurrency Configuration ===");
     for (name, value) in &envs {
-        println!("{name}={value}");
+        preflight_line(diagnostics_to_stderr, format!("{name}={value}"));
     }
-    println!("========================================");
+    preflight_line(diagnostics_to_stderr, "========================================");
 
     Ok(envs)
 }
@@ -869,6 +909,7 @@ fn relevant_flake_output(text: &str) -> Vec<String> {
 mod tests {
     use super::{
         command_available, command_available_in_path, command_failure_details, is_executable_file,
+        shell_quote,
     };
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
@@ -879,6 +920,12 @@ mod tests {
         let mut permissions = fs::metadata(path).expect("metadata").permissions();
         permissions.set_mode(0o755);
         fs::set_permissions(path, permissions).expect("set executable bit");
+    }
+
+    #[test]
+    fn shell_quote_escapes_single_quotes() {
+        assert_eq!(shell_quote("plain"), "'plain'");
+        assert_eq!(shell_quote("can't"), "'can'\''t'");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Move the `scripts/preflight.sh` resource-check and concurrency-cap logic into the existing Rust compatibility facade (`bitnet-task`) to centralize behavior and improve testability. 
- Preserve source-compatible usage for callers that `source` the shell script by providing an `--emit-env` mode that prints shell `export` lines. 
- Ensure CI and other Rust code paths reuse the same preflight logic and diagnostics routing.

### Description

- Add a new `Preflight` subcommand to `bitnet-task` with a `--emit-env` flag and implement `cmd_preflight(emit_env: bool)` to drive the behavior. 
- Extracted and adapted the previous shell logic into Rust: `collect_preflight_env(diagnostics_to_stderr: bool)`, `preflight_line(...)`, and `shell_quote(...)`, and updated diagnostic output routing so diagnostics go to stderr while `--emit-env` prints shell-safe `export` lines. 
- Replace `scripts/preflight.sh` contents with a thin wrapper that preserves both direct execution (`exec cargo run ... preflight`) and sourced usage (invokes `bitnet-task -- preflight --emit-env` and `eval`s the returned exports). 
- Update `cmd_verify_tests` (CI path) to call the Rust preflight collector with `false` for diagnostics, and add a unit test for `shell_quote` to cover emitted-shell escaping.

### Testing

- Ran `cargo check -p bitnet-task` which succeeded. 
- Ran `cargo test -p bitnet-task` (unit tests and smoke tests) which succeeded. 
- Executed the wrapper compatibility smoke `scripts/tests/bitnet-task-wrapper-help-smoke.sh` which succeeded. 
- Verified runtime behavior with `cargo run -p bitnet-task -- preflight --emit-env` and by both sourcing and executing `scripts/preflight.sh`, and also ran `cargo fmt --all --check`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcb9ca99483338dc3af61c9dd3262)