### PR TITLE
ci: add advisory test telemetry lane

### DIFF
--- a/.github/workflows/test-telemetry.yml
+++ b/.github/workflows/test-telemetry.yml
@@ -1,0 +1,147 @@
+name: Test Telemetry
+
+# Advisory observability lane. It produces nextest JUnit and a slow-test
+# summary without changing the required CI Core merge gate.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'crates/**'
+      - 'tests/**'
+      - 'tools/bitnet-task/**'
+      - 'xtask/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.config/nextest.toml'
+      - '.github/workflows/test-telemetry.yml'
+  push:
+    branches: [ main ]
+    paths:
+      - 'crates/**'
+      - 'tests/**'
+      - 'tools/bitnet-task/**'
+      - 'xtask/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.config/nextest.toml'
+      - '.github/workflows/test-telemetry.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: "0"
+  RUST_BACKTRACE: 1
+  BITNET_SKIP_SLOW_TESTS: "1"
+
+jobs:
+  nextest-junit:
+    name: Test Telemetry (JUnit + slow tests)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.93.0"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: test-telemetry-ubuntu
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --version 0.9.131 --locked
+
+      - name: Run nextest (ci profile, JUnit output)
+        run: |
+          cargo nextest run --locked --profile ci \
+            -p bitnet-common \
+            -p bitnet-models \
+            -p bitnet-tokenizers \
+            -p bitnet-quantization \
+            -p bitnet-kernels \
+            -p bitnet-prompt-templates \
+            -p bitnet-receipts \
+            -p bitnet-sampling \
+            -p bitnet-logits \
+            -p bitnet-gguf \
+            -p bitnet-generation \
+            -p bitnet-device-probe \
+            -p bitnet-engine-core \
+            --no-default-features --features cpu \
+            -- --test-threads 4 || true
+
+      - name: Slow-test summary
+        if: always()
+        run: |
+          set -euo pipefail
+          junit=target/nextest/ci/junit.xml
+          if [ ! -f "$junit" ]; then
+            echo "## Test Telemetry" >> "$GITHUB_STEP_SUMMARY"
+            echo "_No JUnit output produced._" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+
+          tree = ET.parse("target/nextest/ci/junit.xml")
+          root = tree.getroot()
+          cases = []
+          totals = {"tests": 0, "failures": 0, "skipped": 0, "time": 0.0}
+
+          for suite in root.iter("testsuite"):
+              totals["tests"] += int(suite.attrib.get("tests", 0))
+              totals["failures"] += int(suite.attrib.get("failures", 0))
+              totals["skipped"] += int(suite.attrib.get("skipped", 0))
+              totals["time"] += float(suite.attrib.get("time", 0) or 0)
+              for case in suite.iter("testcase"):
+                  elapsed = float(case.attrib.get("time", 0) or 0)
+                  name = f"{case.attrib.get('classname', '?')}::{case.attrib.get('name', '?')}"
+                  cases.append((elapsed, name))
+
+          slow = [case for case in sorted(cases, reverse=True) if case[0] >= 0.5][:20]
+
+          print("## Test Telemetry")
+          print()
+          print(f"- **Tests:** {totals['tests']}")
+          print(f"- **Failures:** {totals['failures']}")
+          print(f"- **Skipped:** {totals['skipped']}")
+          print(f"- **Wall time (sum):** {totals['time']:.1f}s")
+          print()
+
+          if slow:
+              print("### Slowest tests (>= 0.5s, top 20)")
+              print()
+              print("| Test | Time (s) |")
+              print("|---|---:|")
+              for elapsed, name in slow:
+                  print(f"| `{name}` | {elapsed:.2f} |")
+          else:
+              print("_No tests took >= 0.5s._")
+          PY
+
+      - name: Upload JUnit artifact
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: nextest-junit
+          path: target/nextest/ci/junit.xml
+          retention-days: 30
+          if-no-files-found: ignore

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -129,6 +129,26 @@ duplicate_of = ["ci-core-build-test where CPU overlap exists"]
 review_after = "2026-06-07"
 expires = "2026-11-07"
 
+[[lane]]
+id = "test-telemetry"
+workflow = ".github/workflows/test-telemetry.yml"
+job = "Test Telemetry (JUnit + slow tests)"
+kind = "observability"
+tier = "frontdoor-advisory"
+default_pr = true
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 18
+owner = "testing/telemetry"
+intent = "Emit nextest JUnit and slow-test summaries for PR test-observability without replacing CI Core."
+failure_mode = "Per-test timing, slow-test, and future flake/actuals signals remain invisible."
+proof_obligation = "Run cargo-nextest on the CI Core Rust test surface and upload target/nextest/ci/junit.xml."
+evidence = ["target/nextest/ci/junit.xml", "GitHub step summary"]
+allowed_triggers = ["pull_request:path-gated", "push", "workflow_dispatch"]
+duplicate_of = ["ci-core-build-test for pass/fail semantics"]
+review_after = "2026-06-07"
+expires = "2026-11-07"
+
 # ---------------------------------------------------------------------------
 # Risk-gated and expensive lanes
 # ---------------------------------------------------------------------------

--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -45,6 +45,12 @@ runner = "ubuntu_22_04"
 default_pr = true
 blocking = true
 
+[lane.test-telemetry]
+base_lem = 18
+runner = "ubuntu_22_04"
+default_pr = true
+blocking = false
+
 [lane.feature-matrix-full]
 base_lem = 70
 runner = "ubuntu_22_04"


### PR DESCRIPTION
## Summary
- add a non-blocking Test Telemetry workflow that runs `cargo nextest` with the existing `ci` profile and uploads JUnit XML
- write a slow-test summary to the GitHub step summary for PR observability
- register the advisory telemetry lane in `policy/ci-lane-whitelist.toml` and `policy/ci-lanes.toml`

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test-telemetry.yml"); puts "test-telemetry.yml parses"'`
- `cargo run --locked -p xtask --no-default-features -- lint-workflows`
- `cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check --fail-on-error`

The whitelist command exits 0 with the two pre-existing duplicate-reference warnings for `ci-core-docs` and `ripr-advisory`.

Extracted from #3765 and updated for current main's Rust 1.93/pinned-action/policy-lane conventions.
