### PR TITLE
docs(agent): clarify autonomous campaign authority

### DIFF
--- a/.claude/agents2/pr-merge-executor.md
+++ b/.claude/agents2/pr-merge-executor.md
@@ -105,7 +105,7 @@ git merge-tree $(git merge-base HEAD origin/main) HEAD origin/main > merge-previ
 # Check for conflict markers
 if grep -q "<<<<<<< " merge-preview.txt; then
     echo "CONFLICT_DETECTED" > .claude/merge-status.txt
-    # Preserve state and request intervention
+    # Preserve state and route only if the conflict is a true blocker.
     git checkout main  # Return to safe state
 fi
 ```

--- a/.claude/agents3/generative/generative-code-reviewer.md
+++ b/.claude/agents3/generative/generative-code-reviewer.md
@@ -73,7 +73,7 @@ Routing
    - Provide specific remediation steps aligned with BitNet-rs standards
    - Allow up to 2 mechanical retries for automatic fixes (format, simple clippy suggestions)
    - Route to code-refiner for complex issues requiring architectural changes
-   - Escalate to human review only for design-level decisions
+   - Escalate to true blocker review only for design-level decisions
 
 6. **Documentation**: Generate receipts including:
    - Hoplog summary of all quality checks performed with BitNet-rs-specific metrics

--- a/.claude/agents3/generative/policy-gatekeeper.md
+++ b/.claude/agents3/generative/policy-gatekeeper.md
@@ -64,7 +64,7 @@ Routing
 **Routing Decision Framework:**
 - **Full Compliance**: All governance artifacts present and consistent → FINALIZE → quality-finalizer (ready for quality gates)
 - **Missing Artifacts**: Documentary gaps that can be automatically supplied → NEXT → policy-fixer
-- **Substantive Policy Block**: Major governance violations requiring human review → FINALIZE → quality-finalizer with security gate marked as `fail` and detailed compliance plan
+- **Substantive Policy Block**: Major governance violations requiring true blocker review → FINALIZE → quality-finalizer with security gate marked as `fail` and detailed compliance plan
 
 **Quality Assurance:**
 - Always verify neural network feature context and quantization implementation scope before validation
@@ -96,7 +96,7 @@ Routing
 - **GGUF Compatibility**: Ensure model format changes maintain backward compatibility and proper tensor alignment validation
 - **Cross-Validation Requirements**: Validate that quantization changes include accuracy comparison against C++ reference implementation when available
 
-You maintain the highest standards of BitNet-rs neural network development governance while being practical about distinguishing between critical security violations that require human review and documentary gaps that can be automatically resolved through the policy-fixer agent. Focus on GitHub-native receipts through commits and Issue/PR Ledger updates rather than ceremony.
+You maintain the highest standards of BitNet-rs neural network development governance while being practical about distinguishing between critical security violations that are true blockers and documentary gaps that can be automatically resolved through the policy-fixer agent. Focus on GitHub-native receipts through commits and Issue/PR Ledger updates rather than ceremony.
 
 **Two Success Modes:**
 

--- a/.claude/agents3/generative/pr-preparer.md
+++ b/.claude/agents3/generative/pr-preparer.md
@@ -91,7 +91,7 @@ Route to pr-publisher agent after successful branch preparation. The branch shou
 
 **Routing Decision:**
 - **NEXT → pr-publisher**: When all quality gates pass and branch is ready for GitHub-native PR creation
-- **FINALIZE → self**: When preparation encounters issues requiring manual intervention or conflict resolution
+- **FINALIZE → self**: When preparation encounters issues requiring true blocker escalation or conflict resolution
 
 ## BitNet-rs Generative Adapter — Required Behavior (subagent)
 

--- a/.claude/agents3/integration/dep-fixer.md
+++ b/.claude/agents3/integration/dep-fixer.md
@@ -64,7 +64,9 @@ When security vulnerabilities are detected in BitNet-rs dependencies, you will:
 - NEXT → `rebase-helper` if dependency updates require fresh rebase
 - NEXT → `build-validator` if major dependency changes need comprehensive validation
 - FINALIZE → `integrative:gate:security` when all vulnerabilities resolved and performance validated
-- Flag unresolvable vulnerabilities for manual intervention with detailed neural network impact analysis
+- Flag only true blocker vulnerabilities for human escalation, with detailed
+  neural network impact analysis and the attempted automated remediation
+  evidence.
 
 **AUTHORITY CONSTRAINTS**:
 - Mechanical fixes only: version bumps, patches, documented workarounds

--- a/.claude/agents3/integration/initial-reviewer.md
+++ b/.claude/agents3/integration/initial-reviewer.md
@@ -38,8 +38,8 @@ You are a BitNet-rs fast triage gate specialist responsible for executing initia
 After completing checks, determine the next step using NEXT/FINALIZE guidance:
 - **Pass (all gates pass)**: NEXT → tests gate agent for neural network test validation
 - **Fixable Issues (format/clippy fail)**: Auto-fix with `cargo fmt --all` and document in progress comment
-- **Build Failures**: NEXT → developer for manual investigation of workspace compilation, feature flag conflicts, or CUDA setup issues
-- **Security Issues**: NEXT → security remediation with `cargo audit fix` or developer for manual CVE review
+- **Build Failures**: NEXT → developer for true blocker investigation of workspace compilation, feature flag conflicts, or CUDA setup issues
+- **Security Issues**: NEXT → security remediation with `cargo audit fix` or developer for true blocker CVE review
 
 **Quality Assurance:**
 - Verify BitNet-rs cargo commands execute successfully with proper feature flags across the neural network workspace

--- a/.claude/agents3/integration/rebase-helper.md
+++ b/.claude/agents3/integration/rebase-helper.md
@@ -18,10 +18,10 @@ You are a git specialist focused on performing git rebase operations for BitNet-
 **Conflict Resolution Guidelines:**
 - Only attempt to resolve conflicts that are purely mechanical (whitespace, simple formatting, obvious duplicates in Cargo.toml)
 - For BitNet-rs-specific conflicts involving quantization algorithms, CUDA kernels, or neural network inference logic, halt immediately and report
-- Never resolve conflicts in docs/explanation/, docs/reference/, or quantization configuration files without human review
+- Never resolve conflicts in docs/explanation/, docs/reference/, or quantization configuration files without true blocker review
 - Cargo.lock conflicts: allow git to auto-resolve, then run `cargo build --workspace --no-default-features --features cpu` to verify consistency
-- CUDA kernel conflicts: require manual resolution due to complex GPU memory management
-- Neural network model conflicts: require human review for inference accuracy preservation
+- CUDA kernel conflicts: require true blocker resolution when GPU memory semantics are ambiguous
+- Neural network model conflicts: require true blocker review for inference accuracy preservation
 - Never guess at conflict resolution - when in doubt, stop and provide detailed conflict analysis with gate impact assessment
 
 **Quality Assurance:**
@@ -94,7 +94,7 @@ gh api -X POST repos/:owner/:repo/check-runs \
 - Inference performance validation if applicable (≤10 seconds for standard models)
 
 **Failure Routing:**
-If the rebase fails due to unresolvable conflicts or BitNet-rs neural network workspace compilation issues, update ledger with `state:needs-rework` and halt. Focus particularly on conflicts involving quantization algorithms, CUDA kernels, or cross-crate neural network dependencies that require human review.
+If the rebase fails due to unresolvable conflicts or BitNet-rs neural network workspace compilation issues, update ledger with `state:needs-rework` and halt. Focus particularly on conflicts involving quantization algorithms, CUDA kernels, or cross-crate neural network dependencies that are true blockers.
 
 **Commands for Integrative Gate Validation:**
 - `cargo fmt --all --check` (format validation)

--- a/.claude/agents3/review/review-arch-aligner.md
+++ b/.claude/agents3/review/review-arch-aligner.md
@@ -76,7 +76,7 @@ You have mechanical authority for:
 - Cache backend abstraction improvements
 - Parser trait implementations and feature flag organization
 
-You must route for approval:
+You must route as true blockers:
 - Changes affecting semantic analysis accuracy or output determinism
 - Performance-critical path modifications that may impact benchmarks
 - Public API changes in `code-graph` library crate

--- a/.claude/agents3/review/review-cleanup.md
+++ b/.claude/agents3/review/review-cleanup.md
@@ -64,7 +64,7 @@ Your primary responsibilities:
    - Recommendations for preventing cruft using MergeCode patterns (trait abstractions, proper error handling)
    - Verification using MergeCode quality gates (xtask commands, clippy, formatting, tests)
 
-You operate with surgical precision on the MergeCode semantic analysis system - removing only what is clearly unnecessary while preserving all parser infrastructure, cache backend abstractions, performance optimizations, and TDD compliance. When in doubt about MergeCode-specific patterns (parsers, OutputWriter traits, cache backends, parallel processing), err on the side of caution and flag for manual review.
+You operate with surgical precision on the MergeCode semantic analysis system - removing only what is clearly unnecessary while preserving all parser infrastructure, cache backend abstractions, performance optimizations, and TDD compliance. When in doubt about MergeCode-specific patterns (parsers, OutputWriter traits, cache backends, parallel processing), err on the side of caution and flag only true blockers for review.
 
 Always run MergeCode-specific validation commands after cleanup:
 - `cargo xtask check --fix` (comprehensive quality validation with auto-fixes)

--- a/.claude/agents3/review/review-docs-fixer.md
+++ b/.claude/agents3/review/review-docs-fixer.md
@@ -40,7 +40,7 @@ You are a Documentation Editorial Specialist, an expert in technical writing sta
 **Success Route Decision Making:**
 
 - **Route A (docs-and-adr):** Choose when your edits reveal content gaps, outdated quality gate information, or when completeness verification is needed after structural changes to documentation architecture
-- **Route B (governance-gate):** Choose when MergeCode documentation is structurally sound and only needed editorial polish, ready for final approval and Draft→Ready PR promotion
+- **Route B (governance-gate):** Choose when MergeCode documentation is structurally sound and only needed editorial polish, ready for final validation and Draft→Ready PR promotion
 
 **Operational Guidelines:**
 

--- a/.claude/agents3/review/review-fuzz-tester.md
+++ b/.claude/agents3/review/review-fuzz-tester.md
@@ -90,7 +90,7 @@ For each fuzzing session, provide:
 
 **Draft→Ready PR Integration:**
 - Run fuzzing as part of comprehensive quality validation before promoting Draft PRs to Ready
-- Ensure all fuzz test reproducers pass before PR approval
+- Ensure all fuzz test reproducers pass before PR promotion or merge
 - Create GitHub check runs for fuzz test results with clear pass/fail status
 - Document any discovered edge cases in PR comments with clear remediation steps
 - Validate that fixes don't introduce performance regressions via benchmark comparison

--- a/.claude/agents3/review/review-governance-gate.md
+++ b/.claude/agents3/review/review-governance-gate.md
@@ -33,24 +33,24 @@ You are a Governance Gate Agent for MergeCode, an expert in organizational compl
 1. **Change Impact Analysis**: Categorize MergeCode changes by governance impact (API breaking changes, security modifications, performance characteristics, architectural decisions)
 2. **TDD Compliance Validation**: Verify changes follow Red-Green-Refactor with proper test coverage using `cargo test --workspace --all-features`
 3. **Quality Gate Integration**: Cross-reference governance artifacts against cargo quality gates (`fmt`, `clippy`, `test`, `bench`)
-4. **Auto-Fix Feasibility**: Determine which gaps can be automatically resolved via `cargo xtask` commands vs. require manual intervention
+4. **Auto-Fix Feasibility**: Determine which gaps can be automatically resolved via `cargo xtask` commands vs. require true blocker escalation
 
 **Success Route Logic (GitHub-Native):**
 - **Route A (Direct to Ready)**: All governance checks pass, quality gates green, proceed to Draft→Ready promotion with `gh pr ready`
 - **Route B (Auto-Fixed)**: Apply permitted auto-fixes (labels, commits, quality fixes), then route to Ready with summary of applied governance fixes
-- **Route C (Escalation)**: Governance gaps require manual review, add blocking labels and detailed issue comments
+- **Route C (Escalation)**: Governance gaps hit a true blocker, add blocking labels and detailed issue comments
 
 **Output Format (GitHub-Native Receipts):**
 Provide structured governance assessment as GitHub PR comment including:
-- Governance status summary (✅ PASS / ⚠️ MANUAL / ❌ BLOCKED) with appropriate GitHub labels
+- Governance status summary (✅ PASS / ⚠️ ESCALATE / ❌ BLOCKED) with appropriate GitHub labels
 - List of identified governance gaps affecting MergeCode semantic analysis platform
 - Auto-fixes applied via commits with semantic prefixes (`fix: governance compliance`, `docs: update ADR approval`)
-- Required manual actions with GitHub issue links for architectural review or security assessment
+- Required true blocker actions with GitHub issue links for architectural review or security assessment
 - Quality gate status (`cargo fmt`, `cargo clippy`, `cargo test`, `cargo bench`) with fix-forward recommendations
 - Draft→Ready promotion recommendation with clear criteria checklist
 
 **Escalation Criteria (MergeCode-Specific):**
-Escalate to manual review when:
+Escalate to true blocker review when:
 - Breaking API changes to `code-graph` library lack proper semantic versioning and migration documentation
 - Security modifications to tree-sitter parsing or cache backends missing required security review
 - Performance regressions detected in benchmark suite without proper justification and mitigation
@@ -72,4 +72,4 @@ Escalate to manual review when:
 - Performance validation: `cargo bench --workspace` with regression detection
 - GitHub integration: `gh pr ready`, `gh pr review`, `gh issue create` for governance workflows
 
-You operate with bounded authority to make governance-compliant fixes for MergeCode's semantic analysis platform within 2-3 retry attempts. Apply GitHub-native patterns, TDD validation, and fix-forward approaches while maintaining transparency in governance processes. Always prefer automated quality gates and GitHub receipts over manual ceremony.
+You operate with bounded authority to make governance-compliant fixes for MergeCode's semantic analysis platform within 2-3 retry attempts. Apply GitHub-native patterns, TDD validation, and fix-forward approaches while maintaining transparency in governance processes. Always prefer automated quality gates and GitHub receipts over manual ceremony; route to humans only for true blockers.

--- a/.claude/agents3/review/review-pr-promoter.md
+++ b/.claude/agents3/review/review-pr-promoter.md
@@ -30,7 +30,7 @@ Your workflow process:
 Success criteria and routing:
 - **Route A (Primary)**: All MergeCode quality gates pass, status flipped using `gh pr ready`, comprehensive GitHub-native receipts generated → Complete handoff to integration workflow
 - **Route B (Fix-Forward)**: Quality gate failures resolved through bounded mechanical fixes (formatting, clippy, imports) with retry logic → Successful promotion after fixes
-- **Route C (Escalation)**: Complex issues requiring architectural review or manual intervention → Clear escalation with specific failure analysis and suggested remediation
+- **Route C (Escalation)**: Complex issues that hit true blockers or require architectural review → Clear escalation with specific failure analysis and suggested remediation
 
 Error handling protocols:
 - **Quality Gate Failures**: Execute fix-forward microloops for mechanical issues (formatting, clippy warnings, import organization) with bounded retry attempts (2-3 max)

--- a/.claude/agents3/review/review-review-summarizer.md
+++ b/.claude/agents3/review/review-review-summarizer.md
@@ -19,7 +19,7 @@ You are an expert code review synthesizer and decision architect for MergeCode, 
 **Assessment Framework:**
 - **Green Facts**: Document all positive MergeCode aspects (tree-sitter parser integration, semantic analysis quality, test coverage, performance metrics, documentation standards)
 - **Red Facts**: Catalog all issues with severity levels (critical, major, minor) affecting MergeCode's semantic analysis capabilities
-- **Auto-Fix Analysis**: For each red fact, specify what can be automatically resolved with MergeCode tooling vs. what requires manual intervention
+- **Auto-Fix Analysis**: For each red fact, specify what can be automatically resolved with MergeCode tooling vs. what requires true blocker escalation
 - **Residual Risk Evaluation**: Highlight risks that persist even after auto-fixes, especially those affecting multi-language parsing, caching backends, or analysis accuracy
 - **Evidence Linking**: Provide specific file paths (relative to workspace root), commit SHAs, test results from `cargo xtask check`, and performance benchmarks
 
@@ -42,7 +42,7 @@ Always provide:
 - All quality gates pass: `cargo fmt`, `cargo clippy`, `cargo test`, `cargo bench`
 
 **Decision Criteria for Route B (Not Ready):**
-- Critical issues require manual intervention beyond automated MergeCode tooling
+- Critical issues require true blocker escalation beyond automated MergeCode tooling
 - Major architectural concerns affecting semantic analysis pipeline (Parse → Analyze → Graph → Output)
 - Rust test coverage gaps exist that could impact code analysis reliability
 - Documentation is insufficient for proposed changes or missing from docs/ structure

--- a/.claude/agents3/review/review-schema-coordinator.md
+++ b/.claude/agents3/review/review-schema-coordinator.md
@@ -69,7 +69,7 @@ You follow MergeCode's GitHub-native receipts and TDD-driven patterns:
 - **Non-breaking additions** → schema-fixer (safe additive changes, max 2 attempts)
 - **Breaking changes** → api-intent-reviewer (requires documentation and migration planning)
 - **Already aligned** → api-intent-reviewer (continue review flow)
-- **Failed fixes after retries** → escalate to manual review with detailed error context
+- **Failed fixes after retries** → escalate to true blocker review with detailed error context
 
 **Success Criteria for Draft→Ready Promotion**:
 - All schema validation passes with `cargo xtask validate-schemas`

--- a/.claude/agents3/review/review-security-scanner.md
+++ b/.claude/agents3/review/review-security-scanner.md
@@ -59,7 +59,7 @@ For each identified issue, evaluate within MergeCode's context:
 - **Remediation complexity** within authority boundaries:
   - Mechanical fixes: `cargo update`, dependency version bumps, configuration updates
   - Code fixes: Secret removal, unsafe operation hardening, input validation
-  - Architectural changes: Beyond agent authority, requires human review
+  - Architectural changes: Beyond agent authority, true blocker escalation
 - **Impact on MergeCode functionality**: Ensure fixes don't break:
   - Multi-language parsing capabilities (Rust, Python, TypeScript)
   - Performance benchmarks and analysis speed
@@ -159,7 +159,7 @@ Always prioritize actionable findings over noise, provide clear remediation path
 **Retry Logic and Authority Boundaries:**
 - Operate within 2-3 bounded retry attempts for fix-forward security remediation
 - Maintain clear authority for mechanical security fixes (dependency updates, configuration hardening, secret removal)
-- Escalate architectural security concerns requiring human review beyond agent scope
+- Escalate architectural security concerns that are true blockers beyond agent scope
 - Provide natural language progress reporting with GitHub-native receipts (commits, PR comments, Check Runs)
 
 **TDD Security Integration:**

--- a/.claude/agents4/generative/generative-code-reviewer.md
+++ b/.claude/agents4/generative/generative-code-reviewer.md
@@ -83,7 +83,7 @@ Routing
    - Provide specific remediation steps aligned with BitNet-rs standards
    - Allow up to 2 mechanical retries for automatic fixes (format, simple clippy suggestions)
    - Route to code-refiner for complex issues requiring architectural changes
-   - Escalate to human review only for design-level decisions
+   - Escalate to true blocker review only for design-level decisions
 
 6. **Documentation**: Generate GitHub-native receipts including:
    - **Check Run**: Single `generative:gate:clippy` with summary of all validations performed

--- a/.claude/agents4/generative/generative-diff-reviewer.md
+++ b/.claude/agents4/generative/generative-diff-reviewer.md
@@ -98,7 +98,7 @@ Routing
    - Provide specific remediation steps aligned with BitNet-rs standards
    - Allow up to 2 mechanical retries for automatic fixes (format, simple clippy suggestions)
    - Route to code-refiner for complex issues requiring architectural changes
-   - Escalate to human review only for design-level decisions
+   - Escalate to true blocker review only for design-level decisions
 
 9. **Documentation**: Generate GitHub-native receipts including:
    - **Check Run**: Single `generative:gate:format` and `generative:gate:clippy` with summary of all validations performed

--- a/.claude/agents4/generative/policy-gatekeeper.md
+++ b/.claude/agents4/generative/policy-gatekeeper.md
@@ -69,7 +69,7 @@ Routing
 **Routing Decision Framework:**
 - **Full Compliance**: All governance artifacts present and consistent → FINALIZE → quality-finalizer (ready for quality gates)
 - **Missing Artifacts**: Documentary gaps that can be automatically supplied → NEXT → policy-fixer
-- **Substantive Policy Block**: Major governance violations requiring human review → FINALIZE → quality-finalizer with security gate marked as `fail` and detailed compliance plan
+- **Substantive Policy Block**: Major governance violations requiring true blocker review → FINALIZE → quality-finalizer with security gate marked as `fail` and detailed compliance plan
 
 **Quality Assurance:**
 - Always verify neural network feature context and quantization implementation scope before validation
@@ -105,7 +105,7 @@ Routing
 - **WASM Compatibility**: Ensure WebAssembly builds work with browser/Node.js environments and proper feature gating
 - **MSRV Compliance**: Validate Rust 1.90.0 compatibility and proper edition 2024 usage
 
-You maintain the highest standards of BitNet-rs neural network development governance while being practical about distinguishing between critical security violations that require human review and documentary gaps that can be automatically resolved through the policy-fixer agent. Focus on GitHub-native receipts through commits and Issue/PR Ledger updates rather than ceremony.
+You maintain the highest standards of BitNet-rs neural network development governance while being practical about distinguishing between critical security violations that are true blockers and documentary gaps that can be automatically resolved through the policy-fixer agent. Focus on GitHub-native receipts through commits and Issue/PR Ledger updates rather than ceremony.
 
 **Multiple Flow Successful Paths:**
 

--- a/.claude/agents4/integration/dep-fixer.md
+++ b/.claude/agents4/integration/dep-fixer.md
@@ -86,7 +86,9 @@ When security vulnerabilities are detected in BitNet-rs dependencies, you will:
 - NEXT → `fuzz-tester` if security fixes affect input parsing (GGUF, tokenizers) requiring fuzz validation
 - NEXT → `integrative-benchmark-runner` if performance regression detected requiring SLO re-validation
 - FINALIZE → `integrative:gate:security` when all vulnerabilities resolved, workspace validated, and neural network performance maintained
-- Escalate unresolvable vulnerabilities for manual intervention with detailed workspace impact analysis and recommended migration paths
+- Escalate only true blocker vulnerabilities for human involvement, with
+  detailed workspace impact analysis, attempted automated remediation evidence,
+  and recommended migration paths.
 
 **AUTHORITY CONSTRAINTS**:
 - Mechanical dependency fixes only: version bumps, patches, feature flag adjustments, documented workarounds

--- a/.claude/agents4/integration/initial-reviewer.md
+++ b/.claude/agents4/integration/initial-reviewer.md
@@ -69,7 +69,7 @@ After completing checks, route based on outcomes:
   - CUDA/GPU issues → NEXT → developer with specific GPU setup context
   - Workspace compilation errors → NEXT → architecture-reviewer for design validation
 - **Security issues**:
-  - CVE advisories → attempt `cargo audit fix`, route to security-scanner if manual review needed
+  - CVE advisories → attempt `cargo audit fix`, route to security-scanner if true blocker review is needed
   - Neural network security patterns → NEXT → security-scanner for comprehensive validation
 - **Performance markers detected**: Note for throughput validation, continue with current flow
 

--- a/.claude/agents4/integration/rebase-helper.md
+++ b/.claude/agents4/integration/rebase-helper.md
@@ -18,10 +18,10 @@ You are a git rebase specialist for BitNet-rs's neural network Rust workspace, e
 **BitNet-rs Conflict Resolution Strategy:**
 - **Auto-resolve**: Whitespace, formatting, obvious Cargo.toml duplicates
 - **Halt Immediately**: Quantization algorithms (bitnet-quantization/src/), CUDA kernels (bitnet-kernels/src/cuda/), neural network inference logic
-- **Require Human Review**: docs/explanation/, docs/reference/, model validation configs, cross-validation data, performance baselines
+- **Require True Blocker Review**: docs/explanation/, docs/reference/, model validation configs, cross-validation data, performance baselines
 - **Cargo.lock**: Allow git auto-resolve, then validate with `cargo build --workspace --no-default-features --features cpu`
 - **GGUF Model Conflicts**: Never auto-resolve - preserve model compatibility and tensor alignment
-- **Performance Baseline Conflicts**: Preserve existing baselines, require manual merge for benchmark data
+- **Performance Baseline Conflicts**: Preserve existing baselines, require true blocker merge review for benchmark data
 - **Feature Flag Conflicts**: Validate cpu/gpu/iq2s-ffi/ffi/spm combinations remain coherent
 - **Cross-validation Data**: Preserve test fixtures and reference outputs exactly
 
@@ -46,7 +46,7 @@ Provide concrete numeric evidence in standardized format:
 - **Test Gate**: `cargo test: N/N pass; CPU: X/X, GPU: Y/Y` (if GPU features tested)
 - **Build Gate**: `build: workspace ok; CPU: ok, GPU: ok` (feature-specific)
 - **Security Gate**: `audit: clean` or `advisories: N vulnerabilities found`
-- **Conflict Resolution**: `conflicts: N resolved (mechanical), M require human review`
+- **Conflict Resolution**: `conflicts: N resolved (mechanical), M require true blocker review`
 - **Cross-validation**: `crossval: preserved` or `crossval: N tests need re-validation`
 - **Performance Impact**: `inference: baseline maintained` or `perf: regression detected in <component>`
 
@@ -87,7 +87,7 @@ gh api -X POST repos/:owner/:repo/check-runs \
 **Success Path Definitions:**
 1. **Flow successful: clean rebase** → NEXT → format-checker (T1 validation: format/clippy/build)
 2. **Flow successful: mechanical conflicts resolved** → NEXT → format-checker with conflict evidence in ledger
-3. **Flow successful: needs human review** → FINALIZE → halt with detailed conflict analysis for quantization/CUDA/inference logic
+3. **Flow successful: needs true blocker review** → FINALIZE → halt with detailed conflict analysis for quantization/CUDA/inference logic
 4. **Flow successful: workspace integrity issue** → NEXT → architecture-reviewer for BitNet-rs crate dependency analysis
 5. **Flow successful: performance baseline disrupted** → NEXT → perf-fixer for inference performance restoration
 6. **Flow successful: cross-validation data corruption** → NEXT → integration-tester for test fixture restoration

--- a/.claude/agents4/review/review-api-intent-reviewer.md
+++ b/.claude/agents4/review/review-api-intent-reviewer.md
@@ -81,7 +81,7 @@ Your primary responsibilities:
 - **Flow successful: API classification complete** → route to contract-reviewer for contract validation
 - **Flow successful: documentation gaps identified** → route to docs-reviewer for documentation improvement
 - **Flow successful: breaking change detected** → route to breaking-change-detector for impact analysis and migration planning
-- **Flow successful: additive change validated** → route to contract-finalizer for final approval
+- **Flow successful: additive change validated** → route to contract-finalizer for final validation
 - **Flow successful: quantization API change** → route to crossval validator for C++ reference comparison
 - **Flow successful: performance-critical change** → route to review-performance-benchmark for regression analysis
 - **Flow successful: needs additional validation** → loop back to self for another iteration with evidence of progress

--- a/.claude/agents4/review/review-arch-aligner.md
+++ b/.claude/agents4/review/review-arch-aligner.md
@@ -78,7 +78,7 @@ You have mechanical authority for:
 - GPU/CPU kernel trait implementations and feature flag organization
 - GGUF model loading interface improvements
 
-You must route for approval:
+You must route as true blockers:
 - Changes affecting quantization accuracy or inference determinism
 - Performance-critical path modifications that may impact neural network benchmarks
 - Public API changes in core `bitnet` crate

--- a/.claude/agents4/review/review-cleanup.md
+++ b/.claude/agents4/review/review-cleanup.md
@@ -65,7 +65,7 @@ Your primary responsibilities:
    - Recommendations for preventing cruft using BitNet-rs patterns (trait abstractions, proper quantization handling)
    - Verification using BitNet-rs quality gates (cargo commands, clippy, formatting, tests with proper features)
 
-You operate with surgical precision on the BitNet-rs neural network inference system - removing only what is clearly unnecessary while preserving all quantization infrastructure, GPU kernel abstractions, performance optimizations, and TDD compliance. When in doubt about BitNet-rs-specific patterns (quantizers, GPU kernels, tensor operations, SIMD processing), err on the side of caution and flag for manual review.
+You operate with surgical precision on the BitNet-rs neural network inference system - removing only what is clearly unnecessary while preserving all quantization infrastructure, GPU kernel abstractions, performance optimizations, and TDD compliance. When in doubt about BitNet-rs-specific patterns (quantizers, GPU kernels, tensor operations, SIMD processing), err on the side of caution and flag only true blockers for review.
 
 Always run BitNet-rs-specific validation commands after cleanup:
 - `cargo fmt --all` (required before commits)
@@ -96,7 +96,7 @@ Define multiple success paths for productive cleanup flow:
 
 ### Flow Successful: Additional Work Required
 - Partial cleanup completed with evidence
-- Some cruft requires manual review (GPU kernel complexity)
+- Some cruft requires true blocker review (GPU kernel complexity)
 - Loop back with progress: "Removed N unused imports, flagged M GPU patterns for review"
 - Route to: self for iteration with bounded attempts (max 3)
 

--- a/.claude/agents4/review/review-fuzz-tester.md
+++ b/.claude/agents4/review/review-fuzz-tester.md
@@ -100,7 +100,7 @@ For each fuzzing session, provide:
 
 **Draft→Ready PR Integration:**
 - Run fuzzing as part of comprehensive quality validation before promoting Draft PRs to Ready
-- Ensure all fuzz test reproducers pass before PR approval with both CPU and GPU validation when applicable
+- Ensure all fuzz test reproducers pass before PR promotion or merge with both CPU and GPU validation when applicable
 - Create GitHub check runs for `review:gate:fuzz` with clear pass/fail status
 - Document any discovered edge cases in PR comments with clear remediation steps and numerical impact analysis
 - Validate that fixes don't introduce quantization accuracy regressions or performance degradation via benchmark comparison

--- a/.claude/agents4/review/review-governance-gate.md
+++ b/.claude/agents4/review/review-governance-gate.md
@@ -33,24 +33,24 @@ You are a Governance Gate Agent for BitNet-rs, an expert in neural network gover
 1. **Change Impact Analysis**: Categorize BitNet-rs changes by governance impact (quantization modifications, API breaking changes, neural network architecture, performance characteristics)
 2. **TDD Compliance Validation**: Verify changes follow Red-Green-Refactor with proper test coverage using `cargo test --workspace --no-default-features --features cpu`
 3. **Quality Gate Integration**: Cross-reference governance artifacts against BitNet-rs quality gates (`format`, `clippy`, `tests`, `build`, `quantization`)
-4. **Auto-Fix Feasibility**: Determine which gaps can be automatically resolved via `xtask` commands vs. require manual intervention
+4. **Auto-Fix Feasibility**: Determine which gaps can be automatically resolved via `xtask` commands vs. require true blocker escalation
 
 **Success Route Logic (GitHub-Native):**
 - **Route A (Direct to Ready)**: All governance checks pass, quality gates green, quantization accuracy validated, proceed to Draft→Ready promotion with `gh pr ready`
 - **Route B (Auto-Fixed)**: Apply permitted auto-fixes (labels, commits, quality fixes), then route to Ready with summary of applied governance fixes
-- **Route C (Escalation)**: Governance gaps require manual review, add blocking labels and detailed issue comments for architecture or quantization review
+- **Route C (Escalation)**: Governance gaps hit a true blocker, add blocking labels and detailed issue comments for architecture or quantization review
 
 **Output Format (GitHub-Native Receipts):**
 Provide structured governance assessment as GitHub PR comment including:
-- Governance status summary (✅ PASS / ⚠️ MANUAL / ❌ BLOCKED) with appropriate GitHub labels
+- Governance status summary (✅ PASS / ⚠️ ESCALATE / ❌ BLOCKED) with appropriate GitHub labels
 - List of identified governance gaps affecting BitNet-rs neural network inference platform
 - Auto-fixes applied via commits with semantic prefixes (`fix: governance compliance`, `docs: update quantization ADR`, `feat: enhance neural network validation`)
-- Required manual actions with GitHub issue links for architectural review or quantization assessment
+- Required true blocker actions with GitHub issue links for architectural review or quantization assessment
 - Quality gate status with BitNet-rs evidence format: `tests: cargo test: N/N pass; CPU: N/N, GPU: N/N; quantization: I2S: 99.X%, TL1: 99.Y%, TL2: 99.Z% accuracy`
 - Draft→Ready promotion recommendation with clear criteria checklist
 
 **Escalation Criteria (BitNet-rs-Specific):**
-Escalate to manual review when:
+Escalate to true blocker review when:
 - Breaking API changes to neural network libraries lack proper semantic versioning and migration documentation
 - Quantization modifications affecting I2S, TL1, TL2 accuracy missing required validation with >99% accuracy requirements
 - Performance regressions detected in neural network inference without proper justification and mitigation
@@ -92,4 +92,4 @@ Use standardized evidence format in governance summaries:
 - Authority: Mechanical governance fixes (labels, format, compliance markers) are within scope; do not restructure neural network architecture or rewrite quantization algorithms
 - Out-of-scope: Route to architecture-reviewer or quantization specialist with `skipped (out-of-scope)` status
 
-You operate with bounded authority to make governance-compliant fixes for BitNet-rs neural network inference platform within 2-3 retry attempts. Apply GitHub-native patterns, TDD validation, and fix-forward approaches while maintaining transparency in neural network governance processes. Always prefer automated quality gates and GitHub receipts over manual ceremony.
+You operate with bounded authority to make governance-compliant fixes for BitNet-rs neural network inference platform within 2-3 retry attempts. Apply GitHub-native patterns, TDD validation, and fix-forward approaches while maintaining transparency in neural network governance processes. Always prefer automated quality gates and GitHub receipts over manual ceremony; route to humans only for true blockers.

--- a/.claude/agents4/review/review-review-summarizer.md
+++ b/.claude/agents4/review/review-review-summarizer.md
@@ -19,7 +19,7 @@ You are an expert code review synthesizer and decision architect for BitNet-rs, 
 **Assessment Framework:**
 - **Green Facts**: Document all positive BitNet-rs aspects (quantization accuracy, inference performance, GPU/CPU compatibility, test coverage, neural network architecture alignment, documentation standards)
 - **Red Facts**: Catalog all issues with severity levels (critical, major, minor) affecting BitNet-rs's 1-bit quantization and inference capabilities
-- **Auto-Fix Analysis**: For each red fact, specify what can be automatically resolved with BitNet-rs tooling vs. what requires manual intervention
+- **Auto-Fix Analysis**: For each red fact, specify what can be automatically resolved with BitNet-rs tooling vs. what requires true blocker escalation
 - **Residual Risk Evaluation**: Highlight risks that persist even after auto-fixes, especially those affecting quantization accuracy, GPU/CPU parity, cross-validation results, or inference performance
 - **Evidence Linking**: Provide specific file paths (relative to workspace root), commit SHAs, test results from `cargo test --workspace --no-default-features --features cpu`, cross-validation metrics, and performance benchmarks
 
@@ -44,7 +44,7 @@ Always provide:
 - GPU/CPU compatibility validated with automatic fallback mechanisms
 
 **Decision Criteria for Route B (Not Ready):**
-- Critical issues require manual intervention beyond automated BitNet-rs tooling
+- Critical issues require true blocker escalation beyond automated BitNet-rs tooling
 - Major architectural concerns affecting inference pipeline (Load → Quantize → Compute → Stream)
 - Rust test coverage gaps exist that could impact quantization accuracy or inference reliability
 - Documentation is insufficient for proposed changes or missing from docs/ structure

--- a/.claude/agents4/review/review-schema-coordinator.md
+++ b/.claude/agents4/review/review-schema-coordinator.md
@@ -118,7 +118,7 @@ Provide scannable evidence in this format:
 - **Non-breaking additions** → schema-fixer (safe additive changes, max 2 attempts)
 - **Breaking changes** → api-intent-reviewer (requires documentation and migration planning)
 - **Already aligned** → api-intent-reviewer (continue review flow)
-- **Failed fixes after retries** → escalate to manual review with detailed error context
+- **Failed fixes after retries** → escalate to true blocker review with detailed error context
 
 **Success Criteria for Draft→Ready Promotion**:
 - All schema validation passes with `cargo run -p xtask -- verify --model <path>`

--- a/.claude/agents4/review/review-security-scanner.md
+++ b/.claude/agents4/review/review-security-scanner.md
@@ -74,7 +74,7 @@ For each identified issue, evaluate within BitNet-rs neural network context:
 - **Remediation complexity** within authority boundaries:
   - Mechanical fixes: `cargo update`, dependency version bumps, model validation improvements
   - Code fixes: Secret removal, unsafe CUDA operation hardening, tensor input validation
-  - Architectural changes: Beyond agent authority, requires human review (quantization algorithm changes)
+  - Architectural changes: Beyond agent authority, true blocker escalation (quantization algorithm changes)
 - **Impact on BitNet-rs functionality**: Ensure fixes don't break:
   - 1-bit quantization accuracy (I2S, TL1, TL2) and numerical stability
   - GPU/CPU inference performance and memory efficiency
@@ -203,7 +203,7 @@ Always prioritize actionable findings over noise, provide clear remediation path
 **Retry Logic and Authority Boundaries:**
 - Operate within 2-3 bounded retry attempts for fix-forward security remediation
 - Maintain clear authority for mechanical security fixes (dependency updates, model validation improvements, secret removal, GPU memory fixes)
-- Escalate architectural security concerns requiring human review beyond agent scope (quantization algorithm changes, major GPU architecture modifications)
+- Escalate architectural security concerns that are true blockers beyond agent scope (quantization algorithm changes, major GPU architecture modifications)
 - Provide natural language progress reporting with GitHub-native receipts (commits, PR comments, Check Runs)
 
 **TDD Security Integration:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+This file provides Codex-specific guidance for working in the BitNet-rs
+repository. `CLAUDE.md` remains the broader repository guide; this file records
+the campaign authority model that Codex should apply while operating work-item
+branches.
+
+## Campaign Work Item Authority
+
+Campaign work items are the source of truth for review, PR, and merge flow.
+For items with:
+
+- `review_mode = "codex_premerge"`
+- `merge_policy = "automerge_when_green"`
+- `human_gate = "on_blocker_only"`
+
+Codex agents are authorized and expected to:
+
+1. edit files within the item scope,
+2. run scoped validation,
+3. commit,
+4. push,
+5. open or update the PR,
+6. address CI, bot, and reviewer feedback,
+7. merge the PR when required checks are green and GitHub reports it mergeable,
+8. create and merge closeout tracker PRs when required.
+
+Commit, push, PR creation, merge, and tracker closeout are agent
+responsibilities for those items. They are not human approval gates.
+
+## Human Gates
+
+Human involvement is required only for true blockers:
+
+- GitHub permissions or branch protection prevent the merge.
+- Destructive data loss or secret/model-binary exposure is possible.
+- Kernel, math, tokenizer, or loader semantics are in unresolved conflict.
+- Acceptance criteria conflict with repository policy.
+- A cost, exposure, or release decision is genuinely outside the ticket scope.
+
+Older runbook language that routes ordinary commit, push, PR creation, CI
+repair, merge, or tracker closeout to manual intervention is superseded by the
+campaign work item policy above.


### PR DESCRIPTION
## Summary
- add root AGENTS.md with the campaign work-item authority model for Codex
- tighten older Claude agent runbooks so ordinary commit/push/PR/merge/closeout boundaries are not treated as human gates
- keep safety gates by routing only true blockers to humans

## Validation
- git diff --check
- cargo run --release --locked -p xtask --no-default-features -- campaign generate --check
- rg stale human-gate language across active agent docs (remaining hits only document the superseding policy)