### PR TITLE
perf(logits): avoid top-k allocation when already sparse

### DIFF
--- a/crates/bitnet-logits-filters/src/lib.rs
+++ b/crates/bitnet-logits-filters/src/lib.rs
@@ -18,10 +18,18 @@ pub fn apply_top_k(logits: &mut [f32], top_k: usize) -> usize {
         return logits.len();
     }
 
-    let mut vals: Vec<f32> = logits.iter().copied().filter(|&x| x > f32::NEG_INFINITY).collect();
-    if vals.len() <= top_k {
-        return vals.len();
+    let unmasked = logits.iter().filter(|&&x| x > f32::NEG_INFINITY).count();
+    if unmasked <= top_k {
+        return unmasked;
     }
+
+    let mut vals = Vec::with_capacity(unmasked);
+    for &logit in logits.iter() {
+        if logit > f32::NEG_INFINITY {
+            vals.push(logit);
+        }
+    }
+
     let partition_idx = vals.len() - top_k;
     vals.select_nth_unstable_by(partition_idx, |a, b| f32_ascending(*a, *b));
     let threshold = vals[partition_idx];
@@ -171,6 +179,14 @@ mod tests {
         assert!(logits[2].is_infinite());
         assert!(logits[3].is_finite());
         assert!(logits[4].is_finite());
+    }
+
+    #[test]
+    fn top_k_all_masked_input_keeps_zero_entries() {
+        let mut logits = vec![f32::NEG_INFINITY; 4];
+        let kept = apply_top_k(&mut logits, 2);
+        assert_eq!(kept, 0);
+        assert!(logits.iter().all(|value| *value == f32::NEG_INFINITY));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Count unmasked logits before allocating the top-k scratch vector.
- Return early when the slice is already sparse enough for the requested `top_k`.
- Pre-size the scratch vector exactly when filtering is still needed.
- Add a regression test for all-masked input.

## Why

`apply_top_k` often runs after earlier filters have already masked most logits. In those cases it can avoid collecting a large scratch vector entirely.

## Validation

- `cargo test --locked -p bitnet-logits-filters --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`
