### PR TITLE
fix(tokenizers): infer GGUF model type from architecture

### DIFF
--- a/crates/bitnet-tokenizers/src/universal.rs
+++ b/crates/bitnet-tokenizers/src/universal.rs
@@ -50,12 +50,7 @@ impl UniversalTokenizer {
         let mmap = MmapFile::open(path)?;
         let reader = GgufReader::new(mmap.as_slice())?;
 
-        let model_type = reader.get_string_metadata("tokenizer.ggml.model").ok_or_else(|| {
-            BitNetError::Inference(InferenceError::TokenizationFailed {
-                reason: "GGUF missing tokenizer.ggml.model; refusing GPT-2 compatibility guess"
-                    .to_string(),
-            })
-        })?;
+        let model_type = Self::resolve_model_type(&reader)?;
 
         let tokens = reader.get_string_array_metadata("tokenizer.ggml.tokens").unwrap_or_default();
         let vocab_size = tokens.len();
@@ -91,6 +86,45 @@ impl UniversalTokenizer {
             bpe_merges: merges,
         };
         Self::new(config)
+    }
+
+    /// Resolve the GGUF tokenizer model type, falling back to architecture
+    /// metadata when `tokenizer.ggml.model` is absent or blank.
+    fn resolve_model_type(reader: &bitnet_models::GgufReader) -> Result<String> {
+        if let Some(model_type) = reader.get_string_metadata("tokenizer.ggml.model")
+            && !model_type.trim().is_empty()
+        {
+            return Ok(model_type);
+        }
+
+        let architecture = reader.get_string_metadata("general.architecture");
+        let normalized_arch = architecture.as_deref().unwrap_or_default().trim().to_lowercase();
+        let inferred = Self::infer_model_type_from_architecture(&normalized_arch);
+
+        if inferred == "unknown" {
+            return Err(BitNetError::Inference(InferenceError::TokenizationFailed {
+                reason: format!(
+                    "GGUF missing tokenizer.ggml.model and general.architecture={architecture:?} \
+                     does not map to a known tokenizer; refusing GPT-2 compatibility guess"
+                ),
+            }));
+        }
+
+        warn!(
+            "Missing tokenizer.ggml.model; inferring tokenizer type {:?} from general.architecture={:?}",
+            inferred, architecture
+        );
+        Ok(inferred.to_string())
+    }
+
+    fn infer_model_type_from_architecture(architecture: &str) -> &'static str {
+        match architecture {
+            "llama" | "llama3" | "mistral" | "gemma" | "qwen" | "qwen2" | "qwen3" | "phi"
+            | "phi2" | "phi3" => "llama",
+            "gpt2" | "gpt-2" => "gpt2",
+            "bloom" | "falcon" | "gptj" | "gpt-j" | "gpt_neox" | "gpt-neox" => "gpt2",
+            _ => "unknown",
+        }
     }
 
     /// Create from model with auto-detection
@@ -229,6 +263,44 @@ impl UniversalTokenizer {
                 Ok(InternalTokenizerBackend::Mock(MockTokenizer::new()))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UniversalTokenizer;
+
+    #[test]
+    fn infer_model_type_maps_sentencepiece_like_architectures_to_llama() {
+        for arch in
+            ["llama", "llama3", "mistral", "gemma", "qwen", "qwen2", "qwen3", "phi", "phi2", "phi3"]
+        {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "llama",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_maps_bpe_architectures_to_gpt2() {
+        for arch in ["gpt2", "gpt-2", "bloom", "falcon", "gpt-j", "gptj", "gpt-neox", "gpt_neox"] {
+            assert_eq!(
+                UniversalTokenizer::infer_model_type_from_architecture(arch),
+                "gpt2",
+                "{arch}"
+            );
+        }
+    }
+
+    #[test]
+    fn infer_model_type_returns_unknown_for_unmapped_architecture() {
+        assert_eq!(
+            UniversalTokenizer::infer_model_type_from_architecture("totally-new-arch"),
+            "unknown"
+        );
+        assert_eq!(UniversalTokenizer::infer_model_type_from_architecture(""), "unknown");
     }
 }
 


### PR DESCRIPTION
## Summary
- resolve GGUF tokenizer model type through `tokenizer.ggml.model` when present, or known `general.architecture` mappings when that metadata is missing/blank
- keep strict behavior for unknown architectures by returning an actionable tokenization error instead of silently guessing GPT-2 compatibility
- add unit coverage for llama-like, BPE-like, and unmapped architecture inference

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p bitnet-tokenizers --no-default-features`

Extracted from #4175 as a focused current-main replacement.
