### PR TITLE
docs(tracker): fill legacy event metadata

### DIFF
--- a/docs/tracking/campaigns/cpu-proof/events/2026-05-07T104033Z-CPU-PHASE-TIMING-001-pr-open.toml
+++ b/docs/tracking/campaigns/cpu-proof/events/2026-05-07T104033Z-CPU-PHASE-TIMING-001-pr-open.toml
@@ -4,6 +4,7 @@ item = "CPU-PHASE-TIMING-001"
 event = "pr_open"
 pr = 3872
 actor = "codex"
+head_sha = "0ba2e47e92315908c891192c8f83a5160ecb4d8a"
 
 notes = [
   "Opened #3872 to tighten CPU phase benchmark receipt timing extraction after the benchmark milestone was marked done.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T062225Z-CPU258V-006-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T062225Z-CPU258V-006-pr-open.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-006"
 event = "pr_open"
 pr = 4001
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-006-warm-phase"
 head_sha = "19150dbdb39f38efeceb0331959ac9cbede0a806"
 summary = "Opened #4001 to add a strict CPU warm phase runner for 258V prefill_512 and decode_128 profile receipts."
+
+notes = [
+  "The runner loads the real GGUF model and tokenizer once, then writes per-profile strict CPU receipts for the benchmark converter.",
+  "The claim boundary remains CPU phase receipt collection only: no sustained throughput, Arc 140V, Intel NPU, speedup, or answer-quality claims.",
+  "The converter now preserves the larger measured prefill receipt when decode and prefill receipts are supplied together.",
+]
 
 details = [
   "The runner loads the real GGUF model and tokenizer once, then writes per-profile strict CPU receipts for the benchmark converter.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T062428Z-CPU258V-006-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T062428Z-CPU258V-006-merged.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-006"
 event = "merged"
 pr = 4001
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-006-warm-phase"
 merge_sha = "7335e8c93d832cea6b006fa8132a3f327e12d2c9"
 summary = "Merged #4001, adding the 258V strict CPU warm phase runner."
+
+notes = [
+  "CPU phase profile collection can now load the real GGUF model and tokenizer once and emit per-profile strict CPU receipts for the benchmark converter.",
+  "The claim boundary remains CPU phase receipt collection only; this does not claim sustained throughput, answer quality, Arc 140V execution, Intel NPU execution, or acceleration.",
+  "The benchmark converter preserves the larger measured prefill receipt when prefill and decode receipts are supplied together.",
+]
 
 details = [
   "CPU phase profile collection can now load the real GGUF model and tokenizer once and emit per-profile strict CPU receipts for the benchmark converter.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T070707Z-CPU258V-007-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T070707Z-CPU258V-007-ready.toml
@@ -7,6 +7,11 @@ branch = "codex/intel-258v-platform/CPU258V-007-answer-template-refresh"
 base_sha = "f5f4bdab67a05e7c53010349bc39f06b3edc5668"
 summary = "Readied CPU258V-007 to record the first 258V AVX2 answer-corpus refresh under the BitNet.cpp answer-ready prompt envelope."
 
+notes = [
+  "The refreshed AVX2 corpus attempt timed out all five cases within the bounded local child-run window and emitted missing_child_receipt rows.",
+  "The artifact is blocker evidence only and does not prove answer quality, scalar/AVX2 parity under the new prompt, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
+
 details = [
   "The refreshed AVX2 corpus attempt timed out all five cases within the bounded local child-run window and emitted missing_child_receipt rows.",
   "The artifact is blocker evidence only and does not prove answer quality, scalar/AVX2 parity under the new prompt, sustained throughput, Arc 140V execution, or Intel NPU execution.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T070824Z-CPU258V-007-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T070824Z-CPU258V-007-pr-open.toml
@@ -3,9 +3,15 @@ campaign = "intel-258v-platform"
 item = "CPU258V-007"
 event = "pr_open"
 pr = 4006
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-007-answer-template-refresh"
 head_sha = "aea84921246f6578d270b3131dcc0ce9ae73a4ab"
 summary = "Opened #4006 to record 258V AVX2 answer-corpus timeout evidence under the BitNet.cpp answer-ready prompt envelope."
+
+notes = [
+  "The artifact records five timeout rows and missing_child_receipt kernels for the refreshed answer-corpus attempt.",
+  "This is blocker evidence only and does not prove answer quality, scalar/AVX2 parity under the new prompt, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "The artifact records five timeout rows and missing_child_receipt kernels for the refreshed answer-corpus attempt.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071023Z-CPU258V-007-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071023Z-CPU258V-007-merged.toml
@@ -3,9 +3,15 @@ campaign = "intel-258v-platform"
 item = "CPU258V-007"
 event = "merged"
 pr = 4006
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-007-answer-template-refresh"
 merge_sha = "2188b175629374073896c1f5f2c9234bee47a304"
 summary = "Merged #4006, recording 258V AVX2 timeout evidence under the BitNet.cpp answer-ready prompt envelope."
+
+notes = [
+  "The committed artifact records five timeout rows and missing_child_receipt kernels for the refreshed answer-corpus attempt.",
+  "This remains blocker evidence only; it does not prove answer quality, scalar/AVX2 parity under the new prompt, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "The committed artifact records five timeout rows and missing_child_receipt kernels for the refreshed answer-corpus attempt.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071910Z-CPU258V-008-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T071910Z-CPU258V-008-ready.toml
@@ -7,6 +7,12 @@ branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
 base_sha = "832e7c846d8c4e66310f3771b65b63539b8543ba"
 summary = "Readied CPU258V-008 to add bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
 
+notes = [
+  "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",
+  "CPU258V-008 narrows follow-up runs with repeatable --case-id filters while preserving full corpus identity and selected case IDs in the aggregate receipt.",
+  "This is diagnostic scope only and does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
+
 details = [
   "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",
   "CPU258V-008 narrows follow-up runs with repeatable --case-id filters while preserving full corpus identity and selected case IDs in the aggregate receipt.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072300Z-CPU258V-008-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072300Z-CPU258V-008-pr-open.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-008"
 event = "pr_open"
 pr = 4008
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-008-answer-case-filter"
 head_sha = "1ac4d98ff73ee9531d2e47022d193412bea5db3a"
 summary = "Opened CPU258V-008 to add bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
+
+notes = [
+  "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",
+  "CPU258V-008 adds repeatable --case-id filters while preserving full corpus identity and selected case IDs in the aggregate receipt.",
+  "This PR does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "CPU258V-007 showed the BitNet.cpp answer-ready prompt envelope timing out across the full 258V AVX2 answer corpus, with missing child receipts.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072640Z-CPU258V-008-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T072640Z-CPU258V-008-merged.toml
@@ -3,8 +3,14 @@ campaign = "intel-258v-platform"
 item = "CPU258V-008"
 event = "merged"
 pr = 4008
+actor = "codex"
 merge_sha = "d4979be17c107200a723bbc8d5c24553983c04e3"
 summary = "Merged CPU258V-008, adding bounded answer-corpus case selection for 258V answer-template refresh diagnostics."
+
+notes = [
+  "The merged command can run selected answer-corpus case IDs and records selected_case_count plus selected_case_ids in the aggregate receipt.",
+  "The claim boundary remains diagnostic only: no selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution is claimed.",
+]
 
 details = [
   "The merged command can run selected answer-corpus case IDs and records selected_case_count plus selected_case_ids in the aggregate receipt.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073609Z-CPU258V-009-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073609Z-CPU258V-009-ready.toml
@@ -7,6 +7,12 @@ branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
 base_sha = "0039a42b3072dbde905f02b157642bfc94847346"
 summary = "Readied CPU258V-009 to record a bounded single-case 258V AVX2 answer-corpus attempt."
 
+notes = [
+  "CPU258V-008 made answer-corpus case selection available after the full BitNet.cpp-template AVX2 answer refresh timed out.",
+  "The selected math_2_plus_2 case still timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",
+  "This is blocker evidence only and does not prove selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
+
 details = [
   "CPU258V-008 made answer-corpus case selection available after the full BitNet.cpp-template AVX2 answer refresh timed out.",
   "The selected math_2_plus_2 case still timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073902Z-CPU258V-009-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T073902Z-CPU258V-009-pr-open.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-009"
 event = "pr_open"
 pr = 4010
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-009-single-case-answer"
 head_sha = "9575a61aa07c5616cb03b3718283abd0ea98f8d9"
 summary = "Opened CPU258V-009 to record a bounded single-case 258V AVX2 answer-corpus timeout."
+
+notes = [
+  "The selected math_2_plus_2 case timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",
+  "The aggregate receipt preserves full corpus identity with selected_case_count=1 and selected_case_ids=[math_2_plus_2].",
+  "This PR does not claim selected-case completion, answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "The selected math_2_plus_2 case timed out within the 420-second local child-run window and emitted a missing_child_receipt row.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T074110Z-CPU258V-009-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T074110Z-CPU258V-009-merged.toml
@@ -3,8 +3,15 @@ campaign = "intel-258v-platform"
 item = "CPU258V-009"
 event = "merged"
 pr = 4010
+actor = "codex"
 merge_sha = "8be1358782649a90bfa21697980bf0613733badf"
 summary = "Merged CPU258V-009, recording bounded single-case 258V AVX2 answer-corpus timeout evidence."
+
+notes = [
+  "The merged artifact records selected_case_count=1 and selected_case_ids=[math_2_plus_2] while preserving full corpus identity.",
+  "The selected case timed out and emitted no child receipt, so the evidence remains diagnostic blocker evidence only.",
+  "No answer quality, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution is claimed.",
+]
 
 details = [
   "The merged artifact records selected_case_count=1 and selected_case_ids=[math_2_plus_2] while preserving full corpus identity.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T074931Z-CPU258V-010-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T074931Z-CPU258V-010-ready.toml
@@ -7,6 +7,12 @@ branch = "codex/intel-258v-platform/CPU258V-010-release-single-case"
 base_sha = "9f7daf644475db4ac38527a97fcad9e7b7c9d72d"
 summary = "Readied CPU258V-010 to record a release-built single-case 258V AVX2 answer-corpus attempt."
 
+notes = [
+  "The debug-built single-case attempt timed out at prompt_prefill_start, but the release-built CLI completed the selected math_2_plus_2 case within the bounded child-run window.",
+  "The strict CPU row records real_gguf loading, explicit tokenizer resolution, selected i2_s-avx2-reference kernel, fallback_used=false, 19 prompt tokens, and 4 generated tokens.",
+  "The generated text fails the exact-answer gate, so this is output-quality evidence rather than answer-readiness, parity, speed, Arc, or NPU proof.",
+]
+
 details = [
   "The debug-built single-case attempt timed out at prompt_prefill_start, but the release-built CLI completed the selected math_2_plus_2 case within the bounded child-run window.",
   "The strict CPU row records real_gguf loading, explicit tokenizer resolution, selected i2_s-avx2-reference kernel, fallback_used=false, 19 prompt tokens, and 4 generated tokens.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075221Z-CPU258V-010-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075221Z-CPU258V-010-pr-open.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-010"
 event = "pr_open"
 pr = 4012
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-010-release-single-case"
 head_sha = "31549ec8f52564463fe275caa81491054eecb572"
 summary = "Opened CPU258V-010 to record release-built single-case 258V AVX2 answer-corpus evidence."
+
+notes = [
+  "The release-built selected math_2_plus_2 case completed strict CPU execution within the bounded child-run window.",
+  "The receipt records real_gguf loading, explicit tokenizer resolution, selected i2_s-avx2-reference kernel, fallback_used=false, 19 prompt tokens, and 4 generated tokens.",
+  "The generated text fails the exact-answer gate, so this PR does not claim answer readiness, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "The release-built selected math_2_plus_2 case completed strict CPU execution within the bounded child-run window.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075423Z-CPU258V-010-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075423Z-CPU258V-010-merged.toml
@@ -3,8 +3,15 @@ campaign = "intel-258v-platform"
 item = "CPU258V-010"
 event = "merged"
 pr = 4012
+actor = "codex"
 merge_sha = "673b3de9c93d159c037478fb695b4137e04c31cd"
 summary = "Merged CPU258V-010, recording release-built single-case 258V AVX2 answer-corpus evidence."
+
+notes = [
+  "The merged artifact shows the selected math_2_plus_2 case completes strict CPU AVX2 execution under release.",
+  "The receipt records real_gguf loading, explicit tokenizer resolution, selected i2_s-avx2-reference kernel, fallback_used=false, 19 prompt tokens, and 4 generated tokens.",
+  "The generated answer fails the exact-answer gate, so no answer readiness, scalar/AVX2 parity, sustained throughput, Arc 140V execution, or Intel NPU execution is claimed.",
+]
 
 details = [
   "The merged artifact shows the selected math_2_plus_2 case completes strict CPU AVX2 execution under release.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075914Z-CPU258V-011-ready.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T075914Z-CPU258V-011-ready.toml
@@ -7,6 +7,12 @@ branch = "codex/intel-258v-platform/CPU258V-011-release-scalar-case"
 base_sha = "aae753c8b51e32c2be2ac88407857f579ba3f371"
 summary = "Readied CPU258V-011 to record release-built scalar and scalar-vs-AVX2 selected-case answer parity."
 
+notes = [
+  "The selected scalar and AVX2 release runs complete strict CPU execution with real GGUF loading, explicit tokenizer resolution, selected i2_s kernels, and fallback_used=false.",
+  "Both lanes produce identical prompt IDs, generated IDs [89048, 124979, 70232, 88162], and decoded text for math_2_plus_2.",
+  "The shared output fails the exact-answer gate, so this is selected-case parity evidence rather than answer correctness, speed, Arc, or NPU proof.",
+]
+
 details = [
   "The selected scalar and AVX2 release runs complete strict CPU execution with real GGUF loading, explicit tokenizer resolution, selected i2_s kernels, and fallback_used=false.",
   "Both lanes produce identical prompt IDs, generated IDs [89048, 124979, 70232, 88162], and decoded text for math_2_plus_2.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T080206Z-CPU258V-011-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T080206Z-CPU258V-011-pr-open.toml
@@ -3,9 +3,16 @@ campaign = "intel-258v-platform"
 item = "CPU258V-011"
 event = "pr_open"
 pr = 4014
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-011-release-scalar-case"
 head_sha = "dd2169a1a40b9f455d24bc12a49b832e18532afb"
 summary = "Opened CPU258V-011 to record release-built scalar and scalar-vs-AVX2 selected-case parity evidence."
+
+notes = [
+  "The selected scalar and AVX2 release runs complete strict CPU execution with real GGUF loading, explicit tokenizer resolution, selected i2_s kernels, and fallback_used=false.",
+  "Both lanes produce identical prompt IDs, generated IDs [89048, 124979, 70232, 88162], and decoded text for math_2_plus_2.",
+  "This PR proves selected-case answer parity only, not answer correctness, full-corpus parity, speed, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "The selected scalar and AVX2 release runs complete strict CPU execution with real GGUF loading, explicit tokenizer resolution, selected i2_s kernels, and fallback_used=false.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T080407Z-CPU258V-011-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T080407Z-CPU258V-011-merged.toml
@@ -3,8 +3,15 @@ campaign = "intel-258v-platform"
 item = "CPU258V-011"
 event = "merged"
 pr = 4014
+actor = "codex"
 merge_sha = "4b0560f95e6cd5feb5a4e4ed642aa63a578b4c65"
 summary = "Merged CPU258V-011, recording release-built scalar-vs-AVX2 selected-case answer parity."
+
+notes = [
+  "The merged artifacts show scalar and AVX2 both complete strict CPU execution for the selected math_2_plus_2 case.",
+  "Both lanes produce identical prompt IDs, generated IDs [89048, 124979, 70232, 88162], and decoded text, so the selected bad answer is not AVX2-specific.",
+  "The shared output fails the exact-answer gate, so no answer correctness, full-corpus parity, sustained throughput, Arc 140V execution, or Intel NPU execution is claimed.",
+]
 
 details = [
   "The merged artifacts show scalar and AVX2 both complete strict CPU execution for the selected math_2_plus_2 case.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T090609Z-CPU258V-012-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T090609Z-CPU258V-012-pr-open.toml
@@ -3,9 +3,17 @@ campaign = "intel-258v-platform"
 item = "CPU258V-012"
 event = "pr_open"
 pr = 4022
+actor = "codex"
 branch = "codex/intel-258v-platform/CPU258V-012-gamma-rootcause"
 head_sha = "e2b42c4594b61a04fc45de8afd65839dfc1ba405"
 summary = "Opened CPU258V-012 to correct BitNet b1.58 CPU mechanics and tied-output-head receipt metadata."
+
+notes = [
+  "BitNet b1.58 defaults now route through RMSNorm and ReLU2 for CPU decode construction.",
+  "The transformer FFN honors the configured activation instead of always applying SiLU.",
+  "The strict scalar one-token raw fixture changes the generated token but still produces a bad answer, so answer quality remains open.",
+  "This PR does not claim answer quality is fixed, scalar/AVX2 parity changed, sustained throughput, Arc 140V execution, or Intel NPU execution.",
+]
 
 details = [
   "BitNet b1.58 defaults now route through RMSNorm and ReLU2 for CPU decode construction.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T092137Z-CPU258V-012-merged.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T092137Z-CPU258V-012-merged.toml
@@ -3,8 +3,17 @@ campaign = "intel-258v-platform"
 item = "CPU258V-012"
 event = "merged"
 pr = 4022
+actor = "codex"
 merge_sha = "9804aa706bbaec101a67bd8f2e23c5d8365291a4"
 summary = "Merged CPU258V-012, correcting BitNet b1.58 CPU mechanics and preserving the shared answer-quality finding."
+
+notes = [
+  "BitNet b1.58 CPU construction now routes architecture defaults through RMSNorm and ReLU2.",
+  "The transformer FFN now honors configured activation instead of always applying SiLU.",
+  "Canonical BitNet run receipts now record tied token embeddings instead of an absent output.weight.",
+  "The strict scalar one-token raw fixture still produces a bad token after the mechanics correction, so the shared answer-quality issue remains open.",
+  "No answer-quality, scalar/AVX2 parity, sustained throughput, Arc 140V, or Intel NPU claims were added.",
+]
 
 details = [
   "BitNet b1.58 CPU construction now routes architecture defaults through RMSNorm and ReLU2.",

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T142800Z-CPU258V-016-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T142800Z-CPU258V-016-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4087
 actor = "codex"
+head_sha = "6782fde3e09d4162f2965cff4c504a394a9fa67a"
 branch = "codex/lunar-lake/post-baseline-next-items"
 summary = "Opened CPU258V-016 to record the post-mechanics 258V CPU reference bundle and queue the next CPU-referenced Lunar Lake items."
 

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T163433Z-ARC140V-005-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T163433Z-ARC140V-005-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4103
 actor = "codex"
+head_sha = "8371e1f69bef5a6f2f11f56687aea76557aa8423"
 branch = "codex/intel-258v-platform/ARC140V-005-opencl-cpu-parity"
 summary = "Opened ARC140V-005 to record native Arc 140V OpenCL CPU-reference parity against the post-mechanics 258V CPU bundle."
 

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T172100Z-LNL258V-COMPARE-002-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T172100Z-LNL258V-COMPARE-002-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4110
 actor = "codex"
+head_sha = "fdb2ed23ec62a5976a7e4e07c245be2c354d1e71"
 branch = "codex/lunar-lake/LNL258V-COMPARE-002"
 summary = "Opened LNL258V-COMPARE-002 to refresh the Lunar Lake same-machine evidence index after CPU, NPU, and Arc parity receipts."
 

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T200400Z-CPU258V-017-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-08T200400Z-CPU258V-017-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4123
 actor = "codex"
+head_sha = "dcdea3234c23d9185339e02db0b0d24d2cddeba8"
 branch = "codex/lunar-lake/CPU258V-017-prompt-token-audit"
 summary = "Opened CPU258V-017 to add a BitNet prompt/token authority audit receipt for the 258V CPU shared input-contract investigation."
 notes = [

--- a/docs/tracking/campaigns/intel-258v-platform/events/2026-05-09T022500Z-CPU258V-018-pr-open.toml
+++ b/docs/tracking/campaigns/intel-258v-platform/events/2026-05-09T022500Z-CPU258V-018-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4178
 actor = "codex"
+head_sha = "b7164fef75329072f1cb5c425586dfff14c7f418"
 branch = "codex/lunar-lake/CPU258V-018-hf-prompt-token-parity"
 summary = "Opened CPU258V-018 to compare HF AutoTokenizer prompt rendering and token IDs against BitNet-rs prompt-authority audit output."
 notes = [

--- a/docs/tracking/campaigns/intel-npu/events/2026-05-08T131400Z-NPU-009-pr-open.toml
+++ b/docs/tracking/campaigns/intel-npu/events/2026-05-08T131400Z-NPU-009-pr-open.toml
@@ -6,6 +6,7 @@ from = "ready"
 to = "pr_open"
 pr = 4068
 actor = "codex"
+head_sha = "66d3dae589edde331aba03ff260b02b5b43417c7"
 branch = "codex/intel-npu/NPU-009-openvino-llamacpp-gguf-reference"
 summary = "Opened NPU-009 for the OpenVINO llama.cpp GGUF external reference lane."
 


### PR DESCRIPTION
## Summary

- fill missing `head_sha` metadata on legacy campaign PR-open events
- add `actor = "codex"` and `notes` to older CPU258V-006 through CPU258V-012 lifecycle events that only had `details`
- preserve existing tracker meaning while removing campaign doctor warning noise

## Validation

- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
