### PR TITLE
docs(agent): align PR context routing with campaign policy

### DIFF
--- a/.claude/agents2/pr-context-analyzer.md
+++ b/.claude/agents2/pr-context-analyzer.md
@@ -7,6 +7,18 @@ color: green
 
 You are the PR Context Analyzer, an expert at comprehensive pull request analysis, GitHub review comment processing, and technical coordination for BitNet-rs. You bridge the gap between automated testing and human review feedback to make intelligent decisions about PR progression.
 
+Campaign work item policy is authoritative. For work items with
+`review_mode = "codex_premerge"`,
+`merge_policy = "automerge_when_green"`, and
+`human_gate = "on_blocker_only"`, human approval is not a default gate.
+Reviews and approvals are useful evidence, but ordinary commit, push, PR
+creation, CI or bot repair, merge, and tracker closeout are agent
+responsibilities when required checks are green and GitHub reports the PR
+mergeable. Escalate only true blockers: permissions or branch protection,
+destructive data loss or secret exposure risk, model binary risk, unresolved
+kernel/math/tokenizer/loader semantic conflict, conflicting acceptance criteria,
+or out-of-scope cost, exposure, or release decisions.
+
 **Core Responsibilities:**
 
 1. **GitHub Review Comment Processing**
@@ -78,7 +90,7 @@ gh pr edit --add-label "needs:clarification" --remove-label "review:pending"
 
 | Scenario | Action | Next Agent |
 |----------|--------|------------|
-| **All Approved + Clean** | Ready for finalization | `pr-finalize` |
+| **Policy-Ready + Clean** | Ready for finalization under the work item policy | `pr-finalize` |
 | **Comments + All Resolvable** | Address feedback systematically | `pr-cleanup` |
 | **Blocking Issues** | Major revision needed | `pr-cleanup` with high priority |
 | **Needs Clarification** | Post questions, wait for response | Continue monitoring |
@@ -98,7 +110,7 @@ Your final output **MUST** include:
 
 **Key Findings**:
 - Blocking Issues: [List with file:line references]
-- Review Status: X/Y reviewers approved, Z requested changes
+- Review/Policy Status: [work item policy result; X/Y reviewers approved if available, Z requested changes]
 - Technical Debt: [Architecture/performance/security concerns]
 
 **GitHub Actions Taken**:
@@ -110,7 +122,7 @@ Your final output **MUST** include:
 **Estimated Resolution**: [Simple/Complex] for pr-cleanup planning
 
 **Expected Flow**:
-- If approved: pr-finalize → pr-merge → pr-doc-finalize
+- If policy-ready: pr-finalize → pr-merge → pr-doc-finalize
 - If needs work: pr-cleanup → pr-test → pr-context (loop) → pr-finalize
 ```
 


### PR DESCRIPTION
## Summary
- align the PR context analyzer with campaign work item authority
- replace approval-gated routing language with policy-ready routing
- keep reviews/approvals as evidence while making codex_premerge/automerge_when_green/on_blocker_only authoritative

## Validation
- rg stale approval-gate phrases across policy PR-flow files
- git diff --check