### PR TITLE
docs: add M3 MacBook Air campaign roadmap

### DIFF
--- a/docs/apple-silicon/m3-macbook-air-roadmap.md
+++ b/docs/apple-silicon/m3-macbook-air-roadmap.md
@@ -21,6 +21,16 @@ These facts make the machine suitable for storage-conscious BitNet artifact
 qualification and dense SLM Apple CPU/NEON cross-checks. They do not create M4
 Mac mini performance evidence and do not prove BitNet local-answer quality.
 
+The campaign-local tracker for this lane is:
+
+```text
+docs/tracking/campaigns/apple-m3-macbook-air/
+```
+
+Use that tracker as the source of truth for work-item state, allowed paths,
+validation commands, and claim boundaries. This roadmap remains the operator
+sequence and evidence rubric.
+
 ## Lane Roles
 
 M3 MacBook Air:
@@ -54,13 +64,14 @@ handoff only after coherent reference output is recorded
 
 | Phase | Work item | Outcome | Evidence |
 |---:|---|---|---|
-| 0 | `MB-AS-007` | M3 Air roadmap, storage policy, sequencing, and claim boundaries | This document and campaign tracking |
-| 1 | `MB-AS-008` | Real M3 Air machine profile, no inference | `ci/hardware/apple-silicon-macbook/.../machine-profile.json` |
-| 2 | `MB-AS-002` | Dense Qwen SLM mirror on M3 Air | Mac validate receipt plus receipts-check output |
-| 3 | `ABAS-001` / `MB-AS-004` | Official Microsoft 2B I2_S artifact qualification | Reference-runner report, SHA256, tokenizer authority |
-| 4 | `ABAS-002` / `MB-AS-005` | Smaller 0.7B BitNet control candidate | Reference-runner report and cleanup record |
-| 5 | `ABAS-003` / `MB-AS-006` | 3B TL1/TL2 diagnostic only | Diagnostic report, explicit I2_S non-support note |
-| 6 | `ABAS-005` | M4 strict-proof handoff for accepted artifacts | Handoff plan only; no manufactured M4 receipt |
+| 0 | `M3MBA-001` | Campaign tracker, roadmap linkage, and claim boundaries | `docs/tracking/campaigns/apple-m3-macbook-air/` |
+| 1 | `M3MBA-002` | Real M3 Air machine profile, no inference | `ci/hardware/apple-silicon-macbook/.../machine-profile.json` |
+| 2 | `M3MBA-003` | Explicit M3 Air receipt label | Validator or label evidence for `apple-m3-air-cpu-neon` |
+| 3 | `M3MBA-004` | Dense Qwen SLM mirror on M3 Air | Mac validate receipt plus receipts-check output |
+| 4 | `M3MBA-005` | Official Microsoft 2B I2_S artifact qualification | Reference-runner report, SHA256, tokenizer authority |
+| 5 | `M3MBA-006` | Smaller 0.7B BitNet control candidate | Reference-runner report and cleanup record |
+| 6 | `M3MBA-007` | 3B TL1/TL2 diagnostic only | Diagnostic report, explicit I2_S non-support note |
+| 7 | `M3MBA-008` | M4 strict-proof handoff for accepted artifacts | Handoff plan only; no manufactured M4 receipt |
 
 ## Milestone Gates
 
@@ -69,14 +80,14 @@ that a reviewer can inspect without access to the local model cache.
 
 | Gate | Owner item | Required committed evidence | Local-only state | Exit decision |
 |---|---|---|---|---|
-| Machine readiness | `MB-AS-008` | Machine-profile receipt, schema-valid profile JSON, campaign event | None | Ready for dense control run |
-| Receipt label readiness | `MB-AS-008` or `MB-AS-002` | Validator or documented label support for `apple-m3-air-cpu-neon` | None | Ready to record M3 timing without M4 wording |
-| Dense control | `MB-AS-002` | Smoke receipt, receipts-check output, model hash, tokenizer metadata, fallback status | Downloaded dense Qwen artifact | Ready for bounded operator run or blocker report |
-| Dense operator | `MB-AS-002` | Operator receipt, allocation-audit summary, thermal/power context | Warm model cache | Ready for BitNet artifact screening |
-| Microsoft 2B screening | `MB-AS-004` | Candidate report with source revision, SHA256, tokenizer authority, reference output, cleanup status | Official 2B GGUF while active | Accept, reject, or block before secondary candidates |
-| Small candidate screening | `MB-AS-005` | Candidate report with route evidence and cleanup status | 0.7B GGUF while active | Keep for fast iteration or reject |
-| Diagnostic candidate | `MB-AS-006` | TL1/TL2 diagnostic report and I2_S non-claim | 3B GGUF while active | Diagnostic only, no proof claim |
-| Strict proof handoff | `ABAS-005` | New M4 work item naming artifact, backend, and receipt requirements | No dependency on M3 cache | Ready for separate M4 proof |
+| Machine readiness | `M3MBA-002` | Machine-profile receipt, schema-valid profile JSON, campaign event | None | Ready for receipt-label work |
+| Receipt label readiness | `M3MBA-003` | Validator or documented label support for `apple-m3-air-cpu-neon` | None | Ready to record M3 timing without M4 wording |
+| Dense control | `M3MBA-004` | Smoke receipt, receipts-check output, model hash, tokenizer metadata, fallback status | Downloaded dense Qwen artifact | Ready for bounded operator run or blocker report |
+| Dense operator | `M3MBA-004` | Operator receipt, allocation-audit summary, thermal/power context | Warm model cache | Ready for BitNet artifact screening |
+| Microsoft 2B screening | `M3MBA-005` | Candidate report with source revision, SHA256, tokenizer authority, reference output, cleanup status | Official 2B GGUF while active | Accept, reject, or block before secondary candidates |
+| Small candidate screening | `M3MBA-006` | Candidate report with route evidence and cleanup status | 0.7B GGUF while active | Keep for fast iteration or reject |
+| Diagnostic candidate | `M3MBA-007` | TL1/TL2 diagnostic report and I2_S non-claim | 3B GGUF while active | Diagnostic only, no proof claim |
+| Strict proof handoff | `M3MBA-008` | New M4 work item naming artifact, backend, and receipt requirements | No dependency on M3 cache | Ready for separate M4 proof |
 
 If a gate cannot pass, the PR should still leave a blocker report instead of
 silently skipping forward. A blocker report is acceptable evidence when it names
@@ -268,12 +279,13 @@ reproduced cheaply. The committed report should state what happened either way.
 
 | Order | Branch / item | Scope | Stop condition |
 |---:|---|---|---|
-| 1 | `MB-AS-008` | Real M3 Air profile receipt | Machine facts and `inference_run=false` committed |
-| 2 | `MB-AS-002` | Dense Qwen smoke/operator mirror | Receipts pass or blocker is recorded |
-| 3 | `MB-AS-004` | Microsoft 2B I2_S artifact qualification | Accept/reject report with tokenizer authority |
-| 4 | `MB-AS-005` | 0.7B 1bitLLM control candidate | Accept/reject report and cleanup state |
-| 5 | `MB-AS-006` | 3B TL1/TL2 diagnostic | Diagnostic report only |
-| 6 | `ABAS-005` | M4 strict-proof handoff | New M4 proof item, not an M3 claim |
+| 1 | `M3MBA-002` | Real M3 Air profile receipt | Machine facts and `inference_run=false` committed |
+| 2 | `M3MBA-003` | Explicit M3 Air receipt label | `apple-m3-air-cpu-neon` validation does not weaken M4 checks |
+| 3 | `M3MBA-004` | Dense Qwen smoke/operator mirror | Receipts pass or blocker is recorded |
+| 4 | `M3MBA-005` | Microsoft 2B I2_S artifact qualification | Accept/reject report with tokenizer authority |
+| 5 | `M3MBA-006` | 0.7B 1bitLLM control candidate | Accept/reject report and cleanup state |
+| 6 | `M3MBA-007` | 3B TL1/TL2 diagnostic | Diagnostic report only |
+| 7 | `M3MBA-008` | M4 strict-proof handoff | New M4 proof item, not an M3 claim |
 
 ## Execution Roadmap
 
@@ -435,14 +447,20 @@ reproduced cheaply. The committed report should state what happened either way.
 
 ## Near-Term Order
 
-1. Treat `MB-AS-007` as complete after PR #4511; keep this document as the lane
-   control plane.
-2. Run `MB-AS-008` to generate a real M3 Air machine-profile receipt under `ci/hardware/apple-silicon-macbook/2026-05-12/m3-air/`.
-3. Add or confirm the `apple-m3-air-cpu-neon` receipt label before model timing is recorded.
-4. Run `MB-AS-002` as an M3 Air dense Qwen mirror now that real MacBook hardware is available.
-5. Run the official Microsoft 2B I2_S reference qualification before any secondary BitNet candidate.
-6. Use the 0.7B 1bitLLM candidate only after the Microsoft path records either acceptance or a clear blocker.
-7. Keep M4 proof handoff separate until a candidate passes reference output with tokenizer authority.
+1. Land `M3MBA-001` so the campaign tracker, generated status, and roadmap link
+   become the lane control plane.
+2. Run `M3MBA-002` to generate a real M3 Air machine-profile receipt under
+   `ci/hardware/apple-silicon-macbook/2026-05-12/m3-air/`.
+3. Run `M3MBA-003` to add or confirm the `apple-m3-air-cpu-neon` receipt label
+   before model timing is recorded.
+4. Run `M3MBA-004` as an M3 Air dense Qwen mirror now that real MacBook hardware
+   is available.
+5. Run `M3MBA-005` for the official Microsoft 2B I2_S reference qualification
+   before any secondary BitNet candidate.
+6. Use the 0.7B 1bitLLM candidate in `M3MBA-006` only after the Microsoft path
+   records either acceptance or a clear blocker.
+7. Keep M4 proof handoff separate in `M3MBA-008` until a candidate passes
+   reference output with tokenizer authority.
 
 ## Review Checklist
 

--- a/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
@@ -1,0 +1,99 @@
+# Apple M3 MacBook Air Campaign
+
+Campaign ID: `apple-m3-macbook-air`
+
+Status: active
+
+## Objective
+
+Turn the available M3 MacBook Air into a disciplined Apple Silicon lane for
+machine-profile evidence, dense SLM cross-checks, large BitNet artifact
+qualification, and M4 strict-proof handoff planning without converting MacBook
+receipts into M4 Mac mini performance or BitNet local-answer claims.
+
+## Why This Exists
+
+The existing M3 MacBook Air roadmap names the right sequence, but the lane needs
+the same campaign-local control plane used by the other active hardware efforts.
+The MacBook has enough local storage for larger candidate artifacts, but it is a
+mobile, fanless Apple Silicon host. Its receipts need power, thermal, storage,
+cache, backend, fallback, and cleanup context before any timing or artifact
+decision can be trusted.
+
+This campaign sits between the completed M4 dense SLM lanes and the Apple BitNet
+artifact sweep. It proves what the MacBook observed, then hands accepted
+artifacts to separate strict proof items.
+
+## End State
+
+- A real M3 MacBook Air machine-profile receipt is committed with
+  `inference_run=false`.
+- M3 Air dense Qwen receipts use an explicit MacBook backend label and record
+  power, thermal, storage, model, tokenizer, and fallback context.
+- Larger BitNet candidate downloads are accepted, rejected, or blocked with
+  source, revision, size, SHA256, tokenizer authority, prompt output, and
+  cleanup status.
+- Accepted artifacts feed separate M4 Mac mini strict Apple CPU/NEON proof
+  items; M3 evidence does not become M4 evidence by wording.
+- The MacBook lane remains storage-aware and never commits model binaries.
+
+## Hard Constraints
+
+- This is the Apple M3 MacBook Air lane, not the M4 Mac mini product,
+  performance, or strict-proof lane.
+- Do not claim BitNet local-answer quality from dense Qwen SLM receipts.
+- Do not claim M4 Mac mini performance, broad Apple Silicon performance, QK256
+  support, full Apple Metal inference, Neural Engine execution, or MPSGraph model
+  inference from this lane.
+- Do not weaken existing M4 receipt checks to make M3 receipts fit; add the
+  smallest MacBook-specific label or validation path instead.
+- Do not add live model downloads, large artifact sweeps, or hardware timing
+  runs to generic required CI.
+- Never commit model binaries.
+
+## Work Items
+
+| Work item | Status | Notes |
+|---|---|---|
+| M3MBA-001 | in_progress | Add the campaign control plane and roadmap linkage for the M3 MacBook Air lane. |
+| M3MBA-002 | proposed | Commit the real M3 Air machine-profile receipt with storage, cache, power, thermal, and visibility fields. |
+| M3MBA-003 | proposed | Add or confirm the explicit `apple-m3-air-cpu-neon` receipt label without weakening M4 validation. |
+| M3MBA-004 | proposed | Mirror the known dense Qwen SLM route on M3 Air with smoke and operator receipts. |
+| M3MBA-005 | proposed | Qualify the official Microsoft 2B I2_S BitNet artifact on M3 Air under tokenizer authority. |
+| M3MBA-006 | proposed | Evaluate the smaller 0.7B 1bitLLM control candidate after Microsoft 2B is accepted, rejected, or blocked. |
+| M3MBA-007 | proposed | Run only diagnostic TL1/TL2 checks for the 3B candidate and record the I2_S non-claim. |
+| M3MBA-008 | proposed | Hand accepted artifacts to separate M4 strict-proof items without claiming proof in this lane. |
+
+## Review Policy
+
+Each PR should own one work item and should leave either passing evidence or a
+blocker report. Hardware and artifact PRs must record the exact command, host,
+artifact identity when relevant, receipt path, cleanup status, and claim
+boundary. A skipped live run is acceptable only when the blocker is explicit and
+the next smallest fix is named.
+
+Generic CI should cover tracker validity, schema shape, parser behavior, and
+synthetic receipt checks. Live M3 model runs, large downloads, timing receipts,
+and artifact sweeps are local or scheduled Apple-hardware evidence, not ordinary
+CI requirements.
+
+## Claim Boundary
+
+Do not claim:
+
+```text
+BitNet local-answer quality from dense Qwen evidence
+M4 Mac mini performance from MacBook timing
+QK256 support on Apple Silicon
+full Apple Metal inference
+Neural Engine execution
+MPSGraph model inference
+broad Apple Silicon performance
+```
+
+Do claim only:
+
+```text
+M3 MacBook Air machine facts, dense SLM cross-checks, artifact decisions,
+or handoff readiness when the named receipt or report provides that evidence
+```

--- a/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
@@ -1,0 +1,337 @@
+id = "apple-m3-macbook-air"
+title = "Apple M3 MacBook Air"
+status = "active"
+
+objective = "Turn the available M3 MacBook Air into a disciplined Apple Silicon lane for machine-profile evidence, dense SLM cross-checks, large BitNet artifact qualification, and M4 strict-proof handoff planning without converting MacBook receipts into M4 Mac mini performance or BitNet local-answer claims."
+
+end_state = [
+  "A real M3 MacBook Air machine-profile receipt is committed with inference_run=false.",
+  "M3 Air dense Qwen receipts use an explicit MacBook backend label and record power, thermal, storage, model, tokenizer, and fallback context.",
+  "Larger BitNet candidate downloads are accepted, rejected, or blocked with source, revision, size, SHA256, tokenizer authority, prompt output, and cleanup status.",
+  "Accepted artifacts feed separate M4 Mac mini strict Apple CPU/NEON proof items; M3 evidence does not become M4 evidence by wording.",
+  "The MacBook lane remains storage-aware and never commits model binaries.",
+]
+
+hard_constraints = [
+  "This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane.",
+  "Do not claim BitNet local-answer quality from dense Qwen SLM receipts.",
+  "Do not claim M4 Mac mini performance, broad Apple Silicon performance, QK256 support, full Apple Metal inference, Neural Engine execution, or MPSGraph model inference from this lane.",
+  "Do not weaken existing M4 receipt checks to make M3 receipts fit; add the smallest MacBook-specific label or validation path instead.",
+  "Do not add live model downloads, large artifact sweeps, or hardware timing runs to generic required CI.",
+  "Never commit model binaries.",
+]
+
+[[work_item]]
+id = "M3MBA-001"
+status = "in_progress"
+branch = "codex/apple-m3-macbook-air/roadmap-campaign"
+stackable = true
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = []
+acceptance = "Add the M3 MacBook Air campaign control plane, roadmap linkage, generated status, and first lifecycle event without running models or changing runtime behavior."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "ci/hardware/**",
+  "models/**",
+]
+may_claim = [
+  "The M3 MacBook Air lane has a campaign-local roadmap and tracker.",
+]
+must_not_claim = [
+  "Any model was run.",
+  "Any BitNet artifact was accepted.",
+  "M3 Air evidence proves M4 Mac mini performance.",
+]
+
+[[work_item]]
+id = "M3MBA-002"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-002-machine-profile"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-001"]
+acceptance = "Commit a real M3 MacBook Air machine-profile receipt with model identifier, chip, core split, memory, macOS version, free disk, cache root, power source, thermal state when available, CPU/NEON visibility, Metal visibility, MPSGraph visibility when available, and inference_run=false."
+commands = [
+  "Machine profile capture on M3 MacBook Air",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "models/**",
+]
+may_claim = [
+  "The M3 Air machine facts and storage budget are recorded.",
+]
+must_not_claim = [
+  "Model inference was run.",
+  "Dense SLM or BitNet answer quality is proven.",
+]
+
+[[work_item]]
+id = "M3MBA-003"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-003-receipt-label"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-002"]
+acceptance = "Add or confirm the smallest receipt validation path for apple-m3-air-cpu-neon, preserving existing apple-m4-cpu-neon checks and making MacBook timing impossible to label as M4 evidence."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo test --locked -p bitnet-cli --no-default-features --features cpu,full-cli mac_receipts -- --nocapture",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "crates/bitnet-cli/**",
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "models/**",
+]
+may_claim = [
+  "M3 Air receipts can use an explicit MacBook Apple CPU/NEON label.",
+]
+must_not_claim = [
+  "M3 Air receipts are M4 Mac mini receipts.",
+  "BitNet local-answer quality is proven.",
+]
+
+[[work_item]]
+id = "M3MBA-004"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-004-dense-qwen-mirror"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-003"]
+acceptance = "Mirror the known dense Qwen2.5 0.5B Mac path on M3 Air with smoke and, if smoke passes, operator receipts that record model hash, tokenizer metadata, deterministic settings, backend label, fallback status, power and thermal context, storage before/after, receipts-check output, and dense-only claim boundary."
+commands = [
+  "cargo run --release --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- mac validate --profile-set smoke --backend-label apple-m3-air-cpu-neon --quiet",
+  "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- mac receipts-check <receipt> --json",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "docs/apple-silicon/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "models/**",
+]
+may_claim = [
+  "The dense Qwen SLM path passed or failed on M3 Air for the recorded context.",
+]
+must_not_claim = [
+  "Dense Qwen evidence proves BitNet behavior.",
+  "M3 Air timing replaces the M4 Mac mini envelope.",
+]
+
+[[work_item]]
+id = "M3MBA-005"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-005-microsoft-2b-i2s"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-004"]
+acceptance = "Qualify the official Microsoft BitNet 2B I2_S GGUF on M3 Air with source revision, filename, size, SHA256, tokenizer/pre-tokenizer authority, reference-runner command, prompt outputs, bad/no-authority rejection evidence, and cleanup status."
+commands = [
+  "Reference runner prompt-suite command on M3 MacBook Air",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "The official Microsoft 2B I2_S artifact is accepted, rejected, or blocked for the recorded M3 Air reference context.",
+]
+must_not_claim = [
+  "Rust M4 BitNet local answers work.",
+  "Apple Metal BitNet inference works.",
+  "QK256 works on Apple Silicon.",
+]
+
+[[work_item]]
+id = "M3MBA-006"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-006-1bitllm-07b"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-005"]
+acceptance = "Evaluate 1bitLLM/bitnet_b1_58-large as the smaller M3 Air control candidate only after the Microsoft 2B path records acceptance, rejection, or a clear blocker."
+commands = [
+  "Reference runner prompt-suite command on M3 MacBook Air",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "The 0.7B candidate is accepted, rejected, or blocked as a smaller M3 Air control artifact.",
+]
+must_not_claim = [
+  "The 0.7B candidate proves official Microsoft 2B behavior.",
+  "Rust M4 BitNet local answers work.",
+]
+
+[[work_item]]
+id = "M3MBA-007"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-007-3b-diagnostic"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-005"]
+acceptance = "Evaluate the 3B candidate only on supported TL1/TL2 diagnostic routes, recording why I2_S remains unsupported and why the result is diagnostic rather than proof."
+commands = [
+  "Reference runner diagnostic command on M3 MacBook Air",
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "ci/hardware/apple-silicon-macbook/**",
+  "ci/model-artifacts/**",
+  "docs/apple-silicon/**",
+  "docs/model-artifacts/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/bitnet-kernels/**",
+  "crates/bitnet-qk256-dispatch/**",
+  "crates/bitnet-quantization/src/qk256/**",
+  "crates/bitnet-server/**",
+  "models/**",
+]
+may_claim = [
+  "The 3B candidate has recorded TL diagnostic evidence for the M3 Air context.",
+]
+must_not_claim = [
+  "3B I2_S is supported.",
+  "The 3B diagnostic route proves Apple local-answer quality.",
+]
+
+[[work_item]]
+id = "M3MBA-008"
+status = "proposed"
+branch = "codex/apple-m3-macbook-air/M3MBA-008-m4-proof-handoff"
+stackable = false
+review_mode = "codex_premerge"
+merge_policy = "automerge_when_green"
+human_gate = "on_blocker_only"
+blocked_by = ["M3MBA-005"]
+acceptance = "Promote accepted M3 Air BitNet artifact evidence into a separate M4 Mac mini strict Apple CPU/NEON proof item, preserving source, hash, tokenizer authority, route, and claim boundary without running or claiming the proof in this handoff item."
+commands = [
+  "cargo fmt --all -- --check",
+  "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
+  "cargo run --locked -p xtask --no-default-features -- campaign doctor",
+  "cargo run --locked -p xtask --no-default-features -- campaign generate --check",
+  "git diff --check",
+]
+allowed_paths = [
+  "docs/apple-silicon/**",
+  "docs/reports/**",
+  "docs/tracking/campaigns/apple-m3-macbook-air/**",
+  "docs/tracking/campaigns/apple-bitnet-artifact-sweep/**",
+  "docs/tracking/generated/**",
+]
+forbidden_paths = [
+  "crates/**",
+  "models/**",
+]
+may_claim = [
+  "Accepted M3 Air artifact evidence is ready for a separate M4 strict-proof item.",
+]
+must_not_claim = [
+  "The M4 strict proof already passed.",
+  "M3 Air evidence is M4 Mac mini evidence.",
+]

--- a/docs/tracking/campaigns/apple-m3-macbook-air/events/2026-05-12T000000Z-M3MBA-001-in-progress.toml
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/events/2026-05-12T000000Z-M3MBA-001-in-progress.toml
@@ -1,0 +1,12 @@
+timestamp = "2026-05-12T00:00:00Z"
+campaign = "apple-m3-macbook-air"
+item = "M3MBA-001"
+event = "in_progress"
+actor = "codex"
+branch = "codex/apple-m3-macbook-air/roadmap-campaign"
+
+notes = [
+  "The item adds campaign-local control files for the live M3 MacBook Air lane.",
+  "Scope is tracker and roadmap documentation only; no model inference, large artifact download, runtime change, or hardware performance claim is introduced.",
+  "The lane remains separate from M4 Mac mini dense SLM performance, strict BitNet proof, QK256, Neural Engine, MPSGraph, and full Apple Metal claims.",
+]

--- a/docs/tracking/campaigns/apple-m3-macbook-air/generated/status.md
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/generated/status.md
@@ -1,0 +1,28 @@
+<!-- GENERATED: do not edit by hand. Run cargo run -p xtask --no-default-features -- campaign generate. -->
+# Apple M3 MacBook Air Campaign Status
+
+- Campaign: `apple-m3-macbook-air`
+- State: `active`
+- Objective: Turn the available M3 MacBook Air into a disciplined Apple Silicon lane for machine-profile evidence, dense SLM cross-checks, large BitNet artifact qualification, and M4 strict-proof handoff planning without converting MacBook receipts into M4 Mac mini performance or BitNet local-answer claims.
+
+## Work Items
+
+| Item | State | PR | Branch | Review | Merge | Human gate | Acceptance |
+|---|---|---:|---|---|---|---|---|
+| M3MBA-001 | in_progress | TBD | `codex/apple-m3-macbook-air/roadmap-campaign` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add the M3 MacBook Air campaign control plane, roadmap linkage, generated status, and first lifecycle event without running models or changing runtime behavior. |
+| M3MBA-002 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-002-machine-profile` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Commit a real M3 MacBook Air machine-profile receipt with model identifier, chip, core split, memory, macOS version, free disk, cache root, power source, thermal state when available, CPU/NEON visibility, Metal visibility, MPSGraph visibility when available, and inference_run=false. |
+| M3MBA-003 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-003-receipt-label` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add or confirm the smallest receipt validation path for apple-m3-air-cpu-neon, preserving existing apple-m4-cpu-neon checks and making MacBook timing impossible to label as M4 evidence. |
+| M3MBA-004 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-004-dense-qwen-mirror` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Mirror the known dense Qwen2.5 0.5B Mac path on M3 Air with smoke and, if smoke passes, operator receipts that record model hash, tokenizer metadata, deterministic settings, backend label, fallback status, power and thermal context, storage before/after, receipts-check output, and dense-only claim boundary. |
+| M3MBA-005 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-005-microsoft-2b-i2s` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Qualify the official Microsoft BitNet 2B I2_S GGUF on M3 Air with source revision, filename, size, SHA256, tokenizer/pre-tokenizer authority, reference-runner command, prompt outputs, bad/no-authority rejection evidence, and cleanup status. |
+| M3MBA-006 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-006-1bitllm-07b` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate 1bitLLM/bitnet_b1_58-large as the smaller M3 Air control candidate only after the Microsoft 2B path records acceptance, rejection, or a clear blocker. |
+| M3MBA-007 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-007-3b-diagnostic` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Evaluate the 3B candidate only on supported TL1/TL2 diagnostic routes, recording why I2_S remains unsupported and why the result is diagnostic rather than proof. |
+| M3MBA-008 | proposed | TBD | `codex/apple-m3-macbook-air/M3MBA-008-m4-proof-handoff` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Promote accepted M3 Air BitNet artifact evidence into a separate M4 Mac mini strict Apple CPU/NEON proof item, preserving source, hash, tokenizer authority, route, and claim boundary without running or claiming the proof in this handoff item. |
+
+## Hard Constraints
+
+- This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane.
+- Do not claim BitNet local-answer quality from dense Qwen SLM receipts.
+- Do not claim M4 Mac mini performance, broad Apple Silicon performance, QK256 support, full Apple Metal inference, Neural Engine execution, or MPSGraph model inference from this lane.
+- Do not weaken existing M4 receipt checks to make M3 receipts fit; add the smallest MacBook-specific label or validation path instead.
+- Do not add live model downloads, large artifact sweeps, or hardware timing runs to generic required CI.
+- Never commit model binaries.

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -7,6 +7,13 @@
 | apple-bitnet-artifact-sweep | ABAS-003 | ABAS-001 | proposed |
 | apple-bitnet-artifact-sweep | ABAS-004 | ABAS-001, ABAS-002 | proposed |
 | apple-bitnet-artifact-sweep | ABAS-005 | ABAS-001 | proposed |
+| apple-m3-macbook-air | M3MBA-002 | M3MBA-001 | proposed |
+| apple-m3-macbook-air | M3MBA-003 | M3MBA-002 | proposed |
+| apple-m3-macbook-air | M3MBA-004 | M3MBA-003 | proposed |
+| apple-m3-macbook-air | M3MBA-005 | M3MBA-004 | proposed |
+| apple-m3-macbook-air | M3MBA-006 | M3MBA-005 | proposed |
+| apple-m3-macbook-air | M3MBA-007 | M3MBA-005 | proposed |
+| apple-m3-macbook-air | M3MBA-008 | M3MBA-005 | proposed |
 | apple-m4 | M4-002 | M4-001 | merged |
 | apple-m4 | M4-003 | M4-002 | merged |
 | apple-m4 | M4-004 | M4-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -5,6 +5,7 @@
 |---|---|---:|---|---|---|
 | amd-cpu-baselines | AMD5700X-003 | TBD | ready | AMD9950X3D-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-bitnet-artifact-sweep | ABAS-001 | TBD | proposed | ABAS-002 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
+| apple-m3-macbook-air | M3MBA-001 | TBD | in_progress | M3MBA-002 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |

--- a/docs/tracking/generated/lane-dashboard.md
+++ b/docs/tracking/generated/lane-dashboard.md
@@ -5,6 +5,7 @@
 |---|---|---|---|
 | amd-cpu-baselines | AMD CPU baselines | AMD5700X-003 | These lanes are CPU proof lanes, not accelerator lanes. |
 | apple-bitnet-artifact-sweep | Apple BitNet artifact sweep | ABAS-001 | Use MacBook first for larger artifact sweeps; do not manufacture MacBook receipts from the M4 Mac mini. |
+| apple-m3-macbook-air | Apple M3 MacBook Air | M3MBA-001 | This is the Apple M3 MacBook Air lane, not the M4 Mac mini product, performance, or strict-proof lane. |
 | apple-m4 | Apple M4 Mac mini validation | M4-018 | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-continuity | Apple M4 continuity | M4-CONT-005 | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | Apple M4 dense SLM regression guardrails | M4-SLM-REG-005 | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |


### PR DESCRIPTION
## Summary
- add the `apple-m3-macbook-air` campaign control plane with M3MBA-001 through M3MBA-008
- link the existing M3 MacBook Air roadmap to the campaign tracker and replace legacy MB-AS references in the active roadmap sequence
- regenerate campaign dashboards so the lane appears in global, lane, blocked-item, and campaign status views

## Validation
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim boundary
Docs/tracker only. No model inference, no large artifact download, no runtime change, no M4 performance claim, and no BitNet local-answer claim.