### PR TITLE
Add Gemma4 architecture & catalog scaffold; docs and tracker updates

### DIFF
--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -26,6 +26,8 @@ pub enum ModelArchitecture {
     Qwen,
     /// Gemma family (Gemma / Gemma-2)
     Gemma,
+    /// Gemma 4 family (distinct from earlier Gemma defaults).
+    Gemma4,
     /// Mistral / Mixtral
     Mistral,
     /// LLaMA family (LLaMA / LLaMA-2 / LLaMA-3)
@@ -126,6 +128,7 @@ impl std::fmt::Display for ModelArchitecture {
             Self::Phi => write!(f, "phi"),
             Self::Qwen => write!(f, "qwen"),
             Self::Gemma => write!(f, "gemma"),
+            Self::Gemma4 => write!(f, "gemma4"),
             Self::Mistral => write!(f, "mistral"),
             Self::Llama => write!(f, "llama"),
             Self::SmolLM => write!(f, "smollm"),
@@ -216,6 +219,9 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("qwen") {
         return ModelArchitecture::Qwen;
     }
+    if lower.contains("gemma-4") || lower.contains("gemma_4") || lower.contains("gemma4") {
+        return ModelArchitecture::Gemma4;
+    }
     if lower.contains("gemma") {
         return ModelArchitecture::Gemma;
     }
@@ -286,6 +292,15 @@ pub fn get_defaults(arch: &ModelArchitecture) -> ArchitectureConfig {
             rope_base: 10_000.0,
             max_context: 8192,
             vocab_size: 256_000,
+            typical_hidden_size: 3072,
+        },
+        ModelArchitecture::Gemma4 => ArchitectureConfig {
+            architecture: ModelArchitecture::Gemma4,
+            activation: ActivationType::Gelu,
+            normalization: NormType::RmsNorm,
+            rope_base: 10_000.0,
+            max_context: 131_072,
+            vocab_size: 262_144,
             typical_hidden_size: 3072,
         },
         ModelArchitecture::Mistral => ArchitectureConfig {
@@ -442,6 +457,7 @@ pub fn supported_architectures() -> Vec<ModelArchitecture> {
         ModelArchitecture::Phi,
         ModelArchitecture::Qwen,
         ModelArchitecture::Gemma,
+        ModelArchitecture::Gemma4,
         ModelArchitecture::Mistral,
         ModelArchitecture::Llama,
         ModelArchitecture::SmolLM,
@@ -475,6 +491,7 @@ mod tests {
         assert_eq!(detect_architecture("microsoft/phi-4"), ModelArchitecture::Phi);
         assert_eq!(detect_architecture("Qwen/Qwen2.5-7B"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("google/gemma-4-E2B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
@@ -489,6 +506,8 @@ mod tests {
         assert_eq!(detect_architecture("qwen2"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("qwen3"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("gemma"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("gemma4"), ModelArchitecture::Gemma4);
+        assert_eq!(detect_architecture("gemma-4-26B-A4B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("bitnet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("falcon"), ModelArchitecture::Falcon);
         assert_eq!(detect_architecture("mpt"), ModelArchitecture::Mpt);
@@ -501,6 +520,7 @@ mod tests {
         assert_eq!(detect_architecture("LLAMA"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("BitNet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("Gemma2"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("Gemma_4_E4B"), ModelArchitecture::Gemma4);
     }
 
     #[test]
@@ -607,6 +627,16 @@ mod tests {
         assert_eq!(cfg.rope_base, 10_000.0);
         assert_eq!(cfg.max_context, 8192);
         assert_eq!(cfg.vocab_size, 256_000);
+    }
+
+    #[test]
+    fn defaults_gemma4() {
+        let cfg = get_defaults(&ModelArchitecture::Gemma4);
+        assert_eq!(cfg.activation, ActivationType::Gelu);
+        assert_eq!(cfg.normalization, NormType::RmsNorm);
+        assert_eq!(cfg.rope_base, 10_000.0);
+        assert_eq!(cfg.max_context, 131_072);
+        assert_eq!(cfg.vocab_size, 262_144);
     }
 
     #[test]

--- a/crates/bitnet-models/src/model_catalog.rs
+++ b/crates/bitnet-models/src/model_catalog.rs
@@ -38,6 +38,27 @@ impl ModelSize {
     }
 }
 
+/// Implementation maturity tier for a catalog entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplementationTier {
+    /// Intended to fit the current CPU or RTX 5070 Ti-class local proof lane.
+    LocalTestable,
+    /// Recognized but expected to need partial offload or reduced-context operation.
+    PartialOffload,
+    /// Design metadata only; no local inference proof is claimed.
+    DesignOnly,
+}
+
+impl ImplementationTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LocalTestable => "local_testable",
+            Self::PartialOffload => "partial_offload",
+            Self::DesignOnly => "design_only",
+        }
+    }
+}
+
 /// Catalog entry for a known model.
 #[derive(Debug, Clone)]
 pub struct CatalogEntry {
@@ -51,6 +72,8 @@ pub struct CatalogEntry {
     pub vocab_size: usize,
     pub license: String,
     pub hf_repo: String,
+    pub implementation_tier: ImplementationTier,
+    pub inference_supported: bool,
 }
 
 /// Model catalog.
@@ -79,6 +102,8 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "MIT".into(),
             hf_repo: "microsoft/bitnet-b1.58-2B-4T-gguf".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -92,6 +117,8 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -105,6 +132,8 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4-mini".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -118,6 +147,8 @@ impl ModelCatalog {
             vocab_size: 151936,
             license: "Apache-2.0".into(),
             hf_repo: "Qwen/Qwen2.5-3B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -131,6 +162,8 @@ impl ModelCatalog {
             vocab_size: 128256,
             license: "Llama3".into(),
             hf_repo: "meta-llama/Meta-Llama-3-8B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -144,6 +177,68 @@ impl ModelCatalog {
             vocab_size: 256128,
             license: "Gemma".into(),
             hf_repo: "google/gemma-2-2b-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e2b-it".into(),
+            name: "Gemma 4 E2B IT".into(),
+            family: "gemma4".into(),
+            params_b: 2.0,
+            size: ModelSize::Small,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E2B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: false,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e4b-it".into(),
+            name: "Gemma 4 E4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 4.0,
+            size: ModelSize::Medium,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E4B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: false,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-31b-it".into(),
+            name: "Gemma 4 31B IT".into(),
+            family: "gemma4".into(),
+            params_b: 31.0,
+            size: ModelSize::XLarge,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-31B-it".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
+            inference_supported: false,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-26b-a4b-it".into(),
+            name: "Gemma 4 26B-A4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 25.2,
+            size: ModelSize::Large,
+            architecture: "Gemma4MoeForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-26B-A4B-it".into(),
+            implementation_tier: ImplementationTier::DesignOnly,
+            inference_supported: false,
         });
 
         cat.add(CatalogEntry {
@@ -157,6 +252,8 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "Apache-2.0".into(),
             hf_repo: "mistralai/Mistral-7B-Instruct-v0.3".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat.add(CatalogEntry {
@@ -170,6 +267,8 @@ impl ModelCatalog {
             vocab_size: 49152,
             license: "Apache-2.0".into(),
             hf_repo: "HuggingFaceTB/SmolLM2-1.7B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
 
         cat
@@ -267,6 +366,22 @@ mod tests {
         let fams = cat.families();
         assert!(fams.contains(&"phi".to_string()));
         assert!(fams.contains(&"llama".to_string()));
+        assert!(fams.contains(&"gemma4".to_string()));
+    }
+
+    #[test]
+    fn test_gemma4_catalog_entries_are_scaffold_only() {
+        let cat = ModelCatalog::builtin();
+        let e2b = cat.get("gemma4-e2b-it").unwrap();
+        assert_eq!(e2b.hf_repo, "google/gemma-4-E2B-it");
+        assert_eq!(e2b.context_length, 131072);
+        assert_eq!(e2b.vocab_size, 262144);
+        assert_eq!(e2b.implementation_tier, ImplementationTier::LocalTestable);
+        assert!(!e2b.inference_supported);
+
+        let moe = cat.get("gemma4-26b-a4b-it").unwrap();
+        assert_eq!(moe.implementation_tier, ImplementationTier::DesignOnly);
+        assert!(!moe.inference_supported);
     }
 
     #[test]
@@ -305,6 +420,8 @@ mod tests {
             vocab_size: 1000,
             license: "MIT".into(),
             hf_repo: "test/test".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+            inference_supported: true,
         });
         assert_eq!(cat.count(), 1);
     }

--- a/crates/bitnet-models/src/model_metadata.rs
+++ b/crates/bitnet-models/src/model_metadata.rs
@@ -5,6 +5,101 @@
 
 use std::collections::HashMap;
 
+/// Gemma 4 variant-level metadata tracked before runtime support exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Gemma4Variant {
+    E2B,
+    E4B,
+    Dense31B,
+    Moe26BA4B,
+}
+
+impl Gemma4Variant {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::E2B => "e2b-it",
+            Self::E4B => "e4b-it",
+            Self::Dense31B => "31b-it",
+            Self::Moe26BA4B => "26b-a4b-it",
+        }
+    }
+}
+
+/// Static Gemma 4 family facts used for catalog and receipt planning.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gemma4Spec {
+    pub variant: Gemma4Variant,
+    pub layers: usize,
+    pub vocab_size: usize,
+    pub context_length: usize,
+    pub sliding_window: usize,
+    pub has_ple: bool,
+    pub has_shared_kv: bool,
+    pub is_moe: bool,
+    pub supports_image: bool,
+    pub supports_audio: bool,
+    pub runtime_supported: bool,
+}
+
+impl Gemma4Spec {
+    pub fn for_variant(variant: Gemma4Variant) -> Self {
+        match variant {
+            Gemma4Variant::E2B => Self {
+                variant,
+                layers: 35,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: true,
+                runtime_supported: false,
+            },
+            Gemma4Variant::E4B => Self {
+                variant,
+                layers: 42,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: true,
+                runtime_supported: false,
+            },
+            Gemma4Variant::Dense31B => Self {
+                variant,
+                layers: 60,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: false,
+                runtime_supported: false,
+            },
+            Gemma4Variant::Moe26BA4B => Self {
+                variant,
+                layers: 30,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: true,
+                supports_image: true,
+                supports_audio: false,
+                runtime_supported: false,
+            },
+        }
+    }
+}
+
 /// Model license type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum License {
@@ -191,6 +286,23 @@ impl ModelCard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_gemma4_variant_specs_are_scaffold_only() {
+        let e2b = Gemma4Spec::for_variant(Gemma4Variant::E2B);
+        assert_eq!(e2b.variant.as_str(), "e2b-it");
+        assert_eq!(e2b.context_length, 131_072);
+        assert_eq!(e2b.vocab_size, 262_144);
+        assert!(e2b.has_ple);
+        assert!(e2b.has_shared_kv);
+        assert!(!e2b.is_moe);
+        assert!(!e2b.runtime_supported);
+
+        let moe = Gemma4Spec::for_variant(Gemma4Variant::Moe26BA4B);
+        assert_eq!(moe.variant.as_str(), "26b-a4b-it");
+        assert!(moe.is_moe);
+        assert!(!moe.runtime_supported);
+    }
 
     #[test]
     fn test_basic_metadata() {

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,44 @@
+# Gemma 4 Foundation
+
+Status: scaffold only. This document makes Gemma 4 visible in the existing architecture/catalog/receipt truth system; it does not claim runtime inference support.
+
+## Claim boundary
+
+- Generic `Gemma` support is not Gemma 4 support.
+- Gemma 4 must use `ModelArchitecture::Gemma4`, not `ModelArchitecture::Gemma`.
+- BitNet QK256/I2S kernels do not count as Gemma 4 dense inference proof.
+- Text-only Gemma 4 support must not imply image, audio, video, MoE, MTP, full-context, or speedup support.
+- Any future receipt must explicitly set `bitnet_kernel_used=false`, `qk256_used=false`, and a dense regular-LLM kernel family when claiming Gemma 4 dense inference.
+
+## Variants
+
+| Variant | Catalog id | First-class role | Context metadata | Vocab metadata | Key requirements | Current repo claim |
+|---|---|---:|---:|---:|---|---|
+| E2B IT | `gemma4-e2b-it` | First target | 128K | 262K | Dense decoder, PLE, shared KV, sliding/global attention | Catalog/detection scaffold only |
+| E4B IT | `gemma4-e4b-it` | Second target | 128K | 262K | Dense decoder, PLE, shared KV, sliding/global attention | Catalog/detection scaffold only |
+| 31B IT | `gemma4-31b-it` | Later dense target | 256K | 262K | Dense decoder, larger sliding window, image-capable model metadata | Partial/offload scaffold only |
+| 26B-A4B IT | `gemma4-26b-a4b-it` | Future MoE target | 256K | 262K | Router, active-vs-total parameter accounting, expert dispatch | Design-only scaffold |
+
+## First target
+
+The first proof target is **Gemma 4 E2B IT, text-only, Q4 GGUF, CPU first, limited runtime context, strict receipt, no fallback**.
+
+That proof does not exist yet. The first proof must show all of the following before this repository can claim Gemma 4 inference:
+
+- Real GGUF metadata was loaded from an explicit model path.
+- Tokenizer and prompt template authority came from the model or an explicit user-provided source.
+- PLE tensors were loaded for E2B/E4B.
+- Shared KV behavior was enabled for E2B/E4B.
+- Sliding/global attention and per-layer RoPE behavior matched Gemma 4 metadata.
+- A dense regular-LLM Q4/Q8/F16 kernel path was used.
+- BitNet QK256 was not used.
+- Fallback was not used.
+- One token was generated and the receipt validated.
+
+## Future-gated work
+
+- Multimodal image/audio/video processors and projectors.
+- 26B-A4B MoE router/expert kernels.
+- Full 128K/256K long-context receipts.
+- MTP draft model loading and speculative decode accounting.
+- CUDA/Metal/OpenCL dense acceleration claims.

--- a/docs/models/lanes/dense-decoder.md
+++ b/docs/models/lanes/dense-decoder.md
@@ -1,0 +1,41 @@
+# Dense Decoder Architecture Lane
+
+Status: design contract only. This lane describes how non-BitNet dense decoder families such as Gemma 4 should enter the existing truth system.
+
+## Boundary
+
+Dense decoder support is not BitNet support. Dense models must not route through QK256/I2S kernels or reuse BitNet receipts as proof of dense GGUF execution.
+
+## Required model metadata
+
+- Architecture family and variant.
+- Context length as model capability, separate from loaded runtime context.
+- Vocabulary size.
+- Layer count.
+- Attention schedule, including local/sliding versus global layers.
+- RoPE mode and any per-layer p-RoPE/pruned-RoPE metadata.
+- KV-cache ownership, including shared-KV mappings where applicable.
+- Quantization family and tensor shapes from real GGUF inspection.
+
+## Receipt fields for future proofs
+
+A dense decoder receipt must include fields equivalent to:
+
+```json
+{
+  "model_family": "gemma4",
+  "variant": "e2b-it",
+  "task": "text_generation",
+  "dense_regular_llm": true,
+  "bitnet_kernel_used": false,
+  "qk256_used": false,
+  "multimodal_claim": false,
+  "moe_claim": false,
+  "long_context_claim": false,
+  "fallback_used": false
+}
+```
+
+## Gemma 4 additions
+
+Gemma 4 E2B/E4B require Per-Layer Embeddings and shared KV in strict mode. The dense lane therefore must fail honestly when those tensors or metadata are missing instead of silently falling back to older Gemma behavior.

--- a/docs/tracking/bitnet-alignment/backend-status.yaml
+++ b/docs/tracking/bitnet-alignment/backend-status.yaml
@@ -1,5 +1,5 @@
 schema: 1
-updated: 2026-05-05
+updated: 2026-05-08
 
 status_values:
   - not_present
@@ -21,6 +21,13 @@ hard_rules:
   - Server inference is not working until it returns real model output.
   - QK256 is validation-only until performance target and receipts exist.
   - Minimal GGUF fallback cannot support correctness or performance claims.
+
+model_claim_rules:
+  - Non-BitNet dense models must not use QK256 receipts.
+  - Multimodal support must be explicitly claimed in receipts.
+  - MoE support must record active vs total params.
+  - Token classification must not be recorded as generation.
+  - Gemma 4 E2B/E4B strict claims must record PLE and shared-KV loading.
 
 backends:
   cpu:

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -1,6 +1,6 @@
 # bitnet-rs Alignment Status
 
-Updated: 2026-05-06
+Updated: 2026-05-08
 
 ## Current Focus
 
@@ -29,11 +29,22 @@ Transition note: campaign-local `active.toml` files and append-only `events/*.to
 | RTX5070TI-003 | #3679 | pr_open | Preserve RTX 5070 Ti CUDA selected-device identity |
 | AMD9950X3D-003 | TBD | ready | Prove 9950X3D scalar AVX2 and AVX-512 dispatch |
 | AMD5700X-003 | TBD | ready | Prove 5700X scalar and AVX2 dispatch |
+| GEMMA4-000 | TBD | ready | Document Gemma 4 tracker rows and claim boundaries; docs only, no inference claim |
+| GEMMA4-001 | TBD | ready | Add Gemma 4 architecture/catalog scaffold; no runtime, kernel, QK256, or model-weight changes |
 
 These rows are coordination markers, not implementation proof. Merged scaffold
 rows stay visible so the A770, NPU, 258V, 8250U, AMD, NVIDIA, and Mac lanes can
 coordinate follow-up work without implying that runtime execution has been built
 or tested.
+
+
+## Model Family Expansion Boundary
+
+Gemma 4 enters bitnet-rs through the existing architecture, catalog, backend-status, and receipt truth system. It must not create a parallel tracker tree. `ModelArchitecture::Gemma4` is distinct from generic `Gemma`/Gemma 2 support, and catalog scaffold entries do not imply runtime inference support.
+
+The first Gemma 4 proof target is E2B IT text-only Q4 GGUF on the dense regular-LLM lane with strict receipt, limited runtime context, explicit tokenizer/template authority, PLE loaded, shared KV enabled, no fallback, and no BitNet QK256/I2S kernel usage. E4B follows after E2B. The 31B dense and 26B-A4B MoE variants remain later or design-only targets until separate loader, kernel, and receipt work lands.
+
+Gemma 4 text-only support, when it exists, must not imply image, audio, video, MoE, MTP, full 128K/256K context, accelerator, or speedup claims. Receipts must distinguish model capabilities from implementation coverage.
 
 ## Hardware Lanes
 

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1,6 +1,6 @@
 schema: 1
 project: bitnet-rs-alignment
-updated: 2026-05-06
+updated: 2026-05-08
 
 states:
   - proposed
@@ -109,7 +109,93 @@ workstreams:
     title: NVIDIA CUDA validation
     objective: Validate RTX 5070 Ti execution through CUDA kernels, CPU/CUDA parity, receipts, and benchmark artifacts, with wgpu/Vulkan as a separate cross-platform comparison lane.
 
+  model_families:
+    title: Model-family expansion
+    objective: Add non-BitNet model families with strict claim boundaries and receipts inside the existing architecture/catalog/backend truth system.
+
 items:
+  - id: GEMMA4-000
+    title: Add Gemma 4 tracker rows and claim boundaries
+    state: ready
+    priority: P1
+    workstream: model_families
+    depends_on: []
+    scope:
+      allowed_paths:
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/models/families/gemma-4.md
+        - docs/models/lanes/dense-decoder.md
+      forbidden_paths:
+        - crates/**
+        - ci/model-receipts/**
+        - models/**
+    acceptance:
+      - Gemma 4 is represented as a non-BitNet dense/MoE family in the existing tracker.
+      - E2B/E4B text-only dense inference is documented as the first target sequence.
+      - 26B-A4B MoE, multimodal, long-context, MTP, and accelerator claims are future-gated.
+      - BitNet QK256 kernels are explicitly rejected as Gemma 4 proof.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-models --no-default-features --features cpu
+    notes:
+      - Docs/tracker only; no runtime, kernel, or receipt proof exists.
+      - Generic Gemma support is not Gemma 4 support.
+    claim_boundary:
+      may_claim:
+        - Gemma 4 planning and claim boundaries are documented.
+      must_not_claim:
+        - Gemma 4 inference works.
+        - Gemma 4 uses BitNet QK256/I2S kernels.
+    receipt_required: false
+    followups:
+      - GEMMA4-001
+
+  - id: GEMMA4-001
+    title: Add Gemma 4 architecture and catalog scaffold
+    state: ready
+    priority: P1
+    workstream: model_families
+    depends_on:
+      - GEMMA4-000
+    scope:
+      allowed_paths:
+        - crates/bitnet-models/src/architecture.rs
+        - crates/bitnet-models/src/model_catalog.rs
+        - crates/bitnet-models/src/model_metadata.rs
+        - docs/models/families/gemma-4.md
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+      forbidden_paths:
+        - crates/bitnet-inference/**
+        - crates/bitnet-kernels/**
+        - crates/bitnet-quantization/**
+        - crates/bitnet-receipts/**
+        - models/**
+    acceptance:
+      - ModelArchitecture::Gemma4 exists and detects separately from Gemma/Gemma2.
+      - Gemma 4 E2B, E4B, 31B, and 26B-A4B variant metadata exists.
+      - ModelCatalog::builtin() includes google/gemma-4-E2B-it, google/gemma-4-E4B-it, google/gemma-4-31B-it, and google/gemma-4-26B-A4B-it entries.
+      - E2B/E4B defaults record 128K context and 262K vocabulary, while 31B/26B-A4B catalog metadata records 256K context.
+      - All Gemma 4 entries remain scaffold-only and do not claim runtime inference support.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-models --no-default-features --features cpu
+    notes:
+      - Do not touch inference runtime, kernels, QK256, GPU/NPU/Mac lanes, or model weights.
+      - First real proof remains E2B IT text-only Q4 GGUF with strict receipt and no fallback.
+    claim_boundary:
+      may_claim:
+        - Gemma 4 is represented in architecture detection, variant metadata, and catalog scaffolding.
+      must_not_claim:
+        - Gemma 4 inference works.
+        - Multimodal, MoE, MTP, full-context, accelerator, or speedup support exists.
+    receipt_required: false
+    followups:
+      - GEMMA4-002
+
   - id: TRUTH-001
     title: Fence server simulated inference
     state: merged


### PR DESCRIPTION
### Motivation
- Represent Gemma 4 as a first-class non-BitNet model family inside the existing architecture/catalog/receipt truth system without touching runtime or kernels. 
- Provide clear claim boundaries (E2B/E4B first targets, MoE/multimodal/long-context future-gated) so receipts and verification can later prevent accidental claim bleed.

### Description
- Add `ModelArchitecture::Gemma4`, detection for `gemma4`/`gemma-4`, display string, and canonical defaults (`max_context=131072`, `vocab_size=262144`) in `crates/bitnet-models/src/architecture.rs`.
- Add scaffold Gemma4 variant types and static `Gemma4Spec` (E2B, E4B, Dense31B, Moe26BA4B) and tests in `crates/bitnet-models/src/model_metadata.rs` to capture PLE/shared-KV/MoE and capability boundaries.
- Extend `ModelCatalog` with an `ImplementationTier` enum and `implementation_tier` + `inference_supported` fields and add scaffold catalog entries for `gemma4-e2b-it`, `gemma4-e4b-it`, `gemma4-31b-it`, and `gemma4-26b-a4b-it` in `crates/bitnet-models/src/model_catalog.rs`.
- Add docs: `docs/models/families/gemma-4.md` (family foundation) and `docs/models/lanes/dense-decoder.md` (dense-lane contract), and extend the tracker: `docs/tracking/bitnet-alignment/workstream-ledger.yaml`, `backend-status.yaml`, and `status.md` with a `model_families` workstream and GEMMA4-000/GEMMA4-001 items plus backend claim rules for non-BitNet dense/MoE/multimodal claims.
- Minimal API/tests changes: unit tests updated/added to cover detection, defaults, metadata and catalog scaffolding; no inference/runtime/kernels were changed.

### Testing
- Ran `cargo fmt --all -- --check` and it passed.
- Ran `cargo test --locked -p bitnet-models --lib --no-default-features --features cpu` (library/unit subset) and unit tests passed (new Gemma4 detection/defaults and catalog tests included) but a full integration run encountered missing gguf fixture files in `ci/fixtures/qk256/*.gguf` when exercising fixture integrity tests.
- Verified tracker YAMLs parse with a small Python yaml check (`yaml.safe_load`) and the updated tracker/backend-status files are valid YAML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe224109688333a37d6b9dd133415a)