### PR TITLE
test(kernels): remove duplicate neon allow

### DIFF
--- a/crates/bitnet-kernels/tests/neon_simd_verification_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_simd_verification_tests.rs
@@ -6,12 +6,7 @@
 //! the outputs. They cover vector arithmetic, comparisons, load/store,
 //! reductions, and integer operations relevant to 2-bit quantization.
 #![cfg(all(feature = "cpu", target_arch = "aarch64"))]
-#![allow(
-    clippy::undocumented_unsafe_blocks,
-    clippy::float_cmp,
-    clippy::needless_range_loop,
-    unused_unsafe
-)]
+#![allow(clippy::undocumented_unsafe_blocks, clippy::float_cmp, clippy::needless_range_loop)]
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary
- removes the duplicate `unused_unsafe` allow from the NEON SIMD verification test module
- keeps the remaining lint allowances scoped to the SIMD test cases that need them

## Why
Workspace clippy treats duplicated attributes as errors under `-D warnings`. This small cleanup unblocks the broader CPU workspace clippy path used by the crate-collapse and Mac support lanes.

## Validation
- `cargo fmt -p bitnet-kernels`
- `cargo clippy --locked -p bitnet-kernels --test neon_simd_verification_tests --no-default-features --features cpu -- -D warnings`
- `git diff --check`
