### PR TITLE
fix(cuda): align attention score fixture gap order

### DIFF
--- a/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-09/dense-gguf-attention-score-fixture-qwen25-q8.json
+++ b/ci/hardware/windows-9950x3d-rtx5070ti/2026-05-09/dense-gguf-attention-score-fixture-qwen25-q8.json
@@ -51,7 +51,6 @@
     "bitnet_packed_i2s_qk256_proof": false,
     "blocks_strict_cuda_one_layer": true,
     "candidate_order": [
-      "attention_scores",
       "attention_softmax",
       "attention_v_mix",
       "mlp_activation"


### PR DESCRIPTION
## Summary
- remove the now-routable `attention_scores` role from the committed attention-score fixture gap candidate order
- keep the fixture aligned with the governed dense one-layer gap order after attention-score CUDA routing landed

## Verification
- cargo test --locked -p bitnet-receipts --test cuda_receipt_validation committed_dense_gguf_attention_score_fixture_receipt_validates -- --exact --nocapture
- cargo test --locked -p bitnet-receipts --test cuda_receipt_validation dense_gguf_attention_score_fixture_rejects_cuda_parity_claim -- --exact --nocapture
- cargo test --locked -p bitnet-receipts --test cuda_receipt_validation -- --nocapture
- git diff --check