### PR TITLE
docs(devex): clarify xtask no-default-features usage

### DIFF
--- a/docs/development/build-commands.md
+++ b/docs/development/build-commands.md
@@ -143,42 +143,42 @@ cargo llvm-cov --workspace --features cpu --html
 ### Model Management
 ```bash
 # Download BitNet model from Hugging Face
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # Vendor GGML quantization files for IQ2_S support
-cargo run -p xtask -- vendor-ggml --commit <llama.cpp-commit>
+cargo run --no-default-features -p xtask -- vendor-ggml --commit <llama.cpp-commit>
 
 # Fetch and build Microsoft BitNet C++ for cross-validation
-cargo run -p xtask -- fetch-cpp
+cargo run --no-default-features -p xtask -- fetch-cpp
 ```
 
 ### Cross-Validation Workflow
 ```bash
 # Run cross-validation tests
-cargo run -p xtask -- crossval
+cargo run --no-default-features -p xtask -- crossval
 # Full workflow (download + fetch + test)
-cargo run -p xtask -- full-crossval
+cargo run --no-default-features -p xtask -- full-crossval
 
 # Check feature flag consistency
-cargo run -p xtask -- check-features
+cargo run --no-default-features -p xtask -- check-features
 ```
 
 ### Model Verification
 ```bash
 # Verify model configuration and tokenizer compatibility
-cargo run -p xtask -- verify --model models/bitnet/model.gguf
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.json
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
-cargo run -p xtask -- verify --model models/bitnet/model.gguf --format json
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.json
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
+cargo run --no-default-features -p xtask -- verify --model models/bitnet/model.gguf --format json
 ```
 
 ### Inference Testing
 ```bash
 # Run simple inference for smoke testing (requires --features inference for real inference)
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.json
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
-cargo run -p xtask -- infer --model models/bitnet/model.gguf --prompt "Hello world" --allow-mock --format json
-cargo run -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "Test prompt" --max-new-tokens 64 --temperature 0.7 --gpu
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.json
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "The capital of France is" --tokenizer models/bitnet/tokenizer.model  # SPM tokenizer
+cargo run --no-default-features -p xtask -- infer --model models/bitnet/model.gguf --prompt "Hello world" --allow-mock --format json
+cargo run --no-default-features -p xtask --features inference -- infer --model models/bitnet/model.gguf --prompt "Test prompt" --max-new-tokens 64 --temperature 0.7 --gpu
 ```
 
 ### Model Validation

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,7 +55,7 @@ cargo build --locked --no-default-features --features "cpu,gpu"
 1. **Download a real BitNet model with trained weights**:
 ```bash
 # Download official Microsoft BitNet model with I2_S quantization
-cargo run -p xtask -- download-model \
+cargo run --no-default-features -p xtask -- download-model \
     --id microsoft/bitnet-b1.58-2B-4T-gguf \
     --file ggml-model-i2_s.gguf
 ```
@@ -74,14 +74,14 @@ cargo run -p bitnet-cli -- inspect \
 3. **Run inference with real neural network weights**:
 ```bash
 # Production inference with strict mode (prevents mock fallbacks)
-BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
+BITNET_STRICT_MODE=1 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Explain quantum computing in simple terms" \
     --deterministic
 
 # Stream generation with device-aware quantization
-BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
+BITNET_STRICT_MODE=1 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Write a story about AI and humans working together" \
@@ -89,7 +89,7 @@ BITNET_STRICT_MODE=1 cargo run -p xtask -- infer \
 
 # Performance measurement with realistic expectations
 # Performance varies by model and hardware; QK256 uses scalar kernels (~0.1 tok/s for 2B models)
-BITNET_DETERMINISTIC=1 BITNET_SEED=42 cargo run -p xtask -- infer \
+BITNET_DETERMINISTIC=1 BITNET_SEED=42 cargo run --no-default-features -p xtask -- infer \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "Benchmark inference performance" \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -139,7 +139,7 @@ cargo run -p bitnet-cli --features cpu,full-cli -- run \
 RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C lto=thin" \
   cargo build --release --no-default-features --features cpu,full-cli
 RAYON_NUM_THREADS=$(nproc) RUST_LOG=warn \
-  cargo run --no-default-features --release -p xtask -- benchmark \
+  cargo run --release --no-default-features -p xtask -- benchmark \
   --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf --tokens 16  # Reduced for QK256
 ```
 

--- a/tools/bitnet-task/src/validation.rs
+++ b/tools/bitnet-task/src/validation.rs
@@ -579,6 +579,13 @@ pub(crate) fn cmd_validate_fixtures(root: &Path) -> Result<()> {
             println!("::warning::Could not inspect {name} - skipping metadata validation");
             continue;
         };
+        if !inspect.status.success() {
+            println!(
+                "::warning::Inspect command failed for {name}; skipping metadata validation: {}",
+                String::from_utf8_lossy(&inspect.stderr).trim()
+            );
+            continue;
+        }
         let inspect_text = String::from_utf8_lossy(&inspect.stdout);
         let inspect_json: Value = match serde_json::from_str(&inspect_text) {
             Ok(value) => value,


### PR DESCRIPTION
## Summary
- document active `xtask` commands with `--no-default-features` in setup/build docs
- normalize the quickstart benchmark command ordering around `--release` and `--no-default-features`
- make fixture validation skip metadata parsing when `bitnet-cli inspect` exits unsuccessfully, surfacing stderr as a warning instead

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --locked -p bitnet-task`

Extracted from the low-risk docs/devex part of #4186. The interactive REPL behavior change is intentionally left out for a separate validation pass.
