### PR TITLE
ci: record workflow actuals via xtask

### DIFF
--- a/.github/workflows/ci-actuals.yml
+++ b/.github/workflows/ci-actuals.yml
@@ -1,0 +1,97 @@
+name: CI Actuals
+
+on:
+  workflow_run:
+    workflows:
+      - "CI (Core)"
+      - "Feature Matrix"
+      - "Compatibility Tests"
+      - "Property-Based Tests"
+      - "Test Telemetry"
+      - "Fuzz CI"
+      - "PR Plan"
+      - "Policy"
+      - "PR Gate"
+      - "ripr"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "GitHub Actions run id to collect"
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ci-actuals-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  record:
+    name: Record CI actuals
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion != 'cancelled' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
+        with:
+          toolchain: "1.93.0"
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
+        with:
+          shared-key: ci-actuals
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Fetch job timing data
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/ci
+          gh api --paginate -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs?per_page=100" \
+            | jq -s '{ jobs: map(.jobs // []) | add }' \
+            > target/ci/jobs-raw.json
+
+      - name: Emit ci-actuals
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          WF_NAME: ${{ github.event.workflow_run.name || 'manual' }}
+          WF_HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          WF_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+          WF_EVENT: ${{ github.event.workflow_run.event || 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --sha "${WF_HEAD_SHA}"
+            --workflow "${WF_NAME}"
+            --workflow-run-id "${RUN_ID}"
+            --event "${WF_EVENT}"
+            --head-branch "${WF_HEAD_BRANCH}"
+            --github-jobs-json target/ci/jobs-raw.json
+            --json-out target/ci/ci-actuals.json
+            --summary-out "${GITHUB_STEP_SUMMARY}"
+          )
+          pr_number="$(jq -r '.workflow_run.pull_requests[0].number // empty' "$GITHUB_EVENT_PATH")"
+          if [ -n "$pr_number" ]; then
+            args+=(--pr "$pr_number")
+          fi
+          cargo run --locked -p xtask --no-default-features -- ci actuals "${args[@]}"
+
+      - name: Upload ci-actuals
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: ci-actuals-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          path: target/ci/ci-actuals.json
+          retention-days: 90
+          if-no-files-found: warn

--- a/policy/ci-lane-whitelist.toml
+++ b/policy/ci-lane-whitelist.toml
@@ -149,6 +149,26 @@ duplicate_of = ["ci-core-build-test for pass/fail semantics"]
 review_after = "2026-06-07"
 expires = "2026-11-07"
 
+[[lane]]
+id = "ci-actuals"
+workflow = ".github/workflows/ci-actuals.yml"
+job = "Record CI actuals"
+kind = "observability"
+tier = "backoffice-advisory"
+default_pr = false
+blocking = false
+runner = "ubuntu_22_04"
+base_lem = 3
+owner = "release/ci"
+intent = "Capture completed workflow job timing as normalized LEM actuals for future estimate calibration."
+failure_mode = "Planner estimates cannot be compared to observed CI cost by workflow run."
+proof_obligation = "Fetch GitHub Actions job timing data, normalize it through xtask ci actuals, and upload ci-actuals.json."
+evidence = ["target/ci/ci-actuals.json", "GitHub step summary"]
+allowed_triggers = ["workflow_run:completed", "workflow_dispatch"]
+duplicate_of = []
+review_after = "2026-06-07"
+expires = "2026-11-07"
+
 # ---------------------------------------------------------------------------
 # Risk-gated and expensive lanes
 # ---------------------------------------------------------------------------

--- a/policy/ci-lanes.toml
+++ b/policy/ci-lanes.toml
@@ -51,6 +51,12 @@ runner = "ubuntu_22_04"
 default_pr = true
 blocking = false
 
+[lane.ci-actuals]
+base_lem = 3
+runner = "ubuntu_22_04"
+default_pr = false
+blocking = false
+
 [lane.feature-matrix-full]
 base_lem = 70
 runner = "ubuntu_22_04"

--- a/xtask/src/ci/actuals.rs
+++ b/xtask/src/ci/actuals.rs
@@ -25,16 +25,18 @@
 //! }
 //! ```
 //!
-//! PR 16 ships this scaffold so future PRs (notably PR 20 — learned
-//! estimates) have a concrete consumer surface. The current
-//! implementation only knows how to emit a synthetic record from
-//! command-line arguments; production runs will swap in a GitHub
-//! API call.
+//! The command supports two inputs:
+//!
+//! * a synthetic single-job record from command-line arguments for
+//!   local smoke tests and fixtures;
+//! * a GitHub Actions jobs API response, used by the `CI Actuals`
+//!   workflow to capture completed workflow-run timing.
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Actuals {
@@ -44,6 +46,12 @@ pub struct Actuals {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pr: Option<u64>,
     pub workflow: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workflow_run_id: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_branch: Option<String>,
     pub jobs: Vec<JobActual>,
 }
 
@@ -62,63 +70,203 @@ pub struct JobActual {
     pub risk_packs: Vec<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct ActualsOptions {
+    pub repo: String,
+    pub sha: String,
+    pub pr: Option<u64>,
+    pub workflow: String,
+    pub workflow_run_id: Option<u64>,
+    pub event: Option<String>,
+    pub head_branch: Option<String>,
+    pub job_name: Option<String>,
+    pub runner: Option<String>,
+    pub actual_seconds: Option<u64>,
+    pub estimated_lem: Option<f64>,
+    pub conclusion: Option<String>,
+    pub cache_hit: bool,
+    pub github_jobs_json: Option<PathBuf>,
+    pub json_out: PathBuf,
+    pub summary_out: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActionsJobsResponse {
+    #[serde(default)]
+    jobs: Vec<ActionsJob>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActionsJob {
+    name: String,
+    #[serde(default)]
+    conclusion: Option<String>,
+    #[serde(default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    completed_at: Option<String>,
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    runner_name: Option<String>,
+}
+
 /// Compute LEM from a runner's wall-clock seconds and a multiplier
 /// table. Multipliers default to the values in
 /// `policy/ci-budget.toml` when not overridden.
 pub fn lem_from_seconds(seconds: u64, runner: &str) -> f64 {
-    let multiplier = match runner {
-        "ubuntu-22.04" | "ubuntu-latest" | "ubuntu_22_04" | "ubuntu_latest" => 1.0,
-        "windows-latest" | "windows_latest" => 2.0,
-        "macos-14" | "macos-latest" | "macos_14" | "macos_latest" => 10.0,
-        "gpu-docker" | "gpu_docker" => 6.0,
-        _ => 1.0,
+    let runner = runner.to_ascii_lowercase().replace('_', "-");
+    let multiplier = if runner.contains("macos") || runner.contains("darwin") {
+        10.0
+    } else if runner.contains("windows") {
+        2.0
+    } else if runner.contains("gpu-docker") {
+        6.0
+    } else {
+        1.0
     };
     let minutes = seconds as f64 / 60.0;
     (minutes * multiplier * 100.0).round() / 100.0
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn run(
-    repo: String,
-    sha: String,
-    pr: Option<u64>,
-    workflow: String,
-    job_name: Option<String>,
-    runner: Option<String>,
-    actual_seconds: Option<u64>,
-    estimated_lem: Option<f64>,
-    conclusion: Option<String>,
-    cache_hit: bool,
-    json_out: PathBuf,
-) -> Result<()> {
-    let mut jobs = Vec::new();
-    if let (Some(name), Some(runner_id), Some(seconds)) =
-        (job_name.clone(), runner.clone(), actual_seconds)
-    {
-        let actual_lem = lem_from_seconds(seconds, &runner_id);
-        jobs.push(JobActual {
-            name,
-            runner: runner_id,
-            estimated_lem,
-            actual_seconds: seconds,
-            actual_lem,
-            conclusion: conclusion.unwrap_or_else(|| "success".into()),
-            cache_hit,
-            risk_packs: vec![],
-        });
-    }
+pub fn run(options: ActualsOptions) -> Result<()> {
+    let jobs = if let Some(path) = &options.github_jobs_json {
+        jobs_from_actions_api(path)?
+    } else {
+        synthetic_job(&options)
+    };
 
-    let actuals = Actuals { schema_version: 1, repo, sha, pr, workflow, jobs };
+    let actuals = Actuals {
+        schema_version: 1,
+        repo: options.repo,
+        sha: options.sha,
+        pr: options.pr,
+        workflow: options.workflow,
+        workflow_run_id: options.workflow_run_id,
+        event: options.event,
+        head_branch: options.head_branch,
+        jobs,
+    };
 
-    if let Some(parent) = json_out.parent()
+    if let Some(parent) = options.json_out.parent()
         && !parent.as_os_str().is_empty()
     {
         fs::create_dir_all(parent)?;
     }
     let body = serde_json::to_string_pretty(&actuals)?;
-    fs::write(&json_out, &body).with_context(|| format!("writing {}", json_out.display()))?;
-    println!("ci-actuals: wrote {} ({} jobs)", json_out.display(), actuals.jobs.len());
+    fs::write(&options.json_out, &body)
+        .with_context(|| format!("writing {}", options.json_out.display()))?;
+    if let Some(summary_out) = &options.summary_out {
+        write_summary(&actuals, summary_out)?;
+    }
+    println!("ci-actuals: wrote {} ({} jobs)", options.json_out.display(), actuals.jobs.len());
     Ok(())
+}
+
+fn synthetic_job(options: &ActualsOptions) -> Vec<JobActual> {
+    let mut jobs = Vec::new();
+    if let (Some(name), Some(runner_id), Some(seconds)) =
+        (options.job_name.clone(), options.runner.clone(), options.actual_seconds)
+    {
+        let actual_lem = lem_from_seconds(seconds, &runner_id);
+        jobs.push(JobActual {
+            name,
+            runner: runner_id,
+            estimated_lem: options.estimated_lem,
+            actual_seconds: seconds,
+            actual_lem,
+            conclusion: options.conclusion.clone().unwrap_or_else(|| "success".into()),
+            cache_hit: options.cache_hit,
+            risk_packs: vec![],
+        });
+    }
+    jobs
+}
+
+fn jobs_from_actions_api(path: &Path) -> Result<Vec<JobActual>> {
+    let body = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let response: ActionsJobsResponse =
+        serde_json::from_str(&body).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(response.jobs.into_iter().filter_map(actions_job_to_actual).collect())
+}
+
+fn actions_job_to_actual(job: ActionsJob) -> Option<JobActual> {
+    let started = parse_github_timestamp(job.started_at.as_deref())?;
+    let completed = parse_github_timestamp(job.completed_at.as_deref())?;
+    let seconds = completed.signed_duration_since(started).num_seconds().max(0) as u64;
+    let runner = runner_label(&job);
+    Some(JobActual {
+        name: job.name,
+        runner: runner.clone(),
+        estimated_lem: None,
+        actual_seconds: seconds,
+        actual_lem: lem_from_seconds(seconds, &runner),
+        conclusion: job.conclusion.unwrap_or_else(|| "unknown".into()),
+        cache_hit: false,
+        risk_packs: vec![],
+    })
+}
+
+fn parse_github_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value?).ok().map(|dt| dt.with_timezone(&Utc))
+}
+
+fn runner_label(job: &ActionsJob) -> String {
+    job.labels
+        .iter()
+        .find(|label| {
+            let label = label.to_ascii_lowercase();
+            label.contains("ubuntu")
+                || label.contains("linux")
+                || label.contains("macos")
+                || label.contains("windows")
+                || label.contains("gpu")
+        })
+        .cloned()
+        .or_else(|| job.runner_name.clone())
+        .unwrap_or_else(|| "unknown".into())
+}
+
+fn write_summary(actuals: &Actuals, path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)?;
+    }
+    let mut jobs = actuals.jobs.clone();
+    jobs.sort_by(|a, b| b.actual_lem.total_cmp(&a.actual_lem));
+    let total_lem: f64 = jobs
+        .iter()
+        .filter(|job| !matches!(job.conclusion.as_str(), "skipped" | "cancelled"))
+        .map(|job| job.actual_lem)
+        .sum();
+    let total_seconds: u64 = jobs
+        .iter()
+        .filter(|job| !matches!(job.conclusion.as_str(), "skipped" | "cancelled"))
+        .map(|job| job.actual_seconds)
+        .sum();
+    let mut summary = format!(
+        "## CI Actuals - `{}`\n\n- Jobs: {}\n- Wall time sum: {:.1} min\n- LEM actual: {:.1}\n",
+        actuals.workflow,
+        jobs.len(),
+        total_seconds as f64 / 60.0,
+        total_lem
+    );
+    if !jobs.is_empty() {
+        summary.push_str("\n| Job | Runner | Wall min | LEM | Conclusion |\n");
+        summary.push_str("|---|---|---:|---:|---|\n");
+        for job in jobs.iter().take(15) {
+            summary.push_str(&format!(
+                "| `{}` | `{}` | {:.2} | {:.2} | {} |\n",
+                job.name,
+                job.runner,
+                job.actual_seconds as f64 / 60.0,
+                job.actual_lem,
+                job.conclusion
+            ));
+        }
+    }
+    fs::write(path, summary).with_context(|| format!("writing {}", path.display()))
 }
 
 #[cfg(test)]
@@ -144,5 +292,106 @@ mod tests {
     #[test]
     fn lem_for_unknown_runner_is_1x() {
         assert_eq!(lem_from_seconds(60, "novel-runner"), 1.0);
+    }
+
+    #[test]
+    fn parses_actions_jobs_into_actuals() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("jobs.json");
+        fs::write(
+            &input,
+            r#"{
+              "jobs": [
+                {
+                  "name": "Build",
+                  "conclusion": "success",
+                  "started_at": "2026-05-09T09:00:00Z",
+                  "completed_at": "2026-05-09T09:02:00Z",
+                  "labels": ["ubuntu-22.04"]
+                },
+                {
+                  "name": "macOS",
+                  "conclusion": "success",
+                  "started_at": "2026-05-09T09:00:00Z",
+                  "completed_at": "2026-05-09T09:01:00Z",
+                  "labels": ["macos-14"]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let jobs = jobs_from_actions_api(&input).unwrap();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[0].actual_seconds, 120);
+        assert_eq!(jobs[0].actual_lem, 2.0);
+        assert_eq!(jobs[1].actual_lem, 10.0);
+    }
+
+    #[test]
+    fn skips_actions_jobs_without_complete_timestamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("jobs.json");
+        fs::write(
+            &input,
+            r#"{
+              "jobs": [
+                {
+                  "name": "Pending",
+                  "conclusion": null,
+                  "started_at": "2026-05-09T09:00:00Z",
+                  "completed_at": null,
+                  "labels": ["ubuntu-latest"]
+                }
+              ]
+            }"#,
+        )
+        .unwrap();
+
+        let jobs = jobs_from_actions_api(&input).unwrap();
+        assert!(jobs.is_empty());
+    }
+
+    #[test]
+    fn summary_excludes_skipped_and_cancelled_totals() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("summary.md");
+        let actuals = Actuals {
+            schema_version: 1,
+            repo: "repo".into(),
+            sha: "sha".into(),
+            pr: None,
+            workflow: "CI".into(),
+            workflow_run_id: Some(42),
+            event: Some("pull_request".into()),
+            head_branch: Some("branch".into()),
+            jobs: vec![
+                JobActual {
+                    name: "Build".into(),
+                    runner: "ubuntu-latest".into(),
+                    estimated_lem: None,
+                    actual_seconds: 60,
+                    actual_lem: 1.0,
+                    conclusion: "success".into(),
+                    cache_hit: false,
+                    risk_packs: vec![],
+                },
+                JobActual {
+                    name: "Skipped".into(),
+                    runner: "ubuntu-latest".into(),
+                    estimated_lem: None,
+                    actual_seconds: 600,
+                    actual_lem: 10.0,
+                    conclusion: "skipped".into(),
+                    cache_hit: false,
+                    risk_packs: vec![],
+                },
+            ],
+        };
+
+        write_summary(&actuals, &output).unwrap();
+        let summary = fs::read_to_string(output).unwrap();
+        assert!(summary.contains("LEM actual: 1.0"));
+        assert!(summary.contains("Jobs: 2"));
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1130,8 +1130,18 @@ enum CiCmd {
         conclusion: Option<String>,
         #[arg(long, default_value_t = false)]
         cache_hit: bool,
+        #[arg(long)]
+        workflow_run_id: Option<u64>,
+        #[arg(long)]
+        event: Option<String>,
+        #[arg(long)]
+        head_branch: Option<String>,
+        #[arg(long)]
+        github_jobs_json: Option<PathBuf>,
         #[arg(long, default_value = "target/ci/ci-actuals.json")]
         json_out: PathBuf,
+        #[arg(long)]
+        summary_out: Option<PathBuf>,
     },
 
     /// Compute the per-PR plan (touched areas, expected lanes, estimated LEM).
@@ -1586,20 +1596,30 @@ fn real_main() -> Result<()> {
                 estimated_lem,
                 conclusion,
                 cache_hit,
+                workflow_run_id,
+                event,
+                head_branch,
+                github_jobs_json,
                 json_out,
-            } => ci::actuals::run(
+                summary_out,
+            } => ci::actuals::run(ci::actuals::ActualsOptions {
                 repo,
                 sha,
                 pr,
                 workflow,
-                job,
+                workflow_run_id,
+                event,
+                head_branch,
+                job_name: job,
                 runner,
-                seconds,
+                actual_seconds: seconds,
                 estimated_lem,
                 conclusion,
                 cache_hit,
+                github_jobs_json,
                 json_out,
-            ),
+                summary_out,
+            }),
             CiCmd::Plan {
                 base,
                 head,


### PR DESCRIPTION
## Summary
- add a CI Actuals workflow_run collector that records completed workflow job timing
- move Actions jobs JSON parsing and LEM normalization into xtask ci actuals
- register the advisory ci-actuals lane in the CI policy ledgers

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p xtask --no-default-features ci::actuals
- cargo run --locked -p xtask --no-default-features -- lint-workflows
- cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check --fail-on-error
- smoke: cargo run --locked -p xtask --no-default-features -- ci actuals --github-jobs-json <fixture> --json-out <tmp>/ci-actuals.json --summary-out <tmp>/summary.md

Note: ci-lane-whitelist still reports the pre-existing duplicate_of warnings for ci-core-docs/docs-automation and ripr-advisory/mutation-nightly.