### PR TITLE
[codex] Clean up disabled CI reporting references

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -36,7 +36,6 @@ on:
       - '.github/workflows/ci-core.yml'
       - '.github/workflows/pr-plan.yml'
       - '.github/workflows/coverage.yml'
-      - '.github/workflows/ci-reporting.yml'
 
       # CI configuration - codecov config affects verification signal
       - 'codecov.yml'

--- a/docs/development/ci-integration.md
+++ b/docs/development/ci-integration.md
@@ -1,6 +1,7 @@
 # CI Integration Guide
 
-This document describes the comprehensive CI integration setup for the BitNet-rs testing framework.
+This document describes the legacy testing-framework CI integration model and
+the current reporting path used by the active GitHub Actions workflows.
 
 > Before adding a new CI workflow or expanding an existing one, read
 > [CI Cost and Verification Policy](../ci/cost-and-verification-policy.md).
@@ -90,11 +91,13 @@ graph TD
   - Triggered by: PR/push to main/develop affecting inference/benchmarks
 
 #### 3. Reporting and Coordination
-- **CI Reporting** (`ci-reporting.yml`)
-  - Aggregates results from all workflows
-  - Generates comprehensive reports
-  - Updates PR comments with status
-  - Creates GitHub status checks
+- **CI Actuals** (`ci-actuals.yml`)
+  - Records completed workflow run timing and job metadata
+  - Emits `ci-actuals.json` artifacts for CI cost and verification analysis
+  - Watches the active default PR lanes, including CI Core, Feature Matrix,
+    Compatibility Tests, Test Telemetry, Fuzz CI, PR Plan, Policy, PR Gate, and
+    ripr
+  - Replaces the disabled legacy `ci-reporting.yml.disabled` reporter
 
 ## Workflow Triggers
 


### PR DESCRIPTION
## Summary
- remove the dead `ci-reporting.yml` path trigger from CI Core
- update the development CI guide to point at active CI Actuals reporting
- mark the disabled legacy reporter as legacy context instead of active CI

## Validation
- `rg -n 'ci-reporting\\.yml|CI Reporting|ci-actuals|CI Actuals' .github docs CONTRIBUTING.md README.md ci 2>/dev/null`\n- `git diff --check`\n- `cargo run --locked -p xtask --no-default-features -- lint-workflows`\n- `make guards`