### PR TITLE
docs(devex): prefer no-default-features for xtask examples

### DIFF
--- a/.github/CI_INTEGRATION.md
+++ b/.github/CI_INTEGRATION.md
@@ -13,7 +13,7 @@ Add this step to your main CI workflow (after benchmark writes `ci/inference.jso
   # Only run if receipt exists (until microbench is implemented)
   if: hashFiles('ci/inference.json') != ''
   run: |
-    cargo run -p xtask -- verify-receipt --path ci/inference.json
+    cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json
 ```
 
 **Location:** Add after your inference benchmark step, before any artifact uploads.
@@ -30,7 +30,7 @@ For GPU CI lanes, add GPU-specific verification:
 - name: Verify GPU receipt (requires GPU kernels)
   if: matrix.backend == 'cuda' || matrix.backend == 'gpu'
   run: |
-    cargo run -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
+    cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
 ```
 
 **Important:** This step will fail if:
@@ -61,11 +61,11 @@ jobs:
 
       # TODO: Add microbench step here
       # - name: Run CPU microbench
-      #   run: cargo run -p xtask -- benchmark --tokens 128 --deterministic
+      #   run: cargo run --no-default-features -p xtask -- benchmark --tokens 128 --deterministic
 
       - name: Verify CPU receipt (strict)
         if: hashFiles('ci/inference.json') != ''
-        run: cargo run -p xtask -- verify-receipt --path ci/inference.json
+        run: cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json
 
   test-gpu:
     runs-on: [self-hosted, cuda]
@@ -83,11 +83,11 @@ jobs:
 
       # TODO: Add GPU microbench step here
       # - name: Run GPU microbench
-      #   run: cargo run -p xtask -- benchmark --backend gpu --tokens 128 --deterministic
+      #   run: cargo run --no-default-features -p xtask --features gpu -- benchmark --backend gpu --tokens 128 --deterministic
 
       - name: Verify GPU receipt (requires GPU kernels)
         if: hashFiles('ci/inference.json') != ''
-        run: cargo run -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
+        run: cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
 ```
 
 ## Branch Protection
@@ -119,7 +119,7 @@ cat > ci/inference.json << 'EOF'
 EOF
 
 # Verify it passes
-cargo run -p xtask -- verify-receipt --path ci/inference.json
+cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json
 
 # Should output:
 # ✅ Receipt verification passed

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
       description: |
         Provide clear steps to reproduce the bug, including commands, environment details, and expected vs actual behavior.
       placeholder: |
-        1. Download model: `cargo run -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf`
+        1. Download model: `cargo run --no-default-features -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf`
         2. Run inference: `cargo run -p bitnet-cli --features cpu -- run --model model.gguf --prompt "Test"`
         3. See error: ...
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ warn_once!("unique_key", "message shown only once at WARN, then at DEBUG");
 ```
 
 ### Receipts
-Benchmarks write a receipt to `ci/inference.json` (schema v1.0.0). `compute_path` must be `"real"` — never `"mock"`. Verify with `cargo run -p xtask -- verify-receipt`.
+Benchmarks write a receipt to `ci/inference.json` (schema v1.0.0). `compute_path` must be `"real"` — never `"mock"`. Verify with `cargo run --no-default-features -p xtask -- verify-receipt`.
 
 ### BITNET_STRICT_MODE
 When `BITNET_STRICT_MODE=1`: validation fails with exit code 8 on suspicious LayerNorm weights, `BITNET_GPU_FAKE` is ignored, and mock inference paths are rejected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,13 +168,13 @@ See [ROADMAP.md](ROADMAP.md) for the project's current direction and priorities.
 3. **Use xtask Commands**
    ```bash
    # Download test models
-   cargo run --locked -p xtask -- download-model
+   cargo run --locked --no-default-features -p xtask -- download-model
 
    # Verify implementation
-   cargo run --locked -p xtask -- verify --model models/test.gguf
+   cargo run --locked --no-default-features -p xtask -- verify --model models/test.gguf
 
    # Cross-validate against C++ reference
-   cargo run --locked -p xtask -- crossval
+   cargo run --locked --no-default-features -p xtask -- crossval
    ```
 
 ### Workflow Boundary
@@ -622,10 +622,10 @@ Before submitting a PR, ensure:
 6. **Verify Inference Receipt** (if you have ci/inference.json)
    ```bash
    # Verify CPU receipt
-   cargo run --locked -p xtask -- verify-receipt --path ci/inference.json
+   cargo run --locked --no-default-features -p xtask -- verify-receipt --path ci/inference.json
 
    # Verify GPU receipt (requires GPU kernels)
-   cargo run --locked -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
+   cargo run --locked --no-default-features -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
    ```
 
 7. **Update Documentation**
@@ -635,7 +635,7 @@ Before submitting a PR, ensure:
 
 8. **Cross-validate Changes** (optional, for inference changes)
    ```bash
-   cargo run --locked -p xtask -- full-crossval
+   cargo run --locked --no-default-features -p xtask -- full-crossval
    ```
 
 ### PR Requirements

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -5,7 +5,7 @@ BitNet-rs. It is enforced by:
 
 * `[workspace.lints.clippy]` in the root `Cargo.toml` (lands staged in
   PR 08 and is promoted in PR 12).
-* `cargo run -p xtask -- check-clippy-exceptions` (added in PR 06),
+* `cargo run --no-default-features -p xtask -- check-clippy-exceptions` (added in PR 06),
   which validates every receipt in `policy/clippy-exceptions.toml`
   and rejects bare `#[allow(clippy::...)]` shapes.
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -66,7 +66,7 @@ If a new file legitimately belongs in the repository:
 2. If it is a genuinely new surface (e.g. a new GPU backend with its
    own shader directory), add a new `[[allow]]` block with a real
    `owner`, `surface`, `classification`, and `covered_by`.
-3. Run `cargo run -p xtask -- check-file-policy` locally; the file
+3. Run `cargo run --no-default-features -p xtask -- check-file-policy` locally; the file
    should disappear from the findings.
 4. Open the PR with the new entry. Policy review is part of normal
    PR review.

--- a/docs/GPU_DEVELOPMENT_WORKFLOW.md
+++ b/docs/GPU_DEVELOPMENT_WORKFLOW.md
@@ -107,7 +107,7 @@ Brief description of what this PR does.
 ### Performance (if applicable)
 - [ ] Benchmark results included in PR description
 - [ ] No regression on existing benchmarks
-- [ ] Receipt verification passes: `cargo run -p xtask -- verify-receipt`
+- [ ] Receipt verification passes: `cargo run --no-default-features -p xtask -- verify-receipt`
 
 ## Hardware Tested On
 
@@ -240,7 +240,7 @@ system tracks inference performance with schema v1.0.0.
 cargo bench --bench srp_ops
 
 # Full inference benchmark (requires model file)
-BITNET_GGUF=models/model.gguf cargo run -p xtask -- verify-receipt
+BITNET_GGUF=models/model.gguf cargo run --no-default-features -p xtask -- verify-receipt
 
 # With native SIMD optimisation
 RUSTFLAGS="-C target-cpu=native -C opt-level=3 -C lto=thin" \
@@ -253,10 +253,10 @@ After any inference-affecting change, verify the receipt:
 
 ```bash
 # CPU receipt
-cargo run -p xtask -- verify-receipt --path ci/inference.json
+cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json
 
 # GPU receipt (requires GPU kernels)
-cargo run -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
+cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json --require-gpu-kernels
 ```
 
 The receipt enforces 8 validation gates including `compute_path = "real"` (never `"mock"`).
@@ -275,7 +275,7 @@ The receipt enforces 8 validation gates including `compute_path = "real"` (never
 | Format | `cargo fmt --all` |
 | Benchmark | `cargo bench --bench srp_ops` |
 | Guards | `make guards` |
-| Verify receipt | `cargo run -p xtask -- verify-receipt --path ci/inference.json` |
+| Verify receipt | `cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json` |
 
 ---
 

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -36,10 +36,10 @@ identity, so the receipt keeps matching across small edits.
 
 ## Workflow
 
-1. Run `cargo run -p xtask -- check-no-panic-family` locally; this
+1. Run `cargo run --no-default-features -p xtask -- check-no-panic-family` locally; this
    reports unallowlisted findings without changing the allowlist.
 2. If a finding is real debt that cannot yet be removed, run
-   `cargo run -p xtask -- no-panic propose` (later PR) — it writes a
+   `cargo run --no-default-features -p xtask -- no-panic propose` (later PR) — it writes a
    draft receipt to `target/bitnet/reports/no-panic-proposed-allowlist.toml`
    for the human to edit and copy in.
 3. The real allowlist is `policy/no-panic-allowlist.toml`. Auto-tools

--- a/docs/benchmarking-setup.md
+++ b/docs/benchmarking-setup.md
@@ -255,10 +255,10 @@ ls -la scripts/
 
 ```bash
 # Verify model integrity
-cargo run -p xtask -- verify --model "path/to/model.gguf"
+cargo run --no-default-features -p xtask -- verify --model "path/to/model.gguf"
 
 # Test inference
-cargo run -p xtask -- infer \
+cargo run --no-default-features -p xtask -- infer \
     --model "path/to/model.gguf" \
     --prompt "Test" \
     --max-new-tokens 10 \

--- a/docs/ci/CHECKLIST.md
+++ b/docs/ci/CHECKLIST.md
@@ -136,12 +136,12 @@ Use this checklist to ensure successful deployment of the cross-validation CI wo
 
 - [ ] Run auto-setup:
   ```bash
-  eval "$(cargo run -p xtask -- setup-cpp-auto --emit=sh)"
+  eval "$(cargo run --no-default-features -p xtask -- setup-cpp-auto --emit=sh)"
   ```
 
 - [ ] Verify preflight:
   ```bash
-  cargo run -p xtask --features crossval-all -- preflight --verbose
+  cargo run --no-default-features -p xtask --features crossval-all -- preflight --verbose
   ```
 
 - [ ] Expected output: "✓ llama.cpp: AVAILABLE"
@@ -150,7 +150,7 @@ Use this checklist to ensure successful deployment of the cross-validation CI wo
 
 - [ ] Download test model:
   ```bash
-  cargo run -p xtask -- download-model
+  cargo run --no-default-features -p xtask -- download-model
   ```
 
 - [ ] Run cross-validation tests:
@@ -167,7 +167,7 @@ Use this checklist to ensure successful deployment of the cross-validation CI wo
 
 - [ ] Run per-token check:
   ```bash
-  cargo run -p xtask --features crossval-all -- crossval-per-token \
+  cargo run --no-default-features -p xtask --features crossval-all -- crossval-per-token \
     --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
     --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
     --prompt "What is 2+2?" \

--- a/docs/ci/SETUP.md
+++ b/docs/ci/SETUP.md
@@ -187,7 +187,7 @@ Ensure local xtask supports cross-validation:
 
 ```bash
 # Check xtask features
-cargo run -p xtask -- --help | grep crossval
+cargo run --no-default-features -p xtask -- --help | grep crossval
 
 # Expected output:
 #   crossval-per-token  Per-token parity comparison
@@ -199,10 +199,10 @@ cargo run -p xtask -- --help | grep crossval
 
 ```bash
 # Auto-setup (recommended)
-eval "$(cargo run -p xtask -- setup-cpp-auto --emit=sh)"
+eval "$(cargo run --no-default-features -p xtask -- setup-cpp-auto --emit=sh)"
 
 # Verify setup
-cargo run -p xtask --features crossval-all -- preflight --verbose
+cargo run --no-default-features -p xtask --features crossval-all -- preflight --verbose
 
 # Expected output:
 # ✓ llama.cpp: AVAILABLE
@@ -213,7 +213,7 @@ cargo run -p xtask --features crossval-all -- preflight --verbose
 
 ```bash
 # Download test model
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # Run local cross-validation
 cargo test -p bitnet-crossval \
@@ -222,7 +222,7 @@ cargo test -p bitnet-crossval \
   -- --nocapture
 
 # Per-token parity check
-cargo run -p xtask --features crossval-all -- crossval-per-token \
+cargo run --no-default-features -p xtask --features crossval-all -- crossval-per-token \
   --model models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf \
   --tokenizer models/microsoft-bitnet-b1.58-2B-4T-gguf/tokenizer.json \
   --prompt "What is 2+2?" \
@@ -271,7 +271,7 @@ Placeholder for performance baseline tracking:
 
 ```bash
 # TODO: Implement baseline comparison
-# cargo run -p xtask -- compare-baselines \
+# cargo run --no-default-features -p xtask -- compare-baselines \
 #   --current crossval/results/latest.json \
 #   --baseline baselines/crossval-baseline.json
 ```
@@ -304,7 +304,7 @@ The cross-validation commands are already documented in `CLAUDE.md`:
 ./scripts/run_crossval_sweep.sh model.gguf tokenizer.json /tmp/crossval
 
 # Per-token logits divergence detection
-cargo run -p xtask --features crossval-all -- crossval-per-token \
+cargo run --no-default-features -p xtask --features crossval-all -- crossval-per-token \
   --model models/model.gguf \
   --tokenizer models/tokenizer.json \
   --prompt "What is 2+2?" \
@@ -377,7 +377,7 @@ ls -la ~/.cache/bitnet_cpp/build
 ```bash
 # Clean and rebuild
 rm -rf ~/.cache/llama_cpp ~/.cache/bitnet_cpp
-eval "$(cargo run -p xtask -- setup-cpp-auto --emit=sh)"
+eval "$(cargo run --no-default-features -p xtask -- setup-cpp-auto --emit=sh)"
 ```
 
 ## Validation Checklist

--- a/docs/ci/ci-lane-whitelist.md
+++ b/docs/ci/ci-lane-whitelist.md
@@ -85,7 +85,7 @@ When adding or modifying a CI workflow:
    `policy/ci-whitelist-exceptions.toml` with a real expiry.
 3. If the lane duplicates an existing proof obligation, set
    `duplicate_of` to the other lane's `id`.
-4. Confirm `cargo run -p xtask -- ci-lane-whitelist check` passes
+4. Confirm `cargo run --no-default-features -p xtask -- ci-lane-whitelist check` passes
    (added in PR 02 of the rollout).
 
 ## Status

--- a/docs/ci/crossval-quick-reference.md
+++ b/docs/ci/crossval-quick-reference.md
@@ -251,7 +251,7 @@ cargo test -p bitnet-crossval --features cpu,ffi,crossval \
   --test dual_backend_integration -- --nocapture
 
 # Per-token parity
-cargo run -p xtask --features crossval-all -- crossval-per-token \
+cargo run --no-default-features -p xtask --features crossval-all -- crossval-per-token \
   --model models/model.gguf \
   --tokenizer models/tokenizer.json \
   --prompt "Test" \

--- a/docs/ci/guardrails.md
+++ b/docs/ci/guardrails.md
@@ -246,13 +246,13 @@ Receipt verification ensures **honest compute** by validating inference executio
 
 ```bash
 # Generate receipt (writes to ci/inference.json)
-cargo run -p xtask -- benchmark --model models/model.gguf --tokens 128
+cargo run --no-default-features -p xtask -- benchmark --model models/model.gguf --tokens 128
 
 # Verify receipt
-cargo run -p xtask -- verify-receipt
+cargo run --no-default-features -p xtask -- verify-receipt
 
 # Verify with GPU kernel requirement
-cargo run -p xtask -- verify-receipt --require-gpu-kernels
+cargo run --no-default-features -p xtask -- verify-receipt --require-gpu-kernels
 ```
 
 ### CI Integration
@@ -375,7 +375,7 @@ gh workflow run repin-actions.yml
 **Fix**: Ensure GPU inference actually runs GPU kernels (check for silent CPU fallback):
 ```bash
 # Verify GPU availability
-cargo run -p xtask -- gpu-preflight
+cargo run --no-default-features -p xtask -- gpu-preflight
 
 # Check receipt kernel IDs
 jq '.kernels' ci/inference.json
@@ -422,4 +422,4 @@ BitNet-rs guardrails ensure:
 
 **Local preflight**: `make guards`
 **Automated repin**: `gh workflow run repin-actions.yml`
-**Receipt verification**: `cargo run -p xtask -- verify-receipt`
+**Receipt verification**: `cargo run --no-default-features -p xtask -- verify-receipt`

--- a/docs/ci/learned-budgets.md
+++ b/docs/ci/learned-budgets.md
@@ -64,7 +64,7 @@ Records without a `lane` field are skipped.
 ## CLI
 
 ```bash
-cargo run -p xtask -- ci estimate \
+cargo run --no-default-features -p xtask -- ci estimate \
   --history .ci/metrics/ci-lane-history.jsonl \
   --lanes-toml policy/ci-lanes.toml \
   --json-out target/ci/ci-lane-estimates.json \

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,7 +22,7 @@ This is the main development guide for BitNet-rs, providing an overview of devel
 
 3. **Download Models for Testing**
    ```bash
-   cargo run -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf
+   cargo run --no-default-features -p xtask -- download-model --id microsoft/bitnet-b1.58-2B-4T-gguf
    ```
 
 ## Development Workflows
@@ -47,13 +47,13 @@ cargo test --package bitnet-quantization --no-default-features --features cpu
 
 ```bash
 # Cross-validate against C++ reference
-cargo run -p xtask -- crossval
+cargo run --no-default-features -p xtask -- crossval
 
 # Verify model compatibility
-cargo run -p xtask -- verify --model models/test.gguf
+cargo run --no-default-features -p xtask -- verify --model models/test.gguf
 
 # Benchmark performance
-cargo run -p xtask -- benchmark --model models/test.gguf --tokens 128
+cargo run --no-default-features -p xtask -- benchmark --model models/test.gguf --tokens 128
 ```
 
 ## Development Guides

--- a/docs/development/ci-integration.md
+++ b/docs/development/ci-integration.md
@@ -239,9 +239,9 @@ BITNET_TEST_SMART_SELECTION: true
   - Verify kernel IDs are populated from actual execution
   - Check backend-kernel alignment (GPU receipts need GPU kernels)
 - **Prevention**:
-  - Use `cargo run -p xtask -- benchmark` to generate valid receipts
+  - Use `cargo run --no-default-features -p xtask -- benchmark` to generate valid receipts
   - Test with example receipts: `docs/tdd/receipts/cpu_positive_example.json`
-  - Validate locally: `cargo run -p xtask -- verify-receipt --path ci/inference.json`
+  - Validate locally: `cargo run --no-default-features -p xtask -- verify-receipt --path ci/inference.json`
 
 ### Debug Information
 

--- a/docs/development/cross-validation-setup.md
+++ b/docs/development/cross-validation-setup.md
@@ -124,7 +124,7 @@ Before running cross-validation tests, you need to provision a GGUF model. The t
 
 ```bash
 # Provision the default model (recommended)
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # This downloads to: models/microsoft-bitnet-b1.58-2B-4T-gguf/ggml-model-i2_s.gguf
 # Tests will auto-discover this location
@@ -142,7 +142,7 @@ cargo test -p bitnet-models --no-default-features --features crossval
 ```
 
 **Troubleshooting:**
-- If tests fail with "No model found", run `cargo run -p xtask -- download-model` first
+- If tests fail with "No model found", run `cargo run --no-default-features -p xtask -- download-model` first
 - The model file is ~2GB and ignored by git (in `.gitignore`)
 - Each developer/CI machine needs to provision the model once
 
@@ -152,7 +152,7 @@ The easiest way to set up cross-validation:
 
 ```bash
 # 1. Provision GGUF model (one-time setup)
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # 2. C++ reference (REQUIRED - tests will fail if not present)
 ./ci/fetch_bitnet_cpp.sh
@@ -377,13 +377,13 @@ No model found for cross-validation testing.
 
 To provision a model, run:
 
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 ```
 
 **Solution:**
 ```bash
 # Provision the default model
-cargo run -p xtask -- download-model
+cargo run --no-default-features -p xtask -- download-model
 
 # Or use a custom model
 export BITNET_GGUF=/path/to/your/model.gguf

--- a/docs/development/gpu-development.md
+++ b/docs/development/gpu-development.md
@@ -47,7 +47,7 @@ match preflight_check() {
 cargo test --no-default-features -p bitnet-kernels --no-default-features --features cpu test_gpu_info_summary
 
 # Run xtask commands with GPU detection
-cargo run -p xtask -- download-model  # Uses GPU detection for optimizations
+cargo run --no-default-features -p xtask -- download-model  # Uses GPU detection for optimizations
 
 # Mock GPU scenarios for testing (see Testing section)
 BITNET_GPU_FAKE="cuda,rocm" cargo test --no-default-features -p bitnet-kernels --no-default-features --features cpu test_gpu_info_mocked_scenarios
@@ -1341,7 +1341,7 @@ BitNet-rs now provides comprehensive memory debugging capabilities with stack tr
    which nvidia-smi rocm-smi
 
    # Test with mock environment
-   BITNET_GPU_FAKE="cuda" cargo run -p xtask -- download-model --dry-run
+   BITNET_GPU_FAKE="cuda" cargo run --no-default-features -p xtask -- download-model --dry-run
    ```
 
 2. **Incorrect Backend Detection**:

--- a/docs/development/test-suite.md
+++ b/docs/development/test-suite.md
@@ -40,8 +40,8 @@ cargo test --workspace --no-default-features --features gpu
 BITNET_SKIP_SLOW_TESTS=1 cargo test --workspace --no-default-features --features cpu
 
 # BDD compile-coverage check (feature-matrix grid)
-cargo run -p xtask -- grid-check
-cargo run -p xtask -- grid-check --dry-run   # show what would be checked
+cargo run --no-default-features -p xtask -- grid-check
+cargo run --no-default-features -p xtask -- grid-check --dry-run   # show what would be checked
 
 # Run including ignored tests (will encounter blocked tests)
 cargo test --workspace --no-default-features --features cpu -- --ignored --include-ignored
@@ -222,7 +222,7 @@ cargo test --no-default-features -p bitnet-kernels --no-default-features --featu
 cargo test --no-default-features --workspace --no-default-features --features "cpu,ffi,crossval"
 
 # Full cross-validation workflow
-cargo run -p xtask -- full-crossval
+cargo run --no-default-features -p xtask -- full-crossval
 
 # Cross-validation with concurrency caps
 scripts/preflight.sh && cargo crossval-capped

--- a/docs/development/validation-framework.md
+++ b/docs/development/validation-framework.md
@@ -95,7 +95,7 @@ scripts/nll-parity.sh
 # Full cross-validation (deterministic)
 export BITNET_GGUF="$PWD/models/bitnet/ggml-model-i2_s.gguf"
 export BITNET_DETERMINISTIC=1 BITNET_SEED=42
-cargo run -p xtask -- full-crossval
+cargo run --no-default-features -p xtask -- full-crossval
 
 # Model compatibility validation with weight mapper
 cargo test --no-default-features --features cpu -p crossval --no-default-features test_validate_model_compatibility

--- a/docs/development/xtask.md
+++ b/docs/development/xtask.md
@@ -98,7 +98,7 @@ models/
 Check system capabilities for BitNet-rs (GPU detection, features).
 
 ```bash
-cargo run -p xtask -- preflight
+cargo run --no-default-features -p xtask -- preflight
 ```
 
 **Output Example**:
@@ -126,7 +126,7 @@ Device Capabilities:
 Advanced GPU preflight check with multiple output formats.
 
 ```bash
-cargo run -p xtask -- gpu-preflight [--require] [--format json|text]
+cargo run --no-default-features -p xtask -- gpu-preflight [--require] [--format json|text]
 ```
 
 **Flags**:


### PR DESCRIPTION
## Summary
- update active contributor, development, CI, and policy docs to show xtask examples with --no-default-features
- keep GPU examples explicit by pairing --no-default-features with --features gpu where the example intentionally uses GPU benchmarking
- leave tutorials/reference/generated/archive surfaces for separate focused passes

## Validation
- cargo check --locked --no-default-features -p xtask
- cargo run --locked --no-default-features -p xtask -- --help
- cargo run --locked --no-default-features -p xtask -- verify-receipt --help
- cargo fmt --all -- --check
- git diff --check
- rg scan for bare active-doc xtask examples