### PR TITLE
backlog B: wasm — :focus-visible outline on scrollable output regions (#3682)

### DIFF
--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -98,6 +98,12 @@
             font-weight: 500;
         }
 
+        .output:focus-visible,
+        .streaming-output:focus-visible {
+            outline: 2px solid #0066cc;
+            outline-offset: 2px;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -88,6 +88,12 @@
             font-weight: 500;
         }
 
+        .output:focus-visible,
+        .streaming-output:focus-visible {
+            outline: 2px solid #0066cc;
+            outline-offset: 2px;
+        }
+
         input, textarea, select {
             width: 100%;
             padding: 8px 12px;


### PR DESCRIPTION
## Summary

Final piece of the #3682 / Palette WASM accessibility cluster.

The `role="region"`, `tabindex="0"`, `aria-labelledby`, and
`aria-live="polite"` wiring on the four output regions (output,
streaming-output, worker-output, benchmark-output) and the bad
`<label>`-around-non-form-content swap to `container-label` have
already landed independently on `main`. The only remaining gap
from the canonical patch was the **keyboard-focus visual cue**:
tab-focusable regions without a visible focus ring fail WCAG
2.4.7 (Focus Visible).

This PR adds a single CSS rule to both browser-example copies:

```css
.output:focus-visible,
.streaming-output:focus-visible {
    outline: 2px solid #0066cc;
    outline-offset: 2px;
}
```

Pure CSS / HTML; no Rust diff.

## Relationship to #3838 / split

Second of the split series (after #3909).

| Item | Status |
| ---- | ------ |
| `<label>` mis-wrapping fix | already on main |
| `role="region"` / `tabindex="0"` | already on main |
| `aria-labelledby` / `aria-live="polite"` | already on main |
| `:focus-visible` outline | **landed here** |

The 52 absorbed Palette PRs (#3375…#3829) were carrying various
incremental versions of this same cluster; once this lands they
can be closed in batch C of the absorption ledger.

## Test plan

- [x] `cargo check --locked -p bitnet-wasm --no-default-features`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [ ] Manual browser keyboard a11y (reviewer spot-check):
  - Tab reaches Output, Streaming Output, Worker Output, Benchmark Results
  - Focus ring (new outline) is visible on each
  - Arrow / Page-Down scrolls inside the focused region
  - Screen reader announces streamed content (aria-live="polite")

https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL

---
_Generated by [Claude Code](https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL)_