### PR TITLE
docs(tracking): close SERVER-003

### DIFF
--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -91,8 +91,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "SERVER-003"
-status = "pr_open"
+status = "merged"
 pr = 4477
+merge_sha = "b3f16139042af4e0aefe35ac973db659c936dcd5"
 branch = "codex/server-003-readiness-certification"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-11T043511Z-SERVER-003-merged.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-11T043511Z-SERVER-003-merged.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-11T04:35:11Z"
+campaign = "server-real-inference"
+item = "SERVER-003"
+event = "merged"
+from = "pr_open"
+to = "merged"
+actor = "codex"
+pr = 4477
+merge_sha = "b3f16139042af4e0aefe35ac973db659c936dcd5"
+branch = "codex/server-003-readiness-certification"
+summary = "SERVER-003 merged after adding fail-closed readiness/certification endpoints."
+notes = [
+  "Merged PR #4477 adds /readiness and /v1/readiness responses for active model, backend, inference, fallback, and claim-boundary state.",
+  "The merged endpoint returns unavailable until a real server inference engine is wired and makes no server answer, CUDA, speedup, or full-residency claim.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -11,7 +11,7 @@
 |---|---|---:|---|---|---|---|---|
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
-| SERVER-003 | pr_open | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
+| SERVER-003 | merged | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| server-real-inference | SERVER-003 | #4477 | `codex/server-003-readiness-certification` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -256,7 +256,7 @@
 | nvidia-5070ti | CUDA-UX-002 | CUDA-UX-001, CUDA-PROD-001 | merged |
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
-| server-real-inference | SERVER-003 | SERVER-002 | pr_open |
+| server-real-inference | SERVER-003 | SERVER-002 | merged |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-003 | #4477 | pr_open | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-003 | #4477 | merged | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- mark SERVER-003 as merged after #4477
- add the SERVER-003 merged event with merge SHA
- regenerate tracker dashboards and remove #4477 from active PRs

## Validation
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`