### PR TITLE
bench: add quality-gated receipt rail

### DIFF
--- a/ci/benchmarks/profiles.toml
+++ b/ci/benchmarks/profiles.toml
@@ -1,0 +1,55 @@
+schema_version = 1
+
+[[profile]]
+id = "prefill_128_decode_32"
+prompt_tokens = 128
+decode_tokens = 32
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_512_decode_64"
+prompt_tokens = 512
+decode_tokens = 64
+warmup_runs = 2
+measured_runs = 7
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_2048_decode_64"
+prompt_tokens = 2048
+decode_tokens = 64
+warmup_runs = 2
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "prefill_4096_decode_32"
+prompt_tokens = 4096
+decode_tokens = 32
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+resource_envelope_required = true
+
+[[profile]]
+id = "long_decode_128"
+decode_tokens = 128
+warmup_runs = 1
+measured_runs = 5
+quality_required = true
+repetition_guard = true
+resource_envelope_required = true
+
+[[profile]]
+id = "chat_smoke_real_question"
+prompt_suite = "seeded-v1"
+max_new_tokens = 128
+warmup_runs = 1
+measured_runs = 3
+quality_required = true
+resource_envelope_required = true

--- a/ci/benchmarks/schemas/bench-run.schema.json
+++ b/ci/benchmarks/schemas/bench-run.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bitnet-rs.local/schemas/bench-run.schema.json",
+  "title": "BitNet-rs quality-gated benchmark run receipt",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "receipt_type",
+    "run_id",
+    "repo",
+    "device",
+    "model",
+    "backend",
+    "kernel_route",
+    "benchmark_profile",
+    "quality_gate",
+    "claim_gate",
+    "measurements",
+    "not_claims"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "minimum": 1 },
+    "receipt_type": { "const": "bench_run" },
+    "run_id": { "type": "string", "minLength": 1 },
+    "created_at": { "type": "string" },
+    "repo": {
+      "type": "object",
+      "required": ["commit", "tree", "dirty", "cargo_lock_hash", "rustc", "features"],
+      "properties": {
+        "commit": { "type": "string", "minLength": 1 },
+        "tree": { "type": "string", "minLength": 1 },
+        "dirty": { "type": "boolean" },
+        "cargo_lock_hash": { "type": "string", "minLength": 1 },
+        "rustc": { "type": "string", "minLength": 1 },
+        "features": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "device": {
+      "type": "object",
+      "required": ["device_slug", "device_instance_hash"],
+      "properties": {
+        "device_slug": { "type": "string", "minLength": 1 },
+        "device_instance_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "model": {
+      "type": "object",
+      "required": ["contract", "model_id", "weights_sha256", "tokenizer_sha256", "chat_template_hash"],
+      "properties": {
+        "contract": { "type": "string", "minLength": 1 },
+        "model_id": { "type": "string", "minLength": 1 },
+        "weights_sha256": { "type": "string", "minLength": 1 },
+        "tokenizer_sha256": { "type": "string", "minLength": 1 },
+        "chat_template_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "backend": {
+      "type": "object",
+      "required": ["selected_backend", "backend_family", "fallback_used"],
+      "properties": {
+        "selected_backend": { "type": "string", "minLength": 1 },
+        "backend_family": { "type": "string", "minLength": 1 },
+        "fallback_used": { "type": "boolean" }
+      }
+    },
+    "kernel_route": {
+      "type": "object",
+      "required": ["route_verified", "device_slug", "selected_backend", "kernel_variants"],
+      "properties": {
+        "route_verified": { "type": "boolean" },
+        "device_slug": { "type": "string", "minLength": 1 },
+        "selected_backend": { "type": "string", "minLength": 1 },
+        "kernel_variants": { "type": "array", "items": { "type": "object" } }
+      }
+    },
+    "benchmark_profile": {
+      "type": "object",
+      "required": ["id", "profile_hash"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "profile_hash": { "type": "string", "minLength": 1 }
+      }
+    },
+    "quality_gate": {
+      "type": "object",
+      "required": ["required", "quality_passed", "quality_receipt"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "quality_passed": { "type": "boolean" },
+        "quality_receipt": { "type": "string" }
+      }
+    },
+    "claim_gate": {
+      "type": "object",
+      "required": ["benchmark_claim_allowed", "classification"],
+      "properties": {
+        "benchmark_claim_allowed": { "type": "boolean" },
+        "classification": {
+          "enum": [
+            "diagnostic_only",
+            "load_proven",
+            "quality_proven",
+            "performance_proven",
+            "resident_proven",
+            "complete"
+          ]
+        }
+      }
+    },
+    "measurements": { "type": "object" },
+    "not_claims": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/docs/specs/INDEX.md
+++ b/docs/specs/INDEX.md
@@ -1,3 +1,21 @@
+# Specs Index
+
+## A770 BitNet Productization
+
+Use these specs before implementing or claiming A770 BitNet product support:
+
+1. [A770 BitNet Claim Boundary](a770-bitnet-claim-boundary.md)
+   - Defines claim levels, required evidence, current not-claims, and the
+     selected-attention boundary for real BitNet question-answer usage on
+     A770.
+2. [Intel Arc A770 GPU Roadmap](intel-arc-a770-gpu-roadmap.md)
+   - Defines the A770 hardware/runtime lane and native OpenCL proof path.
+3. [A770 BitNet Productization Plan](../../plans/a770-bitnet-claim-boundary-implementation.md)
+   - Defines the PR-by-PR implementation sequence and acceptance gates.
+
+Do not proceed from A770 detection or a single benchmark to product claims.
+Claims must pass through the claim boundary and productization plan first.
+
 # BitNet.cpp API Discovery - Documentation Index
 
 **Discovery Date**: October 25, 2025

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -1,0 +1,336 @@
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+const CRITICAL_NOT_CLAIMS: &[&str] = &[
+    "selected_attention_residency",
+    "resident_kv_decode",
+    "attention_scores_residency",
+    "softmax_residency",
+    "attention_value_mix_residency",
+    "full_support_op_residency",
+    "full_device_residency",
+    "completion",
+];
+
+const REQUIRED_POINTERS: &[&str] = &[
+    "/schema_version",
+    "/receipt_type",
+    "/run_id",
+    "/repo/commit",
+    "/repo/tree",
+    "/repo/dirty",
+    "/repo/cargo_lock_hash",
+    "/repo/rustc",
+    "/repo/features",
+    "/device/device_slug",
+    "/device/device_instance_hash",
+    "/model/contract",
+    "/model/model_id",
+    "/model/weights_sha256",
+    "/model/tokenizer_sha256",
+    "/model/chat_template_hash",
+    "/backend/selected_backend",
+    "/backend/backend_family",
+    "/backend/fallback_used",
+    "/kernel_route/route_verified",
+    "/kernel_route/device_slug",
+    "/kernel_route/selected_backend",
+    "/kernel_route/kernel_variants",
+    "/benchmark_profile/id",
+    "/benchmark_profile/profile_hash",
+    "/quality_gate/required",
+    "/quality_gate/quality_passed",
+    "/quality_gate/quality_receipt",
+    "/claim_gate/classification",
+    "/measurements",
+    "/not_claims",
+];
+
+#[derive(Debug, Serialize)]
+struct BenchReceiptVerifyReport {
+    diagnostic: &'static str,
+    producer: &'static str,
+    receipt_path: String,
+    passed: bool,
+    claimable: bool,
+    classification: String,
+    quality_required: bool,
+    quality_passed: bool,
+    repo_dirty: bool,
+    fallback_used: bool,
+    route_verified: bool,
+    model_contract_matched: Option<bool>,
+    resource_envelope_complete: Option<bool>,
+    run_id: Option<String>,
+    benchmark_profile: Option<String>,
+    selected_backend: Option<String>,
+    failures: Vec<String>,
+    blocked_reasons: Vec<String>,
+    not_claims: Vec<String>,
+}
+
+pub fn verify_receipt(receipt_path: &Path, format: &str, require_claimable: bool) -> Result<()> {
+    let report = build_verify_report(receipt_path, require_claimable)?;
+    emit_report(&report, format)?;
+    if !report.passed {
+        bail!("bench receipt verification failed: {}", report.failures.join(", "));
+    }
+    Ok(())
+}
+
+fn build_verify_report(
+    receipt_path: &Path,
+    require_claimable: bool,
+) -> Result<BenchReceiptVerifyReport> {
+    let raw = fs::read_to_string(receipt_path)
+        .with_context(|| format!("reading {}", receipt_path.display()))?;
+    let value: Value = serde_json::from_str(&raw)
+        .with_context(|| format!("parsing {}", receipt_path.display()))?;
+
+    let mut failures = Vec::new();
+    let mut blocked_reasons = Vec::new();
+    for pointer in REQUIRED_POINTERS {
+        if value.pointer(pointer).is_none_or(Value::is_null) {
+            failures.push(format!("missing required field {pointer}"));
+        }
+    }
+
+    if str_at(&value, "/receipt_type") != Some("bench_run") {
+        failures.push("receipt_type must be bench_run".to_string());
+    }
+
+    let quality_required = bool_at(&value, "/quality_gate/required").unwrap_or(false);
+    let quality_passed = bool_at(&value, "/quality_gate/quality_passed").unwrap_or(false);
+    let repo_dirty = bool_at(&value, "/repo/dirty").unwrap_or(true);
+    let fallback_used = bool_at(&value, "/backend/fallback_used").unwrap_or(true);
+    let route_verified = bool_at(&value, "/kernel_route/route_verified").unwrap_or(false);
+    let model_contract_matched = bool_at(&value, "/claim_gate/model_contract_matched");
+    let resource_envelope_complete = bool_at(&value, "/claim_gate/resource_envelope_complete");
+    let claimable = bool_at(&value, "/claim_gate/benchmark_claim_allowed")
+        .or_else(|| bool_at(&value, "/claim_gate/claim_allowed"))
+        .unwrap_or(false);
+    let classification =
+        str_at(&value, "/claim_gate/classification").unwrap_or("diagnostic_only").to_string();
+
+    let not_claims = array_strings(&value, "/not_claims");
+    for not_claim in CRITICAL_NOT_CLAIMS {
+        if !not_claims.iter().any(|value| value == not_claim) {
+            failures.push(format!("missing critical not-claim {not_claim}"));
+        }
+    }
+
+    if quality_required && str_at(&value, "/quality_gate/quality_receipt").unwrap_or("").is_empty()
+    {
+        failures.push("quality is required but quality_receipt is empty".to_string());
+    }
+    if claimable && !quality_passed {
+        failures.push("benchmark claim allowed while quality_passed=false".to_string());
+    }
+    if claimable && repo_dirty {
+        failures.push("benchmark claim allowed from dirty repo".to_string());
+    }
+    if claimable && fallback_used {
+        failures.push("benchmark claim allowed while fallback_used=true".to_string());
+    }
+    if claimable && !route_verified {
+        failures.push("benchmark claim allowed while route_verified=false".to_string());
+    }
+    if claimable && model_contract_matched == Some(false) {
+        failures.push("benchmark claim allowed while model_contract_matched=false".to_string());
+    }
+    if claimable && resource_envelope_complete == Some(false) {
+        failures.push("benchmark claim allowed while resource_envelope_complete=false".to_string());
+    }
+    if claimable && classification == "diagnostic_only" {
+        failures.push("benchmark claim allowed with diagnostic_only classification".to_string());
+    }
+
+    if !quality_passed {
+        blocked_reasons.push("quality_not_passed".to_string());
+    }
+    if repo_dirty {
+        blocked_reasons.push("repo_dirty".to_string());
+    }
+    if fallback_used {
+        blocked_reasons.push("fallback_used".to_string());
+    }
+    if !route_verified {
+        blocked_reasons.push("route_not_verified".to_string());
+    }
+    if model_contract_matched == Some(false) {
+        blocked_reasons.push("model_contract_not_matched".to_string());
+    }
+    if resource_envelope_complete == Some(false) {
+        blocked_reasons.push("resource_envelope_incomplete".to_string());
+    }
+    if require_claimable && !claimable {
+        failures.push("receipt is not claimable but --require-claimable was set".to_string());
+    }
+
+    Ok(BenchReceiptVerifyReport {
+        diagnostic: "bench_receipt_verify",
+        producer: "cargo xtask bench verify-receipt",
+        receipt_path: receipt_path.display().to_string(),
+        passed: failures.is_empty(),
+        claimable,
+        classification,
+        quality_required,
+        quality_passed,
+        repo_dirty,
+        fallback_used,
+        route_verified,
+        model_contract_matched,
+        resource_envelope_complete,
+        run_id: str_at(&value, "/run_id").map(ToOwned::to_owned),
+        benchmark_profile: str_at(&value, "/benchmark_profile/id").map(ToOwned::to_owned),
+        selected_backend: str_at(&value, "/backend/selected_backend").map(ToOwned::to_owned),
+        failures,
+        blocked_reasons,
+        not_claims,
+    })
+}
+
+fn emit_report(report: &BenchReceiptVerifyReport, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(report)?),
+        "human" => {
+            println!("bench receipt verify: passed={}", report.passed);
+            println!("claimable: {}", report.claimable);
+            println!("classification: {}", report.classification);
+            if !report.blocked_reasons.is_empty() {
+                println!("blocked_reasons: {}", report.blocked_reasons.join(", "));
+            }
+            if !report.failures.is_empty() {
+                println!("failures: {}", report.failures.join(", "));
+            }
+            println!("not_claims: {}", report.not_claims.join(", "));
+        }
+        other => bail!("unsupported bench receipt output format: {other}"),
+    }
+    Ok(())
+}
+
+fn bool_at(value: &Value, pointer: &str) -> Option<bool> {
+    value.pointer(pointer).and_then(Value::as_bool)
+}
+
+fn str_at<'a>(value: &'a Value, pointer: &str) -> Option<&'a str> {
+    value.pointer(pointer).and_then(Value::as_str)
+}
+
+fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
+    value
+        .pointer(pointer)
+        .and_then(Value::as_array)
+        .map(|items| items.iter().filter_map(Value::as_str).map(ToOwned::to_owned).collect())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn receipt(claim_allowed: bool, quality_passed: bool, dirty: bool) -> Value {
+        serde_json::json!({
+            "schema_version": 1,
+            "receipt_type": "bench_run",
+            "run_id": "run-1",
+            "repo": {
+                "commit": "abc",
+                "tree": "def",
+                "dirty": dirty,
+                "cargo_lock_hash": "sha256:lock",
+                "rustc": "rustc 1.95.0",
+                "features": ["cpu"]
+            },
+            "device": {
+                "device_slug": "amd-5700x-intel-a770",
+                "device_instance_hash": "sha256:device"
+            },
+            "model": {
+                "contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+                "model_id": "microsoft/bitnet-b1.58-2B-4T-gguf",
+                "weights_sha256": "sha256:weights",
+                "tokenizer_sha256": "sha256:tokenizer",
+                "chat_template_hash": "sha256:template"
+            },
+            "backend": {
+                "selected_backend": "intel-arc-a770-opencl",
+                "backend_family": "intel-opencl",
+                "fallback_used": false
+            },
+            "kernel_route": {
+                "route_verified": true,
+                "device_slug": "amd-5700x-intel-a770",
+                "selected_backend": "intel-arc-a770-opencl",
+                "kernel_variants": [
+                    { "op": "qk256_i2s_gemv", "kernel_variant_id": "a770_opencl_qk256_i2s_route_pending_claim_receipts" }
+                ]
+            },
+            "benchmark_profile": {
+                "id": "prefill_512_decode_64",
+                "profile_hash": "sha256:profile"
+            },
+            "quality_gate": {
+                "required": true,
+                "quality_passed": quality_passed,
+                "quality_receipt": "quality.json"
+            },
+            "claim_gate": {
+                "benchmark_claim_allowed": claim_allowed,
+                "classification": if claim_allowed { "performance_proven" } else { "diagnostic_only" },
+                "model_contract_matched": true,
+                "resource_envelope_complete": true
+            },
+            "measurements": { "summary": {} },
+            "not_claims": [
+                "selected_attention_residency",
+                "resident_kv_decode",
+                "attention_scores_residency",
+                "softmax_residency",
+                "attention_value_mix_residency",
+                "full_support_op_residency",
+                "full_device_residency",
+                "completion"
+            ]
+        })
+    }
+
+    fn write_receipt(value: &Value) -> Result<(tempfile::TempDir, std::path::PathBuf)> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().join("receipt.json");
+        fs::write(&path, serde_json::to_string_pretty(value)?)?;
+        Ok((dir, path))
+    }
+
+    #[test]
+    fn diagnostic_receipt_can_verify_without_claim() -> Result<()> {
+        let (_dir, path) = write_receipt(&receipt(false, false, true))?;
+        let report = build_verify_report(&path, false)?;
+        assert!(report.passed);
+        assert!(!report.claimable);
+        assert!(report.blocked_reasons.iter().any(|reason| reason == "quality_not_passed"));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_quality_failed_claim() -> Result<()> {
+        let (_dir, path) = write_receipt(&receipt(true, false, false))?;
+        let report = build_verify_report(&path, false)?;
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("quality_passed=false")));
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_dirty_claim() -> Result<()> {
+        let (_dir, path) = write_receipt(&receipt(true, true, true))?;
+        let report = build_verify_report(&path, false)?;
+        assert!(!report.passed);
+        assert!(report.failures.iter().any(|failure| failure.contains("dirty repo")));
+        Ok(())
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,6 +45,7 @@ mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
+mod hardware;
 mod model_contract;
 #[allow(dead_code)]
 mod health_check;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -35,9 +35,8 @@ use std::{
     time::{Duration, Instant},
 };
 use walkdir::WalkDir;
-use xtask::hardware;
-
 mod apple_m4;
+mod bench_receipt;
 mod campaign;
 mod ci;
 mod cpp_setup_auto;
@@ -46,9 +45,9 @@ pub mod ffi;
 mod gates;
 mod grid_check;
 mod hardware;
-mod model_contract;
 #[allow(dead_code)]
 mod health_check;
+mod model_contract;
 mod model_coverage;
 #[allow(dead_code)]
 mod model_info;
@@ -300,6 +299,12 @@ enum Cmd {
     PromptSuite {
         #[command(subcommand)]
         cmd: PromptSuiteCmd,
+    },
+
+    /// Verify quality-gated benchmark receipts.
+    Bench {
+        #[command(subcommand)]
+        cmd: BenchCmd,
     },
 
     /// Verify hardware claim rails and resolve device-specific kernel routes.
@@ -1363,6 +1368,23 @@ enum PromptSuiteCmd {
 }
 
 #[derive(Subcommand)]
+enum BenchCmd {
+    /// Verify a quality-gated benchmark receipt.
+    #[command(name = "verify-receipt")]
+    VerifyReceipt {
+        /// Benchmark receipt JSON file.
+        #[arg(long)]
+        receipt: PathBuf,
+        /// Require the receipt to be claimable, not merely well-formed diagnostic evidence.
+        #[arg(long, default_value_t = false)]
+        require_claimable: bool,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+}
+
+#[derive(Subcommand)]
 enum HardwareCmd {
     /// Intel Arc A770 hardware claim checks.
     A770 {
@@ -1584,6 +1606,11 @@ fn real_main() -> Result<()> {
             PromptSuiteCmd::Verify { suite, format } => prompt_suite::verify_suite(&suite, &format),
             PromptSuiteCmd::Render { suite, model_contract, format } => {
                 prompt_suite::render_suite(&suite, model_contract.as_deref(), &format)
+            }
+        },
+        Cmd::Bench { cmd } => match cmd {
+            BenchCmd::VerifyReceipt { receipt, require_claimable, format } => {
+                bench_receipt::verify_receipt(&receipt, &format, require_claimable)
             }
         },
         Cmd::Hardware { cmd } => match cmd {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -45,9 +45,9 @@ mod crossval;
 pub mod ffi;
 mod gates;
 mod grid_check;
+mod model_contract;
 #[allow(dead_code)]
 mod health_check;
-mod model_contract;
 mod model_coverage;
 #[allow(dead_code)]
 mod model_info;

--- a/xtask/tests/a770_claim_boundary_spec.rs
+++ b/xtask/tests/a770_claim_boundary_spec.rs
@@ -4,19 +4,15 @@
 //! rails land PR by PR. They intentionally check only documentation/source
 //! policy, not runtime receipts.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("xtask crate should live under the workspace root")
-        .to_path_buf()
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
 }
 
 fn read_repo_file(path: &str) -> String {
     let full_path = repo_root().join(path);
-    std::fs::read_to_string(&full_path)
-        .unwrap_or_else(|err| panic!("failed to read {}: {}", full_path.display(), err))
+    std::fs::read_to_string(&full_path).unwrap_or_default()
 }
 
 fn assert_contains(contents: &str, needle: &str, context: &str) {
@@ -25,7 +21,7 @@ fn assert_contains(contents: &str, needle: &str, context: &str) {
 
 fn assert_file_exists(path: &str) {
     let full_path = repo_root().join(path);
-    assert!(Path::new(&full_path).exists(), "missing required file {}", full_path.display());
+    assert!(full_path.exists(), "missing required file {}", full_path.display());
 }
 
 #[test]
@@ -42,16 +38,8 @@ fn a770_claim_boundary_docs_link_to_the_spec() {
     let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
     let index = read_repo_file("docs/specs/INDEX.md");
 
-    assert_contains(
-        &roadmap,
-        "docs/specs/a770-bitnet-claim-boundary.md",
-        "A770 roadmap",
-    );
-    assert_contains(
-        &roadmap,
-        "plans/a770-bitnet-claim-boundary-implementation.md",
-        "A770 roadmap",
-    );
+    assert_contains(&roadmap, "docs/specs/a770-bitnet-claim-boundary.md", "A770 roadmap");
+    assert_contains(&roadmap, "plans/a770-bitnet-claim-boundary-implementation.md", "A770 roadmap");
     assert_contains(
         &validation,
         "docs/specs/a770-bitnet-claim-boundary.md",
@@ -120,16 +108,8 @@ fn a770_claim_boundary_keeps_selected_attention_separate() {
         "Selected attention is a separate research lane",
         "A770 claim-boundary spec",
     );
-    assert_contains(
-        &spec,
-        "It is not promoted by trusted",
-        "A770 claim-boundary spec",
-    );
-    assert_contains(
-        &roadmap,
-        "Selected attention, resident KV",
-        "A770 roadmap",
-    );
+    assert_contains(&spec, "It is not promoted by trusted", "A770 claim-boundary spec");
+    assert_contains(&roadmap, "Selected attention, resident KV", "A770 roadmap");
 }
 
 #[test]

--- a/xtask/tests/a770_claim_boundary_spec.rs
+++ b/xtask/tests/a770_claim_boundary_spec.rs
@@ -4,15 +4,19 @@
 //! rails land PR by PR. They intentionally check only documentation/source
 //! policy, not runtime receipts.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..")
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask crate should live under the workspace root")
+        .to_path_buf()
 }
 
 fn read_repo_file(path: &str) -> String {
     let full_path = repo_root().join(path);
-    std::fs::read_to_string(&full_path).unwrap_or_default()
+    std::fs::read_to_string(&full_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {}", full_path.display(), err))
 }
 
 fn assert_contains(contents: &str, needle: &str, context: &str) {
@@ -21,7 +25,7 @@ fn assert_contains(contents: &str, needle: &str, context: &str) {
 
 fn assert_file_exists(path: &str) {
     let full_path = repo_root().join(path);
-    assert!(full_path.exists(), "missing required file {}", full_path.display());
+    assert!(Path::new(&full_path).exists(), "missing required file {}", full_path.display());
 }
 
 #[test]
@@ -38,8 +42,16 @@ fn a770_claim_boundary_docs_link_to_the_spec() {
     let validation = read_repo_file("docs/hardware/intel-arc-a770-validation.md");
     let index = read_repo_file("docs/specs/INDEX.md");
 
-    assert_contains(&roadmap, "docs/specs/a770-bitnet-claim-boundary.md", "A770 roadmap");
-    assert_contains(&roadmap, "plans/a770-bitnet-claim-boundary-implementation.md", "A770 roadmap");
+    assert_contains(
+        &roadmap,
+        "docs/specs/a770-bitnet-claim-boundary.md",
+        "A770 roadmap",
+    );
+    assert_contains(
+        &roadmap,
+        "plans/a770-bitnet-claim-boundary-implementation.md",
+        "A770 roadmap",
+    );
     assert_contains(
         &validation,
         "docs/specs/a770-bitnet-claim-boundary.md",
@@ -108,8 +120,16 @@ fn a770_claim_boundary_keeps_selected_attention_separate() {
         "Selected attention is a separate research lane",
         "A770 claim-boundary spec",
     );
-    assert_contains(&spec, "It is not promoted by trusted", "A770 claim-boundary spec");
-    assert_contains(&roadmap, "Selected attention, resident KV", "A770 roadmap");
+    assert_contains(
+        &spec,
+        "It is not promoted by trusted",
+        "A770 claim-boundary spec",
+    );
+    assert_contains(
+        &roadmap,
+        "Selected attention, resident KV",
+        "A770 roadmap",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add standard benchmark profiles for quality-gated BitNet experience runs.
- Add a canonical `bench_run` JSON schema for repo/device/model/backend/route/profile/quality/claim/measurement identity.
- Add `cargo xtask bench verify-receipt` to reject speed claims when quality, cleanliness, fallback, route, model contract, resource, or not-claim gates are wrong.

## Claim posture
- Benchmark receipt rail only; no benchmark generation, CLI-stage conversion, LLM-experience receipts, history, clean rerun, or claim promotion.
- Selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, and completion remain critical not-claims.

## Verification
- cargo test --locked -p xtask --no-default-features --bin xtask bench_receipt -- --nocapture
- cargo run --locked -p xtask --no-default-features -- bench verify-receipt --help
- git diff --check a770/prompt-suite-rail...HEAD