### PR TITLE
[codex] Close WASM-001 proof contract

### DIFF
--- a/docs/tracking/campaigns/wasm-inference/CAMPAIGN.md
+++ b/docs/tracking/campaigns/wasm-inference/CAMPAIGN.md
@@ -38,7 +38,7 @@ placeholder generation, model parsing, or scalar fallback with real inference.
 
 | Work item | Status | Notes |
 |---|---|---|
-| WASM-001 | ready | Document the proof contract, claim boundary, backend identities, receipt fields, memory plan, and PR ladder. |
+| WASM-001 | merged | Documented the proof contract, claim boundary, backend identities, receipt fields, memory plan, and PR ladder. |
 | WASM-002 | ready | Make the opt-in inference feature compile honestly for `wasm32-unknown-unknown` without claiming runtime inference. |
 | WASM-003 | ready | Add byte-backed GGUF and tokenizer loading so browser paths do not rely on virtual filesystem placeholders. |
 | WASM-004 | ready | Expose a worker-safe JS API for load/generate/stream/unload/memory stats with no fake generation. |

--- a/docs/tracking/campaigns/wasm-inference/active.toml
+++ b/docs/tracking/campaigns/wasm-inference/active.toml
@@ -24,7 +24,9 @@ hard_constraints = [
 
 [[work_item]]
 id = "WASM-001"
-status = "ready"
+status = "merged"
+pr = 4090
+merge_sha = "cac5dea998d2ac75a5c40b579856598dec136888"
 branch = "codex/wasm-inference/WASM-001-proof-contract"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/wasm-inference/events/2026-05-10T012244Z-WASM-001-merged.toml
+++ b/docs/tracking/campaigns/wasm-inference/events/2026-05-10T012244Z-WASM-001-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-10T01:22:44Z"
+campaign = "wasm-inference"
+item = "WASM-001"
+event = "merged"
+actor = "codex"
+pr = 4090
+merge_sha = "cac5dea998d2ac75a5c40b579856598dec136888"
+previous_status = "ready"
+next_item = "WASM-002"
+
+notes = [
+  "Closed out the WASM inference proof contract docs merged in PR #4090.",
+  "The merged docs define the conservative WASM claim boundary, explicit backend identities, receipt requirements, model/tokenizer strategy, memory plan, milestones, and PR ladder.",
+  "This is a tracker-only closeout and does not claim that WASM inference works, browser BitNet 2B inference is feasible at usable speed, WASM SIMD kernels are proven, or byte-backed GGUF/tokenizer loaders exist.",
+]

--- a/docs/tracking/campaigns/wasm-inference/generated/status.md
+++ b/docs/tracking/campaigns/wasm-inference/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| WASM-001 | ready | TBD | `codex/wasm-inference/WASM-001-proof-contract` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Document the WASM proof contract, current scaffold boundary, explicit backend identities, receipt requirements, model/tokenizer strategy, memory plan, milestones, and PR ladder without changing runtime code. |
+| WASM-001 | merged | #4090 | `codex/wasm-inference/WASM-001-proof-contract` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Document the WASM proof contract, current scaffold boundary, explicit backend identities, receipt requirements, model/tokenizer strategy, memory plan, milestones, and PR ladder without changing runtime code. |
 | WASM-002 | ready | TBD | `codex/wasm-inference/WASM-002-honest-inference-compile` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Make cargo check --target wasm32-unknown-unknown -p bitnet-wasm --no-default-features --features browser,inference compile, with unsupported runtime paths returning explicit not-implemented errors rather than placeholder success. |
 | WASM-003 | ready | TBD | `codex/wasm-inference/WASM-003-byte-loaders` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add byte-backed model and tokenizer loader APIs for WASM so browser paths do not depend on virtual filesystem placeholders. |
 | WASM-004 | ready | TBD | `codex/wasm-inference/WASM-004-worker-api` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Expose a worker-safe JS API for loadModel, generate, generateStream, unload, and getMemoryStats, with abort support and no fake generation responses. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -31,4 +31,4 @@
 | server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
-| wasm-inference | WASM-001 | TBD | ready | WASM-002 | WASM detection is not inference. |
+| wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -31,4 +31,4 @@
 | server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-008 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
-| wasm-inference | WASM inference proof lane | WASM-001 | WASM detection is not inference. |
+| wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- mark `WASM-001` merged against PR #4090
- add a tracker event recording the closeout and claim boundaries
- regenerate WASM campaign and global/lane dashboards so the lane advances to `WASM-002`

## Validation
- cargo run --locked -p xtask --no-default-features -- campaign check wasm-inference
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check

## Claim Boundary
Tracker-only closeout. This does not claim WASM inference works, browser BitNet 2B inference is feasible at usable speed, WASM SIMD kernels are proven, or byte-backed GGUF/tokenizer loaders exist.