### PR TITLE
docs(slm): align SLM-CPU-008Y campaign status

### DIFF
--- a/docs/tracking/campaigns/slm-cpu/CAMPAIGN.md
+++ b/docs/tracking/campaigns/slm-cpu/CAMPAIGN.md
@@ -48,8 +48,9 @@ Make the Intel i5-8250U a strict CPU proof host for small dense transformer GGUF
 | SLM-CPU-008V | merged | Post-008U real i5-8250U artifact refresh merged in #4633; first-token parity remained unproven and the official GGUF uses tied token embeddings. |
 | SLM-CPU-008W | merged | Tied-token-embedding logits audit merged in #4641; output-head/vocab boundary remains insufficient to prove first-token parity. |
 | SLM-CPU-008X | merged | Checkpoint-aware reference comparison support merged in #4655; real known-good checkpoint capture remains separate. |
-| SLM-CPU-008Y | blocked | #4696 records that the real Qwen3 reference checkpoint pack is missing, so validation cannot identify the first shared-transformer-math drift yet. |
+| SLM-CPU-008YA | merged | Qwen no-thinking prompt control merged in #4669; first-token parity was not claimed. |
 | SLM-CPU-008YB | merged | Qwen thinking special-token preservation merged in #4699; refreshed no-thinking reference prompt-ID comparison no longer literalizes `<think>` markers. |
+| SLM-CPU-008Y | ready | Capture or ingest the real Qwen3 reference checkpoint pack now that the prompt-policy and tokenizer support slices are merged; do not claim first-token parity until checkpoint-aware validation identifies the first drift. |
 
 ## Review Policy
 


### PR DESCRIPTION
## Summary
- updates the SLM CPU campaign table so `SLM-CPU-008Y` matches the live ready tracker state
- records `SLM-CPU-008YA` as the merged no-thinking support slice
- keeps the claim boundary explicit: checkpoint capture is next, first-token parity is not claimed

## Validation
- `cargo run -p xtask --no-default-features -- campaign generate`
- `cargo run -p xtask --no-default-features -- campaign doctor`
- `git diff --check`