### PR TITLE
docs(ci): encode timeout cap policy

### DIFF
--- a/docs/ci/cost-and-verification-policy.md
+++ b/docs/ci/cost-and-verification-policy.md
@@ -44,6 +44,34 @@ For ordinary PRs, our operating target is:
 
 The `$1` mark is a ceiling, not the goal.
 
+## Timeout and cap policy
+
+Timeouts are pathological-run guards, not budget targets. CI cost should be
+controlled by routing, smaller profiles, fail-fast preflight checks, labels,
+manual dispatch, schedules, and campaign lanes. Once an expensive lane is
+intentionally selected, its timeout must give a healthy run enough room to
+produce a result.
+
+Cutting a job off after it has already spent most of its expected runtime is
+usually the worst outcome: the compute has been spent, no receipt or test result
+is produced, and the next attempt repeats the same cost. Treat that as a policy
+failure unless the timeout exposed a real hang or runaway path.
+
+Long hardware, model, SLM, coverage, fuzz, and release lanes should therefore
+follow this order:
+
+- reject irrelevant work before it starts through CI routing,
+- fail fast on missing prerequisites before downloads, builds, or model runs,
+- choose a smaller bounded profile when the full profile is too expensive,
+- size the selected job cap from recent successful runtimes with cushion,
+- keep aggregator polling deadlines at least as long as the healthy upstream
+  lane they are waiting on.
+
+If the selected lane is too expensive to let finish, it should not be selected
+for that event. It should move to a label, schedule, manual dispatch, release
+gate, or campaign receipt lane instead of using a near-completion timeout as a
+cost control.
+
 ## Why the budget target is aggressive
 
 Our CI budget target is intentionally aggressive — but **not because we want

--- a/docs/ci/learned-budgets.md
+++ b/docs/ci/learned-budgets.md
@@ -18,6 +18,26 @@ flake), so estimating at the median underbudgets ~50 % of PRs. A
 15 % cushion on the p50 still reads "tight but realistic" while
 keeping the planner's headline number close to lived experience.
 
+## Timeout sizing
+
+Learned budgets estimate cost posture. Workflow `timeout-minutes` should be
+sized separately as a completion guard:
+
+```text
+timeout = recent successful p95 wall time + fixed or percentage cushion
+```
+
+Timed-out and cancelled runs are not healthy duration samples. Use them to
+investigate cap sizing, queue behavior, or true hangs; do not let them pull the
+healthy cap downward. A timeout that fires just before the selected lane would
+have produced a receipt wastes the full prior run and should be treated as a
+cap failure, not a normal budget success.
+
+For long lanes, prefer fail-fast prerequisite checks and smaller profile
+selection before expensive work starts. Aggregator jobs should have polling
+windows at least as long as the healthy upstream lane they depend on, plus
+cushion for status propagation.
+
 ## Inputs
 
 | Source                              | Role                                 |

--- a/docs/ci/routed-verification-rollout.md
+++ b/docs/ci/routed-verification-rollout.md
@@ -11,6 +11,13 @@ Default pull requests should get cheap, deterministic, crate/risk-scoped proof.
 Expensive proof still exists, but it runs only on `main`, schedules, release
 lanes, hardware/campaign lanes, manual dispatch, or explicit labels.
 
+Routing controls whether a lane runs. It must not control cost by starting an
+expensive lane and then setting a cap just below healthy completion time. If a
+lane is selected, its timeout should be sized as a hang guard with enough
+cushion to produce the receipt or check result. If that is too expensive for
+the event, route the lane elsewhere or select a smaller bounded profile before
+expensive work begins.
+
 The target shape is:
 
 ```text

--- a/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/CAMPAIGN.md
@@ -275,6 +275,13 @@ synthetic receipt checks. Live M3 model runs, large downloads, timing receipts,
 and artifact sweeps are local or scheduled Apple-hardware evidence, not ordinary
 CI requirements.
 
+M3 live and scheduled jobs should fail before expensive work when disk, cache,
+runner, power, thermal, model, tokenizer, or receipt prerequisites are missing.
+Once a bounded M3 profile is intentionally selected, its cap should allow a
+healthy run to finish with cushion. If that is too costly, choose a smaller
+profile, manual evidence, or a scheduled lane rather than cutting the job off
+near completion and spending the same CI again.
+
 ## Claim Boundary
 
 Do not claim:

--- a/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/active.toml
@@ -18,6 +18,7 @@ hard_constraints = [
   "Do not claim M4 Mac mini performance, broad Apple Silicon performance, QK256 support, full Apple Metal inference, Neural Engine execution, or MPSGraph model inference from this lane.",
   "Do not weaken existing M4 receipt checks to make M3 receipts fit; add the smallest MacBook-specific label or validation path instead.",
   "Do not add live model downloads, large artifact sweeps, or hardware timing runs to generic required CI.",
+  "Do not use near-completion timeouts as M3 lane cost control; route the job away, choose a smaller profile, or cap healthy selected runs with cushion.",
   "Never commit model binaries.",
 ]
 

--- a/docs/tracking/campaigns/apple-m3-macbook-air/generated/status.md
+++ b/docs/tracking/campaigns/apple-m3-macbook-air/generated/status.md
@@ -31,4 +31,5 @@
 - Do not claim M4 Mac mini performance, broad Apple Silicon performance, QK256 support, full Apple Metal inference, Neural Engine execution, or MPSGraph model inference from this lane.
 - Do not weaken existing M4 receipt checks to make M3 receipts fit; add the smallest MacBook-specific label or validation path instead.
 - Do not add live model downloads, large artifact sweeps, or hardware timing runs to generic required CI.
+- Do not use near-completion timeouts as M3 lane cost control; route the job away, choose a smaller profile, or cap healthy selected runs with cushion.
 - Never commit model binaries.

--- a/policy/ci-budget.toml
+++ b/policy/ci-budget.toml
@@ -25,6 +25,13 @@ macos_latest = 10.0
 gpu_docker = 6.0
 external_ai_review = 4.0
 
+[timeout_policy]
+purpose = "prevent pathological hangs, not enforce ordinary PR budget"
+healthy_cap_basis = "recent_success_p95_plus_cushion"
+prefer_routing_over_near_completion_timeout = true
+fail_fast_preflight_required_for_long_lanes = true
+aggregator_deadline_must_cover_upstream_healthy_completion = true
+
 # Bands map (LEM range -> string posture) used by `xtask ci plan`
 # when emitting the markdown summary. Keys are inclusive upper
 # bounds; the lookup is "first matching band wins".


### PR DESCRIPTION
## Summary
- add an explicit CI timeout/cap policy: timeouts guard pathological hangs, not ordinary PR budget
- document learned timeout sizing from healthy p95 wall time plus cushion
- encode the posture in `policy/ci-budget.toml`
- add the same rule to the M3 MacBook Air campaign so selected M3 jobs either fail early or have enough cap to finish

## Why
Ending a long job just before completion spends the CI budget and produces no receipt. CI design should control cost through routing, preflight, smaller profiles, labels, schedules, and campaign lanes. Once a long lane is intentionally selected, the cap needs to be sized for healthy completion.

## Validation
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m3-macbook-air`
- `cargo run --locked -p xtask --no-default-features -- campaign generate`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `git diff --check`

`campaign doctor` reports existing warnings for `CPU258V-030` event metadata, then passes.
