### PR TITLE
backlog G: cli/task/docs — interactive REPL real gen, fixture inspect status, xtask --no-default-features (#3557, #3576, #3543)

### DIFF
--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -511,7 +511,7 @@ impl InferenceCommand {
 
         // Execute based on mode
         match (self.interactive, self.input_file.as_ref(), self.prompt.as_ref()) {
-            (true, _, _) => self.run_interactive_mode(engine, tokenizer).await,
+            (true, _, _) => self.run_interactive_mode(engine).await,
             (false, Some(file), _) => self.run_batch_mode(engine, tokenizer, file).await,
             (false, None, Some(prompt)) => {
                 self.run_single_inference(engine, tokenizer, prompt).await
@@ -1249,19 +1249,12 @@ impl InferenceCommand {
     }
 
     /// Run interactive mode
-    async fn run_interactive_mode(
-        &self,
-        engine: InferenceEngine,
-        tokenizer: Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>,
-    ) -> Result<()> {
-        // Temporary: keep references alive; TODO(use in REPL)
-        let _keep_alive = (&engine, &tokenizer);
-
+    async fn run_interactive_mode(&self, engine: InferenceEngine) -> Result<()> {
         println!("{}", style("BitNet Interactive Mode").bold().cyan());
         println!("Type your prompts below. Press Ctrl+C to exit, Ctrl+D for new session.\n");
 
         let mut conversation_history = Vec::new();
-        let _config = self.create_generation_config()?;
+        let config = self.create_generation_config()?;
 
         loop {
             // Get user input
@@ -1289,7 +1282,11 @@ impl InferenceCommand {
                             continue;
                         }
                         "/metrics" => {
-                            // Show current metrics
+                            println!("Messages in conversation: {}", conversation_history.len());
+                            println!(
+                                "Streaming: {}",
+                                if self.stream { "enabled" } else { "disabled" }
+                            );
                             continue;
                         }
                         "/exit" | "/quit" => break,
@@ -1302,29 +1299,38 @@ impl InferenceCommand {
                     } else {
                         input.to_string()
                     };
-                    // TODO: use prompt in generation
-                    let _ = &prompt;
 
                     // Generate response
                     let start_time = Instant::now();
+                    let response = if self.stream {
+                        engine.reset_decoded_tokens();
+                        let tokenizer = engine.tokenizer();
+                        let engine_config =
+                            self.to_engine_config(&config, Some(tokenizer.as_ref()));
+                        let mut stream =
+                            engine.generate_stream_with_config(&prompt, &engine_config)?;
 
-                    // Placeholder implementation
-                    let response = format!("Response to: {}", input);
-
-                    if self.stream {
                         print!("{} ", style("Assistant:").bold().blue());
                         io::stdout().flush()?;
 
-                        // Simulate streaming
-                        for char in response.chars() {
-                            print!("{}", char);
+                        let mut response = String::new();
+                        while let Some(chunk) = stream.next().await {
+                            let chunk = chunk?;
+                            engine.inc_decoded_tokens_by(chunk.token_ids.len());
+                            print!("{}", chunk.text);
                             io::stdout().flush()?;
-                            tokio::time::sleep(Duration::from_millis(30)).await;
+                            response.push_str(&chunk.text);
                         }
-                        println!(); // New line
+                        println!();
+                        response
                     } else {
+                        let tokenizer = engine.tokenizer();
+                        let engine_config =
+                            self.to_engine_config(&config, Some(tokenizer.as_ref()));
+                        let response = engine.generate_with_config(&prompt, &engine_config).await?;
                         println!("{} {}", style("Assistant:").bold().blue(), response);
-                    }
+                        response
+                    };
 
                     conversation_history.push((input.to_string(), response));
 

--- a/docs/development/build-commands.md
+++ b/docs/development/build-commands.md
@@ -143,42 +143,42 @@ cargo llvm-cov --workspace --features cpu --html
 ### Model Management
 ```bash
 # Download BitNet model from Hugging Face
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # Vendor GGML quantization files for IQ2_S support
-cargo run -p xtask -- vendor-ggml --commit <llama.cpp-commit>
+cargo run --no-default-features -p xtask -- vendor-ggml --commit <llama.cpp-commit>
 
 # Fetch and build Microsoft BitNet C++ for cross-validation
-cargo run -p xtask -- fetch-cpp
+cargo run --no-default-features -p xtask -- fetch-cpp
 ```
 
 ### Cross-Validation Workflow
 ```bash
 # Run cross-validation tests
-cargo run -p xtask -- crossval
+cargo run --no-default-features -p xtask -- crossval
 # Full workflow (download + fetch + test)
-cargo run -p xtask -- full-crossval
+cargo run --no-default-features -p xtask -- full-crossval
 
 # Check feature flag consistency
-cargo run -p xtask -- check-features
+cargo run --no-default-features -p xtask -- check-features
 ```
 
 ### Model Verification
 ```bash
 # Verify model configuration and tokenizer compatibility
-cargo run -p xtask -- verify --model models/bitnet/model.gguf
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.json
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --format json
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.json
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --format json
 ```
 
 ### Inference Testing
 ```bash
 # Run simple inference for smoke testing (requires --features inference for real inference)
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.json
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
-cargo run -p xtask -- infer --model models/bitnet/model.gguf --prompt "Hello world" --allow-mock --format json
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "Test prompt" --max-new-tokens 64 --temperature 0.7 --gpu
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.json
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
+cargo run --no-default-features -p xtask -- infer --model models/bitnet/model.gguf --prompt "Hello world" --allow-mock --format json
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "Test prompt" --max-new-tokens 64 --temperature 0.7 --gpu
 ```
 
 ### Model Validation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ cargo build --locked --no-default-features --features "cpu,gpu"
 1. **Download a real BitNet model with trained weights**:
 ```bash
 # Download official Microsoft BitNet model with I2_S quantization
-cargo run -p xtask -- download-model \
+cargo run --no-default-features -p xtask -- download-model \
     --id microsoft/bitnet-b1.58-2B-4T-gguf \
     --file ggml-model-i2_s.gguf
 ```
@@ -74,14 +74,14 @@ cargo run -p bitnet-cli -- inspect \
 3. **Run inference with real neural network weights**:
 ```bash
 # Production inference with strict mode (prevents mock fallbacks)
-BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
+BITNET_STRICT_MODE=1 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Explain quantum computing in simple terms" \
     --deterministic
 
 # Stream generation with device-aware quantization
-BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
+BITNET_STRICT_MODE=1 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Write a story about AI and humans working together" \
@@ -89,7 +89,7 @@ BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
 
 # Performance measurement with realistic expectations
 # Performance varies by model and hardware; QK256 uses scalar kernels (~0.1 tok/s for 2B models)
-BITNET_DETERMINISTIC=1 BITNET_SEED=42 cargo run -p xtask -- infer \
+BITNET_DETERMINISTIC=1 BITNET_SEED=42 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Benchmark inference performance" \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,7 +139,7 @@ cargo run -p bitnet-cli --features cpu,full-cli -- run \
 RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C lto=thin" \
   cargo build --release --no-default-features --features cpu,full-cli
 RAYON_NUM_THREADS=$(nproc) RUST_LOG=warn \
-  cargo run --no-default-features --release -p xtask -- benchmark \
+  cargo run --release --no-default-features -p xtask -- benchmark \
   --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --tokens 16  # Reduced for QK256
 ```
 

--- a/tools/bitnet-task/src/validation.rs
+++ b/tools/bitnet-task/src/validation.rs
@@ -579,6 +579,13 @@ pub(crate) fn cmd_validate_fixtures(root: &Path) -> Result<()> {
             println!("::warning::Could not inspect {name} - skipping metadata validation");
             continue;
         };
+        if !inspect.status.success() {
+            println!(
+                "::warning::Inspect command failed for {name}; skipping metadata validation: {}",
+                String::from_utf8_lossy(&inspect.stderr).trim()
+            );
+            continue;
+        }
         let inspect_text = String::from_utf8_lossy(&inspect.stdout);
         let inspect_json: Value = match serde_json::from_str(&inspect_text) {
             Ok(value) => value,


### PR DESCRIPTION
## Summary

Three small focused fixes from the #3838 consolidation campaign,
applied as a single CLI/docs/task cleanup PR.

### #3557 — interactive CLI real generation

`bitnet-cli::commands::inference::run_interactive_mode` no longer
echoes a `format!("Response to: {input}")` placeholder. It now
routes both stream and non-stream paths through
`engine.generate_with_config` / `engine.generate_stream_with_config`,
reusing the same `to_engine_config` path the single-prompt and
batch modes use. Chat-template formatting, stop-token resolution,
sampling parameters, and stream chunk handling all match the rest
of the CLI.

The unused `tokenizer: Arc<dyn Tokenizer>` arg is dropped from the
function signature — the engine exposes the tokenizer it loaded
via `engine.tokenizer()`.

`/metrics` now prints the conversation length and stream toggle
rather than silently `continue`ing.

### #3576 — bitnet-task fixture inspect status check

`cmd_validate_fixtures` now checks `inspect.status.success()` after
the cargo subprocess returns. Previously, if `cargo run -p
bitnet-cli -- inspect` exited non-zero with no stdout, the
subsequent `serde_json::from_str` blew up with a confusing
"EOF while parsing" error. Failures now log
`::warning::Inspect command failed for {name}` with the trimmed
stderr and continue, matching the surrounding skip-on-error pattern.

### #3543 — xtask `--no-default-features` in active docs

`xtask` declares `default = ["gpu"]`, so the bare `cargo run -p
xtask --` form silently pulls in CUDA-bound deps and breaks on
CPU-only environments. Updates the three highest-traffic user-
facing entry-point docs to pass `--no-default-features`:

- `docs/quickstart.md`
- `docs/getting-started.md`
- `docs/development/build-commands.md`

The original #3543 covered ~75 active reference/howto/tutorial
docs in one sweep. That breadth is separate-PR material; a
follow-up will rg-fix the remaining files in one go to keep this
review tractable.

## Out of scope vs the original #3838 commit

Commit `37ece232` in #3838 also bundled two unrelated behavioural
changes that I deliberately did **not** carry over:

- removal of the `--strict-tokenizer` CLI flag
- flipping BitNet auto-template detection from `BitnetCppAnswer`
  to `Instruct`

Both deserve their own focused PRs. The repetition-penalty
contract tests from `37ece232` are also dropped — they are perf-
follow-up scaffolding for a `.powi → iterative` swap that has not
been justified by a benchmark and is intentionally deferred per
the original split plan.

## Relationship to #3838 / split

7th of the split series.

| PR | Status |
| -- | ------ |
| #3909 (security + UUID) | **merged** |
| #4173 (WASM a11y) | open |
| #4175 (tokenizer inference) | open |
| PR D (BDD) | no-op (already on main) |
| #4180 (logits filters) | open |
| PR F (GPU discovery) | no-op (already on main) |
| **this PR (CLI/task/docs)** | open |
| PR H (closure ledger) | pending |

## Test plan

- [x] `cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli`
- [x] `cargo check --locked -p bitnet-task`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

Note: full-workspace `cargo clippy -- -D warnings` surfaces 21
pre-existing `clippy::needless_borrow` errors in
`bitnet-cli/src/main.rs`, `mac.rs`, and `model_cache.rs` that
exist on `main` independent of this PR (verified by stashing
this PR's diff and re-running). Out of scope; reported here for
transparency.

https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL

---
_Generated by [Claude Code](https://claude.ai/code/session_014sjmENPFVNjxDvZ4EnaFsL)_