### PR TITLE
policy(rust): enable Rust 1.95 compiler lint floor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -571,11 +571,10 @@ opt-level = 2
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"
 unused_must_use = "deny"
-# `unexpected_cfgs` would fire on a number of legacy build-script
-# cfg names; staged at `allow` until those are inventoried in a
-# follow-up. The xtask file-policy gate already covers the
-# governance angle (no untracked non-Rust files).
-unexpected_cfgs = "allow"
+unexpected_cfgs = "warn"
+const_item_interior_mutations = "deny"
+function_casts_as_integer = "deny"
+unused_visibilities = "warn"
 
 [workspace.lints.clippy]
 # Broad category posture. After PR 07 ("workspace lint inheritance"),


### PR DESCRIPTION
## Summary
- Move the workspace rustc lint floor to the Rust 1.95 policy target.
- Keep the change scoped to [workspace.lints.rust] in Cargo.toml.
- Do not touch Clippy ratchets, no-panic policy, CUDA/runtime/server code, or release versions.

## Lint floor
- unsafe_op_in_unsafe_fn = deny (already active)
- unused_must_use = deny (already active)
- unexpected_cfgs = warn
- const_item_interior_mutations = deny
- function_casts_as_integer = deny
- unused_visibilities = warn

## Validation
- git diff --check
- git diff --cached --check
- git diff --check origin/main..HEAD
- cargo check --locked -p bitnet-prompt-templates-core --all-targets --no-default-features passed with existing benchmark deprecation warnings.
- D:\Code\Rust\BitNet\target\release\xtask.exe check-lint-inheritance passed: 138 crates checked, 0 missing.
- D:\Code\Rust\BitNet\target\release\xtask.exe check-clippy-exceptions completed with the existing 506 advisory errors.
- D:\Code\Rust\BitNet\target\release\xtask.exe policy-report --report-dir target/bitnet/reports completed with existing no-panic/Clippy debt reported.

## Local limitations
- cargo check --locked --workspace --all-targets --features cpu timed out locally after 30 minutes on Windows; matching cargo process was stopped.
- RUSTFLAGS=-D warnings cargo check --locked -p bitnet-common -p bitnet-prompt-templates-core -p bitnet-tokenizers -p bitnet-kernels --all-targets --features cpu timed out locally after 15 minutes; matching cargo process was stopped.
- RUSTFLAGS=-D warnings cargo check --locked -p bitnet-prompt-templates-core --all-targets --no-default-features fails on existing criterion::black_box deprecation warnings in benches/template_ops.rs, not on the new rustc lint floor.
- cargo run --locked -p xtask --no-default-features -- check-lint-inheritance timed out locally while building/running; used the existing built xtask binary for policy-reader validation.