### PR TITLE
docs(lunar-lake): add Arc OpenVINO GPU smoke artifact

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json
+++ b/ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json
@@ -1,0 +1,121 @@
+{
+  "arc140v_identity_matched": true,
+  "artifact_kind": "intel_arc_140v_openvino_gpu_smoke",
+  "artifact_path": "ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json",
+  "backend_runtime": {
+    "device": "GPU",
+    "device_name": "Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)",
+    "name": "openvino",
+    "version": "2026.1.0-21367-63e31528c62-releases/2026/1"
+  },
+  "bitnet_inference": false,
+  "claim": "openvino_gpu_arc140v_tiny_graph_smoke_passed",
+  "cpu_fallback_allowed": false,
+  "error": null,
+  "fallback_backend": null,
+  "fallback_policy": {
+    "cpu_fallback_allowed": false,
+    "fallback_backend": null,
+    "fallback_reason": null,
+    "fallback_used": false
+  },
+  "fallback_reason": null,
+  "fallback_used": false,
+  "graph": {
+    "cache_dir": null,
+    "input_shape": [
+      1,
+      16
+    ],
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0,
+    "name": "tiny_matmul_add_f16_1x16",
+    "output_shape": [
+      1,
+      16
+    ],
+    "precision": "F16",
+    "result": "pass",
+    "tolerance": 0.0010000000474974513
+  },
+  "graph_execution": true,
+  "hardware_lane": "intel-arc-140v-openvino-gpu",
+  "kernel_execution": false,
+  "kernels_or_graphs": [
+    "tiny_matmul_openvino_gpu"
+  ],
+  "machine_id": "intel-258v",
+  "must_not_claim": [
+    "Native OpenCL kernels work on Arc 140V",
+    "BitNet inference works on Arc 140V",
+    "Arc 140V accelerates BitNet",
+    "Packed BitNet QK256 decode works on Arc 140V",
+    "CPU fallback satisfies Arc 140V proof"
+  ],
+  "openvino_gpu_smoke": {
+    "arc140v_identity_matched": true,
+    "bitnet_inference": false,
+    "compile_ms": 937.247900001239,
+    "cpu_fallback_allowed": false,
+    "error": null,
+    "fallback_used": false,
+    "first_infer_ms": 3.9135999977588654,
+    "graph_execution": true,
+    "graph_name": "tiny_matmul_add_f16_1x16",
+    "input_shape": [
+      1,
+      16
+    ],
+    "max_abs_error": 0.0,
+    "mean_abs_error": 0.0,
+    "openvino_available_devices": [
+      "CPU",
+      "GPU",
+      "NPU"
+    ],
+    "openvino_gpu_full_name": "Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)",
+    "openvino_version": "2026.1.0-21367-63e31528c62-releases/2026/1",
+    "output_shape": [
+      1,
+      16
+    ],
+    "passed": true,
+    "precision": "F16",
+    "proof_stage": "kernel_smoke_tested",
+    "qk256_decode": false,
+    "requested_backend": "intel-arc-140v",
+    "runtime_api": "openvino",
+    "runtime_device": "GPU",
+    "selected_backend": "intel-arc-140v-openvino-gpu",
+    "shape_mode": "static",
+    "tolerance": 0.0010000000474974513
+  },
+  "proof_stage": "kernel_smoke_tested",
+  "qk256_decode": false,
+  "requested_backend": "intel-arc-140v",
+  "runtime_api": "openvino",
+  "runtime_device": "GPU",
+  "schema": 1,
+  "selected_backend": "intel-arc-140v-openvino-gpu",
+  "shape_contract": {
+    "input_shape": [
+      1,
+      16
+    ],
+    "output_shape": [
+      1,
+      16
+    ],
+    "shape_mode": "static"
+  },
+  "shape_mode": "static",
+  "strict_mode": false,
+  "timestamp_utc": "2026-05-08T22:03:17Z",
+  "timing": {
+    "cached_compile_ms": 937.247900001239,
+    "compile_ms": 937.247900001239,
+    "first_ever_compile_and_infer_ms": null,
+    "first_infer_ms": 3.9135999977588654,
+    "steady_state_infer_ms": null
+  }
+}

--- a/ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json
+++ b/ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json
@@ -22,6 +22,7 @@
     "cpu_answer_parity": "ci/hardware/intel-258v/2026-05-08/cpu-answer-parity-bitnetcpp-template-full-post-mechanics.json",
     "cpu_reference_bundle": "ci/hardware/intel-258v/2026-05-08/cpu-reference-bundle-post-mechanics.json",
     "arc140v_runtime_probe": "ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json",
+    "arc140v_openvino_gpu_smoke": "ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json",
     "arc140v_opencl_smoke": "ci/hardware/intel-258v/2026-05-07/arc-140v-opencl-smoke.json",
     "arc140v_opencl_cpu_parity": "ci/hardware/intel-258v/2026-05-08/arc-140v-opencl-parity.json",
     "npu_runtime_probe": "ci/hardware/intel-258v/2026-05-08/npu-openvino-runtime-probe.json",
@@ -70,6 +71,7 @@
       "selected_backend": "intel-arc-140v-opencl",
       "proof_stages": [
         "runtime_detected",
+        "openvino_gpu_smoke_tested",
         "kernel_smoke_tested",
         "parity_tested"
       ],
@@ -77,14 +79,16 @@
       "primary_artifact": "ci/hardware/intel-258v/2026-05-08/arc-140v-opencl-parity.json",
       "supporting_artifacts": [
         "ci/hardware/intel-258v/2026-05-06/arc-140v-runtime-probe.json",
+        "ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json",
         "ci/hardware/intel-258v/2026-05-07/arc-140v-opencl-smoke.json",
         "ci/hardware/intel-258v/2026-05-08/cpu-reference-bundle-post-mechanics.json"
       ],
-      "claim_allowed": "Arc 140V native OpenCL executed the recorded tiny vector-add parity kernel and matched the selected 258V CPU reference with fallback_used=false.",
+      "claim_allowed": "Arc 140V OpenVINO GPU executed the recorded tiny static graph, and native OpenCL executed the recorded tiny vector-add parity kernel against the selected 258V CPU reference with fallback_used=false.",
       "claims_not_allowed": [
         "BitNet inference works on Arc 140V.",
         "Arc 140V accelerates BitNet.",
         "Packed BitNet QK256 decode works on Arc 140V.",
+        "OpenVINO GPU.0 smoke proves native OpenCL BitNet kernels.",
         "OpenVINO GPU smoke proves native OpenCL BitNet kernels.",
         "CPU fallback satisfies Arc 140V proof."
       ]
@@ -141,6 +145,7 @@
     "The 258V CPU reference plate is available for later accelerator comparisons.",
     "Arc 140V and Intel NPU evidence remain separately scoped and do not inherit CPU proof.",
     "Arc 140V native OpenCL evidence includes isolated vector-add CPU-reference parity.",
+    "Arc 140V OpenVINO GPU evidence includes a tiny static GPU graph smoke receipt with Arc 140V identity and fallback_used=false.",
     "Intel NPU live OpenVINO evidence includes runtime visibility, tiny static graph smoke, and selected static BitNet-shaped RMSNorm, linear-projection, and FFN/ReLU2 subgraph parity receipts."
   ],
   "must_not_claim": [

--- a/ci/hardware/intel-258v/README.md
+++ b/ci/hardware/intel-258v/README.md
@@ -22,6 +22,7 @@ ci/hardware/intel-258v/<date>/npu-openvino-tiny-graph-smoke.json
 ci/hardware/intel-258v/<date>/npu-bitnet-rmsnorm-subgraph-parity.json
 ci/hardware/intel-258v/<date>/npu-bitnet-linear-projection-subgraph-parity.json
 ci/hardware/intel-258v/<date>/npu-bitnet-ffn-subgraph-parity.json
+ci/hardware/intel-258v/<date>/arc-140v-openvino-gpu-smoke.json
 ci/hardware/intel-258v/<date>/arc-140v-opencl-parity.json
 ci/hardware/intel-258v/<date>/platform-comparison-index.json
 ```
@@ -82,6 +83,12 @@ parity run on Arc 140V against the selected 258V CPU reference bundle. It may
 claim only native OpenCL CPU/iGPU parity for that kernel. It must not claim
 BitNet inference, Arc acceleration, packed QK256 decode, OpenVINO GPU proof as
 native OpenCL proof, or CPU fallback as Arc proof.
+
+`arc-140v-openvino-gpu-smoke.json` records one tiny static OpenVINO GPU graph
+smoke on Arc 140V. It may claim only OpenVINO GPU graph execution with
+`fallback_used=false` and CPU expected-output agreement. It must not claim
+native OpenCL execution, BitNet inference, Arc acceleration, packed QK256
+decode, or CPU fallback proof.
 
 `npu-openvino-runtime-probe.json` records live OpenVINO NPU visibility on the
 258V. It may claim that OpenVINO selected `intel-npu-openvino` with runtime

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -143,10 +143,11 @@ ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json
 ```
 
 The index links the CPU reference bundle, CPU full-corpus scalar-vs-AVX2 parity
-receipts, CPU warm phase receipts, Arc 140V native OpenCL CPU-reference parity,
-and the NPU OpenVINO runtime/smoke/RMSNorm/linear/FFN selected subgraph parity
-receipts. It is not a proof artifact by itself. A lane claim is allowed only
-when the cited lane artifact independently proves it.
+receipts, CPU warm phase receipts, Arc 140V OpenVINO GPU smoke and native
+OpenCL CPU-reference parity, and the NPU OpenVINO
+runtime/smoke/RMSNorm/linear/FFN selected subgraph parity receipts. It is not a
+proof artifact by itself. A lane claim is allowed only when the cited lane
+artifact independently proves it.
 
 The comparison index may claim that the repository has a same-machine artifact
 map for CPU, Arc 140V, and Intel NPU receipts. It must not claim cross-lane
@@ -174,7 +175,8 @@ lane-specific Arc 140V, NPU, CPU BitNet, parity, or benchmark artifacts.
 ### Arc 140V OpenVINO GPU Smoke
 
 Use the Arc 140V OpenVINO GPU smoke command to emit a tiny fixed-shape graph
-receipt from `GPU.0` without loading BitNet models or running native OpenCL:
+receipt from the OpenVINO GPU device without loading BitNet models or running
+native OpenCL:
 
 ```bash
 cargo run --locked -p bitnet-cli \
@@ -185,8 +187,11 @@ cargo run --locked -p bitnet-cli \
 ```
 
 The command records `proof_stage=kernel_smoke_tested` only when OpenVINO reports
-an Arc 140V `GPU.0`, compiles the tiny static graph to that device, and matches
-the CPU expected output. It keeps `fallback_used=false`,
+an Arc 140V GPU device, compiles the tiny static graph to that device, and
+matches the CPU expected output. On the 2026-05-08 Windows 258V artifact,
+OpenVINO 2026.1 reports the selected runtime device as `GPU` with full device
+name `Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)`.
+It keeps `fallback_used=false`,
 `cpu_fallback_allowed=false`, `bitnet_inference=false`, and `qk256_decode=false`.
 It does not prove native OpenCL kernels, BitNet inference, or Arc acceleration.
 
@@ -742,9 +747,14 @@ ARC140V-005:
   artifact: ci/hardware/intel-258v/2026-05-08/arc-140v-opencl-parity.json
   anchor: ci/hardware/intel-258v/2026-05-08/cpu-reference-bundle-post-mechanics.json
 
+ARC140V-003 live artifact:
+  OpenVINO GPU tiny static graph smoke on Arc 140V
+  artifact: ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json
+  claim: OpenVINO GPU graph smoke only; no native OpenCL, BitNet, QK256, or acceleration claim
+
 LNL258V-COMPARE-002:
   refreshed the same-machine comparison index after the new CPU reference
-  bundle and independent NPU/Arc parity receipts
+  bundle, Arc OpenVINO GPU smoke, and independent NPU/Arc parity receipts
 ```
 
 These follow-ups preserve the current priority order:
@@ -770,3 +780,10 @@ platform. The live receipt records `selected_backend=intel-arc-140v-opencl`,
 `tiny_vector_add` kernel against the post-mechanics 258V CPU reference bundle.
 This is native OpenCL parity only; it is not BitNet inference, Arc acceleration,
 packed QK256 decode, OpenVINO GPU proof, or CPU fallback proof.
+
+The 2026-05-08 `ARC140V-003` live OpenVINO GPU smoke artifact records
+`selected_backend=intel-arc-140v-openvino-gpu`, `runtime_api=openvino`,
+`runtime_device=GPU`, `graph_execution=true`, and `fallback_used=false` for
+the tiny `tiny_matmul_add_f16_1x16` graph. It is OpenVINO GPU smoke only and
+does not prove native OpenCL, BitNet inference, packed QK256 decode, Arc
+acceleration, or CPU fallback proof.

--- a/docs/specs/intel-lunar-lake-gpu-roadmap.md
+++ b/docs/specs/intel-lunar-lake-gpu-roadmap.md
@@ -221,10 +221,21 @@ cargo run --locked -p bitnet-cli \
 
 The receipt must keep `requested_backend=intel-arc-140v`,
 `selected_backend=intel-arc-140v-openvino-gpu`, `runtime_api=openvino`,
-`runtime_device=GPU.0`, `fallback_used=false`, `bitnet_inference=false`, and
-`qk256_decode=false`. It may claim tiny OpenVINO GPU graph smoke only when the
-selected `GPU.0` full device name identifies Arc 140V and the graph output
-matches the CPU expected output.
+`runtime_device` equal to the selected OpenVINO GPU token, `fallback_used=false`,
+`bitnet_inference=false`, and `qk256_decode=false`. It may claim tiny OpenVINO
+GPU graph smoke only when the selected GPU full device name identifies Arc 140V
+and the graph output matches the CPU expected output.
+
+The first live 258V artifact is:
+
+```text
+ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json
+```
+
+On that Windows/OpenVINO 2026.1 run, OpenVINO reports the selected runtime
+device as `GPU` and the full name as `Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)`.
+That artifact is OpenVINO GPU graph smoke only; it is not native OpenCL proof,
+BitNet inference, packed QK256 decode, or an acceleration claim.
 
 This is not native OpenCL execution. Native OpenCL starts at `ARC140V-004`.
 


### PR DESCRIPTION
## Summary

- add the live 2026-05-08 Arc 140V OpenVINO GPU tiny graph smoke receipt
- refresh the Lunar Lake comparison index so the Arc lane cites OpenVINO GPU smoke before native OpenCL smoke/parity
- update the 258V artifact README and GPU validation docs with the exact OpenVINO 2026.1 device token/name observed on the laptop

## Evidence

The committed receipt records:

- `requested_backend=intel-arc-140v`
- `selected_backend=intel-arc-140v-openvino-gpu`
- `runtime_api=openvino`
- `runtime_device=GPU`
- `openvino_gpu_full_name=Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)`
- `graph_execution=true`
- `fallback_used=false`
- `bitnet_inference=false`
- `qk256_decode=false`

## Claim boundary

This proves only tiny static OpenVINO GPU graph smoke on Arc 140V. It does not claim native OpenCL proof, BitNet inference, Arc acceleration, packed QK256 decode, or CPU fallback proof.

## Verification

- `cargo run --release --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- intel-arc-140v-openvino-gpu-smoke --json-out target\\arc140v-openvino-gpu-smoke.json`
- parsed `ci/hardware/intel-258v/2026-05-08/arc-140v-openvino-gpu-smoke.json`
- parsed `ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json`
- `git diff --cached --check`