### PR TITLE
feat(vulkan): discover runtime devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,9 @@ dependencies = [
 name = "bitnet-vulkan"
 version = "0.2.1-dev"
 dependencies = [
+ "ash",
  "bitnet-vulkan-shaders",
+ "log",
 ]
 
 [[package]]

--- a/crates/bitnet-vulkan/Cargo.toml
+++ b/crates/bitnet-vulkan/Cargo.toml
@@ -12,7 +12,9 @@ description = "Vulkan GLSL compute shaders for BitNet GPU inference"
 rust-version.workspace = true
 
 [dependencies]
+ash = { version = "0.38", default-features = false, features = ["loaded"], optional = true }
 bitnet-vulkan-shaders = { path = "../bitnet-vulkan-shaders", version = "0.2.1-dev" }
+log.workspace = true
 
 [dev-dependencies]
 
@@ -21,6 +23,7 @@ default = []
 cpu = []
 gpu = ["cuda"]
 cuda = []
+vulkan-runtime = ["dep:ash"]
 
 [lints]
 workspace = true

--- a/crates/bitnet-vulkan/src/runtime.rs
+++ b/crates/bitnet-vulkan/src/runtime.rs
@@ -1,9 +1,67 @@
 //! Vulkan runtime: device discovery via the Vulkan loader.
 
-/// Placeholder for Vulkan runtime device discovery.
+/// Discover Vulkan physical devices available through the Vulkan loader.
 ///
-/// Requires the `vulkan-runtime` feature and a working Vulkan loader.
-pub const fn discover_devices() -> Vec<String> {
-    // TODO: enumerate Vulkan physical devices via ash
+/// Discovery is best-effort: missing loaders, instance creation failures, or
+/// device query errors produce an empty list instead of failing backend setup.
+#[must_use]
+pub fn discover_devices() -> Vec<String> {
+    discover_devices_impl()
+}
+
+#[cfg(not(feature = "vulkan-runtime"))]
+fn discover_devices_impl() -> Vec<String> {
     Vec::new()
+}
+
+#[cfg(feature = "vulkan-runtime")]
+fn discover_devices_impl() -> Vec<String> {
+    use ash::{Entry, vk};
+    use std::ffi::CStr;
+
+    fn device_name_to_string(device_name: &[i8]) -> Option<String> {
+        // SAFETY: Vulkan device name fields are fixed-size, null-terminated strings.
+        let cstr = unsafe { CStr::from_ptr(device_name.as_ptr()) };
+        let name = cstr.to_string_lossy().trim().to_owned();
+        (!name.is_empty()).then_some(name)
+    }
+
+    let entry = match unsafe { Entry::load() } {
+        Ok(entry) => entry,
+        Err(error) => {
+            log::debug!("failed to load Vulkan loader during device discovery: {error:?}");
+            return Vec::new();
+        }
+    };
+
+    let app_info = vk::ApplicationInfo::default().api_version(vk::API_VERSION_1_0);
+    let create_info = vk::InstanceCreateInfo::default().application_info(&app_info);
+    let instance = match unsafe { entry.create_instance(&create_info, None) } {
+        Ok(instance) => instance,
+        Err(error) => {
+            log::debug!("failed to create Vulkan instance during device discovery: {error:?}");
+            return Vec::new();
+        }
+    };
+
+    let result = unsafe { instance.enumerate_physical_devices() };
+    let mut devices = match result {
+        Ok(physical_devices) => physical_devices
+            .into_iter()
+            .filter_map(|physical_device| {
+                let properties =
+                    unsafe { instance.get_physical_device_properties(physical_device) };
+                device_name_to_string(&properties.device_name)
+            })
+            .collect::<Vec<_>>(),
+        Err(error) => {
+            log::debug!("failed to enumerate Vulkan physical devices: {error:?}");
+            Vec::new()
+        }
+    };
+
+    unsafe { instance.destroy_instance(None) };
+    devices.sort();
+    devices.dedup();
+    devices
 }

--- a/crates/bitnet-vulkan/tests/vulkan_integration_tests.rs
+++ b/crates/bitnet-vulkan/tests/vulkan_integration_tests.rs
@@ -7,7 +7,16 @@ fn shader_reexport_matches_kernels_module() {
 }
 
 #[test]
-fn runtime_discovery_placeholder_is_empty() {
+fn runtime_discovery_is_non_panicking() {
     let devices = bitnet_vulkan::runtime::discover_devices();
+
+    assert!(devices.iter().all(|name| !name.trim().is_empty()));
+}
+
+#[test]
+#[cfg(not(feature = "vulkan-runtime"))]
+fn runtime_discovery_without_feature_is_empty() {
+    let devices = bitnet_vulkan::runtime::discover_devices();
+
     assert!(devices.is_empty());
 }


### PR DESCRIPTION
## Summary
- add optional Vulkan runtime discovery through ash behind the vulkan-runtime feature
- return an empty list when the loader or instance/device queries are unavailable
- cover both no-feature empty discovery and feature-enabled non-panic discovery

Supersedes #3548.

## Validation
- cargo fmt --check -p bitnet-vulkan
- cargo test -p bitnet-vulkan --no-default-features runtime_discovery_without_feature_is_empty
- cargo check -p bitnet-vulkan --no-default-features --features vulkan-runtime
- cargo test -p bitnet-vulkan --no-default-features --features vulkan-runtime runtime_discovery_is_non_panicking
- cargo test -p bitnet-vulkan --no-default-features
- git diff --check