### PR TITLE
docs(ci): add routed CI rollout spec, PR Plan schema, and machine-readable rollout queue

### DIFF
--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -17,6 +17,21 @@ discipline: if verification is too expensive, people avoid running it; if it is
 cheap, deterministic, and well-scoped, it becomes part of the normal
 development loop.
 
+## Routed CI rollout authority
+
+The implementation sequence for this policy is tracked in
+[`docs/ci/routed-ci-rollout.md`](./routed-ci-rollout.md), with a machine-readable
+queue in [`policy/ci-rollout.toml`](../../policy/ci-rollout.toml). That rollout
+sequence is the source of truth for scoped agent PRs that remove default-cost
+waste, make `ci-plan.json` authoritative, and later consolidate branch
+protection around `PR Gate Success`.
+
+The rollout north star is:
+
+> Default PRs get cheap, Linux-only, deterministic, crate/risk-scoped proof.
+> Expensive proof still exists, but only on `main`, schedule, release,
+> hardware/campaign lanes, or explicit labels.
+
 ## Cost target
 
 For ordinary PRs, our operating target is:
@@ -376,6 +391,10 @@ after-the-fact billing concerns. The test rig is part of the machine.
 
 - [`docs/ci/labels.md`](./labels.md) — cost-aware CI labels and what they
   authorize.
+- [`docs/ci/routed-ci-rollout.md`](./routed-ci-rollout.md) — phased
+  implementation specs for the routed CI rollout.
+- [`docs/ci/pr-plan.md`](./pr-plan.md) — stable `ci-plan.json` schema consumed
+  by CI routing workflows.
 - [`docs/development/validation-ci.md`](../development/validation-ci.md) —
   validation lanes and how they integrate with CI.
 - [`docs/development/ci-integration.md`](../development/ci-integration.md) —

--- a/docs/ci/labels.md
+++ b/docs/ci/labels.md
@@ -9,6 +9,27 @@ BitNet-rs uses GitHub labels to selectively trigger heavy CI workflows. This kee
 > [CI Cost and Verification Policy](./cost-and-verification-policy.md) for
 > the rationale.
 
+## Routing and budget override labels
+
+These labels are consumed by the routed CI rollout and by `xtask ci plan` once
+the planner becomes the routing authority:
+
+| Label | Purpose | Default PR effect |
+| --- | --- | --- |
+| `full-ci` | Request all relevant expensive proof for the touched risk surface. | Authorizes expanded LEM spend and deep lanes. |
+| `ci-budget-ack` | Acknowledge a high-but-below-hard-ceiling budget estimate. | Allows high advisory budget posture to proceed when enforcement is enabled. |
+| `ci-budget-override` | Override the hard budget ceiling for an explicitly scoped reason. | Allows over-ceiling runs when maintainers intentionally accept the spend. |
+| `macos` | Request macOS runner proof. | Enables macOS lanes that are not ordinary PR defaults. |
+| `apple-silicon` | Request Apple Silicon / ARM64 proof. | Enables Apple-specific lanes where available. |
+| `metal` | Request Metal compile or runtime-adjacent proof. | Enables Mac/Metal-specific lanes where available. |
+| `test-telemetry` / `slow-tests` | Request JUnit and slow-test telemetry. | Enables telemetry lanes that are otherwise main/manual/scheduled. |
+| `performance` / `perf` | Request performance tracking. | Enables performance lanes that are otherwise main/manual/scheduled. |
+| `msrv` / `compatibility` | Request compatibility/MSRV proof. | Enables compatibility lanes for risk not caught by ordinary scoped Linux proof. |
+| `full-cli` / `feature-matrix` | Request expanded feature matrix coverage. | Enables `cpu+full-cli` and deeper feature combinations where scoped. |
+
+Labels authorize routed work; they do not make selected blocking failures
+advisory. If a lane is selected as blocking, it must fail honestly.
+
 ## Label-Gated Workflows
 
 These workflows only run when their corresponding label is applied to a PR:

--- a/docs/ci/pr-plan.md
+++ b/docs/ci/pr-plan.md
@@ -1,0 +1,145 @@
+# PR Plan Routing Schema
+
+`xtask ci plan` is the routing authority for BitNet-rs PR CI. Workflows should
+consume its JSON instead of reimplementing path classifiers in shell.
+
+The planner has two audiences:
+
+1. humans, through the GitHub step summary; and
+2. workflows, through a stable `ci-plan.json` schema.
+
+This document specifies schema version `1`.
+
+## JSON contract
+
+A valid `ci-plan.json` for schema version `1` has this top-level shape:
+
+```json
+{
+  "schema_version": 1,
+  "budget": {
+    "preferred_default_lem": 25,
+    "default_limit_lem": 35,
+    "estimated_lem": 0,
+    "posture": "pennies|default|elevated|high|hard"
+  },
+  "classification": {
+    "docs_only": false,
+    "tracker_only": false,
+    "rust_inputs_changed": false,
+    "manifest_or_toolchain_changed": false,
+    "public_api_changed": false,
+    "gpu_changed": false,
+    "macos_changed": false,
+    "model_validation_changed": false,
+    "coverage_requested": false,
+    "full_ci_requested": false
+  },
+  "selected_lanes": [],
+  "skipped_lanes": [],
+  "packages": {
+    "changed": [],
+    "direct_dependents": [],
+    "canaries": []
+  },
+  "risk_packs": [],
+  "labels": []
+}
+```
+
+Unknown future fields are allowed. Consumers must ignore unknown fields and
+must fail closed when `schema_version` is absent or greater than the highest
+version they understand.
+
+## Budget fields
+
+| Field | Meaning |
+| --- | --- |
+| `preferred_default_lem` | Preferred ordinary-PR budget target from `policy/ci-budget.toml`. |
+| `default_limit_lem` | Normal default upper bound from `policy/ci-budget.toml`. |
+| `estimated_lem` | Sum of selected static or learned lane estimates. |
+| `posture` | Machine-readable posture: `pennies`, `default`, `elevated`, `high`, or `hard`. |
+
+Budget guard labels are `full-ci`, `ci-budget-override`, and `ci-budget-ack`.
+The initial guard is advisory unless the caller passes an explicit enforcement
+mode.
+
+## Classification fields
+
+| Field | True when |
+| --- | --- |
+| `docs_only` | All changed files are documentation or docs-owned metadata. |
+| `tracker_only` | The diff is limited to tracking/campaign files. |
+| `rust_inputs_changed` | Rust source, Cargo manifests, lockfile, toolchain, build scripts, or Rust-affecting config changed. |
+| `manifest_or_toolchain_changed` | `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, or `.cargo/**` changed. |
+| `public_api_changed` | Public crate API, package, or release-facing surfaces changed. |
+| `gpu_changed` | GPU HAL/backend/shader/device-selection paths changed. |
+| `macos_changed` | Apple Silicon, Metal, macOS workflow, or macOS-specific code paths changed. |
+| `model_validation_changed` | Model validation, crossval, fixture, receipt, or model-gate surfaces changed. |
+| `coverage_requested` | Labels include `coverage` or `full-ci`. |
+| `full_ci_requested` | Labels include `full-ci`. |
+
+Phase 3 may add more precise no-Rust fields such as `no_rust_inputs`,
+`tracker_or_campaign_only`, and `hardware_receipt_only`. Until then,
+consumers should derive no-Rust behavior from `rust_inputs_changed == false`
+only when they also understand the changed file set.
+
+## Lane selection fields
+
+`selected_lanes` contains lane IDs that are expected to run for the PR head.
+Blocking lanes in this list are enforced by PR Gate. `skipped_lanes` contains
+lane IDs intentionally not selected, with the reason reported in the human
+summary.
+
+Lane IDs must match `policy/ci-lanes.toml` and the authoritative lane whitelist
+in `policy/ci-lane-whitelist.toml`.
+
+PR Gate behavior:
+
+| Lane state | Selected blocking lane | Unselected lane |
+| --- | --- | --- |
+| `success` | pass | pass |
+| `failure`, `cancelled`, `timed_out` | fail | fail only if workflow policy says it is independently blocking |
+| `skipped` | fail | pass |
+| missing after timeout | fail | pass |
+
+## Package selection fields
+
+The `packages` object is advisory in schema version `1` and becomes actionable
+when CI Core switches to package-selected proof.
+
+| Field | Meaning |
+| --- | --- |
+| `changed` | Workspace packages directly touched by the diff. |
+| `direct_dependents` | Workspace packages that directly depend on changed packages. |
+| `canaries` | Additional packages or test surfaces selected because a risk pack requires them. |
+
+Manifest/toolchain/foundational changes should set a broad-sweep reason in the
+human summary even if `changed` is small.
+
+## Required fixture cases
+
+Planner tests should include fixtures for:
+
+- docs-only changes,
+- tracker-only changes,
+- ordinary Rust changes,
+- manifest/toolchain changes,
+- GPU changes,
+- macOS/Metal changes,
+- coverage label requests,
+- full-ci label requests.
+
+Each fixture should assert the schema version, classification booleans, selected
+lanes, skipped lanes, budget estimate, posture, labels, risk packs, and package
+selection where applicable.
+
+## Workflow consumption rules
+
+Workflows should prefer `ci-plan.json` over duplicated path filters. If a
+workflow still needs native GitHub `paths` filters for cost control, the filter
+must be a coarse launcher only; the job body should still validate whether the
+lane is selected before spending significant work.
+
+No workflow should make macOS, Windows, Docker, model download, or live hardware
+work part of ordinary unlabeled PR execution.

--- a/docs/ci/routed-ci-rollout.md
+++ b/docs/ci/routed-ci-rollout.md
@@ -1,0 +1,411 @@
+# Routed CI Rollout Specification
+
+This document is the implementation map for making sub-`$0.50` ordinary PR CI
+the default in BitNet-rs. It turns the existing CI budget vocabulary into an
+agent-executable sequence of small PRs.
+
+## North star
+
+Default PRs get cheap, Linux-only, deterministic, crate/risk-scoped proof.
+Expensive proof still exists, but only on `main`, schedule, release,
+hardware/campaign lanes, or explicit labels.
+
+The rollout uses Linux-equivalent minutes (LEM) as the shared planning unit:
+
+| Budget term | Value |
+| --- | ---: |
+| Preferred default PR target | 25 LEM |
+| Normal default PR limit | 35 LEM |
+| Windows multiplier | 2x Linux |
+| macOS multiplier | 10x Linux |
+| GPU Docker multiplier | 6x Linux |
+
+Budget override labels are `full-ci`, `ci-budget-override`, and
+`ci-budget-ack`. They authorize extra spend; they do not make failures
+optional.
+
+## Operating rules for every rollout PR
+
+Every rollout PR must be narrow and must include the following PR body sections:
+
+```md
+## Summary
+
+## CI economics
+- Default PR LEM before:
+- Default PR LEM after:
+- Lanes removed from default:
+- Lanes still available by label/main/manual:
+- Branch protection impact:
+
+## Verification preserved
+- What failure mode this still catches:
+- What moved to main/label/nightly:
+- Why that is acceptable:
+
+## Boundaries
+- No macOS default PR runner
+- No Windows default PR runner
+- No Docker/model/download default PR work
+- No branch-protection change unless explicitly scoped
+- No unrelated Rust/runtime changes
+
+## Validation
+- [ ] command
+- [ ] command
+```
+
+Agent behavior for each item:
+
+1. Start from fresh `origin/main`.
+2. Make one boundary change per PR.
+3. Avoid runtime-code edits unless the item explicitly scopes runtime code.
+4. Run targeted local validation.
+5. Fix only the first real failing cause.
+6. Commit and open/update the PR with the sections above.
+7. Merge only when required checks are green and GitHub reports the PR mergeable.
+8. After merge, fast-forward local `main` and re-check the queue state.
+
+## Rollout phases
+
+| Phase | Objective | Items |
+| --- | --- | --- |
+| 1 | Remove immediate default-cost waste | 1-4 |
+| 2 | Make routing authoritative | 5-7 |
+| 3 | Narrow default Linux proof | 8-10 |
+| 4 | Tighten advisory lanes into honest lanes | 11-12 |
+| 5 | Treat coverage as measured evidence | 13-14 |
+| 6 | Increase cheap verification density with policy | 15-16+ |
+| 7 | Consolidate branch protection after routing is proven | 20 |
+
+## Agent-ready queue
+
+### 1. `ci: remove macOS from ordinary PRs`
+
+**Scope:** `.github/workflows/macos-arm64.yml`, `policy/ci-lanes.toml`,
+`policy/ci-lane-whitelist.toml`, `docs/ci/cost-and-verification-policy.md`,
+`docs/ci/labels.md`.
+
+**Change:** Remove broad ordinary-PR macOS triggers. macOS may run on `push` to
+`main`, `workflow_dispatch`, `merge_group` if still required, labels `macos`,
+`apple-silicon`, `metal`, `full-ci`, and Mac/Metal-specific paths.
+
+**Acceptance:** Normal Rust PRs do not launch `macos-14`; Apple proof remains
+available by label/main/manual; policy tables mark macOS as non-default.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error
+```
+
+### 2. `ci: move performance smoke off default PRs`
+
+**Scope:** `.github/workflows/performance-tracking.yml`,
+`policy/ci-lanes.toml`, `policy/ci-lane-whitelist.toml`,
+`docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Run performance tracking only on `push` to `main`, schedule,
+`workflow_dispatch`, or labels `performance`, `perf`, `full-ci`. Do not run the
+workspace smoke check on ordinary PRs.
+
+**Acceptance:** Ordinary PRs do not run `Performance Baseline Tracking`; main,
+schedule, manual, and labeled PR runs still work; branch protection is
+unchanged.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 3. `ci: move test telemetry to main and label`
+
+**Scope:** `.github/workflows/test-telemetry.yml`, `policy/ci-lanes.toml`,
+`policy/ci-lane-whitelist.toml`, `docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Run telemetry only on `push` to `main`, `workflow_dispatch`,
+optional schedule, or labels `test-telemetry`, `slow-tests`, `full-ci`.
+
+**Acceptance:** Ordinary PRs do not run Test Telemetry; main/manual/labeled runs
+still produce JUnit and slow-test summaries; lane tables set
+`default_pr = false`.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 4. `ci: risk-gate MSRV compatibility`
+
+**Scope:** `.github/workflows/compatibility.yml`, `policy/ci-lanes.toml`,
+`policy/ci-lane-whitelist.toml`, `policy/ci-risk-packs.toml`,
+`docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Run MSRV for manifest/toolchain/dependency risk, public API or
+release/package surfaces, `push` to `main`, `workflow_dispatch`, or labels
+`msrv`, `compatibility`, `full-ci`. Preserve the `manifest_release` risk pack as
+the selector for global dependency/toolchain risk.
+
+**Acceptance:** Leaf implementation PRs do not run MSRV by default; manifest,
+toolchain, dependency, public API, release, and main changes still run MSRV.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+cargo check --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --tests --no-default-features --features cpu
+```
+
+### 5. `ci(plan): emit stable routing schema`
+
+**Scope:** `xtask/src/ci/plan.rs`, `xtask/src/ci/mod.rs`,
+`policy/ci-budget.toml`, `policy/ci-lanes.toml`, `policy/ci-risk-packs.toml`,
+`docs/ci/pr-plan.md`, `tests/fixtures/ci-plan/**`.
+
+**Change:** Make `ci-plan.json` conform to the schema in
+[`docs/ci/pr-plan.md`](./pr-plan.md) while preserving the existing human
+summary. Add fixtures for docs-only, tracker-only, ordinary Rust,
+manifest/toolchain, GPU, macOS, `full-ci`, and coverage classifications.
+
+**Acceptance:** The schema is fixture-tested; no workflow behavior changes.
+
+**Validation:**
+
+```bash
+cargo test -p xtask --no-default-features ci_plan --locked
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/rust.txt --labels-json '[]' --json-out target/ci-plan.json --print
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print
+git diff --check
+```
+
+### 6. `ci(gate): make PR Gate consume ci plan`
+
+**Scope:** `.github/workflows/pr-gate.yml`, `.github/workflows/pr-plan.yml`,
+`xtask/src/ci/plan.rs`, `docs/ci/pr-gate-success.md`.
+
+**Change:** PR Gate determines the PR head SHA, computes or downloads
+`ci-plan.json`, waits only for selected blocking lanes, treats selected skipped
+blocking lanes as failures, and treats unselected skipped lanes as OK.
+
+**Acceptance:** PR Gate no longer has its own path classifier; path-filtered
+workflows no longer create missing-required-check traps; branch protection can
+later require only `PR Gate Success`.
+
+**Validation:**
+
+```bash
+cargo test -p xtask --no-default-features ci_plan --locked
+git diff --check
+```
+
+### 7. `ci: add soft budget guard`
+
+**Scope:** `xtask/src/ci/plan.rs`, `.github/workflows/pr-plan.yml`,
+`.github/workflows/pr-gate.yml`, `docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Emit budget posture and advisory guard state from the planner.
+Support these behaviors in schema and summaries: `<=25` preferred, `26-35`
+normal default, `36-75` warning, `76-100` strong warning, `101-125` requires
+`ci-budget-ack` or `full-ci`, and `>125` fails unless `ci-budget-override` or
+`full-ci` is present. Start advisory unless enforcement is explicitly enabled.
+
+**Acceptance:** Budget warnings appear in PR Plan; PR Gate understands budget
+override labels; maintainers do not get accidental new hard failures.
+
+**Validation:**
+
+```bash
+cargo test -p xtask --no-default-features ci_plan_budget --locked
+git diff --check
+```
+
+### 8. `ci-core: broaden no-Rust fast path`
+
+**Scope:** `.github/workflows/ci-core.yml`, `xtask/src/ci/plan.rs`,
+`docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Replace the narrow `tracker_only` fast path with
+`no_rust_inputs`, `docs_only`, `tracker_or_campaign_only`, and
+`hardware_receipt_only` classifications. No-Rust inputs should avoid cargo
+build/test/clippy/doc while still emitting `CI Core Success`.
+
+**Acceptance:** Docs, campaign, and hardware receipt PRs do not compile Rust
+unless they touch Rust inputs; Rust PR behavior is unchanged.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print
+```
+
+### 9. `ci-core: package-select build/test surface`
+
+**Scope:** `xtask/src/ci/plan.rs`, `.github/workflows/ci-core.yml`,
+`docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Have `xtask ci plan` compute changed packages, direct dependents,
+canaries, and `broad_sweep_required`. CI Core should test/clippy selected
+packages and canaries by default, while manifests/toolchain/foundational crates
+still trigger a broad sweep.
+
+**Acceptance:** Leaf crate PRs get scoped tests; global-risk PRs get broad
+coverage; summaries explain selected packages and reasons; no macOS, Windows,
+Docker, model, or download work is added.
+
+**Validation:**
+
+```bash
+cargo test -p xtask --no-default-features ci_plan_packages --locked
+cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/quantization.txt --labels-json '[]' --json-out target/ci-plan-quant.json --print
+git diff --check
+```
+
+### 10. `feature-matrix: reduce ordinary PR feature smoke`
+
+**Scope:** `.github/workflows/feature-matrix.yml`, `policy/ci-risk-packs.toml`,
+`policy/ci-lanes.toml`, `docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Ordinary PRs run `no-features` and `cpu`. Run `cpu+full-cli` for
+CLI/server/validation/model-cache/full-cli feature risk, manifest/toolchain
+changes, or labels `full-cli`, `feature-matrix`, `full-ci`.
+
+**Acceptance:** Ordinary feature smoke is cheaper; CLI/full-cli risk remains
+checked; `main` and `full-ci` still run the full matrix.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 11. `ci: stop selected gates from swallowing failures`
+
+**Scope:** `.github/workflows/validation.yml`, `.github/workflows/test-framework.yml`,
+`.github/workflows/compatibility.yml`, `docs/ci/cost-and-verification-policy.md`,
+`policy/ci-lanes.toml`.
+
+**Change:** If a lane is selected as blocking, failures fail. Lanes too flaky or
+expensive to fail must move to main/nightly/manual/label and be marked
+advisory.
+
+**Acceptance:** No selected blocking lane uses `|| true`; advisory lanes are
+clearly named and not selected by PR Gate as blocking; policy reflects blocking
+versus advisory status.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 12. `gpu-ci: remove duplicate CPU native check`
+
+**Scope:** `.github/workflows/gpu-ci-matrix.yml`, `policy/ci-lanes.toml`,
+`policy/ci-risk-packs.toml`.
+
+**Change:** Remove `native-check(cpu)` from GPU CI. Trigger GPU CI only on GPU
+paths or labels `gpu-ci` / `full-ci`; avoid generic manifest triggers unless
+GPU dependencies changed or `full-ci` is present.
+
+**Acceptance:** GPU path PRs still run GPU feature compile checks; ordinary
+manifest PRs do not fan out GPU CI; Docker remains main/manual/label only.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 13. `coverage: keep Codecov lane quiet and policy-declared`
+
+**Scope:** `.github/workflows/coverage.yml`, `codecov.yml`, `README.md`,
+`docs/ci/coverage.md`, `policy/ci-lanes.toml`,
+`policy/ci-lane-whitelist.toml`.
+
+**Change:** Keep coverage out of CI Core. PR coverage runs only for `coverage`
+or `full-ci`; main gets coverage evidence. Keep Codecov comments and annotation
+spam disabled, keep flag `rust-cpu`, and document the CPU execution-surface
+claim boundary.
+
+**Acceptance:** Ordinary PR cost is unchanged; labeled PRs can request coverage;
+coverage makes no GPU/model/hardware adequacy claim.
+
+**Validation:**
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check
+```
+
+### 14. `coverage: add coverage receipt and ignored-failure accounting`
+
+**Scope:** `.github/workflows/coverage.yml`, `docs/ci/coverage.md`, receipt
+generation in the workflow.
+
+**Change:** Upload a coverage receipt with schema version, repo, lane, flag,
+workflow, artifact booleans, claim boundary, and `ignored_run_failures`. If
+`--ignore-run-fail` remains, main fails when ignored failures are nonzero unless
+an explicit future allow mechanism is scoped in that PR.
+
+**Acceptance:** Coverage artifacts include the receipt; nonzero ignored
+failures are visible and do not masquerade as green proof.
+
+### 15. `policy(clippy): document strict agent lint baseline`
+
+**Scope:** `docs/ci/clippy-policy.md`, `policy/clippy-lints.toml`,
+`clippy.toml`, `Cargo.toml`, `docs/ci/cost-and-verification-policy.md`.
+
+**Change:** Document lint tiers: Active, Staged, Planned 1.94/1.95, Debt, and
+Suppression. Do not activate new lints and do not perform code cleanup in this
+PR.
+
+**Acceptance:** Agents have a stable policy doc and TOML map; behavior is
+unchanged.
+
+**Validation:**
+
+```bash
+cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports --fail-on-error
+git diff --check
+```
+
+### 16+. lint activation slices
+
+Activate one lint family per PR, in this order: suppression governance, panic
+family, silent failure, async/concurrency, then numeric correctness. Each slice
+must include only the minimum code cleanup required for that lint family.
+
+### 20. `ci: make PR Gate the only required check`
+
+**Scope:** `.github/workflows/pr-gate.yml`, `docs/ci/pr-gate-success.md`,
+`docs/ci/branch-protection.md`.
+
+**Change:** After routing is proven, document and perform the branch-protection
+migration so only `PR Gate Success` is required. Leaf checks continue to run as
+normal workflow checks and PR Gate enforces selected blocking lanes.
+
+**Acceptance:** Docs explain the migration; `CI Core Success` may remain for
+compatibility but does not need to be required; path-filtered skipped workflows
+no longer block.
+
+## Expected cost outcomes
+
+| PR type | Target LEM |
+| --- | ---: |
+| Ordinary Rust PR | 25-34 |
+| Docs / tracking PR | 3-8 |
+| Manifest / toolchain PR | 35-50+ |
+
+Manifest and toolchain changes are allowed to exceed ordinary PR targets
+because they create global dependency/toolchain risk.

--- a/policy/ci-rollout.toml
+++ b/policy/ci-rollout.toml
@@ -1,0 +1,154 @@
+schema_version = "1.0"
+policy = "routed-ci-rollout"
+owner = "release/ci"
+status = "spec"
+updated = "2026-05-12"
+
+[north_star]
+statement = "Default PRs get cheap, Linux-only, deterministic, crate/risk-scoped proof. Expensive proof remains available on main, schedule, release, hardware/campaign lanes, or explicit labels."
+preferred_default_lem = 25
+default_limit_lem = 35
+budget_override_labels = ["full-ci", "ci-budget-override", "ci-budget-ack"]
+
+[boundaries]
+no_macos_default_pr_runner = true
+no_windows_default_pr_runner = true
+no_docker_model_download_default_pr_work = true
+no_branch_protection_change_unless_scoped = true
+no_unrelated_runtime_changes = true
+
+[[item]]
+order = 1
+title = "ci: remove macOS from ordinary PRs"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/macos-arm64.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md", "docs/ci/labels.md"]
+acceptance = ["No normal Rust PR launches macos-14", "macos/apple-silicon/metal/full-ci labels still work", "main/manual still preserve Apple proof", "policy lane costs reflect macOS is not default"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check", "cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error"]
+
+[[item]]
+order = 2
+title = "ci: move performance smoke off default PRs"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/performance-tracking.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Ordinary PRs do not run Performance Baseline Tracking", "main/schedule/manual/labeled runs still work", "no branch protection dependency"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 3
+title = "ci: move test telemetry to main and label"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/test-telemetry.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["No ordinary PR runs Test Telemetry", "main/manual/labeled runs still produce JUnit and slow-test summaries", "lane table changes default_pr to false"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 4
+title = "ci: risk-gate MSRV compatibility"
+phase = "remove immediate default-cost waste"
+files = [".github/workflows/compatibility.yml", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml", "policy/ci-risk-packs.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Leaf implementation PRs do not run MSRV by default", "manifest/toolchain/dependency PRs still run MSRV", "main still runs MSRV", "manifest_release risk pack still selects compatibility-msrv"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check", "cargo check --locked -p bitnet-common -p bitnet-models -p bitnet-tokenizers -p bitnet-quantization -p bitnet-kernels --tests --no-default-features --features cpu"]
+
+[[item]]
+order = 5
+title = "ci(plan): emit stable routing schema"
+phase = "make routing authoritative"
+files = ["xtask/src/ci/plan.rs", "xtask/src/ci/mod.rs", "policy/ci-budget.toml", "policy/ci-lanes.toml", "policy/ci-risk-packs.toml", "docs/ci/pr-plan.md", "tests/fixtures/ci-plan/**"]
+acceptance = ["Existing summary still prints", "new JSON schema is fixture-tested", "planner classifies docs/tracker/rust/manifest/gpu/macos/full-ci/coverage", "no workflow behavior changes"]
+validation = ["cargo test -p xtask --no-default-features ci_plan --locked", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/rust.txt --labels-json '[]' --json-out target/ci-plan.json --print", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print", "git diff --check"]
+
+[[item]]
+order = 6
+title = "ci(gate): make PR Gate consume ci plan"
+phase = "make routing authoritative"
+files = [".github/workflows/pr-gate.yml", ".github/workflows/pr-plan.yml", "xtask/src/ci/plan.rs", "docs/ci/pr-gate-success.md"]
+acceptance = ["PR Gate no longer has its own path classifier", "path-filtered workflows no longer cause missing required check traps", "branch protection can later require only PR Gate Success"]
+validation = ["cargo test -p xtask --no-default-features ci_plan --locked", "git diff --check"]
+
+[[item]]
+order = 7
+title = "ci: add soft budget guard"
+phase = "make routing authoritative"
+files = ["xtask/src/ci/plan.rs", ".github/workflows/pr-plan.yml", ".github/workflows/pr-gate.yml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Budget warnings appear in PR Plan summary", "PR Gate understands budget override labels", "no accidental hard failures until maintainers opt in"]
+validation = ["cargo test -p xtask --no-default-features ci_plan_budget --locked", "git diff --check"]
+
+[[item]]
+order = 8
+title = "ci-core: broaden no-Rust fast path"
+phase = "narrow default Linux proof"
+files = [".github/workflows/ci-core.yml", "xtask/src/ci/plan.rs", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Docs/campaign/hardware receipt PRs do not compile Rust unless they touch Rust inputs", "CI Core Success still emits", "Rust PR behavior unchanged"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/docs.txt --labels-json '[]' --json-out target/ci-plan-docs.json --print"]
+
+[[item]]
+order = 9
+title = "ci-core: package-select build/test surface"
+phase = "narrow default Linux proof"
+files = ["xtask/src/ci/plan.rs", ".github/workflows/ci-core.yml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Manifest/toolchain/shared foundational changes still get broad coverage", "leaf crate changes get scoped tests", "CI summary prints selected packages and reason", "no macOS/Windows/Docker/model downloads"]
+validation = ["cargo test -p xtask --no-default-features ci_plan_packages --locked", "cargo run --locked -p xtask --no-default-features -- ci plan --changed-file tests/fixtures/ci-plan/quantization.txt --labels-json '[]' --json-out target/ci-plan-quant.json --print", "git diff --check"]
+
+[[item]]
+order = 10
+title = "feature-matrix: reduce ordinary PR feature smoke"
+phase = "narrow default Linux proof"
+files = [".github/workflows/feature-matrix.yml", "policy/ci-risk-packs.toml", "policy/ci-lanes.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["Ordinary PR feature matrix is cheaper", "CLI/full-cli risk still gets checked", "main/full-ci still runs full matrix"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 11
+title = "ci: stop selected gates from swallowing failures"
+phase = "tighten advisory lanes into honest lanes"
+files = [".github/workflows/validation.yml", ".github/workflows/test-framework.yml", ".github/workflows/compatibility.yml", "docs/ci/cost-and-verification-policy.md", "policy/ci-lanes.toml"]
+acceptance = ["No selected blocking lane uses || true", "advisory lanes are clearly named and not selected by PR Gate as blocking", "policy table reflects blocking versus advisory"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 12
+title = "gpu-ci: remove duplicate CPU native check"
+phase = "tighten advisory lanes into honest lanes"
+files = [".github/workflows/gpu-ci-matrix.yml", "policy/ci-lanes.toml", "policy/ci-risk-packs.toml"]
+acceptance = ["GPU path PRs still run GPU feature compile checks", "ordinary manifest PRs do not automatically fan out GPU CI unless selected", "Docker remains main/manual/label only"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 13
+title = "coverage: keep Codecov lane quiet and policy-declared"
+phase = "coverage as measured evidence"
+files = [".github/workflows/coverage.yml", "codecov.yml", "README.md", "docs/ci/coverage.md", "policy/ci-lanes.toml", "policy/ci-lane-whitelist.toml"]
+acceptance = ["Ordinary PR cost unchanged", "main gets coverage evidence", "labeled PRs can request coverage", "no GPU/model/hardware coverage claim"]
+validation = ["git diff --check", "cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check"]
+
+[[item]]
+order = 14
+title = "coverage: add coverage receipt and ignored-failure accounting"
+phase = "coverage as measured evidence"
+files = [".github/workflows/coverage.yml", "docs/ci/coverage.md"]
+acceptance = ["Artifact includes coverage receipt", "main fails if ignored failures are nonzero unless explicitly allowed", "PR advisory coverage can upload receipt even if non-blocking"]
+validation = ["git diff --check"]
+
+[[item]]
+order = 15
+title = "policy(clippy): document strict agent lint baseline"
+phase = "cheap verification density"
+files = ["docs/ci/clippy-policy.md", "policy/clippy-lints.toml", "clippy.toml", "Cargo.toml", "docs/ci/cost-and-verification-policy.md"]
+acceptance = ["No code cleanup", "no new lint activation", "stable policy doc and TOML map"]
+validation = ["cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports --fail-on-error", "git diff --check"]
+
+[[item]]
+order = 16
+title = "lint activation slices"
+phase = "cheap verification density"
+files = ["policy/clippy-lints.toml", "policy/clippy-debt.toml", "policy/clippy-exceptions.toml", "policy/no-panic-allowlist.toml", "Cargo.toml", "crates/**"]
+acceptance = ["One lint family per PR", "minimum code cleanup required for that lint family", "reasoned expect/suppression governance preserved"]
+validation = ["cargo run --locked -p xtask --no-default-features -- check-lint-policy --report-dir target/bitnet/reports --fail-on-error", "git diff --check"]
+
+[[item]]
+order = 20
+title = "ci: make PR Gate the only required check"
+phase = "move from visibility to enforcement"
+files = [".github/workflows/pr-gate.yml", "docs/ci/pr-gate-success.md", "docs/ci/branch-protection.md"]
+acceptance = ["Docs explain branch-protection migration", "CI Core Success can remain for compatibility but not required", "path-filtered skipped workflows no longer block"]
+validation = ["git diff --check"]


### PR DESCRIPTION
### Motivation

- Reduce default PR CI cost by turning CI into a routed verification system that scopes expensive lanes to main/label/schedule and makes ordinary PRs cheap, Linux-only, and deterministic. 
- Provide an agent-executable, phase-driven implementation queue so follow-up PRs can be small, scoped, and verifiable. 
- Establish a stable machine-readable contract (`ci-plan.json`) so workflows can consume a single routing authority instead of duplicating path classifiers.

### Description

- Add `docs/ci/routed-ci-rollout.md` containing the rollout north star, PR-body template, agent operating rules, phased item queue (PRs 1–20), per-item scope/acceptance/validation, and expected LEM outcomes. 
- Add `docs/ci/pr-plan.md` that defines the `ci-plan.json` schema v1 (budget fields, classification booleans, `selected_lanes`/`skipped_lanes`, `packages` selection, and workflow consumption rules). 
- Add `policy/ci-rollout.toml` as a machine-readable queue of rollout items mapping order → files → acceptance → validation so agents and tools can discover scope and required checks. 
- Update policy docs to reference the new rollout and schema by adding links and routing/budget override label documentation in `docs/ci/cost-and-verification-policy.md` and `docs/ci/labels.md`; this PR is documentation/spec-only and does not change workflow behavior or branch-protection rules.

### Testing

- Ran `cargo run --locked -p xtask --no-default-features -- ci-lane-whitelist check`, which completed and produced the expected whitelist output with advisory warnings about `duplicate_of` references. 
- Ran `cargo run --locked -p xtask --no-default-features -- check-file-policy --report-dir target/bitnet/reports --fail-on-error`, which scanned files and returned `0 findings`. 
- Ran `git diff --cached --check` and static checks referenced in the rollout items, which reported no blocking whitespace/path issues. 
- Validated new TOML with a Python TOML loader (`tomllib.loads`) on `policy/ci-rollout.toml`, which parsed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03b0b90f048333aa6691f662c25bdf)