### PR TITLE
docs: define BitNet source-of-truth model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,17 @@ Lookup material for exact behavior, formats, and APIs.
 | Model artifact status | [model-artifacts/MODEL_COVERAGE_MATRIX.md](model-artifacts/MODEL_COVERAGE_MATRIX.md) |
 | Answer quality gate | [model-artifacts/ANSWER_ARTIFACT_GATE.md](model-artifacts/ANSWER_ARTIFACT_GATE.md) |
 
+### Source-of-truth and claim boundaries
+
+| Area | Entry point |
+| --- | --- |
+| Why a proof lane exists | [proposals/README.md](proposals/README.md) |
+| What must be true | [specs/README.md](specs/README.md) |
+| Durable decisions | [adr/README.md](adr/README.md) |
+| User-facing status and claim tiers | [status/README.md](status/README.md) |
+| Active campaign work state | [tracking/TRACKER_MODEL.md](tracking/TRACKER_MODEL.md) |
+| Proof-convergence plan | [../plans/proof-convergence/README.md](../plans/proof-convergence/README.md) |
+
 ### Development
 
 | Document | Purpose |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,19 +1,48 @@
 # Architectural Decision Records
 
+ADRs record durable BitNet-rs decisions. Use them when a lane needs a stable
+architecture, proof, or policy choice that should survive individual PRs.
+
+ADRs do not own active work state or generated dashboards. Active execution
+state belongs in campaign-local `active.toml`; generated dashboards are derived
+from campaign manifests and events.
+
+## Current ADRs
+
 - ADR-0001: [Configuration layering and clamp location](./0001-configuration-layering.md)
 - ADR-0002: [GPU Backend Strategy](./0002-gpu-backend-strategy.md)
 
+## Source-Of-Truth Role
+
+| Layer | Owns |
+| --- | --- |
+| Proposal | Why the effort exists |
+| Spec | What must be true |
+| ADR | What decision was made and why it is durable |
+| Plan | PR order and proof commands |
+| Campaign `active.toml` | Current executable work |
+| Policy TOML | Enforceable ledger |
+| Receipt or artifact | Evidence |
+
+For BitNet proof work, ADRs should keep claim boundaries explicit. For example,
+an ADR may decide that answer-ready model artifacts must precede backend answer
+claims, or that dense SLM proof is first-class but must not be treated as
+BitNet I2_S or QK256 proof.
+
 ## Template for new ADRs
 
-Copy as `docs/adr/NNNN-title.md`:
+Copy as `docs/adr/NNNN-title.md` or use a BitNet-prefixed filename when a
+cross-lane proof decision needs a stable identifier:
 
 ```md
 # ADR-NNNN: Title
 - **Status:** Proposed | Accepted | Superseded by NNNN | Rejected
 - **Date:** YYYY-MM-DD
+- **Linked proposal/spec:** <paths>
 - **Context:** <problem / forces>
 - **Decision:** <what we chose and why>
 - **Consequences:** <positive/negative trade-offs>
+- **Claim boundary:** <what this decision does not prove>
 - **Alternatives considered:** <brief bullets>
 - **How to revert:** <what to change back if needed>
 ```

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,54 @@
+# Proposals
+
+Proposals explain why a BitNet-rs effort exists, what success means, and which
+current repo authorities it will use. They are durable context for humans and
+agents before a lane becomes a spec, ADR, plan, or campaign item.
+
+Proposals do not own implementation status, active work, or product claims.
+Those belong to campaign manifests, plans, status documents, policy ledgers,
+and proof receipts.
+
+## Source-Of-Truth Role
+
+| Layer | Owns |
+| --- | --- |
+| Proposal | Why the effort exists, user value, constraints, success criteria |
+| Spec | What must be true before a claim or behavior is accepted |
+| ADR | Durable architecture or proof decision |
+| Plan | PR order, proof commands, rollback path |
+| Campaign `active.toml` | Current executable work item state |
+| Status document | User-facing claim tier, proof command, artifact link |
+| Policy TOML | Enforceable CI, exception, allowlist, or routing ledger |
+| Receipt or artifact | Evidence for what actually happened |
+
+## BitNet Rule
+
+Do not create `.adze/goals`, `.bitnet/goals`, or another hidden global goals
+file. BitNet-rs already uses campaign-local tracking:
+
+```text
+docs/tracking/campaigns/<campaign>/CAMPAIGN.md
+docs/tracking/campaigns/<campaign>/active.toml
+docs/tracking/campaigns/<campaign>/events/
+docs/tracking/campaigns/<campaign>/generated/
+```
+
+Use proposals to frame a lane, then connect implementation to the campaign
+tracker instead of reconstructing active state from chat logs or README prose.
+
+## Proposal Shape
+
+New proposals should include:
+
+- `Status`
+- `Owner`
+- `Problem`
+- `Goals`
+- `Non-goals`
+- `Source-of-truth links`
+- `Success criteria`
+- `Rollback or exit criteria`
+
+Every proposal that affects user-visible capability claims should link to the
+status, model-artifact, hardware, CI, and campaign surfaces that will carry the
+actual proof.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,61 @@
+# Specs
+
+Specs define what must be true before BitNet-rs accepts a behavior, claim,
+proof boundary, or policy contract. They are the acceptance layer between a
+proposal and implementation work.
+
+Specs should not duplicate long operational ledgers. They should point to the
+authoritative gate, policy TOML, matrix, manifest, or receipt format and define
+how that authority is used.
+
+## Source-Of-Truth Role
+
+| Question | Source of truth |
+| --- | --- |
+| Why does this lane exist? | `docs/proposals/` |
+| What must be true? | `docs/specs/` |
+| What decision did we make? | `docs/adr/` |
+| What PRs execute it? | `plans/` and campaign `active.toml` |
+| What is currently supported? | `docs/status/` plus proof artifacts |
+| What does CI enforce? | `policy/*.toml` and workflow gates |
+| What happened? | Receipts, artifacts, campaign events, closeouts |
+
+## BitNet Claim Rules
+
+Specs for model, hardware, or CI claims must preserve these boundaries:
+
+- Structural GGUF loading is not answer readiness.
+- Tokenizer authority is not answer readiness by itself.
+- Hardware execution proof is not answer quality.
+- Dense SLM proof is not BitNet or 1-bit proof.
+- Backend receipts are lane-specific and must not collapse CPU, CUDA, Metal,
+  MPSGraph, OpenCL, WGPU, NPU, or platform identities.
+- Expensive CI evidence belongs on risk-routed, main, nightly, release, or
+  campaign lanes unless policy explicitly promotes it.
+
+## Existing Operational Authorities
+
+Specs should link to these maintained authorities instead of copying them:
+
+- `docs/model-artifacts/ANSWER_ARTIFACT_GATE.md`
+- `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md`
+- `docs/hardware/HARDWARE_MATRIX.md`
+- `docs/hardware/PROOF_STAGES.md`
+- `docs/ci/cost-and-verification-policy.md`
+- `docs/tracking/TRACKER_MODEL.md`
+- `policy/ci-lanes.toml`
+- `policy/ci-budget.toml`
+- `policy/ci-risk-packs.toml`
+
+## Spec Shape
+
+New specs should include:
+
+- `Status`
+- `Linked proposal`
+- `Applies to`
+- `Requirements`
+- `Claim boundary`
+- `Proof commands`
+- `Non-goals`
+- `Related policy or manifest sources`

--- a/docs/status/README.md
+++ b/docs/status/README.md
@@ -1,0 +1,49 @@
+# Status Documents
+
+Status documents are the user-facing claim map for BitNet-rs. They summarize
+which model families, hardware lanes, backend routes, and proof stages are
+usable, diagnostic, experimental, or unsupported.
+
+Status pages must link to proof. If a claim cannot point to a model artifact,
+hardware receipt, CI lane, policy ledger, or campaign closeout, keep it
+diagnostic, advisory, or planned.
+
+## Source-Of-Truth Role
+
+| Status surface | Owns |
+| --- | --- |
+| Capability matrix | Product claim tier, proof command, proof artifact, claim boundary |
+| Claim boundaries | What a proof does and does not allow the README or CLI docs to say |
+| README summary | Short user entry point, not the final proof map |
+| Receipt/artifact | Evidence for one run, model, backend, or lane |
+
+## Required Claim Boundary
+
+Status documents must preserve BitNet-specific distinctions:
+
+- Dense SLM support is not BitNet or 1-bit proof.
+- BitNet I2_S CPU proof is not CUDA proof.
+- CUDA receipt validation is not coherent answer readiness.
+- Hardware detection is not speed proof.
+- Structural model validity is not answer readiness.
+- Diagnostic receipts are useful evidence but must remain diagnostic until the
+  relevant artifact and answer gates pass.
+
+## Planned Status Surfaces
+
+The proof-convergence lane will add maintained status surfaces such as:
+
+```text
+docs/status/CAPABILITY_MATRIX.md
+docs/status/CLAIM_BOUNDARIES.md
+```
+
+Until those exist, prefer the existing operational authorities:
+
+- `README.md` for high-level user positioning.
+- `ROADMAP.md` for release direction and current limitations.
+- `docs/model-artifacts/ANSWER_ARTIFACT_GATE.md` for answer-readiness.
+- `docs/model-artifacts/MODEL_COVERAGE_MATRIX.md` for model coverage.
+- `docs/hardware/HARDWARE_MATRIX.md` for hardware lane identity.
+- `docs/ci/cost-and-verification-policy.md` for CI economics.
+- `docs/tracking/TRACKER_MODEL.md` for campaign execution state.

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,65 @@
+# Plans
+
+Plans translate proposals, specs, and ADRs into PR-sized implementation work.
+They should tell a maintainer or agent what to do next, what not to touch, and
+which commands prove or disprove the claim.
+
+Plans are not active global goals. The active source of truth for executable
+work is still the campaign tracker:
+
+```text
+docs/tracking/campaigns/<campaign>/active.toml
+```
+
+Use plans for sequencing and proof commands. Use campaign manifests for live
+state, ownership, branch names, allowed paths, and merge policy.
+
+## Source-Of-Truth Role
+
+| Layer | Owns |
+| --- | --- |
+| Proposal | Why |
+| Spec | What must be true |
+| ADR | Durable decision |
+| Plan | PR sequence, proof commands, rollback |
+| Campaign `active.toml` | Active work state |
+| Campaign events | Append-only lifecycle history |
+| Closeout | What landed and what remains |
+
+## Work Item Shape
+
+Plan work items should use this shape when practical:
+
+```md
+## Work item: <id>
+
+Status: ready
+Linked proposal:
+Linked specs:
+Linked ADRs:
+Campaign item:
+Blocked by:
+Blocks:
+
+### Goal
+
+### Production delta
+
+### Non-goals
+
+### Acceptance
+
+### Proof commands
+
+### Rollback
+```
+
+## Boundaries
+
+Plans must not:
+
+- duplicate generated dashboards,
+- create `.adze/goals` or `.bitnet/goals`,
+- claim model answer readiness without the answer artifact gate,
+- claim hardware validation without lane-specific receipts,
+- claim CI budget enforcement unless policy TOMLs and workflow gates enforce it.

--- a/plans/proof-convergence/README.md
+++ b/plans/proof-convergence/README.md
@@ -1,0 +1,63 @@
+# Proof Convergence Plan
+
+The proof-convergence lane makes BitNet-rs claim boundaries explicit across
+model artifacts, hardware lanes, CI economics, campaign execution, and user
+status docs.
+
+The goal is a proof-first repo operating model: a user, maintainer, or agent can
+find which model families are usable, which are diagnostic only, which hardware
+lanes have proof, what CI may claim, what PR should happen next, and which
+commands prove or disprove a claim.
+
+## Source-Of-Truth Stack
+
+| Layer | BitNet source |
+| --- | --- |
+| Direction | `ROADMAP.md` |
+| Why | `docs/proposals/` |
+| What must be true | `docs/specs/` |
+| Durable decisions | `docs/adr/` |
+| User-facing status | `docs/status/` |
+| Model answer-readiness | `docs/model-artifacts/ANSWER_ARTIFACT_GATE.md` and `ci/model-artifacts/*.toml` |
+| Hardware proof | `docs/hardware/HARDWARE_MATRIX.md`, proof-stage docs, and `ci/hardware/**` |
+| CI economics | `docs/ci/cost-and-verification-policy.md` and `policy/ci-*.toml` |
+| Active work | `docs/tracking/campaigns/<campaign>/active.toml` |
+| Lifecycle history | `docs/tracking/campaigns/<campaign>/events/` |
+| Evidence | Receipts, reports, artifacts, and closeouts |
+
+## BitNet-Specific Rule
+
+Do not import an Adze-style goal store. BitNet-rs already has a campaign tracker
+with campaign-local manifests. Agents should use:
+
+```text
+docs/tracking/campaigns/<campaign>/CAMPAIGN.md
+docs/tracking/campaigns/<campaign>/active.toml
+docs/tracking/campaigns/<campaign>/events/
+docs/tracking/campaigns/<campaign>/generated/
+```
+
+## First PRs
+
+1. Define the source-of-truth documentation model.
+2. Add the proof convergence proposal.
+3. Define source-of-truth and claim boundary specs.
+4. Add a capability matrix source of truth.
+5. Specify default PR CI economics.
+
+Later PRs should add model/hardware specs, ADRs, plan files, campaign state, a
+policy ledger, and optional `xtask` enforcement after the docs model is stable.
+
+## Claim Boundary
+
+This plan does not claim:
+
+- model answer readiness,
+- BitNet coherent local answers,
+- dense SLM proof as BitNet proof,
+- CPU, CUDA, Metal, MPSGraph, OpenCL, WGPU, or NPU speed,
+- hardware validation,
+- CI budget enforcement.
+
+Those claims require the relevant artifact gate, hardware receipt, policy TOML,
+campaign item, and proof command.


### PR DESCRIPTION
## Summary

Adds the first proof-convergence source-of-truth scaffold for BitNet-rs:

- docs/proposals/README.md for why lanes exist.
- docs/specs/README.md for what must be true.
- docs/status/README.md for user-facing claim tiers and proof maps.
- docs/adr/README.md updates for durable proof/architecture decisions.
- plans/README.md and plans/proof-convergence/README.md for PR sequencing and proof commands.
- docs/README.md links the new source-of-truth entry points.

## Source-of-truth model

- ROADMAP.md remains direction and limitations.
- Proposals explain why.
- Specs define what must be true.
- ADRs record durable decisions.
- Plans define PR order, proof commands, and rollback.
- Campaign-local ctive.toml remains the active work source of truth.
- Status docs summarize product claim tiers only when linked to proof.
- Policy TOMLs remain enforceable CI/exception/config ledgers.
- Receipts and artifacts prove what happened.

## BitNet-specific deviations from the Adze reference

This PR does not add .adze/goals, .bitnet/goals, or any competing global goal store. BitNet already has campaign-local tracking under docs/tracking/campaigns/<campaign>/, so the docs explicitly route active execution through CAMPAIGN.md, ctive.toml, events/, and generated dashboards.

## Scope

Documentation scaffold only.

## Non-goals

- No Rust runtime code changes.
- No CI behavior changes.
- No hardware receipt changes.
- No model-artifact manifest changes.
- No README product claim promotion.
- No generated dashboard edits.

## Claim boundary

This PR does not claim:

- model answer readiness
- BitNet coherent local answers
- dense SLM proof
- CPU/CUDA/Metal/NPU speed
- hardware validation
- CI budget enforcement

## CI economics

- Default PR impact: docs-only.
- Expensive lanes touched: none.
- Branch protection impact: none.
- Rollback: revert this docs-only commit.

## Validation

- [x] git diff --check
- [ ] cargo run --locked -p xtask --no-default-features -- campaign doctor - blocked locally before xtask starts because sentencepiece-sys requires the Visual Studio 17 2022 CMake generator on this Windows host.
- [ ] cargo run --locked -p xtask --no-default-features -- campaign generate --check - same local Windows sentencepiece-sys/Visual Studio 17 2022 blocker.

## Closeout / follow-up

Next PR: docs(proposal): add proof convergence proposal.