### PR TITLE
Close M4 SLM eval proof campaign

### DIFF
--- a/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/CAMPAIGN.md
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/CAMPAIGN.md
@@ -2,7 +2,7 @@
 
 Campaign ID: `apple-m4-slm-eval-and-proof`
 
-Status: active
+Status: complete
 
 ## Objective
 

--- a/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/active.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/active.toml
@@ -1,6 +1,6 @@
 id = "apple-m4-slm-eval-and-proof"
 title = "Apple M4 dense SLM eval and proof"
-status = "active"
+status = "complete"
 
 objective = "Turn the usable Apple M4 dense SLM path into a structured, receipt-backed local model runner proof with seeded quality eval, first-class speed/stability metrics, per-model reports, and lightweight regression economics without broad benchmark claims."
 
@@ -256,8 +256,9 @@ must_not_claim = [
 
 [[work_item]]
 id = "M4-SLM-EVAL-006"
-status = "pr_open"
+status = "merged"
 pr = 4677
+merge_sha = "305afdfb0d8e74ffbec924483f145b5f715f0fe3"
 branch = "codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-006-regression"
 stackable = false
 review_mode = "codex_premerge"

--- a/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/events/2026-05-14T021549Z-M4-SLM-EVAL-006-merged.toml
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/events/2026-05-14T021549Z-M4-SLM-EVAL-006-merged.toml
@@ -1,0 +1,16 @@
+timestamp = "2026-05-14T02:15:49Z"
+campaign = "apple-m4-slm-eval-and-proof"
+item = "M4-SLM-EVAL-006"
+event = "merged"
+pr = 4677
+merge_sha = "305afdfb0d8e74ffbec924483f145b5f715f0fe3"
+actor = "codex"
+previous_status = "pr_open"
+new_status = "merged"
+
+notes = [
+  "Merged PR #4677 with dense SLM eval summary regression comparison.",
+  "`bitnet mac regression` and `mac receipts-check --regression-baseline` can compare matching apple_m4_slm_eval_summary reports with advisory thresholds.",
+  "Closed apple-m4-slm-eval-and-proof after M4-SLM-EVAL-001 through M4-SLM-EVAL-006 merged and the seeded corpus, scoring, report schema, per-model reports, CI tiers, and regression comparison were all in place.",
+  "The merged work remains dense-SLM-only regression tooling and does not claim broad model quality, broad performance, BitNet evidence, full Metal inference, QK256, Neural Engine, MPSGraph, MacBook evidence, or speedup.",
+]

--- a/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/generated/status.md
+++ b/docs/tracking/campaigns/apple-m4-slm-eval-and-proof/generated/status.md
@@ -2,7 +2,7 @@
 # Apple M4 dense SLM eval and proof Campaign Status
 
 - Campaign: `apple-m4-slm-eval-and-proof`
-- State: `active`
+- State: `complete`
 - Objective: Turn the usable Apple M4 dense SLM path into a structured, receipt-backed local model runner proof with seeded quality eval, first-class speed/stability metrics, per-model reports, and lightweight regression economics without broad benchmark claims.
 
 ## Work Items
@@ -14,7 +14,7 @@
 | M4-SLM-EVAL-003 | merged | #4663 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-003-report-schema` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Define and validate the per-model Apple M4 dense SLM eval summary report schema with first-class TTFT, input token throughput, output/decode throughput, total wall time, memory, stability, and claim-boundary fields. |
 | M4-SLM-EVAL-004 | merged | #4670 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-004-supported-model-reports` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Run and publish per-model Apple M4 dense SLM eval reports for every supported dense model ID under the seeded corpus and report schema, preserving fallback=false and dense-only claim boundaries. |
 | M4-SLM-EVAL-005 | merged | #4675 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-005-ci-tiers` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Document and wire lightweight Tier 0 parser/schema/report checks for generic PR CI, with advisory/nightly/release M4 tiers defined separately for live model runs. |
-| M4-SLM-EVAL-006 | pr_open | #4677 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-006-regression` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire `bitnet mac regression` or an adjacent checker to compare matching dense SLM eval summary reports over time with explicit thresholds and no broad benchmark claims. |
+| M4-SLM-EVAL-006 | merged | #4677 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-006-regression` | `codex_premerge` | `automerge_when_green` | `on_blocker_only` | Wire `bitnet mac regression` or an adjacent checker to compare matching dense SLM eval summary reports over time with explicit thresholds and no broad benchmark claims. |
 
 ## Hard Constraints
 

--- a/docs/tracking/generated/active-prs.md
+++ b/docs/tracking/generated/active-prs.md
@@ -3,4 +3,3 @@
 
 | Campaign | Item | PR | Branch | Notes |
 |---|---|---:|---|---|
-| apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | #4677 | `codex/apple-m4-slm-eval-and-proof/M4-SLM-EVAL-006-regression` | Wire `bitnet mac regression` or an adjacent checker to compare matching dense SLM eval summary reports over time with explicit thresholds and no broad benchmark claims. |

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -75,7 +75,7 @@
 | apple-m4-slm-eval-and-proof | M4-SLM-EVAL-003 | M4-SLM-EVAL-002 | merged |
 | apple-m4-slm-eval-and-proof | M4-SLM-EVAL-004 | M4-SLM-EVAL-003 | merged |
 | apple-m4-slm-eval-and-proof | M4-SLM-EVAL-005 | M4-SLM-EVAL-003 | merged |
-| apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | M4-SLM-EVAL-004 | pr_open |
+| apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | M4-SLM-EVAL-004 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-002 | M4-SLM-EX-001 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-003 | M4-SLM-EX-002 | merged |
 | apple-m4-slm-excellence | M4-SLM-EX-004 | M4-SLM-EX-003 | merged |

--- a/docs/tracking/generated/global-dashboard.md
+++ b/docs/tracking/generated/global-dashboard.md
@@ -14,7 +14,7 @@
 | apple-m4-operational | M4-OP-006 | #3882 | merged | none | Do not reopen the completed apple-m4 proof campaign. |
 | apple-m4-productization | M4-PROD-005 | #4034 | merged | none | Do not reopen the completed apple-m4, apple-m4-operational, or apple-m4-slm-answer campaigns. |
 | apple-m4-slm-answer | SLM-M4-007 | #3991 | merged | none | Do not reopen the completed apple-m4 or apple-m4-operational campaigns. |
-| apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | #4677 | pr_open | none | This is an M4 Mac mini dense SLM campaign. |
+| apple-m4-slm-eval-and-proof | M4-SLM-EVAL-006 | #4677 | merged | none | This is an M4 Mac mini dense SLM campaign. |
 | apple-m4-slm-excellence | M4-SLM-EX-010 | #4307 | merged | none | This is an M4 Mac mini local campaign. |
 | apple-m4-slm-hardening | M4-SLM-HARDEN-004 | #4161 | merged | none | Do not reopen completed Apple M4 proof, operational, SLM answer, productization, or performance campaigns. |
 | apple-m4-slm-metal-phases | M4-METAL-007 | #4397 | merged | none | This is an M4 Mac mini dense SLM campaign. |


### PR DESCRIPTION
## Summary
- mark M4-SLM-EVAL-006 merged after #4677 landed
- record merge SHA `305afdfb0d8e74ffbec924483f145b5f715f0fe3`
- mark the apple-m4-slm-eval-and-proof campaign complete and refresh generated dashboards

## Validation
- `cargo run --locked -p xtask --no-default-features -- campaign check apple-m4-slm-eval-and-proof`
- `cargo run --locked -p xtask --no-default-features -- campaign doctor`
- `cargo run --locked -p xtask --no-default-features -- campaign generate --check`
- `git diff --check`

## Claim boundary
This is tracker closeout only. It does not add runtime proof or broaden dense SLM evidence into BitNet, full Metal inference, QK256, Neural Engine, MPSGraph, MacBook evidence, broad quality, broad performance, or speedup claims.