### PR TITLE
docs(model): align qwen 1.5b coverage boundary

### DIFF
--- a/ci/model-artifacts/model-coverage-matrix.toml
+++ b/ci/model-artifacts/model-coverage-matrix.toml
@@ -864,18 +864,22 @@ model_class = "small_llm"
 family = "qwen2"
 artifact_kind = "gguf_q4_k_m"
 capability_id = "qwen2.5-1.5b-instruct-q4_k_m"
-status = "registered_candidate"
-current_tier = "registered"
+status = "apple_m4_cpu_neon_supported_non_default"
+current_tier = "cpu_answer_ready"
 verifier_surface = "bitnet model verify qwen2.5-1.5b-instruct-q4_k_m"
 tokenizer_authority = "contract_authoritative_qwen2"
 prompt_authority = "contract_authoritative_chat_template"
-cpu_reference = "candidate_reference_required"
+cpu_reference = "apple_m4_cpu_neon_slm_answer_lane"
 accelerator_routes = []
 required_receipts = [
   "artifact_verify",
   "memory_envelope",
-  "cpu_reference_sanity",
-  "all_layer_plan",
+  "reference_runner_quality",
+  "rust_m4_quality",
+  "model_verify",
+  "slm_answer_receipt",
+  "fallback_free_backend_receipt",
+  "dense_cuda_all_layer_plan",
 ]
 forbidden_claims = [
   "cuda_answer_ready",
@@ -884,14 +888,14 @@ forbidden_claims = [
   "speedup",
   "bitnet_packed_i2s_qk256_proof",
 ]
-next_proof = "artifact verify, memory envelope, CPU reference sanity, and dense CUDA all-layer plan."
-claim_boundary = "The larger Qwen candidate is registered for future small-LLM pressure testing; it is not CUDA answer-ready."
+next_proof = "dense CUDA all-layer plan, KV/sampling policy, one-token proof, and short-decode proof before any CUDA answer claim."
+claim_boundary = "Qwen2.5 1.5B Q4_K_M is an explicit non-default Apple M4 CPU/NEON answer model after reference and Rust M4 quality gates. This does not prove dense CUDA, BitNet QK256, speedup, server readiness, or full residency."
 
   [entry.claims]
   registered = true
-  structurally_valid = false
-  reference_good = false
-  cpu_answer_ready = false
+  structurally_valid = true
+  reference_good = true
+  cpu_answer_ready = true
   accelerator_answer_ready = false
   benchmark_qualified = false
   product_cli_ready = false

--- a/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
+++ b/docs/model-artifacts/MODEL_COVERAGE_MATRIX.md
@@ -80,7 +80,7 @@ before any user-facing or speed claim is allowed.
 
 | Entry | Artifact lane | Current tier | Boundary |
 |---|---|---|---|
-| `small_llm_qwen25_15b_q4km_candidate` | Qwen2.5 1.5B Q4_K_M GGUF candidate | `registered` | Existing larger-Qwen pressure row; needs artifact verify, memory envelope, CPU sanity, and all-layer plan. |
+| `small_llm_qwen25_15b_q4km_candidate` | Qwen2.5 1.5B Q4_K_M GGUF candidate | `cpu_answer_ready` | Supported non-default Apple M4 CPU/NEON answer model after reference and Rust M4 quality gates; still needs its own dense CUDA all-layer plan and CUDA proof before any CUDA claim. |
 | `small_llm_qwen3_17b_q8_candidate` | Qwen3 1.7B-class Q8_0 GGUF candidate | `registered` | Future Qwen3 small-LLM row; does not inherit Qwen2.5 0.5B CUDA receipts. |
 | `small_llm_llama32_3b_candidate` | Llama 3.2 3B-class GGUF candidate | `registered` | Llama-family selected small-LLM row; needs its own memory, CPU, KV, and CUDA plan receipts. |
 | `small_llm_gemma_2b_candidate` | Gemma 2B-class GGUF candidate | `registered` | Alternate architecture selected small-LLM row; cannot inherit Qwen, Llama, or BitNet proof. |


### PR DESCRIPTION
## Summary
- update the cross-family coverage matrix for `qwen2.5-1.5b-instruct-q4_k_m` to reflect its landed non-default Apple M4 CPU/NEON answer support
- keep dense CUDA, BitNet QK256, speedup, server, and full-residency claims explicitly false
- refresh the human-readable coverage table to match the machine-readable row

## Validation
- `cargo run --release --locked -p xtask --no-default-features -- check-model-coverage`
- `cargo test --locked -p xtask --bin xtask --no-default-features model_coverage -- --nocapture`
- `cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- model coverage small_llm_qwen25_15b_q4km_candidate --json`
- `cargo run --release --locked -p xtask --no-default-features -- campaign check model-artifacts`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`