### PR TITLE
test(ffi): fix edge case clippy

### DIFF
--- a/crates/bitnet-ffi/tests/ffi_c_api_edge_cases.rs
+++ b/crates/bitnet-ffi/tests/ffi_c_api_edge_cases.rs
@@ -49,7 +49,7 @@ fn version_contains_semver_pattern() {
 #[test]
 fn init_returns_success() {
     let rc = bitnet_init();
-    assert_eq!(rc, BITNET_SUCCESS as i32);
+    assert_eq!(rc, BITNET_SUCCESS);
     bitnet_cleanup();
 }
 
@@ -57,8 +57,8 @@ fn init_returns_success() {
 fn double_init_is_safe() {
     let rc1 = bitnet_init();
     let rc2 = bitnet_init();
-    assert_eq!(rc1, BITNET_SUCCESS as i32);
-    assert_eq!(rc2, BITNET_SUCCESS as i32);
+    assert_eq!(rc1, BITNET_SUCCESS);
+    assert_eq!(rc2, BITNET_SUCCESS);
     bitnet_cleanup();
 }
 
@@ -145,7 +145,7 @@ fn get_num_threads_returns_positive() {
 #[test]
 fn set_num_threads_roundtrip() {
     let rc = bitnet_set_num_threads(2);
-    assert_eq!(rc, BITNET_SUCCESS as i32);
+    assert_eq!(rc, BITNET_SUCCESS);
     let n = bitnet_get_num_threads();
     assert_eq!(n, 2, "thread count should be 2 after set");
 }
@@ -161,7 +161,7 @@ fn memory_usage_is_sane() {
 #[test]
 fn garbage_collect_returns_success() {
     let rc = bitnet_garbage_collect();
-    assert_eq!(rc, BITNET_SUCCESS as i32);
+    assert_eq!(rc, BITNET_SUCCESS);
 }
 
 #[test]

--- a/crates/bitnet-ffi/tests/ffi_config_error_edge_cases.rs
+++ b/crates/bitnet-ffi/tests/ffi_config_error_edge_cases.rs
@@ -11,6 +11,8 @@
 //! - Thread-local error state (set/get/clear)
 //! - BitNetCPerformanceMetrics defaults
 
+#![allow(clippy::field_reassign_with_default)]
+
 use bitnet_ffi::config::{BitNetCConfig, BitNetCInferenceConfig, BitNetCPerformanceMetrics};
 use bitnet_ffi::error::{BitNetCError, clear_last_error, get_last_error, set_last_error};
 


### PR DESCRIPTION
## Summary
- remove redundant `BITNET_SUCCESS as i32` casts from FFI C API edge tests
- allow `field_reassign_with_default` in config edge tests where mutating C-style default structs is the behavior under test

## Validation
- `cargo fmt -p bitnet-ffi -- --check`
- `cargo clippy --locked -p bitnet-ffi --tests --no-default-features --features cpu -- -D warnings`
- `cargo test --locked -p bitnet-ffi --no-default-features --features cpu --test ffi_c_api_edge_cases --test ffi_config_error_edge_cases`
- `git diff --check`
