### PR TITLE
ci: restore coverage receipt ownership

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -97,6 +97,17 @@ jobs:
               cargo llvm-cov report --text | tee coverage.txt
             '
 
+      - name: Restore coverage receipt ownership
+        if: always()
+        run: |
+          sudo mkdir -p target/bitnet/reports
+          sudo chown -R "$USER:$USER" target/bitnet
+          for file in coverage.json coverage.txt lcov.info; do
+            if [ -e "$file" ]; then
+              sudo chown "$USER:$USER" "$file"
+            fi
+          done
+
       - name: Disk usage after coverage
         if: always()
         run: |


### PR DESCRIPTION
## Summary
- Restore host ownership for the coverage receipt directory after the Docker coverage step.
- Keep coverage collection, threshold enforcement, and upload behavior unchanged.

## Why
The Rust 1.95 main-branch Coverage rerun reached receipt writing, then failed with:

`	ext
mkdir: cannot create directory  target/bitnet: Permission denied
`

The coverage container writes under 	arget as root. This PR creates 	arget/bitnet/reports with sudo and returns the receipt directory plus coverage report files to the host runner user before the existing post-coverage steps run.

## Validation
- git diff --check
- git diff --cached --check
- Attempted cargo run --locked -p xtask --no-default-features -- lint-workflows; local build did not complete within timeout, so CI workflow lint is the authoritative validation.