### PR TITLE
docs: add crate boundary policy

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -61,6 +61,8 @@ cargo run --no-default-features -p xtask -- benchmark --model models/test.gguf -
 ### Core Development
 - **[Build Commands](development/build-commands.md)** - Comprehensive build and test commands
 - **[Development Standards](development/development-standards.md)** - Coding standards and best practices
+- **[Crate Boundary Policy](development/CRATE_BOUNDARY_POLICY.md)** - Rules for deciding when a design seam is a crate versus a module family
+- **[Repository Surfaces](development/REPO_SURFACES.md)** - Target public crate surface, owner map, and migration roadmap
 - **[CI Integration](development/ci-integration.md)** - Continuous integration setup
 - **[Test Suite](development/test-suite.md)** - Testing framework and practices
 

--- a/docs/development/CRATE_BOUNDARY_POLICY.md
+++ b/docs/development/CRATE_BOUNDARY_POLICY.md
@@ -1,0 +1,213 @@
+# Crate Boundary Policy
+
+BitNet-rs is a monorepo, not a single-crate project. The correction this policy
+makes is **not anti-monorepo** and **not anti-SRP**. It is
+**anti-accidental-public-surface**: design seams may be as small as microcrates in
+our architecture, but most of those seams should be implemented as module
+families instead of permanently published package boundaries.
+
+This policy applies to every new or existing `Cargo.toml` in the workspace.
+
+## Boundary doctrine
+
+> Design seams like microcrates, implement most seams as module families, and
+> publish only the seams we are willing to support as real contracts.
+
+The package graph is for stable external surfaces. The module graph is for clean
+architecture. A small responsibility does not automatically deserve a crate.
+
+## Repository layers
+
+Every workspace component must be classified into exactly one of these layers:
+
+| Layer | Definition | Default publishing stance |
+| --- | --- | --- |
+| Public package surface | A crate with a standalone user story and an API we are willing to version and support. | May publish after boundary memo approval. |
+| Internal module family | A cohesive SRP seam owned by one public crate and reached through that crate's facade. | No separate `Cargo.toml`. |
+| Dev-only crate | Test, fixture, grid, policy, benchmark, or local automation support. | `publish = false`. |
+| Hardware lab crate | Experimental or bring-up lane for backend exploration before it has a stable external story. | `publish = false` until promoted. |
+| Evidence/history | Receipts, generated baselines, migration notes, campaign tracking, and archived reports. | Not a package surface. |
+| Forced package boundary | A separate crate required by build target, language binding, proc macro, feature isolation, publication, or binary packaging constraints. | Must document why a module family is not enough. |
+
+## Public crate categories
+
+A public crate should fit one of the following categories.
+
+### Product facades
+
+These are how users enter the system:
+
+- `bitnet` — primary facade, user-facing crate name, documentation entry point,
+  and optional re-export surface.
+- `bitnet-cli` — CLI adapter and command UX.
+- `bitnet-server` — HTTP/OpenAI-compatible serving adapter.
+
+### Core SDK surfaces
+
+These are direct programmatic surfaces:
+
+- `bitnet-inference` — engine, session, prefill/decode, and generation
+  orchestration.
+- `bitnet-models` — artifact inspection, model contracts, GGUF/SafeTensors model
+  authority.
+- `bitnet-tokenizers` — tokenizer authority, prompt/token handling, discovery,
+  and text normalization.
+- `bitnet-sampling` — sampling and logits policy.
+- `bitnet-receipts` — receipt schemas, validators, claim boundaries, and
+  versioned evidence contracts.
+- `bitnet-kernels` — CPU/CUDA/dense/BitNet kernel contracts and supported
+  implementations.
+
+### Hardware/backend surfaces
+
+Backend crates are public only after they have a real external user story:
+
+- documented hardware target,
+- clear feature surface,
+- stable receipt/claim boundary,
+- usefulness outside `bitnet-cli`, and
+- clean package and publish dry-runs.
+
+Before that point, backend work belongs under `bitnet-kernels` or a
+`publish = false` hardware-lab crate.
+
+### Tool, binding, and sidecar surfaces
+
+A separate public crate is appropriate when users install or embed it through a
+different delivery path, for example `bitnet-st2gguf`, `bitnet-ffi`, `bitnet-py`,
+or `bitnet-wasm`.
+
+### Test and development support
+
+Test fixtures, BDD grids, testing policy crates, and local support libraries
+should default to `publish = false` unless another repository genuinely consumes
+them as an external dependency.
+
+## Boundary memo requirement
+
+A new `Cargo.toml` is forbidden unless the proposed boundary has an approved
+boundary memo. The memo must answer:
+
+- crate name,
+- owner,
+- audience,
+- public API,
+- semver promise,
+- standalone README/docs story,
+- who consumes it outside the owner crate,
+- what invariant it owns,
+- why a module family is not enough, and
+- what dependency closure it forces public.
+
+For forced package boundaries, the memo must name the force explicitly: binary,
+proc macro, build target, FFI/binding packaging, feature isolation, publication,
+or another concrete cargo/build-system constraint.
+
+## Survival tests
+
+A crate may remain public when it passes at least one strong test:
+
+- an outsider would choose it directly,
+- multiple surviving public packages need it,
+- it is a stable contract surface,
+- it is a hardware/backend surface with standalone value, or
+- it is a binding or tool users install directly.
+
+A crate should collapse when any of these are true:
+
+- it has a single obvious owner,
+- its name describes an implementation layer,
+- it has no standalone README/docs story,
+- it has no independent semver meaning,
+- it only exists to keep files small, or
+- it is only used by one public crate.
+
+Suffixes such as `-core`, `-contract-core`, `-policy-core`, `-state-core`,
+`-snapshot-core`, and `-diagnostics-core` are warning signs. They often mean
+"architecture seam" rather than "public package".
+
+## Module-family discipline
+
+Collapsing a crate must preserve architecture. A module family is not a junk
+drawer. Each internal SRP module family must have:
+
+- one owner crate,
+- one responsibility,
+- one public or `pub(crate)` facade,
+- private internals,
+- seam-focused tests,
+- clear dependency direction, and
+- no sibling deep imports.
+
+A preferred shape is:
+
+```text
+crates/bitnet-inference/src/generation/
+  mod.rs          # facade
+  events.rs
+  stop.rs
+  policy.rs
+  tests.rs
+```
+
+The facade exposes the seam and hides internals:
+
+```rust
+pub(crate) mod stop;
+pub mod events;
+
+pub use events::{GenerationEvent, GenerationStats};
+pub(crate) use stop::{StopDecision, StopPolicy};
+```
+
+Other modules should import through the facade, not through paths such as:
+
+```rust
+crate::generation::stop::internal_detail
+```
+
+## Collapse waves
+
+Use the following default migration waves unless a boundary memo justifies a
+different target.
+
+| Wave | Current pattern | Target owner | Target module family |
+| --- | --- | --- | --- |
+| Server adapters | `bitnet-client-ip-core`, `bitnet-api-versioning-core`, `bitnet-api-key-auth-core`, `bitnet-server-health-types-core`, `bitnet-endpoint-registry-core`, `bitnet-request-context-core`, `bitnet-request-router-core` | `bitnet-server` | `auth`, `routing`, `request_context`, `health`, `versioning`, `endpoint_registry` |
+| CLI adapters | `bitnet-cli-config-core`, `bitnet-cli-sampling-core`, `bitnet-build-info-core` | `bitnet-cli` | `config`, `sampling`, `build_info`, `commands` |
+| Tokenizer internals | `bitnet-token-merge-core`, `bitnet-tokenizer-model-core`, `bitnet-tokenizer-discovery-core`, `bitnet-tokenizer-text-core` | `bitnet-tokenizers` | `merge`, `model_detection`, `discovery`, `text`, `authority` |
+| Inference/session/generation | `bitnet-generation-events-core`, `bitnet-generation-stop-core`, `bitnet-kv-cache-policy-core`, `bitnet-engine-state-core`, `bitnet-session-config-core`, `bitnet-engine-core`, `bitnet-repl-core`, `bitnet-inference-metrics-core` | `bitnet-inference` | `generation`, `session`, `kv_cache`, `engine`, `metrics` |
+| Models/artifacts | `bitnet-compat-core`, `bitnet-weight-name-core`, `bitnet-layer-index-core`, `bitnet-download-core`, `bitnet-download`, `bitnet-atomic-file-core`, `bitnet-minimal-json-core`, `bitnet-safetensors-ln` | `bitnet-models` or approved `bitnet-artifacts` | `artifacts`, `compatibility`, `download`, `gguf`, `safetensors`, `naming`, `layer_index` |
+| Kernels | `bitnet-cpu-activations`, `bitnet-qk256-layout-core`, `bitnet-dispatch-core`, `bitnet-vulkan-shaders`, `bitnet-wgpu-shaders-i2s`, `bitnet-qk256-dispatch` | `bitnet-kernels` unless explicitly public | `cpu`, `cuda`, `qk256`, `dense`, `dispatch`, `shaders` |
+| Receipts/contracts | `bitnet-receipts-core`, `bitnet-bench-receipts`, `bitnet-bench-regression-core`, `bitnet-feature-contract`, `bitnet-runtime-profile-contract` | `bitnet-receipts` unless separately justified | `schemas`, `validators`, `benchmark`, `feature_contracts`, `explain` |
+
+## Enforcement plan
+
+1. Document the policy and target surfaces.
+2. Add crate-boundary inventory files under `ci/crate-boundaries/`.
+3. Add `xtask crate-boundaries check` in advisory mode.
+4. Make obvious collapses in waves, beginning with server and CLI adapter
+   internals.
+5. Promote the check to blocking once the inventory is stable.
+
+The check should eventually enforce:
+
+- no new public crate without a boundary memo,
+- `publish = false` for internal and dev-only crates,
+- README/description/license/docs metadata for public crates,
+- migration notes for publishable crates depending on collapse candidates, and
+- clean package/doc dry-runs for the surviving public set.
+
+## Done state
+
+The boundary cleanup is done when:
+
+- every public crate has a standalone user story,
+- internal SRP seams have module-family facades,
+- no implementation-layer crate is public by accident,
+- published crates do not depend on unpublished runtime path crates,
+- `workspace.default-members` reflects normal developer workflow,
+- `xtask` enforces this policy,
+- docs explain which crate to use for which job, and
+- `cargo package`, `cargo publish --dry-run`, and `cargo doc --no-deps` pass for
+  every public crate.

--- a/docs/development/REPO_SURFACES.md
+++ b/docs/development/REPO_SURFACES.md
@@ -1,0 +1,260 @@
+# Repository Surfaces
+
+This document is the working map for reducing accidental public package surface
+while preserving the BitNet-rs monorepo and SRP architecture. Use it together
+with the [Crate Boundary Policy](CRATE_BOUNDARY_POLICY.md).
+
+## Target model
+
+BitNet-rs remains one repository for:
+
+- runtime,
+- kernels,
+- model contracts,
+- receipts,
+- CLI,
+- server,
+- bindings,
+- hardware lanes,
+- tests,
+- docs,
+- campaign tracking, and
+- historical evidence.
+
+Inside that monorepo, the workspace must distinguish:
+
+- public package surface,
+- internal module families,
+- dev/test/lab tooling, and
+- historical evidence.
+
+## Target public surface
+
+The target is roughly **20-35 public crates**, not a crate for every SRP seam.
+This is a planning target, not an automatic deletion list. A crate survives by
+passing the policy's boundary memo and survival tests.
+
+### Core product set
+
+| Crate | Role |
+| --- | --- |
+| `bitnet` | Primary facade, user-facing crate name, install/docs entry, optional re-exports. |
+| `bitnet-cli` | CLI adapter and command UX. |
+| `bitnet-server` | HTTP/OpenAI-compatible serving adapter. |
+| `bitnet-inference` | Engine/session/decode orchestration API. |
+| `bitnet-models` | Artifact inspection, contracts, GGUF/SafeTensors model authority. |
+| `bitnet-tokenizers` | Tokenizer authority and prompt/token handling. |
+| `bitnet-prompt-templates` | Prompt and chat-template contracts when useful outside tokenization. |
+| `bitnet-sampling` | Sampling and logits policy. |
+| `bitnet-kernels` | CPU/CUDA/dense/BitNet kernel contracts and implementations. |
+| `bitnet-receipts` | Receipt schemas, validators, and claim boundaries. |
+| `bitnet-device-probe` | Device detection and capability probing when useful outside product facades. |
+
+### Optional backend, binding, and tool set
+
+These crates should be public only when their packaging story is real and their
+standalone dry-runs pass.
+
+| Crate | Public only if... |
+| --- | --- |
+| `bitnet-nvidia` | NVIDIA/CUDA users can consume it directly with documented features and claims. |
+| `bitnet-wgpu` | WGPU backend has a stable, documented backend surface. |
+| `bitnet-metal` | Metal backend has a standalone Apple Silicon/iOS/macOS story. |
+| `bitnet-opencl` | OpenCL backend has a stable hardware target and external use case. |
+| `bitnet-rocm` | ROCm backend has a stable AMD GPU story. |
+| `bitnet-vulkan` | Vulkan backend has a stable external backend API. |
+| `bitnet-st2gguf` | Users install the converter directly. |
+| `bitnet-ffi` | C ABI consumers embed BitNet-rs through the FFI package. |
+| `bitnet-py` | Python users install or build the Python binding. |
+| `bitnet-wasm` | Browser/JS users consume the WASM package. |
+
+### Maybe-public, decide case by case
+
+| Crate | Decision question |
+| --- | --- |
+| `bitnet-gguf` | Is it a stable GGUF parser users would choose directly, or a model-loader implementation detail? |
+| `bitnet-artifacts` | Do fetch/verify/cache/artifact contracts deserve a standalone SDK surface outside `bitnet-models`? |
+| `bitnet-quantization` | Do external low-bit model authors consume it directly? |
+| `bitnet-quantization-bits` | Is the bit layout a stable external contract or an implementation detail? |
+| `bitnet-bench` | Is it a user-installed benchmark product or repository-local validation tooling? |
+| `bitnet-test-support` | Does another repository depend on it, or is it workspace-only support? |
+
+### Likely internal module families
+
+Most crates matching these patterns should move toward module families unless a
+boundary memo says otherwise:
+
+- `*-core`,
+- `*-contract-core`,
+- `*-policy-core`,
+- `*-state-core`,
+- `*-snapshot-core`, and
+- `*-diagnostics-core`.
+
+These names usually indicate a design seam rather than an independent package
+product.
+
+## Owner map
+
+Use this owner map when creating inventory entries or planning collapse PRs.
+
+| Owner crate | Internal module families to prefer |
+| --- | --- |
+| `bitnet-cli` | `config`, `sampling`, `build_info`, `commands`, `output`, `receipts`, `model_aliases`, `device_selection` |
+| `bitnet-server` | `auth`, `routing`, `request_context`, `health`, `versioning`, `endpoint_registry`, `domain`, `ports`, `adapters` |
+| `bitnet-inference` | `generation`, `session`, `kv_cache`, `engine`, `metrics`, `domain`, `ports`, `adapters` |
+| `bitnet-tokenizers` | `merge`, `model_detection`, `discovery`, `text`, `authority` |
+| `bitnet-models` | `artifacts`, `compatibility`, `download`, `gguf`, `safetensors`, `naming`, `layer_index` |
+| `bitnet-kernels` | `cpu`, `cuda`, `qk256`, `dense`, `dispatch`, `shaders` |
+| `bitnet-receipts` | `schemas`, `validators`, `benchmark`, `feature_contracts`, `runtime_profile`, `explain` |
+
+## Clean architecture examples
+
+Use the package graph for public surfaces and the module graph for clean
+architecture.
+
+### `bitnet-inference`
+
+```text
+crates/bitnet-inference/src/
+  domain/
+    session.rs
+    generation.rs
+    kv_cache.rs
+  ports/
+    model.rs
+    tokenizer.rs
+    kernel.rs
+    receipts.rs
+  engine/
+    prefill.rs
+    decode.rs
+    warm_session.rs
+  adapters/
+    cpu.rs
+    cuda.rs
+  metrics/
+```
+
+### `bitnet-server`
+
+```text
+crates/bitnet-server/src/
+  domain/
+    request.rs
+    response.rs
+  ports/
+    inference.rs
+    receipt_sink.rs
+  adapters/
+    axum/
+    openai/
+  auth/
+  routing/
+  health/
+```
+
+### `bitnet-cli`
+
+```text
+crates/bitnet-cli/src/
+  commands/
+  output/
+  config/
+  receipts/
+  model_aliases/
+  device_selection/
+```
+
+## Migration roadmap
+
+### PR 1 — Boundary doctrine
+
+Add this policy set:
+
+- `docs/development/CRATE_BOUNDARY_POLICY.md`
+- `docs/development/REPO_SURFACES.md`
+
+### PR 2 — Crate inventory and owner map
+
+Add:
+
+- `ci/crate-boundaries/public-surfaces.toml`
+- `ci/crate-boundaries/collapse-candidates.toml`
+- `ci/crate-boundaries/dev-only-crates.toml`
+
+Each entry should look like:
+
+```toml
+[crate.bitnet-api-key-auth-core]
+current_role = "internal_workspace_crate"
+target_owner = "bitnet-server"
+target_state = "module_family"
+seam_type = "server_adapter"
+public = false
+collapse_wave = "server-adapters"
+```
+
+### PR 3 — Advisory boundary check
+
+Add `xtask crate-boundaries check` to report:
+
+- new public crates without boundary memos,
+- internal/dev-only crates missing `publish = false`,
+- public crates missing README/description/license/docs metadata, and
+- publishable crates depending on collapse candidates without a migration note.
+
+The check should start advisory and become blocking after the inventory is
+reviewed.
+
+### PR 4 — Server adapter collapse
+
+Collapse obvious server `*-core` crates into `bitnet-server` module families.
+
+### PR 5 — CLI adapter collapse
+
+Collapse CLI config, sampling, and build-info internals into `bitnet-cli`.
+
+### PR 6 — Tokenizer internals collapse
+
+Collapse token merge, model detection, discovery, and text internals into
+`bitnet-tokenizers`.
+
+### PR 7 — Inference/session/generation collapse
+
+Collapse generation, stop, session, engine, KV-cache, REPL, and metrics internals
+into `bitnet-inference`. This is larger than the server and CLI waves and should
+come after the easier migrations.
+
+### PR 8 — Receipts consolidation
+
+Collapse `bitnet-receipts-core` into `bitnet-receipts` unless an independent SDK
+reason is documented.
+
+### PR 9 — Kernel layout consolidation
+
+Move QK256 layout/dispatch and shader catalog crates under `bitnet-kernels`,
+except for seams deliberately kept public.
+
+### PR 10 — Public surface dry-run
+
+For every surviving public crate, run:
+
+```bash
+cargo package --list -p <crate>
+cargo publish --dry-run -p <crate>
+cargo doc -p <crate> --no-deps
+```
+
+## Acceptance criteria
+
+The migration is complete when:
+
+- public crates each have a standalone user story,
+- internal SRP seams have module-family facades,
+- no implementation-layer crate is public by accident,
+- published crates do not depend on unpublished runtime path crates,
+- `workspace.default-members` reflects normal developer workflow,
+- `xtask` enforces crate-boundary policy,
+- docs explain which crate to use for which job, and
+- packaging, publish dry-runs, and docs pass for every public crate.


### PR DESCRIPTION
### Motivation
- The repository has many SRP microcrates that are accidental public package surfaces, so the change defines a doctrine to keep the monorepo and SRP architecture while reducing accidental publishes. 
- The goal is to treat many `*-core` crates as internal module families unless they justify a standalone public contract. 
- Provide a clear, actionable migration roadmap and owner map so collapse waves and enforcement can be automated and reviewed incrementally.

### Description
- Add `docs/development/CRATE_BOUNDARY_POLICY.md` which defines the boundary doctrine, repository layers, boundary memo requirement, survival tests, module-family discipline, collapse waves, enforcement plan, and done-state. 
- Add `docs/development/REPO_SURFACES.md` which maps the target public surface (core product set, optional backends, maybe-public candidates), an owner map, clean-architecture examples, and a PR-by-PR migration roadmap. 
- Link the new docs from the main development guide by updating `docs/development.md` to reference `CRATE_BOUNDARY_POLICY.md` and `REPO_SURFACES.md`.

### Testing
- Run `git diff --check` to ensure no whitespace or trivial diff issues and it passed. 
- Run a local Python Markdown link validation script which checked internal links for `docs/development.md`, `docs/development/CRATE_BOUNDARY_POLICY.md`, and `docs/development/REPO_SURFACES.md`, and it passed. 
- All changes were committed after the checks and the new docs are present under `docs/development/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb84cbac08333b3e76bb5b3656a92)