### PR TITLE
🎨 Palette: Improve range slider layout and visual grouping

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-22 - Focus Visibility and Box Sizing
 **Learning:** Adding `box-sizing: border-box` to inputs prevents them from overflowing containers when padding is applied and `width: 100%` is used. Furthermore, relying on default browser focus rings is insufficient for accessibility; explicit `:focus-visible` styles with custom outlines ensure clear visual feedback for keyboard users across different platforms.
 **Action:** Always include `box-sizing: border-box` for standard form inputs and define clear `:focus-visible` styles for better keyboard navigation.
+
+## 2024-05-22 - Improved Range Slider Layout
+**Learning:** Range sliders with adjacent value readouts can suffer from poor layout and spacing when placed in standard `div` containers. The label and value span can become disjointed or visually misaligned with the slider.
+**Action:** Group the label and value span in a flex container (`display: flex; justify-content: space-between;`) above the range input to create a clear visual header for the slider control. Style the value readout distinctively (e.g., using a pill-shaped badge) to emphasize it as an interactive state value rather than static text.

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -132,7 +132,7 @@
 
         .range-value {
             font-weight: 500;
-            color: #007bff;
+            color: #0056b3;
             background: #e9ecef;
             padding: 2px 8px;
             border-radius: 12px;

--- a/crates/bitnet-wasm/examples/browser/index.html
+++ b/crates/bitnet-wasm/examples/browser/index.html
@@ -119,6 +119,26 @@
             border-color: #007bff;
         }
 
+        .range-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 5px;
+        }
+
+        .range-header label {
+            margin-bottom: 0;
+        }
+
+        .range-value {
+            font-weight: 500;
+            color: #007bff;
+            background: #e9ecef;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+        }
+
         textarea {
             resize: vertical;
             min-height: 100px;
@@ -436,9 +456,11 @@
             </div>
 
             <div class="input-group">
-                <label for="temperature">Temperature:</label>
+                <div class="range-header">
+                    <label for="temperature">Temperature:</label>
+                    <span id="temperature-value" class="range-value">0.7</span>
+                </div>
                 <input type="range" id="temperature" min="0" max="2" step="0.1" value="0.7">
-                <span id="temperature-value">0.7</span>
             </div>
 
             <div class="input-group">
@@ -447,9 +469,11 @@
             </div>
 
             <div class="input-group">
-                <label for="top-p">Top-P:</label>
+                <div class="range-header">
+                    <label for="top-p">Top-P:</label>
+                    <span id="top-p-value" class="range-value">0.9</span>
+                </div>
                 <input type="range" id="top-p" min="0" max="1" step="0.05" value="0.9">
-                <span id="top-p-value">0.9</span>
             </div>
 
             <div class="input-group">

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -132,7 +132,7 @@
 
         .range-value {
             font-weight: 500;
-            color: #007bff;
+            color: #0056b3;
             background: #e9ecef;
             padding: 2px 8px;
             border-radius: 12px;

--- a/examples/wasm/browser/index.html
+++ b/examples/wasm/browser/index.html
@@ -119,6 +119,26 @@
             border-color: #007bff;
         }
 
+        .range-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 5px;
+        }
+
+        .range-header label {
+            margin-bottom: 0;
+        }
+
+        .range-value {
+            font-weight: 500;
+            color: #007bff;
+            background: #e9ecef;
+            padding: 2px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+        }
+
         textarea {
             resize: vertical;
             min-height: 100px;
@@ -436,9 +456,11 @@
             </div>
 
             <div class="input-group">
-                <label for="temperature">Temperature:</label>
+                <div class="range-header">
+                    <label for="temperature">Temperature:</label>
+                    <span id="temperature-value" class="range-value">0.7</span>
+                </div>
                 <input type="range" id="temperature" min="0" max="2" step="0.1" value="0.7">
-                <span id="temperature-value">0.7</span>
             </div>
 
             <div class="input-group">
@@ -447,9 +469,11 @@
             </div>
 
             <div class="input-group">
-                <label for="top-p">Top-P:</label>
+                <div class="range-header">
+                    <label for="top-p">Top-P:</label>
+                    <span id="top-p-value" class="range-value">0.9</span>
+                </div>
                 <input type="range" id="top-p" min="0" max="1" step="0.05" value="0.9">
-                <span id="top-p-value">0.9</span>
             </div>
 
             <div class="input-group">


### PR DESCRIPTION
💡 What: Improved the visual layout of range sliders (Temperature, Top-P) in the settings tab by grouping the label and value indicator in a flex header above the slider, and styling the value indicator as a distinct, pill-shaped badge.
🎯 Why: The previous layout placed the value indicator directly next to the range slider or below the label without clear visual hierarchy, making it harder to read the current value at a glance.
📸 Before/After: The label and value are now horizontally aligned above the slider, with the value styled distinctly.
♿ Accessibility: Maintains existing semantic `label` and `for` attribute relationships.

---
*PR created automatically by Jules for task [15924364143958996878](https://jules.google.com/task/15924364143958996878) started by @EffortlessSteven*