### PR TITLE
test(kernels): fix attention quant clippy

### DIFF
--- a/crates/bitnet-kernels/tests/metal_quantization_shader_tests.rs
+++ b/crates/bitnet-kernels/tests/metal_quantization_shader_tests.rs
@@ -104,12 +104,14 @@ mod tests {
                 let blk_start = blk * block_size;
                 let blk_end = (blk_start + block_size).min(k);
                 let scale = scales[col * num_blocks + blk];
-                for i in blk_start..blk_end {
+                for (i, activation_value) in
+                    activation.iter().enumerate().take(blk_end).skip(blk_start)
+                {
                     let byte_idx = i / 4;
                     let bit_off = (i % 4) * 2;
                     let bits = (weights_packed[col * packed_k + byte_idx] >> bit_off) & 0x03;
                     let w = decode_i2s(bits) as f32 * scale;
-                    acc += w * activation[i];
+                    acc += w * activation_value;
                 }
             }
             out[col] = acc;
@@ -1113,11 +1115,11 @@ mod tests {
         let weights_packed = pack_i2s_vec(&vals);
         let scales = vec![1.0f32];
 
-        let constant = 3.14f32;
+        let constant = 3.125f32;
         let activation = vec![constant; k];
 
         let result = cpu_i2s_matvec(&weights_packed, &scales, &activation, n, k, block_size);
-        // 16 * 3.14 + 16 * (-3.14) = 0
+        // 16 * constant + 16 * (-constant) = 0
         assert!(
             result[0].abs() < 1e-4,
             "Balanced ±1 with constant input should cancel, got {}",

--- a/crates/bitnet-kernels/tests/neon_attention_regression_tests.rs
+++ b/crates/bitnet-kernels/tests/neon_attention_regression_tests.rs
@@ -6,9 +6,7 @@
     clippy::manual_range_contains,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
-    clippy::cast_precision_loss,
-    unused_imports,
-    dead_code
+    clippy::cast_precision_loss
 )]
 
 const TOLERANCE: f32 = 1e-4;
@@ -238,9 +236,9 @@ mod causal_masking {
         apply_causal_mask(&mut scores, seq_len);
 
         // First token (i=0) should only attend to itself
-        assert_eq!(scores[0 * seq_len], 1.0);
+        assert_eq!(scores[0], 1.0);
         for j in 1..seq_len {
-            assert!(scores[0 * seq_len + j].is_infinite());
+            assert!(scores[j].is_infinite());
         }
     }
 


### PR DESCRIPTION
## Summary
- fixes clippy warnings in Metal quantization shader tests
- removes duplicated NEON attention regression test allowances
- simplifies first-token causal mask assertions to avoid erasing arithmetic

## Why
The full workspace clippy gate for the LEAF-001 crate-collapse lane now reaches these kernel tests and treats these lints as hard failures under `-D warnings`.

## Validation
- `cargo fmt -p bitnet-kernels`
- `cargo clippy --locked -p bitnet-kernels --test metal_quantization_shader_tests --test neon_attention_regression_tests --no-default-features --features cpu -- -D warnings`
- `git diff --check`
