### PR TITLE
docs: expand M3 MacBook Air roadmap detail

### DIFF
--- a/docs/GPU_COMPATIBILITY_MATRIX.md
+++ b/docs/GPU_COMPATIBILITY_MATRIX.md
@@ -63,7 +63,7 @@ the CUDA kernel structure. Runtime integration is not yet implemented.
 |------|--------|---------------|-------|
 | M1 / M1 Pro / M1 Max | 🔮 Planned | v0.3.0 | macOS 13+ (Ventura) |
 | M2 / M2 Pro / M2 Max | 🔮 Planned | v0.3.0 | |
-| M3 / M3 Pro / M3 Max | 🔮 Planned | v0.3.0 | |
+| M3 / M3 Pro / M3 Max | 🔮 Planned | v0.3.0 | Metal GPU support remains planned; the live M3 MacBook Air lane is CPU/NEON receipt and artifact-screening work. See `docs/apple-silicon/m3-macbook-air-roadmap.md`. |
 | M4 / M4 Pro / M4 Max | 🔮 Planned | v0.3.0 | |
 
 Metal GPU detection is already present via `system_profiler` in

--- a/docs/apple-silicon/m3-macbook-air-roadmap.md
+++ b/docs/apple-silicon/m3-macbook-air-roadmap.md
@@ -60,6 +60,15 @@ candidate acceptance or rejection
 handoff only after coherent reference output is recorded
 ```
 
+Related control files:
+
+```text
+ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+docs/apple-silicon/bitnet-candidate-matrix.md
+docs/apple-silicon/apple-bitnet-artifact-sweep.md
+docs/tracking/campaigns/apple-bitnet-artifact-sweep/
+```
+
 ## Roadmap Summary
 
 | Phase | Work item | Outcome | Evidence |
@@ -67,11 +76,11 @@ handoff only after coherent reference output is recorded
 | 0 | `M3MBA-001` | Campaign tracker, roadmap linkage, and claim boundaries | `docs/tracking/campaigns/apple-m3-macbook-air/` |
 | 1 | `M3MBA-002` | Real M3 Air machine profile, no inference | `ci/hardware/apple-silicon-macbook/.../machine-profile.json` |
 | 2 | `M3MBA-003` | Explicit M3 Air receipt label | Validator or label evidence for `apple-m3-air-cpu-neon` |
-| 3 | `M3MBA-004` | Dense Qwen SLM mirror on M3 Air | Mac validate receipt plus receipts-check output |
+| 3 | `M3MBA-004` | Dense Qwen SLM mirror on M3 Air | `ci/hardware/apple-silicon-macbook/2026-05-12/m3-air/qwen-mirror-smoke.json` plus report |
 | 4 | `M3MBA-005` | Official Microsoft 2B I2_S artifact qualification | Reference-runner report, SHA256, tokenizer authority |
-| 5 | `M3MBA-006` | Smaller 0.7B BitNet control candidate | Reference-runner report and cleanup record |
-| 6 | `M3MBA-007` | 3B TL1/TL2 diagnostic only | Diagnostic report, explicit I2_S non-support note |
-| 7 | `M3MBA-008` | M4 strict-proof handoff for accepted artifacts | Handoff plan only; no manufactured M4 receipt |
+| 5 | `M3MBA-006` | Smaller 0.7B BitNet control candidate | `docs/reports/apple-silicon-macbook-m3-air-1bitllm-07b.md` |
+| 6 | `M3MBA-007` | 3B TL1/TL2 diagnostic only | `docs/reports/apple-silicon-macbook-m3-air-3b-tl-diagnostic.md` |
+| 7 | `M3MBA-008` | M4 strict-proof handoff for accepted artifacts | `docs/reports/apple-silicon-macbook-m3-air-m4-proof-handoff.md` |
 
 ## Milestone Gates
 
@@ -113,7 +122,7 @@ condition:
 ```text
 foundation lane:
   prove the local machine facts, storage budget, cache root, and receipt label
-  stop when MB-AS-008 records inference_run=false profile evidence
+  stop when M3MBA-002 records inference_run=false profile evidence
 
 dense SLM lane:
   mirror the known-good Qwen route on the M3 Air with deterministic receipts
@@ -360,11 +369,11 @@ reproduced cheaply. The committed report should state what happened either way.
      --corpus-repeat-runs 2 \
      --max-new-tokens 32 \
      --backend-label apple-m3-air-cpu-neon \
-     --json-out target/apple-silicon-macbook/m3-air/MB-AS-002/qwen-mirror-smoke.json \
+     --json-out target/apple-silicon-macbook/m3-air/M3MBA-004/qwen-mirror-smoke.json \
      --quiet
 
    cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- mac receipts-check \
-     target/apple-silicon-macbook/m3-air/MB-AS-002/qwen-mirror-smoke.json \
+     target/apple-silicon-macbook/m3-air/M3MBA-004/qwen-mirror-smoke.json \
      --json
    ```
 
@@ -378,7 +387,7 @@ reproduced cheaply. The committed report should state what happened either way.
      --max-new-tokens 32 \
      --allocation-audit \
      --backend-label apple-m3-air-cpu-neon \
-     --json-out target/apple-silicon-macbook/m3-air/MB-AS-002/qwen-mirror-operator.json \
+     --json-out target/apple-silicon-macbook/m3-air/M3MBA-004/qwen-mirror-operator.json \
      --quiet
    ```
 
@@ -394,6 +403,14 @@ reproduced cheaply. The committed report should state what happened either way.
    authority, external Microsoft pre-tokenizer authority, reference-runner
    command, prompt outputs, bad/no-authority rejection evidence, and cleanup
    status.
+
+   Cross-check candidate priority and route expectations against:
+
+   ```text
+   ci/hardware/apple-silicon-macbook/bitnet-candidate-matrix.toml
+   docs/apple-silicon/bitnet-candidate-matrix.md
+   docs/apple-silicon/apple-bitnet-artifact-sweep.md
+   ```
 
    Required report:
 
@@ -434,6 +451,13 @@ reproduced cheaply. The committed report should state what happened either way.
    Falcon-E candidates remain secondary and should wait until Microsoft and
    1bitLLM behavior is understood.
 
+   Required reports:
+
+   ```text
+   docs/reports/apple-silicon-macbook-m3-air-1bitllm-07b.md
+   docs/reports/apple-silicon-macbook-m3-air-3b-tl-diagnostic.md
+   ```
+
    The 0.7B candidate should answer whether the smaller artifact is useful for
    fast local iteration on this M3 Air. The 3B diagnostic should answer only
    whether supported TL routes provide useful compatibility evidence; it must
@@ -444,6 +468,12 @@ reproduced cheaply. The committed report should state what happened either way.
    Promote only accepted artifacts to a separate M4 strict Apple CPU/NEON proof
    item. The M3 Air can qualify artifacts and compare Apple Silicon behavior; it
    must not be used to manufacture M4 receipts.
+
+   Required handoff report:
+
+   ```text
+   docs/reports/apple-silicon-macbook-m3-air-m4-proof-handoff.md
+   ```
 
 ## Near-Term Order
 

--- a/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
@@ -64,6 +64,39 @@ artifacts to separate strict proof items.
 | M3MBA-007 | proposed | Run only diagnostic TL1/TL2 checks for the 3B candidate and record the I2_S non-claim. |
 | M3MBA-008 | proposed | Hand accepted artifacts to separate M4 strict-proof items without claiming proof in this lane. |
 
+## Phase Roadmap
+
+| Phase | Work item(s) | Purpose | Committed output |
+|---|---|---|---|
+| Foundation | M3MBA-001, M3MBA-002, M3MBA-003 | Make the M3 Air a receipt-backed evidence source before model timing exists. | Campaign tracker, real machine profile, explicit MacBook backend label. |
+| Dense control | M3MBA-004 | Mirror the established dense Qwen SLM path on the exact MacBook host. | Smoke/operator receipts, receipt-check output, thermal and power context. |
+| BitNet artifact qualification | M3MBA-005, M3MBA-006, M3MBA-007 | Use the MacBook storage budget to accept, reject, or block candidate artifacts. | Candidate reports with source, revision, SHA256, tokenizer authority, prompt output, and cleanup state. |
+| Strict-proof handoff | M3MBA-008 | Convert accepted artifact evidence into separate M4 proof work. | Handoff report only; no manufactured M4 receipt. |
+
+## Milestone Gates
+
+The lane advances only when the previous gate leaves durable committed evidence.
+Local cache state, terminal output, and downloaded model files are not enough.
+
+| Gate | Required before advancing |
+|---|---|
+| Machine readiness | Real profile receipt records model identifier, chip, core split, memory, macOS version, cache root, free disk, power, thermal state when available, CPU/NEON visibility, Metal visibility, MPSGraph visibility when available, and `inference_run=false`. |
+| Receipt label readiness | `apple-m3-air-cpu-neon` or a documented successor is accepted without weakening `apple-m4-cpu-neon` validation. |
+| Dense control readiness | Dense Qwen smoke/operator receipts pass validation or leave a blocker report with backend, fallback, model hash, tokenizer metadata, power, thermal, and storage context. |
+| BitNet screening readiness | Official Microsoft 2B I2_S evidence records source revision, filename, size, SHA256, tokenizer authority, reference outputs, no-authority rejection evidence, and cleanup status. |
+| Handoff readiness | Only accepted artifacts are named in separate M4 strict-proof work, and the handoff requires fresh M4 receipts before any M4 claim. |
+
+## Output Map
+
+| Work item | Primary output |
+|---|---|
+| M3MBA-002 | `ci/hardware/apple-silicon-macbook/2026-05-12/m3-air/machine-profile.json` |
+| M3MBA-004 | `ci/hardware/apple-silicon-macbook/2026-05-12/m3-air/qwen-mirror-smoke.json` and `docs/reports/apple-silicon-macbook-m3-air-qwen-mirror.md` |
+| M3MBA-005 | `docs/reports/apple-silicon-macbook-m3-air-microsoft-2b-i2s.md` |
+| M3MBA-006 | `docs/reports/apple-silicon-macbook-m3-air-1bitllm-07b.md` |
+| M3MBA-007 | `docs/reports/apple-silicon-macbook-m3-air-3b-tl-diagnostic.md` |
+| M3MBA-008 | `docs/reports/apple-silicon-macbook-m3-air-m4-proof-handoff.md` |
+
 ## Review Policy
 
 Each PR should own one work item and should leave either passing evidence or a

--- a/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
@@ -68,7 +68,10 @@ human_gate = "on_blocker_only"
 blocked_by = ["M3MBA-001"]
 acceptance = "Commit a real M3 MacBook Air machine-profile receipt with model identifier, chip, core split, memory, macOS version, free disk, cache root, power source, thermal state when available, CPU/NEON visibility, Metal visibility, MPSGraph visibility when available, and inference_run=false."
 commands = [
-  "Machine profile capture on M3 MacBook Air",
+  "sw_vers",
+  "sysctl -n machdep.cpu.brand_string hw.memsize hw.physicalcpu hw.perflevel0.physicalcpu hw.perflevel1.physicalcpu",
+  "system_profiler SPHardwareDataType SPDisplaysDataType SPPowerDataType",
+  "df -k . \"$HOME/Library/Caches\"",
   "cargo fmt --all -- --check",
   "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
   "cargo run --locked -p xtask --no-default-features -- campaign doctor",
@@ -183,7 +186,10 @@ human_gate = "on_blocker_only"
 blocked_by = ["M3MBA-004"]
 acceptance = "Qualify the official Microsoft BitNet 2B I2_S GGUF on M3 Air with source revision, filename, size, SHA256, tokenizer/pre-tokenizer authority, reference-runner command, prompt outputs, bad/no-authority rejection evidence, and cleanup status."
 commands = [
-  "Reference runner prompt-suite command on M3 MacBook Air",
+  "huggingface-cli download microsoft/bitnet-b1.58-2B-4T-gguf ggml-model-i2_s.gguf --revision <revision> --local-dir <cache-root>/microsoft-bitnet-2b-i2s",
+  "shasum -a 256 <cache-root>/microsoft-bitnet-2b-i2s/ggml-model-i2_s.gguf",
+  "cargo run --release --locked -p xtask --no-default-features -- fetch-cpp --backend cpu",
+  "${BITNET_CPP_DIR:-$HOME/.cache/bitnet_cpp}/build/bin/llama-cli -m <cache-root>/microsoft-bitnet-2b-i2s/ggml-model-i2_s.gguf -p <prompt-from-ci/quality/bitnet-answer-corpus.yaml> -n 32 --no-display-prompt --temp 0 --top-k 1 --override-kv tokenizer.ggml.pre=str:llama-bpe --no-mmap",
   "cargo fmt --all -- --check",
   "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
   "cargo run --locked -p xtask --no-default-features -- campaign doctor",
@@ -227,7 +233,9 @@ human_gate = "on_blocker_only"
 blocked_by = ["M3MBA-005"]
 acceptance = "Evaluate 1bitLLM/bitnet_b1_58-large as the smaller M3 Air control candidate only after the Microsoft 2B path records acceptance, rejection, or a clear blocker."
 commands = [
-  "Reference runner prompt-suite command on M3 MacBook Air",
+  "huggingface-cli download 1bitLLM/bitnet_b1_58-large <gguf-file> --revision <revision> --local-dir <cache-root>/1bitllm-07b",
+  "shasum -a 256 <cache-root>/1bitllm-07b/<gguf-file>",
+  "${BITNET_CPP_DIR:-$HOME/.cache/bitnet_cpp}/build/bin/llama-cli -m <cache-root>/1bitllm-07b/<gguf-file> -p <prompt-from-ci/quality/bitnet-answer-corpus.yaml> -n 32 --no-display-prompt --temp 0 --top-k 1 --no-mmap",
   "cargo fmt --all -- --check",
   "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
   "cargo run --locked -p xtask --no-default-features -- campaign doctor",
@@ -269,7 +277,9 @@ human_gate = "on_blocker_only"
 blocked_by = ["M3MBA-005"]
 acceptance = "Evaluate the 3B candidate only on supported TL1/TL2 diagnostic routes, recording why I2_S remains unsupported and why the result is diagnostic rather than proof."
 commands = [
-  "Reference runner diagnostic command on M3 MacBook Air",
+  "huggingface-cli download 1bitLLM/bitnet_b1_58-3B <tl1-or-tl2-gguf-file> --revision <revision> --local-dir <cache-root>/1bitllm-3b-diagnostic",
+  "shasum -a 256 <cache-root>/1bitllm-3b-diagnostic/<tl1-or-tl2-gguf-file>",
+  "${BITNET_CPP_DIR:-$HOME/.cache/bitnet_cpp}/build/bin/llama-cli -m <cache-root>/1bitllm-3b-diagnostic/<tl1-or-tl2-gguf-file> -p <diagnostic-prompt> -n 32 --no-display-prompt --temp 0 --top-k 1 --no-mmap",
   "cargo fmt --all -- --check",
   "cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air",
   "cargo run --locked -p xtask --no-default-features -- campaign doctor",

--- a/docs/tracking/campaigns/apple-silicon-macbook/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-silicon-macbook/CAMPAIGN.md
@@ -26,6 +26,12 @@ Dense Qwen success remains dense SLM evidence. It validates Mac UX and Apple CPU
 
 ## Initial Work Items
 
+The live M3 MacBook Air execution lane now has its own campaign-local control
+plane at `docs/tracking/campaigns/apple-m3-macbook-air/`. Treat this campaign as
+the broader MacBook umbrella and historical cross-reference record; use
+`apple-m3-macbook-air` for current M3 Air item state, validation commands,
+output paths, and merge gates.
+
 | Work item | Status | Notes |
 |---|---|---|
 | MB-AS-001 | merged | Add a MacBook machine/storage/profile receipt contract. |


### PR DESCRIPTION
## Summary
- expand the M3 MacBook Air campaign page with phase roadmap, milestone gates, and output map
- fix stale MB-AS references in the M3 roadmap and add concrete output paths for later M3MBA items
- link the M3 lane to the MacBook candidate matrix, Apple BitNet sweep, umbrella MacBook campaign, and GPU matrix note
- replace generic artifact-lane command placeholders with concrete fetch/hash/reference-runner command shapes

## Validation
- cargo fmt --all -- --check
- cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air
- cargo run --locked -p xtask --no-default-features -- campaign doctor
- cargo run --locked -p xtask --no-default-features -- campaign generate --check
- git diff --check