### PR TITLE
Add Gemma 4 model-family foundation (architecture, catalog, docs, tracker)

### DIFF
--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -26,6 +26,12 @@ pub enum ModelArchitecture {
     Qwen,
     /// Gemma family (Gemma / Gemma-2)
     Gemma,
+    /// Gemma 4 family (E2B/E4B dense, 31B dense, 26B-A4B MoE).
+    ///
+    /// This is intentionally distinct from [`ModelArchitecture::Gemma`]: Gemma 4
+    /// requires family-specific metadata for PLE, shared KV, hybrid attention,
+    /// multimodal capability, and future-gated MoE variants.
+    Gemma4,
     /// Mistral / Mixtral
     Mistral,
     /// LLaMA family (LLaMA / LLaMA-2 / LLaMA-3)
@@ -126,6 +132,7 @@ impl std::fmt::Display for ModelArchitecture {
             Self::Phi => write!(f, "phi"),
             Self::Qwen => write!(f, "qwen"),
             Self::Gemma => write!(f, "gemma"),
+            Self::Gemma4 => write!(f, "gemma4"),
             Self::Mistral => write!(f, "mistral"),
             Self::Llama => write!(f, "llama"),
             Self::SmolLM => write!(f, "smollm"),
@@ -216,6 +223,9 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("qwen") {
         return ModelArchitecture::Qwen;
     }
+    if lower.contains("gemma-4") || lower.contains("gemma4") {
+        return ModelArchitecture::Gemma4;
+    }
     if lower.contains("gemma") {
         return ModelArchitecture::Gemma;
     }
@@ -287,6 +297,18 @@ pub fn get_defaults(arch: &ModelArchitecture) -> ArchitectureConfig {
             max_context: 8192,
             vocab_size: 256_000,
             typical_hidden_size: 3072,
+        },
+        ModelArchitecture::Gemma4 => ArchitectureConfig {
+            architecture: ModelArchitecture::Gemma4,
+            activation: ActivationType::Gelu,
+            normalization: NormType::RmsNorm,
+            rope_base: 10_000.0,
+            // Family default tracks the first local target: E2B/E4B text-only.
+            // Variant-specific helpers in model_metadata.rs record 31B/26B-A4B
+            // as 256K-context future-gated models.
+            max_context: 131_072,
+            vocab_size: 262_144,
+            typical_hidden_size: 2304,
         },
         ModelArchitecture::Mistral => ArchitectureConfig {
             architecture: ModelArchitecture::Mistral,
@@ -442,6 +464,7 @@ pub fn supported_architectures() -> Vec<ModelArchitecture> {
         ModelArchitecture::Phi,
         ModelArchitecture::Qwen,
         ModelArchitecture::Gemma,
+        ModelArchitecture::Gemma4,
         ModelArchitecture::Mistral,
         ModelArchitecture::Llama,
         ModelArchitecture::SmolLM,
@@ -475,6 +498,7 @@ mod tests {
         assert_eq!(detect_architecture("microsoft/phi-4"), ModelArchitecture::Phi);
         assert_eq!(detect_architecture("Qwen/Qwen2.5-7B"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("google/gemma-4-E2B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
@@ -501,6 +525,7 @@ mod tests {
         assert_eq!(detect_architecture("LLAMA"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("BitNet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("Gemma2"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("Gemma4"), ModelArchitecture::Gemma4);
     }
 
     #[test]
@@ -607,6 +632,16 @@ mod tests {
         assert_eq!(cfg.rope_base, 10_000.0);
         assert_eq!(cfg.max_context, 8192);
         assert_eq!(cfg.vocab_size, 256_000);
+    }
+
+    #[test]
+    fn defaults_gemma4_first_target() {
+        let cfg = get_defaults(&ModelArchitecture::Gemma4);
+        assert_eq!(cfg.activation, ActivationType::Gelu);
+        assert_eq!(cfg.normalization, NormType::RmsNorm);
+        assert_eq!(cfg.rope_base, 10_000.0);
+        assert_eq!(cfg.max_context, 131_072);
+        assert_eq!(cfg.vocab_size, 262_144);
     }
 
     #[test]

--- a/crates/bitnet-models/src/model_catalog.rs
+++ b/crates/bitnet-models/src/model_catalog.rs
@@ -38,6 +38,27 @@ impl ModelSize {
     }
 }
 
+/// Implementation/readiness tier for a known model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplementationTier {
+    /// Expected to fit local CPU or a 16GB-class accelerator once implemented.
+    LocalTestable,
+    /// Requires partial/offload execution or a larger memory envelope.
+    PartialOffload,
+    /// Catalog/design metadata only; no local runtime claim is permitted.
+    DesignOnly,
+}
+
+impl ImplementationTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LocalTestable => "local_testable",
+            Self::PartialOffload => "partial_offload",
+            Self::DesignOnly => "design_only",
+        }
+    }
+}
+
 /// Catalog entry for a known model.
 #[derive(Debug, Clone)]
 pub struct CatalogEntry {
@@ -51,6 +72,7 @@ pub struct CatalogEntry {
     pub vocab_size: usize,
     pub license: String,
     pub hf_repo: String,
+    pub implementation_tier: ImplementationTier,
 }
 
 /// Model catalog.
@@ -79,6 +101,7 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "MIT".into(),
             hf_repo: "microsoft/bitnet-b1.58-2B-4T-gguf".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -92,6 +115,7 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
         });
 
         cat.add(CatalogEntry {
@@ -105,6 +129,7 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4-mini".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -118,6 +143,7 @@ impl ModelCatalog {
             vocab_size: 151936,
             license: "Apache-2.0".into(),
             hf_repo: "Qwen/Qwen2.5-3B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -131,6 +157,7 @@ impl ModelCatalog {
             vocab_size: 128256,
             license: "Llama3".into(),
             hf_repo: "meta-llama/Meta-Llama-3-8B-Instruct".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
         });
 
         cat.add(CatalogEntry {
@@ -144,6 +171,63 @@ impl ModelCatalog {
             vocab_size: 256128,
             license: "Gemma".into(),
             hf_repo: "google/gemma-2-2b-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e2b-it".into(),
+            name: "Gemma 4 E2B IT".into(),
+            family: "gemma4".into(),
+            params_b: 2.0,
+            size: ModelSize::Small,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E2B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e4b-it".into(),
+            name: "Gemma 4 E4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 4.0,
+            size: ModelSize::Medium,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E4B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-31b-it".into(),
+            name: "Gemma 4 31B IT".into(),
+            family: "gemma4".into(),
+            params_b: 31.0,
+            size: ModelSize::XLarge,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-31B-it".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-26b-a4b-it".into(),
+            name: "Gemma 4 26B-A4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 25.2,
+            size: ModelSize::Large,
+            architecture: "Gemma4MoeForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-26B-A4B-it".into(),
+            implementation_tier: ImplementationTier::DesignOnly,
         });
 
         cat.add(CatalogEntry {
@@ -157,6 +241,7 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "Apache-2.0".into(),
             hf_repo: "mistralai/Mistral-7B-Instruct-v0.3".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
         });
 
         cat.add(CatalogEntry {
@@ -170,6 +255,7 @@ impl ModelCatalog {
             vocab_size: 49152,
             license: "Apache-2.0".into(),
             hf_repo: "HuggingFaceTB/SmolLM2-1.7B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat
@@ -285,6 +371,19 @@ mod tests {
     }
 
     #[test]
+    fn test_gemma4_catalog_entries() {
+        let cat = ModelCatalog::builtin();
+        let e2b = cat.get("gemma4-e2b-it").unwrap();
+        assert_eq!(e2b.family, "gemma4");
+        assert_eq!(e2b.context_length, 131072);
+        assert_eq!(e2b.vocab_size, 262144);
+        assert_eq!(e2b.implementation_tier, ImplementationTier::LocalTestable);
+
+        let moe = cat.get("gemma4-26b-a4b-it").unwrap();
+        assert_eq!(moe.implementation_tier, ImplementationTier::DesignOnly);
+    }
+
+    #[test]
     fn test_bitnet_in_catalog() {
         let cat = ModelCatalog::builtin();
         let bitnet = cat.get("bitnet-2b").unwrap();
@@ -305,6 +404,7 @@ mod tests {
             vocab_size: 1000,
             license: "MIT".into(),
             hf_repo: "test/test".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
         assert_eq!(cat.count(), 1);
     }

--- a/crates/bitnet-models/src/model_metadata.rs
+++ b/crates/bitnet-models/src/model_metadata.rs
@@ -5,6 +5,105 @@
 
 use std::collections::HashMap;
 
+/// Gemma 4 variant identity used for catalog and receipt scaffolding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Gemma4Variant {
+    E2B,
+    E4B,
+    Dense31B,
+    Moe26BA4B,
+}
+
+impl Gemma4Variant {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::E2B => "e2b-it",
+            Self::E4B => "e4b-it",
+            Self::Dense31B => "31b-it",
+            Self::Moe26BA4B => "26b-a4b-it",
+        }
+    }
+}
+
+/// Static Gemma 4 foundation metadata.
+///
+/// This is descriptive metadata only. Runtime loading, tensor maps, kernels,
+/// prompt templates, multimodal processors, and MoE dispatch are intentionally
+/// future-gated until separate proof PRs land.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gemma4Spec {
+    pub variant: Gemma4Variant,
+    pub layers: usize,
+    pub vocab_size: usize,
+    pub context_length: usize,
+    pub sliding_window: usize,
+    pub has_ple: bool,
+    pub has_shared_kv: bool,
+    pub is_moe: bool,
+    pub supports_image: bool,
+    pub supports_audio: bool,
+    pub inference_future_gated: bool,
+}
+
+impl Gemma4Spec {
+    pub fn for_variant(variant: Gemma4Variant) -> Self {
+        match variant {
+            Gemma4Variant::E2B => Self {
+                variant,
+                layers: 35,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: true,
+                inference_future_gated: true,
+            },
+            Gemma4Variant::E4B => Self {
+                variant,
+                layers: 42,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: true,
+                inference_future_gated: true,
+            },
+            Gemma4Variant::Dense31B => Self {
+                variant,
+                layers: 60,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: false,
+                supports_image: true,
+                supports_audio: false,
+                inference_future_gated: true,
+            },
+            Gemma4Variant::Moe26BA4B => Self {
+                variant,
+                layers: 30,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: true,
+                supports_image: true,
+                supports_audio: false,
+                inference_future_gated: true,
+            },
+        }
+    }
+}
+
 /// Model license type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum License {
@@ -220,6 +319,21 @@ mod tests {
     fn test_summary_millions() {
         let md = ModelCard::new("small", "A").with_params(350_000_000);
         assert!(md.summary().contains("350.0M"));
+    }
+
+    #[test]
+    fn test_gemma4_variant_specs() {
+        let e2b = Gemma4Spec::for_variant(Gemma4Variant::E2B);
+        assert_eq!(e2b.context_length, 131_072);
+        assert_eq!(e2b.vocab_size, 262_144);
+        assert!(e2b.has_ple);
+        assert!(e2b.has_shared_kv);
+        assert!(!e2b.is_moe);
+
+        let moe = Gemma4Spec::for_variant(Gemma4Variant::Moe26BA4B);
+        assert_eq!(moe.context_length, 262_144);
+        assert!(moe.is_moe);
+        assert!(moe.inference_future_gated);
     }
 
     #[test]

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,79 @@
+# Gemma 4 foundation
+
+Status: scaffold / metadata only. This document does not claim Gemma 4 inference works in
+bitnet-rs.
+
+## Architecture identity
+
+Gemma 4 is represented as `ModelArchitecture::Gemma4`, distinct from the older
+`ModelArchitecture::Gemma` family. Generic Gemma detection, Gemma 2 catalog entries, or
+Gemma-style defaults are not sufficient proof of Gemma 4 support.
+
+The first local target is:
+
+```text
+Gemma 4 E2B IT
+text-only
+Q4 GGUF
+CPU-first reference execution
+limited runtime context for proof runs
+strict receipt with fallback=false
+```
+
+## Variants
+
+| Variant | Foundation tier | Context metadata | Vocab metadata | Notes |
+|---|---:|---:|---:|---|
+| E2B IT | Local testable scaffold | 128K | 262K | Dense first target; requires PLE and shared KV. |
+| E4B IT | Local testable scaffold | 128K | 262K | Dense second target; requires PLE and shared KV. |
+| 31B IT | Partial/offload scaffold | 256K | 262K | Dense later target; no local inference claim. |
+| 26B-A4B IT | Design-only scaffold | 256K | 262K | MoE future target; no local inference claim. |
+
+## Required future metadata checks
+
+A strict Gemma 4 loader must prefer model/GGUF metadata over hardcoded defaults and must
+validate:
+
+- exact variant (`e2b-it`, `e4b-it`, `31b-it`, or `26b-a4b-it`);
+- layer count and hidden dimensions;
+- vocabulary size;
+- context length as a model capability, not an automatic runtime claim;
+- sliding/global attention schedule;
+- PLE tensors for E2B/E4B;
+- shared-KV metadata for E2B/E4B;
+- MoE router/expert metadata for 26B-A4B.
+
+## Claim boundaries
+
+- BitNet QK256 kernels do not count as Gemma 4 dense inference proof.
+- Text-only support does not imply image, audio, video, MoE, MTP, tool, or full-context
+  support.
+- A catalog entry is not an inference claim.
+- E2B/E4B strict mode must eventually fail if PLE tensors or shared-KV behavior are
+  unavailable.
+- The 26B-A4B entry is recognition/design metadata only until router, expert loading,
+  shared expert handling, and active-vs-total parameter receipts exist.
+
+## Receipt expectations for the first real proof
+
+The first real proof must be a strict E2B text-only CPU receipt that records at least:
+
+```json
+{
+  "model_family": "gemma4",
+  "variant": "e2b-it",
+  "task": "text_generation",
+  "fallback_used": false,
+  "dense_regular_llm": true,
+  "bitnet_kernel_used": false,
+  "qk256_used": false,
+  "ple_enabled": true,
+  "shared_kv_enabled": true,
+  "multimodal_claim": false,
+  "moe_claim": false,
+  "mtp_claim": false,
+  "long_context_claim": false
+}
+```
+
+Until such a receipt exists, Gemma 4 remains scaffolded metadata only.

--- a/docs/models/lanes/dense-decoder.md
+++ b/docs/models/lanes/dense-decoder.md
@@ -1,0 +1,31 @@
+# Dense decoder lane
+
+Status: design lane / no runtime claim.
+
+Dense decoder models are non-BitNet causal transformer families that should use dense GGUF
+quantization kernels and the generalized transformer stack where appropriate. They must not
+be routed through BitNet packed I2S/QK256 kernels as proof of support.
+
+## Scope
+
+The lane covers text-only causal decoding for dense families such as Gemma 4 E2B/E4B,
+Gemma 4 31B, Qwen dense variants, Phi, Mistral, and related GGUF models.
+
+## Required boundaries
+
+- Dense quant kernels must identify themselves separately from BitNet kernels.
+- `qk256_used=false` is required for regular dense LLM proofs.
+- KV-cache semantics must be model-specific; per-layer KV ownership cannot be assumed for
+  families with shared-KV behavior.
+- Prefill and decode claims must be receipt-backed separately when performance is claimed.
+- Model long-context capability is not the same as runtime proof at that context length.
+
+## Gemma 4 notes
+
+Gemma 4 E2B/E4B are the first dense-decoder foundation targets in this lane, but they need
+family-specific handling before inference can be claimed:
+
+- Per-Layer Embeddings are required for E2B/E4B strict mode.
+- Shared KV is required for E2B/E4B strict mode.
+- Sliding/global attention and p-RoPE behavior must be validated from metadata.
+- Multimodal and MoE support remain future-gated.

--- a/docs/tracking/bitnet-alignment/backend-status.yaml
+++ b/docs/tracking/bitnet-alignment/backend-status.yaml
@@ -1,5 +1,5 @@
 schema: 1
-updated: 2026-05-05
+updated: 2026-05-08
 
 status_values:
   - not_present
@@ -21,6 +21,28 @@ hard_rules:
   - Server inference is not working until it returns real model output.
   - QK256 is validation-only until performance target and receipts exist.
   - Minimal GGUF fallback cannot support correctness or performance claims.
+
+model_claim_rules:
+  - Non-BitNet dense models must not use QK256 receipts.
+  - Multimodal support must be explicitly claimed in receipts.
+  - MoE support must record active vs total params.
+  - Token classification must not be recorded as generation.
+  - Gemma 4 catalog metadata is scaffold-only until strict text-only receipts exist.
+
+model_families:
+  gemma4:
+    status: scaffold
+    notes:
+      - Generic Gemma support is not Gemma 4 support.
+      - First target is Gemma 4 E2B IT text-only Q4 GGUF.
+      - BitNet QK256 kernels do not count as Gemma 4 dense inference proof.
+      - Text-only support does not imply image, audio, video, MoE, MTP, or full-context support.
+      - E2B/E4B require future PLE and shared-KV validation before strict inference claims.
+    blockers:
+      - Inspect real Gemma 4 GGUF metadata and tensor names.
+      - Add dense GGUF kernel receipt identity that cannot claim QK256.
+      - Implement Gemma 4 prompt/template authority.
+      - Add E2B strict text-only proof receipt.
 
 backends:
   cpu:

--- a/docs/tracking/bitnet-alignment/status.md
+++ b/docs/tracking/bitnet-alignment/status.md
@@ -121,6 +121,14 @@ The current CUDA code is scaffolded kernel-provider infrastructure, not end-to-e
 
 Dense regular-LLM CUDA work has moved past the receipt boundary. `CUDA-DENSE-001` established the `dense_regular_llm_cuda` label, and `CUDA-DENSE-002` is adding the first dense FP16 GEMM smoke/parity fixture. It must remain labeled as dense regular LLM execution and cannot claim BitNet packed I2S/QK256 inference, speedup, full dense residency, or general dense GGUF inference.
 
+## Model-family expansion
+
+`GEMMA4-000` is ready as a foundation-only model-family expansion item. It adds
+Gemma 4 architecture/catalog metadata and claim boundaries without runtime, kernel,
+QK256, GPU, NPU, or inference changes. The first proof target remains Gemma 4 E2B IT
+text-only Q4 GGUF with strict receipts; E4B, 31B, 26B-A4B MoE, multimodal, long-context,
+and MTP work remain future-gated.
+
 ## Tracker Notes
 
 HW-002 remains proposed. #3625 added `ci/hardware/README.md` with artifact naming guidance, but maintainers should confirm whether that fully satisfies HW-002 before marking it merged.

--- a/docs/tracking/bitnet-alignment/workstream-ledger.yaml
+++ b/docs/tracking/bitnet-alignment/workstream-ledger.yaml
@@ -1,6 +1,6 @@
 schema: 1
 project: bitnet-rs-alignment
-updated: 2026-05-06
+updated: 2026-05-08
 
 states:
   - proposed
@@ -109,7 +109,58 @@ workstreams:
     title: NVIDIA CUDA validation
     objective: Validate RTX 5070 Ti execution through CUDA kernels, CPU/CUDA parity, receipts, and benchmark artifacts, with wgpu/Vulkan as a separate cross-platform comparison lane.
 
+  model_families:
+    title: Model-family expansion
+    objective: Add non-BitNet model families with strict claim boundaries and receipts.
+
 items:
+
+  - id: GEMMA4-000
+    title: Add Gemma 4 architecture/catalog foundation
+    state: ready
+    priority: P1
+    workstream: model_families
+    depends_on: []
+    scope:
+      allowed_paths:
+        - crates/bitnet-models/src/architecture.rs
+        - crates/bitnet-models/src/model_catalog.rs
+        - crates/bitnet-models/src/model_metadata.rs
+        - docs/models/families/gemma-4.md
+        - docs/models/lanes/dense-decoder.md
+        - docs/tracking/bitnet-alignment/backend-status.yaml
+        - docs/tracking/bitnet-alignment/status.md
+        - docs/tracking/bitnet-alignment/workstream-ledger.yaml
+      forbidden_paths:
+        - crates/bitnet-inference/**
+        - crates/bitnet-kernels/**
+        - crates/bitnet-qk256-dispatch/**
+    acceptance:
+      - Gemma 4 is represented as a distinct non-BitNet model family.
+      - Gemma and Gemma 4 detection remain separate.
+      - Catalog entries exist for E2B IT, E4B IT, 31B IT, and 26B-A4B IT.
+      - E2B/E4B are documented as the first text-only dense targets.
+      - MoE, multimodal, MTP, and long-context runtime claims are future-gated.
+      - BitNet QK256 kernels explicitly do not count as Gemma 4 proof.
+    verification:
+      - cargo fmt --all -- --check
+      - cargo test --locked -p bitnet-models --no-default-features --features cpu
+    notes:
+      - Generic Gemma support is not Gemma 4 support.
+      - Catalog and metadata scaffolding do not claim inference works.
+      - First proof target remains Gemma 4 E2B IT text-only Q4 GGUF with strict receipts.
+    claim_boundary:
+      may_claim:
+        - Gemma 4 is modeled in architecture/catalog metadata.
+        - The first target and future-gated surfaces are documented.
+      must_not_claim:
+        - Gemma 4 inference works.
+        - Gemma 4 uses BitNet QK256 kernels.
+        - Text-only metadata implies image, audio, video, MoE, MTP, or full-context support.
+    receipt_required: false
+    followups:
+      - GEMMA4-001: Inspect real GGUF metadata and tensor names before loader work.
+      - GEMMA4-002: Add capability/receipt fields that separate model capability from runtime coverage.
   - id: TRUTH-001
     title: Fence server simulated inference
     state: merged


### PR DESCRIPTION
### Motivation

- Integrate Gemma 4 as a first-class family into the existing architecture/catalog/tracker control plane instead of creating a parallel model-tracker tree.
- Provide scaffolded, docs-first metadata for Gemma 4 variants so future runtime/kernel work can be gated by strict receipts and capabilities.

### Description

- Add `ModelArchitecture::Gemma4` with detection, `Display` support, and family defaults tuned to the first local target (E2B/E4B scaffold).
- Introduce Gemma 4 descriptive metadata types: `Gemma4Variant` and `Gemma4Spec` capturing E2B/E4B/31B/26B-A4B variant properties (PLE, shared-KV, context, vocab, MoE flag, modality support) and provide `for_variant` helpers.
- Extend the model catalog with an `ImplementationTier` enum and add catalog entries for `gemma4-e2b-it`, `gemma4-e4b-it`, `gemma4-31b-it`, and `gemma4-26b-a4b-it` annotated with appropriate tiers (`LocalTestable`, `PartialOffload`, `DesignOnly`).
- Add documentation: `docs/models/families/gemma-4.md` (foundation guidance, claim boundaries, receipt expectations) and `docs/models/lanes/dense-decoder.md` (dense-decoder lane rules and Gemma 4 notes).
- Extend tracker and backend truth files with a `model_families` workstream and a `GEMMA4-000` ledger entry, and add `model_claim_rules` to `backend-status.yaml` that formalize claim boundaries (e.g. Non-BitNet dense models must not use QK256 receipts).
- Keep all runtime/inference, kernel, or QK256 changes out of scope; Gemma 4 support is explicitly scaffold-only and future-gated until strict proof receipts and loader/tensor inspection land.
- Add unit tests validating Gemma 4 defaults/specs and the new catalog entries.

### Testing

- Ran `cargo fmt --all -- --check` which passed.
- Ran unit tests for the models crate with `cargo test --locked -p bitnet-models --lib --no-default-features --features cpu` which passed (new tests for Gemma4 defaults/specs/catalog entries succeeded).
- Attempted the broader `cargo test --locked -p bitnet-models --no-default-features --features cpu` (integration test run) which exercised more tests but failed due to missing QK256 GGUF fixture files in `ci/fixtures/qk256/` in this checkout (fixtures missing: e.g. `qk256_4x256.gguf`, `qk256_3x300.gguf`, `bitnet32_2x64.gguf`); the failures are environment/fixture-related and not caused by the Gemma 4 code changes.
- Verified tracker YAMLs parse (`python` `yaml.safe_load`) and `git diff --check` produced no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe224109688333a37d6b9dd133415a)