### PR TITLE
fix(wasm): sync browser example interactions

### DIFF
--- a/crates/bitnet-wasm/examples/browser/main.js
+++ b/crates/bitnet-wasm/examples/browser/main.js
@@ -17,6 +17,7 @@ let inference = null;
 let worker = null;
 let streamingActive = false;
 let benchmarkSuite = null;
+let copyFeedbackTimeout = null;
 
 // Initialize the application
 async function initApp() {
@@ -141,12 +142,7 @@ async function loadModel() {
         startStreamingBtn.disabled = false;
         startStreamingBtn.removeAttribute('title');
 
-        // Reset copy button
-        const copyBtn = document.getElementById('copy-output');
-        copyBtn.disabled = true;
-        copyBtn.title = 'No output to copy';
-        copyBtn.style.backgroundColor = '#6c757d';
-        copyBtn.style.cursor = 'not-allowed';
+        resetCopyButton();
 
         updateStatus('Model loaded successfully!', 'success');
         Logger.info('Model loaded and inference engine initialized');
@@ -203,12 +199,7 @@ async function generateText() {
         const tokensPerSec = (estimatedTokens / (generationTime / 1000)).toFixed(1);
         document.getElementById('tokens-per-sec').textContent = tokensPerSec;
 
-        // Enable copy button
-        const copyBtn = document.getElementById('copy-output');
-        copyBtn.disabled = false;
-        copyBtn.removeAttribute('title');
-        copyBtn.style.backgroundColor = '#007bff';
-        copyBtn.style.cursor = 'pointer';
+        setCopyButtonReady();
 
         updateStatus('Text generated successfully!', 'success');
         Logger.info(`Generated ${estimatedTokens} tokens in ${generationTime.toFixed(0)}ms`);
@@ -632,12 +623,35 @@ function clearOutput() {
     document.getElementById('generation-time').textContent = '-';
     document.getElementById('tokens-per-sec').textContent = '-';
 
-    // Reset copy button
+    resetCopyButton();
+}
+
+function resetCopyButton() {
+    if (copyFeedbackTimeout) {
+        clearTimeout(copyFeedbackTimeout);
+        copyFeedbackTimeout = null;
+    }
+
     const copyBtn = document.getElementById('copy-output');
+    copyBtn.textContent = 'Copy';
     copyBtn.disabled = true;
     copyBtn.title = 'No output to copy';
     copyBtn.style.backgroundColor = '#6c757d';
     copyBtn.style.cursor = 'not-allowed';
+}
+
+function setCopyButtonReady() {
+    if (copyFeedbackTimeout) {
+        clearTimeout(copyFeedbackTimeout);
+        copyFeedbackTimeout = null;
+    }
+
+    const copyBtn = document.getElementById('copy-output');
+    copyBtn.textContent = 'Copy';
+    copyBtn.disabled = false;
+    copyBtn.removeAttribute('title');
+    copyBtn.style.backgroundColor = '#007bff';
+    copyBtn.style.cursor = 'pointer';
 }
 
 async function copyToClipboard() {
@@ -648,13 +662,13 @@ async function copyToClipboard() {
         await navigator.clipboard.writeText(outputText);
 
         // Visual feedback
-        const originalText = copyBtn.textContent;
         copyBtn.textContent = 'Copied!';
         copyBtn.style.backgroundColor = '#28a745';
+        copyBtn.disabled = true;
 
-        setTimeout(() => {
-            copyBtn.textContent = originalText;
-            copyBtn.style.backgroundColor = '#007bff';
+        copyFeedbackTimeout = setTimeout(() => {
+            copyFeedbackTimeout = null;
+            setCopyButtonReady();
         }, 2000);
 
     } catch (err) {

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -78,6 +78,16 @@
             cursor: not-allowed;
         }
 
+        button:focus-visible {
+            outline: 3px solid #0056b3;
+            outline-offset: 2px;
+        }
+
+        button.tab:focus-visible {
+            outline: 2px solid #007bff;
+            outline-offset: -2px;
+        }
+
         .input-group {
             margin: 15px 0;
         }
@@ -201,14 +211,25 @@
             margin-bottom: 20px;
         }
 
-        .tab {
+        /* Tab button styles - higher specificity to override generic button styles */
+        button.tab {
+            background: transparent;
+            border: none;
+            border-bottom: 2px solid transparent;
             padding: 12px 20px;
             cursor: pointer;
-            border-bottom: 2px solid transparent;
+            font-family: inherit;
+            font-size: 1rem;
+            color: inherit;
             transition: all 0.2s;
+            border-radius: 0;
         }
 
-        .tab.active {
+        button.tab:hover:not(:disabled) {
+            background-color: rgba(0,0,0,0.05);
+        }
+
+        button.tab.active {
             border-bottom-color: #007bff;
             color: #007bff;
         }
@@ -229,25 +250,25 @@
     </div>
 
     <div class="container">
-        <div id="status" class="status loading">
+        <div id="status" class="status loading" role="status" aria-live="polite">
             Initializing WebAssembly module...
         </div>
 
-        <div class="progress-bar">
+        <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Loading progress">
             <div id="progress" class="progress-fill"></div>
         </div>
     </div>
 
-    <div class="tabs">
-        <div class="tab active" onclick="switchTab('basic')">Basic Inference</div>
-        <div class="tab" onclick="switchTab('streaming')">Streaming</div>
-        <div class="tab" onclick="switchTab('worker')">Web Workers</div>
-        <div class="tab" onclick="switchTab('benchmark')">Benchmarks</div>
-        <div class="tab" onclick="switchTab('settings')">Settings</div>
+    <div class="tabs" role="tablist" aria-label="Application Sections">
+        <button type="button" class="tab active" role="tab" aria-selected="true" aria-controls="basic-tab" id="tab-basic" tabindex="0" onclick="switchTab('basic', this)">Basic Inference</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="streaming-tab" id="tab-streaming" tabindex="-1" onclick="switchTab('streaming', this)">Streaming</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="worker-tab" id="tab-worker" tabindex="-1" onclick="switchTab('worker', this)">Web Workers</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="benchmark-tab" id="tab-benchmark" tabindex="-1" onclick="switchTab('benchmark', this)">Benchmarks</button>
+        <button type="button" class="tab" role="tab" aria-selected="false" aria-controls="settings-tab" id="tab-settings" tabindex="-1" onclick="switchTab('settings', this)">Settings</button>
     </div>
 
     <!-- Basic Inference Tab -->
-    <div id="basic-tab" class="tab-content active">
+    <div id="basic-tab" class="tab-content active" role="tabpanel" aria-labelledby="tab-basic">
         <div class="container">
             <h3>Basic Text Generation</h3>
 
@@ -263,7 +284,7 @@
 
             <div class="controls">
                 <button id="load-model" onclick="loadModel()">Load Model</button>
-                <button id="generate" onclick="generateText()" disabled>Generate Text</button>
+                <button id="generate" onclick="generateText()" disabled title="Load a model first">Generate Text</button>
                 <button id="clear-output" onclick="clearOutput()">Clear Output</button>
             </div>
 
@@ -287,14 +308,17 @@
             </div>
 
             <div class="input-group">
-                <div id="output-label" class="container-label">Output:</div>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 5px;">
+                    <div id="output-label" class="container-label" style="margin-bottom: 0;">Output:</div>
+                    <button id="copy-output" onclick="copyToClipboard()" disabled style="padding: 4px 12px; font-size: 12px; background-color: #6c757d;" aria-label="Copy output to clipboard" title="No output to copy">Copy</button>
+                </div>
                 <div id="output" class="output" tabindex="0" role="region" aria-labelledby="output-label" aria-live="polite">Generated text will appear here...</div>
             </div>
         </div>
     </div>
 
     <!-- Streaming Tab -->
-    <div id="streaming-tab" class="tab-content">
+    <div id="streaming-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-streaming">
         <div class="container">
             <h3>Streaming Text Generation</h3>
 
@@ -304,8 +328,8 @@
             </div>
 
             <div class="controls">
-                <button id="start-streaming" onclick="startStreaming()">Start Streaming</button>
-                <button id="stop-streaming" onclick="stopStreaming()" disabled>Stop Streaming</button>
+                <button id="start-streaming" onclick="startStreaming()" disabled title="Load a model first">Start Streaming</button>
+                <button id="stop-streaming" onclick="stopStreaming()" disabled title="No stream is running">Stop Streaming</button>
                 <button id="clear-streaming" onclick="clearStreaming()">Clear</button>
             </div>
 
@@ -332,7 +356,7 @@
     </div>
 
     <!-- Web Workers Tab -->
-    <div id="worker-tab" class="tab-content">
+    <div id="worker-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-worker">
         <div class="container">
             <h3>Web Workers Integration</h3>
 
@@ -343,8 +367,8 @@
 
             <div class="controls">
                 <button id="init-worker" onclick="initWorker()">Initialize Worker</button>
-                <button id="worker-generate" onclick="workerGenerate()" disabled>Generate in Worker</button>
-                <button id="terminate-worker" onclick="terminateWorker()" disabled>Terminate Worker</button>
+                <button id="worker-generate" onclick="workerGenerate()" disabled title="Initialize the worker first">Generate in Worker</button>
+                <button id="terminate-worker" onclick="terminateWorker()" disabled title="Initialize the worker first">Terminate Worker</button>
             </div>
 
             <div class="input-group">
@@ -360,7 +384,7 @@
     </div>
 
     <!-- Benchmark Tab -->
-    <div id="benchmark-tab" class="tab-content">
+    <div id="benchmark-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-benchmark">
         <div class="container">
             <h3>Performance Benchmarks</h3>
 
@@ -371,7 +395,7 @@
                 <button id="loading-bench" onclick="runLoadingBenchmark()">Loading Performance</button>
             </div>
 
-            <div id="benchmark-progress" class="progress-bar" style="display: none;">
+            <div id="benchmark-progress" class="progress-bar" style="display: none;" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Benchmark progress">
                 <div id="benchmark-progress-fill" class="progress-fill"></div>
             </div>
 
@@ -402,7 +426,7 @@
     </div>
 
     <!-- Settings Tab -->
-    <div id="settings-tab" class="tab-content">
+    <div id="settings-tab" class="tab-content" role="tabpanel" aria-labelledby="tab-settings">
         <div class="container">
             <h3>Configuration Settings</h3>
 

--- a/examples/wasm/browser/main.js
+++ b/examples/wasm/browser/main.js
@@ -17,10 +17,14 @@ let inference = null;
 let worker = null;
 let streamingActive = false;
 let benchmarkSuite = null;
+let copyFeedbackTimeout = null;
 
 // Initialize the application
 async function initApp() {
     try {
+        // Setup keyboard navigation for tabs
+        setupTabNavigation();
+
         updateStatus('Initializing WebAssembly module...', 'loading');
         updateProgress(10);
 
@@ -67,6 +71,10 @@ function updateStatus(message, type = 'loading') {
 function updateProgress(percent) {
     const progressEl = document.getElementById('progress');
     progressEl.style.width = `${percent}%`;
+    const progressBarContainer = progressEl.parentElement;
+    if (progressBarContainer) {
+        progressBarContainer.setAttribute('aria-valuenow', percent);
+    }
 }
 
 // Detect platform features
@@ -90,11 +98,16 @@ async function detectPlatformFeatures() {
 async function loadModel() {
     const fileInput = document.getElementById('model-file');
     const file = fileInput.files[0];
+    const loadButton = document.getElementById('load-model');
 
     if (!file) {
         updateStatus('Please select a model file', 'error');
         return;
     }
+
+    const originalText = loadButton.textContent;
+    loadButton.disabled = true;
+    loadButton.textContent = 'Loading...';
 
     try {
         updateStatus('Loading model...', 'loading');
@@ -121,8 +134,15 @@ async function loadModel() {
         // Update UI
         document.getElementById('model-size').textContent = MemoryUtils.format_bytes(file.size);
         document.getElementById('memory-usage').textContent = MemoryUtils.format_bytes(model.get_memory_usage());
-        document.getElementById('generate').disabled = false;
-        document.getElementById('start-streaming').disabled = false;
+        const generateBtn = document.getElementById('generate');
+        generateBtn.disabled = false;
+        generateBtn.removeAttribute('title');
+
+        const startStreamingBtn = document.getElementById('start-streaming');
+        startStreamingBtn.disabled = false;
+        startStreamingBtn.removeAttribute('title');
+
+        resetCopyButton();
 
         updateStatus('Model loaded successfully!', 'success');
         Logger.info('Model loaded and inference engine initialized');
@@ -130,23 +150,31 @@ async function loadModel() {
     } catch (error) {
         updateStatus(`Model loading failed: ${error.message}`, 'error');
         Logger.error(`Model loading error: ${error}`);
+    } finally {
+        loadButton.disabled = false;
+        loadButton.textContent = originalText;
     }
 }
 
 // Generate text
 async function generateText() {
+    const generateButton = document.getElementById('generate');
     if (!inference) {
         updateStatus('Please load a model first', 'error');
         return;
     }
 
-    try {
-        const prompt = document.getElementById('prompt').value;
-        if (!prompt.trim()) {
-            updateStatus('Please enter a prompt', 'error');
-            return;
-        }
+    const prompt = document.getElementById('prompt').value;
+    if (!prompt.trim()) {
+        updateStatus('Please enter a prompt', 'error');
+        return;
+    }
 
+    const originalText = generateButton.textContent;
+    generateButton.disabled = true;
+    generateButton.textContent = 'Generating...';
+
+    try {
         updateStatus('Generating text...', 'loading');
         const startTime = performance.now();
 
@@ -171,33 +199,44 @@ async function generateText() {
         const tokensPerSec = (estimatedTokens / (generationTime / 1000)).toFixed(1);
         document.getElementById('tokens-per-sec').textContent = tokensPerSec;
 
+        setCopyButtonReady();
+
         updateStatus('Text generated successfully!', 'success');
         Logger.info(`Generated ${estimatedTokens} tokens in ${generationTime.toFixed(0)}ms`);
 
     } catch (error) {
         updateStatus(`Generation failed: ${error.message}`, 'error');
         Logger.error(`Generation error: ${error}`);
+    } finally {
+        generateButton.disabled = false;
+        generateButton.textContent = originalText;
     }
 }
 
 // Start streaming generation
 async function startStreaming() {
+    const startButton = document.getElementById('start-streaming');
+    const stopButton = document.getElementById('stop-streaming');
     if (!inference) {
         updateStatus('Please load a model first', 'error');
         return;
     }
 
+    const prompt = document.getElementById('streaming-prompt').value;
+    if (!prompt.trim()) {
+        updateStatus('Please enter a prompt', 'error');
+        return;
+    }
+
+    streamingActive = true;
+    const originalText = startButton.textContent;
+    startButton.disabled = true;
+    startButton.title = 'Streaming is in progress';
+    startButton.textContent = 'Generating...';
+    stopButton.disabled = false;
+    stopButton.removeAttribute('title');
+
     try {
-        const prompt = document.getElementById('streaming-prompt').value;
-        if (!prompt.trim()) {
-            updateStatus('Please enter a prompt', 'error');
-            return;
-        }
-
-        streamingActive = true;
-        document.getElementById('start-streaming').disabled = true;
-        document.getElementById('stop-streaming').disabled = false;
-
         const outputEl = document.getElementById('streaming-output');
         outputEl.textContent = '';
 
@@ -237,27 +276,31 @@ async function startStreaming() {
             await new Promise(resolve => setTimeout(resolve, 50));
         }
 
-        streamingActive = false;
-        document.getElementById('start-streaming').disabled = false;
-        document.getElementById('stop-streaming').disabled = true;
-
         updateStatus('Streaming completed!', 'success');
         Logger.info(`Streaming completed: ${tokenCount} tokens generated`);
 
     } catch (error) {
-        streamingActive = false;
-        document.getElementById('start-streaming').disabled = false;
-        document.getElementById('stop-streaming').disabled = true;
         updateStatus(`Streaming failed: ${error.message}`, 'error');
         Logger.error(`Streaming error: ${error}`);
+    } finally {
+        streamingActive = false;
+        startButton.disabled = false;
+        startButton.removeAttribute('title');
+        startButton.textContent = originalText;
+        stopButton.disabled = true;
+        stopButton.title = 'No stream is running';
     }
 }
 
 // Stop streaming
 function stopStreaming() {
     streamingActive = false;
-    document.getElementById('start-streaming').disabled = false;
-    document.getElementById('stop-streaming').disabled = true;
+    const startButton = document.getElementById('start-streaming');
+    startButton.disabled = false;
+    startButton.removeAttribute('title');
+    const stopButton = document.getElementById('stop-streaming');
+    stopButton.disabled = true;
+    stopButton.title = 'No stream is running';
     updateStatus('Streaming stopped', 'success');
 }
 
@@ -281,8 +324,12 @@ function initWorker() {
                 case 'initialized':
                     document.getElementById('worker-indicator').classList.add('active');
                     document.getElementById('worker-status-text').textContent = 'Worker initialized';
-                    document.getElementById('worker-generate').disabled = false;
-                    document.getElementById('terminate-worker').disabled = false;
+                    const workerGenerateBtn = document.getElementById('worker-generate');
+                    workerGenerateBtn.disabled = false;
+                    workerGenerateBtn.removeAttribute('title');
+                    const terminateWorkerBtn = document.getElementById('terminate-worker');
+                    terminateWorkerBtn.disabled = false;
+                    terminateWorkerBtn.removeAttribute('title');
                     Logger.info('Web Worker initialized successfully');
                     break;
 
@@ -341,8 +388,12 @@ function terminateWorker() {
 
         document.getElementById('worker-indicator').classList.remove('active');
         document.getElementById('worker-status-text').textContent = 'Worker terminated';
-        document.getElementById('worker-generate').disabled = true;
-        document.getElementById('terminate-worker').disabled = true;
+        const workerGenerateBtn = document.getElementById('worker-generate');
+        workerGenerateBtn.disabled = true;
+        workerGenerateBtn.title = 'Initialize the worker first';
+        const terminateWorkerBtn = document.getElementById('terminate-worker');
+        terminateWorkerBtn.disabled = true;
+        terminateWorkerBtn.title = 'Initialize the worker first';
 
         Logger.info('Web Worker terminated');
     }
@@ -350,10 +401,15 @@ function terminateWorker() {
 
 // Run all benchmarks
 async function runBenchmarks() {
+    const runBtn = document.getElementById('run-benchmarks');
     if (!benchmarkSuite) {
         updateStatus('Benchmark suite not initialized', 'error');
         return;
     }
+
+    const originalText = runBtn.textContent;
+    runBtn.disabled = true;
+    runBtn.textContent = 'Running...';
 
     try {
         updateStatus('Running comprehensive benchmarks...', 'loading');
@@ -370,19 +426,25 @@ async function runBenchmarks() {
                 results.platform_info.estimated_gflops.toFixed(2);
         }
 
-        showBenchmarkProgress(false);
         updateStatus('Benchmarks completed successfully!', 'success');
         Logger.info('Comprehensive benchmarks completed');
 
     } catch (error) {
-        showBenchmarkProgress(false);
         updateStatus(`Benchmark failed: ${error.message}`, 'error');
         Logger.error(`Benchmark error: ${error}`);
+    } finally {
+        showBenchmarkProgress(false);
+        runBtn.disabled = false;
+        runBtn.textContent = originalText;
     }
 }
 
 // Run individual benchmark categories
 async function runKernelBenchmark() {
+    const btn = document.getElementById('kernel-bench');
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Running...';
     try {
         updateStatus('Running kernel benchmarks...', 'loading');
         const results = await benchmarkSuite.benchmark_kernels();
@@ -390,10 +452,17 @@ async function runKernelBenchmark() {
         updateStatus('Kernel benchmarks completed!', 'success');
     } catch (error) {
         updateStatus(`Kernel benchmark failed: ${error.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
     }
 }
 
 async function runMemoryBenchmark() {
+    const btn = document.getElementById('memory-bench');
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Running...';
     try {
         updateStatus('Running memory benchmarks...', 'loading');
         const results = await benchmarkSuite.benchmark_memory();
@@ -401,10 +470,17 @@ async function runMemoryBenchmark() {
         updateStatus('Memory benchmarks completed!', 'success');
     } catch (error) {
         updateStatus(`Memory benchmark failed: ${error.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
     }
 }
 
 async function runLoadingBenchmark() {
+    const btn = document.getElementById('loading-bench');
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Running...';
     try {
         updateStatus('Running loading benchmarks...', 'loading');
         const results = await benchmarkSuite.benchmark_loading();
@@ -412,6 +488,9 @@ async function runLoadingBenchmark() {
         updateStatus('Loading benchmarks completed!', 'success');
     } catch (error) {
         updateStatus(`Loading benchmark failed: ${error.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
     }
 }
 
@@ -425,12 +504,14 @@ function showBenchmarkProgress(show) {
         const interval = setInterval(() => {
             progress += 2;
             document.getElementById('benchmark-progress-fill').style.width = `${progress}%`;
+            progressEl.setAttribute('aria-valuenow', progress);
             if (progress >= 100) {
                 clearInterval(interval);
             }
         }, 100);
     } else {
         progressEl.style.display = 'none';
+        progressEl.setAttribute('aria-valuenow', 0);
     }
 }
 
@@ -445,22 +526,30 @@ function createGenerationConfig() {
 }
 
 // Tab switching
-function switchTab(tabName) {
+function switchTab(tabName, element) {
     // Hide all tab contents
     document.querySelectorAll('.tab-content').forEach(tab => {
         tab.classList.remove('active');
     });
 
-    // Remove active class from all tabs
+    // Remove active class, reset aria-selected, and remove from tab order for all tabs
     document.querySelectorAll('.tab').forEach(tab => {
         tab.classList.remove('active');
+        tab.setAttribute('aria-selected', 'false');
+        tab.setAttribute('tabindex', '-1');
     });
 
     // Show selected tab content
     document.getElementById(`${tabName}-tab`).classList.add('active');
 
-    // Add active class to selected tab
-    event.target.classList.add('active');
+    // Add active class, set aria-selected, and add to tab order for selected tab
+    // Fallback to event.target if element is not provided (backwards compatibility)
+    const target = element || (typeof event !== 'undefined' ? event.target : null);
+    if (target) {
+        target.classList.add('active');
+        target.setAttribute('aria-selected', 'true');
+        target.setAttribute('tabindex', '0');
+    }
 }
 
 // Settings management
@@ -533,6 +622,59 @@ function clearOutput() {
     document.getElementById('output').textContent = 'Generated text will appear here...';
     document.getElementById('generation-time').textContent = '-';
     document.getElementById('tokens-per-sec').textContent = '-';
+
+    resetCopyButton();
+}
+
+function resetCopyButton() {
+    if (copyFeedbackTimeout) {
+        clearTimeout(copyFeedbackTimeout);
+        copyFeedbackTimeout = null;
+    }
+
+    const copyBtn = document.getElementById('copy-output');
+    copyBtn.textContent = 'Copy';
+    copyBtn.disabled = true;
+    copyBtn.title = 'No output to copy';
+    copyBtn.style.backgroundColor = '#6c757d';
+    copyBtn.style.cursor = 'not-allowed';
+}
+
+function setCopyButtonReady() {
+    if (copyFeedbackTimeout) {
+        clearTimeout(copyFeedbackTimeout);
+        copyFeedbackTimeout = null;
+    }
+
+    const copyBtn = document.getElementById('copy-output');
+    copyBtn.textContent = 'Copy';
+    copyBtn.disabled = false;
+    copyBtn.removeAttribute('title');
+    copyBtn.style.backgroundColor = '#007bff';
+    copyBtn.style.cursor = 'pointer';
+}
+
+async function copyToClipboard() {
+    const outputText = document.getElementById('output').textContent;
+    const copyBtn = document.getElementById('copy-output');
+
+    try {
+        await navigator.clipboard.writeText(outputText);
+
+        // Visual feedback
+        copyBtn.textContent = 'Copied!';
+        copyBtn.style.backgroundColor = '#28a745';
+        copyBtn.disabled = true;
+
+        copyFeedbackTimeout = setTimeout(() => {
+            copyFeedbackTimeout = null;
+            setCopyButtonReady();
+        }, 2000);
+
+    } catch (err) {
+        Logger.error('Failed to copy: ' + err);
+        updateStatus('Failed to copy to clipboard', 'error');
+    }
 }
 
 // Event listeners for range inputs
@@ -544,6 +686,44 @@ document.getElementById('top-p').addEventListener('input', function() {
     document.getElementById('top-p-value').textContent = this.value;
 });
 
+// Setup keyboard navigation for tabs
+function setupTabNavigation() {
+    const tabsContainer = document.querySelector('.tabs');
+    if (!tabsContainer) return;
+
+    tabsContainer.addEventListener('keydown', (e) => {
+        const tabs = Array.from(document.querySelectorAll('.tab'));
+        const activeTab = document.activeElement;
+        const index = tabs.indexOf(activeTab);
+
+        if (index === -1) return; // Focus not on a tab
+
+        let nextIndex = index;
+        let handled = false;
+
+        if (e.key === 'ArrowRight') {
+            nextIndex = (index + 1) % tabs.length;
+            handled = true;
+        } else if (e.key === 'ArrowLeft') {
+            nextIndex = (index - 1 + tabs.length) % tabs.length;
+            handled = true;
+        } else if (e.key === 'Home') {
+            nextIndex = 0;
+            handled = true;
+        } else if (e.key === 'End') {
+            nextIndex = tabs.length - 1;
+            handled = true;
+        }
+
+        if (handled) {
+            e.preventDefault();
+            const nextTab = tabs[nextIndex];
+            nextTab.focus();
+            nextTab.click(); // Activate the tab
+        }
+    });
+}
+
 // Make functions globally available
 window.loadModel = loadModel;
 window.generateText = generateText;
@@ -551,6 +731,7 @@ window.startStreaming = startStreaming;
 window.stopStreaming = stopStreaming;
 window.clearStreaming = clearStreaming;
 window.clearOutput = clearOutput;
+window.copyToClipboard = copyToClipboard;
 window.initWorker = initWorker;
 window.workerGenerate = workerGenerate;
 window.terminateWorker = terminateWorker;


### PR DESCRIPTION
## Summary
- sync the top-level WASM browser example with the crate example's remaining interaction/accessibility behavior
- add real tab buttons with ARIA tab state and keyboard navigation
- add loading/benchmark progress ARIA updates, copy-output feedback, and busy states for model/generation/benchmark buttons
- keep copy button state deterministic when output is cleared or a new model is loaded

## Validation
- node --check examples/wasm/browser/main.js
- node --check crates/bitnet-wasm/examples/browser/main.js
- git diff --check origin/main...HEAD

Extracted from the still-useful portion of #3982 while preserving the already-landed output region and focus fixes on main.
