### PR TITLE
[codex][apple-m4-slm-hardening] Close out regression guardrail seed (M4-SLM-HARDEN-004)

### DIFF
--- a/docs/tracking/campaigns/apple-m4-slm-hardening/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-hardening/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-hardening`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -40,7 +40,7 @@ This campaign owns the next user-facing polish layer. It should remove avoidable
 | M4-SLM-HARDEN-001 | merged | Add positional `bitnet mac ask "question"` UX while preserving `--question`, default cache, and backend boundaries. |
 | M4-SLM-HARDEN-002 | merged | Improve first-run cache repair and low-disk guidance for Mac SLM operators. |
 | M4-SLM-HARDEN-003 | merged | Expand the small operator quality corpus without turning it into a broad eval. |
-| M4-SLM-HARDEN-004 | in_progress | Seed regression guardrails from the measured performance envelope. |
+| M4-SLM-HARDEN-004 | merged | Seed regression guardrails from the measured performance envelope. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-slm-hardening/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-hardening/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-slm-hardening"
 title = "Apple M4 SLM hardening"
-status = "active"
+status = "complete"
 
 objective = "Make the completed Apple M4 SLM path boring for local users through simple Mac commands, default verified model-cache behavior, clear first-run guidance, stable receipts, and conservative hardware claim boundaries."
 
@@ -161,8 +161,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-SLM-HARDEN-004"
-status = "pr_open"
+status = "merged"
 pr = 4161
+merge_sha = "9dd5c48608ba7be078507a16f3ca9fb3ade23661"
 branch = "codex/apple-m4-slm-hardening/M4-SLM-HARDEN-004-regression-seed"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-slm-hardening/events/2026-05-09T004321Z-M4-SLM-HARDEN-004-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-hardening/events/2026-05-09T004321Z-M4-SLM-HARDEN-004-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-09T00:43:21Z"
+campaign = "apple-m4-slm-hardening"
+item = "M4-SLM-HARDEN-004"
+event = "merged"
+pr = 4161
+head_sha = "bcdf0e50007a1edb70f5e6bb983bbbb7b4f4b5e7"
+merge_sha = "9dd5c48608ba7be078507a16f3ca9fb3ade23661"
+actor = "codex"
+
+notes = [
+  "Merged the dense Apple M4 SLM regression guardrail seed.",
+  "The apple-m4-dense-slm-regression campaign is active with M4-SLM-REG-001 ready for advisory receipt comparison work.",
+  "This closes the Apple M4 SLM hardening campaign as complete.",
+  "No nightly infrastructure, performance CI enforcement, broad M4 performance claim, BitNet local-answer claim, full apple-m4-metal inference claim, QK256 support, or runtime change was made.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-hardening/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-hardening/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 SLM hardening Campaign Status
 
 - Campaign: `apple-m4-slm-hardening`
-- State: `active`
+- State: `complete`
 - Objective: Make the completed Apple M4 SLM path boring for local users through simple Mac commands, default verified model-cache behavior, clear first-run guidance, stable receipts, and conservative hardware claim boundaries.
 
 ## Work Items
@@ -12,7 +12,7 @@
 | M4-SLM-HARDEN-001 | merged | #4149 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-001-positional-mac-ask` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Allow bitnet mac ask "What is 2+2?" as the shortest supported Mac local-answer command, keep bitnet mac ask --question compatible, reject ambiguous double question input, preserve default verified Qwen2.5 cache resolution, and keep device-boundary errors before cache/model work. |
 | M4-SLM-HARDEN-002 | merged | #4155 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-002-cache-repair` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Improve first-run, corrupted-cache, low-disk, offline, verify, and prune guidance for Mac SLM operators without changing model artifacts or backend claims. |
 | M4-SLM-HARDEN-003 | merged | #4158 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-003-quality-corpus` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Expand the tiny Mac SLM operator quality corpus with a few deterministic factual, short-instruction, and format-constrained prompts while preserving fast runtime and avoiding broad eval claims. |
-| M4-SLM-HARDEN-004 | pr_open | #4161 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-004-regression-seed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the next regression campaign and thresholds from the measured Apple M4 SLM performance envelope without turning one machine run into a broad performance guarantee. |
+| M4-SLM-HARDEN-004 | merged | #4161 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-004-regression-seed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the next regression campaign and thresholds from the measured Apple M4 SLM performance envelope without turning one machine run into a broad performance guarantee. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,5 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | `codex/apple-m4-slm-hardening/M4-SLM-HARDEN-004-regression-seed` | Define the next regression campaign and thresholds from the measured Apple M4 SLM performance envelope without turning one machine run into a broad performance guarantee. |
 | tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -48,7 +48,7 @@
 | apple-m4-slm-answer | SLM-M4-007 | SLM-M4-005, SLM-M4-006 | merged |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-002 | M4-SLM-HARDEN-001 | merged |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-003 | M4-SLM-HARDEN-002 | merged |
-| apple-m4-slm-hardening | M4-SLM-HARDEN-004 | M4-SLM-HARDEN-003 | pr_open |
+| apple-m4-slm-hardening | M4-SLM-HARDEN-004 | M4-SLM-HARDEN-003 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-002 | M4-SLM-PERF-001 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-003 | M4-SLM-PERF-002 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-004 | M4-SLM-PERF-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -10,7 +10,7 @@
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
-| apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | pr_open | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
+| apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |


### PR DESCRIPTION
Campaign: apple-m4-slm-hardening
Work item: M4-SLM-HARDEN-004
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Mark M4-SLM-HARDEN-004 merged with PR #4161 merge SHA 9dd5c48608ba7be078507a16f3ca9fb3ade23661.
- Mark apple-m4-slm-hardening complete.
- Preserve apple-m4-dense-slm-regression as the active follow-up with M4-SLM-REG-001 ready.
- Regenerate campaign/global dashboards.

## Claim boundary
This is tracker-only closeout. It does not claim nightly infrastructure is running, performance drift is enforced in CI, broad M4 performance, BitNet local-answer quality, full apple-m4-metal inference, or QK256 support.

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-hardening
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-dense-slm-regression
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check
