### PR TITLE
docs(tracking): close M4-QA-005 metal decision

### DIFF
--- a/docs/tracking/campaigns/apple-m4-local-answer/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-local-answer/CAMPAIGN.md
@@ -61,7 +61,7 @@ authority; landing that evidence is still separate from enabling BitNet through
 | M4-QA-002 | merged | Repeat-run parity evidence from #4618 shows both Apple M4 CPU/NEON runs used the same answer-ready model, tokenizer, prompt template, greedy settings, and fallback-free backend routing; all five compared cases matched generated token IDs. |
 | M4-QA-003 | merged | Receipt-quality checks from #4618 require generated text, token counts and ID consistency, tokenizer pretokenizer authority, model source/SHA, backend routing/fallback status, and timing fields; the committed Apple M4 CPU/NEON BitNet answer-corpus receipt records those fields for all five passing cases. |
 | M4-QA-004 | merged | Local preflight coverage rejects missing model/tokenizer authority before hidden fallback; unsupported Apple Metal/MPSGraph answer-corpus lanes fail closed, and receipt checks reject hidden fallback plus speedup/full-inference acceleration claims. |
-| M4-QA-005 | proposed | Local decision recorded: the first eligible Metal route is a prefill projection fixture after CPU/NEON proof, greedy determinism, and receipt-quality gates land; current user-facing local-answer path remains CPU/NEON only. |
+| M4-QA-005 | merged | Local decision recorded: the first eligible Metal contribution is a prefill projection fixture with CPU-only greedy reference comparison, CPU/Metal phase parity, unchanged generated token IDs and decoded text, and explicit fallback=false phase receipts; current user-facing local-answer path remains CPU/NEON only. |
 
 ## Review Policy
 

--- a/docs/tracking/campaigns/apple-m4-local-answer/active.toml
+++ b/docs/tracking/campaigns/apple-m4-local-answer/active.toml
@@ -363,7 +363,8 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-QA-005"
-status = "proposed"
+status = "merged"
+merge_sha = "9fa3e532b89c36885c54350700d75a740a93911e"
 branch = "codex/apple-m4-local-answer/M4-QA-005-metal-phase-routing"
 stackable = false
 review_mode = "codex_premerge"
@@ -389,5 +390,16 @@ forbidden_paths = [
   "crates/bitnet-qk256-dispatch/**",
   "crates/bitnet-server/**",
 ]
-may_claim = []
-must_not_claim = []
+may_claim = [
+  "The first eligible future Apple M4 BitNet Metal local-answer contribution has been documented as a prefill projection fixture with CPU-only greedy reference comparison, CPU/Metal phase parity, unchanged generated token IDs and decoded text, and explicit fallback=false phase receipts.",
+]
+must_not_claim = [
+  "A BitNet Metal local-answer route is enabled today.",
+  "Full apple-m4-metal model inference works.",
+  "Apple M4 Metal participates in autoregressive BitNet decode.",
+  "BitNet is selectable through `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve`.",
+  "QK256 works on Apple Silicon.",
+  "Neural Engine execution is proven.",
+  "MPSGraph inference is proven.",
+  "Broad performance or speedup is proven.",
+]

--- a/docs/tracking/campaigns/apple-m4-local-answer/events/2026-05-13T183658Z-M4-QA-005-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-local-answer/events/2026-05-13T183658Z-M4-QA-005-merged.toml
@@ -1,0 +1,14 @@
+timestamp = "2026-05-13T18:36:58Z"
+campaign = "apple-m4-local-answer"
+item = "M4-QA-005"
+event = "merged"
+merge_sha = "9fa3e532b89c36885c54350700d75a740a93911e"
+actor = "codex"
+
+notes = [
+  "Closed M4-QA-005 after M4-QA-002 and M4-QA-003 were recorded merged and the decision-only routing docs were verified.",
+  "docs/hardware/apple-m4-mac-mini-operator-runbook.md keeps the operator local-answer path on apple-m4-cpu-neon and selects the first eligible future Metal contribution as a prefill projection fixture, not a full decode loop.",
+  "docs/specs/apple-m4-mac-mini-roadmap.md requires any later Metal local-answer contribution to compare CPU-only greedy output before and after the Metal phase fixture and record unchanged generated token IDs and decoded text.",
+  "The prior local M4-QA-005 closeout event records required receipt fields for any later Metal contribution: selected apple-m4-metal backend, runtime_api=metal, fallback_used=false, phase_scope=prefill_projection_fixture, full_metal_inference_claimed=false, speedup_claim=false, CPU reference token IDs unchanged, and decoded text unchanged.",
+  "Claim boundaries remain narrow: this is a routing decision only; it does not enable a BitNet Metal local-answer route, bitnet mac ask/chat/server, full Metal inference, Apple QK256 support, Neural Engine execution, MPSGraph inference, or performance claims.",
+]

--- a/docs/tracking/campaigns/apple-m4-local-answer/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-local-answer/generated/status.md
@@ -16,7 +16,7 @@
 | M4-QA-002 | merged | TBD | `codex/apple-m4-local-answer/M4-QA-002-greedy-determinism` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add deterministic greedy local-answer checks so the same model, prompt, tokenizer, backend, and runtime settings produce stable token IDs and receipt identity. |
 | M4-QA-003 | merged | TBD | `codex/apple-m4-local-answer/M4-QA-003-receipt-quality` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Harden local-answer receipts so generated text, token counts, tokenizer authority, model identity, backend routing, fallback status, and timing fields are present and checked. |
 | M4-QA-004 | merged | TBD | `codex/apple-m4-local-answer/M4-QA-004-strict-failure-modes` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Add strict local-answer failure-mode coverage for missing model files, tokenizer authority failures, unsupported Apple backend selections, and attempts to count fallback as acceleration. |
-| M4-QA-005 | proposed | TBD | `codex/apple-m4-local-answer/M4-QA-005-metal-phase-routing` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Decide and document the first safe route for one receipt-backed Apple Metal phase to participate in real generation while preserving CPU fallback visibility and greedy output comparison. |
+| M4-QA-005 | merged | TBD | `codex/apple-m4-local-answer/M4-QA-005-metal-phase-routing` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Decide and document the first safe route for one receipt-backed Apple Metal phase to participate in real generation while preserving CPU fallback visibility and greedy output comparison. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -51,7 +51,7 @@
 | apple-m4-local-answer | M4-QA-002 | M4-QA-001 | merged |
 | apple-m4-local-answer | M4-QA-003 | M4-QA-001 | merged |
 | apple-m4-local-answer | M4-QA-004 | M4-QA-001 | merged |
-| apple-m4-local-answer | M4-QA-005 | M4-QA-002, M4-QA-003 | proposed |
+| apple-m4-local-answer | M4-QA-005 | M4-QA-002, M4-QA-003 | merged |
 | apple-m4-operational | M4-OP-002 | M4-OP-001 | merged |
 | apple-m4-operational | M4-OP-003 | M4-OP-001 | merged |
 | apple-m4-operational | M4-OP-004 | M4-OP-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -9,7 +9,7 @@
 | apple-m4 | M4-018 | #3826 | merged | none | Do not touch QK256 before a BitNet-specific Apple item explicitly allows it. |
 | apple-m4-continuity | M4-CONT-005 | #4270 | merged | none | This is an M4 Mac mini local campaign; do not execute MacBook artifact sweeps or MacBook receipts here. |
 | apple-m4-dense-slm-regression | M4-SLM-REG-005 | #4198 | merged | none | Do not reopen the completed apple-m4, apple-m4-slm-answer, apple-m4-productization, or apple-m4-slm-performance campaigns. |
-| apple-m4-local-answer | M4-QA-005 | TBD | proposed | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
+| apple-m4-local-answer | M4-QA-005 | TBD | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
 | apple-m4-local-server | M4-SERVE-005 | #4374 | merged | none | This is an M4 Mac mini dense SLM service campaign. |
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |


### PR DESCRIPTION
Summary
- mark M4-QA-005 merged now that M4-QA-002 and M4-QA-003 are recorded merged
- close the decision-only Metal routing item using the existing runbook and roadmap text
- preserve the boundary that BitNet local-answer routing remains CPU/NEON today

Evidence
- `docs/hardware/apple-m4-mac-mini-operator-runbook.md` keeps the operator local-answer path on `apple-m4-cpu-neon` and selects the first eligible future Metal contribution as a prefill projection fixture, not a full decode loop.
- `docs/specs/apple-m4-mac-mini-roadmap.md` requires any later Metal local-answer contribution to compare CPU-only greedy output before and after the Metal phase fixture and record unchanged generated token IDs and decoded text.
- `docs/tracking/campaigns/apple-m4-local-answer/events/2026-05-13T131225Z-M4-QA-005-metal-routing-decision-local.toml` records the required future receipt fields: `selected_backend=apple-m4-metal`, `runtime_api=metal`, `fallback_used=false`, `phase_scope=prefill_projection_fixture`, `full_metal_inference_claimed=false`, `speedup_claim=false`, unchanged CPU reference token IDs, and unchanged decoded text.

Validation
- `cargo fmt --all -- --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-answer`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor` (passes with pre-existing CPU tracker metadata warnings)
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

Claim Boundary
- This is a routing decision only.
- It does not enable a BitNet Metal local-answer route, `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve` for BitNet.
- It does not claim broad BitNet chat quality, full Metal inference, Apple QK256 support, Neural Engine execution, MPSGraph inference, speedup, or broad performance.
