### PR TITLE
fix(ci): add required-features to remaining optional-dep test targets

### DIFF
--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -126,10 +126,12 @@ required-features = ["metal-runtime"]
 [[test]]
 name = "metal_performance_tests"
 path = "tests/metal_performance_tests.rs"
+required-features = ["metal-runtime"]
 
 [[test]]
 name = "opencl_fuzz_targets"
 path = "tests/opencl_fuzz_targets.rs"
+required-features = ["opencl"]
 
 [[test]]
 name = "cpu_scalar_parity"
@@ -159,18 +161,22 @@ required-features = ["cpu"]
 [[test]]
 name = "metal_error_recovery_tests"
 path = "tests/metal_error_recovery_tests.rs"
+required-features = ["metal-runtime"]
 
 [[test]]
 name = "metal_compute_pipeline_tests"
 path = "tests/metal_compute_pipeline_tests.rs"
+required-features = ["metal-runtime", "cpu"]
 
 [[test]]
 name = "metal_layernorm_shader_tests"
 path = "tests/metal_layernorm_shader_tests.rs"
+required-features = ["metal-runtime"]
 
 [[test]]
 name = "metal_reduction_shader_tests"
 path = "tests/metal_reduction_shader_tests.rs"
+required-features = ["metal-runtime"]
 
 [[test]]
 name = "bdd_wave_8"

--- a/crates/bitnet-kernels/src/cpu/neon_kv_cache_paged.rs
+++ b/crates/bitnet-kernels/src/cpu/neon_kv_cache_paged.rs
@@ -41,7 +41,7 @@ pub enum EvictionPolicy {
 /// Each token occupies `head_dim` f32 elements; both keys and values are
 /// stored contiguously inside the block.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Fields used by aarch64 methods gated with cfg.
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
 pub struct PagedCacheBlock {
     /// Key vectors: `[tokens_stored, head_dim]` flattened.
     pub keys: Vec<f32>,


### PR DESCRIPTION
## Summary

Follow-up to #4457. Five more `[[test]]` entries in `crates/bitnet-kernels/Cargo.toml` were missing `required-features`, mirroring the same bug that was just fixed for `metal_device_integration_tests`. Without the guard, CPU-only or no-features builds attempt to compile Metal/OpenCL integration tests that import optional `wgpu`/`opencl3` deps, causing unresolved-crate errors.

| Test target | Added `required-features` | Reason |
|---|---|---|
| `metal_performance_tests` | `["metal-runtime"]` | imports `wgpu::util::DeviceExt` |
| `opencl_fuzz_targets` | `["opencl"]` | uses `bitnet_kernels::opencl_*` modules |
| `metal_error_recovery_tests` | `["metal-runtime"]` | Metal-only test |
| `metal_compute_pipeline_tests` | `["metal-runtime", "cpu"]` | file-level `#![cfg(all(feature = "cpu", ...))]` |
| `metal_layernorm_shader_tests` | `["metal-runtime"]` | imports `wgpu::util::DeviceExt` |
| `metal_reduction_shader_tests` | `["metal-runtime"]` | macOS/wgpu-dependent |

Also replaces the blanket `#[allow(dead_code)]` on `PagedCacheBlock` in `neon_kv_cache_paged.rs` with `#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]`, scoping the suppression to platforms where the struct fields are genuinely unused rather than silencing it everywhere.

## Validation

- `cargo fmt --all -- --check` ✅
- `git diff --check` ✅
- `cargo check --locked -p bitnet-kernels --no-default-features --features cpu` (in progress)

## Boundaries

- No Metal runtime behavior changes
- No OpenCL kernel changes
- No inference logic changes

https://claude.ai/code/session_01PGQMDdTY2NxABaSvaMurCX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGQMDdTY2NxABaSvaMurCX)_