### PR TITLE
SERVER-004: add fail-closed chat completions endpoint

### DIFF
--- a/crates/bitnet-server/src/lib.rs
+++ b/crates/bitnet-server/src/lib.rs
@@ -121,6 +121,24 @@ pub struct EnhancedInferenceResponse {
     pub queue_time_ms: u64,
 }
 
+/// OpenAI-compatible chat completions request.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatCompletionMessage>,
+    pub max_tokens: Option<usize>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub stream: Option<bool>,
+}
+
+/// OpenAI-compatible chat message.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChatCompletionMessage {
+    pub role: String,
+    pub content: String,
+}
+
 /// Model loading request
 #[derive(Deserialize)]
 pub struct ModelLoadRequest {
@@ -348,6 +366,7 @@ impl BitNetServer {
             // Core inference endpoints
             .route("/v1/inference", post(enhanced_inference_handler))
             .route("/v1/inference/stream", post(streaming::streaming_handler))
+            .route("/v1/chat/completions", post(chat_completions_handler))
             .route("/inference", post(legacy_inference_handler)) // Legacy compatibility
             // Model management endpoints
             .route("/v1/models/load", post(load_model_handler))
@@ -590,6 +609,30 @@ async fn legacy_inference_handler(
     }
 }
 
+/// OpenAI-compatible chat completions endpoint.
+async fn chat_completions_handler(
+    State(state): State<ProductionAppState>,
+    Json(request): Json<ChatCompletionRequest>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    let readiness = collect_server_readiness_response(&state).await;
+    let details = serde_json::json!({
+        "requested_model": request.model,
+        "message_count": request.messages.len(),
+        "stream": request.stream.unwrap_or(false),
+        "readiness": readiness,
+    });
+
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        create_error_response(
+            "OpenAI-compatible chat completions are unavailable until a real server inference engine is wired",
+            "SERVER_INFERENCE_UNAVAILABLE",
+            Some(Uuid::new_v4().to_string()),
+            Some(details),
+        ),
+    )
+}
+
 /// Load model handler
 async fn load_model_handler(
     State(state): State<ProductionAppState>,
@@ -697,6 +740,13 @@ async fn device_status_handler(
 async fn server_readiness_handler(
     State(state): State<ProductionAppState>,
 ) -> (StatusCode, Json<ServerReadinessResponse>) {
+    let response = collect_server_readiness_response(&state).await;
+    let status = if response.ready { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+    (status, Json(response))
+}
+
+async fn collect_server_readiness_response(state: &ProductionAppState) -> ServerReadinessResponse {
     let model_memory = state.model_manager.get_memory_stats().await;
     let active_model = if let Some(model_id) = &model_memory.active_model_id {
         state.model_manager.get_model_metadata(model_id).await
@@ -705,17 +755,14 @@ async fn server_readiness_handler(
     };
     let device_statuses = state.execution_router.get_device_statuses().await;
 
-    let response = build_server_readiness_response(
+    build_server_readiness_response(
         model_memory,
         active_model,
         state.config.server.default_model_path.is_some(),
         format!("{:?}", state.config.server.default_device),
         state.config.execution_router.fallback_enabled,
         device_statuses,
-    );
-    let status = if response.ready { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
-
-    (status, Json(response))
+    )
 }
 
 fn build_server_readiness_response(

--- a/crates/bitnet-server/src/monitoring/tracing.rs
+++ b/crates/bitnet-server/src/monitoring/tracing.rs
@@ -53,8 +53,18 @@ pub async fn init_tracing(config: &MonitoringConfig) -> Result<TracingGuard> {
         .with_line_number(true)
         .with_writer(file_writer);
 
-    // Build the subscriber
-    tracing_subscriber::registry().with(env_filter).with(console_layer).with(file_layer).init();
+    // Build the subscriber. Tests and embedded server users can construct more
+    // than one server in the same process, so tracing setup must be idempotent.
+    if tracing_subscriber::registry()
+        .with(env_filter)
+        .with(console_layer)
+        .with(file_layer)
+        .try_init()
+        .is_err()
+    {
+        tracing::debug!("Tracing already initialized");
+        return Ok(TracingGuard::new(None));
+    }
 
     tracing::info!(
         log_level = %config.log_level,

--- a/crates/bitnet-server/tests/server_http_integration_tests.rs
+++ b/crates/bitnet-server/tests/server_http_integration_tests.rs
@@ -283,3 +283,48 @@ async fn test_v1_readiness_fails_closed_without_active_model() {
     assert_eq!(json["claim_boundary"]["speedup_claim"], false);
     assert_eq!(json["claim_boundary"]["full_cuda_residency_claimed"], false);
 }
+
+/// `/v1/chat/completions` is OpenAI-compatible but fail-closed until real inference is wired.
+#[tokio::test]
+async fn test_v1_chat_completions_fails_closed_without_simulated_output() {
+    let server = BitNetServer::new(ServerConfig::default()).await.expect("server must initialize");
+    let app = server.create_app();
+
+    let body = json!({
+        "model": "qwen2.5-0.5b-q8",
+        "messages": [
+            {"role": "user", "content": "Explain deferred revenue."}
+        ],
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "stream": false
+    });
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let body =
+        axum::body::to_bytes(resp.into_body(), usize::MAX).await.expect("body read must succeed");
+    let json: Value = serde_json::from_slice(&body).expect("body must be valid JSON");
+
+    assert_eq!(json["error_code"], "SERVER_INFERENCE_UNAVAILABLE");
+    assert_eq!(json["details"]["requested_model"], "qwen2.5-0.5b-q8");
+    assert_eq!(json["details"]["message_count"], 1);
+    assert_eq!(json["details"]["stream"], false);
+    assert_eq!(json["details"]["readiness"]["ready"], false);
+    assert_eq!(json["details"]["readiness"]["reason"], "no_active_model");
+    assert_eq!(json["details"]["readiness"]["inference"]["simulated_inference_enabled"], false);
+    assert_eq!(json["details"]["readiness"]["claim_boundary"]["server_ready_claimed"], false);
+    assert!(json.get("choices").is_none(), "fail-closed response must not look like chat output");
+}

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -131,7 +131,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "SERVER-004"
-status = "in_progress"
+status = "pr_open"
+pr = 4479
 branch = "codex/server-004-openai-chat-fail-closed"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -128,3 +128,42 @@ must_not_claim = [
   "Server performance is proven.",
   "A dense or BitNet CUDA server path is implemented.",
 ]
+
+[[work_item]]
+id = "SERVER-004"
+status = "in_progress"
+branch = "codex/server-004-openai-chat-fail-closed"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["SERVER-003"]
+acceptance = "Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired."
+commands = [
+  "cargo fmt -p bitnet-server -- --check",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu test_v1_chat_completions_fails_closed_without_simulated_output -- --nocapture",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-server/**",
+  "docs/tracking/campaigns/server-real-inference/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+]
+may_claim = [
+  "OpenAI-compatible chat completions fail closed with readiness/certification details.",
+]
+must_not_claim = [
+  "Server answer readiness is proven.",
+  "Real chat inference is implemented.",
+  "A dense or BitNet CUDA server path is implemented.",
+  "Any hardware acceleration works.",
+  "Server performance is proven.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-11T160908Z-SERVER-004-in-progress.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-11T160908Z-SERVER-004-in-progress.toml
@@ -1,0 +1,13 @@
+timestamp = "2026-05-11T16:09:08Z"
+campaign = "server-real-inference"
+item = "SERVER-004"
+event = "in_progress"
+from = "proposed"
+to = "in_progress"
+actor = "codex"
+branch = "codex/server-004-openai-chat-fail-closed"
+summary = "SERVER-004 started to add an OpenAI-compatible chat completions endpoint that fails closed."
+notes = [
+  "The endpoint must return the stable error envelope with readiness/certification details until a real server inference engine is wired.",
+  "The work item must not claim real chat inference, CUDA server execution, server answer readiness, speedup, or full residency.",
+]

--- a/docs/tracking/campaigns/server-real-inference/events/2026-05-11T162132Z-SERVER-004-pr-open.toml
+++ b/docs/tracking/campaigns/server-real-inference/events/2026-05-11T162132Z-SERVER-004-pr-open.toml
@@ -1,0 +1,15 @@
+timestamp = "2026-05-11T16:21:32Z"
+campaign = "server-real-inference"
+item = "SERVER-004"
+event = "pr_open"
+from = "in_progress"
+to = "pr_open"
+actor = "codex"
+pr = 4479
+head_sha = "c387827baa258e4f50a013aad59152baeef1359a"
+branch = "codex/server-004-openai-chat-fail-closed"
+summary = "Opened SERVER-004 PR for the fail-closed OpenAI-compatible chat completions endpoint."
+notes = [
+  "PR #4479 adds POST /v1/chat/completions and returns SERVER_INFERENCE_UNAVAILABLE with readiness/certification details until real inference is wired.",
+  "The PR keeps chat inference, server answer readiness, CUDA server execution, speedup, and full-residency claims false.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -12,6 +12,7 @@
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 | SERVER-003 | merged | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
+| SERVER-004 | in_progress | TBD | `codex/server-004-openai-chat-fail-closed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired. |
 
 ## Hard Constraints
 

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -12,7 +12,7 @@
 | SERVER-001 | merged | #4429 | `codex/server-real-inference/SERVER-001-single-request-engine` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire single-request server inference to real engine execution or explicit 501/503, with no simulated response path in non-test builds. |
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 | SERVER-003 | merged | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
-| SERVER-004 | in_progress | TBD | `codex/server-004-openai-chat-fail-closed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired. |
+| SERVER-004 | pr_open | #4479 | `codex/server-004-openai-chat-fail-closed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,3 +3,4 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
+| server-real-inference | SERVER-004 | #4479 | `codex/server-004-openai-chat-fail-closed` | Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -257,6 +257,7 @@
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
 | server-real-inference | SERVER-003 | SERVER-002 | merged |
+| server-real-inference | SERVER-004 | SERVER-003 | in_progress |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -257,7 +257,7 @@
 | nvidia-5070ti | CUDA-DENSE-014 | CUDA-DENSE-013 | merged |
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
 | server-real-inference | SERVER-003 | SERVER-002 | merged |
-| server-real-inference | SERVER-004 | SERVER-003 | in_progress |
+| server-real-inference | SERVER-004 | SERVER-003 | pr_open |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-004 | TBD | in_progress | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-004 | #4479 | pr_open | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-003 | #4477 | merged | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-004 | TBD | in_progress | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
-| server-real-inference | Server real inference | SERVER-003 | Do not reintroduce simulated inference. |
+| server-real-inference | Server real inference | SERVER-004 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-008 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- add OpenAI-compatible `POST /v1/chat/completions` request parsing and route registration
- fail closed with the existing `ErrorResponse` envelope plus readiness/certification details until real server inference is wired
- make tracing initialization idempotent for repeated in-process server construction and add HTTP coverage proving no fake `choices` output is emitted
- record SERVER-004 as the active server-real-inference tracker item and regenerate dashboards

## Validation
- `cargo fmt -p bitnet-server -- --check`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu test_v1_chat_completions_fails_closed_without_simulated_output -- --nocapture`
- `cargo test --locked -p bitnet-server --no-default-features --features cpu`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim Boundary
- no real chat inference
- no server answer readiness
- no CUDA, dense, or BitNet server path claim
- no speedup or full-residency claim