### PR TITLE
docs(tracking): add server shared engine item

### DIFF
--- a/docs/tracking/campaigns/server-real-inference/CAMPAIGN.md
+++ b/docs/tracking/campaigns/server-real-inference/CAMPAIGN.md
@@ -28,9 +28,11 @@ Replace server-side simulated inference surfaces with real engine execution or e
 | SERVER-002 | merged | Failed closed placeholder model lifecycle scaffolds that previously reported HuggingFace/cache readiness without real I/O or a real inference engine. |
 | SERVER-003 | merged | Added `/readiness` and `/v1/readiness` certification responses for active model, backend, inference, fallback, and claim-boundary state. |
 | SERVER-004 | merged | Added `POST /v1/chat/completions` as an OpenAI-compatible surface that returns `SERVER_INFERENCE_UNAVAILABLE` with readiness/certification details until real inference is wired. |
+| SERVER-005 | proposed | Wire one non-streaming chat-completions path to the same verified local inference surface as CLI ask/chat, with strict fallback rejection and per-request receipts. |
 
-There is no active next item in `active.toml` after `SERVER-004`. Add a new
-campaign work item before reopening server runtime work.
+`SERVER-005` is the first runtime reopening item after the fail-closed server
+surface. It must share the validated CLI loader, tokenizer, planner, receipt,
+and fallback path instead of creating a second inference implementation.
 
 ## Current Claim Boundary
 

--- a/docs/tracking/campaigns/server-real-inference/active.toml
+++ b/docs/tracking/campaigns/server-real-inference/active.toml
@@ -169,3 +169,52 @@ must_not_claim = [
   "Any hardware acceleration works.",
   "Server performance is proven.",
 ]
+
+[[work_item]]
+id = "SERVER-005"
+status = "proposed"
+branch = "codex/server-real-inference/SERVER-005-shared-engine-runtime"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["SERVER-004"]
+acceptance = "Wire one non-streaming server chat-completions request path to the same validated local inference engine surface used by CLI ask/chat for already verified product-ready models, preserving strict model verification, tokenizer/prompt authority, planner route, fallback rejection, per-request receipt semantics, and explicit unavailable responses when no verified engine configuration is present."
+commands = [
+  "cargo fmt -p bitnet-server -- --check",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu server_shared_engine -- --nocapture",
+  "cargo test --locked -p bitnet-server --no-default-features --features cpu",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference",
+  "cargo run --release --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-server/**",
+  "crates/bitnet-cli/**",
+  "crates/bitnet-inference/**",
+  "crates/bitnet-receipts-core/**",
+  "crates/bitnet-receipts/**",
+  "docs/tracking/campaigns/server-real-inference/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/src/gpu/**",
+  "crates/bitnet-kernels/src/metal/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-transformer/**",
+  "crates/bitnet-tokenizers/**",
+  "crates/bitnet-models/**",
+]
+may_claim = [
+  "One non-streaming server chat-completions path uses the same verified local inference surface as CLI ask/chat when a supported model/backend is explicitly configured.",
+  "Server request receipts preserve model, tokenizer, prompt, planner route, fallback, and claim-boundary fields from the shared engine path.",
+  "Unsupported or unconfigured server requests still fail closed with readiness/certification details.",
+]
+must_not_claim = [
+  "Server streaming is implemented.",
+  "Server performance is proven.",
+  "A new model family is answer-ready.",
+  "CUDA speedup is accepted.",
+  "Full CUDA residency is proven.",
+  "BitNet QK256, dense CUDA, tokenizer, loader, transformer, or kernel math changed.",
+]

--- a/docs/tracking/campaigns/server-real-inference/generated/status.md
+++ b/docs/tracking/campaigns/server-real-inference/generated/status.md
@@ -13,6 +13,7 @@
 | SERVER-002 | merged | #4432 | `codex/server-real-inference/SERVER-002-no-placeholder-model-readiness` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Fail closed server model lifecycle scaffolds that previously reported placeholder HuggingFace/cache model readiness without real I/O or a real inference engine. |
 | SERVER-003 | merged | #4477 | `codex/server-003-readiness-certification` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add a server readiness/certification endpoint that exposes active model, backend, inference, fallback, and claim-boundary state while failing closed until a real server inference engine is wired. |
 | SERVER-004 | merged | #4479 | `codex/server-004-openai-chat-fail-closed` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add an OpenAI-compatible /v1/chat/completions endpoint that fails closed with readiness/certification details until a real server inference engine is wired. |
+| SERVER-005 | proposed | TBD | `codex/server-real-inference/SERVER-005-shared-engine-runtime` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire one non-streaming server chat-completions request path to the same validated local inference engine surface used by CLI ask/chat for already verified product-ready models, preserving strict model verification, tokenizer/prompt authority, planner route, fallback rejection, per-request receipt semantics, and explicit unavailable responses when no verified engine configuration is present. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -258,6 +258,7 @@
 | server-real-inference | SERVER-002 | SERVER-001 | merged |
 | server-real-inference | SERVER-003 | SERVER-002 | merged |
 | server-real-inference | SERVER-004 | SERVER-003 | merged |
+| server-real-inference | SERVER-005 | SERVER-004 | proposed |
 | slm-cpu | SLM-CPU-001 | SLM-CPU-000 | merged |
 | slm-cpu | SLM-CPU-002 | SLM-CPU-001 | merged |
 | slm-cpu | SLM-CPU-002A | SLM-CPU-002 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | NPU-011 | #4097 | merged | none | Device-node detection is not inference. |
 | model-artifacts | MODEL-ARTIFACT-002 | #3928 | blocked | none | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | CUDA-DENSE-014 | #4216 | merged | none | CUDA visibility is not kernel execution. |
-| server-real-inference | SERVER-004 | #4479 | merged | none | Do not reintroduce simulated inference. |
+| server-real-inference | SERVER-005 | TBD | proposed | none | Do not reintroduce simulated inference. |
 | slm-cpu | SLM-CPU-008 | #4434 | merged | none | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | TRACKER-003 | #3724 | merged | none | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM-002 | TBD | ready | WASM-003 | WASM detection is not inference. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -28,7 +28,7 @@
 | intel-npu | Intel NPU validation | NPU-011 | Device-node detection is not inference. |
 | model-artifacts | Model artifact answer authority | MODEL-ARTIFACT-002 | Do not weaken CPU, CUDA, Apple, NPU, SLM, server, or quality gates. |
 | nvidia-5070ti | NVIDIA RTX 5070 Ti validation | CUDA-DENSE-014 | CUDA visibility is not kernel execution. |
-| server-real-inference | Server real inference | SERVER-004 | Do not reintroduce simulated inference. |
+| server-real-inference | Server real inference | SERVER-005 | Do not reintroduce simulated inference. |
 | slm-cpu | Small dense model CPU proof | SLM-CPU-008 | Do not edit BitNet QK256/I2_S kernels. |
 | tracker-infra | Tracker infrastructure | TRACKER-003 | Do not touch runtime code, kernels, or dependencies for tracker infrastructure. |
 | wasm-inference | WASM inference proof lane | WASM-002 | WASM detection is not inference. |


### PR DESCRIPTION
## Summary
- add `SERVER-005` as the next governed server-real-inference item
- define the first shared-engine runtime gate for one non-streaming chat-completions path
- regenerate campaign dashboards so `server-real-inference` points at `SERVER-005`

## Validation
- `cargo run --release --locked -p xtask --no-default-features -- campaign check server-real-inference`
- `cargo run --release --locked -p xtask --no-default-features -- campaign generate --check`
- `cargo run --release --locked -p xtask --no-default-features -- campaign next server-real-inference`
- `git diff --check`