### PR TITLE
perf(sampling): drop unused token count state

### DIFF
--- a/crates/bitnet-sampling/src/lib.rs
+++ b/crates/bitnet-sampling/src/lib.rs
@@ -20,7 +20,6 @@ use anyhow::{Context, Result};
 use bitnet_probability::{renormalize_in_place, sample_categorical};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
-use std::collections::HashMap;
 use tracing::debug;
 
 /// Configuration for sampling strategies.
@@ -62,15 +61,14 @@ impl Default for SamplingConfig {
     }
 }
 
-/// Stateful sampling strategy that tracks token counts for repetition penalty.
+/// Stateful sampling strategy with reusable sampling buffers.
 ///
 /// Create with [`SamplingStrategy::new`], then call [`SamplingStrategy::sample`]
 /// for each step in the decode loop.  Call [`SamplingStrategy::reset`] when
-/// starting a new sequence to clear the internal token-count state.
+/// starting a new sequence to clear reusable state.
 pub struct SamplingStrategy {
     config: SamplingConfig,
     rng: ChaCha8Rng,
-    token_counts: HashMap<u32, usize>,
     /// Pre-allocated buffer to avoid allocating on every generation step
     logits_buffer: Vec<f32>,
 }
@@ -96,7 +94,7 @@ impl SamplingStrategy {
             ChaCha8Rng::from_rng(&mut rand::rng())
         };
 
-        Self { config, rng, token_counts: HashMap::new(), logits_buffer: Vec::new() }
+        Self { config, rng, logits_buffer: Vec::new() }
     }
 
     /// Sample the next token from logits.
@@ -164,7 +162,6 @@ impl SamplingStrategy {
         // as Err and breaks ties by lowest token ID for llama.cpp compatibility).
         if self.config.temperature == 0.0 {
             let token = greedy_sample(&buf)?;
-            *self.token_counts.entry(token).or_insert(0) += 1;
             // Restore buffer
             self.logits_buffer = buf;
             return Ok(token);
@@ -192,7 +189,6 @@ impl SamplingStrategy {
         let _ = renormalize_in_place(&mut buf);
 
         let token = self.sample_from_distribution(&buf)?;
-        *self.token_counts.entry(token).or_insert(0) += 1;
 
         // Restore buffer
         self.logits_buffer = buf;
@@ -274,11 +270,11 @@ impl SamplingStrategy {
     /// let logits = vec![0.1f32, 0.9, 0.3];
     /// let _ = strategy.sample(&logits, &[]).unwrap();
     ///
-    /// // reset() clears those counts so the next request is independent.
+    /// // reset() clears reusable state so the next request is independent.
     /// strategy.reset();
     /// ```
     pub fn reset(&mut self) {
-        self.token_counts.clear();
+        self.logits_buffer.clear();
     }
 
     /// Update configuration, re-seeding the PRNG if the seed changed.


### PR DESCRIPTION
## Summary

- Remove the unused `SamplingStrategy::token_counts` `HashMap` state.
- Stop writing sampled tokens into a map that is never read for repetition penalties.
- Keep `reset()` meaningful by clearing the reusable logits buffer.

## Why

`SamplingStrategy` computes count-aware repetition penalties directly from the `context_tokens` passed to `sample()`. The internal `token_counts` map was only written and cleared, so it added unnecessary allocation and per-token HashMap work without affecting output.

## Validation

- `cargo test --locked -p bitnet-sampling --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`
