### PR TITLE
chore(msrv): raise workspace toolchain to Rust 1.95

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # bitnet-rs — Copilot Instructions
 
-High-performance Rust implementation of BitNet 1-bit LLM inference. MSRV: 1.93.0, Rust 2024 edition.
+High-performance Rust implementation of BitNet 1-bit LLM inference. MSRV: 1.95.0, Rust 2024 edition.
 
 ## Build & Test Commands
 

--- a/.github/images/rust-ci/Dockerfile
+++ b/.github/images/rust-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.92-slim-bookworm
+FROM rust:1.95-slim-bookworm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/.github/workflows/a770-nightly.yml
+++ b/.github/workflows/a770-nightly.yml
@@ -6,7 +6,7 @@ name: A770 Nightly Hardware Validation
 # To enable:
 #   1. Provision a self-hosted GitHub Actions runner with an Intel Arc A770 GPU.
 #   2. Tag the runner with labels: self-hosted, Linux, intel-gpu, a770
-#   3. Install: Intel compute-runtime, OpenCL ICD loader, clinfo, Rust 1.93.0+
+#   3. Install: Intel compute-runtime, OpenCL ICD loader, clinfo, Rust 1.95.0+
 #   4. Remove the `if: false` condition from each job.
 #   5. Optionally adjust cron schedule (currently 3:00 AM UTC daily).
 
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Verify Intel GPU present
         run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Build kernels (oneapi)
         run: cargo build --locked --no-default-features --features oneapi -p bitnet-kernels
@@ -103,7 +103,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Build (release, oneapi)
         run: cargo build --locked --release --no-default-features --features oneapi,cpu -p bitnet-kernels
@@ -136,7 +136,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Build (release, oneapi)
         run: cargo build --locked --release --no-default-features --features oneapi,cpu -p bitnet-kernels

--- a/.github/workflows/apple-m4-dense-slm-regression.yml
+++ b/.github/workflows/apple-m4-dense-slm-regression.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2

--- a/.github/workflows/apple-silicon.yml
+++ b/.github/workflows/apple-silicon.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy, rustfmt
 
       - name: Rust cache
@@ -62,7 +62,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy, rustfmt
 
       - name: Rust cache

--- a/.github/workflows/campaign-tracker.yml
+++ b/.github/workflows/campaign-tracker.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/ci-actuals.yml
+++ b/.github/workflows/ci-actuals.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -179,7 +179,7 @@ jobs:
         if: needs.classify-changes.outputs.tracker_only != 'true'
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy,rustfmt
 
       - name: Cache Rust dependencies
@@ -317,7 +317,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -352,7 +352,7 @@ jobs:
         if: needs.classify-changes.outputs.tracker_only != 'true'
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Cache Rust dependencies
@@ -421,7 +421,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Cache Rust dependencies
@@ -461,7 +461,7 @@ jobs:
         if: needs.classify-changes.outputs.tracker_only != 'true'
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         if: needs.classify-changes.outputs.tracker_only != 'true'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - name: Build FFI library
         run: |
           cargo build -p bitnet-ffi --locked --release --no-default-features --features cpu
@@ -210,7 +210,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - name: Install system deps
         run: |
           sudo apt-get update
@@ -248,7 +248,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.10'
@@ -306,7 +306,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.10'
@@ -372,7 +372,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - name: Cache test GGUF
         id: cache-gguf
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
@@ -405,7 +405,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.10'
@@ -450,7 +450,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
       - name: Install cargo-audit
         run: cargo install cargo-audit || true
       - name: Install cargo-deny

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Install Rust (MSRV)
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install cargo-public-api
-        # Pin to a version compatible with MSRV 1.93.0
+        # Pin to a version compatible with MSRV 1.95.0
         run: cargo install cargo-public-api --version "0.43.0" --locked
 
       - name: Compute base and head

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUST_CI_IMAGE: ghcr.io/effortlessmetrics/bitnet-rs-ci:rust-1.93
+  RUST_CI_IMAGE: ghcr.io/effortlessmetrics/bitnet-rs-ci:rust-1.95
 
 jobs:
   coverage:

--- a/.github/workflows/crossval.yml
+++ b/.github/workflows/crossval.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -210,7 +210,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -265,7 +265,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install system dependencies
         run: |
@@ -427,7 +427,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/docs-automation.yml
+++ b/.github/workflows/docs-automation.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -128,7 +128,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -198,7 +198,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@888c2e1ea69ab0d4330cbf0af1ecc7b68f368cc1
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/gpu-ci-matrix.yml
+++ b/.github/workflows/gpu-ci-matrix.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -177,7 +177,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Cache
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4

--- a/.github/workflows/gpu.yml
+++ b/.github/workflows/gpu.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Setup sccache

--- a/.github/workflows/guards-nightly.yml
+++ b/.github/workflows/guards-nightly.yml
@@ -42,13 +42,13 @@ jobs:
           fi
           echo "✅ No floating refs"
 
-      - name: Guard - no stale 1.90.0 MSRV references (should be 1.93.0)
+      - name: Guard - no stale pre-1.95 MSRV references
         run: |
-          if rg -n --glob '!guards.yml' 'toolchain:\s*"?1\.90\.0"?|rust-version\s*=\s*"1\.90\.0"|"RUST_VERSION"\s*:\s*"1\.90\.0"' .github/workflows; then
-            echo "❌ Stale 1.90.0 reference found"
+          if rg -n --glob '!guards.yml' --glob '!guards-nightly.yml' 'toolchain:\s*"?1\.(90|93)\.0"?|rust-version\s*=\s*"1\.(90|93)\.0"|"RUST_VERSION"\s*:\s*"1\.(90|93)\.0"' .github/workflows; then
+            echo "❌ Stale pre-1.95 Rust toolchain/MSRV reference found"
             exit 1
           fi
-          echo "✅ MSRV consistent (1.93.0)"
+          echo "✅ MSRV consistent (1.95.0)"
 
       - name: Guard - cargo/cross --locked
         run: |

--- a/.github/workflows/guards.yml
+++ b/.github/workflows/guards.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -78,18 +78,18 @@ jobs:
           fi
           echo "✅ All actions pinned to 40-hex SHAs"
 
-      - name: Guard - MSRV consistency (1.93.0 only)
+      - name: Guard - MSRV consistency (1.95.0 only)
         run: |
           # Restrict matches to actual toolchain declarations or explicit JSON/env
           if rg -n --color=never --glob '!guards.yml' \
-               -e 'toolchain:\s*"?1\.90\.0"?' \
-               -e 'rust-version\s*=\s*"1\.90\.0"' \
-               -e '"RUST_VERSION"\s*:\s*"1\.90\.0"' \
+               -e 'toolchain:\s*"?1\.(90|93)\.0"?' \
+               -e 'rust-version\s*=\s*"1\.(90|93)\.0"' \
+               -e '"RUST_VERSION"\s*:\s*"1\.(90|93)\.0"' \
                .github/workflows; then
-            echo "❌ Found stale toolchain 1.90.0 in workflows (MSRV is 1.93.0)"
+            echo "❌ Found stale pre-1.95 Rust toolchain/MSRV reference in workflows"
             exit 1
           fi
-          echo "✅ MSRV consistent across all workflows (1.93.0)"
+          echo "✅ MSRV consistent across all workflows (1.95.0)"
 
       - name: Check units
         run: ./scripts/check-units.sh || true

--- a/.github/workflows/intel-gpu-ci.yml
+++ b/.github/workflows/intel-gpu-ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Install OpenCL headers
@@ -78,7 +78,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install OpenCL headers
         run: |
@@ -109,7 +109,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Verify Intel GPU
         run: |

--- a/.github/workflows/intel-gpu-compile.yml
+++ b/.github/workflows/intel-gpu-compile.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install OpenCL headers
         run: |
@@ -148,7 +148,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Install OpenCL headers
         run: |
@@ -185,7 +185,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Install OpenCL headers

--- a/.github/workflows/intel-gpu-feature-matrix.yml
+++ b/.github/workflows/intel-gpu-feature-matrix.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Install OpenCL headers
@@ -100,7 +100,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:
@@ -132,7 +132,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
         with:

--- a/.github/workflows/intel-gpu-nightly.yml
+++ b/.github/workflows/intel-gpu-nightly.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: System info
         run: |

--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -105,7 +105,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -136,7 +136,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: clippy
 
       - name: Cache Rust dependencies
@@ -168,7 +168,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt
 
       - name: Check formatting

--- a/.github/workflows/perf-gate.yml
+++ b/.github/workflows/perf-gate.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
@@ -45,7 +45,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-toolchain-1.93.0
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-toolchain-1.95.0
           restore-keys: |
             ${{ runner.os }}-cargo-
 

--- a/.github/workflows/performance-tracking.yml
+++ b/.github/workflows/performance-tracking.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57  # v4.2.0
@@ -41,9 +41,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: policy-${{ runner.os }}-1.93.0-${{ hashFiles('**/Cargo.lock') }}
+          key: policy-${{ runner.os }}-1.95.0-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            policy-${{ runner.os }}-1.93.0-
+            policy-${{ runner.os }}-1.95.0-
 
       - name: ci-lane-whitelist check
         run: |

--- a/.github/workflows/pr-plan.yml
+++ b/.github/workflows/pr-plan.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Build PR plan (xtask ci plan)
         id: plan

--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Rust cache
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Setup Python

--- a/.github/workflows/quant-matrix.yml
+++ b/.github/workflows/quant-matrix.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
       with:
-        toolchain: "1.93.0"
+        toolchain: "1.95.0"
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -177,7 +177,7 @@ jobs:
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
       with:
-        toolchain: "1.93.0"
+        toolchain: "1.95.0"
 
     - name: Run IQ2_S parity test
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
@@ -146,7 +146,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies
@@ -235,7 +235,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Set up Python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
@@ -270,7 +270,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
@@ -429,7 +429,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/ripr.yml
+++ b/.github/workflows/ripr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Locate ripr binary
         id: locate

--- a/.github/workflows/rocm-smoke.yml
+++ b/.github/workflows/rocm-smoke.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Cache
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4

--- a/.github/workflows/rust-ci-image.yml
+++ b/.github/workflows/rust-ci-image.yml
@@ -45,7 +45,7 @@ jobs:
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           IMAGE="${{ env.REGISTRY }}/${OWNER}/bitnet-rs-ci"
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-          echo "version_tag=rust-1.93" >> "$GITHUB_OUTPUT"
+          echo "version_tag=rust-1.95" >> "$GITHUB_OUTPUT"
           echo "sha_tag=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR

--- a/.github/workflows/test-framework.yml
+++ b/.github/workflows/test-framework.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Cache cargo registry
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -107,7 +107,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo registry
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2
@@ -131,7 +131,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Check documentation
         run: |

--- a/.github/workflows/test-telemetry.yml
+++ b/.github/workflows/test-telemetry.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0  # v2

--- a/.github/workflows/tl-lut-nightly.yml
+++ b/.github/workflows/tl-lut-nightly.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4

--- a/.github/workflows/tl-lut-stress.yml
+++ b/.github/workflows/tl-lut-stress.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache Rust dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4

--- a/.github/workflows/verify-receipts.yml
+++ b/.github/workflows/verify-receipts.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
@@ -162,7 +162,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Cache cargo dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
@@ -227,7 +227,7 @@ jobs:
             ],
             "deterministic": true,
             "environment": {
-              "RUST_VERSION": "1.93.0",
+              "RUST_VERSION": "1.95.0",
               "OS": "linux-x86_64"
             },
             "model_info": {
@@ -307,7 +307,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6  # stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.95.0"
 
       - name: Verify GPU visibility
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to bitnet-rs will be documented in this file.
 
 ### Rust 1.95 / Next Minor CI Economics Continuation (planned)
 
+- chore(msrv): raise workspace toolchain to Rust 1.95.0
+  - Updates `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`,
+    explicit member `rust-version` pins, `policy/clippy-lints.toml`, workflow
+    toolchain pins, and the Rust CI image tag.
+  - Explicitly keeps Rust 1.94/1.95 Clippy ratchets staged so the MSRV bump does
+    not silently activate lint cleanup before the dedicated ratchet PR.
+  - Keeps Clippy test carveouts, lint activation, no-panic baseline work,
+    release version reconciliation, and Rust 1.95 API cleanup scoped to their
+    later rollout PRs.
+  - Carries forward the compatibility-audit caveat: completed Rust 1.95 probe
+    slices passed, but full local workspace validation was blocked by the
+    Windows native SentencePiece/Python build path and still needs full CI or a
+    known-good native build host before release readiness.
 - docs(policy): refresh Rust 1.95 and next-minor rollout map — `docs/development/RUST_1_95_ROLLOUT.md`
   - Continuation of #3866 CI economics control plane; refreshes the existing Rust 1.95
     rollout map against current `main` instead of starting from a blank template.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,7 @@ keywords = ["machine-learning", "llm", "quantization", "inference", "bitnet"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/EffortlessMetrics/BitNet"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 version = "0.2.1-dev"
 
 [dependencies]
@@ -635,6 +635,29 @@ unimplemented = "allow"
 # rather than style debt.
 out_of_bounds_indexing = "deny"
 
+# Rust 1.94/1.95 lint ratchets stay explicitly staged until the
+# dedicated Clippy ratchet and numeric/kernel cleanup PRs. Without
+# these deferrals, raising `clippy.toml`'s MSRV to 1.95.0 silently
+# promotes new Clippy findings to hard CI failures under
+# `RUSTFLAGS=-D warnings`.
+same_length_and_capacity = "allow"
+manual_ilog2 = "allow"
+decimal_bitwise_operands = "allow"
+needless_type_cast = "allow"
+manual_checked_ops = "allow"
+manual_take = "allow"
+manual_pop_if = "allow"
+duration_suboptimal_units = "allow"
+unnecessary_trailing_comma = "allow"
+# Additional `clippy::all` findings newly exposed by the Rust 1.95
+# toolchain. These belong with PR 13's numeric/kernel cleanup rather
+# than this mechanical MSRV bump.
+collapsible_match = "allow"
+if_same_then_else = "allow"
+needless_borrow = "allow"
+unnecessary_min_or_max = "allow"
+unnecessary_sort_by = "allow"
+
 # Silent-failure shapes — staged at `allow` for the same reason as
 # the panic-family above.
 let_underscore_future = "allow"
@@ -689,7 +712,7 @@ keywords = [
   "inference",        # Model inference
   "bitnet",           # BitNet specific
 ]
-msrv = "1.93.0"
+msrv = "1.95.0"
 
 [lints]
 workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,8 +1,9 @@
 # Clippy configuration for bitnet-rs
 # Ensures high code quality standards for crates.io publication
 
-# MSRV compatibility (bumped to 1.93.0 in the strict policy rollout, PR 03).
-msrv = "1.93.0"
+# MSRV compatibility. Clippy test carveouts remain until the dedicated
+# no-test-carveouts rollout PR.
+msrv = "1.95.0"
 
 # Complexity thresholds
 cognitive-complexity-threshold = 30

--- a/crates/bitnet-bench-receipts/Cargo.toml
+++ b/crates/bitnet-bench-receipts/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-bench-receipts"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "Receipt model and JSONL store for benchmark result tracking"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-bench-regression-core/Cargo.toml
+++ b/crates/bitnet-bench-regression-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-bench-regression-core"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "Core benchmark regression detection primitives"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-dispatch-core/Cargo.toml
+++ b/crates/bitnet-dispatch-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-dispatch-core"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "Backend-agnostic compute dispatch sizing and recording primitives"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-kernels/Cargo.toml
+++ b/crates/bitnet-kernels/Cargo.toml
@@ -119,6 +119,16 @@ name = "neon_correctness_exhaustive"
 path = "tests/neon_correctness_exhaustive.rs"
 
 [[test]]
+name = "metal_adapter_detection_tests"
+path = "tests/metal_adapter_detection_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_compute_validation_tests"
+path = "tests/metal_compute_validation_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
 name = "metal_device_integration_tests"
 path = "tests/metal_device_integration_tests.rs"
 required-features = ["metal-runtime"]
@@ -169,13 +179,48 @@ path = "tests/metal_compute_pipeline_tests.rs"
 required-features = ["metal-runtime", "cpu"]
 
 [[test]]
+name = "metal_embedding_shader_tests"
+path = "tests/metal_embedding_shader_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
 name = "metal_layernorm_shader_tests"
 path = "tests/metal_layernorm_shader_tests.rs"
 required-features = ["metal-runtime"]
 
 [[test]]
+name = "metal_matmul_shader_tests"
+path = "tests/metal_matmul_shader_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_normalization_shader_tests"
+path = "tests/metal_normalization_shader_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
 name = "metal_reduction_shader_tests"
 path = "tests/metal_reduction_shader_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_rope_shader_tests"
+path = "tests/metal_rope_shader_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_shader_library_tests"
+path = "tests/metal_shader_library_tests.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_tiny_smoke"
+path = "tests/metal_tiny_smoke.rs"
+required-features = ["metal-runtime"]
+
+[[test]]
+name = "metal_wgpu_adapter_tests"
+path = "tests/metal_wgpu_adapter_tests.rs"
 required-features = ["metal-runtime"]
 
 [[test]]

--- a/crates/bitnet-nvidia/Cargo.toml
+++ b/crates/bitnet-nvidia/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-nvidia"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "NVIDIA-specific GPU tuning heuristics shared across BitNet backends"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-trace/Cargo.toml
+++ b/crates/bitnet-trace/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-trace"
 version = "0.2.1-dev"
 edition.workspace = true
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 license = "MIT OR Apache-2.0"
 description = "Tensor activation tracing for bitnet-rs cross-validation debugging"
 

--- a/crates/bitnet-wgpu-bench/Cargo.toml
+++ b/crates/bitnet-wgpu-bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu-bench"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "Benchmarking and profiling harness for wgpu compute kernels"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-wgpu-runner/Cargo.toml
+++ b/crates/bitnet-wgpu-runner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu-runner"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "Kernel execution runner for wgpu compute pipelines"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
+++ b/crates/bitnet-wgpu-shaders-i2s/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu-shaders-i2s"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "WGSL compute shaders for I2_S 2-bit quantized inference (BitNet)"
 license = "MIT OR Apache-2.0"
 

--- a/crates/bitnet-wgpu/Cargo.toml
+++ b/crates/bitnet-wgpu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bitnet-wgpu"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.93.0"
+rust-version = "1.95.0"
 description = "wgpu-based GPU compute backend for BitNet inference (Vulkan/Metal/DX12)"
 license = "MIT OR Apache-2.0"
 

--- a/docs/CLIPPY_POLICY.md
+++ b/docs/CLIPPY_POLICY.md
@@ -110,10 +110,12 @@ The following changes are planned as part of the Rust 1.95 / next minor wave.
 See `docs/development/RUST_1_95_ROLLOUT.md` for the full PR ladder and
 CI economics framing.
 
-Current `main` still has `clippy.toml` pinned to `msrv = "1.93.0"` and keeps
-the temporary test unwrap/expect carveouts. `policy/clippy-lints.toml` already
-stages Rust 1.94/1.95 lints; the rollout moves from staged policy to measured
-activation after the Rust 1.95 compatibility probe and MSRV bump.
+Current `main` has `clippy.toml` pinned to `msrv = "1.95.0"` and still keeps
+the temporary test unwrap/expect carveouts. `policy/clippy-lints.toml` records
+the Rust 1.95 MSRV, while `Cargo.toml` explicitly keeps the Rust 1.94/1.95
+ratchets staged at `allow` so the MSRV bump does not silently activate lint
+cleanup. The rollout moves from staged policy to measured activation in the
+dedicated lint-ratchet PR.
 
 ### Lint ratchets (PR 5)
 

--- a/docs/RIPR_EVIDENCE_POLICY.md
+++ b/docs/RIPR_EVIDENCE_POLICY.md
@@ -92,6 +92,6 @@ have an owner, a reason, and an expiry.
 
 ## Toolchain dependency
 
-`ripr` requires Rust `1.93` or newer. The current workspace MSRV is 1.93.0; the
-Rust 1.95 / next minor rollout raises the workspace floor to 1.95.0 before the
-real advisory `ripr` provisioning PR.
+`ripr` requires Rust `1.93` or newer. The current workspace MSRV is 1.95.0; the
+Rust 1.95 / next minor rollout keeps the floor ahead of that requirement before
+the real advisory `ripr` provisioning PR.

--- a/docs/ci/ripr.md
+++ b/docs/ci/ripr.md
@@ -39,7 +39,7 @@ The repo already has:
 - `ripr-advisory` in `policy/ci-lane-whitelist.toml`.
 
 The current workflow may record a no-op when the `ripr` binary is not present
-on the runner. That is acceptable for the Rust 1.93 control plane, but it is
+on the runner. That was acceptable for the Rust 1.93 control plane, but it is
 not the Rust 1.95 target state.
 
 ## Rust 1.95 Target State

--- a/docs/development/RUST_1_95_ROLLOUT.md
+++ b/docs/development/RUST_1_95_ROLLOUT.md
@@ -81,17 +81,17 @@ ladder.
 | Layer | Current state on `main` | Target state | PR |
 |---|---|---|---|
 | Edition | Rust 2024 | Rust 2024 | current |
-| Workspace MSRV | `1.93.0` in `Cargo.toml` | `1.95.0` | 3 |
-| Toolchain | `1.93.0` in `rust-toolchain.toml` | `1.95.0` with rustfmt, clippy, rust-analyzer | 3 |
+| Workspace MSRV | `1.95.0` in `Cargo.toml` | `1.95.0` | 3 |
+| Toolchain | `1.95.0` in `rust-toolchain.toml` | `1.95.0` with rustfmt, clippy, rust-analyzer | 3 |
 | Root version | `0.2.1-dev` | next minor dev line | 16 |
-| Clippy MSRV | `msrv = "1.93.0"` | `msrv = "1.95.0"` | 3 |
+| Clippy MSRV | `msrv = "1.95.0"` | `msrv = "1.95.0"` | 3 |
 | Clippy test carveouts | `allow-expect-in-tests = true`, `allow-unwrap-in-tests = true` | no test carveouts | 6 |
-| Clippy 1.94/1.95 lints | staged in `policy/clippy-lints.toml` | active or explicitly deferred with debt | 5 |
+| Clippy 1.94/1.95 lints | `policy/clippy-lints.toml` now records `msrv = "1.95"`; planned lints are explicitly staged at `allow` in `Cargo.toml` | active or explicitly deferred with debt | 5 |
 | No-panic allowlist | present, empty/advisory, identity is `path + family + selector` | exact counted identity | 7 |
 | No-panic baseline | absent | generated no-new-debt baseline | 8 |
 | Non-Rust allowlist | present, broad | narrowed with explicit covered-by evidence | 10 |
 | CI lane whitelist / LEM | present | calibrated for Rust 1.95 and risk-pack routing | 15 |
-| Core CI toolchain | important jobs still pin `1.93.0` | core/policy/coverage/ripr jobs pin `1.95.0` | 3 |
+| Core CI toolchain | workflow toolchain pins use `1.95.0`; coverage image is `rust-1.95` | workflows and the Rust CI image stay on the declared floor | 3 |
 | `ripr` | workflow exists, may skip when binary is absent | real advisory static mutation-exposure signal | 11 |
 | Mutation testing | expensive runtime evidence outside default PR | targeted risk PR, broader nightly, release readiness | 11, 15, 17 |
 
@@ -121,7 +121,7 @@ Each PR below is a single objective. Start every PR from clean `origin/main`.
 |---:|---|---|---|
 | 1 | `docs/rust-1.95-rollout-refresh` | `docs(policy): refresh Rust 1.95 and next-minor rollout map` | Documentation refresh/correction only. No Cargo, workflow, toolchain, or Rust source changes. |
 | 2 | `probe/rust-1.95-compat` | `chore(msrv): probe Rust 1.95 compatibility` | Run current `main` under Rust 1.95 before changing declared MSRV. Audit note preferred. |
-| 3 | `chore/msrv-rust-1.95` | `chore(msrv): raise workspace toolchain to Rust 1.95` | Bump `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, core/policy/coverage/ripr workflows, and `policy/clippy-lints.toml` MSRV. |
+| 3 | `chore/msrv-rust-1.95` | `chore(msrv): raise workspace toolchain to Rust 1.95` | Bump workspace and explicit member MSRV pins, `rust-toolchain.toml`, `clippy.toml`, workflow toolchain pins, the Rust CI image tag, `policy/clippy-lints.toml` MSRV, and explicit lint-ratchet deferrals. |
 | 4 | `policy/rust-1.95-lints` | `policy(rust): enable Rust 1.95 compiler lint floor` | Move compiler lint floor forward. Do not use `unsafe_code = "forbid"` globally. |
 | 5 | `policy/clippy-rust-1.95-ratchets` | `policy(clippy): activate Rust 1.95 lint ratchets` | Measure first, then activate clean or cheaply fixed 1.94/1.95 Clippy ratchets. Keep `disallowed_fields` planned until real fields are configured. |
 | 6 | `policy/no-test-clippy-carveouts` | `policy(clippy): remove test unwrap and expect carveouts` | Remove Clippy test carveouts and convert one narrow helper slice only. |

--- a/policy/clippy-lints.toml
+++ b/policy/clippy-lints.toml
@@ -1,5 +1,5 @@
 schema_version = "1.0"
-msrv = "1.93"
+msrv = "1.95"
 
 [policy]
 panic_free_tests = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,11 +1,11 @@
 # Pinned Rust toolchain for reproducible builds
-# MSRV: 1.93.0 (using Rust 2024 edition)
+# MSRV: 1.95.0 (using Rust 2024 edition)
 #
-# Bumped from 1.92.0 in the strict policy / CI economics rollout (PR 03):
-# - aligns with the strict Clippy profile staged in PR 08+
-# - prerequisite for ripr (>= 1.93) added in PR 13
+# Bumped from 1.93.0 in the Rust 1.95 / next-minor rollout:
+# - keeps local, core CI, policy, coverage, and ripr lanes on the declared floor
+# - leaves lint activation and Clippy test carveout removal to later rollout PRs
 [toolchain]
-channel = "1.93.0"
+channel = "1.95.0"
 profile = "minimal"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 targets = []


### PR DESCRIPTION
## Summary

- raise the workspace MSRV/toolchain surface from Rust 1.93.0 to Rust 1.95.0
- update explicit member `rust-version` pins, `clippy.toml`, `policy/clippy-lints.toml`, workflow toolchain/cache/image pins, and the Rust CI image tag
- keep Rust 1.94/1.95 Clippy ratchets explicitly staged so this PR does not silently activate lint cleanup before PR 5 / PR 13
- update rollout, Clippy, ripr, and changelog docs to keep later PR boundaries explicit

## Scope guardrails

- no Rust source changes
- no release version bump
- no Rust 1.95 API cleanup
- no Clippy lint activation
- no Clippy test carveout removal
- no no-panic baseline reset

## Local validation

- `rtk rustc --version` -> `rustc 1.95.0 (59807616e 2026-04-14)`
- `rtk cargo metadata --locked --no-deps --format-version 1` -> passed; workspace metadata reports `msrv = "1.95.0"`
- `rtk rg ... .github Cargo.toml crates clippy.toml policy rust-toolchain.toml` -> no active 1.93 pins found; remaining 1.93 references are historical/doc or source test-fixture strings outside this mechanical pin scope
- `rtk cargo check -p bitnet-common --locked --no-default-features` -> passed under Rust 1.95.0
- `RUSTFLAGS="-D warnings" rtk cargo clippy --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --lib --no-default-features --features cpu` -> passed after explicit lint-ratchet deferrals
- `rtk D:\Code\Rust\BitNet\target\release\xtask.exe check-lint-inheritance` -> passed (`138 crates checked, 0 missing`)
- `rtk D:\Code\Rust\BitNet\target\release\xtask.exe ci-lane-whitelist check` -> exited 0; existing duplicate-of warnings remain
- `rtk D:\Code\Rust\BitNet\target\release\xtask.exe check-clippy-exceptions` -> exited 0 and reported the existing 506 Clippy receipt errors scheduled for later rollout PRs
- `rtk D:\Code\Rust\BitNet\target\release\xtask.exe policy-report --report-dir target/bitnet/reports` -> exited 0 and reported existing no-panic/Clippy policy debt scheduled for later rollout PRs
- `rtk git diff --check` -> passed

## Local validation gaps

- `rtk cargo fmt --all -- --check` is still blocked locally on Windows by `The filename or extension is too long. (os error 206)`.
- Full local workspace gates remain blocked here by the known native SentencePiece/Python build path. CI is the required full-host validation for this PR.