### PR TITLE
docs(lunar-lake): fix platform probe refresh claims

### DIFF
--- a/ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json
+++ b/ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json
@@ -2,7 +2,7 @@
   "schema": 1,
   "artifact_kind": "lunar_lake_platform_comparison_index",
   "machine_id": "intel-258v",
-  "captured_at_utc": "2026-05-08T17:15:00Z",
+  "captured_at_utc": "2026-05-08T22:21:06Z",
   "proof_stage": "comparison_indexed",
   "comparison_scope": "same_machine_artifact_index",
   "artifact_dates": [

--- a/docs/hardware/intel-258v-validation.md
+++ b/docs/hardware/intel-258v-validation.md
@@ -165,9 +165,8 @@ ci/hardware/intel-258v/2026-05-08/platform-probe-cli.json
 
 It records OpenVINO 2026.1 visibility for `CPU`, `GPU`, and `NPU`, identifies
 the Arc 140V OpenVINO GPU device as `Intel(R) Arc(TM) 140V GPU (16GB) (iGPU)`,
-and keeps Level Zero unavailable because `sycl-ls`/`ze_info` tooling is not
-installed in the current environment. Native OpenCL execution remains proven by
-the separate OpenCL smoke/parity receipts.
+and records Level Zero as unavailable in the current probe. Native OpenCL
+execution remains proven by the separate OpenCL smoke/parity receipts.
 
 ### CLI Platform Probe
 
@@ -179,7 +178,7 @@ cargo run --locked -p bitnet-cli \
   --no-default-features \
   --features cpu,full-cli \
   -- lunar-lake-probe \
-  --json-out ci/hardware/intel-258v/YYYY-MM-DD/platform-probe.json
+  --json-out ci/hardware/intel-258v/YYYY-MM-DD/platform-probe-cli.json
 ```
 
 The command records `proof_stage=runtime_detected`, `runtime_api=platform_probe`,


### PR DESCRIPTION
## Summary
- align the platform comparison index timestamp with the refreshed CLI probe receipt
- remove the unsupported claim that missing sycl-ls/ze_info caused Level Zero unavailability
- update the CLI probe command to write platform-probe-cli.json, matching the committed artifact

## Validation
- jq empty ci/hardware/intel-258v/2026-05-08/platform-comparison-index.json ci/hardware/intel-258v/2026-05-08/platform-probe-cli.json
- git diff --check origin/main..HEAD
- cargo test --locked -p bitnet-device-probe --no-default-features lunar_lake -- --nocapture
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli lunar_lake_probe_receipt_is_visibility_only -- --nocapture