### PR TITLE
fix(models): remove GGUF loader identity shift

### DIFF
--- a/crates/bitnet-models/src/formats/gguf/loader.rs
+++ b/crates/bitnet-models/src/formats/gguf/loader.rs
@@ -1460,7 +1460,7 @@ impl GgufLoader {
                 for l in 0..32 {
                     let is = l / 16;
                     let qh_l = qh[qh_offset + l];
-                    let q1 = i32::from((ql[ql_offset + l] & 0x0f) | (((qh_l >> 0) & 3) << 4)) - 32;
+                    let q1 = i32::from((ql[ql_offset + l] & 0x0f) | ((qh_l & 3) << 4)) - 32;
                     let q2 =
                         i32::from((ql[ql_offset + l + 32] & 0x0f) | (((qh_l >> 2) & 3) << 4)) - 32;
                     let q3 = i32::from((ql[ql_offset + l] >> 4) | (((qh_l >> 4) & 3) << 4)) - 32;


### PR DESCRIPTION
## Summary
- remove the no-op `>> 0` in GGUF loader unpacking that Rust 1.93 clippy flags as `identity_op`
- keep the QK/K quantization math unchanged

## Verification
- `cargo clippy --locked -p bitnet-models --lib --no-default-features --features cpu -- -D warnings`
- `git diff --check`

## Context
This is a narrow mainline CI unblocker exposed by #4295's core Clippy job.