### PR TITLE
docs: refresh documentation index and update MSRV badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml/badge.svg?branch=main)](https://github.com/EffortlessMetrics/BitNet-rs/actions/workflows/ci-core.yml)
 [![Codecov](https://codecov.io/gh/EffortlessMetrics/BitNet-rs/graph/badge.svg?branch=main)](https://codecov.io/gh/EffortlessMetrics/BitNet-rs)
-[![MSRV](https://img.shields.io/badge/MSRV-1.92.0-blue.svg)](./rust-toolchain.toml)
+[![MSRV](https://img.shields.io/badge/MSRV-1.93.0-blue.svg)](./rust-toolchain.toml)
 [![Rust 2024](https://img.shields.io/badge/edition-2024-orange.svg)](./rust-toolchain.toml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](./LICENSE)
 
@@ -61,6 +61,16 @@ Backend receipts remain useful for selected-device execution, tokenizer and prom
 | Honest-compute receipts | Supported | Receipts preserve backend, runtime, fallback, kernel, and timing metadata. |
 | CLI run/chat | Diagnostic | Useful for exercising the pipeline; generated text is not yet a supported answer-quality surface. |
 | Server / HTTP API | Incomplete | Health wiring exists; inference serving is not ready. |
+
+## Requirements
+
+- Rust 1.93.0, pinned by [`rust-toolchain.toml`](rust-toolchain.toml).
+- A host with enough memory for the model artifact you are validating.
+- Optional: `cargo-nextest` for the full workspace test lane.
+- Optional: Nix for reproducible development shells and package builds.
+
+Default features are intentionally empty. Pass `--no-default-features` plus the
+backend feature you need, usually `--features cpu` for local diagnostic work.
 
 ## First Diagnostic Run
 
@@ -191,6 +201,11 @@ The repository contains unit, property, snapshot, fixture, fuzz, BDD, receipt, a
 | [docs/model-artifacts/](docs/model-artifacts/) | Model artifact status and validation. |
 | [docs/hardware/](docs/hardware/) | Hardware validation and benchmark protocol. |
 | [docs/tracking/](docs/tracking/) | Campaign state and active work. |
+
+For a fuller map, see the [documentation index](docs/README.md). Archived notes
+under `docs/archive/` and `archive/` are retained for provenance and may describe
+older targets, toolchains, or workflows. Prefer the active tutorials, how-to
+guides, reference pages, and tracking docs above for current work.
 
 ## What We Are Working On
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,94 +1,111 @@
 # BitNet-rs Documentation
 
-BitNet-rs is a Rust implementation of BitNet — Microsoft's 1-bit weight neural network inference framework.
+BitNet-rs is a pre-alpha Rust-native local model runtime and validation
+workspace for efficient language models, including dense SLMs and BitNet / 1-bit
+model families. The documentation follows the [Diátaxis](https://diataxis.fr/)
+structure so readers can choose learning-oriented tutorials, task-oriented
+how-to guides, explanation, or exact reference material.
 
-Documentation is organized using the [Diátaxis](https://diataxis.fr/) framework.
+> [!IMPORTANT]
+> Generated BitNet text is still a diagnostic surface, not a supported
+> answer-quality claim. Treat receipts, backend identity, tokenizer checks, and
+> parity evidence as validation artifacts; they do not by themselves prove that a
+> generated answer is production-ready.
 
----
+## Choose Your Path
 
-## [Tutorials](tutorials/) — learning by doing
+| If you want to... | Start with... | Then read... |
+|---|---|---|
+| Understand the project status | [Repository README](../README.md) | [Answer artifact gate](model-artifacts/ANSWER_ARTIFACT_GATE.md) |
+| Run the first diagnostic generation path | [First inference tutorial](tutorials/first-inference.md) | [CLI reference](reference/inference-cli-reference.md) |
+| Validate a real model artifact | [Real GGUF model inference](tutorials/real-gguf-model-inference.md) | [Model validation workflow](howto/validate-models.md) |
+| Debug tokenizer or output quality issues | [Tokenizer auto-discovery](tutorials/tokenizer-auto-discovery.md) | [Intelligibility troubleshooting](howto/troubleshoot-intelligibility.md) |
+| Work on Rust code | [Build commands](development/build-commands.md) | [Test suite guide](development/test-suite.md) |
+| Inspect hardware/backend claims | [Hardware matrix](hardware/HARDWARE_MATRIX.md) | [Benchmark protocol](hardware/BENCHMARK_PROTOCOL.md) |
+| Check active campaign state | [Tracking docs](tracking/) | [Generated tracking state](tracking/generated/) |
 
-Step-by-step guides for getting started.
+## Active Documentation Areas
 
-- [Getting started](getting-started.md) — install, run your first model
-- [Your first inference](tutorials/first-inference.md) — load a GGUF and generate tokens
-- [Real GGUF model inference](tutorials/real-gguf-model-inference.md) — end-to-end inference walkthrough
-- [Tokenizer auto-discovery](tutorials/tokenizer-auto-discovery.md) — automatic tokenizer detection
+### Tutorials — learning by doing
 
----
+Step-by-step guides for first-time or infrequent workflows.
 
-## [How-to guides](howto/) — solve specific problems
+- [Getting started](getting-started.md) — install prerequisites and orient around the repo.
+- [Your first inference](tutorials/first-inference.md) — load a GGUF and generate diagnostic tokens.
+- [Real GGUF model inference](tutorials/real-gguf-model-inference.md) — end-to-end model walkthrough.
+- [Tokenizer auto-discovery](tutorials/tokenizer-auto-discovery.md) — automatic tokenizer detection.
 
-Task-oriented. These assume you know what you want to do.
+### How-to guides — solve a specific problem
+
+Task-oriented docs for contributors who already know their goal.
 
 | Guide | Purpose |
-|-------|---------|
-| [cpp-setup.md](howto/cpp-setup.md) | Set up C++ cross-validation reference |
-| [export-clean-gguf.md](howto/export-clean-gguf.md) | Export safe clean GGUF from SafeTensors |
-| [validate-models.md](howto/validate-models.md) | Run 3-stage model validation |
-| [use-qk256-models.md](howto/use-qk256-models.md) | Load and run QK256 format models |
-| [parity-playbook.md](howto/parity-playbook.md) | Verify Rust vs C++ numeric parity |
-| [troubleshoot-intelligibility.md](howto/troubleshoot-intelligibility.md) | Debug incoherent model output |
-| [deterministic-inference-setup.md](howto/deterministic-inference-setup.md) | Set up reproducible inference |
-| [receipt-verification.md](howto/receipt-verification.md) | Verify inference receipts |
-| [strict-mode-validation-workflows.md](howto/strict-mode-validation-workflows.md) | Use strict validation in CI |
-| [automatic-tokenizer-discovery.md](howto/automatic-tokenizer-discovery.md) | Configure tokenizer auto-detection |
-| [quantization-optimization-and-performance.md](howto/quantization-optimization-and-performance.md) | Optimize quantization performance |
+|---|---|
+| [C++ setup](howto/cpp-setup.md) | Set up the C++ cross-validation reference. |
+| [Export clean GGUF](howto/export-clean-gguf.md) | Export a safe clean GGUF from SafeTensors. |
+| [Validate models](howto/validate-models.md) | Run model validation stages and interpret failures. |
+| [Use QK256 models](howto/use-qk256-models.md) | Load and run QK256-format models. |
+| [Parity playbook](howto/parity-playbook.md) | Verify Rust vs. reference numeric parity. |
+| [Troubleshoot intelligibility](howto/troubleshoot-intelligibility.md) | Debug incoherent model output. |
+| [Deterministic inference setup](howto/deterministic-inference-setup.md) | Configure reproducible inference runs. |
+| [Receipt verification](howto/receipt-verification.md) | Inspect and verify inference receipts. |
+| [Strict-mode workflows](howto/strict-mode-validation-workflows.md) | Use strict validation in local and CI workflows. |
+| [Automatic tokenizer discovery](howto/automatic-tokenizer-discovery.md) | Configure tokenizer auto-detection. |
+| [Quantization optimization](howto/quantization-optimization-and-performance.md) | Tune quantization performance and diagnostics. |
 
----
+### Explanation — background and design context
 
-## [Explanation](explanation/) — background and concepts
-
-Understanding-oriented. These explain *why* things work the way they do.
+Conceptual material for understanding why the system is structured as it is.
 
 | Topic | Description |
-|-------|-------------|
-| [adr/README.md](adr/README.md) | Architectural Decision Records |
-| [architecture-overview.md](architecture-overview.md) | System components and design principles |
-| [explanation/FEATURES.md](explanation/FEATURES.md) | Feature flag system |
-| [explanation/dual-backend-crossval.md](explanation/dual-backend-crossval.md) | Dual-backend cross-validation design |
-| [explanation/i2s-dual-flavor.md](explanation/i2s-dual-flavor.md) | I2_S quantization flavor auto-detection |
-| [explanation/correction-policy.md](explanation/correction-policy.md) | Model-specific correction policies |
-| [explanation/cpu-inference-architecture.md](explanation/cpu-inference-architecture.md) | CPU inference pipeline |
-| [explanation/device-feature-detection.md](explanation/device-feature-detection.md) | Runtime device/capability detection |
-| [explanation/backend-detection-and-device-selection-patterns.md](explanation/backend-detection-and-device-selection-patterns.md) | Backend selection patterns |
-| [gpu-kernel-architecture.md](gpu-kernel-architecture.md) | CUDA kernel design |
-| [tokenizer-architecture.md](tokenizer-architecture.md) | Universal tokenizer system |
+|---|---|
+| [Architecture overview](architecture-overview.md) | System components and design principles. |
+| [Architectural decision records](adr/README.md) | Accepted design decisions and rationale. |
+| [Feature flags](explanation/FEATURES.md) | Feature flag strategy and backend predicates. |
+| [Dual-backend cross-validation](explanation/dual-backend-crossval.md) | Reference comparison design. |
+| [I2_S dual flavor detection](explanation/i2s-dual-flavor.md) | I2_S quantization flavor auto-detection. |
+| [Correction policy](explanation/correction-policy.md) | Model-specific correction policies. |
+| [CPU inference architecture](explanation/cpu-inference-architecture.md) | CPU inference pipeline. |
+| [Device feature detection](explanation/device-feature-detection.md) | Runtime device and capability detection. |
+| [Backend selection patterns](explanation/backend-detection-and-device-selection-patterns.md) | Backend selection and fallback patterns. |
+| [GPU kernel architecture](gpu-kernel-architecture.md) | CUDA kernel design notes. |
+| [Tokenizer architecture](tokenizer-architecture.md) | Universal tokenizer system. |
 
----
+### Reference — exact commands, schemas, and contracts
 
-## [Reference](reference/) — technical specifications
-
-Information-oriented. Look up exact behaviors, formats, and APIs.
+Information-oriented pages for looking up behavior rather than learning a flow.
 
 | Document | Contents |
-|----------|---------|
-| [reference/quantization-support.md](reference/quantization-support.md) | All supported quantization formats |
-| [reference/validation-gates.md](reference/validation-gates.md) | Validation system gates and thresholds |
-| [environment-variables.md](environment-variables.md) | All runtime configuration env vars |
-| [reference/api-reference.md](reference/api-reference.md) | Public API contracts |
-| [reference/strict-mode-api.md](reference/strict-mode-api.md) | Strict mode behavior |
-| [api/README.md](api/README.md) | Generated API snapshots and contract baselines |
-| [bitnet/BITNET_CPU_PATH_PLAN.md](bitnet/BITNET_CPU_PATH_PLAN.md) | CPU GGUF/tokenizer/layout/kernel roadmap and strict receipt contract |
-| [specs/intel-lunar-lake-258v-buildout-plan.md](specs/intel-lunar-lake-258v-buildout-plan.md) | Lunar Lake 258V CPU validation, Arc 140V, NPU identity, platform probe, and receipt buildout plan |
+|---|---|
+| [Inference CLI reference](reference/inference-cli-reference.md) | CLI flags and receipt options. |
+| [Quantization support](reference/quantization-support.md) | Supported quantization formats. |
+| [Validation gates](reference/validation-gates.md) | Validation gates and thresholds. |
+| [Environment variables](environment-variables.md) | Runtime configuration environment variables. |
+| [API reference](reference/api-reference.md) | Public API contracts. |
+| [Strict-mode API](reference/strict-mode-api.md) | Strict-mode behavior. |
+| [API snapshots](api/README.md) | Generated API snapshots and contract baselines. |
+| [BitNet CPU path plan](bitnet/BITNET_CPU_PATH_PLAN.md) | CPU GGUF/tokenizer/layout/kernel roadmap and strict receipt contract. |
+| [Lunar Lake 258V buildout plan](specs/intel-lunar-lake-258v-buildout-plan.md) | Intel 258V, Arc 140V, NPU, platform probe, and receipt plan. |
 
----
+### Development
 
-## Development
+Contributor-oriented commands, policies, and validation references.
 
 | Document | Purpose |
-|----------|---------|
-| [development/build-commands.md](development/build-commands.md) | Build matrix and cargo commands |
-| [development/CRATE_BOUNDARY_POLICY.md](development/CRATE_BOUNDARY_POLICY.md) | Rules for deciding when a design seam deserves a Cargo package boundary |
-| [development/REPO_SURFACES.md](development/REPO_SURFACES.md) | Target public crate surface, internal module-family map, and collapse waves |
-| [development/test-suite.md](development/test-suite.md) | Test organization and CI lanes |
-| [development/gpu-development.md](development/gpu-development.md) | CUDA development guide |
-| [development/validation-framework.md](development/validation-framework.md) | Quality assurance pipeline |
-| [development/xtask.md](development/xtask.md) | Developer tooling reference |
-| [performance-benchmarking.md](performance-benchmarking.md) | Benchmarking setup and baselines |
+|---|---|
+| [Build commands](development/build-commands.md) | Build matrix and Cargo commands. |
+| [Crate boundary policy](development/CRATE_BOUNDARY_POLICY.md) | Rules for Cargo package boundaries. |
+| [Repository surfaces](development/REPO_SURFACES.md) | Public crate surface and internal module-family map. |
+| [Test suite](development/test-suite.md) | Test organization and CI lanes. |
+| [GPU development](development/gpu-development.md) | CUDA development guide. |
+| [Validation framework](development/validation-framework.md) | Quality assurance pipeline. |
+| [xtask reference](development/xtask.md) | Developer tooling reference. |
+| [Performance benchmarking](performance-benchmarking.md) | Benchmark setup and baselines. |
 
----
+## Archive Policy
 
-## Archive
-
-Historical sprint notes, issue analysis documents, and implementation plans are preserved in [`archive/`](archive/) but are not maintained.
+Historical sprint notes, issue analysis documents, and implementation plans are
+preserved in [`docs/archive/`](archive/) and [`archive/`](../archive/) for
+provenance. They are not maintained as current guidance and may refer to older
+MSRVs, status claims, command names, or acceptance criteria. When an archived
+page conflicts with an active page, prefer the active page.


### PR DESCRIPTION
### Motivation

- Align the README with the pinned toolchain and make entrypoint guidance clearer for contributors. 
- Provide a reader-friendly documentation index so new and returning contributors can find tutorials, how-tos, reference, and development guidance quickly. 

### Description

- Updated the MSRV badge in `README.md` from `1.92.0` to `1.93.0` and added a new `Requirements` section clarifying the pinned toolchain and feature-flag expectations. 
- Added a pointer in `README.md` to the fuller documentation index and clarified that archived pages are provenance artifacts, not the active guidance. 
- Rewrote `docs/README.md` to add a pre-alpha warning, an explicit “Choose Your Path” table for common reader goals, reorganized active documentation areas (tutorials, how-to, explanation, reference, development), and added an `Archive Policy` section. 
- Files changed: `README.md`, `docs/README.md`.

### Testing

- Ran `git diff --check` which completed with no issues. 
- Executed a local markdown link existence check via a small Python script to validate that internal links in `README.md` and `docs/README.md` point to existing local files, and the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02815b4cbc8333b2fa9bf1ee8a772b)