### PR TITLE
[codex] Prefer actionable campaign dashboard items

### DIFF
--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -15,10 +15,10 @@
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-excellence | M4-SLM-EX-010 | #4307 | merged | none | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
-| apple-m4-slm-metal-phases | M4-METAL-007 | TBD | blocked | none | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-metal-phases | M4-METAL-006 | TBD | ready | M4-METAL-007 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-model-breadth | M4-MODEL-004 | TBD | blocked | M4-MODEL-005 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
-| apple-silicon-macbook | MB-AS-002 | TBD | blocked | MB-AS-004 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
+| apple-silicon-macbook | MB-AS-004 | TBD | proposed | MB-AS-005 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI-COVERAGE-001 | #3620 | merged | none | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | CPU-ANSWER-007 | #4019 | merged | none | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | KBL8250U-004 | #3839 | merged | none | Do not claim performance before strict proof receipts exist. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -15,10 +15,10 @@
 | apple-m4-slm-answer | Apple M4 SLM local answer usability | SLM-M4-007 | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-excellence | Apple M4 SLM excellence | M4-SLM-EX-010 | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | Apple M4 SLM hardening | M4-SLM-HARDEN-004 | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
-| apple-m4-slm-metal-phases | Apple M4 SLM Metal phases | M4-METAL-007 | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-metal-phases | Apple M4 SLM Metal phases | M4-METAL-006 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-model-breadth | Apple M4 SLM model breadth | M4-MODEL-004 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | Apple M4 SLM performance | M4-SLM-PERF-007 | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
-| apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-002 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
+| apple-silicon-macbook | Apple Silicon MacBook cross-reference | MB-AS-004 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |
 | ci-coverage | CI coverage | CI-COVERAGE-001 | Do not block unrelated runtime or tracker work on optional coverage uploads. |
 | cpu-proof | BitNet CPU proof | CPU-ANSWER-007 | 258V CPU is the lead BitNet CPU reference; no GPU or NPU claims. |
 | cpu-qk256-performance | CPU QK256 performance | KBL8250U-004 | Do not claim performance before strict proof receipts exist. |

--- a/xtask/src/campaign.rs
+++ b/xtask/src/campaign.rs
@@ -249,19 +249,7 @@ fn cmd_status(root: &Path, campaign_id: &str) -> Result<()> {
 
 fn cmd_next(root: &Path, campaign_id: &str) -> Result<()> {
     let campaign = load_campaign(root, campaign_id)?;
-    let item_by_id = item_map(&campaign.manifest);
-    let next = campaign
-        .manifest
-        .work_items
-        .iter()
-        .find(|item| item.status == "ready" && deps_met(item, &item_by_id))
-        .or_else(|| {
-            campaign
-                .manifest
-                .work_items
-                .iter()
-                .find(|item| item.status == "proposed" && deps_met(item, &item_by_id))
-        });
+    let next = next_runnable_item(&campaign.manifest);
 
     match next {
         Some(item) => {
@@ -684,11 +672,31 @@ fn deps_met<'a>(item: &WorkItem, item_by_id: &BTreeMap<&'a str, &'a WorkItem>) -
         .all(|dep| item_by_id.get(dep.as_str()).is_some_and(|dep_item| dep_item.status == "merged"))
 }
 
+fn next_runnable_item(manifest: &CampaignManifest) -> Option<&WorkItem> {
+    let item_by_id = item_map(manifest);
+    manifest
+        .work_items
+        .iter()
+        .find(|item| item.status == "ready" && deps_met(item, &item_by_id))
+        .or_else(|| {
+            manifest
+                .work_items
+                .iter()
+                .find(|item| item.status == "proposed" && deps_met(item, &item_by_id))
+        })
+}
+
 fn current_item(manifest: &CampaignManifest) -> Option<&WorkItem> {
-    for status in ["pr_open", "in_progress", "blocked", "ready", "proposed"] {
+    for status in ["pr_open", "in_progress"] {
         if let Some(item) = manifest.work_items.iter().find(|item| item.status == status) {
             return Some(item);
         }
+    }
+    if let Some(item) = next_runnable_item(manifest) {
+        return Some(item);
+    }
+    if let Some(item) = manifest.work_items.iter().find(|item| item.status == "blocked") {
+        return Some(item);
     }
     manifest.work_items.iter().rev().find(|item| item.status == "merged")
 }
@@ -1275,8 +1283,8 @@ fn fail_on_errors(problems: &[Problem]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        CampaignManifest, LoadedCampaign, Severity, TextList, WorkItem, parse_pull_request_ref,
-        text_contains_item_token, validate_campaign,
+        CampaignManifest, LoadedCampaign, Severity, TextList, WorkItem, current_item,
+        parse_pull_request_ref, text_contains_item_token, validate_campaign,
     };
     use std::path::PathBuf;
 
@@ -1366,18 +1374,91 @@ mod tests {
         }));
     }
 
+    #[test]
+    fn current_item_prefers_actionable_work_over_blocked_followup() {
+        let manifest = campaign_manifest(vec![
+            work_item("POLICY-001", "merged", &[]),
+            work_item("POLICY-002", "ready", &["POLICY-001"]),
+            work_item("POLICY-003", "blocked", &["POLICY-002"]),
+        ]);
+
+        assert_eq!(current_item(&manifest).map(|item| item.id.as_str()), Some("POLICY-002"));
+    }
+
+    #[test]
+    fn current_item_prefers_runnable_proposed_work_over_blocked_followup() {
+        let manifest = campaign_manifest(vec![
+            work_item("POLICY-001", "merged", &[]),
+            work_item("POLICY-002", "blocked", &[]),
+            work_item("POLICY-003", "proposed", &["POLICY-001"]),
+        ]);
+
+        assert_eq!(current_item(&manifest).map(|item| item.id.as_str()), Some("POLICY-003"));
+    }
+
+    #[test]
+    fn current_item_keeps_open_pr_and_in_progress_items_first() {
+        let pr_open = campaign_manifest(vec![
+            work_item("POLICY-001", "merged", &[]),
+            work_item("POLICY-002", "pr_open", &["POLICY-001"]),
+            work_item("POLICY-003", "ready", &["POLICY-001"]),
+        ]);
+        let in_progress = campaign_manifest(vec![
+            work_item("POLICY-001", "merged", &[]),
+            work_item("POLICY-002", "in_progress", &["POLICY-001"]),
+            work_item("POLICY-003", "ready", &["POLICY-001"]),
+        ]);
+
+        assert_eq!(current_item(&pr_open).map(|item| item.id.as_str()), Some("POLICY-002"));
+        assert_eq!(current_item(&in_progress).map(|item| item.id.as_str()), Some("POLICY-002"));
+    }
+
+    #[test]
+    fn current_item_skips_unblocked_statuses_with_unmet_dependencies() {
+        let manifest = campaign_manifest(vec![
+            work_item("POLICY-001", "ready", &["POLICY-000"]),
+            work_item("POLICY-002", "blocked", &["POLICY-001"]),
+        ]);
+
+        assert_eq!(current_item(&manifest).map(|item| item.id.as_str()), Some("POLICY-002"));
+    }
+
+    fn campaign_manifest(work_items: Vec<WorkItem>) -> CampaignManifest {
+        CampaignManifest {
+            id: "policy-campaign".to_string(),
+            title: "Policy Campaign".to_string(),
+            status: "active".to_string(),
+            objective: "Validate campaign policy fields.".to_string(),
+            end_state: vec!["Policy validation is covered.".to_string()],
+            hard_constraints: vec!["Do not accept deprecated policy fields.".to_string()],
+            work_items,
+        }
+    }
+
+    fn work_item(id: &str, status: &str, blocked_by: &[&str]) -> WorkItem {
+        WorkItem {
+            id: id.to_string(),
+            status: status.to_string(),
+            branch: format!("codex/policy/{id}"),
+            stackable: Some(false),
+            requires_human_merge: None,
+            review_mode: Some("codex_premerge".to_string()),
+            merge_policy: Some("automerge_when_green".to_string()),
+            human_gate: Some("on_blocker_only".to_string()),
+            blocked_by: blocked_by.iter().map(|dep| dep.to_string()).collect(),
+            acceptance: Some(TextList::One(format!("Complete {id}."))),
+            commands: vec!["cargo fmt --all -- --check".to_string()],
+            allowed_paths: vec!["docs/**".to_string()],
+            forbidden_paths: vec!["crates/**".to_string()],
+            may_claim: vec![format!("{id} is complete.")],
+            must_not_claim: vec![format!("{id} has runtime impact.")],
+        }
+    }
+
     fn policy_campaign(item: WorkItem) -> LoadedCampaign {
         LoadedCampaign {
             dir: PathBuf::from("policy-campaign"),
-            manifest: CampaignManifest {
-                id: "policy-campaign".to_string(),
-                title: "Policy Campaign".to_string(),
-                status: "active".to_string(),
-                objective: "Validate campaign policy fields.".to_string(),
-                end_state: vec!["Policy validation is covered.".to_string()],
-                hard_constraints: vec!["Do not accept deprecated policy fields.".to_string()],
-                work_items: vec![item],
-            },
+            manifest: campaign_manifest(vec![item]),
             events: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary
- share the campaign next runnable-item selection with dashboard current-item selection
- keep open PR and in-progress items first, then prefer dependency-satisfied ready/proposed work before blocked follow-ups
- regenerate global and lane dashboards so actionable Apple M4 Metal and MacBook work is surfaced

## Validation
- cargo fmt --all -- --check
- cargo test --locked -p xtask --no-default-features --bin xtask current_item -- --nocapture
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- git diff --check

## Notes
Blocked work remains visible in `docs/tracking/generated/blocked-items.md`; this only changes which item is used as the dashboard headline current item.