### PR TITLE
[codex] Extend PR gate polling budget

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -58,7 +58,7 @@ jobs:
   pr-gate-success:
     name: PR Gate Success
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - name: Determine head SHA
         id: head
@@ -155,10 +155,10 @@ jobs:
           # lanes.)
           optional_jobs=()
 
-          # Poll for up to 25 minutes (50 * 30s). Most PRs take ~10-15
-          # minutes for these lanes. Anything beyond 25 minutes warrants
-          # human intervention.
-          deadline=$((SECONDS + 1500))
+          # Poll for up to 35 minutes (70 * 30s). Most PRs take ~10-15
+          # minutes, but CI Core can trail the feature and policy lanes
+          # when slower platform tests run near the end of the matrix.
+          deadline=$((SECONDS + 2100))
           api="repos/${OWNER}/${REPO}/commits/${HEAD_SHA}/check-runs"
           missing="${required_jobs[*]}"
 
@@ -204,7 +204,7 @@ jobs:
             sleep 30
           done
 
-          echo "❌ Timed out waiting for upstream lanes after 25 minutes"
+          echo "❌ Timed out waiting for upstream lanes after 35 minutes"
           exit 1
 
       - name: Step summary

--- a/docs/ci/pr-gate-success.md
+++ b/docs/ci/pr-gate-success.md
@@ -65,12 +65,13 @@ fire on the same `pull_request` event. Two patterns are common:
 | Pattern        | Trade-off                                           |
 | -------------- | --------------------------------------------------- |
 | `workflow_run` | Loses the "single check on the PR head" UX         |
-| Checks-API poll | Single check; pays a polling job (~25 min budget)  |
+| Checks-API poll | Single check; pays a polling job (~35 min budget)  |
 
 This PR uses the Checks-API poll pattern because branch protection
 wants a single required check that returns a single conclusion on
-the PR head. The poll uses a 25-minute deadline (50 × 30 s); most
-default PRs converge in 10–15 minutes.
+the PR head. The poll uses a 35-minute deadline (70 × 30 s); most
+default PRs converge in 10–15 minutes, while slower CI Core runs
+still have enough room for their final rollup job.
 
 ## Failure modes
 
@@ -80,7 +81,7 @@ default PRs converge in 10–15 minutes.
 | Any `failure`             | `failure`                              |
 | Any `cancelled`/`timed_out`| `failure`                             |
 | Required lane `skipped`   | `failure` (required lanes must run)    |
-| Pending after 25 minutes  | `failure` (timeout)                    |
+| Pending after 35 minutes  | `failure` (timeout)                    |
 
 Optional lanes (none today) would be allowed to be `skipped`. The
 right place to encode "lane X is conditionally required when paths


### PR DESCRIPTION
## Summary
- extend `PR Gate Success` polling from 25 to 35 minutes
- raise the workflow job timeout to 40 minutes so the poll can complete cleanly
- update the PR gate runbook to match the new budget

## Why
PR #4085 exposed a timing race: all code checks passed, but `CI Core Success` appeared about one minute after `PR Gate Success` hit its 25-minute deadline. The gate rerun passed immediately once the upstream rollup existed.

## Validation
- `git diff --check -- .github/workflows/pr-gate.yml docs/ci/pr-gate-success.md`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/pr-gate.yml'); puts 'yaml ok'"`
- `rg -n "25 minutes|25-minute|1500|Timed out waiting.*25|40 min budget|80 × 30|2400" .github/workflows/pr-gate.yml docs/ci/pr-gate-success.md` returned no matches

Note: `actionlint` is not installed in this local environment, so I could not run that linter locally.