### PR TITLE
fix(cli): use real generation in inference repl

### DIFF
--- a/crates/bitnet-cli/src/commands/inference.rs
+++ b/crates/bitnet-cli/src/commands/inference.rs
@@ -511,7 +511,7 @@ impl InferenceCommand {
 
         // Execute based on mode
         match (self.interactive, self.input_file.as_ref(), self.prompt.as_ref()) {
-            (true, _, _) => self.run_interactive_mode(engine, tokenizer).await,
+            (true, _, _) => self.run_interactive_mode(engine).await,
             (false, Some(file), _) => self.run_batch_mode(engine, tokenizer, file).await,
             (false, None, Some(prompt)) => {
                 self.run_single_inference(engine, tokenizer, prompt).await
@@ -1249,19 +1249,12 @@ impl InferenceCommand {
     }
 
     /// Run interactive mode
-    async fn run_interactive_mode(
-        &self,
-        engine: InferenceEngine,
-        tokenizer: Arc<dyn bitnet_tokenizers::Tokenizer + Send + Sync>,
-    ) -> Result<()> {
-        // Temporary: keep references alive; TODO(use in REPL)
-        let _keep_alive = (&engine, &tokenizer);
-
+    async fn run_interactive_mode(&self, engine: InferenceEngine) -> Result<()> {
         println!("{}", style("BitNet Interactive Mode").bold().cyan());
         println!("Type your prompts below. Press Ctrl+C to exit, Ctrl+D for new session.\n");
 
         let mut conversation_history = Vec::new();
-        let _config = self.create_generation_config()?;
+        let config = self.create_generation_config()?;
 
         loop {
             // Get user input
@@ -1289,7 +1282,11 @@ impl InferenceCommand {
                             continue;
                         }
                         "/metrics" => {
-                            // Show current metrics
+                            println!("Messages in conversation: {}", conversation_history.len());
+                            println!(
+                                "Streaming: {}",
+                                if self.stream { "enabled" } else { "disabled" }
+                            );
                             continue;
                         }
                         "/exit" | "/quit" => break,
@@ -1302,29 +1299,49 @@ impl InferenceCommand {
                     } else {
                         input.to_string()
                     };
-                    // TODO: use prompt in generation
-                    let _ = &prompt;
 
                     // Generate response
                     let start_time = Instant::now();
 
-                    // Placeholder implementation
-                    let response = format!("Response to: {}", input);
+                    let response_result: Result<String> = if self.stream {
+                        engine.reset_decoded_tokens();
+                        let tokenizer = engine.tokenizer();
+                        let engine_config =
+                            self.to_engine_config(&config, Some(tokenizer.as_ref()));
+                        let stream = engine.generate_stream_with_config(&prompt, &engine_config);
 
-                    if self.stream {
                         print!("{} ", style("Assistant:").bold().blue());
                         io::stdout().flush()?;
 
-                        // Simulate streaming
-                        for char in response.chars() {
-                            print!("{}", char);
+                        let mut response = String::new();
+                        let mut stream = stream?;
+                        while let Some(chunk) = stream.next().await {
+                            let chunk = chunk?;
+                            engine.inc_decoded_tokens_by(chunk.token_ids.len());
+                            print!("{}", chunk.text);
                             io::stdout().flush()?;
-                            tokio::time::sleep(Duration::from_millis(30)).await;
+                            response.push_str(&chunk.text);
                         }
-                        println!(); // New line
+                        println!();
+                        Ok(response)
                     } else {
+                        let tokenizer = engine.tokenizer();
+                        let engine_config =
+                            self.to_engine_config(&config, Some(tokenizer.as_ref()));
+                        let response = engine.generate_with_config(&prompt, &engine_config).await?;
                         println!("{} {}", style("Assistant:").bold().blue(), response);
-                    }
+                        Ok(response)
+                    };
+
+                    let response = match response_result {
+                        Ok(response) => response,
+                        Err(e) => {
+                            error!("Inference failed: {}", e);
+                            println!("{}", style(format!("Error: {}", e)).red());
+                            println!();
+                            continue;
+                        }
+                    };
 
                     conversation_history.push((input.to_string(), response));
 


### PR DESCRIPTION
## Summary
- replace the legacy `bitnet inference --interactive` placeholder echo with real engine generation
- support both streaming and non-streaming REPL turns through the existing engine config path
- keep the REPL alive on per-turn generation errors and make `/metrics` print basic session state

## Validation
- cargo fmt --all -- --check
- cargo check --locked -p bitnet-cli --no-default-features --features cpu,full-cli
- cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli cli_arg
- git diff --check

## Manual smoke
Attempted a piped REPL smoke with `tests/models/mini.gguf`, but that fixture is not runnable as a generation model: it fails during model load with `GGUF: missing embedding tensor`. No runnable tiny GGUF fixture was available in-repo for a real generation smoke.