### PR TITLE
docs(a770): add BitNet A770 claim-boundary spec

### DIFF
--- a/docs/hardware/HARDWARE_MATRIX.md
+++ b/docs/hardware/HARDWARE_MATRIX.md
@@ -189,6 +189,8 @@ Do not jump from docs or detection directly to benchmark claims.
 
 BitNet-specific proof also requires:
 
+- `docs/specs/a770-bitnet-claim-boundary.md` for A770 trusted BitNet product claims.
+- `plans/a770-bitnet-claim-boundary-implementation.md` for the PR-by-PR A770 implementation sequence.
 - `docs/bitnet/BITNET_MODEL_CONTRACT.md`
 - `docs/bitnet/BITNET_QUANTIZATION_CONTRACT.md`
 - `docs/bitnet/BITNET_KERNEL_MATRIX.md`

--- a/docs/hardware/intel-arc-a770-validation.md
+++ b/docs/hardware/intel-arc-a770-validation.md
@@ -10,6 +10,12 @@ Roadmap:
 docs/specs/intel-arc-a770-gpu-roadmap.md
 ```
 
+BitNet claim boundary:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+```
+
 ## Required Machine Facts
 
 Record these before moving A770 beyond `scaffold`:
@@ -37,6 +43,9 @@ Record these before moving A770 beyond `scaffold`:
 - CPU/OpenCL parity is parity only.
 - CPU fallback cannot count as A770 execution.
 - Performance claims require benchmark artifacts and receipts.
+- BitNet trusted partial acceleration does not imply selected-attention
+  residency, resident KV decode, attention scores, softmax, attention value
+  mix, full support-op residency, full device residency, or completion.
 
 ## Linux Bundle
 

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -3,6 +3,22 @@
 **Discovery Date**: October 25, 2025
 **Status**: COMPLETE - All APIs identified and documented
 
+## A770 BitNet Productization
+
+Use these specs before implementing or claiming A770 BitNet product support:
+
+1. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+   - Defines claim levels, required evidence, current not-claims, and the
+     selected-attention boundary for real BitNet question-answer usage on
+     A770.
+2. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+   - Defines the A770 hardware/runtime lane and native OpenCL proof path.
+3. [A770 BitNet Productization Plan](../../plans/a770-bitnet-claim-boundary-implementation.md)
+   - Defines the PR-by-PR implementation sequence and acceptance gates.
+
+Do not proceed from A770 detection or a single benchmark to product claims.
+Claims must pass through the claim boundary and productization plan first.
+
 ## Overview
 
 This directory contains comprehensive documentation of the BitNet.cpp API discovered during G2 discovery phase. BitNet.cpp uses the llama.cpp C API; there is no separate BitNet-specific public interface.

--- a/docs/specs/a770-bitnet-claim-boundary.md
+++ b/docs/specs/a770-bitnet-claim-boundary.md
@@ -1,0 +1,233 @@
+# A770 BitNet Claim Boundary
+
+## Purpose
+
+This spec defines what BitNet-rs may claim for real BitNet question-answer
+usage on an Intel Arc A770. It is narrower than generic "GPU support" and
+narrower than full device residency.
+
+The goal is a useful, reproducible product path:
+
+```text
+official BitNet model contract
+real tokenizer and prompt template
+real question-answer prompts
+CPU reference behavior
+explicit A770 route
+fallback_used=false where A770 is claimed
+load, TTFT, prefill, decode, and resource receipts
+same-device history
+clear not-claims
+```
+
+## First Claim Target
+
+The first A770 product claim is:
+
+```text
+BitNet b1.58 i2_s trusted partial A770 acceleration
+```
+
+This means:
+
+- The official BitNet GGUF weights load through the strict model path.
+- The tokenizer and prompt template are authoritative and hashable.
+- Real prompts produce useful, intelligible answers.
+- CPU reference behavior is correct enough to be the comparison baseline.
+- The A770 route is concrete: `intel-arc-a770-opencl`.
+- Claimed A770 operations run on the A770 with `fallback_used=false`.
+- Timings and resources are measured under a named profile.
+- The receipt says exactly what is not claimed.
+
+This does not mean:
+
+- All Intel GPUs are supported.
+- All OpenCL devices inherit the A770 claim.
+- Dense SLM or Gemma-class models are A770-supported.
+- Selected attention is resident on A770.
+- KV cache decode is resident on A770.
+- Attention scores, softmax, or value mix are resident on A770.
+- Full support-op residency or full device residency is complete.
+
+## Claim Levels
+
+Use these levels for A770 BitNet support.
+
+| Level | Meaning | Public claim allowed |
+|---|---|---|
+| `unsupported` | No valid model, route, or kernel evidence. | No |
+| `diagnostic` | Local evidence exists but is dirty, incomplete, or not claim-grade. | No |
+| `load_proven` | Official weights and tokenizer/template load with hashes. | Limited load claim |
+| `quality_proven` | Prompt suite and CPU/A770 behavior gates pass. | Quality claim only |
+| `performance_proven` | Quality-gated benchmark and same-route history are claim-grade. | Trusted partial performance claim |
+| `resident_proven` | A named resident operation is proved with transfer and fallback receipts. | Resident claim for that operation only |
+| `complete` | All required support ops and residency gates are proved. | Full A770 completion claim |
+
+Do not collapse `performance_proven`, `resident_proven`, and `complete`.
+
+## Required Evidence
+
+### Model Contract
+
+Every claimable A770 BitNet run must identify:
+
+- model ID
+- official weight file
+- weight hash
+- tokenizer hash or embedded tokenizer identity
+- chat template or prompt template
+- quantization format
+- max context
+- stop-token policy
+
+No model contract means no model support claim.
+
+### Prompt and Answer Quality
+
+Every claimable run must include prompt evidence that is hard to fake by
+memorizing fixed names or fixed answers:
+
+- rendered prompt hash
+- token ID hash
+- deterministic sampling configuration
+- seeded prompt identities
+- randomized surface names or slots where the prompt suite supports them
+- category coverage
+- paired context checks where the expected answer must change
+- stop and repetition checks
+
+Manual review cases may be stored as diagnostic evidence, but they cannot by
+themselves promote an automated quality claim.
+
+### Route Identity
+
+A claimable A770 route must record:
+
+```json
+{
+  "requested_backend": "intel-arc-a770",
+  "selected_backend": "intel-arc-a770-opencl",
+  "runtime_api": "opencl",
+  "fallback_used": false,
+  "resolved_device": {
+    "name": "Intel(R) Arc(TM) A770 Graphics",
+    "pci_device_id": "0x56A0",
+    "vram_bytes": 17179869184
+  }
+}
+```
+
+A route for A750, Arc 140V, OpenVINO GPU, CUDA, Metal, or CPU is a different
+route and needs its own evidence.
+
+### Experience Measurements
+
+A claimable A770 BitNet experience receipt must include:
+
+- cold load timing
+- warm load timing, when a load-speed claim is made
+- time to first token
+- prefill/input throughput
+- decode/output throughput
+- inter-token latency when claiming streaming quality
+- peak RSS
+- peak VRAM when available
+- host/device transfer bytes when available
+- kernel invocation counts for claimed A770 operations
+- fallback status
+
+Benchmarks may be stored even when incomplete. They are diagnostic until the
+quality, route, model, resource, and history gates pass.
+
+## Parent Benchmark and History
+
+A performance claim requires a parent benchmark receipt with:
+
+```text
+repo.dirty=false
+quality_passed=true
+route_verified=true
+model_contract_matched=true
+fallback_used=false
+claim_allowed=true
+```
+
+Same-device history requires two distinct receipts:
+
+- distinct non-empty run IDs
+- distinct receipt paths
+- same device instance
+- same model contract
+- same backend
+- same benchmark profile
+- same kernel route
+
+Comparing a receipt to itself is not history. Cross-vendor or cross-device
+comparisons are useful diagnostics, not regression evidence.
+
+## Current Not-Claims
+
+Until separate receipts prove them, every A770 trusted-path receipt must keep
+these explicit not-claims:
+
+```text
+selected_attention_residency
+resident_kv_decode
+attention_scores_residency
+softmax_residency
+attention_value_mix_residency
+full_support_op_residency
+full_device_residency
+completion
+```
+
+## Selected Attention Boundary
+
+Selected attention is a separate research lane. It is not promoted by trusted
+partial A770 acceleration.
+
+Before selected attention can be promoted, the repo needs:
+
+- a production-shaped selected-attention score rule
+- decode parity at short and long decode lengths
+- semantic quality unchanged
+- stop behavior unchanged
+- fallback_used=false
+- selected attention actually used
+- no replacement maps, output bias, CPU attention island, or diagnostic knobs
+
+Resident KV, attention scores, softmax, and value mix must wait until selected
+attention itself is claim-grade.
+
+## PR Sequence
+
+Build this path in small PRs:
+
+1. Claim-boundary specs and docs.
+2. Model contract and local asset hash verification.
+3. A770 device route and kernel capability matrix.
+4. Seeded prompt suite and anti-fakery validation.
+5. Quality-gated benchmark receipt schema.
+6. LLM experience receipt generation and verification.
+7. Clean A770 parent benchmark rerun.
+8. Two distinct same-device, same-route history receipts.
+9. Claim ledger and generated dashboard.
+10. Selected-attention fork decision, still non-promoting unless its gates pass.
+
+Each PR must preserve the not-claims unless it is specifically the promotion PR
+for one named capability.
+
+The detailed implementation plan is:
+
+```text
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+## Related Specs
+
+- `docs/specs/intel-arc-a770-gpu-roadmap.md`
+- `docs/hardware/intel-arc-a770-validation.md`
+- `docs/hardware/HARDWARE_MATRIX.md`
+- `docs/hardware/BENCHMARK_PROTOCOL.md`
+- `docs/bitnet/BITNET_MODEL_CONTRACT.md`
+- `docs/bitnet/BITNET_RECEIPT_FIELDS.md`

--- a/docs/specs/intel-arc-a770-gpu-roadmap.md
+++ b/docs/specs/intel-arc-a770-gpu-roadmap.md
@@ -18,6 +18,19 @@ intel-arc-a770-openvino-gpu
 
 The first useful milestone is native OpenCL kernel smoke with CPU parity and a receipt proving the selected A770 backend with `fallback_used=false`.
 
+BitNet product claims for real question-answer usage are governed by the
+stricter claim boundary in:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+```
+
+The PR-by-PR implementation plan is:
+
+```text
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
 ## Hardware Profile
 
 The expected target is Intel Arc A770 16GB:
@@ -52,11 +65,18 @@ Do not claim A770 execution from detection alone.
 | Tiny OpenCL kernel executes on A770 | Kernel smoke tested |
 | CPU/OpenCL parity passes | Parity tested |
 | Receipt records selected A770 backend and no fallback | Receipt backed |
-| Benchmark beats CPU baseline with artifact | Performance claim allowed |
+| Benchmark beats CPU baseline with artifact | Diagnostic performance evidence |
 
 OpenVINO GPU graph smoke is reference-runtime evidence. It is not native BitNet OpenCL kernel proof.
 
 CPU fallback cannot count as A770 execution.
+
+For BitNet b1.58, performance claims also require the stricter claim-boundary
+gates for model contract, prompt quality, route identity, fallback status,
+resources, and same-device history. The first product claim is trusted partial
+A770 acceleration, not full A770 residency. Selected attention, resident KV,
+attention scores, softmax, attention value mix, full support-op residency, and
+full device residency require separate promotion receipts.
 
 ## Backend Labels
 

--- a/plans/a770-bitnet-claim-boundary-implementation.md
+++ b/plans/a770-bitnet-claim-boundary-implementation.md
@@ -1,0 +1,475 @@
+# A770 BitNet Productization Plan
+
+## Goal
+
+Make the A770 path usable for real BitNet question-answer workloads without
+overclaiming hardware residency.
+
+The target product claim is:
+
+```text
+BitNet b1.58 i2_s trusted partial A770 acceleration
+```
+
+The final full-residency claim is explicitly out of scope until separate gates
+prove selected attention, resident KV, attention scores, softmax, attention
+value mix, full support-op residency, and full device residency.
+
+## Required End State
+
+The trusted A770 BitNet lane is product-ready only when the repo can prove:
+
+- official BitNet GGUF weights load through a strict model contract
+- tokenizer and prompt template are authoritative
+- real prompts produce useful answers
+- CPU reference behavior is correct
+- A770 route identity is concrete and device-specific
+- fallback is false where A770 is claimed
+- claimed A770 operations are named
+- load, time-to-first-token, input throughput, output throughput, and resources
+  are measured
+- benchmark claims are quality-gated
+- two distinct same-device, same-route history receipts exist
+- generated docs and CLI summaries preserve not-claims
+
+## Non-Claims Until Promoted
+
+Every PR in this plan must preserve these not-claims unless it is the explicit
+promotion PR for that named capability:
+
+```text
+selected_attention_residency
+resident_kv_decode
+attention_scores_residency
+softmax_residency
+attention_value_mix_residency
+full_support_op_residency
+full_device_residency
+completion
+```
+
+## Stop Rules
+
+- Do not add selected-attention kernels before a reviewed selected-attention
+  score rule exists.
+- Do not treat a CLI smoke as a benchmark claim.
+- Do not treat a dirty-worktree run as claim-grade.
+- Do not treat a same-receipt comparison as history.
+- Do not inherit A770 proof to A750, Arc 140V, OpenVINO GPU, CUDA, Metal, or
+  CPU lanes.
+- Do not benchmark unsupported model families as A770 support.
+
+## PR 0 - Specs and Plan
+
+Purpose: make the lane followable before implementation.
+
+Files:
+
+```text
+docs/specs/a770-bitnet-claim-boundary.md
+docs/specs/intel-arc-a770-gpu-roadmap.md
+docs/hardware/intel-arc-a770-validation.md
+plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+Acceptance:
+
+```text
+the spec defines claim levels
+the spec defines required evidence
+the spec defines current not-claims
+the plan lists PR-by-PR work
+no runtime behavior changes
+```
+
+Verification:
+
+```powershell
+git diff --check -- docs/specs/a770-bitnet-claim-boundary.md docs/specs/intel-arc-a770-gpu-roadmap.md docs/hardware/intel-arc-a770-validation.md plans/a770-bitnet-claim-boundary-implementation.md
+```
+
+## PR 1 - Model Contract and Asset Proof
+
+Purpose: make the official BitNet model identity claimable.
+
+Files:
+
+```text
+docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml
+xtask/src/model_contract.rs
+xtask/src/main.rs
+```
+
+Required command:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- model-contract lint --format json
+```
+
+Required evidence:
+
+```text
+model_id matches the official BitNet GGUF model
+local GGUF hash verified
+local tokenizer hash verified
+chat template recorded
+stop-token policy recorded
+max context recorded
+asset_hashes_verified=true
+```
+
+Not enough:
+
+```text
+model file exists
+tokenizer file exists
+download command succeeded
+```
+
+## PR 2 - A770 Route and Kernel Capability Matrix
+
+Purpose: prevent broad or inherited A770 claims.
+
+Files:
+
+```text
+ci/hardware/device-kernel-routing.toml
+ci/hardware/amd-5700x-intel-a770/a770-kernel-capability-matrix.json
+xtask/src/hardware.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- hardware a770 kernel-capability-check --format json
+cargo run --locked -p xtask --no-default-features -- hardware route resolve --format json
+```
+
+Required evidence:
+
+```text
+A770 route names a concrete device
+route has a concrete kernel variant
+fallback_allowed=false for claimable routes
+proof receipts listed for claimable kernels
+unsupported dense/Gemma routes fail closed
+```
+
+Not enough:
+
+```text
+runtime says OpenCL exists
+device name contains Intel
+kernel is compatible with same-family hardware
+```
+
+## PR 3 - Seeded Prompt Suite and Anti-Fakery Validation
+
+Purpose: prove broad prompt behavior without fixed-name overfitting.
+
+Files:
+
+```text
+ci/prompt-suites/seeded-v1.toml
+xtask/src/prompt_suite.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- prompt-suite verify --suite ci/prompt-suites/seeded-v1.toml --format json
+cargo run --locked -p xtask --no-default-features -- prompt-suite render --suite ci/prompt-suites/seeded-v1.toml --model-contract docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml --format json
+```
+
+Required evidence:
+
+```text
+required categories present
+deterministic sampling for claimable cases
+prompt hashes present
+token ID hashes present
+seeded surface-name slots present
+answer-bound surfaces present
+paired context cases check answer changes
+manual-review cases cannot promote automated quality claims
+```
+
+Not enough:
+
+```text
+one real question
+one benchmark prompt
+prompt strings without token hashes
+manual review only
+```
+
+## PR 4 - Quality-Gated Benchmark Receipt
+
+Purpose: ensure speed evidence cannot promote without answer quality.
+
+Files:
+
+```text
+ci/benchmarks/schemas/bench-run.schema.json
+ci/benchmarks/profiles.toml
+xtask/src/bench.rs or equivalent
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- bench verify-receipt --receipt target/bench-runs/profile-cli-stage.json --format json
+cargo run --locked -p xtask --no-default-features -- bench compare --require-same-route --require-claim-ready --format json
+```
+
+Required evidence:
+
+```text
+quality_passed=true before benchmark_claim_allowed=true
+repo.dirty=false for claim-grade runs
+fallback_used=false for A770 claims
+model contract matched
+kernel route matched
+profile matched
+resource fields present
+```
+
+Not enough:
+
+```text
+tokens per second only
+single smoke timing
+dirty workspace benchmark
+```
+
+## PR 5 - CLI Stage Receipts and Proof Summary
+
+Purpose: let normal user runs expose the claim boundary.
+
+Files:
+
+```text
+crates/bitnet-cli/src/main.rs or command modules
+```
+
+Required evidence:
+
+```text
+backend printed
+model contract printed
+fallback status printed
+claimed A770 ops printed
+not-claims printed
+prompt/token hash identity available in JSON
+load and TTFT stages available in JSON
+```
+
+Not enough:
+
+```text
+human text says A770
+no JSON receipt
+no fallback status
+```
+
+## PR 6 - LLM Experience Receipt
+
+Purpose: combine model, route, quality, timing, resource, and not-claim evidence.
+
+Files:
+
+```text
+ci/benchmarks/schemas/llm-experience-run.schema.json
+xtask/src/llm_experience.rs or equivalent
+docs/benchmarks/llm-experience.md
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- llm-experience run --format json
+cargo run --locked -p xtask --no-default-features -- llm-experience verify --receipt target/llm-experience/a770-bitnet-profile-stage.json --format json
+```
+
+Required evidence:
+
+```text
+model contract matched
+asset hashes verified
+route verified
+quality passed
+fallback=false
+load complete
+TTFT complete
+input speed complete
+output speed complete
+resource envelope complete
+critical not-claims present
+```
+
+Not enough:
+
+```text
+benchmark receipt alone
+CLI smoke alone
+diagnostic supplement alone
+```
+
+## PR 7 - Clean A770 Parent Benchmark
+
+Purpose: produce the first claim-grade parent benchmark.
+
+Required sequence:
+
+```powershell
+git status --short
+cargo run --locked -p xtask --no-default-features -- llm-experience profile-cli-plan --format json
+# run generated CLI command
+cargo run --locked -p xtask --no-default-features -- bench from-cli-stage --format json
+cargo run --locked -p xtask --no-default-features -- bench verify-receipt --receipt target/bench-runs/profile-cli-stage.json --format json
+```
+
+Required evidence:
+
+```text
+git status is empty before run
+parent benchmark claim_allowed=true
+repo.dirty=false
+quality_passed=true
+fallback_used=false
+route_verified=true
+profile matched
+```
+
+Not enough:
+
+```text
+claim_allowed_if_repo_clean=true
+dirty diagnostic run
+```
+
+## PR 8 - Same-Device Same-Route History
+
+Purpose: prove stability and prevent self-comparison.
+
+Required sequence:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- llm-experience publish --format json
+# repeat full clean run for second distinct receipt
+cargo run --locked -p xtask --no-default-features -- llm-experience compare --require-same-route --require-claim-ready --format json
+```
+
+Required evidence:
+
+```text
+two distinct run IDs
+two distinct receipt paths
+same device instance
+same model contract
+same backend
+same profile
+same kernel route
+classification=same_device_regression_signal
+history_scope_ready=true
+```
+
+Not enough:
+
+```text
+same receipt compared to itself
+same route but diagnostic parent benchmark
+cross-device comparison
+```
+
+## PR 9 - Claim Ledger and Generated Dashboard
+
+Purpose: turn verified receipts into public claims.
+
+Files:
+
+```text
+ci/claims/claim-ledger.json
+ci/claims/correctness-ledger.json
+ci/claims/efficiency-ledger.json
+docs/claims.md
+docs/model-support.md
+docs/benchmarks.md
+```
+
+Required commands:
+
+```powershell
+cargo run --locked -p xtask --no-default-features -- claims verify --format json
+cargo run --locked -p xtask --no-default-features -- claims docs --check --format json
+```
+
+Required evidence:
+
+```text
+trusted partial A770 BitNet claim is ledger-derived
+not-claims are present in docs
+unsupported model families stay unsupported
+benchmark claims point to quality-gated receipts
+```
+
+Not enough:
+
+```text
+README prose
+manual claim table
+receipt exists but ledger ignores it
+```
+
+## PR 10 - Selected Attention Decision
+
+Purpose: keep selected attention separate from the trusted product path.
+
+Allowed outcomes:
+
+```text
+defer selected attention
+continue research with a reviewed score-rule design
+```
+
+Promotion requires:
+
+```text
+production-shaped selected-attention score rule
+decode_32 exact
+decode_64 exact
+decode_128 exact
+semantic quality unchanged
+stop behavior unchanged
+fallback_used=false
+selected attention actually used
+no diagnostic knobs
+```
+
+Not enough:
+
+```text
+captured value target without implementation rule
+dirty diagnostic decode
+another score-row variant
+replacement map or output bias
+```
+
+## Done Criteria
+
+The A770 trusted BitNet path is done only when:
+
+```text
+model contract verified
+prompt suite claim-ready
+route verified
+quality passed
+fallback=false
+parent benchmark claim_allowed=true
+two same-device same-route history receipts exist
+claim ledger consumes the evidence
+docs and CLI expose claim boundary
+selected attention and full residency remain explicit not-claims
+```
+
+If any line is missing, the lane is still in progress.


### PR DESCRIPTION
## Summary
- Add the BitNet A770 claim-boundary spec for the first claim target: trusted partial A770 acceleration for BitNet b1.58 i2_s.
- Link the claim boundary from the A770 roadmap, A770 validation doc, and spec index.
- Add the PR-by-PR implementation plan for specs, guards, model contracts, route/capability rails, prompt quality, benchmarks, experience receipts, history, claims, and dashboards.

## Claim posture
- Docs/spec only: no runtime code, receipts, benchmark reruns, or claim promotion.
- Selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, and completion remain explicitly not claimed.
- Claim-grade runs require repo.dirty=false and two distinct same-device/same-route history receipts before ledger consumption.

## Verification
- git diff --check origin/main...HEAD
- rg boundary/not-claim requirements across the spec, roadmap, validation doc, and implementation plan