### PR TITLE
plans(cuda): add 5070 Ti productization plan

### DIFF
--- a/plans/cuda-5070ti-productization/README.md
+++ b/plans/cuda-5070ti-productization/README.md
@@ -1,0 +1,61 @@
+# 9950X3D + RTX 5070 Ti CUDA Productization Plan
+
+This plan turns the existing NVIDIA RTX 5070 Ti proof lane into a normal,
+receipt-backed CUDA product bench without broadening any model, hardware, or
+speed claim.
+
+The product bench identities are fixed by
+[BITNET-ADR-0004](../../docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md):
+
+```text
+CPU reference: amd-9950x3d-cpu-avx512
+CUDA target:  nvidia-rtx-5070-ti-cuda
+```
+
+## Source-Of-Truth Links
+
+- Proposal:
+  [`BITNET-PROP-0002`](../../docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md)
+- Contract spec:
+  [`BITNET-SPEC-0007`](../../docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md)
+- Bench ADR:
+  [`BITNET-ADR-0004`](../../docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md)
+- CUDA campaign:
+  [`docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md`](../../docs/tracking/campaigns/nvidia-5070ti/CAMPAIGN.md)
+- Live campaign state:
+  `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+- Model coverage:
+  `ci/model-artifacts/model-coverage-matrix.toml`
+- Receipt root:
+  `ci/hardware/windows-9950x3d-rtx5070ti/**`
+
+## Files
+
+- [`implementation-plan.md`](implementation-plan.md) lists the PR-sized queue.
+- [`bitnet-official-i2s.md`](bitnet-official-i2s.md) owns the official BitNet
+  2B I2_S/QK256 product path.
+- [`dense-qwen.md`](dense-qwen.md) owns the Qwen2.5 0.5B Q8_0 dense CUDA lane.
+- [`small-llm-candidates.md`](small-llm-candidates.md) owns the candidate
+  onboarding ladder.
+- [`benchmark-qualification.md`](benchmark-qualification.md) owns
+  profile-specific speed decisions.
+
+## Claim Boundary
+
+This plan does not claim new runtime behavior. It only defines the order,
+acceptance, receipts, and rollback paths for future PRs.
+
+Do not use this plan to claim:
+
+- dense Qwen proof as BitNet proof;
+- BitNet QK256 proof as dense SLM proof;
+- generic `cuda` as RTX 5070 Ti proof;
+- hardware execution as answer quality;
+- benchmark baselines as accepted speedup;
+- server readiness from CLI receipts.
+
+## Validation For This Plan PR
+
+```bash
+git diff --check
+```

--- a/plans/cuda-5070ti-productization/benchmark-qualification.md
+++ b/plans/cuda-5070ti-productization/benchmark-qualification.md
@@ -1,0 +1,102 @@
+# CUDA Benchmark Qualification
+
+Benchmark qualification turns timing receipts into narrow speed decisions. It
+does not create model answer proof, hardware execution proof, or global CUDA
+speedup by itself.
+
+## Required Profiles
+
+```text
+one_token
+short_decode_8
+short_decode_32
+warm_session_3_turns
+warm_session_10_turns
+```
+
+## Required Receipt Fields
+
+Every benchmark qualification receipt must record:
+
+```text
+model artifact identity
+tokenizer authority
+prompt template authority
+requested backend
+selected backend
+runtime API
+fallback_used
+CPU mean / p50 / p95
+CUDA mean / p50 / p95
+prompt prefill time
+first-token latency
+steady decode time
+kernel time
+H2D timing source
+D2H timing source
+VRAM high-water
+power/thermal context when available
+speedup_accepted = true|false
+reason
+```
+
+## Decision Rules
+
+- A profile can pass while another profile fails.
+- BitNet profile decisions do not apply to dense SLMs.
+- Dense Qwen decisions do not apply to BitNet QK256.
+- A benchmark baseline is evidence, not an accepted speed claim.
+- Missing transfer, power, thermal, or variance context should usually reject
+  speedup while preserving the measurement.
+
+## Work item: BitNet Official I2_S Qualification
+
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-PROD-010`
+
+Proof:
+
+```bash
+cargo test --locked -p bitnet-bench-receipts --no-default-features
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- bench --device cuda --cuda-benchmark-receipt <receipt>
+git diff --check
+```
+
+Receipt root:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/bitnet-i2s-*-benchmark.json
+```
+
+Rollback:
+
+Remove the qualification receipt or demote the accepted profile. Do not edit
+raw historical benchmark receipts by hand.
+
+## Work item: Dense Qwen Qualification
+
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-DENSE-054`
+
+Proof:
+
+```bash
+python -m json.tool ci/hardware/windows-9950x3d-rtx5070ti/<date>/dense-qwen25-q8-*.json
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+git diff --check
+```
+
+Receipt root:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/dense-qwen25-q8-*-benchmark.json
+```
+
+Rollback:
+
+Remove or demote the dense benchmark qualification. Keep
+`bitnet_packed_i2s_qk256_proof=false`.

--- a/plans/cuda-5070ti-productization/bitnet-official-i2s.md
+++ b/plans/cuda-5070ti-productization/bitnet-official-i2s.md
@@ -1,0 +1,116 @@
+# Official BitNet 2B I2_S/QK256 CUDA Product Path
+
+This file owns the official Microsoft BitNet 2B I2_S/QK256 path on the
+9950X3D + RTX 5070 Ti product bench.
+
+## Current Claim
+
+The current campaign and model coverage matrix say the official I2_S/QK256 row
+is `product_cli_ready`, `accelerator_answer_ready=true`, and
+`speedup_claim=false`.
+
+Allowed route:
+
+```text
+model_class = bitnet
+route = bitnet_qk256_cuda
+selected_backend = nvidia-rtx-5070-ti-cuda
+cpu_reference = amd-9950x3d-cpu-avx512
+bitnet_packed_i2s_qk256_proof = true
+dense_regular_llm_cuda_proof = false
+```
+
+## Canonical Receipts
+
+Existing proof should be reconciled against:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-proof.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-short-decode.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-06/strict-bitnet-cuda-benchmark.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/strict-cuda-ask-math.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-answer-corpus.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cpu-avx512-answer-corpus.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cpu-avx512-vs-cuda-answer-parity.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-002-repeated-strict-ask.json
+ci/hardware/windows-9950x3d-rtx5070ti/2026-05-08/cuda-bitnet-perf-003-warm-session-benchmark.json
+```
+
+## Next PRs
+
+### CUDA-PROD-008: Reconcile Proof State
+
+Link:
+`docs/tracking/campaigns/nvidia-5070ti/active.toml`
+
+Acceptance:
+
+- Current BitNet row lists last strict ask, corpus, parity, warm-session, and
+  benchmark receipts.
+- Next missing proof is benchmark qualification, not basic CUDA execution.
+- `speedup_claim=false` remains visible.
+
+Proof:
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+Rollback: revert the docs reconciliation.
+
+### CUDA-PROD-009: Strict Ask/Chat Preflight
+
+Acceptance:
+
+- `bitnet cuda doctor` and strict ask/chat paths expose selected backend,
+  tokenizer authority, prompt authority, QK256 route readiness, receipt path,
+  fallback status, and speed claim status.
+- Missing tokenizer, generic CUDA proof ambiguity, and CPU fallback fail closed.
+
+Proof:
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli cuda_doctor ask_strict
+cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
+git diff --check
+```
+
+Rollback: revert the CLI preflight changes; keep historical receipts.
+
+### CUDA-PROD-010: Benchmark Qualification
+
+Profiles:
+
+```text
+one_token
+short_decode_8
+short_decode_32
+warm_session_3_turns
+warm_session_10_turns
+```
+
+Acceptance:
+
+- Each profile records CPU and CUDA distributions, transfer timing sources,
+  kernel timing, VRAM high-water mark, fallback status, decision, and reason.
+- Speedup can be accepted or rejected per exact profile.
+- There is no global CUDA speedup claim.
+
+Proof:
+
+```bash
+cargo test --locked -p bitnet-bench-receipts --no-default-features
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- bench --device cuda --cuda-benchmark-receipt <receipt>
+git diff --check
+```
+
+Rollback: remove the new qualification receipts and demote any status row that
+depends on them.
+
+## Claim Boundary
+
+This lane may claim official BitNet I2_S/QK256 strict CUDA proof only for
+committed receipts. It must not claim dense SLM proof, server readiness, full
+CUDA residency, or speedup outside accepted profiles.

--- a/plans/cuda-5070ti-productization/dense-qwen.md
+++ b/plans/cuda-5070ti-productization/dense-qwen.md
@@ -1,0 +1,190 @@
+# Dense Qwen2.5 0.5B Q8_0 CUDA Product Path
+
+This file owns the first dense regular-LLM CUDA product lane. It is useful
+local inference evidence, but it is not BitNet, I2_S, QK256, or 1-bit proof.
+
+## Current Claim
+
+The model coverage matrix records `dense_qwen25_05b_q8_cuda` as a dense SLM row
+with:
+
+```text
+route = dense_regular_llm_cuda
+dense_regular_llm_cuda_proof = true
+bitnet_packed_i2s_qk256_proof = false
+speedup_claim = false
+server_ready = false
+```
+
+The first productization task is to audit which Qwen receipts are real hardware
+user-path receipts versus validators, fixtures, or contracts.
+
+## Work item: CUDA-DENSE-050
+
+Status: ready
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-DENSE-050`
+
+### Goal
+
+Produce `docs/reports/CUDA_DENSE_QWEN25_Q8_PRODUCT_AUDIT.md`.
+
+### Acceptance
+
+The audit answers:
+
+- Is one-token strict CUDA real hardware execution or validator-only?
+- Is short decode real?
+- Is warm session real?
+- Is chat path real?
+- Are CPU and CUDA generated token IDs compared?
+- Which receipts are committed?
+- Which receipts are only synthetic validators?
+- Which benchmark profiles exist?
+- Which gaps block product CLI readiness?
+
+### Proof commands
+
+```bash
+python -m json.tool <each committed dense qwen receipt>
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+git diff --check
+```
+
+### Receipt paths
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/**/dense-*.json
+```
+
+### Claim boundary
+
+Audit only. No new dense CUDA, answer, speed, server, or BitNet claim.
+
+### Rollback
+
+Revert the audit report and any docs-only references.
+
+## Work item: CUDA-DENSE-051
+
+Status: planned
+Campaign item: `CUDA-DENSE-051`
+Blocked by: CUDA-DENSE-050
+
+### Goal
+
+Implement or refresh the dense Qwen one-token strict CUDA receipt.
+
+### Acceptance
+
+The receipt records:
+
+```text
+artifact_kind = dense_gguf_qwen_one_token_strict_cuda
+route = dense_regular_llm_cuda
+selected_backend = nvidia-rtx-5070-ti-cuda
+fallback_used = false
+cpu selected token id
+cuda selected token id
+first divergence if any
+kernel stats
+transfer stats
+quality gate result
+speedup_claim = false
+bitnet_packed_i2s_qk256_proof = false
+```
+
+### Proof command
+
+```powershell
+cargo run --locked --release -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- dense-ask --device nvidia-rtx-5070-ti-cuda --model <qwen2.5-0.5b-q8_0.gguf> --question "What is 2+2? Answer with only the number." --max-new-tokens 1 --temperature 0 --strict-cuda --json-out ci\hardware\windows-9950x3d-rtx5070ti\<date>\dense-qwen25-q8-one-token-cuda.json
+```
+
+### Rollback
+
+Remove the new receipt and demote any matrix/status row that depended on it.
+
+## Work item: CUDA-DENSE-052
+
+Status: planned
+Campaign item: `CUDA-DENSE-052`
+Blocked by: CUDA-DENSE-051
+
+### Goal
+
+Add deterministic 8 to 32 token strict CUDA short-decode proof.
+
+### Acceptance
+
+- no CPU fallback;
+- stable greedy token sequence;
+- valid UTF-8 answer;
+- no raw special-token garbage;
+- prefill, KV, logits, sampler, kernel, and transfer fields recorded;
+- no broad chat or speed claim.
+
+### Proof command
+
+```bash
+cargo run --locked --release -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- dense-answer-corpus <args>
+python -m json.tool ci/hardware/windows-9950x3d-rtx5070ti/<date>/dense-qwen25-q8-short-decode.json
+git diff --check
+```
+
+### Rollback
+
+Remove the short-decode receipt and keep one-token proof scoped.
+
+## Work item: CUDA-DENSE-053
+
+Status: planned
+Campaign item: `CUDA-DENSE-053`
+Blocked by: CUDA-DENSE-052
+
+### Goal
+
+Prove dense Qwen warm-session behavior.
+
+### Acceptance
+
+- model loaded once;
+- tokenizer loaded once;
+- CUDA context initialized once;
+- intended persistent buffers reused;
+- per-turn receipts and a session summary exist;
+- `full_cuda_residency_claimed=false` unless all phases prove residency;
+- `speedup_claim=false` unless benchmark-qualified.
+
+### Receipt path
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/dense-qwen25-q8-warm-session.json
+```
+
+### Rollback
+
+Remove the warm-session receipt and keep dense Qwen product status limited to
+the last proven stage.
+
+## Work item: CUDA-DENSE-054
+
+Status: planned
+Campaign item: `CUDA-DENSE-054`
+Blocked by: CUDA-DENSE-053
+
+### Goal
+
+Add dense Qwen benchmark qualification.
+
+### Acceptance
+
+The review consumes one-token, short-decode, and warm-session receipts,
+explicitly accepts or rejects speedup by profile, records blockers, and keeps
+BitNet proof false.
+
+### Rollback
+
+Remove or demote only the benchmark qualification. Do not edit historical
+execution receipts by hand.

--- a/plans/cuda-5070ti-productization/implementation-plan.md
+++ b/plans/cuda-5070ti-productization/implementation-plan.md
@@ -1,0 +1,367 @@
+# CUDA 5070 Ti Productization Implementation Plan
+
+This queue starts after the source-of-truth proposal, product contract spec, and
+product-bench ADR. Each item is intentionally PR-sized and keeps claim
+promotion tied to receipts.
+
+## Queue
+
+| Order | Work item | PR title | Primary file |
+| --- | --- | --- | --- |
+| 1 | CUDA-PROD-008 | `docs(cuda): reconcile 5070 Ti BitNet and dense proof state` | campaign and status docs |
+| 2 | CUDA-PROD-009 | `cuda(bitnet): harden strict ask/chat user preflight` | CLI/product path |
+| 3 | CUDA-PROD-010 | `cuda(bitnet): benchmark qualification receipts for official I2_S` | benchmark receipts |
+| 4 | CUDA-UX-009 | `docs(cuda): update BitNet user guide for strict CUDA` | tutorial |
+| 5 | CUDA-DENSE-050 | `cuda(dense): audit Qwen2.5 Q8_0 proof state` | dense audit report |
+| 6 | CUDA-DENSE-051 | `cuda(dense): implement or refresh Qwen one-token strict CUDA proof` | dense receipt path |
+| 7 | CUDA-DENSE-052 | `cuda(dense): Qwen short decode strict CUDA proof` | dense receipt path |
+| 8 | CUDA-DENSE-053 | `cuda(dense): Qwen warm-session chat proof` | dense receipt path |
+| 9 | CUDA-DENSE-054 | `cuda(dense): Qwen benchmark qualification` | benchmark receipts |
+| 10 | CUDA-MODEL-001 | `model(cuda): add Qwen3 0.6B artifact contract` | model artifact docs |
+| 11 | CUDA-MODEL-002 | `model(cuda): add Qwen3 CPU answer sanity` | CPU receipts |
+| 12 | CUDA-MODEL-003 | `model(cuda): add Qwen3 CUDA all-layer plan` | all-layer plan |
+| 13 | CUDA-MODEL-004 | `model(cuda): add Qwen3 one-token CUDA proof` | CUDA receipt path |
+| 14 | CUDA-MODEL-005 | `model(cuda): add Qwen3 short-decode and warm-session proof` | CUDA receipt path |
+| 15 | CUDA-UX-008 | `cli(cuda): model support dashboard` | CLI/status surface |
+| 16 | CUDA-UX-010 | `docs(cuda): 9950X3D+5070Ti CUDA quickstart` | tutorial |
+| 17 | CUDA-SERVER-001 | `server(cuda): strict CUDA server smoke` | server path |
+
+## Shared Links
+
+All work items link to:
+
+- Proposal:
+  `docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md`
+- Spec:
+  `docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md`
+- ADR:
+  `docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md`
+- Campaign:
+  `docs/tracking/campaigns/nvidia-5070ti/active.toml`
+- Model coverage:
+  `ci/model-artifacts/model-coverage-matrix.toml`
+- Receipt root:
+  `ci/hardware/windows-9950x3d-rtx5070ti/**`
+
+## Work item: CUDA-PROD-008
+
+Status: ready
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, `rtx5070ti-cuda-answer-readiness`
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-PROD-008`
+Blocked by: merged proposal, spec, ADR
+Blocks: CUDA-PROD-009, CUDA-DENSE-050
+
+### Goal
+
+Reconcile campaign, model coverage, status, and plan docs so there is one
+current-state ledger for official BitNet, dense Qwen, and candidate models.
+
+### Production delta
+
+Docs only. No new receipt or claim promotion.
+
+### Non-goals
+
+No code, model manifest, receipt, workflow, generated-dashboard, or README
+product-claim change.
+
+### Acceptance
+
+Add a table with current state, last real receipt, next missing proof, allowed
+claim, and forbidden claim for:
+
+- official BitNet 2B I2_S CUDA;
+- dense Qwen2.5 0.5B Q8_0 CUDA;
+- Qwen3 0.6B;
+- SmolLM2 360M;
+- Llama 3.2 1B and 3B;
+- Gemma/Phi small.
+
+### Proof commands
+
+```bash
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+cargo run --locked -p xtask --no-default-features -- campaign generate --check
+git diff --check
+```
+
+### Receipt paths
+
+Use committed receipts under:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/**
+```
+
+### Claim boundary
+
+No new model, CUDA, answer, speed, server, or residency claim.
+
+### Rollback
+
+Revert the docs-only reconciliation. Receipts and ledgers stay unchanged.
+
+## Work item: CUDA-PROD-009
+
+Status: planned
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007, `rtx5070ti-cuda-answer-readiness`
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-PROD-009`
+Blocked by: CUDA-PROD-008
+Blocks: CUDA-PROD-010, CUDA-UX-009
+
+### Goal
+
+Make strict BitNet CUDA user commands fail closed before generation and print a
+compact proof summary when they can write a receipt.
+
+### Production delta
+
+Harden normal `bitnet cuda doctor`, `bitnet model verify`, `bitnet ask`, and
+warm-session paths for the official BitNet I2_S/QK256 artifact.
+
+### Non-goals
+
+No dense Qwen work, no benchmark speed promotion, no server path.
+
+### Acceptance
+
+- Missing tokenizer fails before generation.
+- Generic `cuda` does not silently become RTX 5070 Ti proof.
+- CPU fallback fails under strict CUDA.
+- Default receipt path and compact summary are visible.
+- `speedup_claim=false` remains default.
+
+### Proof commands
+
+```bash
+cargo test --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli cuda_doctor ask_strict
+cargo check --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli
+git diff --check
+```
+
+### Receipt paths
+
+```text
+target/bitnet/receipts/cuda-answer-readiness/strict-cuda-ask-latest.json
+ci/hardware/windows-9950x3d-rtx5070ti/**
+```
+
+### Claim boundary
+
+Strict preflight and summary behavior only. No new answer-quality or speed
+claim unless receipts already prove the exact case.
+
+### Rollback
+
+Revert CLI preflight and summary changes; existing receipts remain evidence for
+prior runs.
+
+## Work item: CUDA-PROD-010
+
+Status: planned
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign item: `CUDA-PROD-010`
+Blocked by: CUDA-PROD-008
+Blocks: CUDA-UX-009
+
+### Goal
+
+Make official BitNet I2_S/QK256 speed decisions governed and profile-specific.
+
+### Production delta
+
+Add benchmark qualification receipts for `one_token`, `short_decode_8`,
+`short_decode_32`, `warm_session_3_turns`, and `warm_session_10_turns`.
+
+### Non-goals
+
+No global CUDA speedup claim. No dense Qwen speed claim.
+
+### Acceptance
+
+Each profile records CPU and CUDA p50/p95/mean, prefill, first token, steady
+decode, kernel time, H2D/D2H timing source, VRAM high-water mark, thermal or
+power context when available, fallback status, decision, and reason.
+
+### Proof commands
+
+```bash
+cargo test --locked -p bitnet-bench-receipts --no-default-features
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,cuda,full-cli -- bench --device cuda --cuda-benchmark-receipt <receipt>
+git diff --check
+```
+
+### Receipt paths
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/bitnet-i2s-<profile>-benchmark.json
+```
+
+### Claim boundary
+
+`speedup_claim=true` may apply only to an accepted exact profile and model.
+
+### Rollback
+
+Revert generated benchmark qualification docs or receipts from the PR. Do not
+edit historical receipts by hand.
+
+## Work items: CUDA-DENSE-050 through CUDA-DENSE-054
+
+Status: planned
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign items: `CUDA-DENSE-050` through `CUDA-DENSE-054`
+Blocked by: CUDA-PROD-008
+Blocks: CUDA-MODEL-001
+
+### Goal
+
+Audit and then productize dense Qwen2.5 0.5B Q8_0 as the first dense CUDA SLM
+lane without inheriting any BitNet QK256 claim.
+
+### Production delta
+
+See [`dense-qwen.md`](dense-qwen.md).
+
+### Non-goals
+
+No BitNet proof, no generic dense GGUF claim, no server readiness.
+
+### Acceptance
+
+The lane must distinguish real hardware receipts from validators/contracts and
+then add or refresh one-token, short-decode, warm-session, and benchmark
+receipts as needed.
+
+### Proof commands
+
+```bash
+python -m json.tool <receipt>
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+git diff --check
+```
+
+### Receipt paths
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/dense-qwen25-q8-*.json
+```
+
+### Claim boundary
+
+`dense_regular_llm_cuda_proof` may become true only for exact committed Qwen
+receipts. `bitnet_packed_i2s_qk256_proof=false` stays explicit.
+
+### Rollback
+
+Revert the dense-lane PR and demote any status row if the receipt no longer
+proves the claim.
+
+## Work items: CUDA-MODEL-001 through CUDA-MODEL-005
+
+Status: planned
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign items: `CUDA-MODEL-001` through `CUDA-MODEL-005`
+Blocked by: CUDA-DENSE-050
+Blocks: later SmolLM2/Llama/Gemma/Phi candidate ladders
+
+### Goal
+
+Use Qwen3 0.6B as the first test of generalized dense model onboarding.
+
+### Production delta
+
+See [`small-llm-candidates.md`](small-llm-candidates.md).
+
+### Non-goals
+
+Do not batch-promote all candidates. Do not inherit Qwen2.5 evidence.
+
+### Acceptance
+
+Artifact contract, CPU sanity, all-layer plan, one-token CUDA, and short-decode
+or warm-session proof land as separate PRs.
+
+### Proof commands
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+### Receipt paths
+
+```text
+ci/model-artifacts/<model-id>.toml
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/<model>-*.json
+```
+
+### Claim boundary
+
+Candidate rows stay candidate until their own proof ladders pass.
+
+### Rollback
+
+Revert only the candidate row or receipt introduced by the failed PR.
+
+## Work items: CUDA-UX-008, CUDA-UX-010, CUDA-SERVER-001
+
+Status: planned
+Linked proposal: BITNET-PROP-0002
+Linked specs: BITNET-SPEC-0007
+Linked ADRs: BITNET-ADR-0004
+Campaign items: `CUDA-UX-008`, `CUDA-UX-010`, `CUDA-SERVER-001`
+Blocked by: BitNet and dense Qwen CLI proof surfaces
+Blocks: broader product docs
+
+### Goal
+
+Expose the proof state through user-facing status, quickstart, and later server
+smoke paths.
+
+### Production delta
+
+- `bitnet model status --device nvidia-rtx-5070-ti-cuda`
+- `docs/tutorials/9950x3d-5070ti-cuda-quickstart.md`
+- strict CUDA server smoke only after CLI is stable
+
+### Non-goals
+
+No server production-readiness claim before a fallback-free server receipt.
+
+### Acceptance
+
+Status and quickstart commands say what each row proves and does not prove.
+Server readiness stays false until `CUDA-SERVER-001` lands.
+
+### Proof commands
+
+```bash
+cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- model status --device nvidia-rtx-5070-ti-cuda
+git diff --check
+```
+
+### Receipt paths
+
+```text
+ci/model-artifacts/model-coverage-matrix.toml
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/server-strict-cuda-smoke.json
+```
+
+### Claim boundary
+
+Status and docs summarize proof. They do not create new proof.
+
+### Rollback
+
+Revert the status/docs/server-smoke PR and demote the server row if needed.

--- a/plans/cuda-5070ti-productization/small-llm-candidates.md
+++ b/plans/cuda-5070ti-productization/small-llm-candidates.md
@@ -1,0 +1,123 @@
+# Dense SLM And Small Dense LLM Candidate Onboarding
+
+Candidate rows do not inherit official BitNet or Qwen2.5 receipts. Each model
+must pass its own artifact, tokenizer, prompt, CPU, CUDA, benchmark, status,
+and user-surface gates.
+
+## Priority Order
+
+1. Qwen3 0.6B Q8/Q4.
+2. SmolLM2 360M.
+3. Llama 3.2 1B.
+4. SmolLM2 1.7B.
+5. Llama 3.2 3B.
+6. Gemma or Phi small.
+
+## Per-Model Ladder
+
+Each model uses the same sequence:
+
+| Step | Output | Claim boundary |
+| --- | --- | --- |
+| A. Artifact contract | `ci/model-artifacts/<model-id>.toml`, `docs/reports/<MODEL>_ARTIFACT_CONTRACT.md` | registered or structurally valid only |
+| B. CPU answer sanity | CPU answer receipt | no CUDA claim |
+| C. Dense all-layer plan | route counts, unsupported ops, gaps | plan only |
+| D. Model-boundary fixtures | embedding, norm, LM head, KV, sampling fixtures | fixture proof only |
+| E. One-token CUDA | strict fallback-free one-token receipt | exact model, one-token only |
+| F. Short decode / warm session | decode and session receipts | scoped answer proof |
+| G. Benchmark qualification | profile-specific decision | exact accepted profiles only |
+
+## Work items: CUDA-MODEL-001 through CUDA-MODEL-005
+
+Qwen3 0.6B is the first candidate because it is closest to the existing Qwen2.5
+dense infrastructure.
+
+### CUDA-MODEL-001: Artifact Contract
+
+Acceptance fields:
+
+```text
+repo/source
+file
+SHA256
+bytes
+GGUF type
+architecture
+quantization
+tokenizer
+chat template
+context length
+license
+storage envelope
+VRAM estimate
+```
+
+Proof:
+
+```bash
+git diff --check
+cargo run --locked -p xtask --no-default-features -- campaign check nvidia-5070ti
+```
+
+Rollback: remove the candidate artifact contract and report.
+
+### CUDA-MODEL-002: CPU Answer Sanity
+
+Acceptance prompts:
+
+```text
+math
+capital
+short summary
+basic code
+yes/no
+```
+
+Receipt:
+
+```text
+ci/hardware/windows-9950x3d-rtx5070ti/<date>/qwen3-06b-cpu-answer-corpus.json
+```
+
+Rollback: remove the CPU receipt and leave the model registered only.
+
+### CUDA-MODEL-003: CUDA All-Layer Plan
+
+Acceptance:
+
+- every transformer layer inspected;
+- routed op counts recorded;
+- unsupported ops recorded;
+- model-boundary gaps explicit;
+- strict CUDA readiness false unless all required routes are proven.
+
+Rollback: revert the plan receipt and any matrix status change.
+
+### CUDA-MODEL-004: One-Token CUDA Proof
+
+Acceptance:
+
+- strict selected backend `nvidia-rtx-5070-ti-cuda`;
+- fallback false;
+- CPU and CUDA selected tokens recorded;
+- kernel and transfer stats present;
+- BitNet proof false.
+
+Rollback: remove the one-token receipt and keep CUDA answer readiness false.
+
+### CUDA-MODEL-005: Short Decode And Warm Session
+
+Acceptance:
+
+- deterministic short-decode receipt;
+- warm-session receipt when model/session reuse is claimed;
+- quality gate result present;
+- speedup false unless benchmark-qualified.
+
+Rollback: remove the decode/session receipt and demote status rows.
+
+## Later Candidates
+
+After Qwen3 proves the generalized ladder, repeat the same A through G sequence
+for SmolLM2 360M, Llama 3.2 1B, SmolLM2 1.7B, Llama 3.2 3B, Gemma, and Phi.
+Do not combine candidate families in one PR.


### PR DESCRIPTION
## Summary

Adds the CUDA 5070 Ti productization plan under `plans/cuda-5070ti-productization/`.

The plan turns BITNET-PROP-0002, BITNET-SPEC-0007, BITNET-ADR-0004, and the `nvidia-5070ti` campaign into PR-sized work for official BitNet I2_S/QK256, dense Qwen2.5 Q8_0, candidate dense SLM/small-LLM onboarding, and profile-specific benchmark qualification.

## Source-of-truth links

- Proposal: docs/proposals/BITNET-PROP-0002-9950x3d-5070ti-cuda-productization.md
- Spec: docs/specs/BITNET-SPEC-0007-9950x3d-5070ti-cuda-product-contract.md
- ADR: docs/adr/BITNET-ADR-0004-9950x3d-5070ti-cuda-product-bench.md
- Campaign: docs/tracking/campaigns/nvidia-5070ti/active.toml
- Plan: plans/cuda-5070ti-productization/

## Scope

- Adds the CUDA productization plan README.
- Adds the PR queue and work-item acceptance plan.
- Adds focused plan files for official BitNet I2_S/QK256, dense Qwen, small model candidates, and benchmark qualification.

## Non-goals

- No Rust runtime or CUDA code changes.
- No model manifest or receipt changes.
- No workflow or policy behavior changes.
- No generated dashboard edits.
- No README product claim changes.

## Claim boundary

This PR does not claim model answer readiness, new CUDA runtime behavior, CUDA kernel correctness, dense SLM proof, BitNet proof beyond existing receipts, server readiness, or CUDA speedup. It only defines execution rails for future PRs.

## Validation

- [x] git diff --cached --check

## Rollback

Revert the `plans/cuda-5070ti-productization/` directory. Runtime code, receipts, model manifests, workflows, policies, and generated dashboards are unchanged.