### PR TITLE
test(startup): fix guard test clippy

### DIFF
--- a/crates/bitnet-startup-contract-guard/tests/snapshot_tests.rs
+++ b/crates/bitnet-startup-contract-guard/tests/snapshot_tests.rs
@@ -5,14 +5,13 @@ use bitnet_startup_contract_guard::StartupContractGuard;
 fn startup_contract_guard_component_labels() {
     // Regression: component label strings must stay stable
     insta::assert_snapshot!({
-        let labels = [
+        [
             RuntimeComponent::Cli.label(),
             RuntimeComponent::Server.label(),
             RuntimeComponent::Test.label(),
             RuntimeComponent::Custom.label(),
         ]
-        .join("\n");
-        labels
+        .join("\n")
     });
 }
 

--- a/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
+++ b/crates/bitnet-startup-contract-guard/tests/startup_contract_guard_edge_cases.rs
@@ -38,21 +38,17 @@ fn guard_evaluate_test_observe_succeeds() {
 fn guard_evaluate_cli_enforce_callable() {
     // Enforce may fail if compile-time features don't match contract expectations
     let result = StartupContractGuard::evaluate(RuntimeComponent::Cli, ContractPolicy::Enforce);
-    match result {
-        Ok(guard) => assert!(matches!(guard.policy, ContractPolicy::Enforce)),
-        Err(_) => {} // expected on some feature combos
+    if let Ok(guard) = result {
+        assert!(matches!(guard.policy, ContractPolicy::Enforce));
     }
 }
 
 #[test]
 fn guard_evaluate_test_enforce_callable() {
     let result = StartupContractGuard::evaluate(RuntimeComponent::Test, ContractPolicy::Enforce);
-    match result {
-        Ok(guard) => {
-            assert!(matches!(guard.component, RuntimeComponent::Test));
-            assert!(matches!(guard.policy, ContractPolicy::Enforce));
-        }
-        Err(_) => {} // expected on some feature combos
+    if let Ok(guard) = result {
+        assert!(matches!(guard.component, RuntimeComponent::Test));
+        assert!(matches!(guard.policy, ContractPolicy::Enforce));
     }
 }
 
@@ -145,12 +141,9 @@ fn guard_profile_violations_is_option() {
     let guard =
         StartupContractGuard::evaluate(RuntimeComponent::Cli, ContractPolicy::Observe).unwrap();
     // May be Some or None; just verify accessible
-    match &guard.profile_violations {
-        Some((missing, forbidden)) => {
-            let _ = missing.len();
-            let _ = forbidden.len();
-        }
-        None => {}
+    if let Some((missing, forbidden)) = &guard.profile_violations {
+        let _ = missing.len();
+        let _ = forbidden.len();
     }
 }
 
@@ -203,12 +196,9 @@ fn evaluate_and_emit_server_observe_succeeds() {
 
 #[test]
 fn evaluate_and_emit_test_enforce_callable() {
-    match evaluate_and_emit(RuntimeComponent::Test, ContractPolicy::Enforce) {
-        Ok(guard) => {
-            assert!(matches!(guard.component, RuntimeComponent::Test));
-            assert!(matches!(guard.policy, ContractPolicy::Enforce));
-        }
-        Err(_) => {} // expected on some feature combos
+    if let Ok(guard) = evaluate_and_emit(RuntimeComponent::Test, ContractPolicy::Enforce) {
+        assert!(matches!(guard.component, RuntimeComponent::Test));
+        assert!(matches!(guard.policy, ContractPolicy::Enforce));
     }
 }
 
@@ -222,12 +212,9 @@ fn all_component_policy_combinations() {
     let policies = [ContractPolicy::Observe, ContractPolicy::Enforce];
     for component in &components {
         for policy in &policies {
-            match StartupContractGuard::evaluate(*component, *policy) {
-                Ok(guard) => {
-                    let _ = guard.is_compatible();
-                    guard.emit_to_tracing();
-                }
-                Err(_) => {} // Enforce may fail on some feature combos
+            if let Ok(guard) = StartupContractGuard::evaluate(*component, *policy) {
+                let _ = guard.is_compatible();
+                guard.emit_to_tracing();
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace single-pattern `match` blocks in startup-contract-guard tests with `if let`
- return the snapshot label expression directly to satisfy clippy
- preserve the existing behavior for feature combinations where enforce-mode evaluation is allowed to fail

## Validation
- `cargo fmt -p bitnet-startup-contract-guard -- --check`
- `cargo clippy --locked -p bitnet-startup-contract-guard --tests --no-default-features -- -D warnings`
- `cargo test --locked -p bitnet-startup-contract-guard --no-default-features`
- `git diff --check`
