### PR TITLE
docs(agent): clarify autonomous merge authority

### DIFF
--- a/.claude/agents2/pr-finalize.md
+++ b/.claude/agents2/pr-finalize.md
@@ -12,9 +12,10 @@ You are the PR Finalize Agent, an expert merge coordinator for BitNet-rs. This a
 Campaign work item policy is authoritative. For items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
-`human_gate = "on_blocker_only"`, commit, push, PR creation, and merge are agent
-responsibilities, not human gates. Human involvement is required only for true
-blockers: permissions or branch protection, destructive data loss or
+`human_gate = "on_blocker_only"`, edit, validate, commit, push, PR creation or
+updates, CI/bot/reviewer repair, merge, and required tracker closeout PRs are
+agent responsibilities, not human gates. Human involvement is required only for
+true blockers: permissions or branch protection, destructive data loss or
 secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
 semantic conflict, acceptance criteria conflicting with repository policy, or a
 cost/exposure/release decision outside the ticket scope.

--- a/.claude/agents2/pr-merge-executor.md
+++ b/.claude/agents2/pr-merge-executor.md
@@ -10,10 +10,11 @@ You are the PR Merge Executor, a critical safety-focused agent responsible for e
 Campaign work item policy is authoritative. For items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
-`human_gate = "on_blocker_only"`, the merge boundary is not a human gate. Merge
-when required checks are green and GitHub reports the PR mergeable. Escalate
-only true blockers: permissions or branch protection, destructive data loss or
-secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
+`human_gate = "on_blocker_only"`, the commit, push, PR, CI/bot repair, merge,
+and tracker closeout boundaries are not human gates. Merge when required checks
+are green and GitHub reports the PR mergeable, then perform required closeout.
+Escalate only true blockers: permissions or branch protection, destructive data
+loss or secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
 semantic conflict, acceptance criteria conflicting with repository policy, or a
 cost/exposure/release decision outside the ticket scope.
 

--- a/.claude/agents2/pr-merger.md
+++ b/.claude/agents2/pr-merger.md
@@ -11,13 +11,14 @@ Campaign work item policy is authoritative. For work items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
 `human_gate = "on_blocker_only"`, you are authorized and expected to commit,
-push, open or update the PR, address CI/bot/reviewer feedback, and merge when
-checks are green and GitHub reports the PR mergeable. Do not treat commit, push,
-PR creation, or merge as human approval gates. Escalate only true blockers:
+push, open or update the PR, address CI/bot/reviewer feedback, merge when checks
+are green and GitHub reports the PR mergeable, and create or merge required
+tracker closeout PRs. Do not treat commit, push, PR creation, CI/bot repair,
+merge, or tracker closeout as human approval gates. Escalate only true blockers:
 permissions or branch protection, destructive data loss or secret/model-binary
 exposure risk, unresolved kernel/math/tokenizer/loader semantic conflict,
-acceptance criteria conflicting with repository policy, or a cost/exposure/release
-decision outside the ticket scope.
+acceptance criteria conflicting with repository policy, or a
+cost/exposure/release decision outside the ticket scope.
 
 **Your Core Responsibilities:**
 

--- a/.claude/agents3/integration/pr-merger.md
+++ b/.claude/agents3/integration/pr-merger.md
@@ -10,12 +10,14 @@ You are the PR Merge Operator for BitNet-rs, a specialized agent responsible for
 Campaign work item policy is authoritative. For items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
-`human_gate = "on_blocker_only"`, the agent is authorized and expected to merge
-when required checks are green and GitHub reports the PR mergeable. Do not treat
-commit, push, PR creation, or merge as human approval gates. Escalate only true
-blockers: permissions or branch protection, destructive data loss or
-secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
-semantic conflict, acceptance criteria conflicting with repository policy, or a
+`human_gate = "on_blocker_only"`, the agent is authorized and expected to commit,
+push, open or update the PR, repair CI/bot/reviewer feedback, merge when required
+checks are green and GitHub reports the PR mergeable, and perform required
+tracker closeout. Do not treat commit, push, PR creation, CI/bot repair, merge,
+or tracker closeout as human approval gates. Escalate only true blockers:
+permissions or branch protection, destructive data loss or secret/model-binary
+exposure risk, unresolved kernel/math/tokenizer/loader semantic conflict,
+acceptance criteria conflicting with repository policy, or a
 cost/exposure/release decision outside the ticket scope.
 
 **Core Responsibilities:**

--- a/.claude/agents4/integration/pr-merger.md
+++ b/.claude/agents4/integration/pr-merger.md
@@ -10,12 +10,14 @@ You are the PR Merge Operator for BitNet-rs, the final safety gate in the Integr
 Campaign work item policy is authoritative. For items with
 `review_mode = "codex_premerge"`,
 `merge_policy = "automerge_when_green"`, and
-`human_gate = "on_blocker_only"`, the agent is authorized and expected to merge
-when required checks are green and GitHub reports the PR mergeable. Do not treat
-commit, push, PR creation, or merge as human approval gates. Escalate only true
-blockers: permissions or branch protection, destructive data loss or
-secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
-semantic conflict, acceptance criteria conflicting with repository policy, or a
+`human_gate = "on_blocker_only"`, the agent is authorized and expected to commit,
+push, open or update the PR, repair CI/bot/reviewer feedback, merge when required
+checks are green and GitHub reports the PR mergeable, and perform required
+tracker closeout. Do not treat commit, push, PR creation, CI/bot repair, merge,
+or tracker closeout as human approval gates. Escalate only true blockers:
+permissions or branch protection, destructive data loss or secret/model-binary
+exposure risk, unresolved kernel/math/tokenizer/loader semantic conflict,
+acceptance criteria conflicting with repository policy, or a
 cost/exposure/release decision outside the ticket scope.
 
 **Core Responsibilities:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,8 @@ Codex agents are authorized and expected to:
 7. merge the PR when required checks are green and GitHub reports it mergeable,
 8. create and merge closeout tracker PRs when required.
 
-Commit, push, PR creation, merge, and tracker closeout are agent
-responsibilities for those items. They are not human approval gates.
+Commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker closeout
+are agent responsibilities for those items. They are not human approval gates.
 
 ## Human Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,8 @@ Campaign work items are authoritative for review and merge flow. For items with
 `human_gate = "on_blocker_only"`, Codex agents are expected to edit, validate,
 commit, push, open or update the PR, address CI/bot/reviewer feedback, merge
 when GitHub reports the PR green and mergeable, and close out tracker PRs when
-required. Commit, push, PR creation, and merge are not human approval gates.
+required. Commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker
+closeout are not human approval gates.
 
 Human involvement is required only for true blockers: permissions or branch
 protection prevent the merge, destructive data loss or secret/model-binary

--- a/docs/GPU_DEVELOPMENT_WORKFLOW.md
+++ b/docs/GPU_DEVELOPMENT_WORKFLOW.md
@@ -42,7 +42,13 @@ CI pipeline, and review workflow for GPU backend contributions to BitNet-rs.
 
 - Open a PR following the conventions below
 - CI runs automatically; add labels for GPU-specific checks
-- Address review feedback; maintainer merges when CI is green
+- Address review feedback; for campaign work items with
+  `review_mode = "codex_premerge"`,
+  `merge_policy = "automerge_when_green"`, and
+  `human_gate = "on_blocker_only"`, the agent merges when required checks are
+  green and GitHub reports the PR mergeable. Human involvement is reserved for
+  true blockers such as permissions, branch protection, secret/model-binary
+  exposure risk, or unresolved kernel/math/tokenizer/loader conflicts.
 
 ---
 

--- a/docs/tracking/TRACKER_MODEL.md
+++ b/docs/tracking/TRACKER_MODEL.md
@@ -126,12 +126,13 @@ For work items with `review_mode = "codex_premerge"`,
 7. merge the PR when required checks are green and GitHub reports it mergeable,
 8. create and merge closeout tracker PRs when required.
 
-The commit, push, PR creation, and merge boundaries are not human gates for
-those items. Human involvement is required only for true blockers: GitHub
-permissions or branch protection preventing merge, destructive data loss or
-secret/model-binary exposure risk, unresolved kernel/math/tokenizer/loader
-semantic conflict, acceptance criteria that conflict with repo policy, or a
-cost/exposure/release decision genuinely outside the ticket scope.
+The commit, push, PR creation, CI/bot/reviewer repair, merge, and tracker
+closeout boundaries are not human gates for those items. Human involvement is
+required only for true blockers: GitHub permissions or branch protection
+preventing merge, destructive data loss or secret/model-binary exposure risk,
+unresolved kernel/math/tokenizer/loader semantic conflict, acceptance criteria
+that conflict with repo policy, or a cost/exposure/release decision genuinely
+outside the ticket scope.
 
 This campaign work item policy is the authority for campaign branches. If an
 older agent runbook describes default human approvals, maintainer-ready handoff,


### PR DESCRIPTION
## Summary

- standardize the campaign work item authority language across Codex/Claude agent merge and finalize runbooks
- make CI/bot/reviewer repair and tracker closeout explicit agent responsibilities for `codex_premerge` + `automerge_when_green` + `on_blocker_only`
- replace the stale GPU workflow line that said maintainers merge by default with the current campaign-policy merge rule

## Validation

- `git diff --check`
- `rg --hidden -n "maintainer merges|manual intervention|required reviews approved|all required reviews approved|missing approvals|commit/push boundary|push boundary" .claude/agents2 .claude/agents3 .claude/agents4 docs/GPU_DEVELOPMENT_WORKFLOW.md docs/tracking/TRACKER_MODEL.md AGENTS.md CLAUDE.md`

Docs-only policy clarification; cargo validation was not run.
