### PR TITLE
test(policy): remove unallowlisted expects from cli arg tests

### DIFF
--- a/crates/bitnet-cli/tests/cli_arg_tests.rs
+++ b/crates/bitnet-cli/tests/cli_arg_tests.rs
@@ -1287,33 +1287,35 @@ fn bitnet_answer_corpus_proof_fixture(include_timing: bool) -> serde_json::Value
 #[test]
 fn mac_receipts_check_accepts_valid_cpu_neon_answer_receipt()
 -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("answer.json");
-    let receipt_json = serde_json::to_vec_pretty(&serde_json::json!({
-        "artifact_kind": "inference_result",
-        "requested_backend": "apple-m4-cpu-neon",
-        "selected_backend": "apple-m4-cpu-neon",
-        "runtime_api": "cpu",
-        "fallback_used": false,
-        "text": "4.",
-        "tokens": {
-            "generated": 1,
-            "generated_ids": [19]
-        },
-        "model": {
-            "sha256": "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e"
-        },
-        "tokenizer": {
-            "source": "gguf_metadata"
-        },
-        "mac_claim_boundary": {
-            "full_metal_inference_claimed": false,
-            "neural_engine_execution_claimed": false,
-            "qk256_apple_claimed": false,
-            "bitnet_quality_claimed": false
-        }
-    }))?;
-    std::fs::write(&receipt_path, receipt_json)?;
+    std::fs::write(
+        &receipt_path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "artifact_kind": "inference_result",
+            "requested_backend": "apple-m4-cpu-neon",
+            "selected_backend": "apple-m4-cpu-neon",
+            "runtime_api": "cpu",
+            "fallback_used": false,
+            "text": "4.",
+            "tokens": {
+                "generated": 1,
+                "generated_ids": [19]
+            },
+            "model": {
+                "sha256": "ca59ca7f13d0e15a8cfa77bd17e65d24f6844b554a7b6c12e07a5f89ff76844e"
+            },
+            "tokenizer": {
+                "source": "gguf_metadata"
+            },
+            "mac_claim_boundary": {
+                "full_metal_inference_claimed": false,
+                "neural_engine_execution_claimed": false,
+                "qk256_apple_claimed": false,
+                "bitnet_quality_claimed": false
+            }
+        }))?,
+    )?;
     let receipt_str = receipt_path.to_string_lossy().into_owned();
 
     bitnet()
@@ -1761,7 +1763,7 @@ fn mac_receipts_check_accepts_dense_slm_quality_corpus_gate() {
 
 #[test]
 fn slm_eval_report_schema_accepts_fixture_summary() -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("slm-eval-summary.json");
     std::fs::write(&receipt_path, serde_json::to_vec_pretty(&slm_eval_summary_report())?)?;
     let receipt_str = receipt_path.to_string_lossy().into_owned();
@@ -1780,7 +1782,7 @@ fn slm_eval_report_schema_accepts_fixture_summary() -> Result<(), Box<dyn std::e
 #[test]
 fn slm_eval_report_schema_rejects_missing_input_throughput()
 -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("slm-eval-summary-missing-throughput.json");
     let mut receipt = slm_eval_summary_report();
     receipt["speed"]
@@ -1800,7 +1802,7 @@ fn slm_eval_report_schema_rejects_missing_input_throughput()
 
 #[test]
 fn slm_eval_report_schema_rejects_broad_quality_claim() -> Result<(), Box<dyn std::error::Error>> {
-    let dir = tempfile::tempdir().expect("tempdir");
+    let dir = tempfile::tempdir()?;
     let receipt_path = dir.path().join("slm-eval-summary-broad-claim.json");
     let mut receipt = slm_eval_summary_report();
     receipt["claim_boundary"]["broad_model_quality_claim"] = serde_json::json!(true);


### PR DESCRIPTION
## Summary
- convert the four no-panic-family offending CLI arg test fixture paths from expect-based setup to Result/? setup
- keep the receipt fixture behavior unchanged

## Validation
- rustfmt --check --config skip_children=true,newline_style=Unix --edition 2024 crates/bitnet-cli/tests/cli_arg_tests.rs
- CMAKE_GENERATOR='Visual Studio 17 2022' CMAKE_BUILD_PARALLEL_LEVEL=2 cargo run --locked -p xtask --no-default-features -- check-no-panic-family --report-dir target/bitnet/reports
- CMAKE_GENERATOR='Visual Studio 17 2022' CMAKE_BUILD_PARALLEL_LEVEL=2 cargo check --locked -p bitnet-cli --test cli_arg_tests --no-default-features --features cpu,full-cli -j 1