### PR TITLE
docs(tracking): close SERVER-002

### DIFF
--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -52,8 +52,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "SERVER-002"
-status = "pr_open"
+status = "merged"
 pr = 4432
+merge_sha = "b08910e38a5a3bcc5cadaae014c798044a3743b1"
 branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-10T124100Z-SERVER-002-merged.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-10T124100Z-SERVER-002-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-10T12:41:00Z"
+campaign = "server-real-inference"
+item = "SERVER-002"
+event = "merged"
+from = "pr_open"
+to = "merged"
+actor = "codex"
+pr = 4432
+merge_sha = "b08910e38a5a3bcc5cadaae014c798044a3743b1"
+branch = "codex/server-real-inference/SERVER-002-no-placeholder-model-readiness"
+summary = "SERVER-002 merged after placeholder HuggingFace/cache model readiness paths were changed to fail closed."
+notes = [
+  "Merged PR #4432 keeps HfModelService from reporting placeholder Ready state and keeps ModelCache misses/pre-warm from fabricating mock models.",
+  "The merged item preserves no real HuggingFace server loading, no new answer path, no hardware acceleration, and no performance claims.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -10,7 +10,7 @@
 | Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
-| SERVER-002 | pr_open | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
+| SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| server-real-inference | SERVER-002 | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -239,7 +239,7 @@
 | nvidia-5070ti | CUDA-DENSE-020 | CUDA-DENSE-019 | merged |
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
-| server-real-inference | SERVER-002 | SERVER-001 | pr_open |
+| server-real-inference | SERVER-002 | SERVER-001 | merged |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-002 | #4432 | pr_open | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-002 | #4432 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | TBD | ready | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- mark SERVER-002 merged with merge SHA from #4432
- add the append-only merged lifecycle event
- regenerate server-real-inference and global tracker dashboards

## Validation
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`
