### PR TITLE
docs(slm): remove stale SLM-CPU-008Y blockers

### DIFF
--- a/docs/tracking/campaigns/slm-cpu/active.toml
+++ b/docs/tracking/campaigns/slm-cpu/active.toml
@@ -1026,7 +1026,6 @@ stackable = false
 review_mode = "codex_premerge"
 merge_policy = "automerge_when_green"
 human_gate = "on_blocker_only"
-blocked_by = ["SLM-CPU-008YA", "SLM-CPU-008YB"]
 acceptance = "Capture or ingest a real known-good internal Qwen3 checkpoint pack for the same Qwen3-0.6B Q8_0 model SHA, rendered prompt, prompt IDs, and greedy first-token settings used by the i5-8250U artifact, then validate it with the SLM checkpoint-aware reference-compare path from SLM-CPU-008X. The artifact must identify the first divergent checkpoint before lm_head.top_logits when compared with bitnet-rs. This item must not claim first-token parity, answer quality, tiny corpus success, multi-token stability, warm-session performance, Q4/Q5 expansion, server, GPU, NPU, OpenVINO, UHD 620, Qwen3.5 support, or BitNet QK256 changes."
 commands = [
   "cargo run --locked -p bitnet-cli --no-default-features --features cpu,full-cli -- reference-compare --artifact ci/slm-cpu/intel-i5-8250u/2026-05-07/qwen3-reference-checkpoint-compare.json --json-out target/slm-cpu/qwen3-reference-checkpoint-validation.json",

--- a/docs/tracking/generated/blocked-items.md
+++ b/docs/tracking/generated/blocked-items.md
@@ -357,7 +357,6 @@
 | slm-cpu | SLM-CPU-008X | SLM-CPU-008W | merged |
 | slm-cpu | SLM-CPU-008YA | SLM-CPU-008X | merged |
 | slm-cpu | SLM-CPU-008YB | SLM-CPU-008YA | merged |
-| slm-cpu | SLM-CPU-008Y | SLM-CPU-008YA, SLM-CPU-008YB | ready |
 | tracker-infra | TRACKER-002 | TRACKER-001 | merged |
 | tracker-infra | TRACKER-003 | TRACKER-002 | merged |
 | wasm-inference | WASM-002 | WASM-001 | ready |


### PR DESCRIPTION
## Summary
- removes stale `blocked_by` metadata from `SLM-CPU-008Y` now that its support slices are merged
- regenerates tracker output so the blocked-items dashboard no longer lists the ready item as blocked

## Validation
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`