### PR TITLE
docs(policy): refresh Rust 1.95 and next-minor rollout map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,21 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ### Rust 1.95 / Next Minor CI Economics Continuation (planned)
 
-- policy: map Rust 1.95 CI economics and strict Clippy continuation — `docs/development/RUST_1_95_ROLLOUT.md`
-  - Continuation of #3866 CI economics control plane; rebuilds closed #4136 against current `main`.
-  - Planned 17-PR ladder: compatibility spike → MSRV bump → rustc lint floor →
-    Clippy 1.95 ratchets → remove test carveouts → exact no-panic identity →
-    no-new-debt baseline → no-panic diagnostics → file-policy tightening →
-    real `ripr` advisory → targeted 1.95 API cleanup → numeric/kernel lint cleanup →
-    no-panic owner-lane burndown → LEM/risk-pack tightening →
-    next-minor release prep → release dry-run proof.
-  - Goal: better-shaped CI per PR (cheaper lane selection, clearer risk-pack routing,
-    `ripr` advisory evidence, stricter Clippy receipts, less per-PR churn).
+- docs(policy): refresh Rust 1.95 and next-minor rollout map — `docs/development/RUST_1_95_ROLLOUT.md`
+  - Continuation of #3866 CI economics control plane; refreshes the existing Rust 1.95
+    rollout map against current `main` instead of starting from a blank template.
+  - Corrected doctrine: `ripr` is static mutation-exposure analysis. It catches much
+    of the same weak test/oracle exposure signal mutation testing catches, but earlier
+    and cheaper; mutation testing remains the runtime empirical backstop.
+  - Planned 17-PR ladder: compatibility spike -> MSRV bump -> rustc lint floor ->
+    Clippy 1.95 ratchets -> remove test carveouts -> exact no-panic identity ->
+    no-new-debt baseline -> no-panic diagnostics -> file-policy tightening ->
+    real `ripr` advisory -> targeted 1.95 API cleanup -> numeric/kernel lint cleanup ->
+    no-panic owner-lane burndown -> LEM/risk-pack tightening ->
+    next-minor release prep -> release dry-run proof.
+  - Goal: better-shaped CI per PR: cheaper lane selection, clearer risk-pack routing,
+    `ripr` static mutation-exposure evidence, stricter Clippy receipts, and targeted
+    mutation where owner risk justifies the runtime cost.
   - Raising MSRV from 1.93.0 to 1.95.0 accompanies a minor version bump
     (MSRV change is a user-visible build-requirement break under semver). The
     exact version and tag are finalized in the release-prep PR because this
@@ -1153,4 +1158,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic BitNet model loading and inference
 - CPU-only quantization support
 - Core API design and architecture
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,40 @@ Essential guidance for working with the bitnet-rs codebase.
 
 - **Name:** bitnet-rs — 1-bit LLM inference engine in Rust
 - **Version:** v0.2.1-dev (pre-alpha)
-- **MSRV: 1.93.0 (Rust 2024 edition, pinned in `rust-toolchain.toml`)
+- **MSRV:** 1.93.0 (Rust 2024 edition, pinned in `rust-toolchain.toml`)
 - **Status:** CPU inference works with SIMD optimization. GPU backends are scaffolded but not validated. Do not use in production.
+
+## Rust 1.95 Rollout Rails
+
+The Rust 1.95 / next minor rollout is a continuation of the Rust 1.93 CI
+economics control plane, not a new rollout from scratch. Start each rollout PR
+from clean `origin/main`, keep one PR per objective, open draft PRs first, and
+do not combine MSRV bump, lint activation, no-panic baseline, release bump, or
+API cleanup.
+
+Critical doctrine:
+
+```text
+ripr is static mutation-exposure analysis.
+
+It catches much of the same signal mutation testing catches -- weak test/oracle
+exposure -- but earlier and cheaper, because it runs statically and can run
+per PR.
+
+Mutation testing remains the runtime empirical backstop, especially for
+nightly and release readiness. The CI design should use ripr to shift
+mutation signal left, not to pretend mutation is unnecessary.
+```
+
+First PR is documentation-only:
+
+```text
+docs/rust-1.95-rollout-refresh
+docs(policy): refresh Rust 1.95 and next-minor rollout map
+```
+
+Roadmap and acceptance gates live in
+`docs/development/RUST_1_95_ROLLOUT.md`.
 
 ## Build and Test
 

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -110,6 +110,11 @@ The following changes are planned as part of the Rust 1.95 / next minor wave.
 See `docs/development/RUST_1_95_ROLLOUT.md` for the full PR ladder and
 CI economics framing.
 
+Current `main` still has `clippy.toml` pinned to `msrv = "1.93.0"` and keeps
+the temporary test unwrap/expect carveouts. `policy/clippy-lints.toml` already
+stages Rust 1.94/1.95 lints; the rollout moves from staged policy to measured
+activation after the Rust 1.95 compatibility probe and MSRV bump.
+
 ### Lint ratchets (PR 5)
 
 The lints staged in `policy/clippy-lints.toml` for MSRV 1.95 will be
@@ -118,6 +123,8 @@ promoted to `[workspace.lints.clippy]`:
 | Lint | Level | Reason |
 |---|---|---|
 | `same_length_and_capacity` | `deny` | Catch raw-parts reconstruction mistakes (also staged at 1.94) |
+| `manual_ilog2` | `warn` | Prefer standard integer log helper (also staged at 1.94) |
+| `decimal_bitwise_operands` | `warn` | Make bit masks visually inspectable (also staged at 1.94) |
 | `manual_checked_ops` | `warn` | Prefer checked arithmetic over manual divide-by-zero guards |
 | `manual_take` | `warn` | Use standard ownership helper instead of local reimplementation |
 | `manual_pop_if` | `warn` | Use collection APIs that encode predicate-and-pop intent |
@@ -125,8 +132,11 @@ promoted to `[workspace.lints.clippy]`:
 | `needless_type_cast` | `warn` | Avoid stale numeric type drift (also staged at 1.94) |
 | `unnecessary_trailing_comma` | `warn` | Keep format macro calls clean |
 
-Lints are only promoted after a clean measurement pass confirms zero or
-cheap-to-fix violations in the workspace.
+Lints are only promoted after a measurement pass confirms zero or cheap-to-fix
+violations in the workspace. Because CI Core uses `RUSTFLAGS = "-Dwarnings"`
+and Clippy with `-D warnings`, warning-level Clippy lints can still behave as
+hard failures in default lanes. If measurement finds hits, PR 5 either fixes
+them in scope or keeps the lint staged with a real debt entry.
 
 ### `disallowed_fields` (PR 5 prerequisite)
 

--- a/docs/FILE_POLICY.md
+++ b/docs/FILE_POLICY.md
@@ -92,6 +92,12 @@ The following changes are planned as part of the Rust 1.95 / next minor wave.
 See `docs/development/RUST_1_95_ROLLOUT.md` for the full PR ladder and
 CI economics framing.
 
+Current `main` has a broad but structured non-Rust allowlist. Legitimate
+surfaces include GitHub workflows, docs, policy ledgers, GPU shaders, FFI,
+Python/WASM bindings, runtime config, tooling, fixtures, snapshots, and
+archives. The Rust 1.95 wave tightens this existing ledger; it does not add a
+new broad allowlist layer.
+
 ### Allowlist tightening (PR 10)
 
 PR 10 reviews the current `policy/non-rust-allowlist.toml` and:
@@ -109,6 +115,8 @@ The following constraints apply to PR 10:
 * No broad catch-all globs added.
 * Checker policy is not weakened.
 * Production GPU/FFI code is not reclassified as docs or tooling.
+* Process and network behavior stays in companion policies rather than being
+  buried inside broad non-Rust file allowances.
 
 ### Non-Rust surfaces that must remain explicit
 

--- a/docs/NO_PANIC_POLICY.md
+++ b/docs/NO_PANIC_POLICY.md
@@ -97,6 +97,11 @@ The following changes are planned as part of the Rust 1.95 / next minor wave.
 See `docs/development/RUST_1_95_ROLLOUT.md` for the full PR ladder and
 CI economics framing.
 
+Current `main` has the no-panic allowlist present but intentionally empty and
+advisory-style. There is no generated `policy/no-panic-baseline.toml` yet. The
+Rust 1.95 wave hardens identity first, then generates the baseline and switches
+to no-new-debt mode.
+
 ### Identity hardening (PR 7)
 
 Current allowlist identity is `path + family + selector`. Before bulk baseline
@@ -126,6 +131,7 @@ Required tests before PR 7 merges:
 allowlist_entry_requires_exact_snippet
 allowlist_count_is_consumed_per_occurrence
 allowlist_does_not_cover_same_file_same_callee_different_snippet
+baseline_generation_subtracts_allowlisted_counts
 duplicate_allowlist_keys_are_rejected
 blocking_mode_ignores_baseline_but_honors_counted_allowlist
 ```

--- a/docs/POLICY_ALLOWLISTS.md
+++ b/docs/POLICY_ALLOWLISTS.md
@@ -11,8 +11,26 @@ which `xtask` command checks it.
 | `policy/clippy-exceptions.toml`       | Receipted `#[expect(clippy::...)]` exceptions          | `xtask check-clippy-exceptions`       | core/rust      |
 | `policy/clippy-debt.toml`             | Crate/path-scoped Clippy debt blocking promotion       | `xtask check-clippy-exceptions`       | core/rust      |
 | `policy/no-panic-allowlist.toml`      | Receipted panic-family exceptions                      | `xtask check-no-panic-family`         | testing/policy |
+| `policy/no-panic-baseline.toml`       | Generated no-panic no-new-debt baseline (planned)      | `xtask check-no-panic-family`         | testing/policy |
 | `policy/non-rust-allowlist.toml`      | Allowlisted non-Rust files (with owner / reason)       | `xtask check-file-policy`             | release/ci     |
-| `policy/ripr-suppressions.toml`       | Suppressed `ripr` findings (PR 13)                     | (advisory)                            | testing/oracle |
+| `policy/ripr-suppressions.toml`       | Suppressed `ripr` static mutation-exposure findings    | (advisory)                            | testing/oracle |
+
+`policy/no-panic-baseline.toml` is intentionally absent before PR 8 of the
+Rust 1.95 wave. It is listed here as a planned ledger so agents do not create a
+baseline before exact counted identity lands in PR 7.
+
+## Rust 1.95 planned changes
+
+The Rust 1.95 / next minor rollout keeps these ledgers as the control plane and
+tightens them in order:
+
+1. Clippy lints move from staged policy to measured activation.
+2. Clippy test unwrap/expect carveouts are removed.
+3. No-panic allowlist identity becomes exact and counted.
+4. A generated no-new-debt baseline is added after identity hardening.
+5. The non-Rust allowlist is narrowed without adding broad catch-alls.
+6. `ripr` becomes real advisory static mutation-exposure analysis, while
+   mutation testing remains the runtime backstop.
 
 ## Receipt expiry
 

--- a/docs/RIPR_EVIDENCE_POLICY.md
+++ b/docs/RIPR_EVIDENCE_POLICY.md
@@ -1,13 +1,17 @@
 # `ripr` Evidence Policy
 
-`ripr` is a static oracle-gap analyzer. It asks:
+`ripr` is static mutation-exposure analysis. It asks:
 
 > Does the changed Rust behavior appear gripped by a meaningful test
 > discriminator?
 
-It is **mutation-testing-lite, run at static-analysis prices**. It
-does not run mutants, does not report `killed`/`survived`, and does
-not replace mutation testing.
+It catches much of the same signal mutation testing catches -- weak
+test/oracle exposure -- but earlier and cheaper, because it runs statically and
+can run per PR.
+
+Mutation testing remains the runtime empirical backstop, especially for nightly
+and release readiness. The CI design uses `ripr` to shift mutation signal left,
+not to pretend mutation is unnecessary. See also `docs/ci/ripr.md`.
 
 ## What ripr produces
 
@@ -34,10 +38,10 @@ PR 13 ships ripr **advisory only**. The workflow at
 * writes a step summary;
 * exits 0 regardless of finding severity.
 
-The `ripr` binary is expected to be provisioned on the runner image
-(or installed by a future PR). When it is missing, the workflow
-records that fact in the step summary and still exits 0 — the
-advisory posture means "report what you can; never block merge".
+The Rust 1.95 rollout changes this from "binary may be absent" to "install and
+run `ripr` consistently." When analysis is skipped by policy or cannot run, the
+workflow records that fact in the step summary. Skipped analysis must not be
+reported as passed proof.
 
 ## Why advisory first
 
@@ -63,8 +67,8 @@ advisory posture means "report what you can; never block merge".
 
 ## What ripr is not
 
-* Not a substitute for mutation testing (which still runs in nightly
-  / labeled lanes).
+* Not a substitute for mutation testing (which still runs for targeted risk
+  PRs, nightly, and release readiness).
 * Not a coverage report.
 * Not a code reviewer — its annotations are inputs for review, not
   decisions.
@@ -88,5 +92,6 @@ have an owner, a reason, and an expiry.
 
 ## Toolchain dependency
 
-`ripr` requires Rust `1.93` or newer; PR 03 of this rollout bumped
-the workspace MSRV to 1.93.0, so the prerequisite is in place.
+`ripr` requires Rust `1.93` or newer. The current workspace MSRV is 1.93.0; the
+Rust 1.95 / next minor rollout raises the workspace floor to 1.95.0 before the
+real advisory `ripr` provisioning PR.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -108,7 +108,7 @@ That means we can run deep checks without needing every ordinary PR to
 download models, build external C++ references, start Docker images,
 provision macOS runners, or touch live hardware.
 
-### ripr is mutation-testing-lite at static-analysis prices
+### ripr shifts mutation signal left
 
 The CI design principles in this document are adapted from the
 [ripr](https://github.com/EffortlessMetrics/ripr) project, which we also use
@@ -123,14 +123,16 @@ sit at different points on the cost curve:
 coverage:
   cheap, but often too weak as an oracle signal
 ripr:
-  mutation-testing-shaped static exposure signal
+  static mutation-exposure signal
 mutation testing:
   strong runtime confirmation, but expensive
 ```
 
-`ripr` is the middle layer. It analyzes the diff, builds mutation-shaped
-static probes, and asks whether the changed behavior appears exposed to a
-meaningful test discriminator. The PR-time question it answers is:
+`ripr` is static mutation-exposure analysis. It catches much of the same signal
+mutation testing catches -- weak test/oracle exposure -- but earlier and
+cheaper, because it runs statically and can run per PR.
+
+The PR-time question it answers is:
 
 > For the behavior changed in this diff, do the current tests appear to
 > contain a discriminator that would notice if that behavior were wrong?
@@ -140,8 +142,8 @@ targeted, and cheap enough to run while a PR is still being drafted.
 
 `ripr` does **not** run mutants, does **not** report `killed` / `survived`
 outcomes, and does **not** replace execution-backed mutation testing. It
-*shifts mutation-testing-shaped feedback earlier and cheaper*. Full mutation
-testing remains valuable for calibration, nightly, and high-risk changes.
+shifts mutation signal left. Mutation testing remains the runtime empirical
+backstop, especially for targeted risk PRs, nightly, and release readiness.
 
 ### The verification ladder
 
@@ -149,7 +151,7 @@ testing remains valuable for calibration, nightly, and high-risk changes.
 | -------------------------------------- | ----------: | ---------------------------------------- |
 | `cargo check` / clippy                 |         low | type / lint correctness                  |
 | unit / oracle tests                    |         low | deterministic behavior proof             |
-| `ripr`                                 |  low-medium | static mutation-shaped oracle-gap signal |
+| `ripr`                                 |  low-medium | static mutation-exposure signal |
 | property tests                         |      medium | bounded-input confidence                 |
 | coverage                               | medium-high | execution surface                        |
 | mutation testing                       |        high | runtime adequacy confirmation            |
@@ -383,5 +385,5 @@ after-the-fact billing concerns. The test rig is part of the machine.
 - [PR Plan workflow](../../.github/workflows/pr-plan.yml) — advisory per-PR
   Linux-equivalent-minute (LEM) estimate posted to the run summary.
 - [ripr](https://github.com/EffortlessMetrics/ripr) — source of the CI
-  design principles used here, and the mutation-testing-lite tooling that
+  design principles used here, and the static mutation-exposure tooling that
   makes this verification ladder economically viable.

--- a/docs/ci/pr-gate-success.md
+++ b/docs/ci/pr-gate-success.md
@@ -26,7 +26,7 @@ default-PR lanes that this rollout treats as authoritative:
 
 Lanes that are **not** required by `PR Gate Success`:
 
-* `ripr static exposure` (advisory only)
+* `ripr static exposure` (advisory static mutation-exposure analysis)
 * All macOS / GPU / Docker / Coverage / Crossval / Property /
   Model-validation lanes (label- or path-gated; opting in is the
   PR author's decision)

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -1,0 +1,119 @@
+# ripr Static Mutation-Exposure Analysis
+
+`ripr` is static mutation-exposure analysis.
+
+It catches much of the same signal mutation testing catches -- weak test/oracle
+exposure -- but earlier and cheaper, because it runs statically and can run per
+PR.
+
+Mutation testing remains the runtime empirical backstop, especially for nightly
+and release readiness. The CI design uses `ripr` to shift mutation signal left,
+not to pretend mutation is unnecessary.
+
+## Evidence Stack
+
+```text
+Default PR:
+  ripr + normal gates + policy checks
+
+Risk PR:
+  ripr + targeted mutation for touched high-risk owner surfaces
+
+Nightly:
+  broader mutation matrix
+
+Release:
+  mutation/readiness clean enough to ship
+```
+
+This is one verification stack with multiple cost tiers. `ripr` and mutation
+testing are not unrelated parallel lanes.
+
+## Current State
+
+The repo already has:
+
+- `.github/workflows/ripr.yml`,
+- `ripr.toml`,
+- `policy/ripr-suppressions.toml`,
+- `ripr-advisory` in `policy/ci-lane-whitelist.toml`.
+
+The current workflow may record a no-op when the `ripr` binary is not present
+on the runner. That is acceptable for the Rust 1.93 control plane, but it is
+not the Rust 1.95 target state.
+
+## Rust 1.95 Target State
+
+PR 11 (`ci/ripr-real-advisory`) provisions and runs `ripr` consistently:
+
+```yaml
+- name: Install ripr
+  run: cargo install ripr --locked
+
+- name: Run ripr doctor
+  run: ripr doctor || true
+
+- name: Run ripr check
+  run: |
+    mkdir -p target/ripr
+    ripr check \
+      --base "origin/${{ github.base_ref }}" \
+      --json target/ripr/ripr.json \
+      --sarif target/ripr/ripr.sarif \
+      --markdown target/ripr/ripr.md \
+      --config ripr.toml || true
+```
+
+The job remains advisory in this wave:
+
+- it may annotate or summarize findings,
+- it must upload JSON/SARIF/Markdown evidence when available,
+- it must not become a branch-protection blocker yet,
+- it must not be used as an excuse to remove mutation testing.
+
+Use synchronize-only cancellation:
+
+```yaml
+cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+```
+
+## Outputs
+
+Expected artifacts:
+
+```text
+target/ripr/ripr.json
+target/ripr/ripr.sarif
+target/ripr/ripr.md
+```
+
+The PR summary should make clear whether `ripr` ran, skipped by policy, or was
+unavailable. Skipped analysis must not be presented as a passed proof.
+
+## Suppressions
+
+Known acceptable findings belong in `policy/ripr-suppressions.toml`. Each
+suppression must include:
+
+```toml
+[[suppress]]
+id = "ripr-0001"
+path = "crates/example/src/lib.rs"
+finding = "reachable_unrevealed"
+owner = "core/runtime"
+reason = "Reachable only through dyn dispatch; covered by integration test foo."
+expires = "2026-08-01"
+```
+
+Suppressions are receipts with owner, reason, and expiry. They are not
+permanent allows.
+
+## Review Questions
+
+For every `ripr` finding:
+
+1. Is changed behavior reachable from tests?
+2. Is there a meaningful discriminator, not just execution?
+3. If the static answer is unknown, is a targeted runtime check warranted?
+4. If the surface is high risk, should targeted mutation run for that owner
+   surface?

--- a/docs/ci/test-evidence-lanes.md
+++ b/docs/ci/test-evidence-lanes.md
@@ -1,0 +1,111 @@
+# Test Evidence Lanes
+
+This document maps the Rust 1.95 / next minor rollout evidence stack to CI
+lanes. It exists to keep ordinary PR validation cheap without weakening release
+proof.
+
+## Doctrine
+
+```text
+ripr is static mutation-exposure analysis.
+
+It catches much of the same signal mutation testing catches -- weak test/oracle
+exposure -- but earlier and cheaper, because it runs statically and can run
+per PR.
+
+Mutation testing remains the runtime empirical backstop, especially for
+nightly and release readiness. The CI design should use ripr to shift
+mutation signal left, not to pretend mutation is unnecessary.
+```
+
+## Lane Map
+
+| Lane | Evidence | Cost tier | Trigger |
+|---|---|---:|---|
+| Default PR | fmt, check, clippy, tests, policy checks, `ripr` static mutation-exposure analysis | low | every relevant PR |
+| Risk PR | default PR evidence plus targeted mutation for touched high-risk owner surfaces | medium-high | path, owner, or label |
+| Nightly | broader mutation matrix, deeper coverage, dogfood/report drift | high | schedule |
+| Release | publish dry-run, package list, policy status, no-panic status, Clippy status, file-policy status, `ripr` status, mutation readiness | high | release branch/tag |
+
+## Default PR
+
+Default PR lanes should answer:
+
+```text
+Did this change plausibly break the changed crate, its direct dependents, or
+the canonical CPU/default-member path?
+```
+
+Default PR evidence includes:
+
+- CI Core build/test/doc lanes,
+- Clippy on the canonical CPU surface,
+- strict policy checks,
+- file-policy and lint-inheritance checks,
+- no-panic and Clippy exception checks,
+- `ripr` static mutation-exposure analysis for relevant Rust diffs.
+
+Default PR evidence does not include broad mutation, broad hardware validation,
+or full coverage by default.
+
+## Risk PR
+
+Risk PRs add targeted runtime confirmation when the diff touches high-risk
+owner surfaces:
+
+- kernel math,
+- quantization format correctness,
+- tokenizer/model compatibility,
+- FFI and ABI boundaries,
+- GPU backends and shader surfaces,
+- authentication/request routing,
+- policy checker logic,
+- release/package metadata.
+
+Targeted mutation should be scoped to the touched owner surface. It should not
+be promoted into the default PR lane just because a narrow risk PR needed it.
+
+## Nightly
+
+Nightly lanes are the place for broad runtime confirmation:
+
+- broader mutation matrix,
+- deeper coverage,
+- long-running property/fuzz surfaces,
+- cross-validation and hardware jobs when scheduled resources are available,
+- report and policy drift detection.
+
+Nightly failures must produce actionable reports. They should not silently
+pressure ordinary PR lanes to become broader.
+
+## Release
+
+Release readiness must be clean enough to ship:
+
+- package and publish dry-run status,
+- MSRV/toolchain status,
+- policy-report status,
+- no-panic baseline/no-new-debt status,
+- Clippy ratchet status,
+- file-policy status,
+- `ripr` status,
+- mutation status,
+- GPU/FFI claim boundary,
+- known non-blockers,
+- tag procedure,
+- rollback path.
+
+## Skipped Lanes
+
+Skipped lanes must report that they were skipped by policy. They must not be
+hidden as passed proof.
+
+Use explicit language:
+
+```text
+skipped-by-policy: docs-only diff
+skipped-by-policy: no GPU-owned paths changed
+skipped-by-policy: mutation reserved for nightly unless high-risk owner surface changed
+```
+
+Do not use language that implies validation ran when it did not.

--- a/docs/development/BITNET_STRICT_POLICY_ROLLOUT.md
+++ b/docs/development/BITNET_STRICT_POLICY_ROLLOUT.md
@@ -7,7 +7,7 @@ This document describes the multi-PR rollout that brings BitNet-rs to:
 * a strict Rust policy stack (Clippy receipts, no-panic semantic
   allowlist, non-Rust file allowlist, workspace lint inheritance,
   unsafe islands)
-* `ripr` advisory static-exposure analysis on production Rust diffs
+* `ripr` advisory static mutation-exposure analysis on production Rust diffs
 * an `xtask`-driven CI control plane that emits `ci-plan.json` and
   later learns from observed actuals
 
@@ -71,11 +71,15 @@ explicit `deny` for blocking lints and `warn` for staged debt.
 
 ### `ripr` is advisory first
 
-`ripr` is the static oracle-gap layer ("does the changed behavior
-appear gripped by a meaningful test discriminator?"). It is not a
-substitute for mutation testing. PR 13 adds it as advisory JSON /
-SARIF / step-summary output. Promotion is later, after baseline
-behavior is understood.
+`ripr` is static mutation-exposure analysis. It catches much of the same
+signal mutation testing catches -- weak test/oracle exposure -- but earlier
+and cheaper, because it runs statically and can run per PR.
+
+Mutation testing remains the runtime empirical backstop, especially for
+nightly and release readiness. The CI design uses `ripr` to shift mutation
+signal left, not to pretend mutation is unnecessary. PR 13 adds it as
+advisory JSON / SARIF / step-summary output. Promotion is later, after
+baseline behavior is understood.
 
 ## Status
 
@@ -176,6 +180,8 @@ docs/development/RUST_1_95_ROLLOUT.md
 That document contains:
 
 * the CI economics control-plane intent;
+* the corrected `ripr` doctrine: static mutation-exposure analysis that shifts
+  mutation signal left while preserving runtime mutation as the backstop;
 * the current vs. target state table;
 * the PR ladder (PRs 1–17) with branch names, titles, and acceptance gates;
 * the revised ladder adjustment notes;

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -1,122 +1,145 @@
 # BitNet-rs Rust 1.95 / Next Minor CI Economics Continuation
 
 This document is the control map for the Rust 1.95 / next minor quality wave.
-It is the direct continuation of #3866 (Rust 1.93 CI economics control plane),
-not a speculative rollout.
+It continues the Rust 1.93 CI economics control plane from #3866. It is not a
+new rollout template and it does not reopen already-landed policy machinery.
 
 Reading this document first prevents agents from:
 
-- redoing already-landed #3866 work,
-- mixing MSRV bump + lint activation + release bump in one PR,
-- broadening default CI lanes under pressure,
-- hiding policy debt inside unrelated cleanups.
+- redoing #3866 control-plane work,
+- mixing MSRV bump, lint activation, no-panic baseline, release bump, and API
+  cleanup in one PR,
+- broadening ordinary PR CI under pressure,
+- treating `ripr` and mutation testing as unrelated proof families,
+- hiding policy debt inside unrelated cleanup.
 
-## Control-plane intent
+## Corrected Doctrine
 
-The Rust 1.95 wave is a CI economics continuation.
-The goal is not to make every PR run more checks. The goal is to make each PR
-run a better-shaped set of checks:
+Use this doctrine in docs, PR bodies, and Claude-facing instructions:
 
-- cheaper default lane selection,
-- clearer risk-pack routing,
-- advisory static-exposure evidence from `ripr`,
-- stricter Clippy receipts for intentional exceptions,
-- less mutation-testing-style per-PR churn,
-- no hidden broadening under CI pressure.
+```text
+ripr is static mutation-exposure analysis.
 
-## Relationship to #3866
+It catches much of the same signal mutation testing catches -- weak test/oracle
+exposure -- but earlier and cheaper, because it runs statically and can run
+per PR.
+
+Mutation testing remains the runtime empirical backstop, especially for
+nightly and release readiness. The CI design should use ripr to shift
+mutation signal left, not to pretend mutation is unnecessary.
+```
+
+For BitNet-rs, that maps to this evidence stack:
+
+```text
+Default PR:
+  ripr + normal gates + policy checks
+
+Risk PR:
+  ripr + targeted mutation for touched high-risk owner surfaces
+
+Nightly:
+  broader mutation matrix
+
+Release:
+  mutation/readiness clean enough to ship
+```
+
+The point is CI economics, not weaker proof. At industrialized PR volume,
+verification cost can dominate LLM cost. Small per-PR lane choices compound, so
+the architecture must make high-signal checks cheap and frequent while routing
+expensive runtime confirmation only where it buys signal.
+
+## Relationship To #3866
 
 PR #3866 established the Rust 1.93 CI economics control plane:
 
-- MSRV 1.93.0
-- CI lane whitelist and LEM-aware budgets
-- Policy workflow (CI lane, file-policy, lint-inheritance, Clippy exceptions, no-panic, policy-report)
-- PR Gate observation mode
-- `ripr` advisory surface
-- Lint inheritance checker
-- Strict-policy ledgers (Clippy, no-panic, non-Rust file allowlist)
+- MSRV 1.93.0,
+- CI lane whitelist and LEM-aware budget bands,
+- policy workflow for lane, file-policy, lint-inheritance, Clippy exception,
+  no-panic, and policy-report checks,
+- PR Gate observation mode,
+- `ripr` advisory workflow surface,
+- lint inheritance checker,
+- strict-policy ledgers for Clippy, no-panic, and non-Rust file allowlists.
 
 The 1.93 rollout explicitly deferred:
 
 - strict Clippy ratchets and receipt discipline,
 - removal of test carveouts still in `clippy.toml`,
 - no-panic identity hardening and no-new-debt mode,
-- real `ripr` advisory execution (binary absent),
-- LEM/risk-pack tightening to reduce default per-PR mutation,
-- branch-protection migration to `PR Gate Success` aggregator,
-- learned-estimate planner switch (needs one full sprint of data).
+- real `ripr` advisory execution when the binary is absent,
+- LEM/risk-pack tightening to reduce default per-PR mutation and over-testing,
+- branch-protection migration to the `PR Gate Success` aggregator,
+- learned-estimate planner switch after enough actuals are collected.
 
-This document defines the Rust 1.95 / next minor ladder that addresses those
-deferred items.
+The Rust 1.95 wave addresses those deferred items in a one-objective-per-PR
+ladder.
 
-## Current vs. target state
+## Current Vs Target State
 
-| Layer | Current state | Target | Status |
+| Layer | Current state on `main` | Target state | PR |
 |---|---|---|---|
-| Edition | Rust 2024 | Rust 2024 | done |
-| MSRV | 1.93.0 | 1.95.0 | planned |
-| Release line | 0.2.1-dev | next minor dev line | planned |
-| Clippy ledger | present, 1.94/1.95 lints staged | 1.95 lints active and ratcheted | partial |
-| Clippy debt | present, placeholder entries only | owner/reason/expiry for real debt | partial |
-| Clippy exceptions | present, empty | exact `#[expect]` receipts only | partial |
-| `clippy.toml` carveouts | `allow-expect-in-tests = true` and `allow-unwrap-in-tests = true` still present | no test carveouts | todo |
-| No-panic policy | allowlist exists, advisory/empty | no-new-debt baseline + exact allowlist | partial |
-| Non-Rust policy | broad allowlist exists | tightened, reviewed, generated/executable companions | partial |
-| CI lane whitelist | present | enforced and calibrated for 1.95 | partial |
-| `ripr` | workflow exists, binary may be absent | real advisory analysis running | partial |
+| Edition | Rust 2024 | Rust 2024 | current |
+| Workspace MSRV | `1.93.0` in `Cargo.toml` | `1.95.0` | 3 |
+| Toolchain | `1.93.0` in `rust-toolchain.toml` | `1.95.0` with rustfmt, clippy, rust-analyzer | 3 |
+| Root version | `0.2.1-dev` | next minor dev line | 16 |
+| Clippy MSRV | `msrv = "1.93.0"` | `msrv = "1.95.0"` | 3 |
+| Clippy test carveouts | `allow-expect-in-tests = true`, `allow-unwrap-in-tests = true` | no test carveouts | 6 |
+| Clippy 1.94/1.95 lints | staged in `policy/clippy-lints.toml` | active or explicitly deferred with debt | 5 |
+| No-panic allowlist | present, empty/advisory, identity is `path + family + selector` | exact counted identity | 7 |
+| No-panic baseline | absent | generated no-new-debt baseline | 8 |
+| Non-Rust allowlist | present, broad | narrowed with explicit covered-by evidence | 10 |
+| CI lane whitelist / LEM | present | calibrated for Rust 1.95 and risk-pack routing | 15 |
+| Core CI toolchain | important jobs still pin `1.93.0` | core/policy/coverage/ripr jobs pin `1.95.0` | 3 |
+| `ripr` | workflow exists, may skip when binary is absent | real advisory static mutation-exposure signal | 11 |
+| Mutation testing | expensive runtime evidence outside default PR | targeted risk PR, broader nightly, release readiness | 11, 15, 17 |
 
-**Operating rule:** The first implementation PR after this doc PR is a
-compatibility spike. No MSRV bump, lint activation, no-panic baseline reset,
-release bump, or API cleanup happens in the same PR.
+## Version Note
 
-## Why a minor release?
+The package line is `0.2.1-dev`, but the changelog has historical `0.3.0`
+content. The release-prep PR must reconcile whether the next minor dev line is
+`0.3.0-dev` or `0.4.0-dev`. The semver rule is fixed: MSRV increase ships as a
+minor release.
 
-Raising the MSRV breaks a user-visible contract: callers must now have Rust
-1.95.0 to build the crate. Under semver this is a **minor** version change
-(no existing API is removed, but the build requirement changes). The
-development line therefore moves from `0.2.1-dev` to the next minor dev line.
-The exact version and tag are finalized in the release-prep PR because
-`CHANGELOG.md` already contains a historical `0.3.0` section.
-
-## Rust 1.95 value for BitNet-rs
+## Rust 1.95 Value For BitNet-rs
 
 | Rust 1.95 item | BitNet-rs use |
 |---|---|
-| `if let` guards | dispatch planners, backend routing, tokenizer/model metadata classification, GGUF shape checks, CUDA/CPU route selection |
-| `Vec::push_mut` / `insert_mut` | receipts, campaign dashboards, benchmark reports, API/generation events, diagnostic builders |
-| Atomic `update` / `try_update` | runtime metrics, once-warn counters, request/health/state counters |
-| `cfg_select!` | GPU/CPU/wasm/platform/backend routing without cfg sprawl |
-| `cold_path` | error/report/rejection paths in parser, GGUF validation, download/auth, API routing, policy failures |
+| `if let` guards | CUDA/CPU dispatch planner, backend route classification, GGUF metadata mapping, tokenizer compatibility, API route matching |
+| `Vec::push_mut` / `insert_mut` | benchmark receipts, campaign dashboards, policy reports, generation events, OpenAI-compatible response builders |
+| atomic `update` / `try_update` | runtime counters, once-warn counters, request/health/state counters |
+| `cfg_select!` | GPU backend selection, SIMD path selection, WASM/native surfaces, Python/FFI conditionals, Windows/Linux path handling |
+| `cold_path` | error/report/rejection paths in GGUF validation, download/auth, API routing, and policy failures |
 | Clippy 1.95 | `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, `needless_type_cast`, `unnecessary_trailing_comma` |
 
-## Implementation PR ladder
+## PR Ladder
 
-Each PR below is a single objective. No PR combines MSRV bump, lint activation,
-no-panic baseline changes, release bump, and code cleanup simultaneously.
+Each PR below is a single objective. Start every PR from clean `origin/main`.
 
-| PR | Branch | Title | Scope | Keep? | Adjustment |
-|---|---|---|---|---|---|
-| 1 | `docs/rust-1.95-rollout` | `policy: map Rust 1.95 CI economics and strict Clippy continuation` | **This PR.** Documentation / control-plane map only. | yes | Rebuilt from current `main`. Replaces closed #4136. |
-| 2 | `probe/rust-1.95-compat` | `chore(msrv): probe Rust 1.95 compatibility` | Run repo under 1.95.0 before changing declared MSRV. Audit note only; code changes only for true fallout. Must rerun on current `main`; do not trust old branch data. | yes | Must rerun on current `main`. |
-| 3 | `chore/msrv-rust-1.95` | `chore(msrv): raise workspace toolchain to Rust 1.95` | `rust-toolchain.toml`, `Cargo.toml` `rust-version`, `clippy.toml` `msrv`, workflow toolchain keys. | yes | Only after probe/PR 2 is green. |
-| 4 | `policy/rust-1.95-lints` | `policy(rust): enable Rust 1.95 compiler lint floor` | Activate `const_item_interior_mutations`, `function_casts_as_integer`, move `unexpected_cfgs` to `warn`. Keep narrow; no broad cleanup. | yes | Keep narrow; no broad cleanup. |
-| 5 | `policy/clippy-rust-1.95-ratchets` | `policy(clippy): activate Rust 1.95 lint ratchets` | Promote `manual_checked_ops`, `manual_take`, `manual_pop_if`, `duration_suboptimal_units`, `needless_type_cast`, `unnecessary_trailing_comma` after measurement. Only activate lints with measured debt and receipts. | yes | Only activate with measured debt and receipts. |
-| 6 | `policy/no-test-clippy-carveouts` | `policy(clippy): remove test unwrap and expect carveouts` | Delete `allow-expect-in-tests` / `allow-unwrap-in-tests` from `clippy.toml`. Add fallible test helpers. Current `clippy.toml` still has them. | yes | Current `clippy.toml` still has them. |
-| 7 | `policy/no-panic-exact-identity` | `policy(panic): harden no-panic allowlist identity` | Require `path + family + selector_kind + selector_callee + snippet + count` identity. Counted-consumptive matching. Still aligns with #3866 deferred backlog. | yes | Still aligns with #3866 deferred backlog. |
-| 8 | `policy/no-panic-baseline` | `policy(panic): add no-panic baseline and no-new-debt gate` | Generate baseline, set `no-new-debt` mode, add `.gitattributes` generated marker. | yes | Still aligns with #3866 deferred backlog. |
-| 9 | `policy/no-panic-diagnostics` | `policy(panic): improve no-panic report diagnostics` | Missing-baseline error, stale entries in MD/JSON, blocking-mode messaging, delta details. | yes | Still aligns with #3866 deferred backlog. |
-| 10 | `policy/file-allowlist-tightening` | `policy(files): tighten non-Rust allowlist coverage` | Remove stale entries, narrow broad globs, add `review_after`/`expires`. Tie to reduced mutation/noisy PR surface. | yes | Tie to reduced mutation/noisy PR surface. |
-| 11 | `ci/ripr-real-advisory` | `ci(ripr): provision real advisory static exposure analysis` | Install `ripr`, run `ripr check`, emit JSON/SARIF/Markdown artefacts. Central CI economics item, not a side quest. | yes | Make this a central CI economics item. |
-| 12 | `refactor/rust-1.95-api-cleanups` | `refactor: use Rust 1.95 APIs in dispatch and receipt builders` | Targeted `if let` guards, `Vec::push_mut`, atomic `update`, `cfg_select!`. Only after MSRV bump lands. | yes, but after PR 3 | Only after MSRV bump (PR 3) lands. |
-| 13 | `policy/clippy-numeric-kernel-cleanup` | `policy(clippy): clean numeric and kernel lint debt` | `manual_checked_ops`, `cast_possible_truncation`, `indexing_slicing`. Risk-pack routed, not default broad lane. | yes | Risk-pack routed, not default broad lane. |
-| 14 | `policy/no-panic-first-burndown` | `policy(panic): burn down first no-panic owner lane` | One narrow lane only (e.g. `bitnet-http-retry`, `bitnet-api-key-auth-core`, or `xtask` helpers). | yes | One owner lane only. |
-| 15 | `ci/bitnet-lem-lane-tightening` | `ci: tighten lane whitelist and LEM routing for Rust 1.95` | Update `policy/ci-lane-whitelist.toml`, reclassify `ripr-advisory`, make GPU/FFI lanes label/risk-routed. Make explicit: reduce default PR mutation and over-testing. | yes | Make explicit: reduce default PR mutation. |
-| 16 | `release/next-minor-prep-rust-1.95` | `release: prepare next minor release for Rust 1.95` | Move version from `0.2.1-dev` to the next minor dev line workspace-wide. Update CHANGELOG and reconcile the historical `0.3.0` section before choosing the exact version/tag. | yes | Minor bump because MSRV change is user-visible. |
-| 17 | `release/next-minor-dry-run` | `release: validate next minor publish readiness` | `cargo package --dry-run`, full policy-report, release readiness doc for the chosen version. | yes | Minor bump because MSRV change is user-visible. |
+| PR | Branch | Title | Scope |
+|---:|---|---|---|
+| 1 | `docs/rust-1.95-rollout-refresh` | `docs(policy): refresh Rust 1.95 and next-minor rollout map` | Documentation refresh/correction only. No Cargo, workflow, toolchain, or Rust source changes. |
+| 2 | `probe/rust-1.95-compat` | `chore(msrv): probe Rust 1.95 compatibility` | Run current `main` under Rust 1.95 before changing declared MSRV. Audit note preferred. |
+| 3 | `chore/msrv-rust-1.95` | `chore(msrv): raise workspace toolchain to Rust 1.95` | Bump `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, core/policy/coverage/ripr workflows, and `policy/clippy-lints.toml` MSRV. |
+| 4 | `policy/rust-1.95-lints` | `policy(rust): enable Rust 1.95 compiler lint floor` | Move compiler lint floor forward. Do not use `unsafe_code = "forbid"` globally. |
+| 5 | `policy/clippy-rust-1.95-ratchets` | `policy(clippy): activate Rust 1.95 lint ratchets` | Measure first, then activate clean or cheaply fixed 1.94/1.95 Clippy ratchets. Keep `disallowed_fields` planned until real fields are configured. |
+| 6 | `policy/no-test-clippy-carveouts` | `policy(clippy): remove test unwrap and expect carveouts` | Remove Clippy test carveouts and convert one narrow helper slice only. |
+| 7 | `policy/no-panic-exact-identity` | `policy(panic): harden no-panic allowlist identity` | Add exact counted identity: `path + family + selector_kind + selector_callee + snippet + count`. |
+| 8 | `policy/no-panic-baseline` | `policy(panic): add no-panic baseline and no-new-debt gate` | Generate baseline, set no-new-debt mode, mark generated file in `.gitattributes`. |
+| 9 | `policy/no-panic-diagnostics` | `policy(panic): improve no-panic report diagnostics` | Missing-baseline error, stale baseline entries, delta details, blocking-mode messaging. |
+| 10 | `policy/file-allowlist-tightening` | `policy(files): tighten non-Rust allowlist coverage` | Remove stale entries, narrow broad globs, add review/expiry metadata where supported, keep GPU/FFI/Python/WASM explicit. |
+| 11 | `ci/ripr-real-advisory` | `ci(ripr): provision real static mutation-exposure analysis` | Install and run `ripr`, emit JSON/SARIF/Markdown, keep advisory and not branch-protection blocking. |
+| 12 | `refactor/rust-1.95-api-cleanups` | `refactor: use Rust 1.95 APIs in dispatch and receipt builders` | Targeted use of Rust 1.95 APIs after MSRV bump lands. |
+| 13 | `policy/clippy-numeric-kernel-cleanup` | `policy(clippy): clean numeric and kernel lint debt` | Clean numeric/kernel lint debt without changing semantics. |
+| 14 | `policy/no-panic-first-burndown` | `policy(panic): burn down first no-panic owner lane` | One narrow owner lane only. Baseline refresh may only drop disappeared entries. |
+| 15 | `ci/bitnet-lem-lane-tightening` | `ci: tighten lane whitelist and LEM routing for Rust 1.95` | Reclassify `ripr-advisory` as real static mutation-exposure signal and route GPU/FFI/platform lanes by risk/label/main. |
+| 16 | `release/next-minor-prep-rust-1.95` | `release: prepare next minor release for Rust 1.95` | Reconcile next minor version, update manifests/docs/changelog/release prep. |
+| 17 | `release/next-minor-dry-run` | `release: validate next minor publish readiness` | Publish dry-run and readiness document for the chosen version. |
 
-### Acceptance gate per PR
+## Acceptance Gates
 
-#### PR 1 (this doc PR)
+### PR 1: Documentation Refresh
 
 ```bash
 cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
@@ -128,7 +151,7 @@ cargo fmt --all -- --check
 git diff --check
 ```
 
-#### PR 2 (compatibility spike)
+### PR 2: Rust 1.95 Compatibility Spike
 
 ```bash
 rustup toolchain install 1.95.0 --component rustfmt --component clippy --component rust-analyzer
@@ -138,9 +161,13 @@ cargo +1.95.0 check --locked --workspace --all-targets --features cpu
 cargo +1.95.0 clippy --locked --workspace --all-targets --no-default-features -- -D warnings
 cargo +1.95.0 clippy --locked --workspace --all-targets --features cpu -- -D warnings
 cargo +1.95.0 run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+git diff --check
 ```
 
-#### PR 3 (MSRV bump)
+Merge rule: no MSRV bump, no lint activation, no release bump, and no Rust
+1.95 API cleanup.
+
+### PR 3: MSRV/Toolchain Bump
 
 ```bash
 cargo fmt --all -- --check
@@ -151,20 +178,243 @@ cargo run --locked -p xtask --no-default-features -- policy-report --report-dir 
 git diff --check
 ```
 
-## Commit and PR operating rules
+Do not remove test carveouts here. That belongs in PR 6.
 
-- One PR per objective.
+### PR 4: Rust Compiler Lint Floor
+
+```bash
+cargo check --locked --workspace --all-targets --features cpu
+cargo run --locked -p xtask --no-default-features -- check-lint-inheritance
+cargo run --locked -p xtask --no-default-features -- check-clippy-exceptions
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+```
+
+### PR 5: Clippy 1.95 Ratchets
+
+Measure first:
+
+```bash
+cargo clippy --locked --workspace --all-targets --features cpu -- \
+  -W clippy::same_length_and_capacity \
+  -W clippy::manual_ilog2 \
+  -W clippy::decimal_bitwise_operands \
+  -W clippy::needless_type_cast \
+  -W clippy::manual_checked_ops \
+  -W clippy::manual_take \
+  -W clippy::manual_pop_if \
+  -W clippy::duration_suboptimal_units \
+  -W clippy::unnecessary_trailing_comma
+```
+
+Then:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- check-clippy-exceptions --report-dir target/bitnet/reports
+cargo clippy --locked --workspace --all-targets --features cpu
+```
+
+### PR 6: Remove Clippy Test Carveouts
+
+Remove only:
+
+```toml
+allow-expect-in-tests = true
+allow-unwrap-in-tests = true
+```
+
+Add or extend fallible helpers in the correct test-support crate and convert one
+narrow helper slice only. Do not migrate the whole test suite here.
+
+### PR 7: No-Panic Exact Identity
+
+```bash
+cargo test -p xtask no_panic --locked
+cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
+```
+
+Required test names:
+
+```text
+allowlist_entry_requires_exact_snippet
+allowlist_count_is_consumed_per_occurrence
+allowlist_does_not_cover_same_file_same_callee_different_snippet
+baseline_generation_subtracts_allowlisted_counts
+blocking_mode_ignores_baseline_but_honors_counted_allowlist
+duplicate_allowlist_keys_are_rejected
+```
+
+### PR 8: No-Panic Baseline
+
+```bash
+cargo run --locked -p xtask --no-default-features -- no-panic baseline --reset
+cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
+cargo test -p xtask no_panic --locked
+git diff --check
+```
+
+Baseline refresh may drop disappeared entries. It must refuse to absorb new
+debt unless `--reset` is explicit.
+
+### PR 9: No-Panic Diagnostics
+
+```bash
+cargo test -p xtask no_panic --locked
+cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
+```
+
+### PR 10: File Allowlist Tightening
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+```
+
+### PR 11: Real Advisory `ripr`
+
+Recommended workflow shape:
+
+```yaml
+- name: Install ripr
+  run: cargo install ripr --locked
+
+- name: Run ripr doctor
+  run: ripr doctor || true
+
+- name: Run ripr check
+  run: |
+    mkdir -p target/ripr
+    ripr check \
+      --base "origin/${{ github.base_ref }}" \
+      --json target/ripr/ripr.json \
+      --sarif target/ripr/ripr.sarif \
+      --markdown target/ripr/ripr.md \
+      --config ripr.toml || true
+```
+
+Use synchronize-only cancellation:
+
+```yaml
+cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'synchronize' }}
+```
+
+Keep advisory. Do not add branch protection.
+
+### PR 12: Rust 1.95 API Cleanup
+
+```bash
+cargo test --locked -p bitnet-kernels --lib --no-default-features --features cpu
+cargo test --locked -p bitnet-receipts --all-features
+cargo test --locked -p xtask
+cargo clippy --locked --workspace --all-targets --features cpu
+```
+
+### PR 13: Numeric And Kernel Lint Cleanup
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-clippy-exceptions --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports
+cargo clippy --locked -p bitnet-kernels --all-targets --no-default-features --features cpu
+cargo test --locked -p bitnet-kernels --lib --no-default-features --features cpu
+```
+
+Do not mechanically satisfy Clippy in kernels if semantics change.
+
+### PR 14: No-Panic First Owner-Lane Burndown
+
+```bash
+cargo test --locked -p <touched-crate>
+cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- no-panic baseline
+```
+
+Good first lanes: `bitnet-atomic-file-core`, `bitnet-http-retry`,
+`bitnet-api-key-auth-core`, `bitnet-client-ip-core`,
+`bitnet-request-router-core`, `bitnet-server-health-types-core`, or narrow
+`xtask` policy/report helpers.
+
+### PR 15: LEM / Risk-Pack Tightening
+
+Evidence split:
+
+```text
+Default PR:
+  fmt
+  check
+  clippy
+  tests
+  no-panic
+  file/lint/process/network policy
+  ripr static mutation-exposure analysis
+
+Targeted PR:
+  mutation for changed high-risk owner surfaces
+  coverage when label coverage/full-ci
+
+Nightly:
+  mutation matrix
+  deeper coverage
+  dogfood/report drift
+
+Release:
+  package list
+  publish dry-run
+  release-readiness
+```
+
+Skipped lanes must report `skipped-by-policy`. Do not hide skipped lanes as
+passed.
+
+### PR 16: Next Minor Release Prep
+
+```bash
+cargo check --locked --workspace --all-targets --features cpu
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+cargo run --locked -p xtask --no-default-features -- campaign doctor || true
+git diff --check
+```
+
+Required changelog text:
+
+```markdown
+### Changed
+- Raised MSRV to Rust 1.95.0.
+- Activated Rust 1.94/1.95 Clippy policy ratchets.
+- Removed Clippy test unwrap/expect carveouts.
+- Added exact no-panic baseline/no-new-debt enforcement.
+- Tightened file-policy and CI lane whitelist handling.
+- Applied targeted Rust 1.95 cleanup in dispatch, receipt, and policy paths.
+```
+
+### PR 17: Release Dry-Run Proof
+
+```bash
+cargo package --locked -p bitnet --allow-dirty
+cargo publish --dry-run --locked -p bitnet
+
+cargo check --locked --workspace --all-targets --features cpu
+cargo test --locked -p bitnet-common
+cargo test --locked -p bitnet-math
+cargo test --locked -p bitnet-quantization --no-default-features --features cpu
+cargo test --locked -p bitnet-kernels --lib --no-default-features --features cpu
+
+cargo run --locked -p xtask --no-default-features -- policy-report --report-dir target/bitnet/reports
+```
+
+## Operating Rules
+
 - Start every PR from clean `origin/main`.
-- Do not push `main`.
-- Do not force-push except to your own PR branch after a rebase.
+- One PR per objective.
 - Open PRs as draft first.
+- Do not push `main`.
+- Do not force-push except to your own PR branch after rebase.
 - Address bot comments and CI failures before marking ready.
-- Self-review every PR before marking ready-for-review.
+- Self-review every PR.
 - Merge only when required checks are green.
-- After each merge, fetch and fast-forward `main` before starting the next PR.
+- After each merge, fetch and fast-forward `main` before the next PR.
 - Do not claim green until post-merge `main` checks are green.
 
-## What not to do
+## Do Not
 
 - Do not combine MSRV bump, lint activation, no-panic baseline, release bump,
   and cleanup in one PR.
@@ -173,24 +423,11 @@ git diff --check
 - Do not add bare `#[allow(clippy::...)]` suppressions.
 - Do not reset no-panic baseline except in the dedicated baseline PR.
 - Do not make `ripr` branch-protection blocking yet.
-- Do not route expensive GPU/FFI/platform lanes into default PR without a
-  risk-pack reason.
+- Do not replace mutation testing with `ripr`.
+- Do not put full mutation on ordinary PRs.
 - Do not hide skipped lanes as passed.
-- Do not broadening default CI lanes under CI pressure.
 
-## CI economics operating frame
-
-For each PR, the CI economics question is:
-
-1. Which lanes actually run for this change?
-2. Are those lanes risk-pack appropriate?
-3. Is `ripr` evidence present?
-4. Are any expensive lanes being pulled into the default path without justification?
-
-Lane tightening (PR 15) makes this explicit. Until then, monitor
-`policy/ci-lane-whitelist.toml` and do not add new lanes to the default set.
-
-## Bot and CI loop
+## Bot And CI Loop
 
 For each PR:
 
@@ -212,22 +449,21 @@ Then:
 3. Fix only that failure.
 4. Rerun the matching local gate.
 5. Push.
-6. Re-check bot comments.
+6. Check bot comments again.
 
-If CodeRabbit or another bot comments:
+If a bot comments:
 
-- Real defect → fix.
-- False positive → reply with evidence.
-- Style-only but cheap and in scope → fix.
-- Out of scope → document as follow-up.
-- Stale comment → verify current HEAD and mark stale.
+- Real defect -> fix.
+- False positive -> reply with evidence.
+- Style-only but cheap and in scope -> fix.
+- Out of scope -> document follow-up.
+- Stale comment -> verify current HEAD and mark stale.
 
-## Required self-review checklist
-
-Before marking any PR ready-for-review, add this comment:
+## Required Self-Review Comment
 
 ```markdown
 ## Self-review
+
 - Scope matches PR title:
 - Files touched are expected:
 - No unrelated cleanup:
@@ -237,16 +473,17 @@ Before marking any PR ready-for-review, add this comment:
 - No-panic baseline handling is scoped:
 - Non-Rust allowlist changes are narrow:
 - CI economics: lanes are risk-pack appropriate:
+- ripr mutation-exposure framing preserved:
 - Local validation:
 - CI status:
 - Bot comments addressed:
 - Follow-ups:
 ```
 
-## Current control plane summary
+## Current Control Plane Summary
 
-The repo already has the following policy machinery in place (landed in #3866).
-The 1.95 rollout builds on top of it without replacing it.
+The repo already has the following policy machinery in place. The Rust 1.95
+rollout builds on it without replacing it.
 
 | Component | File | Status |
 |---|---|---|
@@ -258,13 +495,16 @@ The 1.95 rollout builds on top of it without replacing it.
 | Clippy lints ledger | `policy/clippy-lints.toml` | present, 1.94/1.95 staged |
 | Clippy debt | `policy/clippy-debt.toml` | present, placeholder only |
 | Clippy exceptions | `policy/clippy-exceptions.toml` | present, empty |
-| No-panic allowlist | `policy/no-panic-allowlist.toml` | present, advisory |
+| No-panic allowlist | `policy/no-panic-allowlist.toml` | present, empty/advisory |
+| No-panic baseline | `policy/no-panic-baseline.toml` | absent |
 | Non-Rust allowlist | `policy/non-rust-allowlist.toml` | present, broad |
-| ripr suppressions | `policy/ripr-suppressions.toml` | present |
-| Policy workflow | `.github/workflows/policy.yml` | running: CI lane, file-policy, lint-inheritance, Clippy exception, no-panic, policy-report |
-| ripr workflow | `.github/workflows/ripr.yml` | exists, records no-op when binary absent |
+| `ripr` suppressions | `policy/ripr-suppressions.toml` | present |
+| Policy workflow | `.github/workflows/policy.yml` | running policy checks |
+| `ripr` workflow | `.github/workflows/ripr.yml` | exists, records no-op when binary absent |
 
-## Clippy test carveout mismatch (PR 6 target)
+## Focus Notes
+
+### Clippy Test Carveout Mismatch
 
 `clippy.toml` currently has:
 
@@ -280,29 +520,38 @@ panic_free_tests = true
 allow_test_carveouts = false
 ```
 
-This contradiction is intentional during the staging window (see original
-rollout document). PR 6 resolves it by removing the carveouts after PR 5
-activates the fallible test helpers.
+This contradiction is intentional during the staging window. PR 6 resolves it
+by removing the carveouts and converting one narrow helper slice.
 
-## No-panic identity hardening (PR 7 target)
+### No-Panic Identity Hardening
 
-Current allowlist identity is `path + family + selector`. Before bulk baseline
-work begins, the identity must expand to include `snippet` and `count` to
-prevent one allow entry from accidentally covering unrelated calls in the same
-file. PR 7 lands this before PR 8 generates the baseline.
+Current allowlist identity is `path + family + selector`, with line/column
+advisory only. Before real allowlist entries or a generated baseline can be
+trusted, identity must be exact and counted:
 
-## `ripr` advisory status
+```text
+path + family + selector_kind + selector_callee + snippet + count
+```
+
+Matching must be consumptive: exact allowlist counts first, baseline counts
+second unless blocking mode ignores the baseline, and anything remaining is new
+debt.
+
+### `ripr` Advisory Status
 
 `ripr.yml` currently checks whether the `ripr` binary exists and skips when it
-does not. PR 11 replaces this with a real install and run. The job stays
-advisory; it does not become a branch-protection gate in this wave.
-`ripr` is a central CI economics item: its static-exposure evidence reduces
-the need for broad mutation-testing-style PR coverage.
+does not. PR 11 replaces that with a real install and run. The job stays
+advisory and does not become branch-protection blocking in this wave.
 
-## Candidate `disallowed_fields` seams (PR 5 prerequisite)
+`ripr` is central to the CI economics plan because it shifts mutation signal
+left. It catches much of the same weak-test/oracle-exposure signal mutation
+testing catches, but earlier and cheaper. Mutation testing remains the runtime
+backstop for targeted risk PRs, nightly, and release readiness.
 
-The following internal seams are candidates for `disallowed_fields` enforcement.
-They must be defined in `clippy.toml` before the lint can be activated globally.
+### Candidate `disallowed_fields` Seams
+
+`disallowed_fields` stays planned until protected fields are configured in
+`clippy.toml`. Candidate seams:
 
 ```text
 engine lifecycle state
@@ -314,6 +563,3 @@ benchmark receipt internals
 campaign tracker state
 backend dispatch route labels
 ```
-
-Activation of `disallowed_fields` globally is deferred until real seams are
-defined. Use it only after defining protected field paths.


### PR DESCRIPTION
## Summary

Refresh the existing Rust 1.95 / next-minor rollout map against current `main` and correct the `ripr` doctrine: `ripr` is static mutation-exposure analysis that shifts mutation signal left while mutation testing remains the runtime backstop.

## CI Requirements (check all that apply)

- [ ] Actions are **SHA-pinned** (no workflow changes)
- [ ] Workflow `cargo`/`cross` commands use **--locked** (no workflow changes)
- [x] Toolchain respects **rust-toolchain.toml** (no toolchain changes in PR 1)
- [ ] Receipt workflow: builds exclude Python/WASM (`--exclude bitnet-py --exclude bitnet-wasm`) in CPU+GPU lanes (not touching `verify-receipts.yml`)
- [x] **Guards** passes in CI

## Changes

- Refreshed `docs/development/RUST_1_95_ROLLOUT.md` with the 17-PR ladder, current-vs-target state, version reconciliation note, acceptance gates, bot/CI loop, and self-review contract.
- Added `docs/ci/ripr.md` and `docs/ci/test-evidence-lanes.md` to make the default/risk/nightly/release evidence stack explicit.
- Updated Clippy, no-panic, file-policy, allowlist, cost-policy, `ripr`, changelog, and Claude-facing docs to use the corrected static mutation-exposure doctrine.
- Kept PR 1 documentation-only: no `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, workflow, policy TOML, or Rust source changes.

## Testing

- [ ] Tests pass locally with `cargo test --workspace --no-default-features --features cpu` (not run; docs-only PR)
- [ ] Code formatted with `cargo fmt --all` (blocked locally: Windows command-line length, os error 206; no Rust source changed)
- [ ] Linting passes with `cargo clippy --all-targets --all-features -- -D warnings` (not run; docs-only PR)
- [x] `git diff --check`
- [x] `D:\Code\Rust\BitNet\target\release\xtask.exe check-file-policy --report-dir target/bitnet/reports` -> 9307 files scanned, 113 allowlist entries, 0 findings
- [x] `D:\Code\Rust\BitNet\target\release\xtask.exe ci-lane-whitelist check` -> 17 lanes, 2 exceptions; existing duplicate-ref warnings for `docs-automation if overlapping` and `mutation-nightly`
- [x] `D:\Code\Rust\BitNet\target\release\xtask.exe check-lint-inheritance` -> 138 crates checked, 0 missing
- [x] `D:\Code\Rust\BitNet\target\release\xtask.exe policy-report --report-dir target/bitnet/reports` -> generated report; existing no-panic and Clippy exception debt remains current-state/advisory debt
- [x] `D:\Code\Rust\BitNet\target\release\xtask.exe check-clippy-exceptions` -> reports existing 506 Clippy receipt errors; this PR does not change Rust source or policy TOML
- [ ] Direct acceptance form `cargo run --locked -p xtask --no-default-features -- ...` (blocked locally: initial `D:` disk exhaustion; reruns with `CARGO_TARGET_DIR=E:\cargo-targets\BitNet-rust-195-rollout-refresh` reached `sentencepiece-sys` native CMake/MSVC setup and did not complete cleanly in this shell)

## CI cost and verification discipline

Docs-only PR. Heavy labels are intentionally not requested. The rollout docs preserve the default/risk/nightly/release split:

- Default PR: normal gates + policy checks + `ripr` static mutation-exposure analysis
- Risk PR: default evidence + targeted mutation for touched high-risk owner surfaces
- Nightly: broader mutation matrix
- Release: readiness clean enough to ship

## CI Labels (opt-in heavy checks)

- [ ] `coverage` - not needed for docs-only rollout map
- [ ] `receipts` - not needed for docs-only rollout map
- [ ] `framework` - not needed for docs-only rollout map
- [ ] `gpu` - not needed for docs-only rollout map
- [ ] `quant` - not needed for docs-only rollout map
- [ ] `crossval` - not needed for docs-only rollout map
- [ ] `perf` - not needed for docs-only rollout map
- [ ] `lut` - not needed for docs-only rollout map

## Documentation

- [ ] README updated (not user-facing runtime/API change)
- [x] CLAUDE.md updated (development workflow / rollout rails changed)
- [ ] API documentation updated (no public API changes)

## Checklist

- [x] This PR is focused on a single concern
- [x] Commit messages are clear and descriptive
- [x] Breaking changes are documented (planned MSRV increase is documented as next-minor work; no breaking change in this PR)
- [x] All conversation threads resolved before merge