### PR TITLE
Close apple-m4-dense-slm-regression

### DIFF
--- a/docs/tracking/campaigns/apple-m4-dense-slm-regression/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-dense-slm-regression/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-dense-slm-regression`
 
-Status: active
+Status: complete
 
 ## Objective
 

--- a/docs/tracking/campaigns/apple-m4-dense-slm-regression/active.toml
+++ b/docs/tracking/campaigns/apple-m4-dense-slm-regression/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-dense-slm-regression"
 title = "Apple M4 dense SLM regression guardrails"
-status = "active"
+status = "complete"
 
 objective = "Turn the measured Apple M4 dense SLM local-answer envelope into repeatable regression guardrails for quality, determinism, receipt schema, model-cache identity, warm-session timing, and memory drift without broadening the claim beyond the recorded Qwen2.5 dense SLM Apple CPU/NEON path."
 

--- a/docs/tracking/campaigns/apple-m4-dense-slm-regression/events/2026-05-09T150430Z-M4-SLM-REG-closeout.toml
+++ b/docs/tracking/campaigns/apple-m4-dense-slm-regression/events/2026-05-09T150430Z-M4-SLM-REG-closeout.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-09T15:04:30Z"
+campaign = "apple-m4-dense-slm-regression"
+item = "M4-SLM-REG-005"
+event = "merged"
+actor = "codex"
+pr = 4198
+merge_sha = "1043143cc8de25dff666adc32a351bc76579f351"
+
+notes = [
+  "Closed apple-m4-dense-slm-regression after M4-SLM-REG-001 through M4-SLM-REG-005 merged and campaign next reported no remaining item.",
+  "The completed campaign leaves advisory dense SLM receipt comparison, quality/determinism drift checks, staged hardware workflow shape, compact trend history, and tightened thresholds in place.",
+  "The closeout preserves the claim boundary: no BitNet quality, full Apple Metal inference, QK256, Neural Engine, MPSGraph model inference, or broad Apple Silicon performance claim.",
+]

--- a/docs/tracking/campaigns/apple-m4-dense-slm-regression/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-dense-slm-regression/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 dense SLM regression guardrails Campaign Status
 
 - Campaign: `apple-m4-dense-slm-regression`
-- State: `active`
+- State: `complete`
 - Objective: Turn the measured Apple M4 dense SLM local-answer envelope into repeatable regression guardrails for quality, determinism, receipt schema, model-cache identity, warm-session timing, and memory drift without broadening the claim beyond the recorded Qwen2.5 dense SLM Apple CPU/NEON path.
 
 ## Work Items


### PR DESCRIPTION
## Summary
- marks `apple-m4-dense-slm-regression` complete after all five regression guardrail items merged
- records the closeout against `M4-SLM-REG-005` / PR #4198 merge SHA `1043143cc8de25dff666adc32a351bc76579f351`
- preserves the dense SLM claim boundary: no BitNet quality, full Apple Metal inference, QK256, Neural Engine, MPSGraph model inference, or broad Apple Silicon performance claim

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-dense-slm-regression`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Boundaries
- tracker-only closeout
- no runtime changes
- no model binaries
- no BitNet, Metal, QK256, Neural Engine, MPSGraph, server, or MacBook work
