### PR TITLE
[codex][apple-silicon-macbook] Seed Apple Silicon MacBook lane

### DIFF
--- a/.codex/campaigns/apple-silicon-macbook/goal.md
+++ b/.codex/campaigns/apple-silicon-macbook/goal.md
@@ -1,0 +1,13 @@
+Use the MacBook as the Apple Silicon cross-reference and larger-artifact lane.
+
+Keep the M4 Mac mini as the stable Apple Silicon dense SLM product/performance lane. The MacBook lane should cross-check dense Qwen SLM behavior on mobile Apple hardware and run larger BitNet / 1-bit candidate sweeps when storage allows.
+
+Do not claim BitNet quality from dense SLM evidence. Do not claim QK256, Neural Engine execution, MPSGraph model inference, full Apple Metal inference, or broad Apple Silicon performance. Never commit model binaries.
+
+Initial sequence:
+1. MB-AS-001: machine/storage/profile receipt contract.
+2. MB-AS-002: mirror dense Qwen baseline.
+3. MB-AS-003: Apple BitNet candidate matrix.
+4. MB-AS-004: official Microsoft 2B I2_S tokenizer-authority proof.
+5. MB-AS-005: 0.7B 1bitLLM candidate proof.
+6. MB-AS-006: 3B TL1/TL2 diagnostic proof.

--- a/docs/apple-silicon/macbook-lane.md
+++ b/docs/apple-silicon/macbook-lane.md
@@ -1,0 +1,110 @@
+# Apple Silicon MacBook Lane
+
+The MacBook lane is the Apple Silicon cross-reference and larger-artifact lane. It is not a replacement for the M4 Mac mini dense SLM product lane and it is not a shortcut to Apple BitNet claims.
+
+## Roles
+
+M4 Mac mini:
+
+```text
+stable Apple Silicon dense SLM product/performance lane
+published Qwen2.5 Apple CPU/NEON envelope
+resident warm-session UX
+phase-scoped Metal evidence
+```
+
+MacBook:
+
+```text
+mobile Apple Silicon cross-reference
+storage-aware larger-artifact exploration
+thermal/mobile context receipts
+Apple BitNet candidate sweeps before M4 strict proof
+```
+
+BitNet Apple lane:
+
+```text
+artifact-qualified 1-bit / 1.58-bit proof lane
+requires reference-good model/tokenizer authority
+requires strict backend receipts before local-answer claims
+```
+
+## Machine Profile Receipt
+
+The first MacBook receipt should identify:
+
+```text
+machine_id
+chip
+cpu_brand
+memory_bytes
+macos_version
+available_disk_bytes
+model_cache_root
+power_source
+thermal_state when available
+cpu_neon_available
+metal_visible
+mpsgraph_visible when available
+```
+
+This profile decides whether the MacBook should attempt larger artifacts. It should not run model inference or claim answer quality.
+
+## Dense SLM Cross-Check
+
+After the machine profile exists, mirror the known-good dense Qwen Mac path:
+
+```text
+model_id = qwen2.5-0.5b-instruct-q8_0
+model_sha256 = ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e
+requested_backend = apple-m4-cpu-neon or the MacBook Apple CPU/NEON label defined by the item
+selected_backend = recorded actual Apple CPU/NEON route
+fallback_used = false
+quality corpus = apple-m4-slm-quality-determinism-v1 shape
+```
+
+The MacBook receipt should be compared to the M4 Mac mini for behavior and timing context, but it must not replace the M4 performance envelope.
+
+## BitNet Candidate Sweeps
+
+MacBook is the right first Apple machine for larger BitNet candidate exploration. Candidate records should include:
+
+```text
+source repo
+file
+revision
+size_bytes
+sha256
+model family
+kernel routes: I2_S, TL1, TL2, diagnostic only, unsupported
+tokenizer authority
+reference command
+prompt outputs
+acceptance or rejection
+cleanup status
+```
+
+Initial candidate priority:
+
+```text
+official Microsoft BitNet b1.58 2B / 2B4T I2_S with external tokenizer authority
+1bitLLM/bitnet_b1_58-large 0.7B as the smaller Apple candidate
+1bitLLM/bitnet_b1_58-3B only on supported TL1/TL2 diagnostic routes
+Falcon-E candidates after Microsoft / 1bitLLM behavior is understood
+```
+
+No artifact becomes an Apple local-answer claim until a strict backend receipt produces coherent output with real model, tokenizer authority, selected backend, fallback status, generated text, token IDs, and timing.
+
+## Claim Boundaries
+
+Do not claim:
+
+```text
+BitNet local-answer quality from dense Qwen evidence
+QK256 support on Apple Silicon
+full Apple Metal inference from phase evidence
+Neural Engine execution from MPSGraph visibility
+broad Apple Silicon performance from one MacBook run
+M4 Mac mini performance regression from a MacBook-only timing change
+```

--- a/docs/tracking/campaigns/apple-silicon-macbook/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-silicon-macbook/CAMPAIGN.md
@@ -1,0 +1,42 @@
+# Apple Silicon MacBook Cross-Reference Campaign
+
+Campaign ID: `apple-silicon-macbook`
+
+Status: active
+
+## Objective
+
+Use a MacBook as the Apple Silicon cross-reference and larger-artifact validation lane for dense SLM behavior and Apple BitNet candidate sweeps, while keeping M4 Mac mini product/performance claims and BitNet artifact claims separate.
+
+## Why This Exists
+
+The M4 Mac mini is the stable Apple Silicon dense SLM product/performance lane. It proves the practical Mac UX for the dense Qwen2.5 path: model cache, `bitnet mac ask`, Apple CPU/NEON routing, warm sessions, quality receipts, performance receipts, and phase-scoped Metal evidence.
+
+The MacBook has a different job. It should cross-check Apple Silicon behavior on mobile hardware and handle larger model/artifact exploration when storage allows. It is the right place to sweep Apple BitNet candidates before sending accepted artifacts back to the M4 Mac mini for strict local-answer proof.
+
+Dense Qwen success remains dense SLM evidence. It validates Mac UX and Apple CPU/NEON routing, not BitNet math, 1-bit / 1.58-bit layouts, I2_S/TL1/TL2 kernels, QK256, or Apple BitNet local-answer quality.
+
+## End State
+
+- MacBook machine, storage, thermal/mobile context, cache root, CPU/NEON, Metal, and MPSGraph visibility are receipt-backed.
+- The known-good dense Qwen Mac path is mirrored on MacBook with the same model hash, tokenizer metadata, quality corpus, deterministic greedy settings, and receipt schema used by the M4 lane.
+- Larger BitNet / 1-bit candidates are tested on MacBook first with source, size, hash, tokenizer authority, reference output, and cleanup status recorded.
+- Accepted BitNet candidates remain artifact-qualified until a strict backend local-answer receipt proves coherent output on that backend.
+- MacBook receipts can cross-check Apple Silicon behavior without turning one mobile run into a fleet-wide Apple performance guarantee.
+
+## Initial Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| MB-AS-001 | ready | Add a MacBook machine/storage/profile receipt contract. |
+| MB-AS-002 | proposed | Mirror the dense Qwen Apple CPU/NEON baseline on MacBook. |
+| MB-AS-003 | proposed | Add the Apple BitNet candidate artifact matrix for MacBook sweeps. |
+| MB-AS-004 | proposed | Validate official Microsoft 2B I2_S with external tokenizer authority. |
+| MB-AS-005 | proposed | Evaluate 0.7B `1bitLLM/bitnet_b1_58-large` as the smaller Apple BitNet target. |
+| MB-AS-006 | proposed | Evaluate 3B only on supported TL1/TL2 diagnostic routes. |
+
+## Review Policy
+
+Each PR owns one MacBook item. Keep model downloads under cache or `target/`, delete rejected candidates when the item requires cleanup, and never commit model binaries. Hardware and model claims must be scoped to the exact machine, model, tokenizer authority, backend, fallback status, and receipt evidence.
+
+Human direction is required only when a candidate needs a new dependency, a license-sensitive decision, a destructive cleanup, a claim boundary is ambiguous, or branch/repository policy blocks the allowed merge path.

--- a/docs/tracking/campaigns/apple-silicon-macbook/active.toml
+++ b/docs/tracking/campaigns/apple-silicon-macbook/active.toml
@@ -1,0 +1,258 @@
+id = "apple-silicon-macbook"
+title = "Apple Silicon MacBook cross-reference"
+status = "active"
+
+objective = "Use a MacBook as the Apple Silicon cross-reference and larger-artifact validation lane for dense SLM behavior and Apple BitNet candidate sweeps, while keeping M4 Mac mini product/performance claims and BitNet artifact claims separate."
+
+end_state = [
+  "MacBook receipts identify chip, memory, macOS, storage, thermal/mobile context, model cache root, CPU/NEON, Metal, and MPSGraph availability.",
+  "The known-good Qwen2.5 dense SLM Mac path is mirrored on MacBook with the same model hash, tokenizer metadata, quality corpus, deterministic greedy checks, and receipt schema used by the M4 Mac mini lane.",
+  "Larger Apple BitNet / 1-bit candidate artifact sweeps run on MacBook first when storage allows, with source, size, SHA256, tokenizer authority, reference-runner output, and cleanup status recorded.",
+  "Accepted BitNet candidates remain artifact-qualified only until a strict Apple CPU/NEON local-answer receipt passes on the target backend.",
+  "MacBook evidence cross-checks Apple Silicon behavior but does not turn one mobile run into a fleet-wide Apple performance guarantee.",
+]
+
+hard_constraints = [
+  "Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns.",
+  "Do not claim BitNet local-answer quality from dense Qwen SLM evidence.",
+  "Do not claim full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad Apple Silicon performance.",
+  "Do not claim a BitNet candidate is answer-ready unless the reference runner produces coherent short answers with recorded tokenizer authority.",
+  "Do not claim MacBook evidence validates the M4 Mac mini performance envelope without matching model, tokenizer, backend, fallback, profile, and receipt context.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "MB-AS-001"
+status = "ready"
+branch = "codex/apple-silicon-macbook/MB-AS-001-machine-profile"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add a MacBook Apple Silicon machine/storage/profile receipt contract that records chip, memory, macOS, free disk, cache root, thermal/mobile context when available, and CPU/NEON, Metal, and MPSGraph visibility without running model inference."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The MacBook lane has a machine/profile receipt contract for Apple Silicon cross-reference work.",
+]
+must_not_claim = [
+  "MacBook model inference works.",
+  "MacBook dense SLM quality or performance is proven.",
+  "BitNet local-answer quality is proven.",
+  "Full Apple Metal inference works.",
+]
+
+[[work_item]]
+id = "MB-AS-002"
+status = "proposed"
+branch = "codex/apple-silicon-macbook/MB-AS-002-qwen-baseline"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MB-AS-001"]
+acceptance = "Mirror the supported dense Qwen2.5 SLM Mac baseline on MacBook with the same model hash, tokenizer metadata, quality corpus, deterministic greedy settings, backend/fallback receipt schema, and MacBook-specific timing context."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/quality/**",
+  "docs/apple-silicon/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The supported dense Qwen Apple CPU/NEON path has MacBook cross-reference receipts.",
+]
+must_not_claim = [
+  "BitNet local-answer quality is proven.",
+  "MacBook timing replaces the M4 Mac mini envelope.",
+  "Full Apple Metal inference works.",
+]
+
+[[work_item]]
+id = "MB-AS-003"
+status = "proposed"
+branch = "codex/apple-silicon-macbook/MB-AS-003-bitnet-candidate-matrix"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MB-AS-001"]
+acceptance = "Add a MacBook-oriented Apple BitNet candidate matrix covering official Microsoft 2B I2_S, 1bitLLM 0.7B, 1bitLLM 3B TL1/TL2 diagnostic routes, and Falcon-E candidates with storage estimates, supported kernel routes, tokenizer authority requirements, reference-runner commands, and cleanup rules."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "MacBook BitNet candidate artifact priorities and proof requirements are documented.",
+]
+must_not_claim = [
+  "Any candidate is answer-ready before reference output passes.",
+  "Rust Apple BitNet local answers work.",
+  "QK256 works on Apple Silicon.",
+]
+
+[[work_item]]
+id = "MB-AS-004"
+status = "proposed"
+branch = "codex/apple-silicon-macbook/MB-AS-004-microsoft-2b-i2s"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MB-AS-003"]
+acceptance = "Validate the official Microsoft BitNet b1.58 2B / 2B4T I2_S GGUF on MacBook under the required external tokenizer pre-tokenizer authority, recording source, SHA256, tokenizer authority, reference-runner prompt outputs, bad/no-authority rejection evidence, and storage cleanup status."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The official Microsoft 2B I2_S artifact is accepted or rejected for Apple artifact-readiness under recorded tokenizer authority.",
+]
+must_not_claim = [
+  "Rust M4 BitNet answers work.",
+  "Apple Metal BitNet inference works.",
+  "QK256 works on Apple Silicon.",
+]
+
+[[work_item]]
+id = "MB-AS-005"
+status = "proposed"
+branch = "codex/apple-silicon-macbook/MB-AS-005-1bitllm-07b"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MB-AS-003"]
+acceptance = "Evaluate 1bitLLM/bitnet_b1_58-large as the smaller Apple BitNet candidate, recording source, size, SHA256, I2_S/TL1 route evidence, tokenizer authority, reference-runner prompt outputs, acceptance or rejection, and storage cleanup status."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The 0.7B 1bitLLM candidate is accepted or rejected as an Apple BitNet artifact target with evidence.",
+]
+must_not_claim = [
+  "The 0.7B candidate proves Microsoft 2B behavior.",
+  "Rust M4 BitNet answers work.",
+  "Full Apple Metal BitNet inference works.",
+]
+
+[[work_item]]
+id = "MB-AS-006"
+status = "proposed"
+branch = "codex/apple-silicon-macbook/MB-AS-006-3b-tl-diagnostic"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["MB-AS-003"]
+acceptance = "Evaluate 1bitLLM/bitnet_b1_58-3B only on supported TL1/TL2 diagnostic routes, documenting why 3B I2_S is not an Apple proof target unless compatibility evidence changes."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "models/**",
+]
+may_claim = [
+  "The 3B candidate has documented TL1/TL2 diagnostic evidence on Apple Silicon.",
+]
+must_not_claim = [
+  "3B I2_S is supported without new compatibility evidence.",
+  "3B diagnostic evidence proves M4 BitNet local-answer quality.",
+  "QK256 works on Apple Silicon.",
+]

--- a/docs/tracking/campaigns/apple-silicon-macbook/generated/status.md
+++ b/docs/tracking/campaigns/apple-silicon-macbook/generated/status.md
@@ -1,0 +1,26 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple Silicon MacBook cross-reference Campaign Status
+
+- Campaign: `apple-silicon-macbook`
+- State: `active`
+- Objective: Use a MacBook as the Apple Silicon cross-reference and larger-artifact validation lane for dense SLM behavior and Apple BitNet candidate sweeps, while keeping M4 Mac mini product/performance claims and BitNet artifact claims separate.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| MB-AS-001 | ready | TBD | `codex/apple-silicon-macbook/MB-AS-001-machine-profile` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a MacBook Apple Silicon machine/storage/profile receipt contract that records chip, memory, macOS, free disk, cache root, thermal/mobile context when available, and CPU/NEON, Metal, and MPSGraph visibility without running model inference. |
+| MB-AS-002 | proposed | TBD | `codex/apple-silicon-macbook/MB-AS-002-qwen-baseline` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Mirror the supported dense Qwen2.5 SLM Mac baseline on MacBook with the same model hash, tokenizer metadata, quality corpus, deterministic greedy settings, backend/fallback receipt schema, and MacBook-specific timing context. |
+| MB-AS-003 | proposed | TBD | `codex/apple-silicon-macbook/MB-AS-003-bitnet-candidate-matrix` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a MacBook-oriented Apple BitNet candidate matrix covering official Microsoft 2B I2_S, 1bitLLM 0.7B, 1bitLLM 3B TL1/TL2 diagnostic routes, and Falcon-E candidates with storage estimates, supported kernel routes, tokenizer authority requirements, reference-runner commands, and cleanup rules. |
+| MB-AS-004 | proposed | TBD | `codex/apple-silicon-macbook/MB-AS-004-microsoft-2b-i2s` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Validate the official Microsoft BitNet b1.58 2B / 2B4T I2_S GGUF on MacBook under the required external tokenizer pre-tokenizer authority, recording source, SHA256, tokenizer authority, reference-runner prompt outputs, bad/no-authority rejection evidence, and storage cleanup status. |
+| MB-AS-005 | proposed | TBD | `codex/apple-silicon-macbook/MB-AS-005-1bitllm-07b` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate 1bitLLM/bitnet_b1_58-large as the smaller Apple BitNet candidate, recording source, size, SHA256, I2_S/TL1 route evidence, tokenizer authority, reference-runner prompt outputs, acceptance or rejection, and storage cleanup status. |
+| MB-AS-006 | proposed | TBD | `codex/apple-silicon-macbook/MB-AS-006-3b-tl-diagnostic` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate 1bitLLM/bitnet_b1_58-3B only on supported TL1/TL2 diagnostic routes, documenting why 3B I2_S is not an Apple proof target unless compatibility evidence changes. |
+
+## Hard Constraints
+
+- Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns.
+- Do not claim BitNet local-answer quality from dense Qwen SLM evidence.
+- Do not claim full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad Apple Silicon performance.
+- Do not claim a BitNet candidate is answer-ready unless the reference runner produces coherent short answers with recorded tokenizer authority.
+- Do not claim MacBook evidence validates the M4 Mac mini performance envelope without matching model, tokenizer, backend, fallback, profile, and receipt context.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -55,6 +55,11 @@
 | apple-m4-slm-performance | M4-SLM-PERF-005 | M4-SLM-PERF-004 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-006 | M4-SLM-PERF-005 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | M4-SLM-PERF-006 | merged |
+| apple-silicon-macbook | MB-AS-002 | MB-AS-001 | proposed |
+| apple-silicon-macbook | MB-AS-003 | MB-AS-001 | proposed |
+| apple-silicon-macbook | MB-AS-004 | MB-AS-003 | proposed |
+| apple-silicon-macbook | MB-AS-005 | MB-AS-003 | proposed |
+| apple-silicon-macbook | MB-AS-006 | MB-AS-003 | proposed |
 | cpu-proof | CPU-BITNET-001 | CPU-BITNET-000 | merged |
 | cpu-proof | CPU-BITNET-002 | CPU-BITNET-001 | merged |
 | cpu-proof | CPU-BITNET-003 | CPU-BITNET-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -12,6 +12,7 @@
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
+| apple-silicon-macbook | MB-AS-001 | TBD | ready | MB-AS-002 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -12,6 +12,7 @@
 | apple-m4-slm-answer | Apple M4 SLM local answer usability | SLM-M4-007 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-hardening | Apple M4 SLM hardening | M4-SLM-HARDEN-004 | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
 | apple-m4-slm-performance | Apple M4 SLM performance | M4-SLM-PERF-007 | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
+| apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-001 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-ANSWER-007 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |


### PR DESCRIPTION
Campaign: apple-silicon-macbook
Work item: seed campaign
Stackable: false
Review: Codex pre-merge review
Merge policy: auto-merge when green
Human gate: blocker only

## Summary
- Add the apple-silicon-macbook campaign as the Apple Silicon cross-reference and larger-artifact lane.
- Define MB-AS-001 through MB-AS-006: machine/profile receipt, dense Qwen baseline mirror, BitNet candidate matrix, Microsoft 2B I2_S tokenizer-authority proof, 0.7B 1bitLLM proof, and 3B TL1/TL2 diagnostics.
- Add MacBook lane docs and Codex campaign goal guidance.

## Claim Boundary
This is docs/tracker control-plane work only. It does not run model inference, accept a BitNet artifact, claim dense SLM performance, claim BitNet local-answer quality, claim QK256, claim Neural Engine execution, or claim full Apple Metal inference.

## Verification
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-silicon-macbook
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check