### PR TITLE
docs: update roadmap and record CI conventions for contributor guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,40 @@ fn gpu_only_function() { /* ... */ }
 - TDD scaffolds use `panic!("not yet implemented")` inside `#[ignore]` — this is intentional
 - ~58,700 test annotations; ~2,800 intentionally ignored (TDD scaffolds, resource-gated, slow, CUDA, crossval)
 
+### Optional-dependency test targets
+
+Any `[[test]]`, `[[bench]]`, or `[[example]]` that imports an optional crate (e.g. `wgpu`,
+`opencl3`, `pollster`, `cuda-*`) **must** declare `required-features` in `Cargo.toml`:
+
+```toml
+[[test]]
+name = "metal_device_integration_tests"
+path = "tests/metal_device_integration_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_compute_pipeline_tests"
+path = "tests/metal_compute_pipeline_tests.rs"
+required-features = ["metal-runtime", "cpu"]   # match the file-level #![cfg(...)]
+```
+
+Without this gate, CPU-only and no-features builds attempt to compile the test and fail with
+unresolved-crate errors. Check the file-level `#![cfg(...)]` to confirm which features are needed.
+
+### Platform-specific dead code
+
+Use `cfg_attr` rather than a blanket `#[allow(dead_code)]` when a struct or function is only used
+on a specific target:
+
+```rust
+// Only suppress the lint on non-aarch64 targets where NEON methods are absent
+#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
+pub struct PagedCacheBlock { ... }
+```
+
+Do not use `#[allow(dead_code)]` without a `cfg_attr` scope — prefer the cfg guard or remove the
+dead code instead.
+
 ### Feature gates
 
 ```rust

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,9 @@
 
 ## Where We Are
 
-bitnet-rs is a pre-alpha (v0.2.1-dev) Rust inference engine for 1-bit BitNet LLMs. CPU inference with SIMD optimization (AVX2/AVX-512/NEON) works end-to-end. GPU backends are scaffolded but not yet validated.
+bitnet-rs is a pre-alpha (v0.2.1-dev) Rust inference engine for 1-bit BitNet LLMs. CPU inference
+with SIMD optimization (AVX2/AVX-512/NEON) works end-to-end. GPU backends are scaffolded but not
+yet validated.
 
 **What works today:**
 
@@ -13,50 +15,70 @@ bitnet-rs is a pre-alpha (v0.2.1-dev) Rust inference engine for 1-bit BitNet LLM
 - Cross-validation framework against C++ reference (per-token logits comparison)
 - Honest-compute receipts (schema v1.0.0, 8 validation gates)
 - SafeTensors-to-GGUF export with F16 LayerNorm preservation
+- CI test-target gating: all optional-dep `[[test]]` entries guarded by `required-features`
+- Receipt verification workflow with malformed-receipt fallback handling
 
 **By the numbers:**
 
 - ~200 workspace crates, 2,500+ .rs files
-- ~58,700 #[test] annotations (~2,800 intentionally ignored with justification)
+- ~58,700 `#[test]` annotations (~2,800 intentionally ignored with justification)
 - 790 proptest macros, 1,442 snapshot files, 109 fuzz targets
 - 44 bench files, 45 CI workflows
 
 ## Current Limitations
 
-- **QK256 performance**: Scalar kernels only (~0.1 tok/s for 2B models). Not suitable for production.
-- **No validated GPU inference**: CUDA is furthest along but receipt validation is still pending. Metal, Vulkan, OpenCL, ROCm are scaffolded stubs.
-- **Model quality**: microsoft-bitnet-b1.58-2B-4T produces non-sensical output in some configurations (model limitation, not inference bug).
+- **QK256 performance**: Scalar kernels only (~0.1 tok/s for 2B models). Not suitable for
+  production.
+- **No validated GPU inference**: CUDA is furthest along but receipt validation is still pending.
+  Metal, Vulkan, OpenCL, ROCm are scaffolded stubs.
+- **Model quality**: microsoft-bitnet-b1.58-2B-4T produces non-sensical output in some
+  configurations (model limitation, not inference bug).
 - **Server incomplete**: Health endpoints work; inference endpoints have TODOs.
 - **Large scaffold surface**: ~2,800 ignored tests are TDD scaffolds, resource-gated, or slow.
+
+## Completed: CI Foundation (v0.2.1-dev)
+
+Merged in this dev cycle — no further action needed:
+
+- [x] Gate all optional-dep `[[test]]` entries behind `required-features` in
+      `crates/bitnet-kernels/Cargo.toml` (7 targets across Metal, OpenCL, CPU)
+- [x] Harden `verify-receipts.yml` fallback to detect and replace malformed generated receipts
+      missing `schema_version` — preserves raw output as `ci/inference.raw.json`
+- [x] Replace blanket `#[allow(dead_code)]` on `PagedCacheBlock` with
+      `#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]`
+- [x] SHA-pin all GitHub Actions; enforce `--locked` on all cargo invocations in CI
+- [x] All `#[ignore]` attributes carry a justification string (enforced by pre-commit hook)
 
 ## Near-term: v0.2.1
 
 Active workstreams, no date commitments:
 
-- [ ] QK256 AVX2 nibble-LUT + FMA tiling (target 3x over scalar)
+- [ ] QK256 AVX2 nibble-LUT + FMA tiling (target 3× over scalar)
 - [ ] Zero-alloc dense forward pass (BlockWorkspace + ping-pong buffers)
 - [ ] Apple Silicon NEON kernel parity (softmax, attention, matmul)
 - [ ] AVX2+FMA log-softmax and vectorized softmax exp
-- [ ] Reduce test scaffold count (unblock TDD placeholders)
-- [ ] Documentation cleanup (README, CLAUDE.md, ROADMAP accuracy)
+- [ ] Unblock TDD placeholder tests — work through `#[ignore = "TDD scaffold: ..."]` backlog
+- [ ] `xtask benchmark --json` emits `schema_version` natively (removes workflow fallback need)
+- [ ] Documentation cleanup: README accuracy, quickstart tested end-to-end
 
 ## Medium-term: v0.3.0
 
 - [ ] QK256 inference usable for validation (target 1+ tok/s on 2B)
-- [ ] CUDA receipt validation end-to-end
-- [ ] Server MVP with inference endpoints
+- [ ] CUDA receipt validation end-to-end (first validated GPU backend)
+- [ ] Server MVP: wire inference endpoints, fix remaining TODOs
 - [ ] KV cache optimization wired into generation loop
-- [ ] Reduce workspace crate count (consolidate SRP microcrates)
+- [ ] Reduce workspace crate count (consolidate SRP microcrates where boundaries are artificial)
+- [ ] `bitnet-wasm` compilation target validated (browser inference proof-of-concept)
 
 ## Future Directions
 
 These are aspirational and may change:
 
-- Multi-GPU inference and tensor parallelism
-- Metal and Vulkan backend validation
+- Metal and Vulkan backend validation (after CUDA is green)
 - Paged KV cache with eviction policies
-- WebAssembly target for browser inference
+- Multi-GPU inference and tensor parallelism
 - Python bindings via PyO3
+- WebAssembly target for browser inference (beyond proof-of-concept)
 
 ## Non-goals
 


### PR DESCRIPTION
## Summary

Docs-only PR — no code changes.

### ROADMAP.md

- **New section: "Completed: CI Foundation"** — records the work landed in #4457 and #4459: 7 test targets gated behind `required-features`, receipt-verification fallback hardening, `cfg_attr` dead-code cleanup, SHA-pinned actions, `--locked` enforcement, and `#[ignore]` justification policy.
- **Near-term v0.2.1 sharpened**: adds `xtask benchmark --json` emitting `schema_version` natively (which removes the workflow fallback once done), and clarifies the TDD unblock workstream.
- **Medium-term v0.3.0 sharpened**: adds wasm proof-of-concept milestone; clarifies crate consolidation framing.
- **Future Directions**: reordered so Metal/Vulkan follows CUDA (logical dependency order).

### CLAUDE.md — two new subsections under Patterns and Conventions

**Optional-dependency test targets** — explains that any `[[test]]`/`[[bench]]`/`[[example]]` importing an optional crate (`wgpu`, `opencl3`, `pollster`, CUDA crates) must declare `required-features` in `Cargo.toml`. Shows the canonical TOML pattern and explains the failure mode (unresolved-crate errors on CPU/no-features builds).

**Platform-specific dead code** — establishes `cfg_attr` as the correct pattern instead of blanket `#[allow(dead_code)]`. Uses `PagedCacheBlock` as the canonical example.

These two subsections encode the patterns enforced in #4457/#4459 so contributors apply them consistently going forward.

## Validation

- `cargo fmt --all -- --check` ✅
- `git diff --check` ✅
- Docs-only; no Rust compilation affected

https://claude.ai/code/session_01PGQMDdTY2NxABaSvaMurCX

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGQMDdTY2NxABaSvaMurCX)_