### PR TITLE
🎨 Palette: Add focus-visible styles for keyboard navigation

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -11,3 +11,7 @@
 ## 2024-05-22 - Keyboard Navigation in Custom Tabs
 **Learning:** Custom tab implementations using ARIA roles (`tablist`, `tab`) often miss the expected keyboard interaction pattern (arrow keys to navigate), making them inaccessible to keyboard users despite having semantic roles.
 **Action:** Always implement a `keydown` handler for custom tab components to support ArrowRight/ArrowLeft/Home/End navigation and automatic activation.
+
+## 2024-05-22 - Focus Visibility and Box Sizing
+**Learning:** Adding `box-sizing: border-box` to inputs prevents them from overflowing containers when padding is applied and `width: 100%` is used. Furthermore, relying on default browser focus rings is insufficient for accessibility; explicit `:focus-visible` styles with custom outlines ensure clear visual feedback for keyboard users across different platforms.
+**Action:** Always include `box-sizing: border-box` for standard form inputs and define clear `:focus-visible` styles for better keyboard navigation.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -104,6 +104,13 @@
             border: 1px solid #ddd;
             border-radius: 4px;
             font-size: 14px;
+            box-sizing: border-box;
+        }
+
+        input:focus-visible, textarea:focus-visible, select:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: 1px;
+            border-color: #007bff;
         }
 
         textarea {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -94,6 +94,13 @@
             border: 1px solid #ddd;
             border-radius: 4px;
             font-size: 14px;
+            box-sizing: border-box;
+        }
+
+        input:focus-visible, textarea:focus-visible, select:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: 1px;
+            border-color: #007bff;
         }
 
         textarea {


### PR DESCRIPTION
💡 What: Added `focus-visible` styles and `box-sizing` to form inputs (`input`, `textarea`, `select`) in the WASM browser examples.
🎯 Why: Improves keyboard navigation accessibility by clearly indicating which element has focus. `box-sizing: border-box` ensures inputs don't overflow their containers when padding is applied.
📸 Before/After: Before, keyboard focus on inputs was visually subtle or completely missing in some browsers. After, focused inputs have a clear, high-contrast blue outline.
♿ Accessibility: Enhanced keyboard navigation and visual feedback for users relying on keyboard interaction.

---
*PR created automatically by Jules for task [433956988128484896](https://jules.google.com/task/433956988128484896) started by @EffortlessSteven*