### PR TITLE
docs(agent): clarify autonomous commit and merge authority

### DIFF
--- a/.claude/agents2/pr-cleanup.md
+++ b/.claude/agents2/pr-cleanup.md
@@ -228,7 +228,8 @@ Your final output **MUST** include this format:
 **Context Check Needed**:
 - Review any new reviewer comments during cleanup
 - Verify all previous feedback has been addressed
-- Check if additional approvals needed
+- Check only for explicit branch-protection or `human_required` blockers;
+  `codex_premerge` work items do not need default human approval
 
 **Expected Flow**: pr-context → pr-finalize → pr-merge → pr-doc-finalize
 **Priority**: Medium - ready for final review phase

--- a/.claude/agents2/pr-finalize.md
+++ b/.claude/agents2/pr-finalize.md
@@ -301,7 +301,8 @@ Your final output **MUST** include this format based on outcome:
 
 - ✅ All validation commands succeed with exit code 0
 - ✅ No merge conflicts with current main branch
-- ✅ All required GitHub approvals obtained
+- ✅ Review state satisfies the work item's policy; for `codex_premerge`, do not
+  wait for human approval unless GitHub branch protection explicitly requires it
 - ✅ Documentation updates completed appropriately
 - ✅ Performance within acceptable bounds (if applicable)
 - ✅ Cross-validation parity maintained (if FFI changes)

--- a/.claude/agents3/integration/pr-merger.md
+++ b/.claude/agents3/integration/pr-merger.md
@@ -106,4 +106,12 @@ After successful merge, route to pr-merge-finalizer for verification and cleanup
 <!-- decision:end -->
 ```
 
-You are a critical safety gate in the BitNet-rs integration pipeline. Never compromise on integration gate verification, and only proceed when pr-summary-agent has explicitly marked the PR as `state:ready` with all gates satisfied and BitNet-rs-specific Rust neural network validations passing.
+You are a critical safety gate in the BitNet-rs integration pipeline. Never
+compromise on integration gate verification. For campaign work items governed
+by `codex_premerge` plus `automerge_when_green` plus `on_blocker_only`, proceed
+when required checks are green and GitHub reports the PR mergeable; do not wait
+for a separate maintainer approval or pr-summary handoff unless branch
+protection or the work item policy requires it. Outside that campaign policy,
+proceed when pr-summary-agent has explicitly marked the PR as `state:ready` with
+all gates satisfied and BitNet-rs-specific Rust neural network validations
+passing.

--- a/.claude/agents4/integration/pr-merger.md
+++ b/.claude/agents4/integration/pr-merger.md
@@ -177,4 +177,11 @@ You are the **final safety gate** in BitNet-rs's Integrative pipeline. Your auth
 - **VALIDATE** comprehensive gate satisfaction before executing merge
 - **ROUTE** to appropriate specialists when validation fails or rebase required
 
-Never compromise on BitNet-rs neural network validation standards. Only proceed when pr-summary-agent has marked PR as `state:ready` AND all validation requirements are satisfied. The integrity of BitNet-rs's main branch depends on your rigorous enforcement of these standards.
+Never compromise on BitNet-rs neural network validation standards. For campaign
+work items governed by `codex_premerge` plus `automerge_when_green` plus
+`on_blocker_only`, proceed when required checks are green and GitHub reports the
+PR mergeable; do not wait for a separate maintainer approval or pr-summary
+handoff unless branch protection or the work item policy requires it. Outside
+that campaign policy, proceed when pr-summary-agent has marked PR as
+`state:ready` and all validation requirements are satisfied. The integrity of
+BitNet-rs's main branch depends on your rigorous enforcement of these standards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,11 @@ exposure is possible, kernel/math/tokenizer/loader semantics are in unresolved
 conflict, acceptance criteria conflict with repository policy, or a
 cost/exposure/release decision is outside the ticket scope.
 
+This policy supersedes older agent runbook wording that treats ordinary commit,
+push, PR creation, CI repair, merge, or tracker closeout as a human approval
+boundary for `codex_premerge` plus `automerge_when_green` plus
+`on_blocker_only` work items.
+
 ## Critical Gotchas
 
 1. **Empty default features** — `cargo build` alone fails. Always pass `--no-default-features --features cpu|gpu`.

--- a/docs/tracking/TRACKER_MODEL.md
+++ b/docs/tracking/TRACKER_MODEL.md
@@ -133,6 +133,11 @@ secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
 semantic conflict, acceptance criteria that conflict with repo policy, or a
 cost/exposure/release decision genuinely outside the ticket scope.
 
+This campaign work item policy is the authority for campaign branches. If an
+older agent runbook describes default human approvals, maintainer-ready handoff,
+or manual intervention for ordinary commit, push, PR, CI repair, merge, or
+closeout work, follow the campaign work item policy instead.
+
 Allowed `review_mode` values are:
 
 - `codex_premerge`


### PR DESCRIPTION
## Summary
- remove stale approval wording from active PR cleanup/finalize runbooks
- allow campaign-governed PR mergers to proceed when green and mergeable without maintainer-ready handoff
- make CLAUDE.md and TRACKER_MODEL.md explicit that campaign work item policy supersedes older runbook wording

## Validation
- `rg -n "All required GitHub approvals obtained|Check if additional approvals needed|only proceed when pr-summary-agent|manual intervention required|maintainer says" .claude/agents2/pr-finalize.md .claude/agents2/pr-cleanup.md .claude/agents3/integration/pr-merger.md .claude/agents4/integration/pr-merger.md CLAUDE.md docs/tracking/TRACKER_MODEL.md` (no matches)
- `git diff --check`
- `git diff --cached --check`
