### PR TITLE
[codex][apple-bitnet] Seed artifact sweep campaign

### DIFF
--- a/.codex/campaigns/apple-bitnet-artifact-sweep/goal.md
+++ b/.codex/campaigns/apple-bitnet-artifact-sweep/goal.md
@@ -1,0 +1,22 @@
+Use the MacBook Apple Silicon lane to qualify BitNet-family 1-bit / 1.58-bit
+artifacts before sending accepted candidates back to M4 Mac mini strict proof.
+
+Keep dense Qwen Apple Silicon evidence separate from BitNet evidence. Qwen
+validates the Mac dense SLM UX; it does not prove BitNet math, I2_S/TL1/TL2
+kernels, QK256, or Apple BitNet local-answer quality.
+
+Initial sequence:
+
+1. ABAS-001: official Microsoft 2B I2_S with external tokenizer authority on
+   MacBook.
+2. ABAS-002: 0.7B 1bitLLM control candidate.
+3. ABAS-003: 3B TL1/TL2 diagnostic only; I2_S remains unsupported unless the
+   compatibility ledger changes.
+4. ABAS-004: Falcon-E secondary family candidates after Microsoft/1bitLLM
+   behavior is understood.
+5. ABAS-005: hand off the best accepted artifact to a separate M4 strict
+   Apple CPU/NEON proof item.
+
+Never commit model binaries. Keep downloads under cache or target, record
+source/revision/file/size/SHA256/tokenizer authority/reference outputs, and
+delete rejected candidates unless explicitly retained for bounded diagnostics.

--- a/docs/apple-silicon/apple-bitnet-artifact-sweep.md
+++ b/docs/apple-silicon/apple-bitnet-artifact-sweep.md
@@ -1,0 +1,88 @@
+# Apple BitNet Artifact Sweep
+
+The Apple BitNet artifact sweep is the control plane for 1-bit / 1.58-bit
+candidate validation on Apple Silicon. It uses the MacBook lane first for larger
+artifact exploration, then sends accepted candidates back to the M4 Mac mini for
+strict Apple CPU/NEON proof.
+
+This is separate from the dense Qwen SLM path. Qwen2.5 0.5B Instruct is a
+regular dense SLM and remains the practical Mac local-answer baseline. It does
+not prove BitNet model quality, 1-bit layouts, QK256, or full Metal inference.
+
+## Inputs
+
+Primary references:
+
+```text
+ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+docs/apple-silicon/bitnet-candidate-matrix.md
+docs/model-artifacts/ANSWER_ARTIFACT_GATE.md
+ci/model-artifacts/model-kernel-compatibility.toml
+docs/architecture/reference-topology.md
+```
+
+## Candidate Order
+
+```text
+1. Official Microsoft BitNet b1.58 2B / 2B4T I2_S
+2. 0.7B 1bitLLM/bitnet_b1_58-large
+3. 3B 1bitLLM TL1/TL2 diagnostic route only
+4. Falcon-E 1B/3B as secondary BitNet-like family evidence
+```
+
+The official Microsoft I2_S path is first because it is the official target and
+the shared model-artifact gate records answer-ready evidence when external
+Microsoft tokenizer pre-tokenizer authority is supplied. The 0.7B 1bitLLM model
+is a smaller control candidate. The 3B model must not be treated as an I2_S
+target unless the compatibility ledger changes.
+
+## Required Record
+
+Every artifact probe must record:
+
+```text
+source repo
+revision
+file
+size_bytes
+sha256
+format
+quantization
+kernel route
+tokenizer authority
+pre-tokenizer authority
+prompt template
+reference runner
+reference command
+prompt outputs
+acceptance or rejection
+cleanup status
+machine context
+```
+
+## Storage Policy
+
+```text
+download under cache or target
+keep at least 8 GiB free after download when possible
+never commit model binaries
+delete rejected candidates unless a later item explicitly retains them
+record exact SHA256 before accepting or rejecting a candidate
+```
+
+## Claim Boundary
+
+An accepted artifact is not a backend success. It only means the candidate is
+eligible for a strict backend local-answer proof. M4 BitNet local-answer claims
+require a later receipt with:
+
+```text
+real model
+real tokenizer authority
+selected Apple backend
+fallback_used=false or explicit fallback reason
+generated text
+generated token IDs
+timing
+quality result
+```

--- a/docs/apple-silicon/macbook-lane.md
+++ b/docs/apple-silicon/macbook-lane.md
@@ -124,6 +124,12 @@ with the companion guide:
 docs/apple-silicon/bitnet-candidate-matrix.md
 ```
 
+The dedicated Apple BitNet sweep control plane is documented at:
+
+```text
+docs/apple-silicon/apple-bitnet-artifact-sweep.md
+```
+
 No artifact becomes an Apple local-answer claim until a strict backend receipt produces coherent output with real model, tokenizer authority, selected backend, fallback status, generated text, token IDs, and timing.
 
 ## Claim Boundaries

--- a/docs/tracking/campaigns/apple-bitnet-artifact-sweep/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-bitnet-artifact-sweep/CAMPAIGN.md
@@ -1,0 +1,78 @@
+# Apple BitNet Artifact Sweep Campaign
+
+Campaign ID: `apple-bitnet-artifact-sweep`
+
+Status: active
+
+## Objective
+
+Use the MacBook Apple Silicon lane to qualify 1-bit / 1.58-bit BitNet-family
+artifacts before any M4 Mac mini Apple CPU/NEON or Metal BitNet local-answer
+claim.
+
+## Why This Exists
+
+The dense Qwen Apple Silicon path is the practical Mac user-facing SLM lane. It
+proves Mac UX, model cache, warm sessions, receipts, quality corpus behavior,
+and Apple CPU/NEON routing for a regular dense SLM. It does not prove BitNet
+model quality or 1-bit math.
+
+The shared model-artifact gate now records that the official Microsoft I2_S
+artifact can be answer-ready under external tokenizer pre-tokenizer authority,
+but Apple lanes still need their own strict artifact and backend receipts. The
+MacBook is the right first Apple machine for larger artifact sweeps because it
+is the Apple Silicon cross-reference and larger-artifact lane.
+
+## End State
+
+- Official Microsoft 2B I2_S is accepted or rejected on MacBook under recorded
+  tokenizer authority.
+- The smaller 0.7B `1bitLLM/bitnet_b1_58-large` candidate is accepted or
+  rejected as an Apple BitNet control artifact.
+- The 3B 1bitLLM candidate is evaluated only on supported TL diagnostic routes.
+- Falcon-E candidates remain secondary BitNet-like family evidence after
+  Microsoft and 1bitLLM behavior is understood.
+- Accepted candidates feed a separate M4 Mac mini strict Apple CPU/NEON proof
+  item; they do not become M4 answer claims by themselves.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| ABAS-001 | proposed | Validate official Microsoft 2B I2_S on MacBook with external tokenizer authority. |
+| ABAS-002 | proposed | Evaluate 0.7B `1bitLLM/bitnet_b1_58-large` as the smaller Apple BitNet control. |
+| ABAS-003 | proposed | Evaluate 3B only on supported TL1/TL2 diagnostic routes. |
+| ABAS-004 | proposed | Evaluate Falcon-E as a secondary BitNet-like family after primary candidates. |
+| ABAS-005 | proposed | Hand off the best accepted artifact to a separate M4 strict proof item. |
+
+## Review Policy
+
+Each PR owns one artifact decision. Candidate downloads must stay under cache or
+`target/`, rejected candidates should be deleted unless a later item explicitly
+keeps them for a bounded diagnostic reason, and model binaries must never be
+committed.
+
+Do not claim Rust Apple BitNet local answers until the target backend runs a
+strict local-answer receipt with real model, tokenizer authority, selected
+backend, fallback status, generated text, token IDs, and timing.
+
+## Claim Boundary
+
+Do not claim:
+
+```text
+BitNet local-answer quality from dense Qwen evidence
+M4 BitNet local answers from MacBook artifact-only evidence
+QK256 support on Apple Silicon
+full Apple Metal inference
+Neural Engine execution
+MPSGraph model inference
+broad Apple Silicon performance
+```
+
+Do claim only:
+
+```text
+artifact accepted or rejected for the recorded source, file, hash, tokenizer
+authority, runner, prompt suite, machine context, and cleanup status
+```

--- a/docs/tracking/campaigns/apple-bitnet-artifact-sweep/active.toml
+++ b/docs/tracking/campaigns/apple-bitnet-artifact-sweep/active.toml
@@ -1,0 +1,239 @@
+id = "apple-bitnet-artifact-sweep"
+title = "Apple BitNet artifact sweep"
+status = "active"
+
+objective = "Use the MacBook Apple Silicon lane to qualify 1-bit / 1.58-bit BitNet-family artifacts before any M4 Mac mini Apple CPU/NEON or Metal BitNet local-answer claim."
+
+end_state = [
+  "Apple BitNet candidate artifacts are accepted or rejected with source, revision, file, size, SHA256, tokenizer/pre-tokenizer authority, reference runner command, prompt outputs, and cleanup status.",
+  "Official Microsoft 2B I2_S, 0.7B 1bitLLM, 3B TL1/TL2 diagnostic, and Falcon-E candidates are handled according to the MacBook candidate matrix.",
+  "Accepted artifacts remain artifact-qualified until the target backend reruns strict local-answer receipts.",
+  "Dense Qwen Apple Silicon evidence remains separate from BitNet / 1-bit artifact authority.",
+  "MacBook sweeps feed M4 Mac mini strict Apple CPU/NEON BitNet proof only after a candidate passes the reference prompt suite.",
+]
+
+hard_constraints = [
+  "Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini.",
+  "Do not claim Rust Apple BitNet local answers before the target backend runs its own strict receipt gate.",
+  "Do not claim BitNet quality from dense Qwen SLM evidence.",
+  "Do not claim QK256 support, full Apple Metal inference, Neural Engine execution, MPSGraph model inference, or broad Apple Silicon performance.",
+  "Do not weaken the shared answer-artifact gate or model/kernel compatibility ledger.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "ABAS-001"
+status = "proposed"
+branch = "codex/apple-bitnet-artifact-sweep/ABAS-001-microsoft-2b-i2s"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Validate the official Microsoft BitNet b1.58 2B / 2B4T I2_S GGUF on MacBook under external Microsoft tokenizer pre-tokenizer authority, recording source, revision, SHA256, size, tokenizer authority, reference-runner prompt outputs, bad/no-authority rejection evidence, and cleanup status."
+commands = [
+  "Reference runner prompt-suite command on MacBook",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-models/**",
+  "models/**",
+]
+may_claim = [
+  "The official Microsoft 2B I2_S artifact is accepted or rejected as an Apple BitNet artifact candidate under recorded tokenizer authority.",
+]
+must_not_claim = [
+  "Rust M4 BitNet local answers work.",
+  "Apple Metal BitNet inference works.",
+  "QK256 works on Apple Silicon.",
+  "Dense Qwen evidence proves BitNet behavior.",
+]
+
+[[work_item]]
+id = "ABAS-002"
+status = "proposed"
+branch = "codex/apple-bitnet-artifact-sweep/ABAS-002-1bitllm-07b"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["ABAS-001"]
+acceptance = "Evaluate 1bitLLM/bitnet_b1_58-large as the smaller Apple BitNet control candidate, recording exact file, size, SHA256, I2_S/TL1 route evidence, tokenizer authority, coherent reference output or rejection evidence, and cleanup status."
+commands = [
+  "Reference runner prompt-suite command on MacBook",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/campaigns/apple-silicon-macbook/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "The 0.7B 1bitLLM candidate is accepted or rejected as a smaller Apple BitNet artifact target with evidence.",
+]
+must_not_claim = [
+  "The 0.7B candidate proves official Microsoft 2B behavior.",
+  "Rust M4 BitNet local answers work.",
+  "Apple Metal BitNet inference works.",
+]
+
+[[work_item]]
+id = "ABAS-003"
+status = "proposed"
+branch = "codex/apple-bitnet-artifact-sweep/ABAS-003-3b-tl-diagnostic"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["ABAS-001"]
+acceptance = "Evaluate 1bitLLM/bitnet_b1_58-3B only on supported TL1/TL2 diagnostic routes, recording why I2_S remains unsupported, tokenizer authority, reference-runner outcome, and cleanup status."
+commands = [
+  "Reference runner diagnostic command on MacBook",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "The 3B candidate is accepted or rejected only for supported TL diagnostic routes.",
+]
+must_not_claim = [
+  "3B I2_S is supported.",
+  "The 3B diagnostic route proves Apple local-answer quality.",
+  "Rust M4 BitNet local answers work.",
+]
+
+[[work_item]]
+id = "ABAS-004"
+status = "proposed"
+branch = "codex/apple-bitnet-artifact-sweep/ABAS-004-falcon-e-secondary"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["ABAS-001", "ABAS-002"]
+acceptance = "Evaluate Falcon-E 1B/3B GGUFs as secondary BitNet-like family candidates only after Microsoft and 1bitLLM behavior is understood, recording runner path, tokenizer authority, output sanity, license/source notes, and cleanup status."
+commands = [
+  "Reference runner prompt-suite command on MacBook",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "Falcon-E candidates are accepted or rejected as secondary BitNet-like Apple artifact candidates with evidence.",
+]
+must_not_claim = [
+  "Falcon-E replaces official Microsoft BitNet artifact authority.",
+  "Rust M4 BitNet local answers work.",
+  "QK256 works on Apple Silicon.",
+]
+
+[[work_item]]
+id = "ABAS-005"
+status = "proposed"
+branch = "codex/apple-bitnet-artifact-sweep/ABAS-005-m4-proof-handoff"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["ABAS-001"]
+acceptance = "Promote the best accepted Apple BitNet artifact into an M4 Mac mini strict Apple CPU/NEON local-answer proof plan, preserving source, hash, tokenizer authority, kernel route, and claim boundary without running the proof in this handoff item."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/campaigns/apple-m4-local-answer/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "An accepted Apple BitNet artifact is ready for a separate M4 strict proof item after backend receipts run.",
+]
+must_not_claim = [
+  "M4 BitNet local answers work before the strict proof item runs.",
+  "Apple Metal BitNet inference works.",
+  "QK256 works on Apple Silicon.",
+]

--- a/docs/tracking/campaigns/apple-bitnet-artifact-sweep/generated/status.md
+++ b/docs/tracking/campaigns/apple-bitnet-artifact-sweep/generated/status.md
@@ -1,0 +1,25 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple BitNet artifact sweep Campaign Status
+
+- Campaign: `apple-bitnet-artifact-sweep`
+- State: `active`
+- Objective: Use the MacBook Apple Silicon lane to qualify 1-bit / 1.58-bit BitNet-family artifacts before any M4 Mac mini Apple CPU/NEON or Metal BitNet local-answer claim.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| ABAS-001 | proposed | TBD | `codex/apple-bitnet-artifact-sweep/ABAS-001-microsoft-2b-i2s` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Validate the official Microsoft BitNet b1.58 2B / 2B4T I2_S GGUF on MacBook under external Microsoft tokenizer pre-tokenizer authority, recording source, revision, SHA256, size, tokenizer authority, reference-runner prompt outputs, bad/no-authority rejection evidence, and cleanup status. |
+| ABAS-002 | proposed | TBD | `codex/apple-bitnet-artifact-sweep/ABAS-002-1bitllm-07b` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate 1bitLLM/bitnet_b1_58-large as the smaller Apple BitNet control candidate, recording exact file, size, SHA256, I2_S/TL1 route evidence, tokenizer authority, coherent reference output or rejection evidence, and cleanup status. |
+| ABAS-003 | proposed | TBD | `codex/apple-bitnet-artifact-sweep/ABAS-003-3b-tl-diagnostic` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate 1bitLLM/bitnet_b1_58-3B only on supported TL1/TL2 diagnostic routes, recording why I2_S remains unsupported, tokenizer authority, reference-runner outcome, and cleanup status. |
+| ABAS-004 | proposed | TBD | `codex/apple-bitnet-artifact-sweep/ABAS-004-falcon-e-secondary` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate Falcon-E 1B/3B GGUFs as secondary BitNet-like family candidates only after Microsoft and 1bitLLM behavior is understood, recording runner path, tokenizer authority, output sanity, license/source notes, and cleanup status. |
+| ABAS-005 | proposed | TBD | `codex/apple-bitnet-artifact-sweep/ABAS-005-m4-proof-handoff` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Promote the best accepted Apple BitNet artifact into an M4 Mac mini strict Apple CPU/NEON local-answer proof plan, preserving source, hash, tokenizer authority, kernel route, and claim boundary without running the proof in this handoff item. |
+
+## Hard Constraints
+
+- Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini.
+- Do not claim Rust Apple BitNet local answers before the target backend runs its own strict receipt gate.
+- Do not claim BitNet quality from dense Qwen SLM evidence.
+- Do not claim QK256 support, full Apple Metal inference, Neural Engine execution, MPSGraph model inference, or broad Apple Silicon performance.
+- Do not weaken the shared answer-artifact gate or model/kernel compatibility ledger.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -3,6 +3,10 @@
 
 | Campaign | Item | Blocked by | State |
 |---|---|---|---|
+| apple-bitnet-artifact-sweep | ABAS-002 | ABAS-001 | proposed |
+| apple-bitnet-artifact-sweep | ABAS-003 | ABAS-001 | proposed |
+| apple-bitnet-artifact-sweep | ABAS-004 | ABAS-001, ABAS-002 | proposed |
+| apple-bitnet-artifact-sweep | ABAS-005 | ABAS-001 | proposed |
 | apple-m4 | M4-002 | M4-001 | merged |
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -4,6 +4,7 @@
 | Campaign | Active item | PR | State | Next | Notes |
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| apple-bitnet-artifact-sweep | ABAS-001 | TBD | proposed | ABAS-002 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | TBD | proposed | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-QA-001 | #3904 | blocked | M4-QA-MODEL-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -4,6 +4,7 @@
 | Campaign | Title | Current item | Boundary |
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
+| apple-bitnet-artifact-sweep | Apple BitNet artifact sweep | ABAS-001 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
 | apple-m4 | Apple M4 Mac mini validation | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-QA-001 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |


### PR DESCRIPTION
## Summary
- Add a dedicated Apple BitNet artifact sweep campaign for 1-bit / 1.58-bit candidate validation on Apple Silicon.
- Add an operator guide that routes larger artifact sweeps through the MacBook lane first, then back to M4 strict proof only after reference-good evidence exists.
- Link the sweep guide from the MacBook lane and regenerate campaign dashboards.

## Claim boundary
Tracker/docs only. This does not download model artifacts, accept any candidate, run Apple BitNet inference, prove M4 BitNet local answers, prove QK256, prove full Apple Metal inference, or make broad Apple Silicon performance claims.

## Verification
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-bitnet-artifact-sweep`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`