### PR TITLE
docs: specify routed CI verification rollout

### DIFF
--- a/docs/ci/ci-plan-schema.md
+++ b/docs/ci/ci-plan-schema.md
@@ -1,0 +1,112 @@
+# CI Plan JSON Schema
+
+`xtask ci plan` emits `ci-plan.json`, the stable routing contract consumed by
+GitHub Actions workflows and agents. The schema is introduced by the routed
+verification rollout before workflows begin relying on it.
+
+## Compatibility rules
+
+- `schema_version` must be incremented for breaking changes.
+- New optional fields may be added without incrementing the version.
+- Existing fields must not change meaning within a schema version.
+- Workflows must tolerate unknown fields.
+- Required arrays should be emitted as empty arrays instead of being omitted.
+- Required booleans should be emitted as `false` instead of being omitted.
+
+## Schema version 1
+
+```json
+{
+  "schema_version": 1,
+  "budget": {
+    "preferred_default_lem": 25,
+    "default_limit_lem": 35,
+    "estimated_lem": 0,
+    "posture": "pennies|default|elevated|high|hard"
+  },
+  "classification": {
+    "docs_only": false,
+    "tracker_only": false,
+    "rust_inputs_changed": false,
+    "manifest_or_toolchain_changed": false,
+    "public_api_changed": false,
+    "gpu_changed": false,
+    "macos_changed": false,
+    "model_validation_changed": false,
+    "coverage_requested": false,
+    "full_ci_requested": false
+  },
+  "selected_lanes": [],
+  "skipped_lanes": [],
+  "packages": {
+    "changed": [],
+    "direct_dependents": [],
+    "canaries": []
+  },
+  "risk_packs": [],
+  "labels": []
+}
+```
+
+## Field semantics
+
+### `budget`
+
+| Field | Meaning |
+| --- | --- |
+| `preferred_default_lem` | Preferred default PR target from `policy/ci-budget.toml`. |
+| `default_limit_lem` | Normal default PR limit from `policy/ci-budget.toml`. |
+| `estimated_lem` | Sum of selected lane estimates in Linux-equivalent minutes. |
+| `posture` | Stable enum: `pennies`, `default`, `elevated`, `high`, or `hard`. |
+
+### `classification`
+
+| Field | True when |
+| --- | --- |
+| `docs_only` | All changed files are documentation-only and cannot affect Rust build inputs. |
+| `tracker_only` | All changed files are campaign/tracker metadata. |
+| `rust_inputs_changed` | A changed file can affect Rust compile, lint, test, or feature behavior. |
+| `manifest_or_toolchain_changed` | Cargo manifests, lockfiles, toolchain files, or `.cargo/**` changed. |
+| `public_api_changed` | Public API surfaces changed and compatibility/MSRV risk may be elevated. |
+| `gpu_changed` | GPU, accelerator, kernel, or GPU workflow paths changed. |
+| `macos_changed` | Apple Silicon, Metal, macOS runner, or Apple hardware docs/workflow paths changed. |
+| `model_validation_changed` | Model validation, receipts, cross-validation, or golden output surfaces changed. |
+| `coverage_requested` | `coverage` or equivalent coverage label is present. |
+| `full_ci_requested` | `full-ci` label is present. |
+
+### `selected_lanes` and `skipped_lanes`
+
+Each lane entry should use stable lane IDs from `policy/ci-lanes.toml` and
+`policy/ci-lane-whitelist.toml`. A future schema may promote entries from
+strings to objects with reasons; version 1 consumers must treat strings as the
+required interoperable format.
+
+### `packages`
+
+| Field | Meaning |
+| --- | --- |
+| `changed` | Workspace packages directly touched by changed Rust inputs. |
+| `direct_dependents` | Workspace packages that directly depend on changed packages. |
+| `canaries` | Additional packages or smoke checks selected for risk-specific evidence. |
+
+### `risk_packs`
+
+Stable risk-pack IDs selected from `policy/ci-risk-packs.toml`, such as
+`manifest_release`.
+
+### `labels`
+
+Normalized PR labels that influenced routing.
+
+## Required fixture coverage
+
+Schema version 1 must have fixture tests for at least:
+
+- docs-only changes,
+- tracker-only changes,
+- ordinary Rust changes,
+- manifest/toolchain changes,
+- GPU changes,
+- macOS changes,
+- `full-ci` label,
+- coverage label.

--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -29,6 +29,17 @@ For ordinary PRs, our operating target is:
 
 The `$1` mark is a ceiling, not the goal.
 
+## Routed verification rollout
+
+The implementation plan for making this cost model the default is documented in
+`docs/ci/routed-verification-rollout.md`, with the stable PR body template in
+`docs/ci/routed-verification-pr-template.md`, the planner contract in
+`docs/ci/ci-plan-schema.md`, and the machine-readable work queue in
+`policy/ci-routing-rollout.toml`. That rollout is intentionally sequenced:
+first remove immediate default-cost waste, then make `ci-plan.json` the routing
+authority, then narrow Linux proof by package/risk, then consolidate branch
+protection behind `PR Gate Success` only after the routing has proven stable.
+
 ## Why the budget target is aggressive
 
 Our CI budget target is intentionally aggressive — but **not because we want

--- a/docs/ci/inventory.md
+++ b/docs/ci/inventory.md
@@ -49,6 +49,18 @@ view is the whitelist itself, validated by `xtask ci-lane-whitelist check`.
 | `policy.yml` (PR 02 / 03)         | `strict-policy`                                     | Frontdoor blocking, very cheap      |
 | `ripr.yml` (PR 13)                | `ripr-advisory`                                     | Frontdoor advisory                  |
 
+## Routed verification rollout specs
+
+The next CI economics implementation sequence is specified in:
+
+* `docs/ci/routed-verification-rollout.md` — human-readable phased rollout and
+  work-item acceptance criteria.
+* `docs/ci/routed-verification-pr-template.md` — required PR body shape for
+  rollout changes.
+* `docs/ci/ci-plan-schema.md` — stable `ci-plan.json` schema that PR Gate and
+  workflows will consume.
+* `policy/ci-routing-rollout.toml` — compact machine-readable queue for agents.
+
 ## Backlog
 
 The whitelist intentionally covers the highest-signal lanes first.

--- a/docs/ci/pr-gate-success.md
+++ b/docs/ci/pr-gate-success.md
@@ -1,5 +1,11 @@
 # PR Gate Success
 
+> Routing note: the current PR Gate behavior is documented below. The planned
+> migration to make PR Gate consume `ci-plan.json` is specified in
+> `docs/ci/routed-verification-rollout.md` and `docs/ci/ci-plan-schema.md`.
+> Until that work lands, this document describes the existing aggregator
+> posture and the intended branch-protection destination.
+
 `PR Gate Success` is the single required check that branch
 protection should gate merges on. It is the deliverable of PR 19 in
 the strict policy / CI economics rollout.

--- a/docs/ci/routed-verification-pr-template.md
+++ b/docs/ci/routed-verification-pr-template.md
@@ -1,0 +1,42 @@
+# Routed Verification PR Template
+
+Use this body for every PR in the routed verification rollout.
+
+```md
+## Summary
+
+## CI economics
+- Default PR LEM before:
+- Default PR LEM after:
+- Lanes removed from default:
+- Lanes still available by label/main/manual:
+- Branch protection impact:
+
+## Verification preserved
+- What failure mode this still catches:
+- What moved to main/label/nightly:
+- Why that is acceptable:
+
+## Boundaries
+- No macOS default PR runner
+- No Windows default PR runner
+- No Docker/model/download default PR work
+- No branch-protection change unless explicitly scoped
+- No unrelated Rust/runtime changes
+
+## Validation
+- [ ] command
+- [ ] command
+```
+
+## Filling guidance
+
+- **Default PR LEM before/after:** use lane estimates from
+  `policy/ci-lanes.toml` and `policy/ci-lane-whitelist.toml`.
+- **Lanes removed from default:** name stable lane IDs, not just workflow names.
+- **Still available:** identify labels and non-PR triggers that preserve proof.
+- **Branch protection impact:** say `None` unless the work item explicitly scopes
+  branch protection.
+- **Verification preserved:** describe the failure mode, not only the workflow.
+- **Validation:** paste exact commands run locally, then update checkboxes before
+  opening the PR.

--- a/docs/ci/routed-verification-rollout.md
+++ b/docs/ci/routed-verification-rollout.md
@@ -1,0 +1,364 @@
+# Routed Verification Rollout
+
+This document is the implementation spec for the CI economics rollout. It turns
+BitNet-rs CI into a routed verification system where ordinary PRs get cheap,
+Linux-only, deterministic proof and expensive evidence moves to main,
+schedules, release lanes, hardware/campaign lanes, or explicit labels.
+
+## North star
+
+> Default PRs get cheap, Linux-only, deterministic, crate/risk-scoped proof.
+> Expensive proof still exists, but only on main, schedule, release,
+> hardware/campaign lanes, or explicit labels.
+
+The budget vocabulary is already present in the repository policy files:
+
+| Concept | Value |
+| --- | ---: |
+| Preferred default PR budget | 25 LEM |
+| Normal default PR limit | 35 LEM |
+| macOS multiplier | 10x Linux |
+| Windows multiplier | 2x Linux |
+| GPU Docker multiplier | 6x Linux |
+| Budget override labels | `full-ci`, `ci-budget-override`, `ci-budget-ack` |
+
+The rollout must preserve verification quality by removing unrelated work from
+ordinary PRs, not by deleting proof. Moved lanes must remain available through
+main, scheduled, manual, release, hardware, campaign, or label-gated routes.
+
+## Operating rules for each rollout PR
+
+Each implementation PR must follow this sequence:
+
+1. Start from fresh `origin/main`.
+2. Make one boundary change per PR.
+3. Avoid runtime code unless the work item explicitly scopes runtime code.
+4. Run targeted validation listed for the work item.
+5. Watch CI.
+6. Fix only the first real failing cause.
+7. Merge only when required checks are green.
+8. After merge, fast-forward local `main` and re-check queue state.
+
+Use the PR body template in `docs/ci/routed-verification-pr-template.md`.
+
+## Global boundaries
+
+Every rollout PR must preserve these boundaries unless the work item explicitly
+says otherwise:
+
+- No macOS default PR runner.
+- No Windows default PR runner.
+- No Docker, model download, or hardware validation in default PR work.
+- No branch-protection change unless explicitly scoped.
+- No unrelated Rust/runtime changes.
+- No silent widening of ordinary PR triggers.
+
+## Rollout phases
+
+### Phase 1: remove immediate default-cost waste
+
+| Order | Title | Primary outcome | Default PR budget effect |
+| ---: | --- | --- | --- |
+| 1 | `ci: remove macOS from ordinary PRs` | macOS/Metal proof moves to main/manual/labels/path-specific routing. | Removes 10x runner from ordinary Rust PRs. |
+| 2 | `ci: move performance smoke off default PRs` | Performance tracking runs on main, schedule, manual, or perf labels. | Removes duplicate workspace CPU check. |
+| 3 | `ci: move test telemetry to main and label` | Advisory nextest/JUnit telemetry moves off ordinary PRs. | Removes 18 LEM advisory duplicate lane. |
+| 4 | `ci: risk-gate MSRV compatibility` | MSRV runs for global dependency/toolchain/API/release risk and labels. | Removes 12 LEM from leaf implementation PRs. |
+
+### Phase 2: make routing authoritative
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 5 | `ci(plan): emit stable routing schema` | `xtask ci plan` emits stable `ci-plan.json` for workflows and agents. |
+| 6 | `ci(gate): make PR Gate consume ci plan` | PR Gate waits only for selected blocking lanes. |
+| 7 | `ci: add soft budget guard` | Budget posture and override labels become visible in PR Plan and PR Gate. |
+
+### Phase 3: narrow default Linux proof
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 8 | `ci-core: broaden no-Rust fast path` | Docs/tracker/campaign/hardware-receipt PRs skip cargo work. |
+| 9 | `ci-core: package-select build/test surface` | CI Core scopes cargo work to changed packages, direct dependents, and canaries. |
+| 10 | `feature-matrix: reduce ordinary PR feature smoke` | Default feature smoke becomes `no-features` plus `cpu`; `cpu+full-cli` is risk-gated. |
+
+### Phase 4: make advisory lanes honest
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 11 | `ci: stop selected gates from swallowing failures` | Selected blocking lanes fail honestly; flaky lanes become advisory/off-default. |
+| 12 | `gpu-ci: remove duplicate CPU native check` | GPU CI stops duplicating generic CPU compile proof. |
+
+### Phase 5: keep coverage measured and explicit
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 13 | `coverage: keep Codecov lane quiet and policy-declared` | Coverage remains main/manual/label-gated with quiet Codecov behavior. |
+| 14 | `coverage: add coverage receipt and ignored-failure accounting` | Coverage artifacts include a receipt and ignored-failure count. |
+
+### Phase 6: increase cheap proof density
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 15 | `policy(clippy): document strict agent lint baseline` | Strict lint tiers are documented without activating new lints. |
+| 16+ | lint activation slices | One lint family at a time, with small focused PRs. |
+
+### Phase 7: consolidate branch protection
+
+| Order | Title | Primary outcome |
+| ---: | --- | --- |
+| 20 | `ci: make PR Gate the only required check` | Branch protection requires only `PR Gate Success` after routing is proven. |
+
+## Work item specs
+
+The machine-readable queue is `policy/ci-routing-rollout.toml`. The TOML file
+is the compact implementation backlog; this document explains the intent and
+boundaries. If the two drift, update both in the same documentation-only PR.
+
+### PR 1: remove macOS from ordinary PRs
+
+Files:
+
+- `.github/workflows/macos-arm64.yml`
+- `policy/ci-lanes.toml`
+- `policy/ci-lane-whitelist.toml`
+- `docs/ci/cost-and-verification-policy.md`
+- `docs/ci/labels.md`
+
+Required routing:
+
+- Run on push to `main`.
+- Run on `workflow_dispatch`.
+- Keep `merge_group` only if branch protection still needs it.
+- Run on labels `macos`, `apple-silicon`, `metal`, and `full-ci`.
+- Run on Mac/Metal-specific paths only.
+- Remove broad ordinary PR triggers such as all `crates/**`, `tests/**`,
+  `xtask/**`, and generic `Cargo.toml` unless selected by label/path risk.
+
+Acceptance:
+
+- No normal Rust PR launches `macos-14`.
+- `macos`, `apple-silicon`, `metal`, and `full-ci` labels still work.
+- Main/manual still preserves Apple proof.
+- Policy lane costs reflect that macOS is not default.
+
+Validation:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error
+```
+
+### PR 2: move performance smoke off default PRs
+
+Files:
+
+- `.github/workflows/performance-tracking.yml`
+- `policy/ci-lanes.toml`
+- `policy/ci-lane-whitelist.toml`
+- `docs/ci/cost-and-verification-policy.md`
+
+Required routing:
+
+- Run on push to `main`.
+- Run on schedule.
+- Run on `workflow_dispatch`.
+- Run on labels `performance`, `perf`, and `full-ci`.
+- Do not run the workspace smoke check on ordinary PRs.
+
+Acceptance:
+
+- Ordinary PRs do not run `Performance Baseline Tracking`.
+- Main/schedule/manual still run.
+- Labeled PRs still run.
+- No branch-protection dependency is introduced.
+
+Validation:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### PR 3: move test telemetry to main and label
+
+Files:
+
+- `.github/workflows/test-telemetry.yml`
+- `policy/ci-lanes.toml`
+- `policy/ci-lane-whitelist.toml`
+- `docs/ci/cost-and-verification-policy.md`
+
+Required routing:
+
+- Run on push to `main`.
+- Run on `workflow_dispatch`.
+- Schedule is optional.
+- Run on labels `test-telemetry`, `slow-tests`, and `full-ci`.
+
+Acceptance:
+
+- No ordinary PR runs Test Telemetry.
+- Main/manual/labeled runs still produce JUnit and slow-test summaries.
+- Lane table sets `default_pr = false` for `test-telemetry`.
+
+Validation:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### PR 4: risk-gate MSRV compatibility
+
+Files:
+
+- `.github/workflows/compatibility.yml`
+- `policy/ci-lanes.toml`
+- `policy/ci-lane-whitelist.toml`
+- `policy/ci-risk-packs.toml`
+- `docs/ci/cost-and-verification-policy.md`
+
+Required routing:
+
+- Run for `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, and `.cargo/**`.
+- Run for public API surfaces.
+- Run for release/package surfaces.
+- Run on labels `msrv`, `compatibility`, and `full-ci`.
+- Run on push to `main` and `workflow_dispatch`.
+
+Acceptance:
+
+- Leaf implementation PRs do not run MSRV by default.
+- Manifest/toolchain/dependency PRs still run MSRV.
+- Main still runs MSRV.
+- The `manifest_release` risk pack still selects `compatibility-msrv` for global
+  dependency/toolchain risk.
+
+Validation:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+cargo check --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --tests --no-default-features --features cpu
+```
+
+### PR 5: emit stable routing schema
+
+Files:
+
+- `xtask/src/ci/plan.rs`
+- `xtask/src/ci/mod.rs`
+- `policy/ci-budget.toml`
+- `policy/ci-lanes.toml`
+- `policy/ci-risk-packs.toml`
+- `docs/ci/pr-plan.md`
+- `tests/fixtures/ci-plan/**`
+
+Schema requirements are documented in `docs/ci/ci-plan-schema.md`.
+
+Acceptance:
+
+- Existing summary still prints.
+- New JSON schema is fixture-tested.
+- `xtask ci plan` classifies docs-only, tracker-only, ordinary Rust,
+  manifest/toolchain, GPU, macOS, full-ci, and coverage changes.
+- No workflow behavior changes yet.
+
+Validation:
+
+```bash
+cargo test -p xtask --no-default-features ci_plan --locked
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/rust.txt --labels-json '[]' --json-out target/ci-plan.json --print
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print
+git diff --check
+```
+
+### PR 6: make PR Gate consume ci plan
+
+Files:
+
+- `.github/workflows/pr-gate.yml`
+- `.github/workflows/pr-plan.yml`
+- `xtask/src/ci/plan.rs`
+- `docs/ci/pr-gate-success.md`
+
+Acceptance:
+
+- PR Gate no longer has its own path classifier.
+- PR Gate waits only for selected blocking lanes.
+- Selected blocking lane `skipped` is failure.
+- Unselected skipped lanes are OK.
+- Summary prints selected lanes, skipped lanes, budget posture, and label
+  overrides.
+- Branch protection can later require only `PR Gate Success`.
+
+Validation:
+
+```bash
+cargo test -p xtask --no-default-features ci_plan --locked
+git diff --check
+```
+
+Hosted validation:
+
+- Docs-only PR should not wait for Rust lanes.
+- Ordinary Rust PR should wait for CI Core and feature smoke.
+- `full-ci` PR should wait for selected expanded lanes.
+
+### PR 7: add soft budget guard
+
+Files:
+
+- `xtask/src/ci/plan.rs`
+- `.github/workflows/pr-plan.yml`
+- `.github/workflows/pr-gate.yml`
+- `docs/ci/cost-and-verification-policy.md`
+
+Budget guard behavior:
+
+| Estimated LEM | Behavior |
+| ---: | --- |
+| <= 25 | Preferred |
+| 26-35 | Normal default |
+| 36-75 | Warning |
+| 76-100 | Strong warning |
+| 101-125 | Require `ci-budget-ack` or `full-ci` |
+| > 125 | Fail unless `ci-budget-override` or `full-ci` |
+
+Acceptance:
+
+- Budget warnings appear in PR Plan summary.
+- PR Gate understands budget override labels.
+- No accidental hard failures until maintainers opt in.
+
+Validation:
+
+```bash
+cargo test -p xtask --no-default-features ci_plan_budget --locked
+git diff --check
+```
+
+### PRs 8-20
+
+The remaining work items are fully enumerated in
+`policy/ci-routing-rollout.toml`. Keep each PR scoped to one item and copy the
+TOML acceptance and validation fields into the PR body.
+
+## Expected cost outcome
+
+After phases 1-4, an ordinary Rust PR should be approximately:
+
+```text
+PR Plan                         1 LEM
+PR Gate                         1 LEM
+CI Core scoped Linux proof      12-18 LEM
+Feature smoke                   4-8 LEM
+Policy                          3 LEM
+ripr advisory                   4 LEM
+--------------------------------------
+Target                         25-34 LEM
+```
+
+Docs, tracking, campaign, and receipt-only PRs should target 3-8 LEM. Manifest
+or toolchain PRs may exceed ordinary limits because they are global-risk PRs,
+not ordinary implementation PRs.

--- a/policy/ci-routing-rollout.toml
+++ b/policy/ci-routing-rollout.toml
@@ -1,0 +1,156 @@
+schema_version = "1.0"
+policy = "ci-routing-rollout"
+owner = "release/ci"
+status = "spec"
+updated = "2026-05-12"
+
+[north_star]
+summary = "Default PRs get cheap, Linux-only, deterministic, crate/risk-scoped proof. Expensive proof remains available on main, schedule, release, hardware/campaign lanes, or explicit labels."
+preferred_default_lem = 25
+default_limit_lem = 35
+macos_multiplier = 10
+windows_multiplier = 2
+gpu_docker_multiplier = 6
+override_labels = ["full-ci", "ci-budget-override", "ci-budget-ack"]
+
+[boundaries]
+no_macos_default_pr_runner = true
+no_windows_default_pr_runner = true
+no_docker_model_download_default_pr_work = true
+no_branch_protection_change_unless_scoped = true
+no_unrelated_runtime_changes = true
+
+[[item]]
+order = 1
+title = "ci: remove macOS from ordinary PRs"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/macos-arm64.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md", "docs/ci/labels.md"]
+labels = ["macos", "apple-silicon", "metal", "full-ci"]
+acceptance = ["No normal Rust PR launches macos-14", "macOS labels still work", "Main/manual preserves Apple proof", "Policy lane costs reflect macOS is not default"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check", "cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error"]
+
+[[item]]
+order = 2
+title = "ci: move performance smoke off default PRs"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/performance-tracking.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md"]
+labels = ["performance", "perf", "full-ci"]
+acceptance = ["Ordinary PRs do not run Performance Baseline Tracking", "Main/schedule/manual still run", "Labeled PRs still run", "No branch protection dependency"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 3
+title = "ci: move test telemetry to main and label"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/test-telemetry.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md"]
+labels = ["test-telemetry", "slow-tests", "full-ci"]
+acceptance = ["No ordinary PR runs Test Telemetry", "Main/manual/labeled runs still produce JUnit and slow-test summaries", "Lane table changes default_pr to false"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 4
+title = "ci: risk-gate MSRV compatibility"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/compatibility.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "policy/ci-risk-packs.toml", "docs/ci/cost-and-verification-policy.md"]
+labels = ["msrv", "compatibility", "full-ci"]
+acceptance = ["Leaf implementation PRs do not run MSRV by default", "Manifest/toolchain/dependency PRs still run MSRV", "Main still runs MSRV", "manifest_release risk pack still selects compatibility-msrv"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check", "cargo check --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --tests --no-default-features --features cpu"]
+
+[[item]]
+order = 5
+title = "ci(plan): emit stable routing schema"
+phase = "make routing authoritative"
+files = ["xtask/src/ci/plan.rs", "xtask/src/ci/mod.rs", "policy/ci-budget.toml", "policy/ci-lanes.toml", "policy/ci-risk-packs.toml", "docs/ci/pr-plan.md", "tests/fixtures/ci-plan/**"]
+acceptance = ["Existing summary still prints", "New JSON schema is fixture-tested", "xtask ci plan classifies docs-only, tracker-only, ordinary Rust, manifest/toolchain, GPU, macOS, full-ci, and coverage", "No workflow behavior changes"]
+validation = ["cargo test -p xtask --no-default-features ci_plan --locked", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/rust.txt --labels-json '[]' --json-out target/ci-plan.json --print", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print", "git diff --check"]
+
+[[item]]
+order = 6
+title = "ci(gate): make PR Gate consume ci plan"
+phase = "make routing authoritative"
+files = [".github/workflows/pr-gate.yml", ".github/workflows/pr-plan.yml", "xtask/src/ci/plan.rs", "docs/ci/pr-gate-success.md"]
+acceptance = ["PR Gate no longer has its own path classifier", "PR Gate waits only for selected blocking lanes", "Selected blocking skipped lanes fail", "Unselected skipped lanes are OK", "Summary prints routing and budget details"]
+validation = ["cargo test -p xtask --no-default-features ci_plan --locked", "git diff --check"]
+
+[[item]]
+order = 7
+title = "ci: add soft budget guard"
+phase = "make routing authoritative"
+files = ["xtask/src/ci/plan.rs", ".github/workflows/pr-plan.yml", ".github/workflows/pr-gate.yml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Budget warnings appear in PR Plan summary", "PR Gate understands budget override labels", "No accidental hard failures until maintainers opt in"]
+validation = ["cargo test -p xtask --no-default-features ci_plan_budget --locked", "git diff --check"]
+
+[[item]]
+order = 8
+title = "ci-core: broaden no-Rust fast path"
+phase = "narrow default Linux proof"
+files = [".github/workflows/ci-core.yml", "xtask/src/ci/plan.rs", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Docs/campaign/hardware receipt PRs do not compile Rust unless they touch Rust inputs", "CI Core Success still emits", "Rust PR behavior unchanged"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print"]
+
+[[item]]
+order = 9
+title = "ci-core: package-select build/test surface"
+phase = "narrow default Linux proof"
+files = ["xtask/src/ci/plan.rs", ".github/workflows/ci-core.yml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Manifest/toolchain/shared foundational changes still get broad coverage", "Leaf crate changes get scoped tests", "CI summary prints selected packages and reason", "No macOS/Windows/Docker/model downloads"]
+validation = ["cargo test -p xtask --no-default-features ci_plan_packages --locked", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/quantization.txt --labels-json '[]' --json-out target/ci-plan-quant.json --print", "git diff --check"]
+
+[[item]]
+order = 10
+title = "feature-matrix: reduce ordinary PR feature smoke"
+phase = "narrow default Linux proof"
+files = [".github/workflows/feature-matrix.yml", "policy/ci-risk-packs.toml", "policy/ci-lanes.toml", "docs/ci/cost-and-verification-policy.md"]
+labels = ["full-cli", "feature-matrix", "full-ci"]
+acceptance = ["Ordinary PR feature matrix is cheaper", "CLI/full-cli risk still gets checked", "Main/full-ci still runs full matrix"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 11
+title = "ci: stop selected gates from swallowing failures"
+phase = "tighten advisory lanes into honest lanes"
+files = [".github/workflows/validation.yml", ".github/workflows/test-framework.yml", ".github/workflows/compatibility.yml", "docs/ci/cost-and-verification-policy.md", "policy/ci-lanes.toml"]
+acceptance = ["No selected blocking lane uses || true", "Advisory lanes are clearly named advisory and not selected by PR Gate as blocking", "Policy table reflects blocking vs advisory"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 12
+title = "gpu-ci: remove duplicate CPU native check"
+phase = "tighten advisory lanes into honest lanes"
+files = [".github/workflows/gpu-ci-matrix.yml", "policy/ci-lanes.toml", "policy/ci-risk-packs.toml"]
+labels = ["gpu-ci", "full-ci"]
+acceptance = ["GPU path PRs still run GPU feature compile checks", "Ordinary manifest PRs do not automatically fan out GPU CI unless selected", "Docker remains main/manual/label only"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 13
+title = "coverage: keep Codecov lane quiet and policy-declared"
+phase = "coverage as measured evidence"
+files = [".github/workflows/coverage.yml", "codecov.yml", "README.md", "docs/ci/coverage.md", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml"]
+labels = ["coverage", "full-ci"]
+acceptance = ["Ordinary PR cost unchanged", "Main gets coverage evidence", "Labeled PRs can request coverage", "No GPU/model/hardware coverage claim"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 14
+title = "coverage: add coverage receipt and ignored-failure accounting"
+phase = "coverage as measured evidence"
+files = [".github/workflows/coverage.yml", "docs/ci/coverage.md"]
+acceptance = ["Artifact includes coverage receipt", "Main fails if ignored failures are nonzero unless explicitly allowed", "PR advisory coverage can upload receipt even if non-blocking"]
+validation = ["git diff --check"]
+
+[[item]]
+order = 15
+title = "policy(clippy): document strict agent lint baseline"
+phase = "clippy/no-panic policy as cheap verification density"
+files = ["docs/ci/clippy-policy.md", "policy/clippy-lints.toml", "clippy.toml", "Cargo.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["No code cleanup yet", "No new lint activation yet", "Agents have a stable policy doc and TOML map"]
+validation = ["cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports --fail-on-error", "git diff --check"]
+
+[[item]]
+order = 20
+title = "ci: make PR Gate the only required check"
+phase = "move from visibility to enforcement"
+files = [".github/workflows/pr-gate.yml", "docs/ci/pr-gate-success.md", "docs/ci/branch-protection.md"]
+acceptance = ["Docs explain branch-protection migration", "Existing CI Core Success can remain for compatibility but not be required", "Path-filtered skipped workflows no longer block"]
+validation = ["git diff --check"]


### PR DESCRIPTION
### Motivation
- Provide a concrete, agent-friendly implementation plan to turn CI into a routed verification system that makes cheap Linux-only, crate/risk-scoped proof the default while preserving expensive proof behind labels/main/schedule. 
- Capture the North Star, LEM budget vocabulary, operating rules, scoped PR body template, and the phased rollout order so implementers and agents can follow small, safe PRs. 
- Define a stable planner contract (`ci-plan.json` schema) so workflows and the PR Gate can migrate from duplicated path logic to a single routing authority. 

### Description
- Added a human-readable rollout spec at `docs/ci/routed-verification-rollout.md` that enumerates phases, per-PR boundaries, and detailed work-item acceptance/validation criteria. 
- Added a required PR body template at `docs/ci/routed-verification-pr-template.md` to standardize rollout PR shape and mandatory validation steps. 
- Added the CI planner schema spec at `docs/ci/ci-plan-schema.md` describing schema v1 for `ci-plan.json` and required fixture coverage. 
- Added a machine-readable work queue `policy/ci-routing-rollout.toml` with ordered rollout items, files touched, acceptance criteria, labels, and validation commands; and linked the new specs from `docs/ci/cost-and-verification-policy.md`, `docs/ci/inventory.md`, and `docs/ci/pr-gate-success.md`. 
- Modified documentation files to reference the new rollout artifacts; no workflow behavior was changed in this PR. 

### Testing
- `python3` TOML parse check of `policy/ci-routing-rollout.toml` succeeded (parsed with `tomllib`).
- `git diff --check` returned clean results (no whitespace/path errors) and completed successfully.
- `xtask check-file-policy` was run via `cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error` and reported `0 findings`, succeeding. 
- `xtask ci-lane-whitelist check` was run via `cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check` and exited successfully; it emitted two non-fatal warnings about `duplicate_of` referencing unknown lanes which are informational and do not block this docs/spec change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b0b90f048333aa6691f662c25bdf)