### PR TITLE
docs(tracking): refresh generated campaign dashboards

### DIFF
--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,5 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| intel-npu | NPU-011 | #4097 | `codex/intel-npu/NPU-011-ffn-subgraph-parity` | Add selected static BitNet FFN/ReLU2 subgraph parity on OpenVINO NPU without full inference, acceleration, QK256, or CPU fallback proof claims. |
+| intel-npu | NPU-011 | #4097 | `codex/intel-npu/NPU-011-ffn-subgraph-parity` | Add a selected static BitNet-shaped OpenVINO NPU FFN/ReLU2 subgraph parity experiment with CPU reference comparison, static shape metadata, tolerance, timing, selected backend/runtime identity, fallback_used=false, and no full inference, acceleration, QK256, or CPU fallback proof claims. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |


### PR DESCRIPTION
## Summary
- refresh generated campaign dashboards after current `origin/main`
- sync the generated active PR text for NPU-011 so `campaign doctor` passes again

## Validation
- `C:\Code\Rust\BitNet-rs\target\debug\xtask.exe campaign doctor`
- `git diff --check`

## Boundaries
- generated tracker files only
- no runtime, kernel, receipt, benchmark, server, GPU/NPU behavior, or answer-quality changes