### PR TITLE
fix(ci): repair Rust 1.95 check failures

### DIFF
--- a/crates/bitnet-kernels/src/cuda/kernel_cache.rs
+++ b/crates/bitnet-kernels/src/cuda/kernel_cache.rs
@@ -705,6 +705,7 @@ impl BinaryCache {
         }
 
         let path = self.cache_dir.join(&filename);
+        ensure_dir(&self.cache_dir)?;
         // Serialize: 8-byte compile_time_nanos + 8-byte compiled_at + entry_point_len(4) + entry_point + binary
         let mut data = Vec::new();
         data.extend_from_slice(&kernel.compile_time.as_nanos().to_le_bytes());
@@ -1691,6 +1692,21 @@ mod tests {
         let loaded = bc.load(&key).unwrap().unwrap();
         assert_eq!(loaded.entry_point, "test_store");
         assert_eq!(loaded.binary, kernel.binary);
+        cleanup_dir(&dir);
+    }
+
+    #[test]
+    fn binary_cache_store_recreates_missing_dir() {
+        let dir = temp_dir();
+        let mut bc = BinaryCache::open(&dir, 1024 * 1024, 0).unwrap();
+        cleanup_dir(&dir);
+
+        let key = make_key("recreate_dir");
+        let kernel = make_kernel("recreate_dir");
+        bc.store(&key, &kernel).unwrap();
+
+        assert!(dir.exists());
+        assert!(bc.contains(&key));
         cleanup_dir(&dir);
     }
 

--- a/crates/bitnet-spirv/src/lib.rs
+++ b/crates/bitnet-spirv/src/lib.rs
@@ -299,7 +299,7 @@ impl SpirVValidator {
     /// Check whether the binary might contain a given SPIR-V capability.
     #[must_use]
     pub fn has_capability(bytes: &[u8], capability_id: u32) -> bool {
-        let op_capability: u32 = (2 << 16) | 17;
+        let op_capability: u32 = (2 << 16) | 0x0011;
         if bytes.len() < 24 {
             return false;
         }


### PR DESCRIPTION
## Summary
- Recreate the binary cache directory in BinaryCache::store before writing cache files.
- Add regression coverage for a cache directory deleted after open().
- Use hexadecimal notation for the SPIR-V OpCapability opcode operand so the Rust 1.95 Clippy ratchet passes without suppressions.

## Validation
- PASS: cargo fmt -p bitnet-kernels -p bitnet-spirv -- --check
- PASS: cargo clippy -p bitnet-spirv --locked --no-default-features -- -D warnings
- PASS: git diff --check
- BLOCKED locally: cargo test -p bitnet-kernels binary_cache_store_recreates_missing_dir --lib --no-default-features --features cpu --locked (Windows sentencepiece-sys build requires the MSVC C++ environment before the kernel test binary is built; CI proved the macOS CPU test path after the first commit).

## CI Evidence
- Fix-forward for post-merge main macOS (Apple Silicon) failure in cuda::kernel_cache::tests::binary_cache_clear: failed to write binary cache: No such file or directory.
- Fix-forward for PR Intel GPU Feature Matrix failure: clippy::decimal_bitwise_operands in bitnet-spirv.