### PR TITLE
feat(mac): add BitNet one-shot ask route

### DIFF
--- a/crates/bitnet-cli/src/mac.rs
+++ b/crates/bitnet-cli/src/mac.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, anyhow};
 use bitnet_repl_core::{ReplInput, parse_repl_input};
 use clap::{ArgAction, Args, Subcommand, ValueEnum};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::io::{self, BufRead, IsTerminal, Read, Write};
 #[cfg(unix)]
 use std::mem::MaybeUninit;
@@ -110,6 +111,14 @@ enum MacAction {
         /// Override model cache root. Defaults to ~/.cache/bitnet-rs/models.
         #[arg(long, value_name = "PATH")]
         cache_dir: Option<PathBuf>,
+
+        /// Explicit BitNet GGUF path for the one-shot BitNet ask route.
+        #[arg(long = "model-path", value_name = "PATH")]
+        model_path: Option<PathBuf>,
+
+        /// Explicit tokenizer.json path for the one-shot BitNet ask route.
+        #[arg(long, value_name = "PATH")]
+        tokenizer: Option<PathBuf>,
 
         /// Optional system prompt.
         #[arg(long = "system", value_name = "TEXT")]
@@ -410,7 +419,7 @@ enum MacAction {
         json_out: PathBuf,
     },
 
-    /// Validate M4 BitNet proof inputs without enabling Mac ask/chat routing.
+    /// Validate M4 BitNet proof inputs without enabling BitNet chat/serve routing.
     BitnetProof {
         /// Accepted BitNet GGUF path. This command never downloads model artifacts.
         #[arg(long, value_name = "PATH")]
@@ -534,6 +543,8 @@ impl MacCommand {
                 question_flag,
                 model_id,
                 cache_dir,
+                model_path,
+                tokenizer,
                 system_prompt,
                 max_new_tokens,
                 temperature,
@@ -549,6 +560,8 @@ impl MacCommand {
                 run_ask(
                     &model_id,
                     cache_dir,
+                    model_path,
+                    tokenizer,
                     question,
                     system_prompt,
                     max_new_tokens,
@@ -1053,12 +1066,12 @@ fn run_bitnet_proof_preflight(
 
     if proof_valid {
         println!(
-            "M4 BitNet proof receipt verified; this still does not enable BitNet through `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve`. Receipt: {}",
+            "M4 BitNet proof receipt verified; BitNet remains limited to explicit one-shot `bitnet mac ask` and does not enable `bitnet mac chat` or `bitnet mac serve`. Receipt: {}",
             json_out.display()
         );
     } else {
         println!(
-            "M4 BitNet proof preflight passed; this still does not enable BitNet through `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve`. Receipt: {}",
+            "M4 BitNet proof preflight passed; BitNet remains limited to explicit one-shot `bitnet mac ask` and does not enable `bitnet mac chat` or `bitnet mac serve`. Receipt: {}",
             json_out.display()
         );
     }
@@ -1320,6 +1333,8 @@ fn run_check(model_id: &str, cache_dir: Option<PathBuf>, json: bool) -> Result<(
 async fn run_ask(
     model_id: &str,
     cache_dir: Option<PathBuf>,
+    model_path: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
     question: String,
     system_prompt: Option<String>,
     max_new_tokens: usize,
@@ -1331,6 +1346,30 @@ async fn run_ask(
     threads: usize,
     json_out: PathBuf,
 ) -> Result<()> {
+    if model_cache::is_apple_m4_bitnet_artifact_id(model_id) {
+        return run_bitnet_ask(
+            model_id,
+            cache_dir,
+            model_path,
+            tokenizer,
+            question,
+            system_prompt,
+            max_new_tokens,
+            temperature,
+            top_k,
+            top_p,
+            repetition_penalty,
+            seed,
+            threads,
+            json_out,
+        )
+        .await;
+    }
+    if model_path.is_some() || tokenizer.is_some() {
+        anyhow::bail!(
+            "`bitnet mac ask` accepts --model-path/--tokenizer only for the explicit BitNet one-shot route; dense SLM models use --model-id and the verified model cache"
+        );
+    }
     let model = model_cache::verified_apple_m4_slm_model(model_id, cache_dir)?;
     eprintln!("{}", mac_ask_operator_summary_line(&model, &json_out));
     run_one_shot_mac_answer(
@@ -1351,6 +1390,91 @@ async fn run_ask(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+async fn run_bitnet_ask(
+    model_id: &str,
+    cache_dir: Option<PathBuf>,
+    model_path: Option<PathBuf>,
+    tokenizer: Option<PathBuf>,
+    question: String,
+    system_prompt: Option<String>,
+    max_new_tokens: usize,
+    temperature: f32,
+    top_k: usize,
+    top_p: f32,
+    repetition_penalty: f32,
+    seed: Option<u64>,
+    threads: usize,
+    json_out: PathBuf,
+) -> Result<()> {
+    if temperature != 0.0 || top_p != 1.0 {
+        anyhow::bail!(
+            "BitNet Mac ask is currently scoped to deterministic greedy proof settings; use --temperature 0.0 --top-p 1.0"
+        );
+    }
+    if !matches!(top_k, 0 | 1) {
+        anyhow::bail!("BitNet Mac ask is currently scoped to greedy top-k 0 or 1");
+    }
+    let tokenizer = tokenizer.ok_or_else(|| {
+        anyhow!(
+            "BitNet Mac ask requires explicit tokenizer authority; pass --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json"
+        )
+    })?;
+    if !tokenizer.exists() {
+        anyhow::bail!(
+            "BitNet Mac ask tokenizer is missing at {}; pass the accepted external tokenizer.json",
+            tokenizer.display()
+        );
+    }
+    let tokenizer_sha256 = verify_bitnet_m4_tokenizer(&tokenizer)?;
+    let model = model_cache::verified_apple_m4_bitnet_model(model_id, cache_dir, model_path)?;
+    eprintln!(
+        "{}",
+        mac_bitnet_ask_operator_summary_line(&model, &tokenizer, &tokenizer_sha256, &json_out)
+    );
+    crate::run_simple_generation(
+        APPLE_M4_CPU_NEON,
+        model.path.clone(),
+        "auto".to_string(),
+        None,
+        Some(tokenizer.clone()),
+        question,
+        max_new_tokens,
+        temperature,
+        top_k,
+        top_p,
+        repetition_penalty,
+        seed,
+        false,
+        false,
+        true,
+        true,
+        Some(json_out.clone()),
+        false,
+        false,
+        true,
+        true,
+        threads,
+        BITNET_M4_PROMPT_TEMPLATE.to_string(),
+        system_prompt,
+        vec!["<|eot_id|>".to_string(), "<|end_of_text|>".to_string()],
+        Vec::new(),
+        None,
+        10,
+        false,
+        None,
+        None,
+        false,
+        None,
+        true,
+        Some("mac_bitnet_ask".to_string()),
+        false,
+    )
+    .await?;
+    annotate_and_validate_bitnet_mac_ask_receipt(&json_out, &model, &tokenizer, &tokenizer_sha256)?;
+    Ok(())
+}
+
 fn mac_ask_operator_summary_line(model: &VerifiedCachedModel, json_out: &Path) -> String {
     let sha = model.sha256.get(..12).unwrap_or(&model.sha256);
     format!(
@@ -1362,6 +1486,53 @@ fn mac_ask_operator_summary_line(model: &VerifiedCachedModel, json_out: &Path) -
         json_out.display(),
         sha
     )
+}
+
+fn mac_bitnet_ask_operator_summary_line(
+    model: &VerifiedCachedModel,
+    tokenizer: &Path,
+    tokenizer_sha256: &str,
+    json_out: &Path,
+) -> String {
+    let sha = model.sha256.get(..12).unwrap_or(&model.sha256);
+    let tokenizer_sha = tokenizer_sha256.get(..12).unwrap_or(tokenizer_sha256);
+    format!(
+        "mac ask bitnet: model={} quant={} model_path={} tokenizer={} tokenizer_sha256={}... backend={} fallback=false receipt={} sha256={}... chat=false serve=false",
+        model.id,
+        model.quantization,
+        model.path.display(),
+        tokenizer.display(),
+        tokenizer_sha,
+        APPLE_M4_CPU_NEON,
+        json_out.display(),
+        sha
+    )
+}
+
+fn verify_bitnet_m4_tokenizer(path: &Path) -> Result<String> {
+    let mut file = std::fs::File::open(path)
+        .with_context(|| format!("failed to open BitNet tokenizer {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to read BitNet tokenizer {}", path.display()))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let sha256 = format!("{:x}", hasher.finalize());
+    if sha256 != BITNET_M4_EXPECTED_TOKENIZER_SHA256 {
+        anyhow::bail!(
+            "BitNet Mac ask requires tokenizer SHA256 {}; got {} for {}",
+            BITNET_M4_EXPECTED_TOKENIZER_SHA256,
+            sha256,
+            path.display()
+        );
+    }
+    Ok(sha256)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2557,7 +2728,7 @@ fn mac_serve_check_models_result(status: u16, body: &serde_json::Value) -> serde
         "default_model_id": body["catalog"]["default_model_id"],
         "resident_model_id": body["resident_model_id"],
         "generation_executed": body["generation_executed"],
-        "bitnet_blocked": mac_serve_models_catalog_has_blocked_bitnet(body),
+        "bitnet_ask_only": mac_serve_models_catalog_has_bitnet_ask_only(body),
         "disk_available_bytes": body["catalog"]["disk"]["available_bytes"],
         "recommended_first_model_id": body["catalog"]["disk"]["recommended_first_model_id"],
         "recommended_fetch_command": mac_serve_models_catalog_recommended_command(body, "fetch_command"),
@@ -2578,7 +2749,7 @@ fn mac_serve_check_models_catalog_pass(status: u16, body: &serde_json::Value) ->
         && body["catalog"]["disk"]["default_model_headroom_bytes"].as_u64().is_some()
         && mac_serve_models_catalog_has_supported_model(body, model_cache::M4_SLM_RUNTIME_MODEL_ID)
         && mac_serve_models_catalog_has_supported_model(body, "qwen2.5-1.5b-instruct-q4_k_m")
-        && mac_serve_models_catalog_has_blocked_bitnet(body)
+        && mac_serve_models_catalog_has_bitnet_ask_only(body)
         && mac_serve_models_catalog_recommended_commands_are_coherent(body)
 }
 
@@ -2592,23 +2763,26 @@ fn mac_serve_models_catalog_has_supported_model(body: &serde_json::Value, model_
     })
 }
 
-fn mac_serve_models_catalog_has_blocked_bitnet(body: &serde_json::Value) -> bool {
+fn mac_serve_models_catalog_has_bitnet_ask_only(body: &serde_json::Value) -> bool {
     body["catalog"]["rows"].as_array().is_some_and(|rows| {
         rows.iter().any(|row| {
             row["id"].as_str() == Some("microsoft-bitnet-b1.58-2B-4T-i2s")
-                && row["state"].as_str() == Some("blocked")
-                && row["selection"].as_str() == Some("not selectable for M4 local answers")
+                && row["state"].as_str() == Some("supported-ask")
+                && row["mac_ask_enabled"].as_bool() == Some(true)
+                && row["mac_chat_enabled"].as_bool() == Some(false)
                 && row["mac_ask_chat_enabled"].as_bool() == Some(false)
                 && row["mac_serve_enabled"].as_bool() == Some(false)
                 && row["proof_status"].as_str()
-                    == Some("answer-corpus-proof-receipt-check-available-route-disabled")
+                    == Some("answer-corpus-proof-passed-one-shot-ask-explicit-artifact")
                 && row["proof_command"].as_str().is_some_and(|command| {
                     command.contains("mac bitnet-proof")
                         && command.contains("--proof-receipt")
                         && command.contains("bitnet-answer-corpus-full-release.json")
                 })
-                && row["fetch_command"].is_null()
-                && row["recommended_fetch_headroom_bytes"].is_null()
+                && row["fetch_command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains("bitnet model fetch microsoft-bitnet"))
+                && row["recommended_fetch_headroom_bytes"].as_u64().is_some()
         })
     })
 }
@@ -3838,6 +4012,88 @@ fn annotate_and_validate_mac_receipt_silent(
     std::fs::write(path, serde_json::to_vec_pretty(&receipt)?)
         .with_context(|| format!("failed to update Mac receipt {}", path.display()))?;
     Ok(summary)
+}
+
+fn annotate_and_validate_bitnet_mac_ask_receipt(
+    path: &Path,
+    model: &VerifiedCachedModel,
+    tokenizer: &Path,
+    tokenizer_sha256: &str,
+) -> Result<()> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read BitNet Mac ask receipt {}", path.display()))?;
+    let mut receipt: serde_json::Value = serde_json::from_slice(&bytes)
+        .with_context(|| format!("invalid BitNet Mac ask receipt {}", path.display()))?;
+    let summary = validate_mac_receipt_value(path, &receipt)?;
+    if receipt["model"]["sha256"].as_str() != Some(BITNET_M4_EXPECTED_MODEL_SHA256) {
+        anyhow::bail!("{} does not use the accepted Microsoft BitNet I2_S GGUF", path.display());
+    }
+    if receipt["model"]["family"].as_str() != Some("bitnet")
+        || receipt["loader"]["mode"].as_str()
+            != Some(bitnet_models::GgufLoaderMode::RealGguf.as_str())
+    {
+        anyhow::bail!("{} does not record strict real-GGUF BitNet loading", path.display());
+    }
+    if receipt["tokenizer"]["strict"].as_bool() != Some(true)
+        || receipt["tokenizer"]["pretokenizer_authority"].as_str() != Some("llama-bpe")
+    {
+        anyhow::bail!(
+            "{} does not record strict external llama-bpe tokenizer authority",
+            path.display()
+        );
+    }
+    if receipt["prompt_render"]["template_family"].as_str() != Some(BITNET_M4_PROMPT_TEMPLATE) {
+        anyhow::bail!("{} does not use the BitNet.cpp answer prompt template", path.display());
+    }
+    let Some(object) = receipt.as_object_mut() else {
+        anyhow::bail!("BitNet Mac ask receipt {} is not a JSON object", path.display());
+    };
+    object.insert("operator_command".to_string(), serde_json::json!("mac ask"));
+    object.insert(
+        "model_cache".to_string(),
+        serde_json::json!({
+            "id": model.id,
+            "display_name": model.display_name,
+            "cache_root": model.cache_root,
+            "path": model.path,
+            "sha256": model.sha256,
+            "bytes": model.bytes,
+            "architecture": model.architecture,
+            "quantization": model.quantization,
+            "tokenizer_model": model.tokenizer_model,
+            "tokenizer_pre": model.tokenizer_pre,
+            "chat_template": model.chat_template,
+            "support_note": model.support_note,
+        }),
+    );
+    object.insert(
+        "mac_bitnet_claim_boundary".to_string(),
+        serde_json::json!({
+            "bitnet_one_shot_mac_ask": true,
+            "answer_corpus_proof_gate": "MODEL-ARTIFACT-007/M4-QA-001",
+            "requested_backend": APPLE_M4_CPU_NEON,
+            "tokenizer_path": tokenizer,
+            "tokenizer_sha256": tokenizer_sha256,
+            "chat_enabled": false,
+            "serve_enabled": false,
+            "full_metal_inference_claimed": false,
+            "mpsgraph_inference_claimed": false,
+            "neural_engine_execution_claimed": false,
+            "qk256_apple_claimed": false,
+            "broad_performance_claim": false,
+        }),
+    );
+    object.entry("bitnet_quality_claimed".to_string()).or_insert(serde_json::json!(false));
+    object.entry("memory".to_string()).or_insert_with(memory_receipt_json);
+    std::fs::write(path, serde_json::to_vec_pretty(&receipt)?)
+        .with_context(|| format!("failed to update BitNet Mac ask receipt {}", path.display()))?;
+    println!(
+        "Mac BitNet receipt checked: {} ({}, generated_tokens={:?}, chat=false, serve=false)",
+        path.display(),
+        summary.artifact_kind,
+        summary.generated_tokens
+    );
+    Ok(())
 }
 
 fn run_receipts_check(path: &Path, regression_baseline: Option<&Path>, json: bool) -> Result<()> {
@@ -5474,15 +5730,19 @@ mod tests {
         }));
         assert!(rows.iter().any(|row| {
             row["id"] == "microsoft-bitnet-b1.58-2B-4T-i2s"
-                && row["state"] == "blocked"
+                && row["state"] == "supported-ask"
+                && row["mac_ask_enabled"] == true
+                && row["mac_chat_enabled"] == false
                 && row["mac_ask_chat_enabled"] == false
                 && row["mac_serve_enabled"] == false
                 && row["proof_status"]
-                    == "answer-corpus-proof-receipt-check-available-route-disabled"
+                    == "answer-corpus-proof-passed-one-shot-ask-explicit-artifact"
                 && row["proof_command"].as_str().is_some_and(|command| {
                     command.contains("mac bitnet-proof") && command.contains("--proof-receipt")
                 })
-                && row["fetch_command"].is_null()
+                && row["fetch_command"]
+                    .as_str()
+                    .is_some_and(|command| command.contains("bitnet model fetch microsoft-bitnet"))
         }));
         assert_eq!(models["claim_boundary"]["bitnet_quality_claimed"], false);
         Ok(())

--- a/crates/bitnet-cli/src/model_cache.rs
+++ b/crates/bitnet-cli/src/model_cache.rs
@@ -210,6 +210,8 @@ struct AppleM4ModelRow {
     route: String,
     selection: String,
     reason: String,
+    mac_ask_enabled: bool,
+    mac_chat_enabled: bool,
     mac_ask_chat_enabled: bool,
     mac_serve_enabled: bool,
     proof_status: Option<String>,
@@ -279,7 +281,7 @@ const APPLE_M4_POLICY_MODELS: &[AppleM4PolicyModel] = &[
 ];
 
 #[cfg(feature = "full-cli")]
-const APPLE_M4_BITNET_ROUTE_BOUNDARY: &str = "BitNet answer-ready artifact authority and local Apple M4 CPU/NEON answer-corpus proof receipts exist via MODEL-ARTIFACT-007/M4-QA-001 evidence, but BitNet is not selectable through `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve` until that user-facing route is wired and separately checked; dense SLM success must not be counted as BitNet Mac UX proof.";
+const APPLE_M4_BITNET_ROUTE_BOUNDARY: &str = "BitNet answer-ready artifact authority and local Apple M4 CPU/NEON answer-corpus proof receipts exist via MODEL-ARTIFACT-007/M4-QA-001 evidence. The BitNet Mac route is limited to one-shot `bitnet mac ask` with an explicit verified GGUF and external tokenizer authority; `bitnet mac chat` and `bitnet mac serve` remain disabled for BitNet, and dense SLM success must not be counted as BitNet Mac UX proof.";
 
 #[cfg(feature = "full-cli")]
 const APPLE_M4_BITNET_PROOF_MODEL_PATH: &str = "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf";
@@ -505,6 +507,66 @@ pub(crate) fn verified_apple_m4_slm_model(
     }
     let result = verify_model(model, &path)?;
     write_cache_metadata(&cache_root, model, &path, &result)?;
+    Ok(VerifiedCachedModel {
+        id: model.id.to_string(),
+        display_name: model.display_name.to_string(),
+        path,
+        cache_root,
+        sha256: model.sha256.to_string(),
+        bytes: model.bytes,
+        architecture: model.architecture.to_string(),
+        quantization: model.quantization.to_string(),
+        tokenizer_model: model.tokenizer_model.to_string(),
+        tokenizer_pre: model.tokenizer_pre.to_string(),
+        chat_template: model.chat_template,
+        support_note: model.support_note.to_string(),
+    })
+}
+
+#[cfg(feature = "full-cli")]
+pub(crate) fn is_apple_m4_bitnet_artifact_id(id: &str) -> bool {
+    find_supported_model(id).is_some_and(|model| model.id == "microsoft-bitnet-b1.58-2B-4T-i2s")
+}
+
+#[cfg(feature = "full-cli")]
+pub(crate) fn verified_apple_m4_bitnet_model(
+    id: &str,
+    cache_dir: Option<PathBuf>,
+    explicit_model_path: Option<PathBuf>,
+) -> Result<VerifiedCachedModel> {
+    let model = find_supported_model(id)
+        .filter(|model| model.id == "microsoft-bitnet-b1.58-2B-4T-i2s")
+        .ok_or_else(|| {
+            anyhow!(
+                "model `{id}` is not the accepted Apple M4 BitNet artifact; use microsoft-bitnet-b1.58-2B-4T-i2s"
+            )
+        })?;
+    let cache_root = resolve_cache_root(cache_dir)?;
+    let cache_path = model_path(&cache_root, model);
+    let path = explicit_model_path.unwrap_or_else(|| cache_path.clone());
+    let result = verify_model(model, &path)?;
+    if !result.passed {
+        let source = if path == cache_path {
+            format!(
+                "run `bitnet model fetch {}` or pass --model-path <accepted-bitnet-gguf>",
+                model.id
+            )
+        } else {
+            "replace --model-path with the accepted Microsoft I2_S GGUF".to_string()
+        };
+        anyhow::bail!(
+            "Apple M4 BitNet ask requires the accepted GGUF for `{}` at {}; expected bytes={}, sha256={}; got bytes={:?}, sha256={:?}. {source}",
+            model.id,
+            path.display(),
+            model.bytes,
+            model.sha256,
+            result.actual_bytes,
+            result.actual_sha256
+        );
+    }
+    if path == cache_path {
+        write_cache_metadata(&cache_root, model, &path, &result)?;
+    }
     Ok(VerifiedCachedModel {
         id: model.id.to_string(),
         display_name: model.display_name.to_string(),
@@ -1233,7 +1295,7 @@ fn apple_m4_model_catalog(cache_dir: Option<PathBuf>) -> Result<AppleM4ModelCata
         cache_root,
         default_model_id: M4_SLM_RUNTIME_MODEL_ID,
         disk,
-        claim_boundary: "default/supported rows are dense Qwen Apple M4 CPU/NEON answer paths only; blocked, diagnostic-only, candidate, and rejected rows are not selectable M4 answer claims and do not prove BitNet local answers",
+        claim_boundary: "default/supported rows are dense Qwen Apple M4 CPU/NEON answer paths; supported-ask BitNet rows are one-shot ask only with explicit GGUF/tokenizer authority; diagnostic-only, candidate, and rejected rows are not selectable M4 answer claims",
         rows,
     })
 }
@@ -1254,11 +1316,11 @@ fn apple_m4_registered_model_row(
         )
     } else if model.apple_m4_cpu_neon_supported {
         ("supported", "explicit --model-id only", "apple-m4-cpu-neon", model.support_note)
-    } else if model.model_contract.is_some() {
+    } else if model.id == "microsoft-bitnet-b1.58-2B-4T-i2s" {
         (
-            "blocked",
-            "not selectable for M4 local answers",
-            "artifact contract only",
+            "supported-ask",
+            "explicit --model-id with --model-path/--tokenizer for one-shot ask only",
+            "apple-m4-cpu-neon bitnet one-shot ask",
             APPLE_M4_BITNET_ROUTE_BOUNDARY,
         )
     } else {
@@ -1270,9 +1332,10 @@ fn apple_m4_registered_model_row(
         )
     };
     let selectable_m4_answer = matches!(state, "default" | "supported");
-    let bitnet_contract_only = state == "blocked" && model.model_contract.is_some();
-    let recommended_fetch_headroom_bytes =
-        selectable_m4_answer.then(|| recommended_fetch_headroom_bytes(model.bytes));
+    let bitnet_ask_only = state == "supported-ask" && model.model_contract.is_some();
+    let bitnet_contract_only = bitnet_ask_only;
+    let recommended_fetch_headroom_bytes = (selectable_m4_answer || bitnet_ask_only)
+        .then(|| recommended_fetch_headroom_bytes(model.bytes));
     let recommended_fetch_headroom =
         recommended_fetch_headroom_bytes.map(|bytes| format_size(bytes, DECIMAL));
     let fits_current_disk = recommended_fetch_headroom_bytes
@@ -1280,7 +1343,7 @@ fn apple_m4_registered_model_row(
     let disk_state = match fits_current_disk {
         Some(true) => Some("enough-headroom".to_string()),
         Some(false) => Some("low-headroom".to_string()),
-        None if selectable_m4_answer => Some("unknown".to_string()),
+        None if selectable_m4_answer || bitnet_ask_only => Some("unknown".to_string()),
         None => None,
     };
 
@@ -1309,10 +1372,12 @@ fn apple_m4_registered_model_row(
         route: route.to_string(),
         selection: selection.to_string(),
         reason: reason.to_string(),
+        mac_ask_enabled: selectable_m4_answer || bitnet_ask_only,
+        mac_chat_enabled: selectable_m4_answer,
         mac_ask_chat_enabled: selectable_m4_answer,
         mac_serve_enabled: selectable_m4_answer,
         proof_status: bitnet_contract_only
-            .then(|| "answer-corpus-proof-receipt-check-available-route-disabled".to_string()),
+            .then(|| "answer-corpus-proof-passed-one-shot-ask-explicit-artifact".to_string()),
         proof_command: bitnet_contract_only.then(apple_m4_bitnet_proof_command),
         proof_receipt_path: bitnet_contract_only
             .then(|| APPLE_M4_BITNET_PROOF_RECEIPT_PATH.to_string()),
@@ -1320,9 +1385,9 @@ fn apple_m4_registered_model_row(
         recommended_fetch_headroom,
         fits_current_disk,
         disk_state,
-        fetch_command: selectable_m4_answer
+        fetch_command: (selectable_m4_answer || bitnet_ask_only)
             .then(|| model_command("fetch", model, Some(cache_root))),
-        verify_command: selectable_m4_answer
+        verify_command: (selectable_m4_answer || bitnet_ask_only)
             .then(|| model_command("verify", model, Some(cache_root))),
     }
 }
@@ -1360,6 +1425,8 @@ fn apple_m4_policy_rows() -> Vec<AppleM4ModelRow> {
             route: "none".to_string(),
             selection: model.selection.to_string(),
             reason: model.reason.to_string(),
+            mac_ask_enabled: false,
+            mac_chat_enabled: false,
             mac_ask_chat_enabled: false,
             mac_serve_enabled: false,
             proof_status: None,
@@ -1484,11 +1551,12 @@ fn apple_m4_state_order(state: &str) -> u8 {
     match state {
         "default" => 0,
         "supported" => 1,
-        "blocked" => 2,
-        "diagnostic-only" => 3,
-        "candidate" => 4,
-        "rejected" => 5,
-        _ => 6,
+        "supported-ask" => 2,
+        "blocked" => 3,
+        "diagnostic-only" => 4,
+        "candidate" => 5,
+        "rejected" => 6,
+        _ => 7,
     }
 }
 
@@ -1498,9 +1566,15 @@ fn apple_m4_slm_supported_model(id: &str) -> Result<&'static SupportedModel> {
         if model.apple_m4_cpu_neon_supported {
             return Ok(model);
         }
-        let state = if model.model_contract.is_some() { "blocked" } else { "not selectable" };
+        let state = if model.id == "microsoft-bitnet-b1.58-2B-4T-i2s" {
+            "supported-ask"
+        } else if model.model_contract.is_some() {
+            "blocked"
+        } else {
+            "not selectable"
+        };
         anyhow::bail!(
-            "model `{}` is {state} for Apple M4 CPU/NEON local answers and cannot be used by `bitnet mac` answer commands. {}\nSelectable Apple M4 models: {}.\nUse `bitnet mac models` for cache/disk guidance. {}",
+            "model `{}` is {state} for Apple M4 CPU/NEON local answers and cannot be used by this dense SLM command. {}\nSelectable dense Apple M4 models: {}.\nUse `bitnet mac models` for cache/disk guidance. {}",
             model.id,
             model.support_note,
             selectable_apple_m4_model_ids(),
@@ -1519,7 +1593,7 @@ fn apple_m4_slm_supported_model(id: &str) -> Result<&'static SupportedModel> {
     }
 
     anyhow::bail!(
-        "unsupported Apple M4 model `{id}`. Selectable Apple M4 models: {}. Use `bitnet mac models` to inspect default/supported/blocked/candidate/rejected states.",
+        "unsupported Apple M4 model `{id}`. Selectable dense Apple M4 models: {}. Use `bitnet mac models` to inspect default/supported/supported-ask/candidate/rejected states.",
         selectable_apple_m4_model_ids()
     )
 }
@@ -1728,7 +1802,7 @@ fn apple_m4_cache_repair_guidance(cache_root: &Path, status: &CacheStatus) -> St
         });
     if cache_state_label(status) == "missing" {
         format!(
-            "{base} First-run model selection: run `{models_command}` to inspect default/supported/blocked model states and disk headroom. Disk guidance: {disk_guidance}"
+            "{base} First-run model selection: run `{models_command}` to inspect default/supported/supported-ask model states and disk headroom. Disk guidance: {disk_guidance}"
         )
     } else {
         format!(
@@ -2132,14 +2206,15 @@ mod tests {
 
     #[cfg(feature = "full-cli")]
     #[test]
-    fn apple_m4_slm_supported_model_rejects_blocked_bitnet_artifact() {
+    fn apple_m4_slm_supported_model_rejects_bitnet_for_dense_commands() {
         let error = apple_m4_slm_supported_model("microsoft-bitnet-b1.58-2B-4T-i2s")
-            .expect_err("blocked BitNet artifact");
+            .expect_err("BitNet is not a dense SLM artifact");
         let message = error.to_string();
 
-        assert!(message.contains("blocked for Apple M4 CPU/NEON local answers"));
+        assert!(message.contains("supported-ask for Apple M4 CPU/NEON local answers"));
         assert!(message.contains("MODEL-ARTIFACT-007"));
         assert!(message.contains("M4-QA-001"));
+        assert!(message.contains("one-shot `bitnet mac ask`"));
         assert!(message.contains("bitnet mac models"));
         assert!(message.contains("qwen2.5-0.5b-instruct-q8_0"));
     }

--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -335,10 +335,10 @@ fn mac_models_lists_operator_model_states() -> Result<(), Box<dyn std::error::Er
         .stdout(predicate::str::contains("qwen2.5-1.5b-instruct-q4_k_m"))
         .stdout(predicate::str::contains("supported"))
         .stdout(predicate::str::contains("microsoft-bitnet-b1.58-2B-4T-i2s"))
-        .stdout(predicate::str::contains("blocked"))
+        .stdout(predicate::str::contains("supported-ask"))
         .stdout(predicate::str::contains("candidate"))
         .stdout(predicate::str::contains("rejected"))
-        .stdout(predicate::str::contains("do not prove BitNet local answers"))
+        .stdout(predicate::str::contains("one-shot ask only"))
         .stdout(predicate::str::contains("Proof bridge: microsoft-bitnet-b1.58-2B-4T-i2s"))
         .stdout(predicate::str::contains("mac bitnet-proof --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf"))
         .stdout(predicate::str::contains("--proof-receipt ci/hardware/apple-m4-mac-mini/YYYY-MM-DD/bitnet-local-answer/bitnet-answer-corpus-full-release.json"));
@@ -371,7 +371,7 @@ fn mac_models_json_exposes_claim_boundaries_without_fetching()
     assert!(recommendation.contains("default") || recommendation.contains("Disk"));
     let claim_boundary =
         json["claim_boundary"].as_str().ok_or_else(|| std::io::Error::other("claim boundary"))?;
-    assert!(claim_boundary.contains("do not prove BitNet local answers"));
+    assert!(claim_boundary.contains("one-shot ask only"));
     let rows = json["rows"].as_array().ok_or_else(|| std::io::Error::other("rows"))?;
     assert!(rows.iter().any(|row| {
         row["id"] == "qwen2.5-0.5b-instruct-q8_0"
@@ -385,18 +385,21 @@ fn mac_models_json_exposes_claim_boundaries_without_fetching()
     );
     assert!(rows.iter().any(|row| {
         row["id"] == "microsoft-bitnet-b1.58-2B-4T-i2s"
-            && row["state"] == "blocked"
-            && row["selection"] == "not selectable for M4 local answers"
+            && row["state"] == "supported-ask"
+            && row["selection"]
+                == "explicit --model-id with --model-path/--tokenizer for one-shot ask only"
+            && row["mac_ask_enabled"] == true
+            && row["mac_chat_enabled"] == false
             && row["mac_ask_chat_enabled"] == false
             && row["mac_serve_enabled"] == false
-            && row["proof_status"] == "answer-corpus-proof-receipt-check-available-route-disabled"
+            && row["proof_status"] == "answer-corpus-proof-passed-one-shot-ask-explicit-artifact"
             && row["proof_command"]
                 .as_str()
                 .is_some_and(|command| command.contains("mac bitnet-proof --model models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf"))
             && row["proof_receipt_path"]
                 == "ci/hardware/apple-m4-mac-mini/YYYY-MM-DD/bitnet-local-answer/bitnet-answer-corpus-full-release.json"
-            && row["recommended_fetch_headroom_bytes"].is_null()
-            && row["fetch_command"].is_null()
+            && row["recommended_fetch_headroom_bytes"].as_u64().is_some()
+            && row["fetch_command"].as_str().is_some_and(|command| command.contains("bitnet model fetch microsoft-bitnet"))
     }));
     assert!(rows.iter().any(|row| row["state"] == "candidate"));
     assert!(rows.iter().any(|row| row["state"] == "rejected"));
@@ -470,10 +473,10 @@ fn mac_check_rejects_blocked_bitnet_model_before_cache_guidance() {
         .args(["mac", "check", "--model-id", "microsoft-bitnet-b1.58-2B-4T-i2s"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("blocked for Apple M4 CPU/NEON local answers"))
+        .stderr(predicate::str::contains("supported-ask for Apple M4 CPU/NEON local answers"))
         .stderr(predicate::str::contains("MODEL-ARTIFACT-007"))
         .stderr(predicate::str::contains("M4-QA-001"))
-        .stderr(predicate::str::contains("not selectable through `bitnet mac ask`"))
+        .stderr(predicate::str::contains("one-shot `bitnet mac ask`"))
         .stderr(predicate::str::contains("bitnet mac models"))
         .stderr(predicate::str::contains("bitnet model fetch microsoft-bitnet").not());
 }
@@ -596,18 +599,62 @@ fn mac_ask_rejects_full_metal_request_before_cache_lookup() {
 }
 
 #[test]
-fn mac_ask_rejects_blocked_bitnet_model_before_cache_lookup() {
+fn mac_ask_bitnet_requires_explicit_tokenizer_before_cache_lookup() {
     bitnet()
         .args(["mac", "ask", "What is 2+2?", "--model-id", "microsoft-bitnet-b1.58-2B-4T-i2s"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("blocked for Apple M4 CPU/NEON local answers"))
-        .stderr(predicate::str::contains("M4-QA-001"))
-        .stderr(predicate::str::contains("not selectable through `bitnet mac ask`"))
+        .stderr(predicate::str::contains("requires explicit tokenizer authority"))
         .stderr(predicate::str::contains(
-            "dense SLM success must not be counted as BitNet Mac UX proof",
+            "--tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json",
         ))
         .stderr(predicate::str::contains("bitnet model fetch microsoft-bitnet").not());
+}
+
+#[test]
+fn mac_ask_bitnet_rejects_wrong_tokenizer_sha_before_model_lookup()
+-> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let tokenizer = dir.path().join("tokenizer.json");
+    std::fs::write(&tokenizer, b"{\"not\":\"the accepted tokenizer\"}")?;
+    let tokenizer_str = tokenizer.to_string_lossy().into_owned();
+
+    bitnet()
+        .args([
+            "mac",
+            "ask",
+            "What is 2+2?",
+            "--model-id",
+            "microsoft-bitnet-b1.58-2B-4T-i2s",
+            "--model-path",
+            "missing-bitnet.gguf",
+            "--tokenizer",
+            tokenizer_str.as_str(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires tokenizer SHA256"))
+        .stderr(predicate::str::contains("accepted GGUF").not());
+    Ok(())
+}
+
+#[test]
+fn mac_ask_rejects_dense_model_path_tokenizer_overrides() {
+    bitnet()
+        .args([
+            "mac",
+            "ask",
+            "What is 2+2?",
+            "--model-path",
+            "models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf",
+            "--tokenizer",
+            "models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--model-path/--tokenizer only for the explicit BitNet one-shot route",
+        ));
 }
 
 #[test]
@@ -1013,7 +1060,9 @@ fn mac_bitnet_proof_preflight_accepts_artifact_contract_without_running_model()
         .assert()
         .success()
         .stdout(predicate::str::contains("preflight passed"))
-        .stdout(predicate::str::contains("does not enable BitNet through `bitnet mac ask`"));
+        .stdout(predicate::str::contains(
+            "does not enable `bitnet mac chat` or `bitnet mac serve`",
+        ));
 
     let receipt_json: serde_json::Value = serde_json::from_slice(&std::fs::read(&receipt)?)?;
     assert_eq!(receipt_json["artifact_kind"], "apple_m4_bitnet_proof_preflight");
@@ -1051,7 +1100,9 @@ fn mac_bitnet_proof_validates_answer_corpus_receipt_without_artifact_sweep()
         .assert()
         .success()
         .stdout(predicate::str::contains("proof receipt verified"))
-        .stdout(predicate::str::contains("does not enable BitNet through `bitnet mac ask`"));
+        .stdout(predicate::str::contains(
+            "does not enable `bitnet mac chat` or `bitnet mac serve`",
+        ));
 
     let receipt_json: serde_json::Value = serde_json::from_slice(&std::fs::read(&receipt)?)?;
     assert_eq!(receipt_json["result"], "verified");

--- a/docs/hardware/apple-m4-mac-mini-operator-runbook.md
+++ b/docs/hardware/apple-m4-mac-mini-operator-runbook.md
@@ -456,8 +456,18 @@ bitnet mac bitnet-proof \
 
 This validates the strict Apple M4 BitNet answer-corpus receipt, including
 case-level backend/fallback, token IDs, tokenizer authority, prompt-prefill, and
-timing fields. It still does not make BitNet selectable through `bitnet mac ask`,
-`bitnet mac chat`, or `bitnet mac serve`.
+timing fields. BitNet is now limited to explicit one-shot ask with the verified
+GGUF and external tokenizer:
+
+```bash
+bitnet mac ask \
+  --model-id microsoft-bitnet-b1.58-2B-4T-i2s \
+  --model-path models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json \
+  "What is 2+2? Answer with only the number."
+```
+
+This does not enable BitNet through `bitnet mac chat` or `bitnet mac serve`.
 
 If this command fails the content gate with non-empty but incoherent text, treat
 that as a real inference-quality blocker. Do not count the run as a local-answer

--- a/docs/slm/apple-m4-bitnet-proof-prep.md
+++ b/docs/slm/apple-m4-bitnet-proof-prep.md
@@ -3,8 +3,9 @@
 `M4-CONT-005` prepared the M4 Mac mini side of the BitNet proof path. The same
 command now has two bounded modes: artifact preflight and strict receipt
 validation. Receipt validation can verify a completed Apple M4 BitNet
-`answer-corpus` proof, but it still does not enable BitNet through `bitnet mac
-ask`, `bitnet mac chat`, or `bitnet mac serve`.
+`answer-corpus` proof. BitNet is now limited to explicit one-shot
+`bitnet mac ask` with the accepted GGUF plus external tokenizer; `bitnet mac
+chat` and `bitnet mac serve` remain disabled for BitNet.
 
 ## Command Contract
 

--- a/docs/slm/apple-m4-local-server-command-config.md
+++ b/docs/slm/apple-m4-local-server-command-config.md
@@ -201,7 +201,7 @@ receipt under `receipt_dir`. `M4-SERVE-004` exports those receipts through
 `GET /receipts/{id}` after rejecting unsafe IDs and missing receipt files.
 
 `GET /models` exposes the same Mac operator catalog as `bitnet mac models`,
-including default/supported dense Qwen rows, blocked BitNet rows,
+including default/supported dense Qwen rows, the BitNet one-shot ask row,
 candidate/rejected rows, cache state, disk-headroom guidance, and the
 receipt-only BitNet proof bridge command. It does not run generation, does not
 fetch artifacts, and does not expose BitNet as a server completion model.

--- a/docs/slm/apple-m4-mini-user-expectation-envelope.md
+++ b/docs/slm/apple-m4-mini-user-expectation-envelope.md
@@ -19,17 +19,25 @@ bitnet mac regression <receipt.json> --baseline <baseline.json>
 ```
 
 `bitnet mac models` is the operator-facing model-selection view. It lists the
-default model, supported explicit-only dense models, cache state, blocked BitNet
-rows, candidate/rejected rows, and disk-headroom guidance without downloading
-artifacts. The text view also prints exact `Next fetch` and `Next verify`
-commands for the recommended first supported model when disk headroom is
-adequate. Blocked BitNet rows include a receipt-only proof bridge command for
-validating a strict `answer-corpus` proof receipt; that bridge does not make
-BitNet selectable through `bitnet mac ask`, `bitnet mac chat`, or
-`bitnet mac serve`.
-If a blocked, diagnostic-only, candidate, rejected, or unknown model ID is passed
-to `bitnet mac ask`, `chat`, `check`, `smoke`, `doctor`, `validate`, or `serve`,
-the wrapper fails before cache repair guidance and points back to
+default model, supported explicit-only dense models, cache state, the BitNet
+one-shot ask row, candidate/rejected rows, and disk-headroom guidance without
+downloading artifacts. The text view also prints exact `Next fetch` and
+`Next verify` commands for the recommended first supported model when disk
+headroom is adequate. The BitNet row includes a receipt bridge command for
+validating a strict `answer-corpus` proof receipt and is limited to explicit
+one-shot ask with a verified GGUF plus external tokenizer:
+
+```bash
+bitnet mac ask \
+  --model-id microsoft-bitnet-b1.58-2B-4T-i2s \
+  --model-path models/BitNet-b1.58-2B-4T/ggml-model-i2_s.gguf \
+  --tokenizer models/microsoft-bitnet-b1.58-2B-4T/tokenizer.json \
+  "What is 2+2? Answer with only the number."
+```
+
+BitNet is still not enabled for `bitnet mac chat` or `bitnet mac serve`. If a
+diagnostic-only, candidate, rejected, or unknown model ID is passed to the dense
+Mac commands, the wrapper fails before cache repair guidance and points back to
 `bitnet mac models`.
 When `bitnet mac ask` starts with a verified model, it prints a compact stderr
 summary covering model ID, quantization, cache root, backend, fallback status,

--- a/docs/slm/apple-m4-slm-local-answer-baseline.md
+++ b/docs/slm/apple-m4-slm-local-answer-baseline.md
@@ -12,7 +12,9 @@ prompt in
 -> intelligible text out
 ```
 
-This is the current user-facing Mac path. It is separate from the blocked BitNet local-answer lane and from future Metal acceleration work.
+This is the dense SLM user-facing Mac path. BitNet has a separate explicit
+one-shot ask route after the strict answer-corpus proof, and remains separate
+from dense SLM chat/server and future Metal acceleration work.
 
 For the broader validation graph that separates dense SLM UX evidence from
 BitNet / 1-bit model evidence, see
@@ -87,14 +89,15 @@ support status. Fetch warns on low disk headroom and honors `--offline` /
 blocked, candidate, and rejected model states plus disk-headroom guidance for
 first fetches. Its text output prints exact `Next fetch` and `Next verify`
 commands for the recommended first supported model when disk headroom is
-adequate. Blocked BitNet rows also print a receipt-only `bitnet mac
+adequate. The BitNet row also prints a receipt-only `bitnet mac
 bitnet-proof --proof-receipt ...` bridge command so operators can validate the
-strict BitNet answer-corpus proof without treating BitNet as an enabled Mac
-ask/chat/server route. `bitnet model list` is the lower-level cache inventory; use `bitnet
+strict BitNet answer-corpus proof. BitNet is limited to explicit one-shot
+`bitnet mac ask` with verified GGUF/tokenizer authority; it is not an enabled
+Mac chat/server route. `bitnet model list` is the lower-level cache inventory; use `bitnet
 model verify <id>` or `bitnet mac check` when SHA integrity matters.
-Mac answer/service wrappers reject blocked BitNet, diagnostic-only, candidate,
-rejected, and unknown model IDs before cache repair guidance, so operators are
-not pointed at a fetch command for a non-selectable M4 answer model.
+Dense Mac answer/service wrappers reject diagnostic-only, candidate, rejected,
+and unknown model IDs before cache repair guidance, so operators are not pointed
+at a fetch command for a non-selectable M4 answer model.
 
 First-run and repair guidance is intentionally explicit:
 

--- a/docs/specs/apple-m4-mac-mini-roadmap.md
+++ b/docs/specs/apple-m4-mac-mini-roadmap.md
@@ -705,8 +705,9 @@ inspectable. The next campaign should make it quality-gated:
    local-answer lane is blocked on Apple backend parity rather than a weaker
    quality gate. `bitnet mac bitnet-proof --proof-receipt <answer-corpus.json>
    --strict` is the Mac-facing receipt bridge for this proof; it validates the
-   strict answer-corpus receipt and records that BitNet still is not enabled
-   through `bitnet mac ask`, `bitnet mac chat`, or `bitnet mac serve`.
+   strict answer-corpus receipt. BitNet is limited to explicit one-shot
+   `bitnet mac ask` with the accepted GGUF plus external tokenizer, and remains
+   disabled for `bitnet mac chat` and `bitnet mac serve`.
 2. Greedy determinism for fixed prompt/model/settings.
 3. Receipt checks for output text validity, token counts, model/tokenizer
    identity, backend identity, and fallback status.


### PR DESCRIPTION
## Summary
- add an explicit BitNet one-shot `bitnet mac ask` route gated by the accepted GGUF SHA and external tokenizer SHA
- keep dense SLM commands/cache behavior separate, with BitNet chat and serve still disabled
- update `bitnet mac models`, `/models`, tests, and operator docs to report BitNet as `supported-ask`

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-local-answer`
- `cargo run --locked -p xtask --no-default-features -- campaign next apple-m4-local-answer`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_ask_`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_models_`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_bitnet_proof_`
- `cargo test --locked -p bitnet-cli --test cli_arg_tests mac_check_`
- `cargo test --locked -p bitnet-cli model_cache::tests::apple_m4_slm_supported_model_rejects_bitnet_for_dense_commands`
- `cargo test --locked -p bitnet-cli mac::tests::mac_serve_check_models_result_records_recommended_commands`
- `cargo test --locked -p bitnet-cli mac::tests::mac_serve_http_models_route_reports_catalog_no_generation`
- `cargo test --locked -p bitnet-cli mac::tests::mac_serve_check_models_catalog_pass_requires_operator_catalog_shape`

## Boundary
A debug runtime smoke was attempted with the accepted local BitNet artifact and tokenizer, but it did not complete within the local run window and produced no receipt. This PR claims only the explicit CLI/catalog/docs route and pre-runtime validation behavior, not a fresh runtime smoke proof.