### PR TITLE
SERVER-003: add fail-closed readiness certification

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -150,6 +150,72 @@ pub struct ServerStats {
     pub concurrency_stats: concurrency::ConcurrencyStats,
 }
 
+/// Server readiness and certification response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessResponse {
+    pub ready: bool,
+    pub status: String,
+    pub reason: Option<String>,
+    pub model: ServerReadinessModelState,
+    pub backend: ServerReadinessBackendState,
+    pub inference: ServerReadinessInferenceState,
+    pub claim_boundary: ServerReadinessClaimBoundary,
+}
+
+/// Model state used by the server readiness endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessModelState {
+    pub default_model_configured: bool,
+    pub loaded_models: usize,
+    pub total_size_mb: u64,
+    pub cache_size_limit: usize,
+    pub memory_limit_gb: Option<f64>,
+    pub active_model_id: Option<String>,
+    pub active_model: Option<ServerReadinessActiveModel>,
+}
+
+/// Active model summary used by the server readiness endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessActiveModel {
+    pub model_id: String,
+    pub model_path: String,
+    pub device: String,
+    pub quantization_type: String,
+    pub size_mb: u64,
+    pub parameters: u64,
+    pub context_length: u32,
+}
+
+/// Backend state used by the server readiness endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessBackendState {
+    pub requested_default_device: String,
+    pub selected_backend: Option<String>,
+    pub configured_fallback_enabled: bool,
+    pub server_fallback_policy: String,
+    pub device_statuses: Vec<execution_router::DeviceStatus>,
+}
+
+/// Server inference readiness state.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessInferenceState {
+    pub real_server_inference_ready: bool,
+    pub batch_inference_ready: bool,
+    pub simulated_inference_enabled: bool,
+    pub runtime_path: String,
+    pub unavailable_reason: String,
+}
+
+/// Claim boundaries reported by the server readiness endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerReadinessClaimBoundary {
+    pub server_ready_claimed: bool,
+    pub dense_regular_llm_cuda_inference_claimed: bool,
+    pub bitnet_packed_i2s_qk256_proof: bool,
+    pub speedup_claim: bool,
+    pub full_cuda_residency_claimed: bool,
+}
+
 /// BitNet inference server (pre-alpha; inference endpoints incomplete)
 pub struct BitNetServer {
     config: ServerConfig,
@@ -286,11 +352,13 @@ impl BitNetServer {
             // Model management endpoints
             .route("/v1/models/load", post(load_model_handler))
             .route("/v1/models", get(list_models_handler))
-            .route("/v1/models/:model_id", get(get_model_handler))
-            .route("/v1/models/:model_id", axum::routing::delete(unload_model_handler))
+            .route("/v1/models/{model_id}", get(get_model_handler))
+            .route("/v1/models/{model_id}", axum::routing::delete(unload_model_handler))
             // Server statistics and management
             .route("/v1/stats", get(server_stats_handler))
             .route("/v1/devices", get(device_status_handler))
+            .route("/readiness", get(server_readiness_handler))
+            .route("/v1/readiness", get(server_readiness_handler))
             // GPU streaming endpoint
             .route("/api/v1/generate/stream", post(gpu_streaming::gpu_stream_handler))
             // Root endpoint
@@ -625,6 +693,103 @@ async fn device_status_handler(
     Json(statuses)
 }
 
+/// Readiness and certification handler.
+async fn server_readiness_handler(
+    State(state): State<ProductionAppState>,
+) -> (StatusCode, Json<ServerReadinessResponse>) {
+    let model_memory = state.model_manager.get_memory_stats().await;
+    let active_model = if let Some(model_id) = &model_memory.active_model_id {
+        state.model_manager.get_model_metadata(model_id).await
+    } else {
+        None
+    };
+    let device_statuses = state.execution_router.get_device_statuses().await;
+
+    let response = build_server_readiness_response(
+        model_memory,
+        active_model,
+        state.config.server.default_model_path.is_some(),
+        format!("{:?}", state.config.server.default_device),
+        state.config.execution_router.fallback_enabled,
+        device_statuses,
+    );
+    let status = if response.ready { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+    (status, Json(response))
+}
+
+fn build_server_readiness_response(
+    model_memory: model_manager::ModelMemoryStats,
+    active_model: Option<model_manager::ModelMetadata>,
+    default_model_configured: bool,
+    requested_default_device: String,
+    configured_fallback_enabled: bool,
+    device_statuses: Vec<execution_router::DeviceStatus>,
+) -> ServerReadinessResponse {
+    let active_model_summary = active_model.as_ref().map(|metadata| ServerReadinessActiveModel {
+        model_id: metadata.model_id.clone(),
+        model_path: metadata.model_path.clone(),
+        device: metadata.device.clone(),
+        quantization_type: metadata.quantization_type.clone(),
+        size_mb: metadata.size_mb,
+        parameters: metadata.parameters,
+        context_length: metadata.context_length,
+    });
+    let selected_backend = active_model.as_ref().map(|metadata| metadata.device.clone());
+
+    let real_server_inference_ready = false;
+    let batch_inference_ready = false;
+    let simulated_inference_enabled = false;
+    let reason = if model_memory.active_model_id.is_none() {
+        Some("no_active_model".to_string())
+    } else if !real_server_inference_ready {
+        Some("server_batch_inference_not_implemented".to_string())
+    } else {
+        None
+    };
+    let ready = model_memory.active_model_id.is_some()
+        && real_server_inference_ready
+        && !simulated_inference_enabled;
+
+    ServerReadinessResponse {
+        ready,
+        status: if ready { "ready".to_string() } else { "not_ready".to_string() },
+        reason,
+        model: ServerReadinessModelState {
+            default_model_configured,
+            loaded_models: model_memory.total_models,
+            total_size_mb: model_memory.total_size_mb,
+            cache_size_limit: model_memory.cache_size_limit,
+            memory_limit_gb: model_memory.memory_limit_gb,
+            active_model_id: model_memory.active_model_id,
+            active_model: active_model_summary,
+        },
+        backend: ServerReadinessBackendState {
+            requested_default_device,
+            selected_backend,
+            configured_fallback_enabled,
+            server_fallback_policy: "fail_closed_until_real_engine".to_string(),
+            device_statuses,
+        },
+        inference: ServerReadinessInferenceState {
+            real_server_inference_ready,
+            batch_inference_ready,
+            simulated_inference_enabled,
+            runtime_path: "unavailable".to_string(),
+            unavailable_reason:
+                "batch inference rejects requests until a real server inference engine is wired"
+                    .to_string(),
+        },
+        claim_boundary: ServerReadinessClaimBoundary {
+            server_ready_claimed: false,
+            dense_regular_llm_cuda_inference_claimed: false,
+            bitnet_packed_i2s_qk256_proof: false,
+            speedup_claim: false,
+            full_cuda_residency_claimed: false,
+        },
+    }
+}
+
 /// Enhanced middleware for comprehensive request metrics collection
 async fn enhanced_metrics_middleware(request: Request, next: Next) -> Response {
     let start = Instant::now();
@@ -790,8 +955,11 @@ fn extract_client_ip_from_headers(headers: &HeaderMap) -> Option<IpAddr> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_device;
+    use super::{build_server_readiness_response, parse_device};
     use bitnet_common::Device;
+    use std::time::SystemTime;
+
+    use crate::model_manager::{ModelMemoryStats, ModelMetadata};
 
     #[test]
     fn parse_device_supports_vulkan_and_opencl_aliases() {
@@ -805,5 +973,78 @@ mod tests {
         assert_eq!(parse_device("vulkan:2").unwrap(), Device::Cuda(2));
         assert_eq!(parse_device("opencl:3").unwrap(), Device::Cuda(3));
         assert_eq!(parse_device("ocl:4").unwrap(), Device::Cuda(4));
+    }
+
+    #[test]
+    fn server_readiness_without_active_model_fails_closed() {
+        let response = build_server_readiness_response(
+            ModelMemoryStats {
+                total_models: 0,
+                total_size_mb: 0,
+                active_model_id: None,
+                cache_size_limit: 3,
+                memory_limit_gb: Some(16.0),
+            },
+            None,
+            false,
+            "Auto".to_string(),
+            true,
+            Vec::new(),
+        );
+
+        assert!(!response.ready);
+        assert_eq!(response.status, "not_ready");
+        assert_eq!(response.reason.as_deref(), Some("no_active_model"));
+        assert!(!response.model.default_model_configured);
+        assert_eq!(response.model.loaded_models, 0);
+        assert!(response.model.active_model.is_none());
+        assert_eq!(response.backend.server_fallback_policy, "fail_closed_until_real_engine");
+        assert!(!response.inference.real_server_inference_ready);
+        assert!(!response.inference.batch_inference_ready);
+        assert!(!response.inference.simulated_inference_enabled);
+        assert!(!response.claim_boundary.server_ready_claimed);
+        assert!(!response.claim_boundary.speedup_claim);
+        assert!(!response.claim_boundary.full_cuda_residency_claimed);
+    }
+
+    #[test]
+    fn server_readiness_with_active_model_still_fails_until_real_engine() {
+        let response = build_server_readiness_response(
+            ModelMemoryStats {
+                total_models: 1,
+                total_size_mb: 512,
+                active_model_id: Some("model-1".to_string()),
+                cache_size_limit: 3,
+                memory_limit_gb: Some(16.0),
+            },
+            Some(ModelMetadata {
+                model_id: "model-1".to_string(),
+                model_path: "models/qwen2.5-0.5b-q8_0.gguf".to_string(),
+                device: "Cuda(0)".to_string(),
+                quantization_type: "Q8_0".to_string(),
+                loaded_at: SystemTime::UNIX_EPOCH,
+                size_mb: 512,
+                parameters: 500_000_000,
+                context_length: 32_768,
+                inference_count: 0,
+                avg_tokens_per_second: 0.0,
+            }),
+            true,
+            "Gpu(0)".to_string(),
+            false,
+            Vec::new(),
+        );
+
+        assert!(!response.ready);
+        assert_eq!(response.status, "not_ready");
+        assert_eq!(response.reason.as_deref(), Some("server_batch_inference_not_implemented"));
+        assert!(response.model.default_model_configured);
+        assert_eq!(response.model.active_model_id.as_deref(), Some("model-1"));
+        assert_eq!(response.backend.selected_backend.as_deref(), Some("Cuda(0)"));
+        assert!(!response.backend.configured_fallback_enabled);
+        assert!(!response.inference.real_server_inference_ready);
+        assert_eq!(response.inference.runtime_path, "unavailable");
+        assert!(!response.claim_boundary.dense_regular_llm_cuda_inference_claimed);
+        assert!(!response.claim_boundary.bitnet_packed_i2s_qk256_proof);
     }
 }

--- a/crates/bitnet-server/tests/server_http_integration_tests.rs
+++ b/crates/bitnet-server/tests/server_http_integration_tests.rs
@@ -16,7 +16,7 @@ use serde_json::{Value, json};
 use tower::ServiceExt;
 
 use bitnet_server::{
-    ErrorResponse,
+    BitNetServer, ErrorResponse, ServerConfig,
     concurrency::{ConcurrencyConfig, ConcurrencyManager},
     config::ConfigBuilder,
     monitoring::{
@@ -254,4 +254,32 @@ async fn test_health_response_build_info_present() {
     let build = json.get("build").expect("/health JSON must contain 'build' key");
     assert!(build.get("version").is_some(), "'build' object must contain 'version'");
     assert!(build.get("git_sha").is_some(), "'build' object must contain 'git_sha'");
+}
+
+/// `/v1/readiness` reports fail-closed certification state for the production app.
+#[tokio::test]
+async fn test_v1_readiness_fails_closed_without_active_model() {
+    let server = BitNetServer::new(ServerConfig::default()).await.expect("server must initialize");
+    let app = server.create_app();
+
+    let resp = app
+        .oneshot(Request::builder().uri("/v1/readiness").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body =
+        axum::body::to_bytes(resp.into_body(), usize::MAX).await.expect("body read must succeed");
+    let json: Value = serde_json::from_slice(&body).expect("body must be valid JSON");
+
+    assert_eq!(json["ready"], false);
+    assert_eq!(json["status"], "not_ready");
+    assert_eq!(json["reason"], "no_active_model");
+    assert_eq!(json["inference"]["real_server_inference_ready"], false);
+    assert_eq!(json["inference"]["simulated_inference_enabled"], false);
+    assert_eq!(json["backend"]["server_fallback_policy"], "fail_closed_until_real_engine");
+    assert_eq!(json["claim_boundary"]["server_ready_claimed"], false);
+    assert_eq!(json["claim_boundary"]["speedup_claim"], false);
+    assert_eq!(json["claim_boundary"]["full_cuda_residency_claimed"], false);
 }

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -91,7 +91,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "SERVER-003"
-status = "in_progress"
+status = "pr_open"
+pr = 4477
 branch = "codex/server-003-readiness-certification"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -88,3 +88,41 @@ must_not_claim = [
   "Any hardware acceleration works.",
   "Server performance is proven.",
 ]
+
+[[work_item]]
+id = "SERVER-003"
+status = "in_progress"
+branch = "codex/server-003-readiness-certification"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["SERVER-002"]
+acceptance = "Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired."
+commands = [
+  "cargo fmt -p bitnet-server -- --check",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu server_readiness -- --nocapture",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-server/**",
+  "docs/tracking/campaigns/server-real-inference/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "Server readiness/certification exposes fail-closed active model, backend, inference, fallback, and claim-boundary state.",
+]
+must_not_claim = [
+  "Server answer readiness is proven.",
+  "Any hardware acceleration works.",
+  "Server performance is proven.",
+  "A dense or BitNet CUDA server path is implemented.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-11T041041Z-SERVER-003-in-progress.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-11T041041Z-SERVER-003-in-progress.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-11T04:10:41Z"
+campaign = "server-real-inference"
+item = "SERVER-003"
+event = "in_progress"
+from = "proposed"
+to = "in_progress"
+branch = "codex/server-003-readiness-certification"
+actor = "codex"
+summary = "Started SERVER-003 to add a fail-closed readiness/certification endpoint exposing active model, backend, inference, fallback, and claim-boundary state."
+notes = [
+  "SERVER-001 and SERVER-002 are merged.",
+  "The endpoint must fail closed until a real server inference engine is wired.",
+  "Scope is server contract/readiness only; no model runtime, CUDA kernel, or speed claim changes.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-11T042336Z-SERVER-003-pr-open.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-11T042336Z-SERVER-003-pr-open.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-11T04:23:36Z"
+campaign = "server-real-inference"
+item = "SERVER-003"
+event = "pr_open"
+from = "in_progress"
+to = "pr_open"
+actor = "codex"
+pr = 4477
+branch = "codex/server-003-readiness-certification"
+head_sha = "b86244f559e7ca7d82fff4b38bc68a433f1769dd"
+summary = "Opened SERVER-003 PR to add a fail-closed server readiness/certification endpoint."
+notes = [
+  "PR exposes active model, backend, inference, fallback, and claim-boundary state through /readiness and /v1/readiness.",
+  "The endpoint returns unavailable until a real server inference engine is wired, with no server answer, CUDA, speedup, or full-residency claim.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -11,6 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
+| SERVER-003 | in_progress | TBD | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
-| SERVER-003 | in_progress | TBD | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
+| SERVER-003 | pr_open | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| server-real-inference | SERVER-003 | #4477 | `codex/server-003-readiness-certification` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -256,7 +256,7 @@
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
-| server-real-inference | SERVER-003 | SERVER-002 | in_progress |
+| server-real-inference | SERVER-003 | SERVER-002 | pr_open |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -256,6 +256,7 @@
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
+| server-real-inference | SERVER-003 | SERVER-002 | in_progress |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-002 | #4432 | merged | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-003 | TBD | in_progress | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-003 | TBD | in_progress | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-003 | #4477 | pr_open | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
-| server-real-inference | Server real inference | SERVER-002 | Do not reintroduce simulated inference. |
+| server-real-inference | Server real inference | SERVER-003 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-008 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- add `/readiness` and `/v1/readiness` readiness/certification responses for server model/backend/inference state
- fail closed with `503` until a real server inference path is wired, while preserving simulated inference and claim boundaries as false
- fix the existing Axum 0.8 model-id route syntax so `create_app()` can build, and register SERVER-003 in the server-real-inference tracker

## Validation
- `cargo fmt -p bitnet-server -- --check`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu server_readiness -- --nocapture`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu test_v1_readiness_fails_closed_without_active_model -- --nocapture`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim boundary
- no server answer readiness claim
- no CUDA, dense, or BitNet acceleration claim
- no speedup or full-residency claim