### PR TITLE
ci(coverage): add receipt artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -124,6 +124,40 @@ jobs:
           fi
           echo "Coverage OK"
 
+      - name: Write coverage receipt
+        if: always()
+        run: |
+          mkdir -p target/bitnet/reports
+          python3 - <<'PYTHON'
+          import json
+          import pathlib
+
+          receipt = {
+              "schema_version": 1,
+              "repo": "bitnet-rs",
+              "lane": "coverage",
+              "flag": "rust-cpu",
+              "workflow": "Coverage",
+              "artifacts": {
+                  "coverage_json": pathlib.Path("coverage.json").exists(),
+                  "coverage_text": pathlib.Path("coverage.txt").exists(),
+                  "lcov": pathlib.Path("lcov.info").exists(),
+              },
+              "claim_boundary": [
+                  "execution_surface_only",
+                  "cpu_path_only",
+                  "not_gpu_validation",
+                  "not_model_quality",
+                  "not_crossval",
+                  "not_mutation_adequacy",
+              ],
+          }
+          pathlib.Path("target/bitnet/reports/coverage-receipt.json").write_text(
+              json.dumps(receipt, indent=2) + "\n",
+              encoding="utf-8",
+          )
+          PYTHON
+
       - name: Detect Codecov token
         id: codecov-token
         if: always()
@@ -165,4 +199,5 @@ jobs:
             coverage.json
             coverage.txt
             lcov.info
+            target/bitnet/reports/coverage-receipt.json
           retention-days: 7


### PR DESCRIPTION
## Summary
- write a small JSON receipt for the Coverage workflow under `target/bitnet/reports/coverage-receipt.json`
- record which coverage artifacts were produced and the validation claim boundary for the `rust-cpu` lane
- upload the receipt alongside the existing coverage artifacts

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/coverage.yml"); puts "coverage.yml parses"'`

Extracted from the useful one-file portion of #3880 as a focused, current-main replacement.
