### PR TITLE
docs: add crate boundary doctrine and repository surfaces roadmap

### DIFF
--- a/docs/development/CRATE_BOUNDARY_POLICY.md
+++ b/docs/development/CRATE_BOUNDARY_POLICY.md
@@ -1,0 +1,184 @@
+# Crate Boundary Policy
+
+BitNet-rs is a monorepo with multiple supported products, SDK surfaces,
+backends, bindings, tests, docs, and historical evidence. The repository should
+stay broad, but the public Cargo package surface must stay intentional.
+
+The guiding rule is:
+
+> Design seams like microcrates, implement most seams as module families, and
+> publish only the seams we are willing to support as real contracts.
+
+This policy exists to prevent accidental public surface area. A small file or a
+single-responsibility seam is not, by itself, a reason to create or preserve a
+public crate.
+
+## Boundary classes
+
+Every Rust boundary in this repository must fit one of these classes.
+
+| Class | Meaning | Typical location | Default publish state |
+| --- | --- | --- | --- |
+| Public package | A crate users install, import, document against, or expect semver stability from. | `crates/<name>` or root package | Publishable when packaging checks pass. |
+| Internal module family | A crate-grade design seam implemented inside an owner crate. | `crates/<owner>/src/<family>` | Not a Cargo package. |
+| Dev-only crate | Test, fixture, benchmark, CI, or repository workflow support. | `crates/`, `tests/`, `tools/`, `xtask/` | `publish = false`. |
+| Hardware lab crate | Experimental backend or hardware investigation code without a stable external story. | `crates/bitnet-*-lab`, backend submodules, or opt-in crates | `publish = false` until promoted. |
+| Evidence/history | Reports, receipts, validation records, migration notes, and campaign tracking. | `docs/reports`, `docs/`, `ci/` | Not a package boundary. |
+| Forced package boundary | A separate crate required by Rust, Cargo, FFI, proc macro, wasm, Python, or packaging constraints. | Case by case | Decided by boundary memo. |
+
+## Non-negotiable rule for new crates
+
+New `Cargo.toml` files are forbidden unless the boundary memo passes review.
+
+A new package boundary is allowed only when it is stronger than an internal
+module family. The memo must be committed with, or before, the new package.
+
+## Boundary memo template
+
+Use this template in the PR description or in a checked-in design note when a
+crate is added, preserved as public, or promoted from internal to public.
+
+```text
+crate name:
+owner:
+boundary class:
+audience:
+public API:
+semver promise:
+standalone README/docs:
+external consumers outside owner crate:
+invariant owned by this boundary:
+why a module family is not enough:
+public dependency closure forced by this crate:
+packaging command and result:
+migration or collapse plan if temporary:
+```
+
+## Tests for a surviving public crate
+
+A crate should survive as a public package only if it passes at least one strong
+test:
+
+- An outsider would knowingly choose it directly.
+- Multiple surviving public packages need it as a stable contract.
+- It owns a versioned schema, receipt, model contract, or other external
+  compatibility promise.
+- It is a hardware/backend surface with a documented target, feature surface,
+  and standalone value.
+- It is a binding or tool users install directly.
+- A Cargo, Rust, FFI, wasm, Python, or build-system constraint forces a package
+  boundary.
+
+## Collapse signals
+
+A crate should become an internal module family when most of these are true:
+
+- It has one obvious owner crate.
+- Its name reads as an implementation layer, such as `*-core`, `*-policy-core`,
+  `*-state-core`, `*-snapshot-core`, `*-diagnostics-core`, or
+  `*-contract-core`.
+- It has no standalone README story.
+- It has no independent semver meaning.
+- It exists mainly to keep files small.
+- It is consumed only by one public crate or one product adapter.
+- Publishing it would force internal dependencies into the public graph.
+
+## Module-family discipline
+
+Collapsing a crate must not create a junk drawer. Internal module families keep
+crate-grade design discipline:
+
+- One owner crate.
+- One responsibility.
+- One public or `pub(crate)` facade.
+- Private internals by default.
+- Seam-focused tests.
+- Clear dependency direction.
+- No sibling deep imports.
+
+A good shape is:
+
+```text
+crates/bitnet-inference/src/generation/
+  mod.rs
+  events.rs
+  stop.rs
+  policy.rs
+  tests.rs
+```
+
+The facade controls what other modules can use:
+
+```rust
+pub(crate) mod stop;
+pub mod events;
+
+pub use events::{GenerationEvent, GenerationStats};
+pub(crate) use stop::{StopDecision, StopPolicy};
+```
+
+Code outside the family should depend on `crate::generation` exports rather
+than `crate::generation::stop::internal_detail`.
+
+## Public package requirements
+
+Every public package should have:
+
+- A clear audience and install/import story.
+- `description`, `license`, `readme`, and documentation metadata in
+  `Cargo.toml`.
+- A standalone README or equivalent docs section.
+- A defined semver surface.
+- Feature flags that describe user-facing capabilities instead of internal
+  implementation accidents.
+- A clean packaging dry run before publication.
+- No dependency on unpublished runtime path crates unless the dependency is
+  explicitly documented as temporary and guarded by migration notes.
+
+Recommended checks for publishable crates:
+
+```bash
+cargo package --list -p <crate>
+cargo publish --dry-run -p <crate>
+cargo doc -p <crate> --no-deps
+```
+
+## Dev-only and internal package requirements
+
+A workspace crate that remains separate for tests, tooling, or temporary
+migration must make that status explicit:
+
+```toml
+publish = false
+```
+
+Dev-only crates should not be part of the public dependency closure of a
+publishable crate. If a publishable crate temporarily depends on a dev-only or
+collapse-candidate crate, document the migration note in the crate-boundary
+inventory.
+
+## Promotion path
+
+A module family or dev-only crate can be promoted later. Promotion requires:
+
+1. A boundary memo.
+2. A standalone user story.
+3. API documentation.
+4. A packaging dry run.
+5. Agreement on semver ownership.
+6. An explicit decision about whether existing internal names remain private or
+   become public API.
+
+## Migration posture
+
+The cleanup should be incremental and low drama:
+
+1. Document the doctrine.
+2. Inventory public surfaces, collapse candidates, and dev-only crates.
+3. Add advisory `xtask crate-boundaries check` enforcement.
+4. Collapse low-risk owner-local crates first.
+5. Promote only the seams that earn a public contract.
+6. Make boundary checks blocking after the inventory is trustworthy.
+
+The goal is not fewer architectural seams. The goal is fewer accidental package
+contracts.

--- a/docs/development/REPO_SURFACES.md
+++ b/docs/development/REPO_SURFACES.md
@@ -1,0 +1,387 @@
+# Repository Surfaces
+
+This document maps the intended BitNet-rs repository shape. It is a planning
+document for reducing accidental Cargo package boundaries while preserving the
+monorepo and single-responsibility design seams.
+
+## Target model
+
+The monorepo remains the home for:
+
+- Runtime and inference orchestration.
+- Kernels and hardware lanes.
+- Model, tokenizer, prompt, and artifact contracts.
+- Receipts and claim validation.
+- CLI and server products.
+- Bindings and installable sidecars.
+- Tests, fixtures, benchmarks, CI, and docs.
+- Campaign tracking and historical evidence.
+
+Inside the monorepo, boundaries should be classified as:
+
+- Public package surface.
+- Internal module family.
+- Dev/test/lab tooling.
+- Historical evidence.
+
+## Proposed public package set
+
+The target public surface should be closer to 20-35 well-documented crates than
+to every single SRP seam in the workspace.
+
+### Product facades
+
+| Crate | Role |
+| --- | --- |
+| `bitnet` | Primary user-facing facade, docs entry, install entry, and optional re-exports. |
+| `bitnet-cli` | Command-line adapter and command UX. |
+| `bitnet-server` | HTTP and OpenAI-compatible serving adapter. |
+
+### Core SDK surfaces
+
+| Crate | Role |
+| --- | --- |
+| `bitnet-inference` | Engine, session, prefill/decode, and generation orchestration API. |
+| `bitnet-models` | Model artifact inspection, contracts, GGUF/SafeTensors authority, and compatibility checks. |
+| `bitnet-tokenizers` | Tokenizer authority, prompt/token handling, discovery, and text normalization. |
+| `bitnet-prompt-templates` | Prompt template contracts intended for application users. |
+| `bitnet-sampling` | Sampling, logits policy, and decode choice configuration. |
+| `bitnet-kernels` | CPU/CUDA/dense/BitNet kernel contracts and implementations. |
+| `bitnet-receipts` | Receipt schemas, validators, and claim boundaries. |
+| `bitnet-device-probe` | Hardware discovery when the external device-selection story is stable. |
+
+### Optional backend, binding, and tool surfaces
+
+These should be public only when each crate has a real external consumer story,
+documented feature surface, stable claim boundary, and clean packaging dry run.
+
+| Crate | Public condition |
+| --- | --- |
+| `bitnet-nvidia` | NVIDIA-specific backend or tuning API useful outside the CLI. |
+| `bitnet-wgpu` | Cross-platform WebGPU backend with a standalone integration path. |
+| `bitnet-metal` | Apple Metal backend with documented hardware targets. |
+| `bitnet-opencl` | OpenCL backend with stable device support claims. |
+| `bitnet-rocm` | AMD ROCm backend with stable packaging and support claims. |
+| `bitnet-vulkan` | Vulkan backend with stable shader and dispatch contracts. |
+| `bitnet-st2gguf` | Installable conversion tool. |
+| `bitnet-ffi` | C ABI surface. |
+| `bitnet-py` | Python binding package. |
+| `bitnet-wasm` | WebAssembly binding package. |
+
+### Maybe-public decisions
+
+These need case-by-case boundary memos before they are treated as public
+contracts:
+
+- `bitnet-gguf`
+- `bitnet-artifacts` if created for fetch, verify, cache, and artifact authority
+- `bitnet-quantization`
+- `bitnet-quantization-bits`
+- `bitnet-bench`
+- `bitnet-test-support`
+- `bitnet-qk256-layout-core` or a renamed public QK256 layout crate, if external
+  low-bit kernel authors genuinely need it
+
+## Planned collapse waves
+
+Collapse candidates should move into owner crates as module families unless a
+boundary memo proves standalone value.
+
+### CLI adapter internals
+
+Owner crate: `bitnet-cli`
+
+Candidate crates:
+
+- `bitnet-cli-config-core`
+- `bitnet-cli-sampling-core`
+- `bitnet-build-info-core`
+
+Target layout:
+
+```text
+crates/bitnet-cli/src/
+  build_info/
+  commands/
+  config/
+  sampling/
+```
+
+### Server adapter internals
+
+Owner crate: `bitnet-server`
+
+Candidate crates:
+
+- `bitnet-client-ip-core`
+- `bitnet-api-versioning-core`
+- `bitnet-api-key-auth-core`
+- `bitnet-http-auth-core`
+- `bitnet-server-health-types-core`
+- `bitnet-endpoint-registry-core`
+- `bitnet-request-context-core`
+- `bitnet-request-router-core`
+
+Target layout:
+
+```text
+crates/bitnet-server/src/
+  auth/
+  endpoint_registry/
+  health/
+  request_context/
+  routing/
+  versioning/
+```
+
+### Inference, session, and generation internals
+
+Owner crate: `bitnet-inference`
+
+Candidate crates:
+
+- `bitnet-generation-events-core`
+- `bitnet-generation-stop-core`
+- `bitnet-kv-cache-policy-core`
+- `bitnet-engine-state-core`
+- `bitnet-session-config-core`
+- `bitnet-engine-core`
+- `bitnet-repl-core`
+- `bitnet-inference-metrics-core`
+
+Target layout:
+
+```text
+crates/bitnet-inference/src/
+  engine/
+    lifecycle.rs
+    ports.rs
+  generation/
+    events.rs
+    stop.rs
+  kv_cache/
+    policy.rs
+  metrics/
+  session/
+    config.rs
+    state.rs
+```
+
+### Tokenizer internals
+
+Owner crate: `bitnet-tokenizers`
+
+Candidate crates:
+
+- `bitnet-token-merge-core`
+- `bitnet-tokenizer-model-core`
+- `bitnet-tokenizer-discovery-core`
+- `bitnet-tokenizer-text-core`
+
+Target layout:
+
+```text
+crates/bitnet-tokenizers/src/
+  authority/
+  discovery/
+  merge/
+  model_detection/
+  text/
+```
+
+### Model and artifact internals
+
+Owner crate: `bitnet-models`, unless `bitnet-artifacts` is explicitly promoted
+as a public artifact authority.
+
+Candidate crates:
+
+- `bitnet-compat-core`
+- `bitnet-weight-name-core`
+- `bitnet-layer-index-core`
+- `bitnet-download-core`
+- `bitnet-download`
+- `bitnet-atomic-file-core`
+- `bitnet-minimal-json-core`
+- `bitnet-safetensors-ln`
+
+Target layout:
+
+```text
+crates/bitnet-models/src/
+  artifacts/
+  compatibility/
+  download/
+  gguf/
+  layer_index/
+  naming/
+  safetensors/
+```
+
+### Kernel implementation internals
+
+Owner crate: `bitnet-kernels`
+
+Candidate crates:
+
+- `bitnet-cpu-activations`
+- `bitnet-qk256-layout-core`
+- `bitnet-dispatch-core`
+- `bitnet-vulkan-shaders`
+- `bitnet-wgpu-shaders-i2s`
+- `bitnet-qk256-dispatch`
+
+Target layout:
+
+```text
+crates/bitnet-kernels/src/
+  cpu/
+  cuda/
+  dense/
+  dispatch/
+  qk256/
+    dispatch.rs
+    layout.rs
+  shaders/
+    vulkan/
+    wgpu/
+```
+
+### Receipt and claim internals
+
+Owner crate: `bitnet-receipts`
+
+Candidate crates:
+
+- `bitnet-receipts-core`
+- `bitnet-bench-receipts`
+- `bitnet-bench-regression-core`
+- `bitnet-feature-contract`
+- `bitnet-runtime-profile-contract`
+- `bitnet-runtime-profile-contract-core`
+
+Target layout:
+
+```text
+crates/bitnet-receipts/src/
+  benchmark/
+  explain/
+  feature_contracts/
+  schemas/
+  validators/
+```
+
+### Dev and test support
+
+Default state: workspace crates may remain separate when useful for CI or test
+composition, but they should normally be `publish = false`.
+
+Examples:
+
+- `bitnet-test-support`
+- `bitnet-test-fixtures-core`
+- `bitnet-bdd-grid`
+- `bitnet-bdd-grid-core`
+- `bitnet-testing-policy`
+- `bitnet-testing-policy-*`
+- `bitnet-testing-scenarios-*`
+
+## Clean architecture mapping
+
+Use the package graph for public surfaces and the module graph for clean
+architecture.
+
+### `bitnet-inference`
+
+```text
+crates/bitnet-inference/src/
+  adapters/
+    cpu.rs
+    cuda.rs
+  domain/
+    generation.rs
+    kv_cache.rs
+    session.rs
+  engine/
+    decode.rs
+    prefill.rs
+    warm_session.rs
+  metrics/
+  ports/
+    kernel.rs
+    model.rs
+    receipts.rs
+    tokenizer.rs
+```
+
+### `bitnet-server`
+
+```text
+crates/bitnet-server/src/
+  adapters/
+    axum/
+    openai/
+  auth/
+  domain/
+    request.rs
+    response.rs
+  health/
+  ports/
+    inference.rs
+    receipt_sink.rs
+  routing/
+```
+
+### `bitnet-cli`
+
+```text
+crates/bitnet-cli/src/
+  commands/
+  config/
+  device_selection/
+  model_aliases/
+  output/
+  receipts/
+```
+
+Ports and adapters remain explicit. They just do not need a separate package for
+every port.
+
+## Initial implementation roadmap
+
+1. **Boundary doctrine**: keep this file and `CRATE_BOUNDARY_POLICY.md` as the
+   baseline architectural agreement.
+2. **Inventory and owner map**: add `ci/crate-boundaries/public-surfaces.toml`,
+   `ci/crate-boundaries/collapse-candidates.toml`, and
+   `ci/crate-boundaries/dev-only-crates.toml`.
+3. **Advisory checker**: add `xtask crate-boundaries check` to report missing
+   boundary memos, missing `publish = false`, missing public metadata, and
+   publishable crates depending on internal path crates without migration notes.
+4. **Server adapter collapse**: move obvious server `*-core` crates into
+   `bitnet-server` module families.
+5. **CLI adapter collapse**: move CLI config, sampling, and build-info internals
+   into `bitnet-cli`.
+6. **Tokenizer internals collapse**: move merge, model detection, discovery, and
+   text internals into `bitnet-tokenizers`.
+7. **Inference/session/generation collapse**: move generation, stop, KV policy,
+   session, engine, REPL, and metrics seams into `bitnet-inference`.
+8. **Receipts consolidation**: move receipt implementation shards into
+   `bitnet-receipts` unless a memo proves a separate SDK surface.
+9. **Kernel layout consolidation**: move QK256 layout/dispatch and shader catalog
+   internals into `bitnet-kernels`, except for deliberately public seams.
+10. **Publish surface dry run**: run package listing, publish dry run, and docs
+    generation for every surviving public crate.
+
+## Done criteria
+
+The migration is complete when:
+
+- Public crates each have a standalone user story.
+- Internal SRP seams have module-family facades.
+- Implementation-layer crates are not public by accident.
+- Published crates do not depend on unpublished runtime path crates.
+- `workspace.default-members` reflects normal developer workflow.
+- `xtask` enforces crate-boundary policy.
+- Docs explain which crate to use for each job.
+- `cargo package`, `cargo publish --dry-run`, and `cargo doc --no-deps` pass for
+  every public crate.

--- a/docs/development/development-standards.md
+++ b/docs/development/development-standards.md
@@ -96,6 +96,14 @@ The following patterns are explicitly banned to maintain API stability:
 3. **Banned Patterns Script**: Explicit pattern checking
 4. **Clippy Lints**: Code quality enforcement
 
+## Crate Boundary Doctrine
+
+BitNet-rs keeps the monorepo, but public Cargo package boundaries must be intentional. New
+`Cargo.toml` files require a passing boundary memo, and implementation seams should usually be
+internal module families instead of accidental public crates. See
+[`CRATE_BOUNDARY_POLICY.md`](CRATE_BOUNDARY_POLICY.md) and
+[`REPO_SURFACES.md`](REPO_SURFACES.md).
+
 ## Development Workflow
 
 ### Pre-Commit Checks


### PR DESCRIPTION
### Motivation

- Prevent accidental expansion of the public Cargo package surface while preserving the monorepo and single-responsibility seams.
- Provide a clear, reviewable process for when a design seam becomes a publishable crate and when it should be an internal module family.
- Give a practical roadmap and acceptance criteria to drive an incremental, low-risk collapse of many `*-core` implementation crates into owner crates.

### Description

- Add `docs/development/CRATE_BOUNDARY_POLICY.md` which defines boundary classes, a non‑negotiable rule forbidding new `Cargo.toml` files without a boundary memo, a boundary memo template, collapse/promotion signals, and module-family discipline. 
- Add `docs/development/REPO_SURFACES.md` which maps the intended public package set, planned collapse waves (CLI, server, inference, tokenizers, models, kernels, receipts, dev/test), clean-architecture layouts, an implementation roadmap, and done criteria. 
- Link the doctrine into the developer guide by inserting a `Crate Boundary Doctrine` section in `docs/development/development-standards.md` that references the new files. 

### Testing

- Ran `git diff --check` to validate no whitespace or diff-check issues, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb84cbac08333b3e76bb5b3656a92)