### PR TITLE
test(qk256): align test oracles with grouped layout

### DIFF
--- a/crates/bitnet-kernels/tests/proptest_wave10.rs
+++ b/crates/bitnet-kernels/tests/proptest_wave10.rs
@@ -506,12 +506,16 @@ proptest! {
     fn prop_qk256_unpack_roundtrip(
         codes in prop::collection::vec(0u8..=3u8, 256..=256)
     ) {
-        // Pack 256 codes into 64 bytes
+        // Pack 256 codes into the BitNet.cpp/GGML grouped I2_S layout:
+        // two 128-value chunks, each chunk storing four 32-value lanes.
         let mut packed = [0u8; 64];
         for (i, &code) in codes.iter().enumerate() {
-            let byte_idx = i / 4;
-            let bit_shift = (i % 4) * 2;
-            packed[byte_idx] |= code << bit_shift;
+            let chunk = i / 128;
+            let chunk_pos = i % 128;
+            let lane = chunk_pos / 32;
+            let group_pos = chunk_pos % 32;
+            let byte_idx = chunk * 32 + group_pos;
+            packed[byte_idx] |= code << (6 - lane * 2);
         }
 
         // Unpack using the same logic as QK256

--- a/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
+++ b/crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs
@@ -10,6 +10,7 @@ use bitnet_quantization::i2s_qk256::{
     code_to_f32, gemv_qk256, gemv_qk256_row, gemv_qk256_with_kernel_selection,
     select_qk256_gemv_kernel, unpack_qk256_block,
 };
+#[cfg(target_arch = "x86_64")]
 use bitnet_quantization::i2s_qk256_avx2::gemv_qk256_avx2;
 
 /// Pack 256 2-bit codes into BitNet.cpp I2_S grouped QK256 layout.
@@ -122,11 +123,9 @@ fn deterministic_prng_activation(cols: usize) -> Vec<f32> {
         .collect()
 }
 
+#[cfg(target_arch = "x86_64")]
 fn avx2_selection_available() -> bool {
-    cfg!(feature = "avx2")
-        && cfg!(target_arch = "x86_64")
-        && is_x86_feature_detected!("avx2")
-        && is_x86_feature_detected!("fma")
+    cfg!(feature = "avx2") && is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
 }
 
 fn assert_close_vectors(label: &str, expected: &[f32], actual: &[f32], tolerance: f32) {


### PR DESCRIPTION
## Summary
- guard AVX2 parity-test imports and runtime feature macros behind x86_64 so the test target compiles on Apple Silicon
- update the bitnet-kernels QK256 property oracle to pack codes in the canonical grouped I2_S layout before calling `unpack_qk256_block`

## Verification
- `rustfmt --check --config skip_children=true --edition 2024 crates/bitnet-quantization/tests/qk256_avx2_parity_tests.rs crates/bitnet-kernels/tests/proptest_wave10.rs`
- `cargo test --locked -p bitnet-quantization --no-default-features bitnet_i8s -- --nocapture`
- `cargo test --locked -p bitnet-kernels --test proptest_wave10 --no-default-features --features cpu prop_qk256_unpack_roundtrip -- --nocapture`
- `GITHUB_REPOSITORY=EffortlessMetrics/BitNet-rs GITHUB_EVENT_NAME=pull_request cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check origin/main...HEAD`
