### PR TITLE
SERVER-002: fail closed placeholder model readiness

### DIFF
--- a/crates/bitnet-server/src/caching/model_cache.rs
+++ b/crates/bitnet-server/src/caching/model_cache.rs
@@ -14,7 +14,7 @@ use super::CachingConfig;
 pub struct CachedModel {
     /// Model identifier
     pub id: String,
-    /// Model data (placeholder - in real implementation this would be the actual model)
+    /// Serialized or resident model bytes inserted by a real loader.
     pub data: Vec<u8>,
     /// Model size in bytes
     pub size_bytes: usize,
@@ -249,42 +249,13 @@ impl ModelCache {
         access_order.push(model_id.to_string());
     }
 
-    /// Load a model (placeholder implementation)
-    async fn load_model(&self, model_id: &str) -> Result<Option<CachedModel>> {
-        let start_time = Instant::now();
-
-        // Simulate model loading time
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Create a mock model
-        let model_data = vec![0u8; 1024 * 1024]; // 1MB mock model
-        let model = CachedModel {
-            id: model_id.to_string(),
-            data: model_data.clone(),
-            size_bytes: model_data.len(),
-            last_accessed: Instant::now(),
-            created_at: Instant::now(),
-            access_count: 0,
-            metadata: ModelMetadata {
-                name: format!("model-{}", model_id),
-                version: "1.0.0".to_string(),
-                quantization: "I2_S".to_string(),
-                size_mb: model_data.len() as f64 / (1024.0 * 1024.0),
-                parameters: 1_580_000_000, // 1.58B parameters
-                context_length: 2048,
-            },
-        };
-
-        // Update load time statistics
-        let load_time = start_time.elapsed();
-        {
-            let mut stats = self.statistics.write().await;
-            let total_load_time = stats.average_load_time_ms * stats.cache_misses as f64;
-            stats.average_load_time_ms =
-                (total_load_time + load_time.as_millis() as f64) / (stats.cache_misses + 1) as f64;
-        }
-
-        Ok(Some(model))
+    /// Load a model into the cache.
+    ///
+    /// The server cache is not a model loader. Until a real verified loader is
+    /// wired into this layer, misses must remain misses instead of fabricating
+    /// model bytes or answer-ready metadata.
+    async fn load_model(&self, _model_id: &str) -> Result<Option<CachedModel>> {
+        Ok(None)
     }
 
     /// Start cleanup task for expired models
@@ -373,5 +344,42 @@ impl ModelCache {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cache_miss_does_not_create_placeholder_model() {
+        let cache = ModelCache::new(&CachingConfig::default()).await.unwrap();
+
+        let model = cache.get_model("missing-model").await.unwrap();
+
+        assert!(model.is_none());
+        let stats = cache.get_statistics().await;
+        assert_eq!(stats.total_requests, 1);
+        assert_eq!(stats.cache_hits, 0);
+        assert_eq!(stats.cache_misses, 1);
+        assert_eq!(stats.total_models, 0);
+        assert_eq!(stats.total_size_mb, 0.0);
+        assert_eq!(stats.pre_warmed_models, 0);
+    }
+
+    #[tokio::test]
+    async fn pre_warm_does_not_create_placeholder_models() {
+        let cache = ModelCache::new(&CachingConfig::default()).await.unwrap();
+        let model_ids = vec!["model-a".to_string(), "model-b".to_string()];
+
+        cache.pre_warm(&model_ids).await.unwrap();
+
+        let stats = cache.get_statistics().await;
+        assert_eq!(stats.total_requests, 0);
+        assert_eq!(stats.cache_hits, 0);
+        assert_eq!(stats.cache_misses, 0);
+        assert_eq!(stats.total_models, 0);
+        assert_eq!(stats.total_size_mb, 0.0);
+        assert_eq!(stats.pre_warmed_models, 0);
     }
 }

--- a/crates/bitnet-server/src/hf_model_service.rs
+++ b/crates/bitnet-server/src/hf_model_service.rs
@@ -198,42 +198,26 @@ impl HfModelService {
         self.state = ModelLoadState::Error(reason);
     }
 
-    /// Simulate a model load (no real I/O) and return a response.
+    /// Attempt to load a model through this service.
     ///
-    /// In production this would delegate to `HuggingFaceLoader` from
-    /// `bitnet-models`; here we perform the state-machine transition and
-    /// build a `HfModelLoadResponse`.
+    /// This scaffold is not wired to a real HuggingFace or GGUF inference
+    /// engine, so it must fail closed instead of reporting placeholder model
+    /// readiness.
     pub fn load_model(&mut self, req: &HfModelLoadRequest) -> HfModelLoadResponse {
         let start = Instant::now();
         self.begin_loading();
 
-        let format =
-            req.model_format.clone().unwrap_or_else(|| ModelFormat::from_path(&req.model_path));
-        let arch = req.architecture.clone().unwrap_or_else(|| "unknown".to_string());
-
-        // Build placeholder model info
-        let info = ModelInfo {
-            architecture: arch,
-            num_parameters: 0,
-            hidden_size: 0,
-            num_layers: 0,
-            num_heads: 0,
-            vocab_size: 0,
-            max_context: 0,
-            dtype: match format {
-                ModelFormat::Safetensors => "float16".to_string(),
-                ModelFormat::Gguf => "i2_s".to_string(),
-                ModelFormat::Auto => "auto".to_string(),
-            },
-        };
-
-        self.finish_loading(info.clone());
+        let reason = format!(
+            "real HuggingFace server model loading is not wired for {}; use the verified ModelManager path instead",
+            req.model_path
+        );
+        self.fail_loading(reason.clone());
 
         HfModelLoadResponse {
-            success: true,
-            model_info: Some(info),
+            success: false,
+            model_info: None,
             load_time_ms: start.elapsed().as_millis() as u64,
-            error: None,
+            error: Some(reason),
         }
     }
 }
@@ -345,15 +329,18 @@ mod tests {
     }
 
     #[test]
-    fn service_load_model_ends_in_ready() {
+    fn service_load_model_fails_closed_without_placeholder_readiness() {
         let mut svc = HfModelService::new();
         let resp = svc.load_model(&HfModelLoadRequest {
             model_path: "model.safetensors".into(),
             model_format: None,
             architecture: Some("llama3".into()),
         });
-        assert!(resp.success);
-        assert_eq!(*svc.state(), ModelLoadState::Ready);
+        assert!(!resp.success);
+        assert!(resp.model_info.is_none());
+        assert!(resp.error.as_deref().unwrap().contains("real HuggingFace server model loading"));
+        assert!(matches!(*svc.state(), ModelLoadState::Error(_)));
+        assert!(svc.model_info().is_none());
     }
 
     // -- ModelInfo construction for architectures ---------------------------

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -49,3 +49,40 @@ must_not_claim = [
   "Any hardware acceleration works.",
   "Server performance is proven.",
 ]
+
+[[work_item]]
+id = "SERVER-002"
+status = "in_progress"
+branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["SERVER-001"]
+acceptance = "Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-server/**",
+  "docs/tracking/campaigns/server-real-inference/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "Placeholder server model lifecycle scaffolds fail closed instead of reporting answer-ready model state.",
+]
+must_not_claim = [
+  "Real HuggingFace server model loading is implemented.",
+  "Any server endpoint can answer through a new model family.",
+  "Any hardware acceleration works.",
+  "Server performance is proven.",
+]

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -52,7 +52,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "SERVER-002"
-status = "in_progress"
+status = "pr_open"
+pr = 4432
 branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T120000Z-SERVER-002-in-progress.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T120000Z-SERVER-002-in-progress.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-10T12:00:00Z"
+campaign = "server-real-inference"
+item = "SERVER-002"
+event = "in_progress"
+from = "proposed"
+to = "in_progress"
+actor = "codex"
+branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
+summary = "Started SERVER-002 placeholder model lifecycle fail-closed cleanup."
+notes = [
+  "Scope is server-only lifecycle scaffolds that previously reported placeholder HuggingFace or cache model readiness without real I/O.",
+  "The implementation must not introduce real model loading claims, answer claims, hardware claims, tokenizer changes, loader changes, transformer behavior changes, or kernel changes.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T122446Z-SERVER-002-pr-open.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T122446Z-SERVER-002-pr-open.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-10T12:24:46Z"
+campaign = "server-real-inference"
+item = "SERVER-002"
+event = "pr_open"
+from = "in_progress"
+to = "pr_open"
+actor = "codex"
+pr = 4432
+branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
+head_sha = "8931f489c2253228293cac1ef30cecfd225990f5"
+summary = "Opened SERVER-002 PR to fail closed placeholder server model lifecycle readiness."
+notes = [
+  "PR keeps HuggingFace service and model cache scaffolds from reporting placeholder ready state or fabricated cached models.",
+  "No real server model loading, answer, hardware acceleration, speedup, or performance claim is made.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
-| SERVER-002 | in_progress | TBD | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
+| SERVER-002 | pr_open | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -10,6 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
+| SERVER-002 | in_progress | TBD | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| server-real-inference | SERVER-002 | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -239,6 +239,7 @@
 | nvidia-5070ti | CUDA-DENSE-020 | CUDA-DENSE-019 | merged |
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
+| server-real-inference | SERVER-002 | SERVER-001 | in_progress |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -239,7 +239,7 @@
 | nvidia-5070ti | CUDA-DENSE-020 | CUDA-DENSE-019 | merged |
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
-| server-real-inference | SERVER-002 | SERVER-001 | in_progress |
+| server-real-inference | SERVER-002 | SERVER-001 | pr_open |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-001 | #4429 | merged | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-002 | TBD | in_progress | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-002 | TBD | in_progress | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-002 | #4432 | pr_open | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
-| server-real-inference | Server real inference | SERVER-001 | Do not reintroduce simulated inference. |
+| server-real-inference | Server real inference | SERVER-002 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-008 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- make `HfModelService::load_model` fail closed instead of reporting placeholder Ready state/model info
- make `ModelCache` misses remain misses instead of fabricating a 1MB mock I2_S model
- add regression tests and register SERVER-002 in the server-real-inference tracker

## Validation
- `cargo fmt -p bitnet-server -- --check`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Notes
- `cargo fmt --all -- --check` still fails locally on Windows with OS error 206, so package fmt was used for the touched crate.
- This does not implement real HuggingFace server loading, server answers for a new model family, hardware acceleration, speedup, or server performance claims.
