### PR TITLE
Add Gemma4 architecture and catalog foundation

### DIFF
--- a/crates/bitnet-models/src/architecture.rs
+++ b/crates/bitnet-models/src/architecture.rs
@@ -26,6 +26,13 @@ pub enum ModelArchitecture {
     Qwen,
     /// Gemma family (Gemma / Gemma-2)
     Gemma,
+    /// Gemma 4 family (E2B/E4B dense, 31B dense, 26B-A4B MoE).
+    ///
+    /// This is intentionally distinct from [`ModelArchitecture::Gemma`] because
+    /// Gemma 4 requires variant-specific metadata such as PLE/shared-KV for E
+    /// variants, hybrid sliding/global attention, and future-gated MoE or
+    /// multimodal support.
+    Gemma4,
     /// Mistral / Mixtral
     Mistral,
     /// LLaMA family (LLaMA / LLaMA-2 / LLaMA-3)
@@ -126,6 +133,7 @@ impl std::fmt::Display for ModelArchitecture {
             Self::Phi => write!(f, "phi"),
             Self::Qwen => write!(f, "qwen"),
             Self::Gemma => write!(f, "gemma"),
+            Self::Gemma4 => write!(f, "gemma4"),
             Self::Mistral => write!(f, "mistral"),
             Self::Llama => write!(f, "llama"),
             Self::SmolLM => write!(f, "smollm"),
@@ -216,6 +224,13 @@ pub fn detect_architecture(model_name: &str) -> ModelArchitecture {
     if lower.contains("qwen") {
         return ModelArchitecture::Qwen;
     }
+    if lower.contains("gemma-4")
+        || lower.contains("gemma4")
+        || lower.contains("gemma_4")
+        || lower.contains("gemma 4")
+    {
+        return ModelArchitecture::Gemma4;
+    }
     if lower.contains("gemma") {
         return ModelArchitecture::Gemma;
     }
@@ -287,6 +302,15 @@ pub fn get_defaults(arch: &ModelArchitecture) -> ArchitectureConfig {
             max_context: 8192,
             vocab_size: 256_000,
             typical_hidden_size: 3072,
+        },
+        ModelArchitecture::Gemma4 => ArchitectureConfig {
+            architecture: ModelArchitecture::Gemma4,
+            activation: ActivationType::Gelu,
+            normalization: NormType::RmsNorm,
+            rope_base: 10_000.0,
+            max_context: 131_072,
+            vocab_size: 262_144,
+            typical_hidden_size: 2304,
         },
         ModelArchitecture::Mistral => ArchitectureConfig {
             architecture: ModelArchitecture::Mistral,
@@ -442,6 +466,7 @@ pub fn supported_architectures() -> Vec<ModelArchitecture> {
         ModelArchitecture::Phi,
         ModelArchitecture::Qwen,
         ModelArchitecture::Gemma,
+        ModelArchitecture::Gemma4,
         ModelArchitecture::Mistral,
         ModelArchitecture::Llama,
         ModelArchitecture::SmolLM,
@@ -475,6 +500,7 @@ mod tests {
         assert_eq!(detect_architecture("microsoft/phi-4"), ModelArchitecture::Phi);
         assert_eq!(detect_architecture("Qwen/Qwen2.5-7B"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("google/gemma-2-9b"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("google/gemma-4-E2B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("mistralai/Mistral-7B-v0.1"), ModelArchitecture::Mistral);
         assert_eq!(detect_architecture("meta-llama/Llama-3-8B"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("microsoft/BitNet-b1.58-2B-4T"), ModelArchitecture::BitNet,);
@@ -489,6 +515,8 @@ mod tests {
         assert_eq!(detect_architecture("qwen2"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("qwen3"), ModelArchitecture::Qwen);
         assert_eq!(detect_architecture("gemma"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("gemma4"), ModelArchitecture::Gemma4);
+        assert_eq!(detect_architecture("gemma-4-26B-A4B-it"), ModelArchitecture::Gemma4);
         assert_eq!(detect_architecture("bitnet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("falcon"), ModelArchitecture::Falcon);
         assert_eq!(detect_architecture("mpt"), ModelArchitecture::Mpt);
@@ -501,6 +529,7 @@ mod tests {
         assert_eq!(detect_architecture("LLAMA"), ModelArchitecture::Llama);
         assert_eq!(detect_architecture("BitNet"), ModelArchitecture::BitNet);
         assert_eq!(detect_architecture("Gemma2"), ModelArchitecture::Gemma);
+        assert_eq!(detect_architecture("Gemma 4"), ModelArchitecture::Gemma4);
     }
 
     #[test]
@@ -607,6 +636,16 @@ mod tests {
         assert_eq!(cfg.rope_base, 10_000.0);
         assert_eq!(cfg.max_context, 8192);
         assert_eq!(cfg.vocab_size, 256_000);
+    }
+
+    #[test]
+    fn defaults_gemma4() {
+        let cfg = get_defaults(&ModelArchitecture::Gemma4);
+        assert_eq!(cfg.activation, ActivationType::Gelu);
+        assert_eq!(cfg.normalization, NormType::RmsNorm);
+        assert_eq!(cfg.rope_base, 10_000.0);
+        assert_eq!(cfg.max_context, 131_072);
+        assert_eq!(cfg.vocab_size, 262_144);
     }
 
     #[test]

--- a/crates/bitnet-models/src/model_catalog.rs
+++ b/crates/bitnet-models/src/model_catalog.rs
@@ -38,6 +38,27 @@ impl ModelSize {
     }
 }
 
+/// Implementation maturity tier for a cataloged model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImplementationTier {
+    /// Fits the current local proof target envelope once an architecture lane exists.
+    LocalTestable,
+    /// Requires partial offload, tighter memory management, or hardware-specific work.
+    PartialOffload,
+    /// Catalog/tracker metadata only; no local inference claim is allowed.
+    DesignOnly,
+}
+
+impl ImplementationTier {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::LocalTestable => "local_testable",
+            Self::PartialOffload => "partial_offload",
+            Self::DesignOnly => "design_only",
+        }
+    }
+}
+
 /// Catalog entry for a known model.
 #[derive(Debug, Clone)]
 pub struct CatalogEntry {
@@ -51,6 +72,7 @@ pub struct CatalogEntry {
     pub vocab_size: usize,
     pub license: String,
     pub hf_repo: String,
+    pub implementation_tier: ImplementationTier,
 }
 
 /// Model catalog.
@@ -79,6 +101,7 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "MIT".into(),
             hf_repo: "microsoft/bitnet-b1.58-2B-4T-gguf".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -92,6 +115,7 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -105,6 +129,7 @@ impl ModelCatalog {
             vocab_size: 100352,
             license: "MIT".into(),
             hf_repo: "microsoft/phi-4-mini".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -118,6 +143,7 @@ impl ModelCatalog {
             vocab_size: 151936,
             license: "Apache-2.0".into(),
             hf_repo: "Qwen/Qwen2.5-3B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -131,6 +157,7 @@ impl ModelCatalog {
             vocab_size: 128256,
             license: "Llama3".into(),
             hf_repo: "meta-llama/Meta-Llama-3-8B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -144,6 +171,63 @@ impl ModelCatalog {
             vocab_size: 256128,
             license: "Gemma".into(),
             hf_repo: "google/gemma-2-2b-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e2b-it".into(),
+            name: "Gemma 4 E2B IT".into(),
+            family: "gemma4".into(),
+            params_b: 2.0,
+            size: ModelSize::Small,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E2B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-e4b-it".into(),
+            name: "Gemma 4 E4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 4.0,
+            size: ModelSize::Medium,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 131072,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-E4B-it".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-31b-it".into(),
+            name: "Gemma 4 31B IT".into(),
+            family: "gemma4".into(),
+            params_b: 31.0,
+            size: ModelSize::XLarge,
+            architecture: "Gemma4ForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-31B-it".into(),
+            implementation_tier: ImplementationTier::PartialOffload,
+        });
+
+        cat.add(CatalogEntry {
+            id: "gemma4-26b-a4b-it".into(),
+            name: "Gemma 4 26B-A4B IT".into(),
+            family: "gemma4".into(),
+            params_b: 25.2,
+            size: ModelSize::Large,
+            architecture: "Gemma4MoeForConditionalGeneration".into(),
+            context_length: 262144,
+            vocab_size: 262144,
+            license: "Gemma".into(),
+            hf_repo: "google/gemma-4-26B-A4B-it".into(),
+            implementation_tier: ImplementationTier::DesignOnly,
         });
 
         cat.add(CatalogEntry {
@@ -157,6 +241,7 @@ impl ModelCatalog {
             vocab_size: 32000,
             license: "Apache-2.0".into(),
             hf_repo: "mistralai/Mistral-7B-Instruct-v0.3".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat.add(CatalogEntry {
@@ -170,6 +255,7 @@ impl ModelCatalog {
             vocab_size: 49152,
             license: "Apache-2.0".into(),
             hf_repo: "HuggingFaceTB/SmolLM2-1.7B-Instruct".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
 
         cat
@@ -224,7 +310,7 @@ mod tests {
     #[test]
     fn test_builtin_count() {
         let cat = ModelCatalog::builtin();
-        assert!(cat.count() >= 8);
+        assert!(cat.count() >= 12);
     }
 
     #[test]
@@ -245,6 +331,9 @@ mod tests {
         let cat = ModelCatalog::builtin();
         let phi = cat.by_family("phi");
         assert!(phi.len() >= 2);
+
+        let gemma4 = cat.by_family("gemma4");
+        assert_eq!(gemma4.len(), 4);
     }
 
     #[test]
@@ -292,6 +381,20 @@ mod tests {
     }
 
     #[test]
+    fn test_gemma4_catalog_entries() {
+        let cat = ModelCatalog::builtin();
+        let e2b = cat.get("gemma4-e2b-it").unwrap();
+        assert_eq!(e2b.hf_repo, "google/gemma-4-E2B-it");
+        assert_eq!(e2b.context_length, 131072);
+        assert_eq!(e2b.vocab_size, 262144);
+        assert_eq!(e2b.implementation_tier, ImplementationTier::LocalTestable);
+
+        let moe = cat.get("gemma4-26b-a4b-it").unwrap();
+        assert_eq!(moe.context_length, 262144);
+        assert_eq!(moe.implementation_tier, ImplementationTier::DesignOnly);
+    }
+
+    #[test]
     fn test_add_custom() {
         let mut cat = ModelCatalog::new();
         cat.add(CatalogEntry {
@@ -305,6 +408,7 @@ mod tests {
             vocab_size: 1000,
             license: "MIT".into(),
             hf_repo: "test/test".into(),
+            implementation_tier: ImplementationTier::LocalTestable,
         });
         assert_eq!(cat.count(), 1);
     }

--- a/crates/bitnet-models/src/model_metadata.rs
+++ b/crates/bitnet-models/src/model_metadata.rs
@@ -5,6 +5,117 @@
 
 use std::collections::HashMap;
 
+/// Gemma 4 model variants tracked by the architecture/catalog foundation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Gemma4Variant {
+    E2B,
+    E4B,
+    Dense31B,
+    Moe26BA4B,
+}
+
+impl Gemma4Variant {
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::E2B => "e2b-it",
+            Self::E4B => "e4b-it",
+            Self::Dense31B => "31b-it",
+            Self::Moe26BA4B => "26b-a4b-it",
+        }
+    }
+}
+
+/// Modality metadata exposed by Gemma 4 model cards.
+///
+/// These fields describe model capability only. Runtime receipts must separately
+/// state which modalities were actually loaded and claimed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Gemma4Modalities {
+    pub text: bool,
+    pub image: bool,
+    pub audio: bool,
+}
+
+/// Static Gemma 4 variant expectations used by catalog and loader validation.
+///
+/// The presence of a [`Gemma4Spec`] is not an inference claim. E2B/E4B require
+/// PLE and shared KV before strict text-only proof can be accepted, while MoE,
+/// multimodal, long-context, and MTP behavior remain future-gated until receipts
+/// prove otherwise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Gemma4Spec {
+    pub variant: Gemma4Variant,
+    pub layers: usize,
+    pub vocab_size: usize,
+    pub context_length: usize,
+    pub sliding_window: usize,
+    pub has_ple: bool,
+    pub has_shared_kv: bool,
+    pub is_moe: bool,
+    pub active_experts: Option<usize>,
+    pub total_experts: Option<usize>,
+    pub modalities: Gemma4Modalities,
+}
+
+impl Gemma4Spec {
+    pub fn for_variant(variant: Gemma4Variant) -> Self {
+        match variant {
+            Gemma4Variant::E2B => Self {
+                variant,
+                layers: 35,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                active_experts: None,
+                total_experts: None,
+                modalities: Gemma4Modalities { text: true, image: true, audio: true },
+            },
+            Gemma4Variant::E4B => Self {
+                variant,
+                layers: 42,
+                vocab_size: 262_144,
+                context_length: 131_072,
+                sliding_window: 512,
+                has_ple: true,
+                has_shared_kv: true,
+                is_moe: false,
+                active_experts: None,
+                total_experts: None,
+                modalities: Gemma4Modalities { text: true, image: true, audio: true },
+            },
+            Gemma4Variant::Dense31B => Self {
+                variant,
+                layers: 60,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: false,
+                active_experts: None,
+                total_experts: None,
+                modalities: Gemma4Modalities { text: true, image: true, audio: false },
+            },
+            Gemma4Variant::Moe26BA4B => Self {
+                variant,
+                layers: 30,
+                vocab_size: 262_144,
+                context_length: 262_144,
+                sliding_window: 1024,
+                has_ple: false,
+                has_shared_kv: false,
+                is_moe: true,
+                active_experts: Some(8),
+                total_experts: Some(128),
+                modalities: Gemma4Modalities { text: true, image: true, audio: false },
+            },
+        }
+    }
+}
+
 /// Model license type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum License {
@@ -191,6 +302,33 @@ impl ModelCard {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_gemma4_e_variants_require_ple_and_shared_kv() {
+        let e2b = Gemma4Spec::for_variant(Gemma4Variant::E2B);
+        assert_eq!(e2b.layers, 35);
+        assert_eq!(e2b.context_length, 131_072);
+        assert_eq!(e2b.vocab_size, 262_144);
+        assert!(e2b.has_ple);
+        assert!(e2b.has_shared_kv);
+        assert!(e2b.modalities.audio);
+
+        let e4b = Gemma4Spec::for_variant(Gemma4Variant::E4B);
+        assert_eq!(e4b.layers, 42);
+        assert_eq!(e4b.sliding_window, 512);
+        assert!(e4b.has_ple);
+        assert!(e4b.has_shared_kv);
+    }
+
+    #[test]
+    fn test_gemma4_moe_variant_records_experts() {
+        let moe = Gemma4Spec::for_variant(Gemma4Variant::Moe26BA4B);
+        assert!(moe.is_moe);
+        assert_eq!(moe.context_length, 262_144);
+        assert_eq!(moe.active_experts, Some(8));
+        assert_eq!(moe.total_experts, Some(128));
+        assert!(!moe.modalities.audio);
+    }
 
     #[test]
     fn test_basic_metadata() {

--- a/docs/models/families/gemma-4.md
+++ b/docs/models/families/gemma-4.md
@@ -1,0 +1,78 @@
+# Gemma 4 Foundation
+
+Gemma 4 is tracked as a first-class non-BitNet model family. Generic Gemma or
+Gemma 2 support is not Gemma 4 support, and Gemma 4 proof must stay inside the
+existing architecture, catalog, backend-status, and receipt truth system rather
+than a parallel model tracker.
+
+## First Target
+
+The first implementation target is **Gemma 4 E2B IT, text-only, Q4 GGUF, CPU
+first, limited context**. The initial proof must be a strict receipt-backed text
+generation proof with no fallback and no BitNet QK256 kernel use. E4B follows
+only after the E2B path has a validated text-only proof.
+
+## Architecture Identity
+
+Gemma 4 must use `ModelArchitecture::Gemma4`, not `ModelArchitecture::Gemma`.
+Detection should recognize at least these strings as Gemma 4:
+
+- `gemma-4`
+- `gemma4`
+- `google/gemma-4-E2B-it`
+- `google/gemma-4-E4B-it`
+- `google/gemma-4-31B-it`
+- `google/gemma-4-26B-A4B-it`
+
+Gemma 2 strings such as `google/gemma-2-2b-it` must continue to resolve to the
+older `Gemma` family.
+
+## Variant Expectations
+
+| Variant | Runtime priority | Layers | Context | Sliding window | Vocab | Required notes |
+|---|---:|---:|---:|---:|---:|---|
+| E2B IT | 1 | 35 | 128K | 512 | 262K | Dense text-first; PLE and shared KV required for strict proof |
+| E4B IT | 2 | 42 | 128K | 512 | 262K | Dense text-first after E2B; PLE and shared KV required |
+| 31B IT | Later | 60 | 256K | 1024 | 262K | Dense but partial/offload tier; no local proof claim yet |
+| 26B-A4B IT | Future | 30 | 256K | 1024 | 262K | MoE design-only locally; receipts must record active vs total params |
+
+The 26B-A4B variant is recognized for metadata and catalog routing only. It must
+not imply local MoE inference support.
+
+## Required Metadata Fields
+
+A Gemma 4 metadata record should carry these fields before runtime work attempts
+strict loading:
+
+- `variant`
+- `layers`
+- `vocab_size`
+- `context_length`
+- `sliding_window`
+- `has_ple`
+- `has_shared_kv`
+- `is_moe`
+- `active_experts` and `total_experts` for MoE variants
+- model modalities as capability metadata, not runtime coverage
+
+## Strict Claim Boundaries
+
+Gemma 4 scaffold may claim only architecture/catalog recognition and documented
+future gates. It must not claim inference, multimodal loading, MoE dispatch,
+full-context support, MTP/speculative drafting, performance, or hardware
+acceleration.
+
+BitNet QK256 kernels do not count as Gemma 4 dense inference proof. A future
+Gemma 4 receipt must identify a dense regular-LLM kernel family and explicitly
+record `bitnet_kernel_used=false` and `qk256_used=false`.
+
+## Future-Gated Work
+
+- Multimodal image/audio support requires separate processor, projector/encoder,
+  placeholder-token, and `modalities_loaded` receipt coverage.
+- MoE support requires router logits, top-k expert selection, shared expert
+  handling, expert loading, and active-vs-total parameter receipt fields.
+- Long-context support requires an explicit runtime claim and receipt; the model
+  context length alone is not a bitnet-rs runtime claim.
+- MTP/speculative drafting requires target/draft loading, accept/reject
+  accounting, and dedicated receipt fields.

--- a/docs/models/lanes/dense-decoder.md
+++ b/docs/models/lanes/dense-decoder.md
@@ -1,0 +1,46 @@
+# Dense Decoder Architecture Lane
+
+The dense decoder lane covers non-BitNet decoder-only or decoder-centric models
+that use dense matrix kernels. It is separate from the BitNet QK256/I2S lane even
+when the same CLI, catalog, tokenizer, loader, and receipt machinery are reused.
+
+## Scope
+
+- Uses the existing model architecture and catalog control plane.
+- Uses dense quantized or floating-point kernels, not packed BitNet QK256 kernels.
+- Preserves transformer concepts such as token embeddings, attention blocks,
+  RoPE variants, MLPs, KV cache, prefill, and decode.
+- Records exact kernel family and fallback state in receipts.
+
+## Non-Claims
+
+A dense decoder catalog entry or architecture enum variant is not an inference
+claim. It does not prove tokenizer compatibility, prompt-template correctness,
+GGUF tensor-map coverage, kernel parity, long-context support, or performance.
+
+## Gemma 4 E2B/E4B Notes
+
+Gemma 4 E2B and E4B are dense decoder targets, but strict support requires
+Gemma-4-specific behavior before any proof can be accepted:
+
+- Per-Layer Embeddings are required.
+- Shared KV behavior is required.
+- Sliding/global attention schedule must be validated from model metadata or an
+  explicit variant expectation.
+- Standard RoPE versus p-RoPE must be selected per attention kind.
+- Text-only support must not imply image, audio, video, MoE, MTP, or full-context
+  support.
+
+## Receipt Expectations
+
+A future dense decoder proof should record at least:
+
+- `model_family`
+- `variant`
+- `task`
+- `kernel_family`
+- `dense_regular_llm=true`
+- `bitnet_kernel_used=false`
+- `qk256_used=false`
+- `fallback_used=false`
+- model-capability fields separately from runtime-coverage fields


### PR DESCRIPTION
### Motivation
- Make Gemma 4 a first-class, non-BitNet model family inside the existing architecture/catalog/receipt control plane rather than introducing a parallel registry.  
- Capture Gemma 4 variant expectations (E2B/E4B/31B/26B-A4B), required metadata (PLE, shared-KV, sliding/global attention), and clear claim boundaries so runtime/inference work can be gated and receipt-backed later.  
- Provide documentation and catalog scaffolding to guide staged implementation (text-only E2B first) without touching inference kernels or runtime claims.

### Description
- Add `ModelArchitecture::Gemma4` with display, detection for `gemma-4`/`gemma4` slugs, supported-architecture registration, and Gemma4 defaults (larger context/vocab). (`crates/bitnet-models/src/architecture.rs`)  
- Extend the model catalog with an `ImplementationTier` enum and Gemma 4 entries for `gemma4-e2b-it`, `gemma4-e4b-it`, `gemma4-31b-it`, and `gemma4-26b-a4b-it` (26B marked `DesignOnly`). (`crates/bitnet-models/src/model_catalog.rs`)  
- Add Gemma 4 metadata scaffolding: `Gemma4Variant`, `Gemma4Modalities`, and `Gemma4Spec` capturing PLE/shared-KV and MoE expert counts for validation/expectation purposes. (`crates/bitnet-models/src/model_metadata.rs`)  
- Add docs and tracker updates: `docs/models/families/gemma-4.md`, `docs/models/lanes/dense-decoder.md`, and new tracker workstream rows plus backend model-claim rules to record that non-BitNet dense models must not rely on QK256 receipts and that Gemma 4 inference claims are future-gated. (`docs/tracking/bitnet-alignment/*`, `docs/models/*`)  

### Testing
- Ran formatting check with `cargo fmt --all -- --check`, which succeeded.  
- Ran targeted unit tests for the changes with `cargo test --locked -p bitnet-models --no-default-features --features cpu --lib gemma4`, and the gemma4-related unit tests passed.  
- Validated modified YAML tracker files by parsing them with Python/YAML (safe load) which succeeded.  
- A full `cargo test --locked -p bitnet-models --no-default-features --features cpu` was attempted but failed unrelated to these changes because the CI environment is missing required QK256 fixture files under `ci/fixtures/qk256/`, causing `fixture_integrity_tests` failures; the failures are environmental and not caused by the Gemma 4 scaffolding. `cargo test` subset for the new features passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe224109688333a37d6b9dd133415a)