### PR TITLE
test(testing-policy): collapse compatible snapshot check

### DIFF
--- a/crates/bitnet-testing-policy/tests/bitnet_testing_policy_tests.rs
+++ b/crates/bitnet-testing-policy/tests/bitnet_testing_policy_tests.rs
@@ -71,10 +71,10 @@ fn validate_explicit_profile_unit_local_returns_without_panic() {
 #[test]
 fn policy_snapshot_is_compatible_reflects_violations() {
     let snapshot = snapshot_from_env();
-    if snapshot.is_compatible() {
-        if let Some((missing, forbidden)) = snapshot.violations() {
-            assert!(missing.is_empty() && forbidden.is_empty());
-        }
+    if snapshot.is_compatible()
+        && let Some((missing, forbidden)) = snapshot.violations()
+    {
+        assert!(missing.is_empty() && forbidden.is_empty());
     }
 }
 


### PR DESCRIPTION
## Summary
- collapse nested compatibility/violation checks in `bitnet-testing-policy` tests

## Why
Full workspace clippy with `-D warnings` flags the nested `if` as `collapsible_if`. This is unrelated to LEAF-001, so it is split as a narrow blocker fix.

## Validation
- `cargo fmt -p bitnet-testing-policy`
- `cargo clippy --locked -p bitnet-testing-policy --test bitnet_testing_policy_tests --no-default-features -- -D warnings`
- `git diff --check`
