### PR TITLE
Seed M4 SLM expansion roadmap

### DIFF
--- a/.codex/campaigns/apple-m4-local-server/goal.md
+++ b/.codex/campaigns/apple-m4-local-server/goal.md
@@ -1,0 +1,9 @@
+# apple-m4-local-server
+
+Goal: turn the working Apple M4 dense SLM CLI appliance into a local service
+surface with health, ready, streaming completion, and receipt-export behavior
+while reusing the same model cache, tokenizer authority, backend routing,
+resident-session, and no-hidden-fallback discipline.
+
+Do not claim server parity, OpenAI compatibility, or production readiness until
+the corresponding endpoints and receipts are implemented and checked.

--- a/.codex/campaigns/apple-m4-slm-metal-phases/goal.md
+++ b/.codex/campaigns/apple-m4-slm-metal-phases/goal.md
@@ -1,0 +1,9 @@
+# apple-m4-slm-metal-phases
+
+Goal: expand Apple M4 dense SLM Metal participation through named,
+phase-scoped, parity-gated prefill/projection phases while keeping CPU/NEON as
+the default full-pipeline route and avoiding any full `apple-m4-metal`
+inference claim until a later strict receipt proves it.
+
+Every phase must record CPU parity, Metal `fallback_used=false`, explicit CPU
+routing for remaining phases, timing deltas, and claim boundaries.

--- a/.codex/campaigns/apple-m4-slm-model-breadth/goal.md
+++ b/.codex/campaigns/apple-m4-slm-model-breadth/goal.md
@@ -1,0 +1,9 @@
+# apple-m4-slm-model-breadth
+
+Goal: expand the Apple M4 dense SLM path beyond the current Qwen2.5 supported
+set by adding exact, pinned, storage-conscious dense instruct models only after
+reference output sanity, Rust M4 quality, tokenizer authority, cache metadata,
+receipt validation, and deterministic behavior gates pass.
+
+Keep Qwen2.5 Q8_0 as the default until a future item explicitly changes that
+with receipts. Never commit model binaries.

--- a/docs/slm/apple-m4-slm-next-roadmap.md
+++ b/docs/slm/apple-m4-slm-next-roadmap.md
@@ -1,0 +1,62 @@
+# Apple M4 Dense SLM Next Roadmap
+
+The M4 dense SLM appliance baseline is complete. The supported local path now
+has `bitnet mac ask`, `bitnet mac chat`, `bitnet mac smoke`, `bitnet mac
+doctor`, `bitnet mac regression`, model-cache verification, quality corpus 2.0,
+long-session soak receipts, a measured expectation envelope, and strict claim
+boundaries.
+
+The next work is expansion, not baseline completion.
+
+## Maintenance Baseline
+
+Keep the appliance healthy with:
+
+```bash
+bitnet mac doctor
+bitnet mac smoke
+bitnet mac regression <receipt.json> --baseline <baseline.json>
+bitnet mac receipts-check <receipt-or-directory>
+```
+
+Run these after changes to tokenization, prompt templates, sampling, model-cache
+behavior, receipt schema, Mac CLI behavior, or runtime timing.
+
+## Next Campaigns
+
+### `apple-m4-slm-model-breadth`
+
+Goal: add more supported dense instruct model families without weakening the
+existing gates.
+
+Model candidates must stay exact and pinned. A model can become supported only
+after source, revision, file, size, SHA256, tokenizer authority, prompt
+template, reference output sanity, Rust M4 output quality, cache metadata,
+receipt validation, and deterministic behavior where required are recorded.
+
+### `apple-m4-slm-metal-phases`
+
+Goal: expand Apple Metal contribution phase by phase while preserving CPU/NEON
+as the honest default path.
+
+Every Metal phase needs CPU-only versus CPU-plus-Metal greedy parity,
+`fallback_used=false` for the Metal phase, explicit CPU/NEON routing for the
+rest of the pipeline, timing delta receipts, and no full `apple-m4-metal`
+inference claim.
+
+### `apple-m4-local-server`
+
+Goal: expose the M4 dense SLM appliance as a local service while reusing the
+same model-cache, tokenizer authority, resident-session, streaming, and receipt
+discipline.
+
+The first server surface should target an OpenAI-compatible local endpoint,
+streaming responses, health and ready endpoints, receipt export, and no hidden
+fallback.
+
+## Still Separate
+
+Dense SLM success is not BitNet success. The M4 BitNet path still requires an
+accepted BitNet artifact, strict `apple-m4-cpu-neon` proof, coherent generated
+output, token IDs, `fallback_used=false`, determinism, receipt hardening, warm
+sessions, and then phase-scoped Metal.

--- a/docs/tracking/campaigns/apple-m4-local-server/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-local-server/CAMPAIGN.md
@@ -1,0 +1,34 @@
+# Apple M4 Local Server
+
+Campaign ID: `apple-m4-local-server`
+
+Status: active
+
+## Objective
+
+Turn the M4 dense SLM CLI appliance into a local service surface that preserves
+the same cache, tokenizer, backend, fallback, streaming, and receipt discipline.
+
+## End State
+
+- Server command/config is explicit.
+- Health and ready endpoints expose cache/model/backend state.
+- Streaming completions use the supported dense SLM path.
+- Server requests can export strict receipts.
+- Doctor/smoke/regression flows can verify server readiness.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-SERVE-001 | ready | Define command and configuration contract. |
+| M4-SERVE-002 | pending | Add health and ready endpoint behavior. |
+| M4-SERVE-003 | pending | Add streaming completion endpoint. |
+| M4-SERVE-004 | pending | Add receipt export for server requests. |
+| M4-SERVE-005 | pending | Integrate doctor/smoke/regression readiness flow. |
+
+## Claim Boundary
+
+Local server work does not prove production readiness, full OpenAI
+compatibility, BitNet quality, full Apple Metal inference, QK256, Neural Engine
+execution, MPSGraph model inference, or broad M4 performance.

--- a/docs/tracking/campaigns/apple-m4-local-server/active.toml
+++ b/docs/tracking/campaigns/apple-m4-local-server/active.toml
@@ -1,0 +1,200 @@
+id = "apple-m4-local-server"
+title = "Apple M4 local server"
+status = "active"
+
+objective = "Expose the working Apple M4 dense SLM appliance as a local service with command/config, health and ready endpoints, streaming completions, receipt export, model-cache verification, and no hidden fallback, while reusing the same Mac model/cache/tokenizer/backend discipline."
+
+end_state = [
+  "The M4 local server has a clear command shape and configuration contract.",
+  "Health and ready endpoints report cache/model/backend/fallback state without running expensive generation by default.",
+  "Streaming completion endpoint reuses the supported dense SLM model cache, tokenizer authority, resident-session behavior, and receipt discipline.",
+  "Receipt export records model, tokenizer, backend, fallback status, generated text, token IDs, timing, and server request context.",
+  "Doctor/smoke behavior integrates with server readiness without overclaiming production readiness.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini dense SLM service campaign.",
+  "Do not claim production server readiness until endpoints and receipts are implemented.",
+  "Do not claim full OpenAI API compatibility until request/response semantics are tested.",
+  "Do not claim BitNet local-answer quality, full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad M4 performance.",
+  "Do not execute MacBook, x86, CUDA, A770, Lunar Lake, or NPU work.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M4-SERVE-001"
+status = "ready"
+branch = "codex/apple-m4-local-server/M4-SERVE-001-command-config"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Define the Apple M4 local server command and configuration contract, including model-id, cache-dir, device, host/port, streaming defaults, receipt path, cache verification, and unsupported-backend failure behavior without implementing serving endpoints."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".codex/campaigns/apple-m4-local-server/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-local-server/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The M4 local server command/config contract is defined.",
+]
+must_not_claim = [
+  "A server endpoint is implemented.",
+  "OpenAI compatibility is proven.",
+]
+
+[[work_item]]
+id = "M4-SERVE-002"
+status = "blocked"
+branch = "codex/apple-m4-local-server/M4-SERVE-002-health-ready"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-SERVE-001"]
+acceptance = "Add health and ready endpoint behavior for model-cache, tokenizer, backend/fallback, disk/cache, and unsupported-backend state, with tests and no expensive generation by default."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-server/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-local-server/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "Health and ready endpoints report local M4 dense SLM readiness.",
+]
+must_not_claim = [
+  "Streaming completions work.",
+]
+
+[[work_item]]
+id = "M4-SERVE-003"
+status = "blocked"
+branch = "codex/apple-m4-local-server/M4-SERVE-003-streaming-completions"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-SERVE-002"]
+acceptance = "Add a streaming local completion endpoint for the supported dense SLM path, preserving model/tokenizer authority, resident session reuse, generated text and token IDs, backend identity, fallback_used=false, and timing receipts."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-server/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-local-server/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The M4 local server can stream dense SLM completions if endpoint tests and receipts pass.",
+]
+must_not_claim = [
+  "Full OpenAI compatibility is proven.",
+]
+
+[[work_item]]
+id = "M4-SERVE-004"
+status = "blocked"
+branch = "codex/apple-m4-local-server/M4-SERVE-004-receipt-export"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-SERVE-003"]
+acceptance = "Add receipt export for local server requests, including model, tokenizer, backend, fallback, generated text, token IDs, timing, request metadata, streaming status, and claim boundaries."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-server/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-local-server/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "M4 local server requests can export strict receipts.",
+]
+must_not_claim = [
+  "Server receipts prove BitNet quality or full Metal inference.",
+]
+
+[[work_item]]
+id = "M4-SERVE-005"
+status = "blocked"
+branch = "codex/apple-m4-local-server/M4-SERVE-005-doctor-smoke"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-SERVE-004"]
+acceptance = "Integrate local server health with Mac doctor/smoke/regression workflows, documenting how operators verify server readiness and receipt export without making production uptime claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-server/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-local-server/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "Operators can verify local M4 server readiness through documented health/smoke flows.",
+]
+must_not_claim = [
+  "Production deployment readiness is proven.",
+]

--- a/docs/tracking/campaigns/apple-m4-local-server/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-local-server/generated/status.md
@@ -1,0 +1,25 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 local server Campaign Status
+
+- Campaign: `apple-m4-local-server`
+- State: `active`
+- Objective: Expose the working Apple M4 dense SLM appliance as a local service with command/config, health and ready endpoints, streaming completions, receipt export, model-cache verification, and no hidden fallback, while reusing the same Mac model/cache/tokenizer/backend discipline.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-SERVE-001 | ready | TBD | `codex/apple-m4-local-server/M4-SERVE-001-command-config` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define the Apple M4 local server command and configuration contract, including model-id, cache-dir, device, host/port, streaming defaults, receipt path, cache verification, and unsupported-backend failure behavior without implementing serving endpoints. |
+| M4-SERVE-002 | blocked | TBD | `codex/apple-m4-local-server/M4-SERVE-002-health-ready` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add health and ready endpoint behavior for model-cache, tokenizer, backend/fallback, disk/cache, and unsupported-backend state, with tests and no expensive generation by default. |
+| M4-SERVE-003 | blocked | TBD | `codex/apple-m4-local-server/M4-SERVE-003-streaming-completions` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a streaming local completion endpoint for the supported dense SLM path, preserving model/tokenizer authority, resident session reuse, generated text and token IDs, backend identity, fallback_used=false, and timing receipts. |
+| M4-SERVE-004 | blocked | TBD | `codex/apple-m4-local-server/M4-SERVE-004-receipt-export` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add receipt export for local server requests, including model, tokenizer, backend, fallback, generated text, token IDs, timing, request metadata, streaming status, and claim boundaries. |
+| M4-SERVE-005 | blocked | TBD | `codex/apple-m4-local-server/M4-SERVE-005-doctor-smoke` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Integrate local server health with Mac doctor/smoke/regression workflows, documenting how operators verify server readiness and receipt export without making production uptime claims. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini dense SLM service campaign.
+- Do not claim production server readiness until endpoints and receipts are implemented.
+- Do not claim full OpenAI API compatibility until request/response semantics are tested.
+- Do not claim BitNet local-answer quality, full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad M4 performance.
+- Do not execute MacBook, x86, CUDA, A770, Lunar Lake, or NPU work.
+- Never commit model binaries.

--- a/docs/tracking/campaigns/apple-m4-slm-excellence/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-excellence/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-excellence`
 
-Status: active
+Status: complete
 
 ## Objective
 

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/CAMPAIGN.md
@@ -1,0 +1,36 @@
+# Apple M4 SLM Metal Phases
+
+Campaign ID: `apple-m4-slm-metal-phases`
+
+Status: active
+
+## Objective
+
+Expand Apple M4 dense SLM acceleration phase by phase while preserving CPU/NEON
+as the honest full-pipeline route until a later strict full-route receipt proves
+otherwise.
+
+## End State
+
+- Each Metal phase has a CPU reference.
+- CPU-only and CPU-plus-Metal outputs pass parity for the phase scope.
+- Metal receipts record `fallback_used=false`, timing deltas, and CPU routing
+  for remaining phases.
+- Resident-session routing is added only after parity and receipt validation.
+- No full `apple-m4-metal` inference claim is made from phase evidence.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-METAL-001 | ready | Choose the next phase target and receipt shape. |
+| M4-METAL-002 | pending | Add CPU/Metal parity fixture. |
+| M4-METAL-003 | pending | Integrate phase receipt validation. |
+| M4-METAL-004 | pending | Route the phase in resident sessions with parity. |
+| M4-METAL-005 | pending | Record measured phase-local timing deltas. |
+
+## Claim Boundary
+
+Metal phase evidence does not prove full `apple-m4-metal` inference, Neural
+Engine execution, MPSGraph model inference, QK256 support, BitNet quality, or
+broad Apple Silicon performance.

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/active.toml
@@ -1,0 +1,199 @@
+id = "apple-m4-slm-metal-phases"
+title = "Apple M4 SLM Metal phases"
+status = "active"
+
+objective = "Expand Apple M4 dense SLM acceleration through named, phase-scoped Metal prefill/projection contributions with CPU-only versus CPU-plus-Metal parity, Metal fallback_used=false receipts, explicit CPU/NEON routing for the rest of the pipeline, and timing deltas, without claiming full apple-m4-metal inference."
+
+end_state = [
+  "The next Metal phase is chosen from a bounded prefill/projection candidate list.",
+  "Each Metal phase has a CPU reference and CPU-plus-Metal parity fixture.",
+  "Metal phase receipts record selected_backend=apple-m4-metal, runtime_api=metal, fallback_used=false, execution phase, timing delta, and claim boundaries.",
+  "Resident-session routing remains explicit about CPU/NEON for non-Metal phases.",
+  "No full apple-m4-metal inference claim is made before a later full-route receipt proves it.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini dense SLM campaign.",
+  "Do not claim full apple-m4-metal inference from a named phase.",
+  "Do not claim Apple Metal accelerates the full SLM answer path.",
+  "Do not claim BitNet local-answer quality, QK256 support, Neural Engine execution, MPSGraph model inference, or broad M4 performance.",
+  "Do not touch QK256, bitnet-qk256-dispatch, server inference, or MacBook work.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M4-METAL-001"
+status = "ready"
+branch = "codex/apple-m4-slm-metal-phases/M4-METAL-001-next-phase"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Choose the next Apple Metal dense SLM phase candidate, recording why it is safe, CPU reference scope, expected tensor shape, parity method, timing fields, fallback rules, and claim boundaries without adding kernels or routing."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".codex/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The next phase-scoped Metal target is selected for implementation.",
+]
+must_not_claim = [
+  "A new Metal phase is implemented.",
+  "Full apple-m4-metal inference works.",
+]
+
+[[work_item]]
+id = "M4-METAL-002"
+status = "blocked"
+branch = "codex/apple-m4-slm-metal-phases/M4-METAL-002-parity-fixture"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-METAL-001"]
+acceptance = "Add the CPU reference versus CPU-plus-Metal parity fixture for the selected phase, requiring same greedy-relevant outputs or a bounded documented tolerance, and no hidden fallback."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-kernels --no-default-features --features metal",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The selected phase has CPU/Metal parity in the fixture if tests pass.",
+]
+must_not_claim = [
+  "The phase participates in resident generation.",
+]
+
+[[work_item]]
+id = "M4-METAL-003"
+status = "blocked"
+branch = "codex/apple-m4-slm-metal-phases/M4-METAL-003-phase-receipt"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-METAL-002"]
+acceptance = "Integrate a phase receipt for the selected Metal contribution with selected_backend=apple-m4-metal, runtime_api=metal, fallback_used=false, timing delta, CPU remainder routing, and mac receipts-check validation."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,metal,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-kernels/**",
+  "crates/**/tests/**",
+  "ci/hardware/apple-m4-mac-mini/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "A named Metal phase has a validated phase receipt.",
+]
+must_not_claim = [
+  "Full apple-m4-metal inference works.",
+]
+
+[[work_item]]
+id = "M4-METAL-004"
+status = "blocked"
+branch = "codex/apple-m4-slm-metal-phases/M4-METAL-004-resident-route"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-METAL-003"]
+acceptance = "Route the validated phase into resident-session flow only where parity holds, with CPU-only versus CPU-plus-Metal greedy comparison, quality corpus pass, explicit CPU fallback for non-Metal phases, and phase receipts per relevant turn."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,metal,full-cli",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-models/**",
+  "crates/**/tests/**",
+  "ci/hardware/apple-m4-mac-mini/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "A named Metal phase participates in resident dense SLM generation with parity receipts.",
+]
+must_not_claim = [
+  "Apple Metal accelerates the full SLM answer path.",
+]
+
+[[work_item]]
+id = "M4-METAL-005"
+status = "blocked"
+branch = "codex/apple-m4-slm-metal-phases/M4-METAL-005-measured-delta"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-METAL-004"]
+acceptance = "Record measured phase-local timing deltas for the resident-routed Metal phase, keeping speedup claims phase-local and updating docs without broad M4 or full Metal inference claims."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-m4-mac-mini/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-metal-phases/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "Phase-local Metal timing deltas are recorded for the named phase.",
+]
+must_not_claim = [
+  "The measured phase proves full-pipeline speedup.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/generated/status.md
@@ -1,0 +1,25 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 SLM Metal phases Campaign Status
+
+- Campaign: `apple-m4-slm-metal-phases`
+- State: `active`
+- Objective: Expand Apple M4 dense SLM acceleration through named, phase-scoped Metal prefill/projection contributions with CPU-only versus CPU-plus-Metal parity, Metal fallback_used=false receipts, explicit CPU/NEON routing for the rest of the pipeline, and timing deltas, without claiming full apple-m4-metal inference.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-METAL-001 | ready | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-001-next-phase` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Choose the next Apple Metal dense SLM phase candidate, recording why it is safe, CPU reference scope, expected tensor shape, parity method, timing fields, fallback rules, and claim boundaries without adding kernels or routing. |
+| M4-METAL-002 | blocked | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-002-parity-fixture` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the CPU reference versus CPU-plus-Metal parity fixture for the selected phase, requiring same greedy-relevant outputs or a bounded documented tolerance, and no hidden fallback. |
+| M4-METAL-003 | blocked | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-003-phase-receipt` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Integrate a phase receipt for the selected Metal contribution with selected_backend=apple-m4-metal, runtime_api=metal, fallback_used=false, timing delta, CPU remainder routing, and mac receipts-check validation. |
+| M4-METAL-004 | blocked | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-004-resident-route` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Route the validated phase into resident-session flow only where parity holds, with CPU-only versus CPU-plus-Metal greedy comparison, quality corpus pass, explicit CPU fallback for non-Metal phases, and phase receipts per relevant turn. |
+| M4-METAL-005 | blocked | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-005-measured-delta` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record measured phase-local timing deltas for the resident-routed Metal phase, keeping speedup claims phase-local and updating docs without broad M4 or full Metal inference claims. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini dense SLM campaign.
+- Do not claim full apple-m4-metal inference from a named phase.
+- Do not claim Apple Metal accelerates the full SLM answer path.
+- Do not claim BitNet local-answer quality, QK256 support, Neural Engine execution, MPSGraph model inference, or broad M4 performance.
+- Do not touch QK256, bitnet-qk256-dispatch, server inference, or MacBook work.
+- Never commit model binaries.

--- a/docs/tracking/campaigns/apple-m4-slm-model-breadth/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-model-breadth/CAMPAIGN.md
@@ -1,0 +1,35 @@
+# Apple M4 SLM Model Breadth
+
+Campaign ID: `apple-m4-slm-model-breadth`
+
+Status: active
+
+## Objective
+
+Add more storage-conscious dense instruct model families to the Apple M4 Mac
+mini path without weakening the completed Qwen appliance baseline.
+
+## End State
+
+- Candidate models are exact, pinned artifacts.
+- Reference output sanity passes before Rust M4 work.
+- Rust M4 quality, tokenizer authority, backend/fallback identity, generated
+  token IDs, timing, cache metadata, and receipt validation pass before support.
+- The model matrix distinguishes `default`, `supported`, `candidate`,
+  `diagnostic-only`, and `rejected`.
+- No model binaries are committed.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M4-MODEL-001 | ready | Select the next exact dense instruct GGUF candidate set. |
+| M4-MODEL-002 | pending | Run reference output sanity and record exact artifact metadata. |
+| M4-MODEL-003 | pending | Run Rust M4 quality, receipts, and deterministic gates. |
+| M4-MODEL-004 | pending | Register cache/model selection only after quality passes. |
+| M4-MODEL-005 | pending | Update model matrix and user envelope. |
+
+## Claim Boundary
+
+Dense model breadth does not prove BitNet, QK256, Neural Engine execution,
+MPSGraph model inference, full Apple Metal inference, or broad M4 performance.

--- a/docs/tracking/campaigns/apple-m4-slm-model-breadth/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-model-breadth/active.toml
@@ -1,0 +1,195 @@
+id = "apple-m4-slm-model-breadth"
+title = "Apple M4 SLM model breadth"
+status = "active"
+
+objective = "Add more storage-conscious dense instruct model families to the Apple M4 Mac mini path through exact artifact selection, reference output sanity, Rust M4 quality gates, tokenizer authority, cache metadata, receipt validation, and deterministic checks without weakening the completed Qwen appliance baseline."
+
+end_state = [
+  "The supported M4 dense SLM model matrix can grow beyond Qwen2.5 only through exact pinned artifacts.",
+  "Each accepted model records source, revision, file, size, SHA256, tokenizer authority, prompt template, quantization, Rust support status, M4 support status, cache policy, and quality status.",
+  "Reference output sanity passes before Rust M4 support is attempted.",
+  "Rust M4 output quality, receipt validation, backend identity, fallback status, and deterministic behavior pass before a model is selectable as supported.",
+  "Qwen2.5 Q8_0 remains the default unless a later explicit item changes that with receipts.",
+]
+
+hard_constraints = [
+  "This is an M4 Mac mini dense SLM campaign.",
+  "Do not execute MacBook artifact sweeps or MacBook receipts here.",
+  "Do not reopen completed Apple M4 dense SLM baseline, performance, excellence, continuity, or regression campaigns.",
+  "Never commit model binaries.",
+  "Do not accept unpinned or random community GGUFs.",
+  "Do not mark a model supported just because it loads.",
+  "Do not claim BitNet local-answer quality from dense SLM evidence.",
+  "Do not claim full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad M4 performance.",
+]
+
+[[work_item]]
+id = "M4-MODEL-001"
+status = "ready"
+branch = "codex/apple-m4-slm-model-breadth/M4-MODEL-001-candidate-selection"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Select the next exact dense instruct GGUF candidate or candidates for M4 evaluation, recording source, license notes, revision, file, expected size, tokenizer expectations, prompt template, storage budget, and rejection criteria without downloading or accepting a model."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  ".codex/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The next M4 dense SLM candidate set is selected for evaluation.",
+]
+must_not_claim = [
+  "A new model is supported.",
+  "A model artifact was downloaded or accepted.",
+]
+
+[[work_item]]
+id = "M4-MODEL-002"
+status = "blocked"
+branch = "codex/apple-m4-slm-model-breadth/M4-MODEL-002-reference-sanity"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-MODEL-001"]
+acceptance = "Run reference output sanity for the selected candidate, recording exact artifact source, revision, file, size, SHA256, tokenizer authority, prompt template, reference command, prompt outputs, and reject/accept evidence."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/quality/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "A candidate is reference-good for the bounded prompt suite if receipts prove it.",
+]
+must_not_claim = [
+  "Rust M4 support works.",
+  "A model is supported by the Mac wrapper.",
+]
+
+[[work_item]]
+id = "M4-MODEL-003"
+status = "blocked"
+branch = "codex/apple-m4-slm-model-breadth/M4-MODEL-003-rust-m4-quality"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-MODEL-002"]
+acceptance = "Run the candidate through Rust M4 apple-m4-cpu-neon quality gates with valid UTF-8, non-empty output, non-degenerate output, backend/fallback receipts, generated token IDs, timing, and deterministic behavior where required."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/bitnet-models/**",
+  "crates/**/tests/**",
+  "ci/quality/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The candidate passes Rust M4 quality only if receipts prove it.",
+]
+must_not_claim = [
+  "The candidate is registered as supported before cache metadata lands.",
+]
+
+[[work_item]]
+id = "M4-MODEL-004"
+status = "blocked"
+branch = "codex/apple-m4-slm-model-breadth/M4-MODEL-004-cache-registration"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-MODEL-003"]
+acceptance = "Register the accepted candidate in model cache metadata and Mac model selection only after quality passes, with verify/fetch/list behavior, receipt validation, and no default-model change unless explicitly accepted."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli --test cli_arg_tests mac -- --nocapture",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "crates/**/tests/**",
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The candidate is selectable by model ID if cache and receipt gates pass.",
+]
+must_not_claim = [
+  "The default model changed unless explicitly recorded.",
+]
+
+[[work_item]]
+id = "M4-MODEL-005"
+status = "blocked"
+branch = "codex/apple-m4-slm-model-breadth/M4-MODEL-005-docs-envelope"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M4-MODEL-004"]
+acceptance = "Update the dense model support matrix and M4 user expectation envelope with the accepted model, receipt evidence, cache size, supported/candidate/rejected state, and claim boundaries."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/slm/**",
+  "docs/tracking/campaigns/apple-m4-slm-model-breadth/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "models/**",
+]
+may_claim = [
+  "The M4 dense SLM model matrix reflects the newly accepted model.",
+]
+must_not_claim = [
+  "Broad model-family quality is proven.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-model-breadth/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-model-breadth/generated/status.md
@@ -1,0 +1,27 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M4 SLM model breadth Campaign Status
+
+- Campaign: `apple-m4-slm-model-breadth`
+- State: `active`
+- Objective: Add more storage-conscious dense instruct model families to the Apple M4 Mac mini path through exact artifact selection, reference output sanity, Rust M4 quality gates, tokenizer authority, cache metadata, receipt validation, and deterministic checks without weakening the completed Qwen appliance baseline.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M4-MODEL-001 | ready | TBD | `codex/apple-m4-slm-model-breadth/M4-MODEL-001-candidate-selection` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Select the next exact dense instruct GGUF candidate or candidates for M4 evaluation, recording source, license notes, revision, file, expected size, tokenizer expectations, prompt template, storage budget, and rejection criteria without downloading or accepting a model. |
+| M4-MODEL-002 | blocked | TBD | `codex/apple-m4-slm-model-breadth/M4-MODEL-002-reference-sanity` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run reference output sanity for the selected candidate, recording exact artifact source, revision, file, size, SHA256, tokenizer authority, prompt template, reference command, prompt outputs, and reject/accept evidence. |
+| M4-MODEL-003 | blocked | TBD | `codex/apple-m4-slm-model-breadth/M4-MODEL-003-rust-m4-quality` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run the candidate through Rust M4 apple-m4-cpu-neon quality gates with valid UTF-8, non-empty output, non-degenerate output, backend/fallback receipts, generated token IDs, timing, and deterministic behavior where required. |
+| M4-MODEL-004 | blocked | TBD | `codex/apple-m4-slm-model-breadth/M4-MODEL-004-cache-registration` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Register the accepted candidate in model cache metadata and Mac model selection only after quality passes, with verify/fetch/list behavior, receipt validation, and no default-model change unless explicitly accepted. |
+| M4-MODEL-005 | blocked | TBD | `codex/apple-m4-slm-model-breadth/M4-MODEL-005-docs-envelope` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Update the dense model support matrix and M4 user expectation envelope with the accepted model, receipt evidence, cache size, supported/candidate/rejected state, and claim boundaries. |
+
+## Hard Constraints
+
+- This is an M4 Mac mini dense SLM campaign.
+- Do not execute MacBook artifact sweeps or MacBook receipts here.
+- Do not reopen completed Apple M4 dense SLM baseline, performance, excellence, continuity, or regression campaigns.
+- Never commit model binaries.
+- Do not accept unpinned or random community GGUFs.
+- Do not mark a model supported just because it loads.
+- Do not claim BitNet local-answer quality from dense SLM evidence.
+- Do not claim full apple-m4-metal inference, Neural Engine execution, MPSGraph model inference, QK256 support, or broad M4 performance.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -39,6 +39,10 @@
 | apple-m4-local-answer | M4-QA-003 | M4-QA-001 | proposed |
 | apple-m4-local-answer | M4-QA-004 | M4-QA-001 | proposed |
 | apple-m4-local-answer | M4-QA-005 | M4-QA-002, M4-QA-003 | proposed |
+| apple-m4-local-server | M4-SERVE-002 | M4-SERVE-001 | blocked |
+| apple-m4-local-server | M4-SERVE-003 | M4-SERVE-002 | blocked |
+| apple-m4-local-server | M4-SERVE-004 | M4-SERVE-003 | blocked |
+| apple-m4-local-server | M4-SERVE-005 | M4-SERVE-004 | blocked |
 | apple-m4-operational | M4-OP-002 | M4-OP-001 | merged |
 | apple-m4-operational | M4-OP-003 | M4-OP-001 | merged |
 | apple-m4-operational | M4-OP-004 | M4-OP-003 | merged |
@@ -66,6 +70,14 @@
 | apple-m4-slm-hardening | M4-SLM-HARDEN-002 | M4-SLM-HARDEN-001 | merged |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-003 | M4-SLM-HARDEN-002 | merged |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | M4-SLM-HARDEN-003 | merged |
+| apple-m4-slm-metal-phases | M4-METAL-002 | M4-METAL-001 | blocked |
+| apple-m4-slm-metal-phases | M4-METAL-003 | M4-METAL-002 | blocked |
+| apple-m4-slm-metal-phases | M4-METAL-004 | M4-METAL-003 | blocked |
+| apple-m4-slm-metal-phases | M4-METAL-005 | M4-METAL-004 | blocked |
+| apple-m4-slm-model-breadth | M4-MODEL-002 | M4-MODEL-001 | blocked |
+| apple-m4-slm-model-breadth | M4-MODEL-003 | M4-MODEL-002 | blocked |
+| apple-m4-slm-model-breadth | M4-MODEL-004 | M4-MODEL-003 | blocked |
+| apple-m4-slm-model-breadth | M4-MODEL-005 | M4-MODEL-004 | blocked |
 | apple-m4-slm-performance | M4-SLM-PERF-002 | M4-SLM-PERF-001 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-003 | M4-SLM-PERF-002 | merged |
 | apple-m4-slm-performance | M4-SLM-PERF-004 | M4-SLM-PERF-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,11 +9,14 @@
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | M4-QA-001 | #3904 | blocked | M4-QA-MODEL-002 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
+| apple-m4-local-server | M4-SERVE-002 | TBD | blocked | M4-SERVE-003 | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-excellence | M4-SLM-EX-010 | #4307 | merged | none | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
+| apple-m4-slm-metal-phases | M4-METAL-002 | TBD | blocked | M4-METAL-003 | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-model-breadth | M4-MODEL-002 | TBD | blocked | M4-MODEL-003 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | MB-AS-002 | TBD | blocked | MB-AS-004 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -9,11 +9,14 @@
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
 | apple-m4-local-answer | Apple M4 local answer usability | M4-QA-001 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
+| apple-m4-local-server | Apple M4 local server | M4-SERVE-002 | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | Apple M4 operational readiness | M4-OP-006 | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | Apple M4 local answer productization | M4-PROD-005 | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | Apple M4 SLM local answer usability | SLM-M4-007 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-excellence | Apple M4 SLM excellence | M4-SLM-EX-010 | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | Apple M4 SLM hardening | M4-SLM-HARDEN-004 | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
+| apple-m4-slm-metal-phases | Apple M4 SLM Metal phases | M4-METAL-002 | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-model-breadth | Apple M4 SLM model breadth | M4-MODEL-002 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | Apple M4 SLM performance | M4-SLM-PERF-007 | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-002 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |


### PR DESCRIPTION
## Summary
- seeds three M4-local follow-on campaigns after the dense SLM appliance baseline:
  - `apple-m4-slm-model-breadth`
  - `apple-m4-slm-metal-phases`
  - `apple-m4-local-server`
- adds `docs/slm/apple-m4-slm-next-roadmap.md` to keep maintenance, model breadth, Metal phases, server surface, and BitNet separation explicit
- fixes stale `apple-m4-slm-excellence` CAMPAIGN status text from active to complete
- regenerates tracking dashboards

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-model-breadth`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-server`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Boundaries
- docs/control-plane only
- no model downloads or model binaries
- no Metal implementation or routing
- no server endpoint implementation
- no BitNet, QK256, Neural Engine, MPSGraph, MacBook, x86, CUDA, A770, Lunar Lake, or NPU work
