### PR TITLE
ci: split AVX2 test steps

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -272,7 +272,7 @@ jobs:
             -p bitnet-testing-policy-interop \
             --no-default-features --features cpu
 
-      - name: "Run unit tests: AVX2 (x86_64 static +avx2)"
+      - name: "Run unit tests: AVX2 quantization (x86_64 static +avx2)"
         if: needs.classify-changes.outputs.tracker_only != 'true' && runner.os == 'Linux' && runner.arch == 'X64'
         env:
           RUSTFLAGS: "-D warnings -C target-feature=+avx2"
@@ -282,6 +282,12 @@ jobs:
             --lib \
             --no-default-features --features cpu \
             -- --nocapture
+
+      - name: "Run unit tests: AVX2 kernels (x86_64 static +avx2)"
+        if: needs.classify-changes.outputs.tracker_only != 'true' && runner.os == 'Linux' && runner.arch == 'X64'
+        env:
+          RUSTFLAGS: "-D warnings -C target-feature=+avx2"
+        run: |
           cargo test --locked \
             -p bitnet-kernels \
             --lib \


### PR DESCRIPTION
## Summary
- split the Linux AVX2 CI test tail into separate quantization and kernel steps
- keep the same conditions, RUSTFLAGS, feature sets, and cargo test commands
- make future AVX2 stalls/failures attributable to the package under test

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-core.yml'); puts 'ci-core.yml parsed'"`
- `git diff --check`

## Notes
This does not reduce coverage or change test selection. It is a devex/diagnostics improvement after the AVX2 step was the long tail on several PRs.
