### PR TITLE
[codex] Skip fuzz build for docs-only PRs

### DIFF
--- a/.github/workflows/fuzz-ci.yml
+++ b/.github/workflows/fuzz-ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'crates/**'
+      - 'fuzz/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - '.cargo/**'
+      - '.github/workflows/fuzz-ci.yml'
   workflow_dispatch: {}
   schedule:
     # Run nightly fuzz sessions at 02:00 UTC

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -72,6 +72,12 @@ verification:
 - high-cost validation should require explicit labels, main-branch execution,
   nightly execution, release gates, or campaign gates.
 
+PR-time fuzz target builds follow that routing rule: they run for changes to
+the fuzz harness, Rust crates, lockfiles, toolchain, Cargo configuration, or
+the fuzz workflow itself. Docs / tracking-only PRs use the docs and campaign
+tracker lanes instead of spending CI minutes compiling fuzz targets that
+cannot be affected by the diff.
+
 The goal is not to spend less by testing less. **The goal is to spend less on
 unrelated work so we can afford more verification where the change actually
 creates risk.**
@@ -170,7 +176,7 @@ surface**, not test adequacy or model quality.
 
 ### What coverage answers
 
-Coverage tells us: _Did tests exercise this Rust code?_
+Coverage tells us: *Did tests exercise this Rust code?*
 
 It does **not** tell us:
 


### PR DESCRIPTION
## Summary

- Add a pull-request path filter to `Fuzz CI` so PR-time fuzz target builds only run when Rust crates, fuzz harnesses, lockfiles, toolchain, Cargo config, or the workflow itself change.
- Document that docs/tracking-only PRs should rely on docs and campaign tracker lanes instead of unrelated fuzz compilation.
- Clean up one markdown emphasis-style warning in the touched policy document.

## Why

Docs and tracking-only PRs were still paying for the representative fuzz target build even though those diffs cannot affect fuzz target compilation. This keeps scheduled/manual fuzz coverage intact and preserves main-push behavior while removing an unrelated PR-time lane.

## Review follow-up

Agent review caught that `.cargo/config.toml` can affect fuzz compilation. The path filter now includes `.cargo/**` so Cargo configuration changes still trigger the fuzz compile check.

## Validation

- `cargo run --locked -p xtask --no-default-features -- lint-workflows`
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc docs/ci/cost-and-verification-policy.md`
- `git diff --check`