### PR TITLE
[codex] Refresh validation CI documentation

### DIFF
--- a/.github/workflows/README_VALIDATION.md
+++ b/.github/workflows/README_VALIDATION.md
@@ -12,38 +12,43 @@ This directory contains the comprehensive validation CI workflow for bitnet-rs.
 
 ## What This Workflow Does
 
-The validation workflow (`validation.yml`) enforces quality standards for bitnet-rs:
+The validation workflow (`validation.yml`) exercises validation quality checks for bitnet-rs:
 
 ### 🔒 Security Guard
-- Blocks correction flags in CI (BITNET_ALLOW_RUNTIME_CORRECTIONS, BITNET_CORRECTION_POLICY)
+
+- Reports correction flags in CI (BITNET_ALLOW_RUNTIME_CORRECTIONS, BITNET_CORRECTION_POLICY)
 - Verifies strict mode is enabled
 - Ensures models are validated without runtime corrections
 
 ### 🔨 Build Validation Tools
+
 - Builds bitnet-cli with full-cli features
 - Builds bitnet-st2gguf (SafeTensors to GGUF converter)
 - Builds bitnet-st-tools (st-ln-inspect, st-merge-ln-f16)
-- Cross-platform: Ubuntu, Windows, macOS
+- Linux-only for CI efficiency
 
 ### 🧪 Integration Testing
+
 - Runs validation workflow tests
 - Tests inspect command functionality
 - Validates LayerNorm RMS calculations
 - Tests architecture detection and rulesets
 
 ### 📊 Model Validation
+
 - Validates GGUF models in strict mode
 - Checks for suspicious LayerNorm weights
 - Verifies correct ruleset detection
 - Can be skipped for tooling-only changes
 
 ### ✅ Quality Gate
-- Final gate that blocks PR merge on validation failure
+
+- Final status reporter for validation failure
 - Always runs, provides detailed troubleshooting guidance
 
 ## File Structure
 
-```
+```text
 .github/workflows/
 ├── validation.yml                      # Main workflow (562 lines)
 ├── VALIDATION_WORKFLOW_SUMMARY.md      # Quick overview (237 lines)
@@ -86,7 +91,7 @@ cargo run -p bitnet-cli -- inspect --ln-stats --json your-model.gguf
 **After creating a PR:**
 
 1. Check workflow runs automatically
-2. Verify all jobs pass (security-guard, build-tools, validation-tests, quality-gate)
+2. Verify the hard build job passes and review informational validation reports
 3. Fix any failures locally before pushing
 
 ### For Maintainers
@@ -117,26 +122,30 @@ gh run download <run-id>
 ## Key Features
 
 ### ✨ Comprehensive Validation
+
 - Security checks for forbidden correction flags
-- Cross-platform tool builds (Ubuntu, Windows, macOS)
+- Linux validation tool builds
 - Integration tests for validation workflows
 - Model validation with strict mode
 - Quality gate blocking PR merge
 
 ### 🚀 Performance Optimized
+
 - Aggressive caching with Swatinem/rust-cache
 - Parallel execution (build-tools, validation-tests run in parallel)
-- Typical duration: 15-25 minutes with caching
+- Typical duration: 10-20 minutes with caching
 - Optional model validation skip for tooling changes
 
 ### 🔐 Security Enforced
+
 - No correction flags allowed in CI
 - Strict mode always enabled (BITNET_STRICT_MODE=1)
 - Minimal workflow permissions
 - Early detection of suspicious weights
 
 ### 📦 Rich Artifacts
-- Built binaries for all platforms (7 days retention)
+
+- Built Linux binaries (7 days retention)
 - Validation test reports (30 days retention)
 - Model validation outputs (30 days retention)
 - Detailed job summaries in GitHub Actions UI
@@ -144,16 +153,19 @@ gh run download <run-id>
 ## Integration with Other Workflows
 
 ### Main CI (`ci.yml`)
+
 - Main CI: Broad test suite including crossval
 - Validation workflow: Focused on validation tooling
 - Both: Enforce strict mode and block corrections
 
 ### GGUF Build (`gguf_build_and_validate.yml`)
+
 - GGUF Build: Exports and validates new models
 - Validation workflow: Validates existing models and tools
 - Both: Use strict mode, block corrections
 
 ### Guards (`guards.yml`)
+
 - Guards: Broader checks for scripts and workflows
 - Validation workflow: Validation-specific security checks
 - Both: Check for forbidden correction flags
@@ -202,36 +214,39 @@ See [`VALIDATION_CHECKLIST.md`](./VALIDATION_CHECKLIST.md) for detailed troubles
 ## Documentation
 
 ### For Quick Reference
+
 - **Checklist**: [`VALIDATION_CHECKLIST.md`](./VALIDATION_CHECKLIST.md) - Quick reference checklist
 - **Summary**: [`VALIDATION_WORKFLOW_SUMMARY.md`](./VALIDATION_WORKFLOW_SUMMARY.md) - One-page overview
 
 ### For Visual Understanding
+
 - **Diagram**: [`VALIDATION_WORKFLOW_DIAGRAM.md`](./VALIDATION_WORKFLOW_DIAGRAM.md) - Job flow diagrams
 
 ### For Deep Dive
+
 - **Full Docs**: [`../../docs/development/validation-ci.md`](../../docs/development/validation-ci.md) - Comprehensive guide
 
 ## Timeline
 
 Typical execution times (with caching):
 
-```
+```text
 0-1 min:   security-guard
-1-10 min:  build-tools (parallel: Ubuntu, Windows, macOS)
+1-10 min:  build-tools (Ubuntu)
 10-15 min: validation-tests + validate-models (parallel)
 15-20 min: validation-summary + quality-gate
-Total:     15-25 minutes
+Total:     10-20 minutes
 ```
 
 ## Success Criteria
 
-For PR merge, these jobs must pass:
+Current merge behavior:
 
-- ✅ `security-guard` - Critical (blocks merge)
-- ✅ `build-tools` - Critical (blocks merge)
-- ✅ `validation-tests` - Critical (blocks merge)
+- ✅ `build-tools` - Hard validation workflow job
+- ℹ️ `security-guard` - Informational while stabilizing
+- ℹ️ `validation-tests` - Informational while stabilizing
 - ⚠️ `validate-models` - Optional (may be skipped)
-- ✅ `quality-gate` - Critical (blocks merge)
+- ℹ️ `quality-gate` - Informational while stabilizing
 
 ## Support
 

--- a/.github/workflows/VALIDATION_CHECKLIST.md
+++ b/.github/workflows/VALIDATION_CHECKLIST.md
@@ -7,6 +7,7 @@ Quick reference checklist for the validation workflow.
 ### Before Creating PR
 
 - [ ] Test validation tools locally with strict mode:
+
   ```bash
   export BITNET_STRICT_MODE=1
   export BITNET_DETERMINISTIC=1
@@ -15,6 +16,7 @@ Quick reference checklist for the validation workflow.
   ```
 
 - [ ] Build all validation tools:
+
   ```bash
   cargo build -p bitnet-cli --release --no-default-features --features cpu,full-cli
   cargo build -p bitnet-st2gguf --release
@@ -22,18 +24,21 @@ Quick reference checklist for the validation workflow.
   ```
 
 - [ ] Run validation tests locally:
+
   ```bash
   cargo test -p bitnet-cli --test validation_workflow \
     --no-default-features --features cpu,full-cli -- --nocapture
   ```
 
 - [ ] If modifying models, validate without corrections:
+
   ```bash
   cargo run -p bitnet-cli -- inspect --ln-stats --json your-model.gguf
   # Check that status is "ok" and suspicious counts are 0
   ```
 
 - [ ] Verify no correction flags in your changes:
+
   ```bash
   git diff main | grep -i "BITNET_ALLOW_RUNTIME_CORRECTIONS"
   git diff main | grep -i "BITNET_CORRECTION_POLICY"
@@ -44,11 +49,11 @@ Quick reference checklist for the validation workflow.
 ### After PR Creation
 
 - [ ] Check that validation workflow runs automatically
-- [ ] Verify security-guard passes (no correction flags detected)
-- [ ] Verify build-tools passes on all platforms (Ubuntu, Windows, macOS)
-- [ ] Verify validation-tests passes
+- [ ] Review security-guard warnings for correction flags
+- [ ] Verify build-tools passes on Ubuntu
+- [ ] Review validation-tests output and uploaded report
 - [ ] Verify validate-models passes (or is skipped if appropriate)
-- [ ] Check quality-gate status (must be green for merge)
+- [ ] Review quality-gate status report
 
 ### If Validation Fails
 
@@ -65,7 +70,7 @@ Quick reference checklist for the validation workflow.
 - [ ] Review validation workflow performance monthly
 - [ ] Check cache effectiveness (aim for < 10 minute builds)
 - [ ] Update Rust toolchain versions as needed
-- [ ] Verify all platforms still supported
+- [ ] Verify the Linux workflow still covers validation-tool build requirements
 - [ ] Review artifact retention policies
 
 ### When Adding New Validation Features
@@ -74,7 +79,7 @@ Quick reference checklist for the validation workflow.
 - [ ] Update security-guard checks if new env vars added
 - [ ] Document new features in `docs/development/validation-ci.md`
 - [ ] Add examples to workflow summary
-- [ ] Test locally on all platforms if possible
+- [ ] Test locally on additional platforms if the change touches platform-specific code
 
 ### When Updating Dependencies
 
@@ -85,7 +90,7 @@ Quick reference checklist for the validation workflow.
 
 ### Security Reviews
 
-- [ ] Verify correction flags still blocked in security-guard
+- [ ] Verify correction flags are still reported by security-guard
 - [ ] Check no new correction mechanisms bypass security-guard
 - [ ] Review workflow permissions (minimal required)
 - [ ] Audit artifact contents (no secrets leaked)
@@ -212,12 +217,12 @@ rg -n 'BITNET_FIX_LN_SCALE' .github/workflows
 
 ## Quick Reference
 
-### Required Jobs (Must Pass)
+### Current Merge Behavior
 
-- ✅ `security-guard` - Critical
-- ✅ `build-tools` - Critical
-- ✅ `validation-tests` - Critical
-- ✅ `quality-gate` - Critical
+- ✅ `build-tools` - Hard validation workflow job
+- ℹ️ `security-guard` - Informational while stabilizing
+- ℹ️ `validation-tests` - Informational while stabilizing
+- ℹ️ `quality-gate` - Informational while stabilizing
 
 ### Optional Jobs (Can Skip)
 
@@ -225,12 +230,12 @@ rg -n 'BITNET_FIX_LN_SCALE' .github/workflows
 
 ### Typical Timeline
 
-```
+```text
 0-1 min:   security-guard
-1-10 min:  build-tools (parallel across 3 platforms)
+1-10 min:  build-tools (Ubuntu)
 10-15 min: validation-tests + validate-models (parallel)
 15-20 min: validation-summary + quality-gate
-Total:     15-25 minutes with caching
+Total:     10-20 minutes with caching
 ```
 
 ### Key Environment Variables
@@ -241,7 +246,7 @@ BITNET_DETERMINISTIC=1            # Required - reproducible tests
 BITNET_SEED=42                    # Required - deterministic seed
 RAYON_NUM_THREADS=1               # Required - single-threaded
 
-# BLOCKED in CI (security-guard enforces):
+# Reported by security-guard:
 # BITNET_ALLOW_RUNTIME_CORRECTIONS  ❌
 # BITNET_CORRECTION_POLICY          ❌
 # BITNET_FIX_LN_SCALE               ❌ (deprecated)
@@ -249,7 +254,7 @@ RAYON_NUM_THREADS=1               # Required - single-threaded
 
 ### Monitored Paths
 
-```
+```text
 crates/bitnet-cli/**
 crates/bitnet-st-tools/**
 crates/bitnet-st2gguf/**

--- a/.github/workflows/VALIDATION_WORKFLOW_SUMMARY.md
+++ b/.github/workflows/VALIDATION_WORKFLOW_SUMMARY.md
@@ -7,46 +7,55 @@ The `validation.yml` workflow implements comprehensive validation gates for bitn
 ## Key Features
 
 ### 1. Security Guard
-- **Blocks correction flags in CI** (BITNET_ALLOW_RUNTIME_CORRECTIONS, BITNET_CORRECTION_POLICY)
-- Verifies strict mode is enabled
-- Fails immediately if forbidden flags are detected
 
-### 2. Multi-Platform Tool Builds
-- Builds validation tools on Ubuntu, Windows, macOS
+- **Reports correction flags in CI** (BITNET_ALLOW_RUNTIME_CORRECTIONS, BITNET_CORRECTION_POLICY)
+- Verifies strict mode is enabled
+- Informational while baselines stabilize (`continue-on-error: true`)
+
+### 2. Linux Tool Builds
+
+- Builds validation tools on Ubuntu
 - Tools: bitnet-cli (full-cli), bitnet-st2gguf, bitnet-st-tools
 - Verifies binaries execute correctly
 - Uploads artifacts for downstream jobs
 
 ### 3. Integration Testing
+
 - Runs validation workflow tests (`validation_workflow.rs`)
 - Tests inspect command, LayerNorm validation, architecture detection
 - Validates JSON output format and exit codes
-- Coverage across all platforms
+- Linux-only, informational while baselines stabilize
 
 ### 4. Model Validation
+
 - Validates GGUF models with strict mode enabled
 - Checks LayerNorm RMS values for suspicious weights
 - Verifies correct ruleset detection
 - Can be skipped for tooling-only changes
 
 ### 5. Quality Gate
-- Final gate that blocks PR merge on failure
+
+- Final status reporter for validation failures
 - Always runs, even if previous jobs fail
+- Informational while baselines stabilize (`continue-on-error: true`)
 - Provides detailed troubleshooting guidance
 
 ## Integration with Existing CI
 
 ### Complements Main CI (`ci.yml`)
+
 - Main CI: Broad test suite including crossval
 - Validation workflow: Focused on validation tooling
 - Both: Enforce strict mode and block corrections
 
 ### Extends GGUF Build Workflow (`gguf_build_and_validate.yml`)
+
 - GGUF Build: Exports and validates new models
 - Validation workflow: Validates existing models and tools
 - Both: Use strict mode, block corrections
 
 ### Reinforces Guards (`guards.yml`)
+
 - Guards: Broader checks for scripts and workflows
 - Validation workflow: Validation-specific security checks
 - Both: Check for forbidden correction flags
@@ -62,7 +71,7 @@ BITNET_DETERMINISTIC=1
 BITNET_SEED=42
 RAYON_NUM_THREADS=1
 
-# Blocked flags (security-guard enforces)
+# Correction flags reported by security-guard
 # BITNET_ALLOW_RUNTIME_CORRECTIONS - NOT ALLOWED
 # BITNET_CORRECTION_POLICY - NOT ALLOWED
 # BITNET_FIX_LN_SCALE - NOT ALLOWED (deprecated)
@@ -76,7 +85,7 @@ RAYON_NUM_THREADS=1
 
 ### Monitored Paths
 
-```
+```text
 crates/bitnet-cli/**
 crates/bitnet-st-tools/**
 crates/bitnet-st2gguf/**
@@ -88,35 +97,35 @@ scripts/export_clean_gguf.sh
 
 ## Job Dependencies
 
-```
-security-guard (blocks everything on failure)
+```text
+security-guard (informational correction-flag report)
     ↓
-build-tools (parallel across platforms)
+build-tools (Ubuntu)
     ↓
 validation-tests + validate-models (parallel)
     ↓
 validation-summary (aggregates results)
     ↓
-quality-gate (blocks PR merge on failure)
+quality-gate (informational status report)
 ```
 
 ## Success Criteria
 
-For PR merge, these jobs must pass:
+Current merge behavior:
 
-- ✅ `security-guard` - Critical
-- ✅ `build-tools` - Critical
-- ✅ `validation-tests` - Critical
+- ✅ `build-tools` - Hard validation workflow job
+- ℹ️ `security-guard` - Informational while stabilizing
+- ℹ️ `validation-tests` - Informational while stabilizing
 - ⚠️ `validate-models` - Optional (may be skipped)
-- ✅ `quality-gate` - Critical
+- ℹ️ `quality-gate` - Informational while stabilizing
 
 ## Artifacts Generated
 
-1. **{os}-validation-tools** (7 days)
+1. **bitnet-linux-x64-validation-tools** (7 days)
    - Built binaries for bitnet-cli, st2gguf, st-tools
 
-2. **validation-test-report-{os}** (30 days)
-   - Test execution reports per platform
+2. **validation-test-report-ubuntu** (30 days)
+   - Test execution report
 
 3. **model-validation-{model_name}** (30 days)
    - Validation JSON output and reports
@@ -124,15 +133,17 @@ For PR merge, these jobs must pass:
 ## Common Use Cases
 
 ### PR Workflow
+
 1. Developer makes changes to validation code
 2. Workflow triggers automatically on PR
 3. Security guard checks for forbidden flags
-4. Tools build across platforms
-5. Integration tests run
+4. Tools build on Ubuntu
+5. Integration tests run and publish an informational report
 6. Models validated (if applicable)
-7. Quality gate blocks merge if validation fails
+7. Quality gate reports validation status
 
 ### Manual Testing
+
 ```bash
 # Trigger workflow manually
 gh workflow run validation.yml
@@ -142,6 +153,7 @@ gh workflow run validation.yml -f skip_model_validation=true
 ```
 
 ### Local Validation
+
 ```bash
 # Match CI environment
 export BITNET_STRICT_MODE=1
@@ -165,36 +177,42 @@ cargo run -p bitnet-cli -- inspect --ln-stats --json your-model.gguf
 ## Troubleshooting
 
 ### Security Guard Fails
+
 - **Problem**: Correction flags detected in workflow files
 - **Solution**: Remove BITNET_ALLOW_RUNTIME_CORRECTIONS, BITNET_CORRECTION_POLICY from workflows
 
 ### Build Tools Fails
+
 - **Problem**: Compilation errors
 - **Solution**: Test locally with same features: `--no-default-features --features cpu,full-cli`
 
 ### Validation Tests Fail
+
 - **Problem**: Integration test failures
 - **Solution**: Run tests locally with `--nocapture` to see detailed output
 
 ### Model Validation Fails
+
 - **Problem**: Suspicious LayerNorm weights detected
 - **Solution**: Regenerate model with `bitnet-st2gguf --strict` or `just model-clean`
 
 ## Performance
 
-- **Typical Duration**: 15-25 minutes (with caching)
+- **Typical Duration**: 10-20 minutes (with caching)
 - **Parallel Execution**: build-tools and validation-tests run in parallel
-- **Caching**: Cargo dependencies cached per OS
+- **Caching**: Cargo dependencies cached on Ubuntu
 - **Optimization**: Skip model validation for tooling-only changes
 
 ## Best Practices
 
 ### For Contributors
+
 1. Test locally with strict mode before pushing
 2. Run validation tests: `cargo test -p bitnet-cli --test validation_workflow`
 3. Ensure models pass inspection without corrections
 
 ### For Maintainers
+
 1. Never disable strict mode in CI
 2. Keep validation fast with aggressive caching
 3. Provide clear error messages and troubleshooting guidance
@@ -210,6 +228,7 @@ cargo run -p bitnet-cli -- inspect --ln-stats --json your-model.gguf
 ## Support
 
 For issues:
+
 1. Review workflow logs in GitHub Actions
 2. Check `docs/development/validation-ci.md` for detailed troubleshooting
 3. Test locally with provided commands

--- a/docs/development/validation-ci.md
+++ b/docs/development/validation-ci.md
@@ -11,11 +11,17 @@ Comprehensive documentation for the BitNet-rs validation CI workflow (`.github/w
 
 ## Overview
 
-The validation workflow enforces quality standards for all model operations and validation tooling in BitNet-rs. It ensures that:
+The validation workflow exercises validation tooling and model checks for
+validation-related changes in BitNet-rs. It currently runs as a Linux-only
+stabilization workflow: build failures are gating, while the security guard,
+validation tests, summary, and quality gate report problems without blocking
+merge while baselines are being stabilized.
 
-1. **Security**: No runtime correction flags are enabled in CI
-2. **Tooling**: All validation tools build and execute correctly across platforms
-3. **Testing**: Integration tests pass for validation workflows
+It ensures that:
+
+1. **Security visibility**: Runtime correction flags are reported if they appear in CI
+2. **Tooling**: Validation tools build and execute correctly on Linux
+3. **Testing**: Integration tests run for validation workflows and publish reports
 4. **Models**: GGUF models pass strict validation without corrections
 
 ## Workflow Structure
@@ -68,25 +74,29 @@ VERGEN_IDEMPOTENT=1
 
 ### Security Configuration
 
-**Blocked Environment Variables** (enforced by `security-guard` job):
+**Correction Environment Variables** (reported by `security-guard` job):
 
 - `BITNET_ALLOW_RUNTIME_CORRECTIONS` - Must not be set in CI
 - `BITNET_CORRECTION_POLICY` - Must not be set in CI
 - `BITNET_FIX_LN_SCALE` - Deprecated, must not be set in CI
 
-These flags are blocked to ensure models pass validation without runtime corrections. Runtime corrections are only allowed for known-bad models in local development with explicit fingerprinting.
+These flags should stay out of CI so models pass validation without runtime
+corrections. The current `security-guard` job is informational
+(`continue-on-error: true`) and reports violations while the workflow baseline
+is stabilizing. Runtime corrections are only allowed for known-bad models in
+local development with explicit fingerprinting.
 
 ## Jobs
 
 ### 1. Security Guard (`security-guard`)
 
-**Purpose**: Block correction flags and verify strict mode configuration
+**Purpose**: Report correction flags and verify strict mode configuration
 
 **Key Checks**:
 
 - Scans workflow files for forbidden correction environment variables
 - Verifies `BITNET_STRICT_MODE=1` is enabled in validation workflow
-- Fails immediately if any correction flags are found
+- Emits warnings if correction flags are found; currently exits successfully
 
 **Why This Matters**:
 
@@ -99,11 +109,11 @@ Runtime corrections mask underlying issues. CI must validate models with their a
 **Exit Codes**:
 
 - `0` - No forbidden flags found, strict mode verified
-- `1` - Forbidden flags detected or strict mode not enabled
+- `0` - Forbidden flags detected or strict mode missing while the guard is informational
 
 ### 2. Build Tools (`build-tools`)
 
-**Purpose**: Build validation tools across all platforms
+**Purpose**: Build validation tools on Linux
 
 **Tools Built**:
 
@@ -119,11 +129,9 @@ Runtime corrections mask underlying issues. CI must validate models with their a
    - `st-ln-inspect`: Inspect LayerNorm weights in SafeTensors
    - `st-merge-ln-f16`: Merge F16 LayerNorm weights into SafeTensors
 
-**Platform Matrix**:
+**Platform Coverage**:
 
 - Ubuntu (Linux x86_64)
-- Windows (x86_64)
-- macOS (x86_64)
 
 **Verification Steps**:
 
@@ -134,7 +142,7 @@ Runtime corrections mask underlying issues. CI must validate models with their a
 
 **Artifacts**:
 
-- `{os}-validation-tools` - Contains all built validation binaries
+- `bitnet-linux-x64-validation-tools` - Contains all built validation binaries
 - Retention: 7 days
 
 ### 3. Validation Tests (`validation-tests`)
@@ -158,7 +166,11 @@ Runtime corrections mask underlying issues. CI must validate models with their a
    - Quantized tensor handling
    - Text and JSON output formats
 
-**Platform Coverage**: Ubuntu, Windows, macOS
+**Platform Coverage**: Ubuntu (Linux x86_64)
+
+The test commands currently use `|| true` and the job has
+`continue-on-error: true`, so failures are surfaced in logs and artifacts
+without blocking the workflow.
 
 **Test Features**:
 
@@ -193,7 +205,8 @@ cargo test -p bitnet-cli --test validation_workflow \
    - Correct ruleset detected
    - Validation status (ok/warning/failed)
    - Suspicious weight counts for LayerNorm and projection
-5. Fail if suspicious weights detected in strict mode
+5. Fail on ruleset mismatches or strict-mode `status == "failed"`
+6. Warn if suspicious weights are detected in strict mode
 
 **JSON Output Structure**:
 
@@ -239,12 +252,12 @@ Can be skipped via workflow_dispatch input `skip_model_validation: true` for too
 
 **Success Criteria**:
 
-- All jobs must pass (or validate-models may be skipped)
-- Fails if any required job fails
+- Records whether each job passed, failed, or was skipped
+- Runs a gate script, but the job is currently non-blocking while baselines stabilize
 
 ### 6. Quality Gate (`quality-gate`)
 
-**Purpose**: Final gate that blocks PR merge on validation failure
+**Purpose**: Report whether validation passed
 
 **Permissions**:
 
@@ -258,7 +271,8 @@ permissions:
 
 - Always runs (even if previous jobs fail)
 - Checks validation-summary result
-- Fails with detailed error message if validation did not pass
+- Emits a detailed error message if validation did not pass, but is currently
+  non-blocking (`continue-on-error: true`)
 - Provides common troubleshooting guidance
 
 **Common Issues Reported**:
@@ -334,13 +348,13 @@ The validation workflow complements other CI workflows:
 
 ### Status Check Requirements
 
-For PR merges, the following validation jobs must pass:
+Current merge behavior:
 
-- `security-guard` - Critical (blocks merge)
-- `build-tools` - Critical (blocks merge)
-- `validation-tests` - Critical (blocks merge)
-- `validate-models` - Optional (may be skipped)
-- `quality-gate` - Critical (blocks merge)
+- `build-tools` is the only hard validation workflow job.
+- `security-guard`, `validation-tests`, `validation-summary`, and
+  `quality-gate` are informational while baselines stabilize.
+- `validate-models` runs when not skipped and can fail on ruleset mismatches
+  or strict-mode failed status.
 
 ## Troubleshooting
 
@@ -398,12 +412,14 @@ cargo test -p bitnet-cli --test validation_workflow \
 **Solution**:
 
 1. Regenerate model with proper LayerNorm preservation:
+
    ```bash
    cargo run -p bitnet-st2gguf --no-default-features --features cpu -- --input model.safetensors \
      --output model.gguf --strict
    ```
 
 2. Or use export scripts:
+
    ```bash
    just model-clean <model_dir> <tokenizer.json>
    ```
@@ -451,6 +467,7 @@ cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- inspect
    - Use `bitnet-st2gguf` with strict mode
 
 2. **Test locally with strict mode**
+
    ```bash
    export BITNET_STRICT_MODE=1
    cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- inspect --ln-stats your-model.gguf
@@ -470,15 +487,15 @@ cargo run -p bitnet-cli --no-default-features --features cpu,full-cli -- inspect
    - Update feature specs
    - Add examples to help text
 
-3. **Test across platforms**
-   - Ensure tools build on Windows, macOS, Linux
-   - Test platform-specific code paths
+3. **Test beyond Linux when needed**
+   - CI validates this workflow on Linux
+   - Test Windows or macOS locally when touching platform-specific code paths
 
 ### For CI Maintainers
 
 1. **Never disable strict mode in CI**
    - Always use `BITNET_STRICT_MODE=1`
-   - Block correction flags in security-guard
+   - Keep correction-flag reporting in security-guard
 
 2. **Keep validation fast**
    - Cache dependencies aggressively

--- a/tests/CI_REPORTING_GUIDE.md
+++ b/tests/CI_REPORTING_GUIDE.md
@@ -1,6 +1,11 @@
-# BitNet-rs CI Reporting and Notifications Guide
+# BitNet-rs Legacy CI Reporting and Notifications Guide
 
-This guide explains how to use the comprehensive CI reporting and notifications system implemented for BitNet-rs.
+This guide documents the legacy CI reporting helpers under `tests/`. The
+GitHub Actions workflow that originally ran them, `ci-reporting.yml`, is no
+longer active; the disabled copy remains as
+`.github/workflows/ci-reporting.yml.disabled`. Current workflow-run metadata is
+collected by `.github/workflows/ci-actuals.yml`, which uploads
+`ci-actuals.json` artifacts for CI cost and verification analysis.
 
 ## Overview
 
@@ -75,11 +80,14 @@ reporter.record_test_results(&test_results, &metadata).await?;
 let report = reporter.generate_trend_report(30, Some("main")).await?;
 ```
 
-## GitHub Actions Integration
+## Legacy GitHub Actions Integration
 
 ### Workflow Configuration
 
-The CI reporting system integrates with GitHub Actions through the `ci-reporting.yml` workflow:
+The legacy CI reporting system was designed to integrate with GitHub Actions
+through `ci-reporting.yml`. That workflow is disabled in this repository. Use
+`.github/workflows/ci-actuals.yml` for current run metadata collection; keep the
+snippet below only as historical context for the helper binaries.
 
 ```yaml
 name: CI Reporting and Notifications
@@ -136,6 +144,7 @@ cargo run --bin generate_ci_report -- \
 ```
 
 **Outputs:**
+
 - `status-checks.json`: GitHub status check data
 - `pr-comment.md`: Pull request comment content
 - `test-results.json`: Processed test results
@@ -155,6 +164,7 @@ cargo run --bin check_performance_regressions -- \
 ```
 
 **Exit Codes:**
+
 - `0`: No regressions detected
 - `1`: Performance regressions found
 
@@ -171,6 +181,7 @@ cargo run --bin generate_trend_analysis -- \
 ```
 
 **Outputs:**
+
 - `trend-analysis.html`: Interactive HTML report
 - `trend-analysis.json`: Machine-readable data
 - `performance-trends.json`: Performance trend data
@@ -206,6 +217,7 @@ pub struct TrendConfig {
 ### Status Checks
 
 GitHub status checks are created for:
+
 - Overall test suite status
 - Individual test suite status
 - Performance regression status
@@ -213,6 +225,7 @@ GitHub status checks are created for:
 ### Pull Request Comments
 
 PR comments include:
+
 - Overall test summary with pass/fail counts
 - Test suite breakdown with individual results
 - Failed test details with error messages
@@ -221,6 +234,7 @@ PR comments include:
 ### Trend Reports
 
 HTML trend reports provide:
+
 - Test stability analysis over time
 - Performance trend visualization
 - Regression detection results
@@ -348,6 +362,7 @@ cargo run --example ci_reporting_example
 ## Future Enhancements
 
 Planned improvements include:
+
 - Slack/Teams integration for notifications
 - Advanced statistical analysis for regression detection
 - Interactive performance dashboards


### PR DESCRIPTION
## Summary
- align validation workflow docs with the current Linux-only stabilization behavior
- document informational security/test/quality jobs instead of describing them as merge blockers
- mark the legacy tests CI reporting guide as disabled and point current metadata collection at CI Actuals
- apply configured markdownlint formatting to the touched docs

## Validation
- `npx --yes markdownlint-cli2@0.18.1 --config .markdownlint.jsonc .github/workflows/README_VALIDATION.md .github/workflows/VALIDATION_WORKFLOW_SUMMARY.md .github/workflows/VALIDATION_CHECKLIST.md docs/development/validation-ci.md tests/CI_REPORTING_GUIDE.md`
- `cargo run --locked -p xtask --no-default-features -- lint-workflows`
- `make guards`
- `git diff --check`