### PR TITLE
fix(prompt-audit): use resolved tokenizer metadata

### DIFF
--- a/crates/bitnet-cli/src/main.rs
+++ b/crates/bitnet-cli/src/main.rs
@@ -1782,8 +1782,15 @@ async fn handle_prompt_authority_audit_command(
         })
         .or_else(|| gguf.get_u32_metadata("llama.vocab_size"));
 
-    let tokenizer_json_metadata =
-        tokenizer_path.as_deref().and_then(read_tokenizer_json_prompt_metadata);
+    let tokenizer_resolution =
+        bitnet_tokenizers::auto::resolve_tokenizer(&model_path, tokenizer_path.as_deref(), true)?;
+    let tokenizer_source = tokenizer_resolution.source;
+    let tokenizer_path_resolved = tokenizer_resolution.path.clone();
+    let tokenizer: std::sync::Arc<dyn Tokenizer + Send + Sync> = tokenizer_resolution.tokenizer;
+    let tokenizer_json_metadata = read_resolved_tokenizer_json_prompt_metadata(
+        tokenizer_source,
+        tokenizer_path_resolved.as_deref(),
+    );
     let external_chat_template =
         tokenizer_json_metadata.as_ref().and_then(|metadata| metadata.chat_template.clone());
     let chat_template_for_detection =
@@ -1791,12 +1798,6 @@ async fn handle_prompt_authority_audit_command(
     let tokenizer_name_hint = gguf_tokenizer_model.as_deref().or_else(|| {
         tokenizer_json_metadata.as_ref().and_then(|metadata| metadata.family.as_deref())
     });
-
-    let tokenizer_resolution =
-        bitnet_tokenizers::auto::resolve_tokenizer(&model_path, tokenizer_path.as_deref(), true)?;
-    let tokenizer_source = tokenizer_resolution.source;
-    let tokenizer_path_resolved = tokenizer_resolution.path.clone();
-    let tokenizer: std::sync::Arc<dyn Tokenizer + Send + Sync> = tokenizer_resolution.tokenizer;
     let tokenizer_family = infer_tokenizer_label(tokenizer.as_ref(), tokenizer_source);
     let tokenizer_type = tokenizer_type_for_receipt(&tokenizer_family, tokenizer_source);
     let tokenizer_vocab_size = tokenizer.real_vocab_size();
@@ -1940,6 +1941,20 @@ async fn handle_prompt_authority_audit_command(
 struct TokenizerJsonPromptMetadata {
     family: Option<String>,
     chat_template: Option<String>,
+}
+
+fn read_resolved_tokenizer_json_prompt_metadata(
+    source: bitnet_tokenizers::auto::TokenizerSource,
+    path: Option<&std::path::Path>,
+) -> Option<TokenizerJsonPromptMetadata> {
+    match source {
+        bitnet_tokenizers::auto::TokenizerSource::Explicit
+        | bitnet_tokenizers::auto::TokenizerSource::Sibling => {
+            path.and_then(read_tokenizer_json_prompt_metadata)
+        }
+        bitnet_tokenizers::auto::TokenizerSource::GgufMetadata
+        | bitnet_tokenizers::auto::TokenizerSource::CompatibilityFallback => None,
+    }
 }
 
 fn read_tokenizer_json_prompt_metadata(
@@ -10562,6 +10577,41 @@ mod tests {
             ),
             "external_tokenizer_file"
         );
+    }
+
+    #[test]
+    fn prompt_authority_reads_sibling_tokenizer_json_metadata_after_resolution() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let tokenizer_path = temp_dir.path().join("tokenizer.json");
+        std::fs::write(
+            &tokenizer_path,
+            r#"{"tokenizer_class":"LlamaTokenizerFast","chat_template":"{{ messages[0]['content'] }}"}"#,
+        )
+        .expect("write tokenizer fixture");
+
+        let metadata = read_resolved_tokenizer_json_prompt_metadata(
+            bitnet_tokenizers::auto::TokenizerSource::Sibling,
+            Some(&tokenizer_path),
+        )
+        .expect("sibling tokenizer metadata");
+
+        assert_eq!(metadata.family.as_deref(), Some("LlamaTokenizerFast"));
+        assert_eq!(metadata.chat_template.as_deref(), Some("{{ messages[0]['content'] }}"));
+    }
+
+    #[test]
+    fn prompt_authority_does_not_parse_gguf_path_as_tokenizer_json_metadata() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let model_path = temp_dir.path().join("model.gguf");
+        std::fs::write(&model_path, br#"{"chat_template":"not-tokenizer-json"}"#)
+            .expect("write gguf-like fixture");
+
+        let metadata = read_resolved_tokenizer_json_prompt_metadata(
+            bitnet_tokenizers::auto::TokenizerSource::GgufMetadata,
+            Some(&model_path),
+        );
+
+        assert!(metadata.is_none());
     }
 
     #[test]

--- a/crates/bitnet-tokenizers/src/download.rs
+++ b/crates/bitnet-tokenizers/src/download.rs
@@ -72,6 +72,8 @@ impl SmartTokenizerDownload {
     ///     files: vec!["tokenizer.json".to_string()],
     ///     cache_key: "llama2-32k".to_string(),
     ///     expected_vocab: Some(32000),
+    ///     tokenizer_type: bitnet_tokenizers::TokenizerType::Unknown,
+    ///     special_tokens: bitnet_tokenizers::SpecialTokenConfig::default(),
     /// };
     /// let tokenizer_path = downloader.download_tokenizer(&info).await?;
     /// # Ok(())

--- a/crates/bitnet-tokenizers/tests/tokenizer_subsystem_tests.rs
+++ b/crates/bitnet-tokenizers/tests/tokenizer_subsystem_tests.rs
@@ -114,7 +114,7 @@ fn detect_gpt2_from_vocab_size() {
 
 #[test]
 fn detect_unknown_from_unrecognized_vocab_size() {
-    assert_eq!(ModelTypeDetector::detect_from_vocab_size(100352), "unknown");
+    assert_eq!(ModelTypeDetector::detect_from_vocab_size(100353), "unknown");
     assert_eq!(ModelTypeDetector::detect_from_vocab_size(1), "unknown");
     assert_eq!(ModelTypeDetector::detect_from_vocab_size(999999), "unknown");
 }
@@ -165,8 +165,8 @@ fn expected_vocab_size_known_models() {
 
 #[test]
 fn expected_vocab_size_unknown() {
-    assert_eq!(ModelTypeDetector::expected_vocab_size("phi4"), None);
-    assert_eq!(ModelTypeDetector::expected_vocab_size("gemma"), None);
+    assert_eq!(ModelTypeDetector::expected_vocab_size("unknown-family"), None);
+    assert_eq!(ModelTypeDetector::expected_vocab_size("not-a-model"), None);
 }
 
 // --- ModelCompatibilityMatrix tests ---


### PR DESCRIPTION
Follow-up to #4123.\n\nFixes a review finding in the new prompt/token authority audit: sibling tokenizer.json metadata was ignored because the command read tokenizer prompt metadata before tokenizer auto-resolution. The audit now reads prompt metadata from the resolved tokenizer path for explicit and sibling tokenizer sources, while leaving GGUF metadata paths alone.\n\nAlso fixes stale tokenizer doctest/test expectations exposed by the focused package run.\n\nLocal validation:\n- cargo fmt --check -p bitnet-cli -p bitnet-tokenizers\n- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli prompt_authority\n- cargo test --locked -p bitnet-tokenizers --no-default-features --doc\n- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli\n- git diff --check origin/main..HEAD