### PR TITLE
ci: unblock core clippy and timeout gates

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -158,7 +158,7 @@ jobs:
   build-test-linux:
     name: Build & Test (ubuntu-latest)
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 40
     needs: [classify-changes]
     env:
       RUSTFLAGS: "-D warnings"

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -158,6 +158,9 @@ jobs:
   build-test-linux:
     name: Build & Test (ubuntu-latest)
     runs-on: ubuntu-22.04
+    # Keep this above the normal completion time for the expanded core test
+    # lane. CI timeouts are guardrails against wedged jobs, not targets that
+    # should routinely cancel useful proof near completion.
     timeout-minutes: 40
     needs: [classify-changes]
     env:

--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -63,6 +63,9 @@ jobs:
         with:
           shared-key: macos-arm64-cpu
 
+      - name: Prefer installed Rust toolchain binaries
+        run: echo "$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin" >> "$GITHUB_PATH"
+
       - name: Build core crates (CPU)
         run: |
           cargo build --locked \
@@ -112,6 +115,9 @@ jobs:
         with:
           shared-key: macos-arm64-metal
 
+      - name: Prefer installed Rust toolchain binaries
+        run: echo "$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin" >> "$GITHUB_PATH"
+
       - name: Check Metal feature compiles
         run: |
           cargo check --locked \
@@ -144,6 +150,9 @@ jobs:
         with:
           shared-key: macos-arm64-clippy
 
+      - name: Prefer installed Rust toolchain binaries
+        run: echo "$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin" >> "$GITHUB_PATH"
+
       - name: Run clippy (CPU, libs only)
         run: |
           cargo clippy --locked \
@@ -170,6 +179,9 @@ jobs:
         with:
           toolchain: "1.95.0"
           components: rustfmt
+
+      - name: Prefer installed Rust toolchain binaries
+        run: echo "$HOME/.rustup/toolchains/1.95.0-aarch64-apple-darwin/bin" >> "$GITHUB_PATH"
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
+++ b/crates/bitnet-testing-policy-contract/tests/snapshot_tests.rs
@@ -25,5 +25,5 @@ fn drift_check_matches_consistency() {
     let consistent = feature_contract_snapshot().is_consistent();
     let has_drift = drift_check().is_some();
     // drift_check returns Some iff is_consistent() is false
-    insta::assert_snapshot!((consistent == !has_drift).to_string());
+    insta::assert_snapshot!((consistent != has_drift).to_string());
 }

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -363,6 +363,13 @@ A useful CI minute either:
 CI minutes spent on duplicated checks, no-op jobs, broad unrelated workflows,
 unnecessary model downloads, or non-blocking confirmation lanes are waste.
 
+Timeouts are cost guardrails, not budget targets. A timeout should catch
+runaway or wedged jobs with enough diagnostic output to act on. It should not
+regularly fire just before a valid lane completes, because that burns nearly
+the full runner budget while discarding the proof. When a lane repeatedly times
+out after useful work has passed, either split the lane, reduce its scope, or
+raise the cap to a value that lets the lane finish with normal variance.
+
 The expected result is a CI system that is **cheaper than conventional broad
 PR validation, but stronger where it matters**.
 


### PR DESCRIPTION
## Summary
- simplify the snapshot drift consistency assertion to satisfy clippy's `nonminimal_bool` lint
- increase the Ubuntu core build/test timeout from 30 to 40 minutes so the expanded AVX2 kernel test step can complete instead of being cancelled after passing test output
- document the CI timeout design rule: caps are guardrails against wedged jobs, not targets that should routinely discard nearly-complete proof
- harden Apple Silicon CI by preferring the installed Rust 1.95.0 toolchain binaries over a possibly broken rustup proxy path on macOS runners

## Validation
- `cargo fmt -p bitnet-testing-policy-contract -- --check`
- `cargo clippy --locked -p bitnet-testing-policy-contract --test snapshot_tests --no-default-features --features cpu -- -D warnings`
- `cargo test --locked -p bitnet-testing-policy-contract --no-default-features --features cpu --test snapshot_tests`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-core.yml'); puts 'ci-core.yml parsed'"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/macos-arm64.yml'); puts 'macos-arm64.yml parsed'"`
- `git diff --check`
