### PR TITLE
feat(opencl): discover runtime devices

### DIFF
--- a/crates/bitnet-opencl/src/lib.rs
+++ b/crates/bitnet-opencl/src/lib.rs
@@ -14,12 +14,14 @@ pub mod backend_registry;
 pub mod context_pool;
 pub mod kv_cache;
 pub mod paged_attention;
+pub mod runtime;
 
 pub use backend_dispatcher::{
     BackendCapabilityMatrix, BackendDispatcher, BackendStatus, DispatchDecision, DispatchError,
     DispatchLog, DispatchStrategy, Operation,
 };
 pub use backend_registry::{BackendInfo, BackendProvider, BackendRegistry};
+pub use runtime::discover_devices;
 pub mod quantized_kernels;
 pub mod quantized_ops;
 pub mod spirv;

--- a/crates/bitnet-opencl/src/runtime.rs
+++ b/crates/bitnet-opencl/src/runtime.rs
@@ -1,9 +1,61 @@
-//! OpenCL runtime: platform/device discovery via the OpenCL ICD loader.
+//! OpenCL runtime discovery via the OpenCL ICD loader.
 
-/// Placeholder for OpenCL runtime discovery.
+#[cfg(feature = "oneapi")]
+use opencl3::{
+    device::{CL_DEVICE_TYPE_ALL, Device},
+    platform::get_platforms,
+};
+
+/// Discover OpenCL devices available through the installed ICD loader.
 ///
-/// Requires the `opencl-runtime` feature and a working OpenCL ICD loader.
+/// Discovery is best-effort: missing drivers, loader failures, or device query
+/// errors produce an empty list instead of failing backend initialization.
+#[cfg(feature = "oneapi")]
 pub fn discover_devices() -> Vec<String> {
-    // TODO: enumerate OpenCL platforms and devices via opencl3
+    let mut devices = Vec::new();
+
+    let Ok(platforms) = get_platforms() else {
+        return devices;
+    };
+
+    for platform in platforms {
+        let platform_name = platform.name().unwrap_or_else(|_| "Unknown OpenCL Platform".into());
+        let Ok(device_ids) = platform.get_devices(CL_DEVICE_TYPE_ALL) else {
+            continue;
+        };
+
+        for device_id in device_ids {
+            let device = Device::new(device_id);
+            if let Ok(device_name) = device.name() {
+                devices.push(format!("{platform_name} :: {device_name}"));
+            }
+        }
+    }
+
+    devices.sort();
+    devices.dedup();
+    devices
+}
+
+/// Device discovery is unavailable when the OpenCL runtime feature is disabled.
+#[cfg(not(feature = "oneapi"))]
+pub fn discover_devices() -> Vec<String> {
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::discover_devices;
+
+    #[test]
+    #[cfg(not(feature = "oneapi"))]
+    fn discover_devices_is_empty_without_oneapi_feature() {
+        assert!(discover_devices().is_empty());
+    }
+
+    #[test]
+    #[cfg(feature = "oneapi")]
+    fn discover_devices_does_not_panic_with_oneapi_feature() {
+        let _ = discover_devices();
+    }
 }


### PR DESCRIPTION
## Summary
- export the OpenCL runtime discovery API from bitnet-opencl
- enumerate OpenCL platforms and devices through opencl3 when the oneapi feature is enabled
- keep discovery best-effort and return an empty list without the runtime feature or when ICD queries fail

Supersedes #3546.

## Validation
- cargo fmt --check -p bitnet-opencl
- cargo test -p bitnet-opencl --no-default-features runtime::tests::discover_devices_is_empty_without_oneapi_feature
- cargo check -p bitnet-opencl --no-default-features --features oneapi
- git diff --check