### PR TITLE
docs(tracking): close SERVER-001

### DIFF
--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -18,9 +18,9 @@ hard_constraints = [
 
 [[work_item]]
 id = "SERVER-001"
-status = "pr_open"
+status = "merged"
 pr = 4429
-head_sha = "72d9f6d4669cb8c8a377fcb128d25e9e45a09b69"
+merge_sha = "355a6301c245dd363cd73efd7a57e5a300b0803e"
 branch = "codex/server-real-inference/SERVER-001-single-request-engine"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T114923Z-SERVER-001-merged.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T114923Z-SERVER-001-merged.toml
@@ -1,0 +1,17 @@
+timestamp = "2026-05-10T11:49:23Z"
+campaign = "server-real-inference"
+item = "SERVER-001"
+event = "merged"
+previous_status = "pr_open"
+new_status = "merged"
+pr = 4429
+merge_sha = "355a6301c245dd363cd73efd7a57e5a300b0803e"
+actor = "codex"
+next_item = "none"
+
+notes = [
+  "Merged SERVER-001 implementation PR.",
+  "Server streaming routes now fail closed with explicit unavailable responses when no real engine is loaded or wired.",
+  "The request-batching scaffold no longer synthesizes generated text in non-test builds.",
+  "The implementation did not change hardware kernels, tokenizer behavior, loader behavior, transformer semantics, BitNet QK256, server performance claims, or hardware acceleration claims.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -9,7 +9,7 @@
 
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
-| SERVER-001 | pr_open | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
+| SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| server-real-inference | SERVER-001 | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-001 | #4429 | pr_open | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-001 | #4429 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- marks SERVER-001 merged after #4429 landed
- records the #4429 merge SHA in the server-real-inference tracker
- refreshes generated tracker dashboards and removes the active PR row

## Validation
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`