### PR TITLE
docs: add crate boundary policy and repository surfaces guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,8 @@ Information-oriented. Look up exact behaviors, formats, and APIs.
 | [development/gpu-development.md](development/gpu-development.md) | CUDA development guide |
 | [development/validation-framework.md](development/validation-framework.md) | Quality assurance pipeline |
 | [development/xtask.md](development/xtask.md) | Developer tooling reference |
+| [development/CRATE_BOUNDARY_POLICY.md](development/CRATE_BOUNDARY_POLICY.md) | Policy for public crates, internal module families, dev-only crates, and new package boundaries |
+| [development/REPO_SURFACES.md](development/REPO_SURFACES.md) | Target public surface map, collapse lanes, and crate owner migration plan |
 | [performance-benchmarking.md](performance-benchmarking.md) | Benchmarking setup and baselines |
 
 ---

--- a/docs/development/CRATE_BOUNDARY_POLICY.md
+++ b/docs/development/CRATE_BOUNDARY_POLICY.md
@@ -1,0 +1,310 @@
+# Crate Boundary Policy
+
+BitNet-rs is a monorepo with multiple legitimate public surfaces, but every
+architecture seam does not need to be a Cargo package. This policy keeps the
+monorepo and the single-responsibility design discipline while reducing
+accidental public API, release choreography, and dependency blast radius.
+
+The doctrine is:
+
+> Design seams like microcrates, implement most seams as module families, and
+> publish only the boundaries we are willing to support as real contracts.
+
+## Goals
+
+- Keep the monorepo as the container for runtime, kernels, model contracts,
+  receipts, CLI, server, bindings, hardware lanes, tests, docs, campaign
+  tracking, and historical evidence.
+- Separate public package surface from internal module families, dev/test/lab
+  tooling, and archived evidence.
+- Make every surviving public crate explain its audience, invariant, API, and
+  semver promise.
+- Prevent new `Cargo.toml` files from appearing merely because a design seam is
+  useful or because a file grew large.
+- Preserve clean architecture inside owner crates with crate-grade module
+  discipline.
+
+## Boundary categories
+
+### Public package
+
+A public package is a Cargo crate that users may choose directly, read about as
+an installable or embeddable unit, and reasonably expect to have a stable API or
+schema boundary.
+
+A public package must have:
+
+- a standalone user story;
+- an owner;
+- a documented audience;
+- a stable public API or explicit pre-stable contract;
+- a semver promise appropriate for its maturity;
+- a README or equivalent docs entry;
+- package metadata suitable for `cargo package` and docs generation;
+- a dependency closure we are willing to expose.
+
+Public packages are the exception, not the default.
+
+### Internal module family
+
+An internal module family is an SRP seam implemented inside one owner crate. It
+may be as carefully designed as a microcrate, but its support boundary is the
+owner crate rather than a separate package.
+
+A module family must have:
+
+- one owner crate;
+- one responsibility;
+- one `pub` or `pub(crate)` facade;
+- private internals;
+- seam-focused tests;
+- clear dependency direction;
+- no sibling deep imports around the facade.
+
+A good shape is:
+
+```text
+crates/bitnet-inference/src/generation/
+  mod.rs
+  events.rs
+  stop.rs
+  policy.rs
+  tests.rs
+```
+
+The facade owns what other modules may touch:
+
+```rust
+pub(crate) mod stop;
+pub mod events;
+
+pub use events::{GenerationEvent, GenerationStats};
+pub(crate) use stop::{StopDecision, StopPolicy};
+```
+
+Other modules should depend on `crate::generation` rather than reaching through
+`crate::generation::stop::internal_detail`.
+
+### Dev-only crate
+
+A dev-only crate supports local development, tests, fuzzing, fixtures,
+benchmarks, policy snapshots, generated checks, or CI lanes. It may remain a
+workspace crate when a package boundary materially improves build times,
+isolation, or test ergonomics, but it is not a product surface.
+
+Default rule: dev-only crates use `publish = false` unless another repository
+has a documented consumer and a boundary memo approves publishing.
+
+### Hardware lab crate
+
+A hardware lab crate explores or validates a backend, shader catalog, dispatch
+strategy, device profile, or architecture-specific optimization. It becomes a
+public backend crate only after it has a real external user story and stable
+claim boundary.
+
+Until then, prefer modules under `bitnet-kernels`, `bitnet-device-probe`, or a
+clearly marked lab crate with `publish = false`.
+
+### Evidence and history
+
+Evidence, campaign tracking, migration notes, generated dashboards, and archived
+implementation records document what happened. They are not API surfaces and
+must not drive package boundaries by themselves.
+
+### Forced package boundary
+
+A forced package boundary is allowed when a module family cannot satisfy a hard
+constraint without a crate. Examples include:
+
+- a different crate type, such as `cdylib`, `staticlib`, or `proc-macro`;
+- a separate binary or installed tool;
+- platform-specific packaging that cannot be expressed cleanly with features;
+- dependency isolation for heavyweight optional toolchains;
+- fuzz, benchmark, or integration-test harnesses that need separate manifests;
+- published bindings with a distinct installation path.
+
+Forced package boundaries still need a boundary memo.
+
+## New crate rule
+
+New `Cargo.toml` files are forbidden unless the boundary memo passes review.
+
+The memo must answer:
+
+```text
+crate name
+owner
+audience
+public API or intentionally private API
+semver promise or publish=false rationale
+standalone README/docs plan
+who consumes it outside the owner crate
+what invariant it owns
+why a module family is not enough
+what dependency closure it forces public
+whether it is public, dev-only, lab, evidence, or forced-boundary
+```
+
+If the crate is public, the memo must also identify at least one strong reason
+it cannot be an internal module family.
+
+## Survival tests for public crates
+
+A crate can remain public if it passes at least one strong test:
+
+- an outsider would choose it directly;
+- multiple surviving public packages need it as a shared stable contract;
+- it is a stable schema, receipt, model, tokenizer, or runtime contract surface;
+- it is a hardware/backend surface with standalone value;
+- it is a binding or tool users install directly;
+- it has a distinct packaging or crate-type requirement.
+
+A crate should collapse when most of these are true:
+
+- it has a single obvious owner;
+- its name reads like an implementation layer, policy, state object, or `*-core`
+  seam;
+- it has no standalone README story;
+- it has no independent semver meaning;
+- it exists mainly to keep files small;
+- it is used only by one public crate;
+- publishing it would expose dependencies we do not want to support.
+
+## Default target surfaces
+
+The expected public set should be small enough that every crate can be reviewed,
+packaged, documented, and supported. A healthy target is roughly 20-35 public
+crates, not every workspace member.
+
+### Product facades
+
+```text
+bitnet
+bitnet-cli
+bitnet-server
+```
+
+### Core SDK surfaces
+
+```text
+bitnet-inference
+bitnet-models
+bitnet-tokenizers
+bitnet-sampling
+bitnet-receipts
+bitnet-kernels
+```
+
+### Backend, binding, and tool surfaces
+
+These are public only when their boundary memo proves standalone value:
+
+```text
+bitnet-device-probe
+bitnet-nvidia
+bitnet-wgpu
+bitnet-metal
+bitnet-opencl
+bitnet-rocm
+bitnet-vulkan
+bitnet-st2gguf
+bitnet-ffi
+bitnet-py
+bitnet-wasm
+```
+
+### Maybe-public surfaces
+
+Decide case by case:
+
+```text
+bitnet-gguf
+bitnet-artifacts
+bitnet-quantization
+bitnet-quantization-bits
+bitnet-bench
+bitnet-test-support
+```
+
+### Likely internal seams
+
+Most crates with these suffixes should become module families unless a memo says
+otherwise:
+
+```text
+*-core
+*-contract-core
+*-policy-core
+*-state-core
+*-snapshot-core
+*-diagnostics-core
+```
+
+## Module-family discipline
+
+Collapsing a crate boundary is not permission to create a junk drawer. The
+owner crate must preserve clean architecture in its module graph.
+
+Required practices:
+
+- expose only the seam facade from `mod.rs`;
+- keep implementation modules private or `pub(crate)`;
+- colocate tests with the seam when practical;
+- avoid sibling modules importing private leaf modules from each other;
+- keep dependencies pointing inward to domain contracts and outward through
+  ports/adapters;
+- document any public re-export from the owner crate as part of that owner
+  crate's API.
+
+## Collapse waves
+
+Use small migration waves. Each wave should preserve behavior, move one family
+of seams into its owner crate, and leave compatibility shims only when necessary.
+
+Suggested order:
+
+1. server adapter internals into `bitnet-server`;
+2. CLI config, sampling, and build-info internals into `bitnet-cli`;
+3. tokenizer merge, model, discovery, and text internals into
+   `bitnet-tokenizers`;
+4. generation, session, engine, KV-cache, REPL, and metrics internals into
+   `bitnet-inference`;
+5. receipt implementation shards into `bitnet-receipts`;
+6. QK256 layout, dispatch, and shader catalog internals into `bitnet-kernels`,
+   except seams deliberately kept public.
+
+## Enforcement roadmap
+
+Start advisory, then make the policy blocking once the inventory is complete.
+
+Advisory checks should report:
+
+- new workspace crates without a boundary memo;
+- internal/dev/lab crates missing `publish = false`;
+- public crates missing README, description, license, docs, or package metadata;
+- public crates depending on unpublished path-only runtime crates without a
+  migration note;
+- collapse candidates still exposed as public package surfaces;
+- `workspace.default-members` drifting away from normal developer workflow.
+
+Blocking checks should require:
+
+- a boundary memo for every new `Cargo.toml`;
+- `publish = false` for internal and dev-only crates;
+- complete package metadata for public crates;
+- a migration note for each public crate that temporarily depends on a collapse
+  candidate.
+
+## Review checklist
+
+Use this checklist for PRs that add, remove, publish, or collapse crates:
+
+- [ ] Does this change preserve the monorepo as the development container?
+- [ ] Is the seam public, internal, dev-only, lab, evidence, or forced-boundary?
+- [ ] If public, would an outside user choose this crate directly?
+- [ ] If internal, does it have an owner crate and facade module?
+- [ ] Does any new `Cargo.toml` have an approved boundary memo?
+- [ ] Are internal/dev/lab crates marked `publish = false`?
+- [ ] Are public package metadata and docs complete?
+- [ ] Does the dependency graph avoid accidental public exposure?
+- [ ] Does the migration keep tests and receipts stable?

--- a/docs/development/REPO_SURFACES.md
+++ b/docs/development/REPO_SURFACES.md
@@ -1,0 +1,395 @@
+# Repository Surfaces
+
+This document maps BitNet-rs workspace members into intended support surfaces.
+It is the working companion to the crate boundary policy: the policy explains
+how to decide; this map explains where the repository should move.
+
+The target shape is:
+
+```text
+large monorepo
+clear public crate set
+crate-grade internal module families
+stable documented APIs where public
+versioned schemas where external
+strict layer checks replacing accidental crate boundaries
+```
+
+## Layer model
+
+The repository has four different kinds of things. They may all live in one
+workspace, but they must not be treated as the same support boundary.
+
+| Layer | Meaning | Default package stance |
+| --- | --- | --- |
+| Public package surface | Crates users install, embed, read docs for, or depend on directly. | Publishable only with a boundary memo and package metadata. |
+| Internal module family | SRP seams owned by one public or product crate. | Implement under the owner crate as modules. |
+| Dev/test/lab tooling | Fixtures, harnesses, benchmarks, hardware experiments, policy snapshots, CI helpers. | Workspace crate only when useful; usually `publish = false`. |
+| Historical evidence | Tracking, campaign logs, archive notes, generated dashboards. | Documentation/data, not crates. |
+
+## Target public package set
+
+The public set is intentionally smaller than the workspace. It should be large
+enough to support real users and small enough that each package has a clear
+contract.
+
+### Product facades
+
+| Crate | Role |
+| --- | --- |
+| `bitnet` | Primary user-facing crate, install/docs entry point, and optional re-export facade. |
+| `bitnet-cli` | Command-line adapter and user workflow surface. |
+| `bitnet-server` | HTTP and OpenAI-compatible serving adapter. |
+
+### Core SDK surfaces
+
+| Crate | Role |
+| --- | --- |
+| `bitnet-inference` | Engine, session, prefill/decode, and orchestration API. |
+| `bitnet-models` | Model artifact inspection, compatibility, GGUF/SafeTensors authority, and naming contracts. |
+| `bitnet-tokenizers` | Tokenizer authority, prompt/token handling, model detection, and text conversion. |
+| `bitnet-sampling` | Sampling, logits policy, filters, and probability behavior. |
+| `bitnet-receipts` | Receipt schemas, validators, and claim boundaries. |
+| `bitnet-kernels` | CPU/CUDA/dense/BitNet kernel contracts and implementations. |
+
+### Backend, binding, and tool surfaces
+
+These become public only when they have a clear standalone user story,
+documented hardware or packaging target, stable claim boundary, and clean dry-run
+packaging.
+
+| Crate | Intended public story |
+| --- | --- |
+| `bitnet-device-probe` | Device and capability inspection usable outside the CLI. |
+| `bitnet-nvidia` | NVIDIA backend/tuning surface when stable enough to use independently. |
+| `bitnet-wgpu` | WebGPU backend surface when stable enough to embed directly. |
+| `bitnet-metal` | Apple Metal backend surface. |
+| `bitnet-opencl` | OpenCL backend surface, especially for Intel/portable GPU paths. |
+| `bitnet-rocm` | AMD ROCm backend surface. |
+| `bitnet-vulkan` | Vulkan backend surface. |
+| `bitnet-st2gguf` | SafeTensors-to-GGUF conversion tool surface. |
+| `bitnet-ffi` | C-compatible embedding boundary. |
+| `bitnet-py` | Python package/binding boundary. |
+| `bitnet-wasm` | WebAssembly package/binding boundary. |
+
+### Maybe-public decisions
+
+These require explicit boundary memos before publishing or long-term support.
+
+| Crate | Decision question |
+| --- | --- |
+| `bitnet-gguf` | Is GGUF authority useful as a standalone SDK surface or only through `bitnet-models`? |
+| `bitnet-artifacts` | Should fetch, verify, cache, and artifact authority stand alone from `bitnet-models`? |
+| `bitnet-quantization` | Is quantization a user-facing API or a kernel/model implementation detail? |
+| `bitnet-quantization-bits` | Do external low-bit authors need these contracts directly? |
+| `bitnet-bench` | Is there an installable benchmark product or only internal performance tracking? |
+| `bitnet-test-support` | Is another repository a real consumer, or should this remain dev-only? |
+
+## Owner map for collapse candidates
+
+The entries below are starting targets. They are not a command to delete crates
+in one PR; they are migration lanes for inventory, advisory checks, and focused
+collapse waves.
+
+### Server adapter internals -> `bitnet-server`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-client-ip-core` | `client_ip` or `request_context::client_ip` | Internal module family. |
+| `bitnet-api-versioning-core` | `versioning` | Internal module family. |
+| `bitnet-api-key-auth-core` | `auth::api_key` | Internal module family. |
+| `bitnet-server-health-types-core` | `health` | Internal module family. |
+| `bitnet-endpoint-registry-core` | `endpoint_registry` | Internal module family. |
+| `bitnet-request-context-core` | `request_context` | Internal module family. |
+| `bitnet-request-router-core` | `routing` | Internal module family. |
+
+Target layout:
+
+```text
+crates/bitnet-server/src/
+  auth/
+  routing/
+  request_context/
+  health/
+  versioning/
+  endpoint_registry/
+```
+
+### CLI internals -> `bitnet-cli`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-cli-config-core` | `config` | Internal module family. |
+| `bitnet-cli-sampling-core` | `sampling` | Internal module family. |
+| `bitnet-build-info-core` | `build_info` | Internal module family. |
+
+Target layout:
+
+```text
+crates/bitnet-cli/src/
+  config/
+  sampling/
+  build_info/
+  commands/
+```
+
+### Inference/session/generation internals -> `bitnet-inference`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-generation-events-core` | `generation::events` | Internal module family, with selected public re-exports if part of the SDK. |
+| `bitnet-generation-stop-core` | `generation::stop` | Internal module family. |
+| `bitnet-kv-cache-policy-core` | `kv_cache::policy` | Internal module family. |
+| `bitnet-engine-state-core` | `session::state` or `engine::state` | Internal module family. |
+| `bitnet-session-config-core` | `session::config` | Internal module family. |
+| `bitnet-engine-core` | `engine` | Internal module family. |
+| `bitnet-repl-core` | `repl` or CLI-owned module if only CLI uses it. | Internal module family. |
+| `bitnet-inference-metrics-core` | `metrics` | Internal module family or public re-export from `bitnet-inference`. |
+
+Target layout:
+
+```text
+crates/bitnet-inference/src/
+  generation/
+    events.rs
+    stop.rs
+  session/
+    config.rs
+    state.rs
+  kv_cache/
+    policy.rs
+  engine/
+    ports.rs
+    lifecycle.rs
+  metrics/
+```
+
+### Tokenizer internals -> `bitnet-tokenizers`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-token-merge-core` | `merge` | Internal module family unless external tokenizer authors use it directly. |
+| `bitnet-tokenizer-model-core` | `model_detection` or `model` | Internal module family. |
+| `bitnet-tokenizer-discovery-core` | `discovery` | Internal module family. |
+| `bitnet-tokenizer-text-core` | `text` | Internal module family. |
+
+Target layout:
+
+```text
+crates/bitnet-tokenizers/src/
+  merge/
+  model_detection/
+  discovery/
+  text/
+  authority/
+```
+
+### Model/artifact internals -> `bitnet-models` or `bitnet-artifacts`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-compat-core` | `compatibility` | Internal module family unless compatibility diagnostics are public SDK. |
+| `bitnet-weight-name-core` | `naming` | Internal module family. |
+| `bitnet-layer-index-core` | `layer_index` | Internal module family. |
+| `bitnet-download-core` | `artifacts::download` | Internal module family or part of `bitnet-artifacts`. |
+| `bitnet-download` | `artifacts::download` | Maybe-public only if model download is a standalone tool/API. |
+| `bitnet-atomic-file-core` | `artifacts::atomic_file` | Internal implementation detail. |
+| `bitnet-minimal-json-core` | `artifacts::json` or private utility | Internal implementation detail. |
+| `bitnet-safetensors-ln` | `safetensors::layer_norm` | Internal module family unless standalone conversion users exist. |
+
+Target layout if owned by `bitnet-models`:
+
+```text
+crates/bitnet-models/src/
+  artifacts/
+  compatibility/
+  download/
+  gguf/
+  safetensors/
+  naming/
+  layer_index/
+```
+
+Create `bitnet-artifacts` only if fetch, verify, cache, and artifact authority
+have a standalone SDK audience.
+
+### Kernel internals -> `bitnet-kernels`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-cpu-activations` | `cpu::activations` | Internal module family unless external CPU kernel authors depend on it. |
+| `bitnet-qk256-layout-core` | `qk256::layout` | Watchlist: maybe public if external low-bit authors need it. |
+| `bitnet-dispatch-core` | `dispatch` | Internal module family unless backend authors need a stable contract. |
+| `bitnet-vulkan-shaders` | `shaders::vulkan` | Internal module family or backend-private artifact catalog. |
+| `bitnet-wgpu-shaders-i2s` | `shaders::wgpu` | Internal module family or backend-private artifact catalog. |
+| `bitnet-qk256-dispatch` | `qk256::dispatch` | Internal module family unless standalone dispatch tuning is public. |
+
+Target layout:
+
+```text
+crates/bitnet-kernels/src/
+  cpu/
+  cuda/
+  qk256/
+    layout.rs
+    dispatch.rs
+  dense/
+  dispatch/
+  shaders/
+    vulkan/
+    wgpu/
+```
+
+### Receipts and contracts -> `bitnet-receipts`
+
+| Current crate | Target module family | Target state |
+| --- | --- | --- |
+| `bitnet-receipts-core` | `schemas` and `validators` | Internal module family with public re-exports for schema types. |
+| `bitnet-bench-receipts` | `benchmark` | Internal module family unless benchmark receipts are a standalone API. |
+| `bitnet-bench-regression-core` | `benchmark::regression` | Internal module family. |
+| `bitnet-feature-contract` | `feature_contracts` | Internal module family or public receipt contract if externally consumed. |
+| `bitnet-runtime-profile-contract` | `runtime_profile` | Internal module family or public receipt contract if externally consumed. |
+
+Target layout:
+
+```text
+crates/bitnet-receipts/src/
+  schemas/
+  validators/
+  benchmark/
+  feature_contracts/
+  explain/
+```
+
+## Clean architecture examples
+
+Use the package graph for support surfaces and the module graph for clean
+architecture.
+
+### `bitnet-inference`
+
+```text
+crates/bitnet-inference/src/
+  domain/
+    session.rs
+    generation.rs
+    kv_cache.rs
+  ports/
+    model.rs
+    tokenizer.rs
+    kernel.rs
+    receipts.rs
+  engine/
+    prefill.rs
+    decode.rs
+    warm_session.rs
+  adapters/
+    cpu.rs
+    cuda.rs
+  metrics/
+```
+
+### `bitnet-server`
+
+```text
+crates/bitnet-server/src/
+  domain/
+    request.rs
+    response.rs
+  ports/
+    inference.rs
+    receipt_sink.rs
+  adapters/
+    axum/
+    openai/
+  auth/
+  routing/
+  health/
+```
+
+### `bitnet-cli`
+
+```text
+crates/bitnet-cli/src/
+  commands/
+  output/
+  config/
+  receipts/
+  model_aliases/
+  device_selection/
+```
+
+## Migration plan
+
+### PR 1: boundary doctrine
+
+Add the policy and surface map documents. This establishes vocabulary and stops
+new accidental public package surfaces.
+
+### PR 2: crate inventory and owner map
+
+Add machine-readable inventories:
+
+```text
+ci/crate-boundaries/public-surfaces.toml
+ci/crate-boundaries/collapse-candidates.toml
+ci/crate-boundaries/dev-only-crates.toml
+```
+
+Each entry should record the current role, target owner, target state, seam type,
+public flag, and collapse wave.
+
+Example:
+
+```toml
+[crate.bitnet-api-key-auth-core]
+current_role = "internal_workspace_crate"
+target_owner = "bitnet-server"
+target_state = "module_family"
+seam_type = "server_adapter"
+public = false
+collapse_wave = "server-adapters"
+```
+
+### PR 3: `xtask crate-boundaries check`
+
+Add advisory checks for the policy:
+
+```text
+no new public crate without boundary memo
+publish=false for internal/dev-only crates
+public crates have README/description/license/docs
+internal collapse candidates are not dependencies of publishable crates without a migration note
+```
+
+### PRs 4-9: collapse waves
+
+Collapse one owner family per PR, in the order listed in the policy. Prefer
+compatibility shims over large breaking changes when a public surface temporarily
+needs time to move.
+
+### PR 10: publish surface dry-run
+
+For each surviving public crate, run:
+
+```text
+cargo package --list -p <crate>
+cargo publish --dry-run -p <crate>
+cargo doc -p <crate> --no-deps
+```
+
+The migration is not complete until the published package graph is real.
+
+## Completion criteria
+
+The migration is complete when:
+
+- public crates each have a standalone user story;
+- internal SRP seams have module-family facades;
+- no implementation-layer crate is public by accident;
+- published crates do not depend on unpublished runtime path crates;
+- `workspace.default-members` reflects normal developer workflow;
+- `xtask` enforces the crate-boundary policy;
+- docs explain which crate to use for which job;
+- package listing, publish dry-runs, and docs generation pass for every public
+  crate.


### PR DESCRIPTION
### Motivation

- The repository has too many accidental package boundaries (many `*-core` crates) and needs a clear doctrine to distinguish public package surfaces from internal module families.
- Keep the monorepo while reducing the public package blast radius and ensuring SRP seams are implemented as module families unless a crate-level surface is justified.
- Provide a practical migration and enforcement plan so new `Cargo.toml` files require explicit justification and future collapse waves can be executed safely.

### Description

- Add `docs/development/CRATE_BOUNDARY_POLICY.md` which defines public package rules, internal module family discipline, dev-only/lab stances, a `New crate` memo checklist, and enforcement roadmap. 
- Add `docs/development/REPO_SURFACES.md` which maps workspace members into target public surfaces, owner/collapse mappings (server, CLI, inference, tokenizer, models, kernels, receipts), suggested collapse waves, and a phased migration plan.
- Update `docs/README.md` to link the new guidance from the development index so the policy and surface map are discoverable.

### Testing

- Ran a local Python markdown link existence check against `docs/README.md`, `docs/development/CRATE_BOUNDARY_POLICY.md`, and `docs/development/REPO_SURFACES.md`, and all local links were found. 
- Verified the new files exist with a filesystem check (`test -f ...`) which reported `docs-present`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb84cbac08333b3e76bb5b3656a92)