### PR TITLE
[codex][tracker] Close TRACKER-003

### DIFF
--- a/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
+++ b/docs/tracking/campaigns/tracker-infra/CAMPAIGN.md
@@ -28,7 +28,7 @@ Finish the move from global hand-edited alignment trackers to campaign-local TOM
 |---|---|---|
 | TRACKER-001 | merged | Advisory campaign check/generate/doctor commands and generated dashboards merged in #3660. |
 | TRACKER-002 | merged | CI enforcement for campaign doctor and generated-dashboard freshness merged in #3681. |
-| TRACKER-003 | pr_open | Scope live GitHub PR reconciliation to the current PR in pull-request CI to avoid cross-branch campaign deadlocks; open in #3724. |
+| TRACKER-003 | merged | Scope live GitHub PR reconciliation to the current PR in pull-request CI to avoid cross-branch campaign deadlocks; merged in #3724. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/tracker-infra/active.toml
+++ b/docs/tracking/campaigns/tracker-infra/active.toml
@@ -93,7 +93,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "TRACKER-003"
-status = "pr_open"
+status = "merged"
+pr = 3724
+merge_sha = "6f44b77538492182e1a33484ff6683fa2debd8ee"
 branch = "codex/tracker-infra/TRACKER-003-current-pr-reconciliation"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/tracker-infra/events/2026-05-09T105000Z-TRACKER-003-merged.toml
+++ b/docs/tracking/campaigns/tracker-infra/events/2026-05-09T105000Z-TRACKER-003-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-09T10:50:00Z"
+campaign = "tracker-infra"
+item = "TRACKER-003"
+event = "merged"
+from = "pr_open"
+to = "merged"
+pr = 3724
+merge_sha = "6f44b77538492182e1a33484ff6683fa2debd8ee"
+actor = "codex"
+branch = "codex/tracker-infra/TRACKER-003-current-pr-reconciliation"
+summary = "Closed TRACKER-003 after GitHub reported PR #3724 merged."
+notes = [
+  "Campaign doctor reported TRACKER-003 as stale pr_open because GitHub PR #3724 had already merged.",
+  "This tracker-only closeout unblocks generated dashboard checks for unrelated campaign branches.",
+]

--- a/docs/tracking/campaigns/tracker-infra/generated/status.md
+++ b/docs/tracking/campaigns/tracker-infra/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | TRACKER-001 | merged | #3660 | `codex/tracker-infra/TRACKER-001-campaign-local-gates` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add campaign-local tracker model docs, missing campaign manifests, append-only event rules, advisory xtask campaign check/generate/doctor commands, and generated global dashboards. |
 | TRACKER-002 | merged | #3681 | `codex/tracker-infra/TRACKER-002-ci-enforcement` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add CI enforcement for campaign doctor and generated-dashboard freshness after the advisory tracker gate has landed, with stale generated dashboards and normal legacy tracker edits treated as hard failures. |
-| TRACKER-003 | pr_open | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
+| TRACKER-003 | merged | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| tracker-infra | TRACKER-003 | #3724 | `codex/tracker-infra/TRACKER-003-current-pr-reconciliation` | Scope GitHub PR reconciliation to the current pull request in PR CI so parallel campaign branches do not need to carry each other's item TOML changes. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -192,7 +192,7 @@
 | slm-cpu | SLM-CPU-007B | SLM-CPU-007A | merged |
 | slm-cpu | SLM-CPU-008 | SLM-CPU-007B | ready |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
-| tracker-infra | TRACKER-003 | TRACKER-002 | pr_open |
+| tracker-infra | TRACKER-003 | TRACKER-002 | merged |
 | wasm-inference | WASM-002 | WASM-001 | ready |
 | wasm-inference | WASM-003 | WASM-002 | ready |
 | wasm-inference | WASM-004 | WASM-003 | ready |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -25,5 +25,5 @@
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
-| tracker-infra | TRACKER-003 | #3724 | pr_open | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
+| tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-001 | TBD | ready | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- mark TRACKER-003 merged after GitHub reported #3724 merged
- add merged event with merge SHA `6f44b77538492182e1a33484ff6683fa2debd8ee`
- remove TRACKER-003 from active PR dashboards

## Why
`campaign doctor` is failing unrelated PRs because TRACKER-003 is stale `pr_open` while GitHub reports #3724 merged.

## Verification
- `python` TOML parse for tracker-infra and intel-258v-platform active files
- `git diff --check`