### PR TITLE
SERVER-001: fail closed server inference without real engine

### DIFF
--- a/crates/bitnet-server/src/caching/request_batching.rs
+++ b/crates/bitnet-server/src/caching/request_batching.rs
@@ -279,20 +279,17 @@ impl RequestBatcher {
         let start_time = Instant::now();
         let batch_size = batch.requests.len();
 
-        // Simulate batch processing (in real implementation, this would call the inference engine)
-        let processing_time = Duration::from_millis(50 + (batch_size as u64 * 10)); // Simulate processing time
-        tokio::time::sleep(processing_time).await;
-
         let processing_time_ms = start_time.elapsed().as_millis() as u64;
 
-        // Send responses to all requests in the batch
+        // Request batching is a queueing scaffold only until it is wired to
+        // the real inference engine. Do not synthesize generated text here.
         for request in batch.requests {
             let wait_time_ms = start_time.duration_since(request.timestamp).as_millis() as u64;
 
             let response = BatchedResponse {
                 request_id: request.id,
-                text: format!("Generated response for: {}", request.prompt),
-                tokens_generated: request.max_tokens as u64,
+                text: "Batch inference unavailable: real server inference is not wired".to_string(),
+                tokens_generated: 0,
                 processing_time_ms,
                 batch_size,
             };

--- a/crates/bitnet-server/src/gpu_streaming.rs
+++ b/crates/bitnet-server/src/gpu_streaming.rs
@@ -1,17 +1,17 @@
 //! SSE endpoint for GPU-accelerated token streaming.
 //!
-//! Provides `/api/v1/generate/stream` which uses the GPU-aware generation
-//! stream when a GPU backend is available, falling back to mock tokens.
+//! Provides `/api/v1/generate/stream` for GPU-aware generation.
+//!
+//! The server must not synthesize tokens when the real GPU stream is not wired.
 
 use axum::{
+    Json,
     extract::State,
-    response::sse::{Event, KeepAlive, Sse},
+    http::StatusCode,
+    response::{IntoResponse, Response},
 };
-use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
-use std::convert::Infallible;
-use std::pin::Pin;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tracing::info;
 
 use crate::ProductionAppState;
@@ -31,23 +31,12 @@ pub struct GpuStreamRequest {
     pub timeout_seconds: Option<u64>,
 }
 
-/// SSE token payload.
 #[derive(Serialize)]
-struct SseToken {
-    token: String,
-    token_id: u32,
-    position: usize,
-    cumulative_time_ms: u64,
-    transfer_latency_us: Option<u64>,
-}
-
-/// SSE completion payload.
-#[derive(Serialize)]
-struct SseComplete {
-    total_tokens: u64,
-    total_time_ms: u64,
-    tokens_per_second: f64,
-    backpressure_events: u64,
+struct GpuStreamUnavailable {
+    error: &'static str,
+    error_code: &'static str,
+    fallback_used: bool,
+    tokens_generated: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -58,82 +47,26 @@ struct SseComplete {
 pub async fn gpu_stream_handler(
     State(state): State<ProductionAppState>,
     axum::Json(request): axum::Json<GpuStreamRequest>,
-) -> impl axum::response::IntoResponse {
+) -> Response {
+    let _ = state;
     info!(
         prompt_len = request.prompt.len(),
         max_tokens = ?request.max_tokens,
         "GPU stream request received"
     );
 
-    let max_tokens = request.max_tokens.unwrap_or(64);
-    let timeout = Duration::from_secs(request.timeout_seconds.unwrap_or(60));
+    let _timeout = Duration::from_secs(request.timeout_seconds.unwrap_or(60));
 
-    let stream = build_gpu_sse_stream(state, request.prompt, max_tokens, timeout);
-
-    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(1)).text("ping"))
-}
-
-fn build_gpu_sse_stream(
-    _state: ProductionAppState,
-    prompt: String,
-    max_tokens: usize,
-    _timeout: Duration,
-) -> Pin<Box<dyn Stream<Item = Result<Event, Infallible>> + Send>> {
-    Box::pin(async_stream::stream! {
-        let start = Instant::now();
-        let tokens = generate_mock_gpu_tokens(&prompt, max_tokens);
-
-        for (i, (text, id)) in tokens.iter().enumerate() {
-            tokio::time::sleep(Duration::from_millis(30)).await;
-            let elapsed = start.elapsed();
-
-            let data = SseToken {
-                token: text.clone(),
-                token_id: *id,
-                position: i + 1,
-                cumulative_time_ms: elapsed.as_millis() as u64,
-                transfer_latency_us: Some(50),
-            };
-
-            yield Ok(Event::default()
-                .event("token")
-                .json_data(&data)
-                .unwrap_or_else(|_| Event::default().data("serialization error")));
-        }
-
-        let elapsed = start.elapsed();
-        let total = tokens.len() as u64;
-        let tps = if elapsed.as_millis() > 0 {
-            (total as f64 * 1000.0) / elapsed.as_millis() as f64
-        } else {
-            0.0
-        };
-
-        let complete = SseComplete {
-            total_tokens: total,
-            total_time_ms: elapsed.as_millis() as u64,
-            tokens_per_second: tps,
-            backpressure_events: 0,
-        };
-
-        info!(total_tokens = total, tps = %format!("{tps:.2}"), "GPU stream complete");
-
-        yield Ok(Event::default()
-            .event("complete")
-            .json_data(&complete)
-            .unwrap_or_else(|_| Event::default().data("serialization error")));
-    })
-}
-
-/// Produce mock tokens for testing.
-fn generate_mock_gpu_tokens(prompt: &str, max_tokens: usize) -> Vec<(String, u32)> {
-    let _ = prompt;
-    let base = ["The", " answer", " is", " 42", ".", " GPU", " stream", " done"];
-    base.iter()
-        .take(max_tokens.min(base.len()))
-        .enumerate()
-        .map(|(i, t)| (t.to_string(), i as u32))
-        .collect()
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(GpuStreamUnavailable {
+            error: "GPU streaming inference is unavailable until it is wired to a real engine",
+            error_code: "SERVER_REAL_INFERENCE_UNAVAILABLE",
+            fallback_used: false,
+            tokens_generated: 0,
+        }),
+    )
+        .into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -143,39 +76,30 @@ fn generate_mock_gpu_tokens(prompt: &str, max_tokens: usize) -> Vec<(String, u32
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn mock_tokens_respect_max() {
-        let tokens = generate_mock_gpu_tokens("hi", 3);
-        assert_eq!(tokens.len(), 3);
-    }
-
-    #[test]
-    fn mock_tokens_cap_at_base_length() {
-        let tokens = generate_mock_gpu_tokens("hi", 1000);
-        assert_eq!(tokens.len(), 8);
-    }
+    use axum::response::IntoResponse;
+    use http_body_util::BodyExt;
+    use std::time::Instant;
 
     #[tokio::test]
-    async fn gpu_stream_produces_events() {
-        use futures::StreamExt;
-
+    async fn gpu_stream_without_real_engine_returns_503_instead_of_mock_tokens() {
         let state = build_test_state().await;
-        let stream = build_gpu_sse_stream(state, "test".into(), 4, Duration::from_secs(10));
-        let events: Vec<_> = stream.collect().await;
-        // 4 token events + 1 complete = 5
-        assert_eq!(events.len(), 5);
-    }
+        let request = GpuStreamRequest {
+            prompt: "test".into(),
+            max_tokens: Some(4),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            timeout_seconds: Some(10),
+        };
+        let response = gpu_stream_handler(State(state), axum::Json(request)).await.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
-    #[tokio::test]
-    async fn gpu_stream_last_event_is_complete() {
-        use futures::StreamExt;
-
-        let state = build_test_state().await;
-        let stream = build_gpu_sse_stream(state, "test".into(), 2, Duration::from_secs(10));
-        let events: Vec<_> = stream.collect().await;
-        // 2 token + 1 complete = 3
-        assert_eq!(events.len(), 3);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+        assert!(body_str.contains("SERVER_REAL_INFERENCE_UNAVAILABLE"));
+        assert!(body_str.contains("\"fallback_used\":false"));
+        assert!(body_str.contains("\"tokens_generated\":0"));
+        assert!(!body_str.contains(" answer"));
     }
 
     async fn build_test_state() -> ProductionAppState {

--- a/crates/bitnet-server/src/streaming.rs
+++ b/crates/bitnet-server/src/streaming.rs
@@ -2,8 +2,11 @@
 
 use anyhow::Result;
 use axum::{
+    Json,
     extract::State,
+    http::StatusCode,
     response::sse::{Event, KeepAlive, Sse},
+    response::{IntoResponse, Response},
 };
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
@@ -82,7 +85,7 @@ pub struct StreamingError {
 pub(crate) async fn streaming_handler(
     State(state): State<ProductionAppState>,
     axum::Json(request): axum::Json<StreamingRequest>,
-) -> impl axum::response::IntoResponse {
+) -> Response {
     info!(
         "Streaming request received: prompt_len={}, max_tokens={:?}, timeout={:?}s",
         request.prompt.len(),
@@ -99,12 +102,24 @@ pub(crate) async fn streaming_handler(
         debug!("Creating real stream with {}s timeout", timeout_seconds);
         Box::pin(create_error_handling_stream(real_stream(model, request).await, detailed_errors))
     } else {
-        warn!("No inference engine available, using mock stream");
-        Box::pin(create_error_handling_stream(mock_stream(request).await, detailed_errors))
+        warn!("No inference engine available for streaming request");
+        let error = StreamingError {
+            error_type: "unavailable".to_string(),
+            message: "Streaming inference is unavailable until a real model engine is loaded"
+                .to_string(),
+            recovery_hints: Some(vec![
+                "Load a verified model before requesting streaming inference".to_string(),
+                "Use a non-streaming endpoint only after real server inference is wired"
+                    .to_string(),
+            ]),
+            tokens_before_error: 0,
+        };
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(error)).into_response();
     };
 
     Sse::new(stream)
         .keep_alive(KeepAlive::new().interval(Duration::from_secs(1)).text("keep-alive"))
+        .into_response()
 }
 
 /// Create a stream with error handling (timeout handled at higher level)
@@ -251,131 +266,14 @@ async fn real_stream(
     }
 }
 
-/// Mock streaming for testing without a model
-async fn mock_stream(
-    request: StreamingRequest,
-) -> impl Stream<Item = Result<Event, anyhow::Error>> {
-    let start = std::time::Instant::now();
-    let tokens = ["Hello", " ", "from", " ", "BitNet", " ", "server", "!"];
-    let max_tokens = request.max_tokens.unwrap_or(8).min(tokens.len());
-
-    async_stream::stream! {
-        for (i, token) in tokens.iter().take(max_tokens).enumerate() {
-            tokio::time::sleep(Duration::from_millis(50)).await;
-
-            let elapsed = start.elapsed();
-            let data = StreamingToken {
-                token: token.to_string(),
-                token_id: 0, // Mock token ID matching test tokenizer behavior
-                cumulative_time_ms: elapsed.as_millis() as u64,
-                position: i + 1,
-            };
-
-            yield Ok(Event::default()
-                .event("token")
-                .json_data(data)
-                .unwrap());
-        }
-
-        // Send completion
-        let elapsed = start.elapsed();
-        let complete = StreamingComplete {
-            total_tokens: max_tokens as u64,
-            total_time_ms: elapsed.as_millis() as u64,
-            tokens_per_second: (max_tokens as f64 * 1000.0) / elapsed.as_millis() as f64,
-            completed_normally: true,
-            completion_reason: Some("Mock generation completed".to_string()),
-        };
-
-        debug!("Mock stream completed: {} tokens", max_tokens);
-
-        yield Ok(Event::default()
-            .event("complete")
-            .json_data(complete)
-            .unwrap());
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::response::IntoResponse;
-    use bitnet_common::{BitNetConfig, ConcreteTensor};
-    use bitnet_inference::InferenceEngine;
-    use bitnet_models::Model;
-    use bitnet_tokenizers::Tokenizer;
     use http_body_util::BodyExt;
 
-    use std::any::Any;
-
-    #[derive(Clone)]
-    struct TestTokenizer;
-
-    impl Tokenizer for TestTokenizer {
-        fn encode(
-            &self,
-            text: &str,
-            _add_bos: bool,
-            _add_special: bool,
-        ) -> bitnet_common::Result<Vec<u32>> {
-            if let Some(id) = text.strip_prefix("token_") {
-                Ok(vec![id.parse().unwrap_or(0)])
-            } else {
-                Ok(vec![0])
-            }
-        }
-
-        fn decode(&self, tokens: &[u32]) -> bitnet_common::Result<String> {
-            Ok(format!("token_{}", tokens[0]))
-        }
-
-        fn vocab_size(&self) -> usize {
-            1000
-        }
-
-        fn token_to_piece(&self, token: u32) -> Option<String> {
-            Some(format!("token_{}", token))
-        }
-    }
-
-    struct DummyModel {
-        config: BitNetConfig,
-    }
-
-    impl DummyModel {
-        fn new() -> Self {
-            Self { config: BitNetConfig::default() }
-        }
-    }
-
-    impl Model for DummyModel {
-        fn config(&self) -> &BitNetConfig {
-            &self.config
-        }
-
-        fn forward(
-            &self,
-            _input: &ConcreteTensor,
-            _cache: &mut dyn Any,
-        ) -> bitnet_common::Result<ConcreteTensor> {
-            Ok(ConcreteTensor::mock(vec![1, 50257]))
-        }
-
-        fn embed(&self, tokens: &[u32]) -> bitnet_common::Result<ConcreteTensor> {
-            Ok(ConcreteTensor::mock(vec![1, tokens.len(), 1]))
-        }
-
-        fn logits(&self, _hidden: &ConcreteTensor) -> bitnet_common::Result<ConcreteTensor> {
-            Ok(ConcreteTensor::mock(vec![1, 1, 50257]))
-        }
-    }
-
     #[tokio::test]
-    async fn sse_token_ids_match_model_outputs() {
-        let model = Arc::new(DummyModel::new());
-        let tokenizer = Arc::new(TestTokenizer);
-        let _engine =
-            InferenceEngine::new(model, tokenizer.clone(), bitnet_common::Device::Cpu).unwrap();
+    async fn streaming_without_loaded_model_returns_503_instead_of_mock_tokens() {
         let app_state = ProductionAppState {
             config: crate::config::ServerConfig::default(),
             model_manager: Arc::new(crate::model_manager::ModelManager::new(
@@ -421,18 +319,12 @@ mod tests {
 
         let sse = streaming_handler(State(app_state), axum::Json(request)).await;
         let response = sse.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
-
-        for event in body_str.split("\n\n") {
-            if event.starts_with("event: token")
-                && let Some(data_line) = event.lines().find(|l| l.starts_with("data: "))
-            {
-                let json = &data_line[6..];
-                let token: StreamingToken = serde_json::from_str(json).unwrap();
-                let expected = tokenizer.encode(&token.token, false, false).unwrap();
-                assert_eq!(expected[0], token.token_id);
-            }
-        }
+        assert!(body_str.contains("Streaming inference is unavailable"));
+        assert!(!body_str.contains("event: token"));
+        assert!(!body_str.contains("BitNet server"));
     }
 }

--- a/crates/bitnet-server/tests/config_builder_edge_cases.rs
+++ b/crates/bitnet-server/tests/config_builder_edge_cases.rs
@@ -31,7 +31,13 @@ fn device_config_from_str_gpu_variants() {
     assert_eq!("vulkan".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
     assert_eq!("opencl".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
     assert_eq!("ocl".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
-    assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::Gpu(0));
+}
+
+#[test]
+fn device_config_from_str_specialized_backend_variants() {
+    assert_eq!("npu".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(0));
+    assert_eq!("intel-npu:1".parse::<DeviceConfig>().unwrap(), DeviceConfig::IntelNpu(1));
+    assert_eq!("metal".parse::<DeviceConfig>().unwrap(), DeviceConfig::Metal);
 }
 
 #[test]
@@ -48,7 +54,6 @@ fn device_config_from_str_gpu_with_id() {
 #[test]
 fn device_config_from_str_invalid() {
     assert!("invalid".parse::<DeviceConfig>().is_err());
-    assert!("metal".parse::<DeviceConfig>().is_err());
     assert!("tpu".parse::<DeviceConfig>().is_err());
     assert!("".parse::<DeviceConfig>().is_err());
 }

--- a/crates/bitnet-server/tests/server_config_batch_edge_cases.rs
+++ b/crates/bitnet-server/tests/server_config_batch_edge_cases.rs
@@ -67,7 +67,13 @@ fn device_config_parse_ocl() {
 #[test]
 fn device_config_parse_npu() {
     let dc: DeviceConfig = "npu".parse().unwrap();
-    assert_eq!(dc, DeviceConfig::Gpu(0));
+    assert_eq!(dc, DeviceConfig::IntelNpu(0));
+}
+
+#[test]
+fn device_config_parse_metal() {
+    let dc: DeviceConfig = "metal".parse().unwrap();
+    assert_eq!(dc, DeviceConfig::Metal);
 }
 
 #[test]

--- a/crates/bitnet-server/tests/server_config_edge_cases.rs
+++ b/crates/bitnet-server/tests/server_config_edge_cases.rs
@@ -54,7 +54,13 @@ fn device_config_parse_ocl() {
 #[test]
 fn device_config_parse_npu() {
     let dc: DeviceConfig = "npu".parse().unwrap();
-    assert!(matches!(dc, DeviceConfig::Gpu(0)));
+    assert!(matches!(dc, DeviceConfig::IntelNpu(0)));
+}
+
+#[test]
+fn device_config_parse_metal() {
+    let dc: DeviceConfig = "metal".parse().unwrap();
+    assert!(matches!(dc, DeviceConfig::Metal));
 }
 
 #[test]

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -18,7 +18,7 @@ hard_constraints = [
 
 [[work_item]]
 id = "SERVER-001"
-status = "proposed"
+status = "in_progress"
 branch = "codex/server-real-inference/SERVER-001-single-request-engine"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -18,7 +18,9 @@ hard_constraints = [
 
 [[work_item]]
 id = "SERVER-001"
-status = "in_progress"
+status = "pr_open"
+pr = 4429
+head_sha = "72d9f6d4669cb8c8a377fcb128d25e9e45a09b69"
 branch = "codex/server-real-inference/SERVER-001-single-request-engine"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T111721Z-SERVER-001-in-progress.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T111721Z-SERVER-001-in-progress.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-10T11:17:21Z"
+campaign = "server-real-inference"
+item = "SERVER-001"
+event = "in_progress"
+from = "proposed"
+to = "in_progress"
+actor = "codex"
+branch = "codex/server-real-inference/SERVER-001-single-request-engine"
+summary = "Started SERVER-001 single-request server real inference wiring."
+notes = [
+  "Scope is explicit unavailable responses or real engine execution for non-test server inference paths; no simulated generated output may remain in production endpoints.",
+  "The implementation must not touch hardware kernels, tokenizer behavior, loader behavior, or hardware acceleration claims.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T113547Z-SERVER-001-pr-open.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T113547Z-SERVER-001-pr-open.toml
@@ -1,0 +1,16 @@
+timestamp = "2026-05-10T11:35:47Z"
+campaign = "server-real-inference"
+item = "SERVER-001"
+event = "pr_open"
+previous_status = "in_progress"
+new_status = "pr_open"
+pr = 4429
+head_sha = "72d9f6d4669cb8c8a377fcb128d25e9e45a09b69"
+actor = "codex"
+
+notes = [
+  "Opened SERVER-001 implementation PR for fail-closed server inference behavior when a real engine is unavailable.",
+  "The server streaming routes now return explicit 503 unavailable responses instead of synthesized token streams.",
+  "The request-batching scaffold no longer synthesizes generated text in non-test builds.",
+  "No hardware acceleration, server performance, tokenizer, loader, transformer, QK256, or CUDA kernel math claim is introduced.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| SERVER-001 | proposed | TBD | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
+| SERVER-001 | in_progress | TBD | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| SERVER-001 | in_progress | TBD | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
+| SERVER-001 | pr_open | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| server-real-inference | SERVER-001 | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-001 | TBD | in_progress | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-001 | #4429 | pr_open | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-001 | TBD | proposed | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-001 | TBD | in_progress | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- removes non-test simulated streaming output from the server streaming endpoints
- returns explicit 503 unavailable responses until a real model/GPU engine is loaded or wired
- stops the request-batching scaffold from synthesizing generated text
- aligns server device-config edge tests with the current shared NPU/Metal parser behavior
- starts SERVER-001 tracker state and refreshes generated dashboards

## Claim boundary
- no hardware acceleration claim
- no server performance claim
- no tokenizer, loader, transformer, QK256, or CUDA kernel math changes

## Validation
- `cargo fmt -p bitnet-server -- --check`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

Note: `cargo fmt --all -- --check` is still blocked locally by Windows OS error 206, so package-scoped fmt was used for the touched crate.