### PR TITLE
backlog C: tokenizers — infer model type from architecture metadata (#3554)

### DIFF
--- a/crates/bitnet-tokenizers/src/universal.rs
+++ b/crates/bitnet-tokenizers/src/universal.rs
@@ -50,12 +50,7 @@ impl UniversalTokenizer {
         let mmap = MmapFile::open(path)?;
         let reader = GgufReader::new(mmap.as_slice())?;
 
-        let model_type = reader.get_string_metadata("tokenizer.ggml.model").ok_or_else(|| {
-            BitNetError::Inference(InferenceError::TokenizationFailed {
-                reason: "GGUF missing tokenizer.ggml.model; refusing GPT-2 compatibility guess"
-                    .to_string(),
-            })
-        })?;
+        let model_type = Self::resolve_model_type(&reader)?;
 
         let tokens = reader.get_string_array_metadata("tokenizer.ggml.tokens").unwrap_or_default();
         let vocab_size = tokens.len();
@@ -91,6 +86,51 @@ impl UniversalTokenizer {
             bpe_merges: merges,
         };
         Self::new(config)
+    }
+
+    /// Resolve the GGUF tokenizer model type, falling back to architecture
+    /// inference when `tokenizer.ggml.model` metadata is absent or blank.
+    ///
+    /// Returns an error rather than silently guessing `gpt2` when the GGUF
+    /// neither declares a tokenizer model nor a recognised
+    /// `general.architecture`. This keeps the strict-mode contract: callers
+    /// that get a tokenizer back can trust that its type is grounded in
+    /// metadata present in the GGUF file.
+    fn resolve_model_type(reader: &bitnet_models::GgufReader) -> Result<String> {
+        if let Some(model_type) = reader.get_string_metadata("tokenizer.ggml.model")
+            && !model_type.trim().is_empty()
+        {
+            return Ok(model_type);
+        }
+
+        let architecture = reader.get_string_metadata("general.architecture");
+        let normalized_arch = architecture.as_deref().unwrap_or_default().trim().to_lowercase();
+        let inferred = Self::infer_model_type_from_architecture(&normalized_arch);
+
+        if inferred == "unknown" {
+            return Err(BitNetError::Inference(InferenceError::TokenizationFailed {
+                reason: format!(
+                    "GGUF missing tokenizer.ggml.model and general.architecture={architecture:?} \
+                     does not map to a known tokenizer; refusing GPT-2 compatibility guess"
+                ),
+            }));
+        }
+
+        warn!(
+            "Missing tokenizer.ggml.model; inferring tokenizer type {:?} from general.architecture={:?}",
+            inferred, architecture
+        );
+        Ok(inferred.to_string())
+    }
+
+    fn infer_model_type_from_architecture(architecture: &str) -> &'static str {
+        match architecture {
+            "llama" | "mistral" | "gemma" | "qwen" | "qwen2" | "qwen3" | "phi" | "phi2"
+            | "phi3" => "llama",
+            "gpt2" | "gpt-2" => "gpt2",
+            "bloom" | "falcon" | "gptj" | "gpt-j" | "gpt_neox" | "gpt-neox" => "gpt2",
+            _ => "unknown",
+        }
     }
 
     /// Create from model with auto-detection
@@ -279,5 +319,41 @@ impl Tokenizer for UniversalTokenizer {
             InternalTokenizerBackend::SentencePiece(t) => t.token_to_piece(token),
             InternalTokenizerBackend::Mock(t) => t.token_to_piece(token),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UniversalTokenizer;
+
+    #[test]
+    fn infer_model_type_maps_sentencepiece_architectures_to_llama() {
+        for arch in ["llama", "mistral", "gemma", "qwen", "qwen2", "qwen3", "phi", "phi2", "phi3"] {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "llama",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_maps_bpe_architectures_to_gpt2() {
+        for arch in ["gpt2", "gpt-2", "bloom", "falcon", "gpt-j", "gptj", "gpt-neox", "gpt_neox"] {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "gpt2",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_unknown_when_no_arch_mapping_exists() {
+        assert_eq!(
+            UniversalTokenizer::infer_model_type_from_architecture("totally-new-arch"),
+            "unknown"
+        );
+        assert_eq!(UniversalTokenizer::infer_model_type_from_architecture(""), "unknown");
     }
 }


### PR DESCRIPTION
## Summary

`UniversalTokenizer::from_gguf` previously hard-required the
`tokenizer.ggml.model` metadata key and refused to construct a
tokenizer otherwise. Many real-world GGUFs (especially older or
hand-converted ones) omit that key but do declare
`general.architecture`, leaving callers no recourse short of
patching the file.

This change adds a `resolve_model_type` helper that:

1. **Prefers `tokenizer.ggml.model`** when present and non-blank
   (preserves existing behaviour).
2. **Falls back to inferring** tokenizer type from
   `general.architecture` via a small explicit mapping:

   | Architectures | Inferred type |
   | ------------- | ------------- |
   | `llama`, `mistral`, `gemma`, `qwen{,2,3}`, `phi{,2,3}` | `llama` (SentencePiece-flavoured) |
   | `gpt2`, `gpt-2`, `bloom`, `falcon`, `gpt-j`, `gpt-neox` | `gpt2` (BPE) |

3. **Returns `TokenizationFailed`** rather than silently guessing
   `gpt2` when the architecture is also unknown — this preserves
   the strict-mode contract that a tokenizer returned by
   `from_gguf` has its type grounded in real GGUF metadata.

The error message for the unknown-architecture case quotes the
observed `general.architecture` value so users have something
concrete to either add metadata for or open an issue about.

3 new unit tests cover the SentencePiece, BPE, and unknown/empty
paths.

## Relationship to #3838 / split

3rd of the split series (after #3909, #4173). Carries **only** the
tokenizer slice of #3838's commit `2a68a80`; the BDD-grid slices
(#3565, #3575) are split into their own follow-up PR.

## Test plan

- [x] `cargo test --locked -p bitnet-tokenizers --no-default-features --features cpu --lib universal` — **3/3 pass** (`infer_model_type_maps_sentencepiece_architectures_to_llama`, `infer_model_type_maps_bpe_architectures_to_gpt2`, `infer_model_type_unknown_when_no_arch_mapping_exists`)
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL

---
_Generated by [Claude Code](https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL)_