### PR TITLE
perf(cuda): add QK256 timing and transfer receipts

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -4196,6 +4196,8 @@ async fn run_simple_generation(
         } else {
             None
         };
+        let cuda_runtime_stats =
+            strict_cuda_selected_artifact.then(bitnet_qk256_dispatch::qk256_cuda_runtime_stats);
         let weights_uploaded_once = cuda_weight_residency
             .as_ref()
             .map(|residency| residency.weights_uploaded_once)
@@ -4212,6 +4214,7 @@ async fn run_simple_generation(
             cuda_execution_residency_receipt(
                 &bitnet_linear_coverage,
                 cuda_weight_residency.as_ref(),
+                cuda_runtime_stats.as_ref(),
                 prompt_tokens_len,
                 generated_tokens.len(),
                 "cpu",
@@ -4418,6 +4421,16 @@ async fn run_simple_generation(
                 "decode_total_ms": rounded_ms(decode_total_ms),
                 "decode_steady_state_tok_s": decode_steady_state_tok_s,
                 "sampling_ms_per_token": sampling_ms_per_token.map(rounded_ms),
+                "cuda_kernel_time_ms": cuda_runtime_stats
+                    .as_ref()
+                    .and_then(|stats| stats.kernel_time_ms)
+                    .map(rounded_ms),
+                "host_to_device_bytes": cuda_runtime_stats
+                    .as_ref()
+                    .map(|stats| stats.host_to_device_bytes),
+                "device_to_host_bytes": cuda_runtime_stats
+                    .as_ref()
+                    .map(|stats| stats.device_to_host_bytes),
             },
             "throughput": {
                 "tokens_per_second": tok_per_sec,
@@ -4573,15 +4586,7 @@ async fn run_simple_generation(
             );
             object.insert(
                 "kernel_stats".to_string(),
-                serde_json::json!([{
-                    "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
-                    "invocations": cuda_kernel_invocations,
-                    "fallback_invocations": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
-                    "host_to_device_bytes": serde_json::Value::Null,
-                    "device_to_host_bytes": serde_json::Value::Null,
-                    "kernel_launches": cuda_kernel_invocations,
-                    "kernel_time_ms": serde_json::Value::Null,
-                }]),
+                qk256_kernel_stats_receipt(&bitnet_linear_coverage, cuda_runtime_stats.as_ref()),
             );
             object.insert(
                 "kernel".to_string(),
@@ -4693,6 +4698,16 @@ async fn run_simple_generation(
                     "decode_total_ms": rounded_ms(decode_total_ms),
                     "decode_steady_state_tok_s": decode_steady_state_tok_s,
                     "sampling_ms_per_token": sampling_ms_per_token.map(rounded_ms),
+                    "cuda_kernel_time_ms": cuda_runtime_stats
+                        .as_ref()
+                        .and_then(|stats| stats.kernel_time_ms)
+                        .map(rounded_ms),
+                    "host_to_device_bytes": cuda_runtime_stats
+                        .as_ref()
+                        .map(|stats| stats.host_to_device_bytes),
+                    "device_to_host_bytes": cuda_runtime_stats
+                        .as_ref()
+                        .map(|stats| stats.device_to_host_bytes),
                     "decode_step_ms": timing_samples_json(&decode_step_ms),
                     "embed_ms": timing_samples_json(&embed_step_ms),
                     "forward_ms": timing_samples_json(&forward_step_ms),
@@ -4716,15 +4731,7 @@ async fn run_simple_generation(
             );
             object.insert(
                 "kernel_stats".to_string(),
-                serde_json::json!([{
-                    "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
-                    "invocations": cuda_kernel_invocations,
-                    "fallback_invocations": bitnet_linear_coverage.bitnet_linear_layers_cpu_fallback,
-                    "host_to_device_bytes": serde_json::Value::Null,
-                    "device_to_host_bytes": serde_json::Value::Null,
-                    "kernel_launches": cuda_kernel_invocations,
-                    "kernel_time_ms": serde_json::Value::Null,
-                }]),
+                qk256_kernel_stats_receipt(&bitnet_linear_coverage, cuda_runtime_stats.as_ref()),
             );
             object.insert(
                 "kernel".to_string(),
@@ -5812,6 +5819,7 @@ async fn run_cuda_warm_session(
     for (index, prompt) in prompts.iter().enumerate() {
         let prompt_start = std::time::Instant::now();
         let coverage_before = bitnet_qk256_dispatch::qk256_dispatch_coverage();
+        let runtime_stats_before = bitnet_qk256_dispatch::qk256_cuda_runtime_stats();
         let formatted_prompt = template_type.apply(prompt, system_prompt.as_deref());
         let rendered_prompt_sha256 = compute_sha256_bytes(formatted_prompt.as_bytes());
 
@@ -5974,10 +5982,14 @@ async fn run_cuda_warm_session(
 
         let coverage_after = bitnet_qk256_dispatch::qk256_dispatch_coverage();
         let coverage_delta = qk256_dispatch_coverage_delta(&coverage_before, &coverage_after);
+        let runtime_stats_after = bitnet_qk256_dispatch::qk256_cuda_runtime_stats();
+        let runtime_stats_delta =
+            qk256_cuda_runtime_stats_delta(&runtime_stats_before, &runtime_stats_after);
         let residency_after = bitnet_qk256_dispatch::qk256_cuda_weight_residency();
         let cuda_execution_residency = cuda_execution_residency_receipt(
             &coverage_delta,
             residency_after.as_ref(),
+            Some(&runtime_stats_delta),
             prompt_token_count,
             generated_tokens.len(),
             "cpu",
@@ -6035,6 +6047,9 @@ async fn run_cuda_warm_session(
                 "decode_total_ms": rounded_ms(decode_total_ms),
                 "decode_steady_state_tok_s": decode_steady_state_tok_s,
                 "sampling_ms_per_token": sampling_ms_per_token.map(rounded_ms),
+                "cuda_kernel_time_ms": runtime_stats_delta.kernel_time_ms.map(rounded_ms),
+                "host_to_device_bytes": runtime_stats_delta.host_to_device_bytes,
+                "device_to_host_bytes": runtime_stats_delta.device_to_host_bytes,
                 "total_ms": rounded_ms(prompt_total_ms),
                 "embed_ms": timing_samples_json(&embed_step_ms),
                 "forward_ms": timing_samples_json(&forward_step_ms),
@@ -6071,15 +6086,7 @@ async fn run_cuda_warm_session(
                 "dequantizes_before_compute": false,
                 "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
             },
-            "kernel_stats": [{
-                "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
-                "invocations": coverage_delta.bitnet_linear_layers_on_cuda,
-                "fallback_invocations": coverage_delta.bitnet_linear_layers_cpu_fallback,
-                "kernel_launches": coverage_delta.bitnet_linear_layers_on_cuda,
-                "host_to_device_bytes": serde_json::Value::Null,
-                "device_to_host_bytes": serde_json::Value::Null,
-                "kernel_time_ms": serde_json::Value::Null,
-            }],
+            "kernel_stats": qk256_kernel_stats_receipt(&coverage_delta, Some(&runtime_stats_delta)),
             "execution_coverage": qk256_dispatch_coverage_receipt(&coverage_delta),
             "cuda_execution_residency": cuda_execution_residency,
             "bitnet": {
@@ -6159,6 +6166,7 @@ async fn run_cuda_warm_session(
 
     let total_session_ms = elapsed_ms(session_start);
     let total_coverage = bitnet_qk256_dispatch::qk256_dispatch_coverage();
+    let total_runtime_stats = bitnet_qk256_dispatch::qk256_cuda_runtime_stats();
     let final_residency = bitnet_qk256_dispatch::qk256_cuda_weight_residency();
     let cuda_memory_after_bytes = nvidia_smi_memory_used_bytes(Some(0));
     let cuda_memory_hwm_bytes =
@@ -6178,6 +6186,7 @@ async fn run_cuda_warm_session(
     let cuda_execution_residency = cuda_execution_residency_receipt(
         &total_coverage,
         final_residency.as_ref(),
+        Some(&total_runtime_stats),
         turn_summaries
             .iter()
             .filter_map(|turn| turn["prompt_tokens"].as_u64())
@@ -6255,6 +6264,9 @@ async fn run_cuda_warm_session(
             "cuda_context_init_timing_source": "not_separately_measured; included in strict CUDA session setup and first CUDA work",
             "weight_upload_ms": serde_json::Value::Null,
             "weight_upload_timing_source": "not_separately_measured; upload-once weight residency is verified by qk256 weight-handle counters",
+            "cuda_kernel_time_ms": total_runtime_stats.kernel_time_ms.map(rounded_ms),
+            "host_to_device_bytes": total_runtime_stats.host_to_device_bytes,
+            "device_to_host_bytes": total_runtime_stats.device_to_host_bytes,
             "total_session_ms": rounded_ms(total_session_ms),
         },
         "speed": speed_summary,
@@ -6301,15 +6313,7 @@ async fn run_cuda_warm_session(
             "dequantizes_before_compute": false,
             "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
         },
-        "kernel_stats": [{
-            "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
-            "invocations": total_coverage.bitnet_linear_layers_on_cuda,
-            "fallback_invocations": total_coverage.bitnet_linear_layers_cpu_fallback,
-            "kernel_launches": total_coverage.bitnet_linear_layers_on_cuda,
-            "host_to_device_bytes": serde_json::Value::Null,
-            "device_to_host_bytes": serde_json::Value::Null,
-            "kernel_time_ms": serde_json::Value::Null,
-        }],
+        "kernel_stats": qk256_kernel_stats_receipt(&total_coverage, Some(&total_runtime_stats)),
         "execution_coverage": qk256_dispatch_coverage_receipt(&total_coverage),
         "cuda_execution_residency": cuda_execution_residency,
         "bitnet": {
@@ -6419,9 +6423,60 @@ fn qk256_dispatch_coverage_receipt(
     })
 }
 
+#[cfg(feature = "full-cli")]
+fn qk256_cuda_runtime_stats_delta(
+    before: &bitnet_qk256_dispatch::Qk256CudaRuntimeStats,
+    after: &bitnet_qk256_dispatch::Qk256CudaRuntimeStats,
+) -> bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
+    bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
+        host_to_device_bytes: after
+            .host_to_device_bytes
+            .saturating_sub(before.host_to_device_bytes),
+        device_to_host_bytes: after
+            .device_to_host_bytes
+            .saturating_sub(before.device_to_host_bytes),
+        kernel_time_ms: match (before.kernel_time_ms, after.kernel_time_ms) {
+            (Some(before), Some(after)) => Some((after - before).max(0.0)),
+            (None, Some(after)) => Some(after),
+            _ => None,
+        },
+        kernel_time_samples: after.kernel_time_samples.saturating_sub(before.kernel_time_samples),
+    }
+}
+
+fn qk256_kernel_stats_receipt(
+    coverage: &bitnet_qk256_dispatch::Qk256DispatchCoverageCounters,
+    runtime_stats: Option<&bitnet_qk256_dispatch::Qk256CudaRuntimeStats>,
+) -> serde_json::Value {
+    serde_json::json!([{
+        "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
+        "invocations": coverage.bitnet_linear_layers_on_cuda,
+        "fallback_invocations": coverage.bitnet_linear_layers_cpu_fallback,
+        "host_to_device_bytes": runtime_stats
+            .map(|stats| stats.host_to_device_bytes)
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+        "device_to_host_bytes": runtime_stats
+            .map(|stats| stats.device_to_host_bytes)
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+        "kernel_launches": coverage.bitnet_linear_layers_on_cuda,
+        "kernel_time_ms": runtime_stats
+            .and_then(|stats| stats.kernel_time_ms)
+            .map(rounded_ms)
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+        "kernel_time_samples": runtime_stats
+            .map(|stats| stats.kernel_time_samples)
+            .map(serde_json::Value::from)
+            .unwrap_or(serde_json::Value::Null),
+    }])
+}
+
 fn cuda_execution_residency_receipt(
     coverage: &bitnet_qk256_dispatch::Qk256DispatchCoverageCounters,
     residency: Option<&bitnet_qk256_dispatch::Qk256CudaWeightResidency>,
+    runtime_stats: Option<&bitnet_qk256_dispatch::Qk256CudaRuntimeStats>,
     prompt_tokens: usize,
     generated_tokens: usize,
     kv_cache_device: &str,
@@ -6451,7 +6506,10 @@ fn cuda_execution_residency_receipt(
     };
     let kv_cache_residency =
         if kv_cache_device == "cuda" { "cuda_resident" } else { "cpu_resident" };
-    let non_resident_or_unmeasured_phases = [
+    let transfer_bytes_measured = runtime_stats
+        .is_some_and(|stats| stats.host_to_device_bytes > 0 || stats.device_to_host_bytes > 0);
+    let kernel_time_measured = runtime_stats.is_some_and(|stats| stats.kernel_time_ms.is_some());
+    let mut non_resident_or_unmeasured_phases = vec![
         "token_embeddings",
         "rmsnorm",
         "sub_layernorm",
@@ -6463,9 +6521,13 @@ fn cuda_execution_residency_receipt(
         "kv_cache",
         "lm_head",
         "sampling",
-        "host_device_transfer_bytes",
-        "kernel_time_ms",
     ];
+    if !transfer_bytes_measured {
+        non_resident_or_unmeasured_phases.push("host_device_transfer_bytes");
+    }
+    if !kernel_time_measured {
+        non_resident_or_unmeasured_phases.push("kernel_time_ms");
+    }
 
     serde_json::json!({
         "schema_version": "1.0.0",
@@ -6543,11 +6605,33 @@ fn cuda_execution_residency_receipt(
             },
         },
         "host_device_transfer_accounting": {
-            "status": "not_measured",
-            "host_to_device_bytes": serde_json::Value::Null,
-            "device_to_host_bytes": serde_json::Value::Null,
-            "kernel_time_ms": serde_json::Value::Null,
-            "note": "QK256 routing and weight-handle residency are recorded; per-phase transfer bytes and kernel timings require a later benchmark/instrumentation gate.",
+            "status": if transfer_bytes_measured || kernel_time_measured {
+                "qk256_measured"
+            } else {
+                "not_measured"
+            },
+            "host_to_device_bytes": runtime_stats
+                .map(|stats| stats.host_to_device_bytes)
+                .map(serde_json::Value::from)
+                .unwrap_or(serde_json::Value::Null),
+            "device_to_host_bytes": runtime_stats
+                .map(|stats| stats.device_to_host_bytes)
+                .map(serde_json::Value::from)
+                .unwrap_or(serde_json::Value::Null),
+            "kernel_time_ms": runtime_stats
+                .and_then(|stats| stats.kernel_time_ms)
+                .map(rounded_ms)
+                .map(serde_json::Value::from)
+                .unwrap_or(serde_json::Value::Null),
+            "kernel_time_samples": runtime_stats
+                .map(|stats| stats.kernel_time_samples)
+                .map(serde_json::Value::from)
+                .unwrap_or(serde_json::Value::Null),
+            "note": if transfer_bytes_measured || kernel_time_measured {
+                "QK256 activation/output transfer bytes and CUDA event kernel time are measured for the routed QK256 GEMV path only; full transformer residency and transfer timing remain separate claims."
+            } else {
+                "QK256 routing and weight-handle residency are recorded; per-phase transfer bytes and kernel timings require a later benchmark/instrumentation gate."
+            },
         },
         "unresident_or_unmeasured_phases": non_resident_or_unmeasured_phases,
         "claim_boundary": {
@@ -6556,6 +6640,8 @@ fn cuda_execution_residency_receipt(
             "upload_once_weight_residency_claimed": weights_uploaded_once && !per_token_weight_upload,
             "full_transformer_cuda_residency_claimed": false,
             "kv_cache_cuda_residency_claimed": kv_cache_device == "cuda",
+            "qk256_kernel_timing_claimed": kernel_time_measured,
+            "qk256_transfer_byte_accounting_claimed": transfer_bytes_measured,
             "transfer_timing_claimed": false,
             "speedup_claim": false,
         },
@@ -8056,6 +8142,7 @@ async fn run_ask_generation(
             "repo": run_receipt["model"]["repo"].clone(),
             "file": run_receipt["model"]["file"].clone(),
             "path": run_receipt["model"]["path"].clone(),
+            "sha256": run_receipt["model"]["sha256"].clone(),
             "loader_mode": run_receipt["model"]["loader_mode"].clone(),
             "fallback_loader_used": run_receipt["model"]["fallback_loader_used"].clone(),
             "tokenizer": run_receipt["model"]["tokenizer"].clone(),
@@ -8095,7 +8182,9 @@ async fn run_ask_generation(
             "per_token_weight_upload": run_receipt["bitnet"]["per_token_weight_upload"].clone(),
         },
         "execution_coverage": run_receipt["execution_coverage"].clone(),
+        "kernel_stats": run_receipt["kernel_stats"].clone(),
         "cuda_execution_residency": run_receipt["cuda_execution_residency"].clone(),
+        "timing": run_receipt["timing"].clone(),
         "quality": quality,
         "receipt": {
             "requested": !receipt_out_was_defaulted,
@@ -8171,6 +8260,33 @@ fn validate_strict_cuda_ask_receipt(run_receipt: &serde_json::Value) -> Result<(
         .unwrap_or(1);
     if cpu_fallback != 0 {
         anyhow::bail!("strict CUDA ask recorded {cpu_fallback} BitNet linear CPU fallback layers");
+    }
+    let kernel_stats = run_receipt["kernel_stats"]
+        .as_array()
+        .and_then(|stats| stats.first())
+        .ok_or_else(|| anyhow::anyhow!("strict CUDA ask receipt is missing kernel_stats[0]"))?;
+    let kernel_time_ms = kernel_stats["kernel_time_ms"].as_f64().unwrap_or(-1.0);
+    let host_to_device_bytes = kernel_stats["host_to_device_bytes"].as_u64().unwrap_or(0);
+    let device_to_host_bytes = kernel_stats["device_to_host_bytes"].as_u64().unwrap_or(0);
+    if kernel_time_ms < 0.0 || host_to_device_bytes == 0 || device_to_host_bytes == 0 {
+        anyhow::bail!(
+            "strict CUDA ask receipt is missing measured QK256 timing/transfer accounting: kernel_time_ms={}, host_to_device_bytes={}, device_to_host_bytes={}",
+            kernel_stats["kernel_time_ms"],
+            kernel_stats["host_to_device_bytes"],
+            kernel_stats["device_to_host_bytes"]
+        );
+    }
+    let transfer_accounting =
+        &run_receipt["cuda_execution_residency"]["host_device_transfer_accounting"];
+    if transfer_accounting["status"].as_str() != Some("qk256_measured")
+        || transfer_accounting["kernel_time_ms"].as_f64().is_none()
+        || transfer_accounting["host_to_device_bytes"].as_u64().unwrap_or(0) == 0
+        || transfer_accounting["device_to_host_bytes"].as_u64().unwrap_or(0) == 0
+    {
+        anyhow::bail!(
+            "strict CUDA ask receipt is missing measured QK256 residency accounting: {}",
+            transfer_accounting
+        );
     }
     Ok(())
 }
@@ -9613,6 +9729,72 @@ mod tests {
     }
 
     #[test]
+    fn strict_cuda_ask_receipt_accepts_measured_qk256_accounting() {
+        let run_receipt = serde_json::json!({
+            "selected_backend": "nvidia-rtx-5070-ti-cuda",
+            "runtime_api": "cuda",
+            "fallback_used": false,
+            "execution_coverage": {
+                "bitnet_linear_layers_cpu_fallback": 0
+            },
+            "kernel_stats": [{
+                "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
+                "invocations": 4,
+                "fallback_invocations": 0,
+                "host_to_device_bytes": 4096,
+                "device_to_host_bytes": 2048,
+                "kernel_launches": 4,
+                "kernel_time_ms": 1.25,
+                "kernel_time_samples": 4
+            }],
+            "cuda_execution_residency": {
+                "host_device_transfer_accounting": {
+                    "status": "qk256_measured",
+                    "host_to_device_bytes": 4096,
+                    "device_to_host_bytes": 2048,
+                    "kernel_time_ms": 1.25,
+                    "kernel_time_samples": 4
+                }
+            }
+        });
+
+        validate_strict_cuda_ask_receipt(&run_receipt).unwrap();
+    }
+
+    #[test]
+    fn strict_cuda_ask_receipt_rejects_missing_qk256_accounting() {
+        let run_receipt = serde_json::json!({
+            "selected_backend": "nvidia-rtx-5070-ti-cuda",
+            "runtime_api": "cuda",
+            "fallback_used": false,
+            "execution_coverage": {
+                "bitnet_linear_layers_cpu_fallback": 0
+            },
+            "kernel_stats": [{
+                "kernel_id": bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID,
+                "invocations": 4,
+                "fallback_invocations": 0,
+                "host_to_device_bytes": null,
+                "device_to_host_bytes": null,
+                "kernel_launches": 4,
+                "kernel_time_ms": null
+            }],
+            "cuda_execution_residency": {
+                "host_device_transfer_accounting": {
+                    "status": "not_measured",
+                    "host_to_device_bytes": null,
+                    "device_to_host_bytes": null,
+                    "kernel_time_ms": null
+                }
+            }
+        });
+
+        let err = validate_strict_cuda_ask_receipt(&run_receipt).unwrap_err().to_string();
+
+        assert!(err.contains("measured QK256 timing/transfer accounting"), "got: {err}");
+    }
+
+    #[test]
     fn strict_ask_default_receipt_path_is_only_for_strict_modes() {
         assert!(
             strict_ask_default_receipt_path(false, false).is_none(),
@@ -9662,6 +9844,7 @@ mod tests {
         let receipt = cuda_execution_residency_receipt(
             &coverage,
             Some(&residency),
+            None,
             18,
             8,
             "cpu",
@@ -9699,6 +9882,7 @@ mod tests {
         let receipt = cuda_execution_residency_receipt(
             &coverage,
             None,
+            None,
             4,
             1,
             "cpu",
@@ -9725,6 +9909,77 @@ mod tests {
                 .any(|value| value == "host_device_transfer_bytes")
         );
         assert_eq!(receipt["claim_boundary"]["qk256_cuda_residency_claimed"], false);
+    }
+
+    #[test]
+    fn qk256_kernel_stats_receipt_records_measured_cuda_accounting() {
+        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
+            bitnet_linear_layers_total: 4,
+            bitnet_linear_layers_on_cuda: 4,
+            bitnet_linear_layers_cpu_fallback: 0,
+            unsupported_ops: Vec::new(),
+            execution_claim: "cuda_inference_contribution",
+        };
+        let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
+            host_to_device_bytes: 4096,
+            device_to_host_bytes: 2048,
+            kernel_time_ms: Some(1.23456),
+            kernel_time_samples: 4,
+        };
+
+        let receipt = qk256_kernel_stats_receipt(&coverage, Some(&runtime_stats));
+
+        assert_eq!(receipt[0]["kernel_id"], bitnet_kernels::cuda::CUDA_QK256_GEMV_KERNEL_ID);
+        assert_eq!(receipt[0]["invocations"], 4);
+        assert_eq!(receipt[0]["fallback_invocations"], 0);
+        assert_eq!(receipt[0]["host_to_device_bytes"], 4096);
+        assert_eq!(receipt[0]["device_to_host_bytes"], 2048);
+        assert_eq!(receipt[0]["kernel_time_ms"], 1.235);
+        assert_eq!(receipt[0]["kernel_time_samples"], 4);
+    }
+
+    #[test]
+    fn cuda_execution_residency_receipt_records_measured_qk256_accounting() {
+        let coverage = bitnet_qk256_dispatch::Qk256DispatchCoverageCounters {
+            bitnet_linear_layers_total: 4,
+            bitnet_linear_layers_on_cuda: 4,
+            bitnet_linear_layers_cpu_fallback: 0,
+            unsupported_ops: Vec::new(),
+            execution_claim: "cuda_inference_contribution",
+        };
+        let runtime_stats = bitnet_qk256_dispatch::Qk256CudaRuntimeStats {
+            host_to_device_bytes: 4096,
+            device_to_host_bytes: 2048,
+            kernel_time_ms: Some(1.25),
+            kernel_time_samples: 4,
+        };
+
+        let receipt = cuda_execution_residency_receipt(
+            &coverage,
+            None,
+            Some(&runtime_stats),
+            12,
+            3,
+            "cpu",
+            "per_run_incremental_decode",
+            "decode",
+            "strict_cuda_ask_or_run",
+        );
+
+        assert_eq!(receipt["host_device_transfer_accounting"]["status"], "qk256_measured");
+        assert_eq!(receipt["host_device_transfer_accounting"]["host_to_device_bytes"], 4096);
+        assert_eq!(receipt["host_device_transfer_accounting"]["device_to_host_bytes"], 2048);
+        assert_eq!(receipt["host_device_transfer_accounting"]["kernel_time_ms"], 1.25);
+        assert_eq!(receipt["claim_boundary"]["qk256_kernel_timing_claimed"], true);
+        assert_eq!(receipt["claim_boundary"]["qk256_transfer_byte_accounting_claimed"], true);
+        assert_eq!(receipt["claim_boundary"]["transfer_timing_claimed"], false);
+        assert!(
+            !receipt["unresident_or_unmeasured_phases"]
+                .as_array()
+                .expect("phase list")
+                .iter()
+                .any(|value| value == "kernel_time_ms")
+        );
     }
 
     #[test]

--- a/crates/bitnet-kernels/src/cuda/bitnet_context.rs
+++ b/crates/bitnet-kernels/src/cuda/bitnet_context.rs
@@ -21,7 +21,8 @@ use super::quantized_matmul::{I2S_MATMUL_KERNEL_SRC, I2sMatmulConfig};
 #[cfg(feature = "cuda")]
 use cudarc::driver::{
     CudaContext, CudaFunction, CudaModule, CudaSlice, CudaStream, LaunchConfig, PushKernelArg,
-    result::device as cu_device, sys::CUdevice_attribute,
+    result::device as cu_device,
+    sys::{self, CUdevice_attribute},
 };
 #[cfg(feature = "cuda")]
 use cudarc::nvrtc::{Ptx, compile_ptx};
@@ -429,6 +430,7 @@ impl CudaBitnetKernelInvocationStats {
         &mut self,
         host_to_device_bytes: u64,
         device_to_host_bytes: u64,
+        kernel_time_ms: Option<f64>,
         weights_uploaded_once: bool,
         per_token_weight_upload: bool,
     ) {
@@ -437,6 +439,10 @@ impl CudaBitnetKernelInvocationStats {
         self.kernel_launches += 1;
         self.host_to_device_bytes += host_to_device_bytes;
         self.device_to_host_bytes += device_to_host_bytes;
+        if let Some(kernel_time_ms) = kernel_time_ms {
+            self.kernel_time_ms =
+                Some(self.kernel_time_ms.unwrap_or(0.0) + kernel_time_ms.max(0.0));
+        }
         self.weights_uploaded_once = weights_uploaded_once;
         self.per_token_weight_upload = per_token_weight_upload;
     }
@@ -969,7 +975,7 @@ impl CudaBitnetContext {
         activation: &[f32],
         output: &mut [f32],
         config: &Qk256GemvConfig,
-    ) -> Result<()> {
+    ) -> Result<Option<f64>> {
         self.ensure_qk256_gemv_function()?;
 
         let stream = self.stream.as_ref().ok_or_else(|| KernelError::DeviceUnavailable {
@@ -1033,9 +1039,25 @@ impl CudaBitnetContext {
         builder.arg(&bitnet_i8s_weight_scale_arg);
         builder.arg(&use_bitnet_i8s_arg);
 
+        let start_event =
+            stream.record_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT)).map_err(|err| {
+                KernelError::GpuError {
+                    reason: format!("failed to record CUDA QK256 GEMV start event: {err:?}"),
+                }
+            })?;
         unsafe { builder.launch(launch_config) }.map_err(|err| KernelError::GpuError {
             reason: format!("failed to launch CUDA QK256 GEMV kernel: {err:?}"),
         })?;
+        let end_event =
+            stream.record_event(Some(sys::CUevent_flags::CU_EVENT_DEFAULT)).map_err(|err| {
+                KernelError::GpuError {
+                    reason: format!("failed to record CUDA QK256 GEMV end event: {err:?}"),
+                }
+            })?;
+        let kernel_time_ms =
+            f64::from(start_event.elapsed_ms(&end_event).map_err(|err| KernelError::GpuError {
+                reason: format!("failed to measure CUDA QK256 GEMV event time: {err:?}"),
+            })?);
         stream.synchronize().map_err(|err| KernelError::GpuError {
             reason: format!("failed to synchronize CUDA QK256 GEMV kernel: {err:?}"),
         })?;
@@ -1045,7 +1067,7 @@ impl CudaBitnetContext {
                 reason: format!("failed to copy CUDA QK256 GEMV output to host: {err:?}"),
             })?;
         output[..output_len].copy_from_slice(&output_host[..output_len]);
-        Ok(())
+        Ok(Some(kernel_time_ms))
     }
 }
 
@@ -1248,7 +1270,12 @@ impl CudaBitnetLinearBackend for CudaBitnetContext {
         {
             let mut config = Qk256GemvConfig::for_shape(seq_len, output_features, input_features)?;
             config.bitnet_i8s_weight_scale = bitnet_i8s_weight_scale;
-            self.launch_qk256_gemv_cuda(weights, &activation[..activation_len], output, &config)?;
+            let kernel_time_ms = self.launch_qk256_gemv_cuda(
+                weights,
+                &activation[..activation_len],
+                output,
+                &config,
+            )?;
             stats.record_qk256_gemv(
                 u64::try_from(activation_bytes).map_err(|_| KernelError::InvalidArguments {
                     reason: "QK256 activation byte count exceeds receipt counter range".to_string(),
@@ -1256,6 +1283,7 @@ impl CudaBitnetLinearBackend for CudaBitnetContext {
                 u64::try_from(output_bytes).map_err(|_| KernelError::InvalidArguments {
                     reason: "QK256 output byte count exceeds receipt counter range".to_string(),
                 })?,
+                kernel_time_ms,
                 weights.uploaded_once,
                 self.stats.per_token_weight_uploads > 0,
             );
@@ -1822,6 +1850,25 @@ mod tests {
         assert!(!fields.per_token_weight_upload);
         assert!(fields.activation_workspace_reused);
         assert!(!fields.full_inference_claim);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn qk256_invocation_stats_accumulate_transfer_bytes_and_event_time() {
+        let mut stats = CudaBitnetKernelInvocationStats::new(CUDA_QK256_GEMV_KERNEL_ID);
+
+        stats.record_qk256_gemv(1024, 512, Some(0.25), true, false);
+        stats.record_qk256_gemv(2048, 1024, Some(0.5), true, false);
+
+        assert_eq!(stats.kernel_id, CUDA_QK256_GEMV_KERNEL_ID);
+        assert_eq!(stats.invocations, 2);
+        assert_eq!(stats.kernel_launches, 2);
+        assert_eq!(stats.fallback_invocations, 0);
+        assert_eq!(stats.host_to_device_bytes, 3072);
+        assert_eq!(stats.device_to_host_bytes, 1536);
+        assert_eq!(stats.kernel_time_ms, Some(0.75));
+        assert!(stats.weights_uploaded_once);
+        assert!(!stats.per_token_weight_upload);
     }
 
     #[cfg(not(feature = "cuda"))]

--- a/crates/bitnet-qk256-dispatch/src/lib.rs
+++ b/crates/bitnet-qk256-dispatch/src/lib.rs
@@ -22,6 +22,10 @@ static BITNET_LINEAR_TOTAL: AtomicU64 = AtomicU64::new(0);
 static BITNET_LINEAR_ON_CUDA: AtomicU64 = AtomicU64::new(0);
 static BITNET_LINEAR_CPU_FALLBACK: AtomicU64 = AtomicU64::new(0);
 static BITNET_LINEAR_UNSUPPORTED: AtomicU64 = AtomicU64::new(0);
+static CUDA_QK256_HOST_TO_DEVICE_BYTES: AtomicU64 = AtomicU64::new(0);
+static CUDA_QK256_DEVICE_TO_HOST_BYTES: AtomicU64 = AtomicU64::new(0);
+static CUDA_QK256_KERNEL_TIME_MICROS: AtomicU64 = AtomicU64::new(0);
+static CUDA_QK256_KERNEL_TIME_SAMPLES: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(feature = "cuda")]
 thread_local! {
@@ -52,6 +56,19 @@ pub struct Qk256CudaWeightResidency {
     pub weights_uploaded_once: bool,
     /// True if the CUDA context recorded any per-token weight upload.
     pub per_token_weight_upload: bool,
+}
+
+/// Aggregate CUDA QK256 runtime counters for receipt timing and transfer accounting.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Qk256CudaRuntimeStats {
+    /// Host-to-device activation bytes copied for QK256 CUDA GEMV calls.
+    pub host_to_device_bytes: u64,
+    /// Device-to-host output bytes copied for QK256 CUDA GEMV calls.
+    pub device_to_host_bytes: u64,
+    /// Aggregate measured CUDA event time for QK256 kernel launches, in milliseconds.
+    pub kernel_time_ms: Option<f64>,
+    /// Number of kernel launches with a measured CUDA event time.
+    pub kernel_time_samples: u64,
 }
 
 /// Snapshot the current QK256 dispatch coverage counters.
@@ -91,12 +108,28 @@ pub fn reset_qk256_dispatch_coverage() {
     BITNET_LINEAR_ON_CUDA.store(0, Ordering::Relaxed);
     BITNET_LINEAR_CPU_FALLBACK.store(0, Ordering::Relaxed);
     BITNET_LINEAR_UNSUPPORTED.store(0, Ordering::Relaxed);
+    CUDA_QK256_HOST_TO_DEVICE_BYTES.store(0, Ordering::Relaxed);
+    CUDA_QK256_DEVICE_TO_HOST_BYTES.store(0, Ordering::Relaxed);
+    CUDA_QK256_KERNEL_TIME_MICROS.store(0, Ordering::Relaxed);
+    CUDA_QK256_KERNEL_TIME_SAMPLES.store(0, Ordering::Relaxed);
     reset_cuda_qk256_context();
 }
 
 /// Snapshot CUDA QK256 weight residency for the current thread-local proof run.
 pub fn qk256_cuda_weight_residency() -> Option<Qk256CudaWeightResidency> {
     cuda_qk256_weight_residency()
+}
+
+/// Snapshot CUDA QK256 timing and transfer counters for the current process.
+pub fn qk256_cuda_runtime_stats() -> Qk256CudaRuntimeStats {
+    let samples = CUDA_QK256_KERNEL_TIME_SAMPLES.load(Ordering::Relaxed);
+    let kernel_time_micros = CUDA_QK256_KERNEL_TIME_MICROS.load(Ordering::Relaxed);
+    Qk256CudaRuntimeStats {
+        host_to_device_bytes: CUDA_QK256_HOST_TO_DEVICE_BYTES.load(Ordering::Relaxed),
+        device_to_host_bytes: CUDA_QK256_DEVICE_TO_HOST_BYTES.load(Ordering::Relaxed),
+        kernel_time_ms: (samples > 0).then(|| kernel_time_micros as f64 / 1000.0),
+        kernel_time_samples: samples,
+    }
 }
 
 /// Record a BitNet linear CPU fallback outside the QK256 raw-tensor path.
@@ -281,9 +314,13 @@ fn forward_qk256_cuda(
         };
         let mut stats =
             bitnet_kernels::cuda::CudaBitnetKernelInvocationStats::new(CUDA_QK256_GEMV_KERNEL_ID);
-        context
+        let result = context
             .qk256_gemv(&handle, &input_flat, &mut output_flat, seq_len, inline_scale, &mut stats)
-            .map_err(BitNetError::from)
+            .map_err(BitNetError::from);
+        if result.is_ok() {
+            record_cuda_qk256_runtime_stats(&stats);
+        }
+        result
     })?;
 
     tensor_from_flat_output(output_flat, &prepared.shape, &prepared.layout, input)
@@ -436,6 +473,17 @@ fn tensor_from_flat_output(
     };
 
     Ok(output_tensor)
+}
+
+#[cfg(feature = "cuda")]
+fn record_cuda_qk256_runtime_stats(stats: &bitnet_kernels::cuda::CudaBitnetKernelInvocationStats) {
+    CUDA_QK256_HOST_TO_DEVICE_BYTES.fetch_add(stats.host_to_device_bytes, Ordering::Relaxed);
+    CUDA_QK256_DEVICE_TO_HOST_BYTES.fetch_add(stats.device_to_host_bytes, Ordering::Relaxed);
+    if let Some(kernel_time_ms) = stats.kernel_time_ms {
+        let micros = (kernel_time_ms.max(0.0) * 1000.0).round() as u64;
+        CUDA_QK256_KERNEL_TIME_MICROS.fetch_add(micros, Ordering::Relaxed);
+        CUDA_QK256_KERNEL_TIME_SAMPLES.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 fn backend_env_matches(name: &str) -> bool {

--- a/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
+++ b/crates/bitnet-qk256-dispatch/tests/cuda_coverage.rs
@@ -1,6 +1,7 @@
 use bitnet_qk256_dispatch::{
-    forward_qk256, qk256_dispatch_coverage, record_bitnet_linear_cpu_fallback,
-    record_bitnet_linear_unsupported, reset_qk256_dispatch_coverage,
+    forward_qk256, qk256_cuda_runtime_stats, qk256_dispatch_coverage,
+    record_bitnet_linear_cpu_fallback, record_bitnet_linear_unsupported,
+    reset_qk256_dispatch_coverage,
 };
 use candle_core::{DType, Device, Tensor};
 use std::sync::Mutex;
@@ -81,6 +82,20 @@ fn strict_unsupported_counter_records_receipt_boundary() {
     assert_eq!(coverage.unsupported_ops, vec!["qk256_strict_cuda_unsupported"]);
     assert_eq!(coverage.execution_claim, "cuda_bitnet_not_routed");
     clear_backend_env();
+}
+
+#[test]
+fn reset_clears_cuda_runtime_accounting_counters() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    clear_backend_env();
+    reset_qk256_dispatch_coverage();
+
+    let stats = qk256_cuda_runtime_stats();
+
+    assert_eq!(stats.host_to_device_bytes, 0);
+    assert_eq!(stats.device_to_host_bytes, 0);
+    assert_eq!(stats.kernel_time_ms, None);
+    assert_eq!(stats.kernel_time_samples, 0);
 }
 
 #[cfg(not(feature = "cuda"))]


### PR DESCRIPTION
## Summary
- add CUDA event timing around `qk256_gemv_cuda` launches and aggregate measured QK256 kernel time
- add QK256 H2D/D2H byte counters in the dispatch layer and surface them in strict ask, warm-session, and benchmark-source receipts
- make strict CUDA ask receipt validation reject missing measured QK256 timing/transfer accounting while keeping `speedup_claim=false` and full-residency claims false

## Validation
- `cargo fmt -p bitnet-kernels -p bitnet-qk256-dispatch -p bitnet-cli -- --check`
- `cargo fmt -p bitnet-cli -- --check`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli`
- `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- `cargo test --locked -p bitnet-kernels --lib --no-default-features --features cuda qk256_invocation_stats_accumulate_transfer_bytes_and_event_time -- --nocapture`
- `cargo test --locked -p bitnet-qk256-dispatch --no-default-features --features cpu --test cuda_coverage -- --nocapture`
- `cargo test --locked -p bitnet-cli --bin bitnet --no-default-features --features cpu,full-cli cuda -- --nocapture`
- strict RTX 5070 Ti CUDA ask live receipt: answer `4`, `fallback_used=false`, `kernel=qk256_gemv_cuda`, measured `kernel_time_ms=1008.944`, `host_to_device_bytes=56125440`, `device_to_host_bytes=57415680`, `speedup_claim=false`
- strict RTX 5070 Ti CUDA warm-session live receipt: measured aggregate `kernel_time_ms=2015.659`, `host_to_device_bytes=114923520`, `device_to_host_bytes=117565440`, `speedup_claim=false`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check nvidia-5070ti`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim Boundary
- does not change QK256 math, tokenizer, loader, transformer semantics, or dense CUDA
- does not claim broad CUDA speedup or full transformer CUDA residency