### PR TITLE
docs: add crate boundary policy and repository surfaces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,8 @@ Information-oriented. Look up exact behaviors, formats, and APIs.
 | Document | Purpose |
 |----------|---------|
 | [development/build-commands.md](development/build-commands.md) | Build matrix and cargo commands |
+| [development/CRATE_BOUNDARY_POLICY.md](development/CRATE_BOUNDARY_POLICY.md) | Rules for deciding when a design seam deserves a Cargo package boundary |
+| [development/REPO_SURFACES.md](development/REPO_SURFACES.md) | Target public crate surface, internal module-family map, and collapse waves |
 | [development/test-suite.md](development/test-suite.md) | Test organization and CI lanes |
 | [development/gpu-development.md](development/gpu-development.md) | CUDA development guide |
 | [development/validation-framework.md](development/validation-framework.md) | Quality assurance pipeline |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,8 @@
 - [Development](development.md)
 - [Codegen](codegen.md)
 - [Testing](testing.md)
+- [Crate Boundary Policy](development/CRATE_BOUNDARY_POLICY.md)
+- [Repository Surfaces](development/REPO_SURFACES.md)
 
 ## Performance
 - [Benchmarking Setup](benchmarking-setup.md)

--- a/docs/development/CRATE_BOUNDARY_POLICY.md
+++ b/docs/development/CRATE_BOUNDARY_POLICY.md
@@ -1,0 +1,205 @@
+# Crate Boundary Policy
+
+BitNet-rs is a monorepo with multiple public surfaces, not a loose collection of publishable microcrates. Design seams may be small and SRP-focused, but only a subset of seams should become Cargo package boundaries. The default implementation shape for an internal seam is a module family inside an owning crate.
+
+This policy turns the doctrine into working rules:
+
+> Design seams like microcrates, implement most as module families, and publish only the seams we are willing to support as real contracts.
+
+## Scope
+
+This policy applies to every workspace package in the repository and every new `Cargo.toml` proposed under the repo. It governs whether a seam is a public package, an internal module family, a dev-only crate, a hardware lab crate, evidence/history, or a forced package boundary.
+
+The monorepo remains the container for runtime code, kernels, model contracts, receipts, CLI, server, bindings, hardware lanes, tests, docs, campaign tracking, and historical evidence. The policy only narrows which seams become public package surface.
+
+## Core terms
+
+### Public package
+
+A public package is a crate whose package boundary is part of the supported product or SDK surface. It has a standalone user story, a documented API, a semver promise, package metadata, and a path to `cargo package` / `cargo publish --dry-run` success.
+
+Public packages are appropriate for:
+
+- product facades users install or run directly;
+- SDK surfaces programmatic users choose directly;
+- hardware/backend surfaces with independent external value;
+- bindings and sidecar tools with distinct installation paths;
+- stable schema or contract surfaces that other public crates and external users rely on.
+
+### Internal module family
+
+An internal module family is an SRP seam implemented inside one owner crate. It has a local facade (`mod.rs` or equivalent), private internals, seam-focused tests, and explicit dependency direction, but it does not have its own package identity.
+
+Module families are the default for implementation layers, single-owner seams, and code splits that exist primarily to keep files small or agent-editable.
+
+### Dev-only crate
+
+A dev-only crate is a workspace crate for tests, fixtures, fuzzing, benchmarks, policy harnesses, migration tooling, or CI support. It should normally use `publish = false` and must not become a dependency of a publishable package unless the boundary memo explains why that is safe.
+
+### Hardware lab crate
+
+A hardware lab crate is a workspace package used to explore, benchmark, or validate a backend before it has a stable standalone public story. Hardware lab crates should default to `publish = false` until they have a clear feature surface, documented hardware target, stable receipt/claim boundary, and clean packaging dry run.
+
+### Evidence/history
+
+Evidence/history is material retained to explain past decisions, validation results, campaigns, migration notes, and receipts. It belongs in docs, tracking, archive, benchmarks, or generated evidence locations, not in newly published crates.
+
+### Forced package boundary
+
+A forced package boundary is a crate that remains separate because Cargo or distribution mechanics require it, even if the design seam would otherwise be a module family. Examples include proc macros, build helpers that must compile independently, FFI/sys crates with native build semantics, fuzz targets, workspace tools, generated bindings, or packages with incompatible feature/dependency constraints.
+
+Forced package boundaries still need a memo. The memo can cite the mechanic instead of an external user story.
+
+## Boundary rule
+
+New `Cargo.toml` files are forbidden unless a boundary memo passes review.
+
+A change that adds or preserves a crate as public must include or update a boundary memo that answers the questions in this policy. A change that adds an internal/dev/lab package must explicitly mark why it cannot be a module family and whether it must be `publish = false`.
+
+## Boundary memo template
+
+Use this template in the PR description or in a colocated design document when adding a new crate, making a crate public, or deciding that an existing crate survives a collapse wave.
+
+```text
+crate name:
+owner:
+classification: public package | internal module family | dev-only crate | hardware lab crate | forced package boundary | evidence/history
+intended audience:
+public API or local facade:
+semver promise:
+standalone README/docs:
+external consumers outside the owner crate/repo:
+invariant owned by this boundary:
+why a module family is not enough:
+forced package mechanic, if any:
+dependency closure made public by this boundary:
+packaging/doc dry-run status:
+migration/collapse note, if applicable:
+```
+
+## Survival tests for public crates
+
+A crate may remain public when at least one strong test is true:
+
+- an outsider would choose it directly by name;
+- multiple surviving public packages need it as a stable shared contract;
+- it owns a stable schema, receipt, API, or hardware claim boundary;
+- it is a hardware/backend package with real standalone value;
+- it is a binding, converter, CLI, server, or tool users install directly;
+- Cargo mechanics force a separate package and the dependency closure is acceptable.
+
+A crate should collapse when one or more of these are true and no survival test applies:
+
+- it has a single obvious owner crate;
+- the name reads like an implementation layer (`*-core`, `*-policy-core`, `*-state-core`, `*-snapshot-core`, `*-diagnostics-core`);
+- it has no standalone README story or docs entry;
+- it has no independent semver meaning;
+- it exists mainly to keep files small;
+- it is only consumed by one public crate;
+- publishing it would expose accidental dependencies or release choreography.
+
+## Module-family discipline
+
+Collapsing a crate must preserve architecture. A collapsed seam must not become a junk drawer.
+
+Each internal module family must have:
+
+- one owner crate;
+- one responsibility;
+- one public or `pub(crate)` facade;
+- private internals behind that facade;
+- seam-focused tests;
+- clear dependency direction;
+- no sibling deep imports that bypass the facade.
+
+Preferred shape:
+
+```text
+crates/bitnet-inference/src/generation/
+  mod.rs
+  events.rs
+  stop.rs
+  policy.rs
+  tests.rs
+```
+
+Facade example:
+
+```rust
+pub(crate) mod stop;
+pub mod events;
+
+pub use events::{GenerationEvent, GenerationStats};
+pub(crate) use stop::{StopDecision, StopPolicy};
+```
+
+Other modules should depend on `crate::generation` exports, not on private paths like `crate::generation::stop::internal_detail`.
+
+## Public package quality bar
+
+Every public package should have:
+
+- complete package metadata: `description`, `license`, `repository`, `readme` where applicable, and docs metadata;
+- a README or docs page that explains who should use it;
+- an explicit feature story and default-feature policy;
+- a documented semver/API contract;
+- a clean or intentionally documented dependency closure;
+- no dependency on unpublished runtime path crates unless the release plan explains how packaging works;
+- `cargo package --list -p <crate>` coverage before publication;
+- `cargo publish --dry-run -p <crate>` before actual publication;
+- `cargo doc -p <crate> --no-deps` for public API review.
+
+## Internal and dev-only package rules
+
+Internal/dev/lab crates that remain as workspace packages should:
+
+- set `publish = false` unless the boundary memo says otherwise;
+- document their owner crate or owning subsystem;
+- avoid being dependencies of publishable crates;
+- have a migration note if they are collapse candidates;
+- avoid public README language that implies external support.
+
+## Promotion and demotion workflow
+
+### Promote a module family to a public crate
+
+1. Write the boundary memo.
+2. Identify the audience, invariant, and semver promise.
+3. Add package metadata and standalone docs.
+4. Confirm no accidental dependency closure is exposed.
+5. Run package/doc dry-runs.
+6. Update the repo surface inventory.
+
+### Demote a public/internal crate to a module family
+
+1. Pick the owner crate.
+2. Move code behind a local facade that preserves the seam.
+3. Rewrite callers to use the facade.
+4. Remove package dependencies and workspace membership when safe.
+5. Add compatibility shims only when an existing public API requires them.
+6. Update the collapse inventory and migration notes.
+
+## Review checklist
+
+Reviewers should ask:
+
+- Who is the user of this crate boundary?
+- What invariant does the boundary own?
+- What breaks if this is a module family instead?
+- Does the crate force internal dependencies into public packaging?
+- Does it have a README/docs story independent of the owner crate?
+- Does semver for this crate mean anything by itself?
+- Is this a Cargo/distribution constraint rather than an architectural preference?
+- If internal, is `publish = false` set or explicitly justified?
+
+## Enforcement roadmap
+
+Initial enforcement is documentation-first and advisory. The intended follow-up is an `xtask crate-boundaries check` command that can enforce:
+
+- no new public crate without a boundary memo;
+- `publish = false` for internal/dev/lab crates;
+- public crates have README, description, license, repository, and docs metadata;
+- collapse candidates are not dependencies of publishable crates without a migration note;
+- repo surface inventory files stay in sync with the workspace manifest.
+
+Once the inventory is stable, CI can make the check blocking.

--- a/docs/development/REPO_SURFACES.md
+++ b/docs/development/REPO_SURFACES.md
@@ -1,0 +1,390 @@
+# Repository Surfaces
+
+This document maps the desired BitNet-rs monorepo shape. It is a working target for crate-boundary cleanup, not a declaration that every listed crate already satisfies the public package quality bar.
+
+The target is:
+
+```text
+large monorepo
+clear public crate set
+crate-grade internal module families
+stable documented APIs where public
+versioned schemas where external
+strict layer checks replacing accidental crate boundaries
+```
+
+## Surface model
+
+The repo should distinguish these layers:
+
+| Layer | Meaning | Default package posture |
+|---|---|---|
+| Public package surface | Product, SDK, backend, binding, tool, or schema surfaces with external users. | Publishable only after a boundary memo and package dry-run. |
+| Internal module families | SRP implementation seams owned by one public/product crate. | No separate crate; expose a local facade. |
+| Dev/test/lab tooling | Test support, fixtures, fuzzing, benchmark harnesses, hardware experiments, migration tools. | Workspace-only and usually `publish = false`. |
+| Historical evidence | Campaign events, receipts, archive notes, generated dashboards, baseline reports. | Docs/tracking/archive data, not package surface. |
+| Forced package boundaries | Proc macros, sys/FFI, build helpers, fuzz, xtask, or feature-isolated packages. | Separate only because Cargo/distribution mechanics require it. |
+
+## Target public surfaces
+
+The desired public package set should be closer to 20-35 crates than 130+ crates. The categories below define the target vocabulary for future inventory work.
+
+### Product facades
+
+| Crate | Role |
+|---|---|
+| `bitnet` | Primary facade, user-facing crate name, install/docs entry, optional re-exports. |
+| `bitnet-cli` | CLI adapter and command UX. |
+| `bitnet-server` | HTTP/OpenAI-compatible serving adapter. |
+
+### Core SDK surfaces
+
+| Crate | Role |
+|---|---|
+| `bitnet-inference` | Engine, session, prefill/decode, and orchestration API. |
+| `bitnet-models` | Artifact inspection, model contracts, GGUF/SafeTensors authority. |
+| `bitnet-tokenizers` | Tokenizer authority, prompt/token handling, tokenizer discovery facade. |
+| `bitnet-sampling` | Sampling, probability, logits, and logits policy surface. |
+| `bitnet-receipts` | Receipt schemas, validators, claim boundaries, and explainability contracts. |
+| `bitnet-kernels` | CPU/CUDA/dense/BitNet kernel contracts and implementations. |
+| `bitnet-prompt-templates` | Prompt templates that are intentionally reusable outside the CLI/server. |
+
+### Hardware/backend surfaces
+
+Backend crates should be public only when they can stand alone. A backend needs a clear feature surface, documented hardware target, stable receipt/claim boundary, usefulness outside `bitnet-cli`, and clean package dry-runs.
+
+Candidate public backend surfaces:
+
+```text
+bitnet-device-probe
+bitnet-nvidia
+bitnet-wgpu
+bitnet-metal
+bitnet-opencl
+bitnet-rocm
+bitnet-vulkan
+```
+
+Backends that do not yet pass the standalone test should live under `bitnet-kernels`, an owner backend module, or a hardware lab crate with `publish = false`.
+
+### Tool, binding, and product sidecars
+
+These are legitimate package surfaces when users install them directly or embed them through language/runtime-specific packaging:
+
+```text
+bitnet-st2gguf
+bitnet-ffi
+bitnet-py
+bitnet-wasm
+```
+
+### Maybe-public, decide case by case
+
+These require individual boundary memos before publication is assumed:
+
+```text
+bitnet-gguf
+bitnet-artifacts
+bitnet-quantization
+bitnet-quantization-bits
+bitnet-bench
+bitnet-test-support
+```
+
+## Likely collapse waves
+
+The lists below name seams that look like implementation layers today. They should be inventoried, assigned owners, and either collapsed into module families or explicitly justified with boundary memos.
+
+### Server adapter internals -> `bitnet-server`
+
+Likely owner layout:
+
+```text
+crates/bitnet-server/src/
+  auth/
+  routing/
+  request_context/
+  health/
+  versioning/
+  endpoint_registry/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-client-ip-core
+bitnet-api-versioning-core
+bitnet-api-key-auth-core
+bitnet-server-health-types-core
+bitnet-endpoint-registry-core
+bitnet-request-context-core
+bitnet-request-router-core
+```
+
+### CLI adapter internals -> `bitnet-cli`
+
+Likely owner layout:
+
+```text
+crates/bitnet-cli/src/
+  config/
+  sampling/
+  build_info/
+  commands/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-cli-config-core
+bitnet-cli-sampling-core
+bitnet-build-info-core
+```
+
+### Inference/session/generation internals -> `bitnet-inference`
+
+Likely owner layout:
+
+```text
+crates/bitnet-inference/src/
+  generation/
+    events.rs
+    stop.rs
+  session/
+    config.rs
+    state.rs
+  kv_cache/
+    policy.rs
+  engine/
+    ports.rs
+    lifecycle.rs
+  metrics/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-generation-events-core
+bitnet-generation-stop-core
+bitnet-kv-cache-policy-core
+bitnet-engine-state-core
+bitnet-session-config-core
+bitnet-engine-core
+bitnet-repl-core
+bitnet-inference-metrics-core
+```
+
+### Tokenizer internals -> `bitnet-tokenizers`
+
+Likely owner layout:
+
+```text
+crates/bitnet-tokenizers/src/
+  merge/
+  model_detection/
+  discovery/
+  text/
+  authority/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-token-merge-core
+bitnet-tokenizer-model-core
+bitnet-tokenizer-discovery-core
+bitnet-tokenizer-text-core
+```
+
+### Model/artifact support -> `bitnet-models` or `bitnet-artifacts`
+
+If model fetch, verify, cache, and artifact authority are intended as a standalone SDK, introduce or preserve a public `bitnet-artifacts` surface. Otherwise, keep these under `bitnet-models`.
+
+Likely owner layout under `bitnet-models`:
+
+```text
+crates/bitnet-models/src/
+  artifacts/
+  compatibility/
+  download/
+  gguf/
+  safetensors/
+  naming/
+  layer_index/
+```
+
+Likely collapse candidates or case-by-case public surfaces:
+
+```text
+bitnet-compat-core
+bitnet-weight-name-core
+bitnet-layer-index-core
+bitnet-download-core
+bitnet-download
+bitnet-atomic-file-core
+bitnet-minimal-json-core
+bitnet-safetensors-ln
+```
+
+### Kernel implementation seams -> `bitnet-kernels`
+
+Likely owner layout:
+
+```text
+crates/bitnet-kernels/src/
+  cpu/
+  cuda/
+  qk256/
+    layout.rs
+    dispatch.rs
+  dense/
+  dispatch/
+  shaders/
+    vulkan/
+    wgpu/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-cpu-activations
+bitnet-qk256-layout-core
+bitnet-dispatch-core
+bitnet-vulkan-shaders
+bitnet-wgpu-shaders-i2s
+bitnet-qk256-dispatch
+```
+
+`qk256-layout` is a watch item. If low-bit kernel authors outside the repo would choose it directly, it may deserve a public boundary. Otherwise it belongs under `bitnet-kernels::qk256`.
+
+### Receipt and contract seams -> `bitnet-receipts`
+
+The receipt system is a real public surface, but each implementation shard does not need a package identity.
+
+Likely owner layout:
+
+```text
+crates/bitnet-receipts/src/
+  schemas/
+  validators/
+  benchmark/
+  feature_contracts/
+  explain/
+```
+
+Likely collapse candidates:
+
+```text
+bitnet-receipts-core
+bitnet-bench-receipts
+bitnet-bench-regression-core
+bitnet-feature-contract
+bitnet-runtime-profile-contract
+```
+
+## Clean architecture module maps
+
+The package graph should express public surfaces. The module graph should express clean architecture.
+
+### `bitnet-inference`
+
+```text
+crates/bitnet-inference/src/
+  domain/
+    session.rs
+    generation.rs
+    kv_cache.rs
+  ports/
+    model.rs
+    tokenizer.rs
+    kernel.rs
+    receipts.rs
+  engine/
+    prefill.rs
+    decode.rs
+    warm_session.rs
+  adapters/
+    cpu.rs
+    cuda.rs
+  metrics/
+```
+
+### `bitnet-server`
+
+```text
+crates/bitnet-server/src/
+  domain/
+    request.rs
+    response.rs
+  ports/
+    inference.rs
+    receipt_sink.rs
+  adapters/
+    axum/
+    openai/
+  auth/
+  routing/
+  health/
+```
+
+### `bitnet-cli`
+
+```text
+crates/bitnet-cli/src/
+  commands/
+  output/
+  config/
+  receipts/
+  model_aliases/
+  device_selection/
+```
+
+## Work sequence
+
+Recommended order:
+
+1. Add the boundary doctrine and repo surface docs.
+2. Add crate inventory and owner-map files under `ci/crate-boundaries/`.
+3. Add advisory `xtask crate-boundaries check` enforcement.
+4. Collapse server adapter internals into `bitnet-server`.
+5. Collapse CLI adapter internals into `bitnet-cli`.
+6. Collapse tokenizer internals into `bitnet-tokenizers`.
+7. Collapse inference/session/generation internals into `bitnet-inference`.
+8. Consolidate receipts under `bitnet-receipts` unless a separate SDK reason survives.
+9. Consolidate kernel layout/dispatch/shader catalog seams under `bitnet-kernels`, except deliberately public seams.
+10. Run publish-surface dry-runs for every surviving public package.
+
+## Inventory file targets
+
+Follow-up inventory should live under:
+
+```text
+ci/crate-boundaries/public-surfaces.toml
+ci/crate-boundaries/collapse-candidates.toml
+ci/crate-boundaries/dev-only-crates.toml
+```
+
+Example entry:
+
+```toml
+[crate.bitnet-api-key-auth-core]
+current_role = "internal_workspace_crate"
+target_owner = "bitnet-server"
+target_state = "module_family"
+seam_type = "server_adapter"
+public = false
+collapse_wave = "server-adapters"
+```
+
+## Completion criteria
+
+The migration is done when:
+
+- public crates each have a standalone user story;
+- internal SRP seams have module-family facades;
+- no implementation-layer crate is public by accident;
+- published crates do not depend on unpublished runtime path crates;
+- `workspace.default-members` reflects normal developer workflow;
+- `xtask` enforces crate-boundary policy;
+- docs explain which crate to use for which job;
+- `cargo package`, `cargo publish --dry-run`, and `cargo doc --no-deps` pass for every public crate.


### PR DESCRIPTION
### Motivation
- Prevent accidental public package surfaces by turning the boundary doctrine into explicit, reviewable rules. 
- Preserve the monorepo architecture while making package boundaries intentional and auditable. 
- Provide a clear roadmap and vocabulary for collapsing implementation-layer crates into owned module families. 
- Give reviewers and engineers a reproducible checklist and enforcement path for adding or keeping public crates. 

### Description
- Add `docs/development/CRATE_BOUNDARY_POLICY.md` with definitions for public packages, internal module families, dev-only/hardware-lab crates, forced boundaries, a boundary memo template, survival/collapse tests, module-family discipline, and promotion/demotion workflow. 
- Add `docs/development/REPO_SURFACES.md` mapping the target public surfaces, likely collapse waves (server/CLI/tokenizers/inference/kernels/receipts), work sequence, inventory file targets, and completion criteria. 
- Link the new documents from the main docs index by updating `docs/README.md` and `docs/SUMMARY.md` so the guidance appears in documentation navigation. 
- Define follow-up artifacts and automation targets (inventory files under `ci/crate-boundaries/` and an `xtask crate-boundaries check` enforcement roadmap). 

### Testing
- Verified internal doc links resolve with the included link-check script by running the Python link-resolution check (`python - <<'PY' ... PY`), which returned success. 
- Ran repository checks for staged changes with `git diff --cached --check` to surface formatting/link issues, which produced no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb84cbac08333b3e76bb5b3656a92)