### PR TITLE
bench(prompt-templates): use std black box

### DIFF
--- a/crates/bitnet-prompt-templates/benches/template_ops.rs
+++ b/crates/bitnet-prompt-templates/benches/template_ops.rs
@@ -3,7 +3,9 @@
 //! Measures throughput of template detection, application, and multi-turn
 //! chat rendering across representative template families.
 
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use bitnet_prompt_templates::{ChatRole, ChatTurn, TemplateType};
 


### PR DESCRIPTION
## Summary
- replace deprecated `criterion::black_box` in prompt-template benches with `std::hint::black_box`
- keep Criterion imports limited to benchmark setup macros/types

## Why
Full workspace clippy with `-D warnings` now treats Criterion's deprecated re-export as a hard failure when checking all targets. This blocker is unrelated to the warn-once crate-collapse work, so it is split into a narrow PR.

## Validation
- `cargo fmt -p bitnet-prompt-templates`
- `cargo clippy --locked -p bitnet-prompt-templates --bench template_ops --no-default-features -- -D warnings`
- `git diff --check`
