### PR TITLE
perf(gpu-hal): avoid cloning HNSW prune query

### DIFF
--- a/crates/bitnet-gpu-hal/src/semantic_search.rs
+++ b/crates/bitnet-gpu-hal/src/semantic_search.rs
@@ -449,7 +449,7 @@ impl HNSWIndex {
     }
 
     fn prune_neighbors(&mut self, node: usize, level: usize) {
-        let query = &self.vectors[node].vector.clone();
+        let query = &self.vectors[node].vector;
         let neighbors = &self.nodes[node].neighbors[level];
         let mut scored: Vec<(usize, f32)> = neighbors
             .iter()


### PR DESCRIPTION
## Summary

- Borrow the HNSW prune query vector instead of cloning it before scoring neighbors.

## Why

`prune_neighbors` only needs a read-only slice for distance calculation. Cloning the vector allocates and copies the full embedding on every prune call without changing behavior.

## Validation

- `cargo test --locked -p bitnet-gpu-hal semantic_search --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`
