### PR TITLE
[codex][apple-m4-slm-performance] Close out performance envelope (M4-SLM-PERF-007)

### DIFF
--- a/docs/tracking/campaigns/apple-m4-slm-performance/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-performance/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-performance`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -44,7 +44,7 @@ That is working, but not yet excellent. This campaign owns the next layer: relea
 | M4-SLM-PERF-004 | merged | Optimize the measured CPU/NEON bottleneck while preserving greedy output. |
 | M4-SLM-PERF-005 | merged | Expand only parity-gated Metal prefill/projection phases with explicit fallback boundaries. |
 | M4-SLM-PERF-006 | merged | Add streaming, time-to-first-token receipts, quiet logs, and operator-friendly progress. |
-| M4-SLM-PERF-007 | ready | Publish a measured performance envelope for supported profiles and hardware only. |
+| M4-SLM-PERF-007 | merged | Publish a measured performance envelope for supported profiles and hardware only. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-slm-performance/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-performance/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-slm-performance"
 title = "Apple M4 SLM performance"
-status = "active"
+status = "complete"
 
 objective = "Turn the working Apple M4 SLM answer path into a fast, efficient, repeatable local-answer engine by measuring release-mode warm-session bottlenecks, removing hot-loop overhead, improving CPU/NEON execution, expanding only parity-gated Metal phases, and keeping every speed claim tied to receipts."
 
@@ -317,8 +317,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-SLM-PERF-007"
-status = "pr_open"
+status = "merged"
 pr = 4081
+merge_sha = "7474cefe5e84703bc7e8bd2f99c304563f942820"
 branch = "codex/apple-m4-slm-performance/M4-SLM-PERF-007-performance-envelope"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-slm-performance/events/2026-05-08T141927Z-M4-SLM-PERF-007-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-performance/events/2026-05-08T141927Z-M4-SLM-PERF-007-merged.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-08T14:19:27Z"
+campaign = "apple-m4-slm-performance"
+item = "M4-SLM-PERF-007"
+event = "merged"
+pr = 4081
+merge_sha = "7474cefe5e84703bc7e8bd2f99c304563f942820"
+actor = "codex"
+
+notes = [
+  "M4-SLM-PERF-007 measured Apple M4 SLM performance envelope PR merged.",
+  "The merged work publishes current-schema release baseline and allocation-audit receipts, a checked-in Metal phase receipt, and a bounded performance envelope for the named model, profiles, backend, and machine.",
+  "The apple-m4-slm-performance campaign is complete.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-performance/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-performance/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 SLM performance Campaign Status
 
 - Campaign: `apple-m4-slm-performance`
-- State: `active`
+- State: `complete`
 - Objective: Turn the working Apple M4 SLM answer path into a fast, efficient, repeatable local-answer engine by measuring release-mode warm-session bottlenecks, removing hot-loop overhead, improving CPU/NEON execution, expanding only parity-gated Metal phases, and keeping every speed claim tied to receipts.
 
 ## Work Items
@@ -15,7 +15,7 @@
 | M4-SLM-PERF-004 | merged | #4057 | `codex/apple-m4-slm-performance/M4-SLM-PERF-004-cpu-neon-hotpath` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Optimize the highest measured Apple M4 CPU/NEON bottleneck while preserving greedy token IDs, deterministic quality corpus results, fallback status, and before/after warm-session receipts. |
 | M4-SLM-PERF-005 | merged | #4069 | `codex/apple-m4-slm-performance/M4-SLM-PERF-005-metal-phase-expansion` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Expand only named Apple Metal prefill/projection phases after CPU baseline stability, requiring CPU-only versus CPU-plus-Metal greedy parity, Metal phase fallback_used=false, explicit CPU fallback for the rest of the pipeline, and timing delta receipts. |
 | M4-SLM-PERF-006 | merged | #4075 | `codex/apple-m4-slm-performance/M4-SLM-PERF-006-streaming-ux` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add streaming token output, time-to-first-token receipts, quiet default logs, operator-friendly progress, and clear failure messages without changing backend claim boundaries. |
-| M4-SLM-PERF-007 | pr_open | #4081 | `codex/apple-m4-slm-performance/M4-SLM-PERF-007-performance-envelope` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish a measured Apple M4 SLM performance envelope for supported models and profiles only, recording machine context, backend, profile, timings, phase contributions, fallback status, and explicit unsupported claims. |
+| M4-SLM-PERF-007 | merged | #4081 | `codex/apple-m4-slm-performance/M4-SLM-PERF-007-performance-envelope` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Publish a measured Apple M4 SLM performance envelope for supported models and profiles only, recording machine context, backend, profile, timings, phase contributions, fallback status, and explicit unsupported claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-08T140001Z-NPU-010-in-progress.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-08T140001Z-NPU-010-in-progress.toml
@@ -1,12 +1,10 @@
 timestamp = "2026-05-08T14:00:01Z"
 campaign = "intel-npu"
 item = "NPU-010"
-event = "ready"
-from = "proposed"
-to = "ready"
+event = "in_progress"
 actor = "codex"
 branch = "codex/intel-npu/NPU-010-live-openvino-receipts"
-summary = "Readied NPU-010 to record live OpenVINO NPU receipts from the 258V laptop."
+summary = "Started NPU-010 to record live OpenVINO NPU receipts from the 258V laptop."
 
 notes = [
   "The local 258V environment now has OpenVINO 2026.1 available through a workspace-local Python target directory and reports CPU, GPU, and NPU devices.",

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,6 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | `codex/apple-m4-slm-performance/M4-SLM-PERF-007-performance-envelope` | Publish a measured Apple M4 SLM performance envelope for supported models and profiles only, recording machine context, backend, profile, timings, phase contributions, fallback status, and explicit unsupported claims. |
 | intel-npu | NPU-010 | #4080 | `codex/intel-npu/NPU-010-live-openvino-receipts` | Record live 258V OpenVINO 2026.1 Intel NPU runtime visibility, tiny static graph smoke, and selected BitNet RMSNorm and linear-projection static subgraph parity receipts with selected_backend=intel-npu-openvino, runtime_api=openvino, runtime_device=NPU, fallback_used=false, and no full BitNet inference, acceleration, QK256 decode, or CPU fallback proof claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -47,7 +47,7 @@
 | apple-m4-slm-performance | M4-SLM-PERF-004 | M4-SLM-PERF-003 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-005 | M4-SLM-PERF-004 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-006 | M4-SLM-PERF-005 | merged |
-| apple-m4-slm-performance | M4-SLM-PERF-007 | M4-SLM-PERF-006 | pr_open |
+| apple-m4-slm-performance | M4-SLM-PERF-007 | M4-SLM-PERF-006 | merged |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
-| apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | pr_open | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
+| apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-m4-slm-performance
Work item: M4-SLM-PERF-007 closeout
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Mark M4-SLM-PERF-007 merged with PR #4081 merge SHA `7474cefe5e84703bc7e8bd2f99c304563f942820`.
- Add the append-only M4-SLM-PERF-007 merged event.
- Mark the apple-m4-slm-performance campaign complete and regenerate dashboards.
- Fix the NPU-010 event type from invalid `ready` to valid `in_progress` so the global campaign doctor gate passes on current main.

## Claim boundary
This is tracker-only closeout plus one tracker hygiene fix for an invalid event type. It does not change runtime behavior, SLM measurements, Metal scope, BitNet claims, QK256 support, MPSGraph inference, or Neural Engine claims.

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-performance
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check
