### PR TITLE
Close out M4 SLM Metal phases

### DIFF
--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-metal-phases`
 
-Status: active
+Status: complete
 
 ## Objective
 
@@ -29,7 +29,7 @@ otherwise.
 | M4-METAL-004 | merged | Recorded the resident-route runtime boundary and prerequisite path. |
 | M4-METAL-005 | merged | Promoted Q/K/V Metal dispatch from test-only fixture to runtime API. |
 | M4-METAL-006 | merged | Route the phase in resident sessions with parity. |
-| M4-METAL-007 | in progress | Record measured phase-local timing deltas. |
+| M4-METAL-007 | merged | Record measured phase-local timing deltas. |
 
 ## Current Decision
 

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-slm-metal-phases"
 title = "Apple M4 SLM Metal phases"
-status = "active"
+status = "complete"
 
 objective = "Expand Apple M4 dense SLM acceleration through named, phase-scoped Metal prefill/projection contributions with CPU-only versus CPU-plus-Metal parity, Metal fallback_used=false receipts, explicit CPU/NEON routing for the rest of the pipeline, and timing deltas, without claiming full apple-m4-metal inference."
 
@@ -251,7 +251,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-METAL-007"
-status = "in_progress"
+status = "merged"
+pr = 4397
+merge_sha = "5254d4a125770796588fa567946344b4267849c9"
 branch = "codex/apple-m4-slm-metal-phases/M4-METAL-007-measured-delta"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/events/2026-05-10T023538Z-M4-METAL-007-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/events/2026-05-10T023538Z-M4-METAL-007-merged.toml
@@ -1,0 +1,16 @@
+timestamp = "2026-05-10T02:35:38Z"
+campaign = "apple-m4-slm-metal-phases"
+item = "M4-METAL-007"
+event = "merged"
+actor = "codex"
+pr = 4397
+merge_sha = "5254d4a125770796588fa567946344b4267849c9"
+previous_status = "in_progress"
+next_item = ""
+
+notes = [
+  "Merged phase-local timing evidence for the resident-routed dense SLM Q/K/V Metal contribution.",
+  "The timing evidence records the named phase only and preserves CPU/NEON generation for the rest of the resident flow.",
+  "All apple-m4-slm-metal-phases work items are now merged and the campaign is marked complete.",
+  "No full apple-m4-metal inference claim, full-pipeline speedup claim, BitNet claim, QK256 claim, Neural Engine claim, MPSGraph claim, MacBook work, model binary, or broad performance claim is introduced.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-metal-phases/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-metal-phases/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 SLM Metal phases Campaign Status
 
 - Campaign: `apple-m4-slm-metal-phases`
-- State: `active`
+- State: `complete`
 - Objective: Expand Apple M4 dense SLM acceleration through named, phase-scoped Metal prefill/projection contributions with CPU-only versus CPU-plus-Metal parity, Metal fallback_used=false receipts, explicit CPU/NEON routing for the rest of the pipeline, and timing deltas, without claiming full apple-m4-metal inference.
 
 ## Work Items
@@ -15,7 +15,7 @@
 | M4-METAL-004 | merged | #4385 | `codex/apple-m4-slm-metal-phases/M4-METAL-004-runtime-boundary` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record the resident-routing feasibility boundary for the validated Q/K/V Metal phase, explicitly documenting that live dispatch is currently test-local, choosing the required runtime extraction path, and blocking resident routing until a non-dev Metal runtime API exists. |
 | M4-METAL-005 | merged | #4391 | `codex/apple-m4-slm-metal-phases/M4-METAL-005-runtime-api` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Promote the validated dense prefill Q/K/V Metal dispatch from test-only code into a non-dev runtime API with target/feature-gated dependencies, generic CI-safe fixture tests, live M4 opt-in proof, and no resident generation routing. |
 | M4-METAL-006 | merged | #4395 | `codex/apple-m4-slm-metal-phases/M4-METAL-006-resident-route` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Route the runtime Q/K/V Metal phase into resident-session flow only where parity holds, with CPU-only versus CPU-plus-Metal greedy comparison, quality corpus pass, explicit CPU/NEON routing for non-Metal phases, and phase receipts per relevant turn. |
-| M4-METAL-007 | in_progress | TBD | `codex/apple-m4-slm-metal-phases/M4-METAL-007-measured-delta` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record measured phase-local timing deltas for the resident-routed Metal phase, keeping speedup claims phase-local and updating docs without broad M4 or full Metal inference claims. |
+| M4-METAL-007 | merged | #4397 | `codex/apple-m4-slm-metal-phases/M4-METAL-007-measured-delta` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Record measured phase-local timing deltas for the resident-routed Metal phase, keeping speedup claims phase-local and updating docs without broad M4 or full Metal inference claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -15,7 +15,7 @@
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-slm-excellence | M4-SLM-EX-010 | #4307 | merged | none | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
-| apple-m4-slm-metal-phases | M4-METAL-007 | TBD | in_progress | none | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-metal-phases | M4-METAL-007 | #4397 | merged | none | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-model-breadth | M4-MODEL-004 | TBD | blocked | M4-MODEL-005 | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-performance | M4-SLM-PERF-007 | #4081 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, apple-m4-slm-answer, or apple-m4-productization campaigns. |
 | apple-silicon-macbook | MB-AS-004 | TBD | proposed | MB-AS-005 | Do not reopen the completed apple-m4 proof, operational, SLM answer, productization, performance, hardening, or regression campaigns. |


### PR DESCRIPTION
## Summary
- marks `M4-METAL-007` merged with PR #4397 and merge SHA `5254d4a125770796588fa567946344b4267849c9`
- marks `apple-m4-slm-metal-phases` complete
- regenerates campaign dashboards

## Validation
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-metal-phases`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim boundary
Tracker-only closeout. No runtime behavior change, no full Apple Metal inference claim, no full-pipeline speedup claim, no BitNet claim, no QK256 claim, no Neural Engine or MPSGraph claim, no MacBook work, and no model binaries.