### PR TITLE
docs(agent): align merge flow with campaign authority

### DIFF
--- a/.claude/agents3/pr-to-merge.md
+++ b/.claude/agents3/pr-to-merge.md
@@ -2,6 +2,24 @@
 
 You orchestrate the Integrative Flow: validate Ready PRs through gate-focused validation until they can be safely merged to main with objective receipts and MergeCode quality compliance.
 
+## Campaign Work Item Authority
+
+Campaign work item policy overrides the older Integrative handoff sequence for
+campaign PRs. For work items with `review_mode = "codex_premerge"`,
+`merge_policy = "automerge_when_green"`, and
+`human_gate = "on_blocker_only"`, commit, push, PR creation, CI/bot repair,
+merge, and tracker closeout are agent responsibilities, not human approval
+gates. If required checks are green and GitHub reports the PR mergeable, route
+directly to merge execution; do not require a separate maintainer-ready signal,
+`state:ready` label, or `pr-summary-agent` handoff unless branch protection or
+the work item policy explicitly requires it.
+
+Escalate only true blockers: permissions or branch protection preventing merge,
+destructive data loss or secret/model-binary exposure risk, unresolved
+kernel/math/tokenizer/loader semantic conflict, acceptance criteria conflicting
+with repository policy, or a cost/exposure/release decision outside the ticket
+scope.
+
 ## Starting Condition
 
 - Input: Open GitHub PR marked "Ready for review"

--- a/.claude/agents4/pr-to-merge.md
+++ b/.claude/agents4/pr-to-merge.md
@@ -4,6 +4,24 @@ ultrathink agentically
 
 You orchestrate the Integrative Flow: validate Ready PRs through gate-focused validation until they can be safely merged to main with objective receipts and BitNet-rs neural network quality compliance.
 
+## Campaign Work Item Authority
+
+Campaign work item policy overrides the older Integrative handoff sequence for
+campaign PRs. For work items with `review_mode = "codex_premerge"`,
+`merge_policy = "automerge_when_green"`, and
+`human_gate = "on_blocker_only"`, commit, push, PR creation, CI/bot repair,
+merge, and tracker closeout are agent responsibilities, not human approval
+gates. If required checks are green and GitHub reports the PR mergeable, route
+directly to merge execution; do not require a separate maintainer-ready signal,
+`state:ready` label, or `pr-summary-agent` handoff unless branch protection or
+the work item policy explicitly requires it.
+
+Escalate only true blockers: permissions or branch protection preventing merge,
+destructive data loss or secret/model-binary exposure risk, unresolved
+kernel/math/tokenizer/loader semantic conflict, acceptance criteria conflicting
+with repository policy, or a cost/exposure/release decision outside the ticket
+scope.
+
 ## Starting Condition
 
 - Input: Open GitHub PR marked "Ready for review"


### PR DESCRIPTION
## Summary
- add campaign work-item authority notes to the agents3/agents4 PR-to-merge orchestration docs
- make `codex_premerge` + `automerge_when_green` + `on_blocker_only` explicitly bypass stale `state:ready` / pr-summary / maintainer-ready handoff requirements when checks are green and GitHub is mergeable
- preserve true blocker gates for permissions, branch protection, destructive/secret/model-binary risk, semantic conflicts, policy conflicts, and out-of-scope cost/exposure/release decisions

## Validation
- `git diff --check`

## Notes
- The core finalize/merge executor policy was already landed on main in earlier agent-policy docs commits; this PR closes the remaining ambiguity in the top-level merge-flow orchestration docs.
