### PR TITLE
Add Gemma 4 model foundation (architecture, catalog, docs, tracker)

### DIFF
--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -26,6 +26,8 @@ pub enum ModelArchitecture {
     Qwen,
     /// Gemma family (Gemma / Gemma-2)
     Gemma,
+    /// Gemma 4 family (E2B/E4B dense, 31B dense, 26B-A4B MoE)
+    Gemma4,
     /// Mistral / Mixtral
     Mistral,
     /// LLaMA family (LLaMA / LLaMA-2 / LLaMA-3)
@@ -126,6 +128,7 @@ impl std::fmt::Display for ModelArchitecture {
             Self::Phi => write!(f, "phi"),
             Self::Qwen => write!(f, "qwen"),
             Self::Gemma => write!(f, "gemma"),
+            Self::Gemma4 => write!(f, "gemma4"),
             Self::Mistral => write!(f, "mistral"),
             Self::Llama => write!(f, "llama"),
             Self::SmolLM => write!(f, "smollm"),
@@ -216,6 +219,13 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("qwen") {
         return ModelArchitecture::Qwen;
     }
+    if lower.contains("gemma-4")
+        || lower.contains("gemma4")
+        || lower.contains("gemma_4")
+        || lower.contains("gemma 4")
+    {
+        return ModelArchitecture::Gemma4;
+    }
     if lower.contains("gemma") {
         return ModelArchitecture::Gemma;
     }
@@ -287,6 +297,15 @@ pub fn get_defaults(arch: &ModelArchitecture) -> ArchitectureConfig {
             max_context: 8192,
             vocab_size: 256_000,
             typical_hidden_size: 3072,
+        },
+        ModelArchitecture::Gemma4 => ArchitectureConfig {
+            architecture: ModelArchitecture::Gemma4,
+            activation: ActivationType::Gelu,
+            normalization: NormType::RmsNorm,
+            rope_base: 10_000.0,
+            max_context: 131_072,
+            vocab_size: 262_144,
+            typical_hidden_size: 2304,
         },
         ModelArchitecture::Mistral => ArchitectureConfig {
             architecture: ModelArchitecture::Mistral,
@@ -442,6 +461,7 @@ pub fn supported_architectures() -> Vec<ModelArchitecture> {
         ModelArchitecture::Phi,
         ModelArchitecture::Qwen,
         ModelArchitecture::Gemma,
+        ModelArchitecture::Gemma4,
         ModelArchitecture::Mistral,
         ModelArchitecture::Llama,
         ModelArchitecture::SmolLM,
@@ -475,6 +495,7 @@ mod tests {
         assert_eq!(detect_architecture("microsoft/phi-4"), ModelArchitecture::Phi);
         assert_eq!(detect_architecture("Qwen/Qwen2.5-7B"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("google/gemma-4-E2B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
@@ -501,6 +522,7 @@ mod tests {
         assert_eq!(detect_architecture("LLAMA"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("BitNet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("Gemma2"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("Gemma4"), ModelArchitecture::Gemma4);
     }
 
     #[test]
@@ -610,6 +632,15 @@ mod tests {
     }
 
     #[test]
+    fn defaults_gemma4() {
+        let cfg = get_defaults(&ModelArchitecture::Gemma4);
+        assert_eq!(cfg.activation, ActivationType::Gelu);
+        assert_eq!(cfg.normalization, NormType::RmsNorm);
+        assert_eq!(cfg.max_context, 131_072);
+        assert_eq!(cfg.vocab_size, 262_144);
+    }
+
+    #[test]
     fn defaults_mistral() {
         let cfg = get_defaults(&ModelArchitecture::Mistral);
         assert_eq!(cfg.activation, ActivationType::Silu);
@@ -641,8 +672,8 @@ mod tests {
     #[test]
     fn supported_list_complete() {
         let list = supported_architectures();
-        // At least 19 known architectures
-        assert!(list.len() >= 19, "expected ≥19, got {}", list.len());
+        // At least 20 known architectures
+        assert!(list.len() >= 20, "expected ≥20, got {}", list.len());
         // No Unknown in the list
         assert!(
             !list.iter().any(|a| matches!(a, ModelArchitecture::Unknown(_))),

--- a/crates/bitnet-models/src/model_catalog.rs
+++ b/crates/bitnet-models/src/model_catalog.rs
@@ -147,6 +147,58 @@ impl ModelCatalog {
         });
 
         cat.add(CatalogEntry {
+            id: "gemma4-e2b-it".into(),
+            name: "Gemma 4 E2B IT".into(),
+            family: "gemma4".into(),
+            params_b: 2.0,
+            size: ModelSize::Small,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E2B-it".into(),
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e4b-it".into(),
+            name: "Gemma 4 E4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 4.0,
+            size: ModelSize::Medium,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E4B-it".into(),
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-31b-it".into(),
+            name: "Gemma 4 31B IT".into(),
+            family: "gemma4".into(),
+            params_b: 31.0,
+            size: ModelSize::XLarge,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-31B-it".into(),
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-26b-a4b-it".into(),
+            name: "Gemma 4 26B-A4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 25.2,
+            size: ModelSize::Large,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-26B-A4B-it".into(),
+        });
+
+        cat.add(CatalogEntry {
             id: "mistral-7b".into(),
             name: "Mistral 7B".into(),
             family: "mistral".into(),
@@ -289,6 +341,20 @@ mod tests {
         let cat = ModelCatalog::builtin();
         let bitnet = cat.get("bitnet-2b").unwrap();
         assert_eq!(bitnet.vocab_size, 32000);
+    }
+
+    #[test]
+    fn test_gemma4_entries_in_catalog() {
+        let cat = ModelCatalog::builtin();
+        let e2b = cat.get("gemma4-e2b-it").unwrap();
+        assert_eq!(e2b.family, "gemma4");
+        assert_eq!(e2b.context_length, 131072);
+        assert_eq!(e2b.vocab_size, 262144);
+        assert_eq!(e2b.hf_repo, "google/gemma-4-E2B-it");
+
+        let moe = cat.get("gemma4-26b-a4b-it").unwrap();
+        assert_eq!(moe.context_length, 262144);
+        assert_eq!(moe.params_b, 25.2);
     }
 
     #[test]

--- a/crates/bitnet-models/src/model_metadata.rs
+++ b/crates/bitnet-models/src/model_metadata.rs
@@ -50,6 +50,101 @@ impl License {
     }
 }
 
+/// Gemma 4 variant metadata used by catalog and loader planning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Gemma4Variant {
+    E2B,
+    E4B,
+    Dense31B,
+    Moe26BA4B,
+}
+
+impl Gemma4Variant {
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::E2B => "e2b-it",
+            Self::E4B => "e4b-it",
+            Self::Dense31B => "31b-it",
+            Self::Moe26BA4B => "26b-a4b-it",
+        }
+    }
+}
+
+/// Static Gemma 4 shape/capability facts for foundation planning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gemma4Spec {
+    pub variant: Gemma4Variant,
+    pub layers: usize,
+    pub vocab_size: usize,
+    pub context_length: usize,
+    pub sliding_window: usize,
+    pub has_ple: bool,
+    pub has_shared_kv: bool,
+    pub is_moe: bool,
+    pub image_capable: bool,
+    pub audio_capable: bool,
+    pub first_text_only_target: bool,
+}
+
+impl Gemma4Spec {
+    pub fn for_variant(variant: Gemma4Variant) -> Self {
+        match variant {
+            Gemma4Variant::E2B => Self {
+                variant,
+                layers: 35,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                image_capable: true,
+                audio_capable: true,
+                first_text_only_target: true,
+            },
+            Gemma4Variant::E4B => Self {
+                variant,
+                layers: 42,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                image_capable: true,
+                audio_capable: true,
+                first_text_only_target: false,
+            },
+            Gemma4Variant::Dense31B => Self {
+                variant,
+                layers: 60,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: false,
+                image_capable: true,
+                audio_capable: false,
+                first_text_only_target: false,
+            },
+            Gemma4Variant::Moe26BA4B => Self {
+                variant,
+                layers: 30,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: true,
+                image_capable: true,
+                audio_capable: false,
+                first_text_only_target: false,
+            },
+        }
+    }
+}
+
 /// Quantization information.
 #[derive(Debug, Clone)]
 pub struct QuantInfo {
@@ -285,5 +380,27 @@ mod tests {
         let lic = License::from_str_relaxed("");
         assert_eq!(lic, License::Unknown);
         assert_eq!(lic.name(), "Unknown");
+    }
+
+    #[test]
+    fn test_gemma4_e2b_spec_marks_first_text_only_target() {
+        let spec = Gemma4Spec::for_variant(Gemma4Variant::E2B);
+        assert_eq!(spec.layers, 35);
+        assert_eq!(spec.context_length, 131_072);
+        assert_eq!(spec.vocab_size, 262_144);
+        assert!(spec.has_ple);
+        assert!(spec.has_shared_kv);
+        assert!(!spec.is_moe);
+        assert!(spec.first_text_only_target);
+    }
+
+    #[test]
+    fn test_gemma4_moe_spec_is_future_gated_shape() {
+        let spec = Gemma4Spec::for_variant(Gemma4Variant::Moe26BA4B);
+        assert_eq!(spec.variant.id(), "26b-a4b-it");
+        assert_eq!(spec.context_length, 262_144);
+        assert!(spec.is_moe);
+        assert!(!spec.audio_capable);
+        assert!(!spec.first_text_only_target);
     }
 }

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,62 @@
+# Gemma 4 Foundation
+
+Status: scaffold only. This document records the Gemma 4 model-family boundary for `bitnet-rs`; it does not claim Gemma 4 inference support.
+
+## Architecture identity
+
+Gemma 4 is represented as `ModelArchitecture::Gemma4`, distinct from the older `ModelArchitecture::Gemma` family. Generic Gemma or Gemma 2 detection must not be treated as proof that Gemma 4 model semantics are implemented.
+
+Detected names include:
+
+- `gemma-4`
+- `gemma4`
+- `google/gemma-4-E2B-it`
+- `google/gemma-4-E4B-it`
+- `google/gemma-4-31B-it`
+- `google/gemma-4-26B-A4B-it`
+
+## Variants
+
+| Variant | Lane | Catalog id | Context metadata | Runtime claim |
+|---|---|---|---:|---|
+| E2B IT | dense decoder | `gemma4-e2b-it` | 128K | first target, text-only scaffold |
+| E4B IT | dense decoder | `gemma4-e4b-it` | 128K | second target, text-only scaffold |
+| 31B IT | dense decoder | `gemma4-31b-it` | 256K | future-gated |
+| 26B-A4B IT | MoE decoder | `gemma4-26b-a4b-it` | 256K | future-gated |
+
+The first proof target is Gemma 4 E2B IT, text-only, Q4 GGUF, CPU first, strict receipt, and limited runtime context. The catalog context length records model metadata only; it is not a runtime long-context claim.
+
+## Required implementation facts for E2B/E4B
+
+E2B and E4B require Gemma 4-specific implementation work before strict inference can be claimed:
+
+- Per-Layer Embeddings (PLE) must be loaded and enabled in strict mode.
+- Shared KV behavior must be represented in the cache plan.
+- Alternating sliding/global attention must be driven by model metadata or an explicit validated schedule.
+- Global attention p-RoPE/unified-KV behavior must not be collapsed into the older generic Gemma path.
+- Prompt-template and tokenizer authority must be explicit before receipts claim real model output.
+
+## Claim boundaries
+
+Gemma 4 is not a BitNet or QK256 proof path.
+
+- BitNet QK256 kernels do not count as Gemma 4 dense inference proof.
+- Text-only support must not imply image, audio, video, MoE, MTP, or full-context support.
+- Dense Gemma 4 variants require dense regular-LLM kernels and receipts with `qk256_used=false`.
+- The 26B-A4B MoE variant must report MoE status, active parameters, and total parameters before any future runtime claim.
+- Multimodal capability must be receipt-gated separately from text-only loading.
+- Long-context capability must be receipt-gated separately from model metadata.
+
+## Acceptance boundary for the first real proof
+
+Gemma 4 becomes a real runtime claim only when an E2B text-only strict receipt records:
+
+- real GGUF weights;
+- real tokenizer/template authority;
+- `model_family=gemma4` and `variant=e2b-it`;
+- PLE loaded and enabled;
+- shared KV enabled;
+- dense Q4 execution with `bitnet_kernel_used=false` and `qk256_used=false`;
+- no fallback;
+- no multimodal, MoE, MTP, speedup, or long-context claim; and
+- at least one generated token from the strict CPU user path.

--- a/docs/tracking/bitnet-alignment/backend-status.yaml
+++ b/docs/tracking/bitnet-alignment/backend-status.yaml
@@ -22,6 +22,13 @@ hard_rules:
   - QK256 is validation-only until performance target and receipts exist.
   - Minimal GGUF fallback cannot support correctness or performance claims.
 
+model_claim_rules:
+  - Non-BitNet dense models must not use QK256 receipts.
+  - Multimodal support must be explicitly claimed in receipts.
+  - MoE support must record active versus total parameters.
+  - Token classification must not be recorded as generation.
+  - Gemma 4 text-only scaffolding must not imply image, audio, video, MoE, MTP, or long-context runtime support.
+
 backends:
   cpu:
     status: receipt_backed

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -29,11 +29,17 @@ Transition note: campaign-local `active.toml` files and append-only `events/*.to
 | RTX5070TI-003 | #3679 | pr_open | Preserve RTX 5070 Ti CUDA selected-device identity |
 | AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
 | AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |
+| GEMMA4-000 | TBD | proposed | Add Gemma 4 tracker and claim-boundary scaffold; no runtime execution |
+| GEMMA4-001 | TBD | proposed | Add Gemma 4 architecture/catalog foundation; no inference claim |
 
 These rows are coordination markers, not implementation proof. Merged scaffold
 rows stay visible so the A770, NPU, 258V, 8250U, AMD, NVIDIA, and Mac lanes can
 coordinate follow-up work without implying that runtime execution has been built
 or tested.
+
+## Model-family Lanes
+
+Gemma 4 is tracked under the shared backend/receipt truth system rather than a parallel tracker. The first target is Gemma 4 E2B IT text-only Q4 GGUF with strict receipts. Generic Gemma support is not Gemma 4 support, and BitNet QK256 execution does not count as Gemma 4 dense inference proof. MoE, multimodal, MTP, and long-context behavior remain future-gated until their own receipts exist. See `docs/models/families/gemma-4.md`.
 
 ## Hardware Lanes
 

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -73,6 +73,10 @@ workstreams:
     title: CPU runtime proof
     objective: Make strict CPU QK256 CLI inference receipt-backed and measurable.
 
+  model_families:
+    title: Model-family expansion
+    objective: Add non-BitNet model families with strict claim boundaries and receipts.
+
   legacy_mobile_cpu:
     title: Legacy mobile CPU validation
     objective: Validate the CPU-first BitNet path on Intel Core i5-8250U-class AVX2 mobile hardware, with receipts that separate short turbo behavior from sustained low-power operation.
@@ -110,6 +114,57 @@ workstreams:
     objective: Validate RTX 5070 Ti execution through CUDA kernels, CPU/CUDA parity, receipts, and benchmark artifacts, with wgpu/Vulkan as a separate cross-platform comparison lane.
 
 items:
+  - id: GEMMA4-000
+    title: Gemma 4 tracker and claim-boundary scaffold
+    state: proposed
+    priority: P1
+    workstream: model_families
+    depends_on: []
+    scope:
+      allowed_paths:
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/models/families/gemma-4.md
+      forbidden_paths:
+        - crates/**
+    acceptance:
+      - Gemma 4 is represented as a non-BitNet dense/MoE model family.
+      - E2B/E4B text-only is the first target.
+      - 26B-A4B, multimodal, long context, and MTP are future-gated.
+      - BitNet QK256 kernels do not count as Gemma 4 dense inference proof.
+    verification:
+      - cargo fmt --all -- --check
+    notes:
+      - Generic Gemma support is not Gemma 4 support.
+      - First target is Gemma 4 E2B IT text-only Q4 GGUF.
+      - Text-only support does not imply image, audio, video, MoE, MTP, or full-context support.
+
+  - id: GEMMA4-001
+    title: Gemma 4 architecture and catalog foundation
+    state: proposed
+    priority: P1
+    workstream: model_families
+    depends_on:
+      - GEMMA4-000
+    scope:
+      allowed_paths:
+        - crates/bitnet-models/src/architecture.rs
+        - crates/bitnet-models/src/model_catalog.rs
+        - crates/bitnet-models/src/model_metadata.rs
+      forbidden_paths:
+        - crates/bitnet-inference/**
+        - crates/bitnet-kernels/**
+    acceptance:
+      - ModelArchitecture::Gemma4 exists without claiming runtime support.
+      - Gemma and Gemma4 detection are distinct.
+      - E2B, E4B, 31B, and 26B-A4B catalog and metadata scaffold exists.
+      - MoE, multimodal, long context, and MTP behavior is future-gated.
+    verification:
+      - cargo test --locked -p bitnet-models --no-default-features --features cpu
+    notes:
+      - Add ModelArchitecture::Gemma4 without inference runtime changes.
+
   - id: TRUTH-001
     title: Fence server simulated inference
     state: merged


### PR DESCRIPTION
### Motivation

- Represent Gemma 4 as a first-class model family inside the existing architecture/catalog/receipt truth system without claiming runtime/inference support. 
- Provide doc-first scaffolding and clear claim boundaries so E2B/E4B text-only work can be tracked and validated later.

### Description

- Add `ModelArchitecture::Gemma4` with dedicated detection (matches `gemma-4`, `gemma4`, etc.), display, and architecture defaults (`max_context`, `vocab_size`, `typical_hidden_size`).
- Add Gemma 4 variant metadata: `Gemma4Variant` and `Gemma4Spec` describing E2B, E4B, 31B, and 26B-A4B facts (PLE, shared KV, MoE, modalities, first-text-only target) and unit tests validating the specs.
- Add builtin `ModelCatalog` entries for `gemma4-e2b-it`, `gemma4-e4b-it`, `gemma4-31b-it`, and `gemma4-26b-a4b-it` and catalog tests.
- Add documentation `docs/models/families/gemma-4.md` describing variant lanes, PLE/shared-KV requirements, claim boundaries (no QK256/BitNet proof), and acceptance criteria for the first strict proof.
- Wire Gemma 4 into the existing tracker/truth files by adding a `model_families` workstream, `GEMMA4-000`/`GEMMA4-001` items, and `model_claim_rules` in `backend-status.yaml`, while explicitly avoiding any runtime, kernel, or inference implementation changes.

### Testing

- Ran `cargo fmt --all -- --check` which succeeded.
- Ran targeted unit tests for the Gemma4 additions with `cargo test --locked -p bitnet-models --no-default-features --features cpu gemma4` which passed.
- Verified the broader `bitnet-models` test command `cargo test --locked -p bitnet-models --no-default-features --features cpu`, which executes the full test suite, exercised many tests successfully but ultimately failed the existing fixture-integrity checks because required QK256 fixture files under `ci/fixtures/qk256/*.gguf` are not present in this checkout. 
- Validated tracker YAML parsing with `ruby -e 'require "yaml"; YAML.unsafe_load_file("docs/tracking/bitnet-alignment/workstream-ledger.yaml"); YAML.unsafe_load_file("docs/tracking/bitnet-alignment/backend-status.yaml")'` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe224109688333a37d6b9dd133415a)