### PR TITLE
bench: reject CPU CLI stage as A770 evidence

### DIFF
--- a/ci/benchmarks/schemas/bench-run.schema.json
+++ b/ci/benchmarks/schemas/bench-run.schema.json
@@ -65,9 +65,10 @@
     },
     "kernel_route": {
       "type": "object",
-      "required": ["route_verified", "device_slug", "selected_backend", "kernel_variants"],
+      "required": ["route_verified", "route_claimable", "device_slug", "selected_backend", "kernel_variants"],
       "properties": {
         "route_verified": { "type": "boolean" },
+        "route_claimable": { "type": "boolean" },
         "device_slug": { "type": "string", "minLength": 1 },
         "selected_backend": { "type": "string", "minLength": 1 },
         "kernel_variants": { "type": "array", "items": { "type": "object" } }

--- a/xtask/src/bench_receipt.rs
+++ b/xtask/src/bench_receipt.rs
@@ -1,8 +1,10 @@
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 const CRITICAL_NOT_CLAIMS: &[&str] = &[
     "selected_attention_residency",
@@ -36,6 +38,7 @@ const REQUIRED_POINTERS: &[&str] = &[
     "/backend/backend_family",
     "/backend/fallback_used",
     "/kernel_route/route_verified",
+    "/kernel_route/route_claimable",
     "/kernel_route/device_slug",
     "/kernel_route/selected_backend",
     "/kernel_route/kernel_variants",
@@ -62,6 +65,7 @@ struct BenchReceiptVerifyReport {
     repo_dirty: bool,
     fallback_used: bool,
     route_verified: bool,
+    route_claimable: bool,
     model_contract_matched: Option<bool>,
     resource_envelope_complete: Option<bool>,
     run_id: Option<String>,
@@ -79,6 +83,205 @@ pub fn verify_receipt(receipt_path: &Path, format: &str, require_claimable: bool
         bail!("bench receipt verification failed: {}", report.failures.join(", "));
     }
     Ok(())
+}
+
+pub fn from_cli_stage(
+    plan_path: &Path,
+    cli_stage_receipt: &Path,
+    model_contract: &Path,
+    quality_receipt: &Path,
+    quality_passed: bool,
+    output: &Path,
+    format: &str,
+) -> Result<()> {
+    let plan = read_json(plan_path)?;
+    let cli_stage = read_json(cli_stage_receipt)?;
+    let contract = read_yaml(model_contract)?;
+    let receipt = build_from_cli_stage_receipt(
+        plan_path,
+        &plan,
+        cli_stage_receipt,
+        &cli_stage,
+        model_contract,
+        &contract,
+        quality_receipt,
+        quality_passed,
+    )?;
+
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    fs::write(output, serde_json::to_vec_pretty(&receipt)?)
+        .with_context(|| format!("writing {}", output.display()))?;
+    emit_json_or_human(&receipt, format)?;
+    Ok(())
+}
+
+fn build_from_cli_stage_receipt(
+    plan_path: &Path,
+    plan: &Value,
+    cli_stage_path: &Path,
+    cli_stage: &Value,
+    model_contract_path: &Path,
+    contract: &Value,
+    quality_receipt: &Path,
+    quality_passed: bool,
+) -> Result<Value> {
+    let identity = cli_stage_identity(plan, cli_stage, model_contract_path);
+    let repo = repo_identity()?;
+    let planned_backend = str_at(plan, "/backend").unwrap_or("unknown-backend");
+    let actual_selected_backend = str_at(cli_stage, "/proof_summary/selected_backend")
+        .or_else(|| str_at(cli_stage, "/proof_summary/execution_backend"))
+        .unwrap_or("unknown-backend");
+    let actual_execution_backend =
+        str_at(cli_stage, "/proof_summary/execution_backend").unwrap_or(actual_selected_backend);
+    let fallback_used = bool_at(cli_stage, "/proof_summary/fallback_used").unwrap_or(true);
+    let route_declared = bool_at(&identity, "/route_declared").unwrap_or(false);
+    let execution_backend_matched =
+        bool_at(&identity, "/execution_backend_matched").unwrap_or(false);
+    let route_claimable = bool_at(&identity, "/route_claimable").unwrap_or(false);
+    let route_identity_matched = bool_at(&identity, "/route_identity_matched").unwrap_or(false);
+    let route_verified = route_identity_matched && execution_backend_matched && !fallback_used;
+    let model_contract_matched = bool_at(&identity, "/model_matched").unwrap_or(false);
+    let profile_identity_matched = bool_at(&identity, "/profile_matched").unwrap_or(false);
+    let resource_envelope_complete = false;
+
+    let mut blocked_reasons = Vec::new();
+    if !quality_passed {
+        blocked_reasons.push("quality_not_passed");
+    }
+    if bool_at(&repo, "/dirty").unwrap_or(true) {
+        blocked_reasons.push("repo_dirty");
+    }
+    if fallback_used {
+        blocked_reasons.push("fallback_used");
+    }
+    if !profile_identity_matched {
+        blocked_reasons.push("profile_identity_mismatch");
+    }
+    if !model_contract_matched {
+        blocked_reasons.push("model_contract_not_matched");
+    }
+    if !route_declared {
+        blocked_reasons.push("route_not_declared");
+    }
+    if !route_identity_matched {
+        blocked_reasons.push("route_identity_mismatch");
+    }
+    if !execution_backend_matched {
+        blocked_reasons.push("execution_backend_mismatch");
+        if planned_backend.contains("a770") {
+            blocked_reasons.push("execution_backend_not_a770");
+        }
+    }
+    if !route_verified {
+        blocked_reasons.push("route_not_verified");
+    }
+    if !route_claimable {
+        blocked_reasons.push("route_not_claimable");
+    }
+    if !resource_envelope_complete {
+        blocked_reasons.push("resource_envelope_incomplete");
+    }
+    blocked_reasons.sort_unstable();
+    blocked_reasons.dedup();
+
+    let benchmark_claim_allowed = quality_passed
+        && !bool_at(&repo, "/dirty").unwrap_or(true)
+        && !fallback_used
+        && route_verified
+        && route_identity_matched
+        && route_claimable
+        && resource_envelope_complete
+        && profile_identity_matched
+        && model_contract_matched;
+
+    let profile_id = str_at(plan, "/profile/id").unwrap_or("unknown-profile");
+    let run_id = format!(
+        "{}_{}_{}",
+        chrono::Utc::now().format("%Y%m%dT%H%M%SZ"),
+        str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+        profile_id
+    );
+    let prompt_tokens = number_at(cli_stage, "/tokens/prompt")
+        .or_else(|| number_at(plan, "/profile/target_prompt_tokens"));
+    let generated_tokens = number_at(cli_stage, "/tokens/generated");
+    let tokens_per_second = number_at(cli_stage, "/throughput/tokens_per_second");
+    let prefill_ms = number_at(cli_stage, "/ttft/first_decode_ms")
+        .or_else(|| number_at(cli_stage, "/latency/decode_first_ms"));
+
+    Ok(serde_json::json!({
+        "schema_version": 1,
+        "receipt_type": "bench_run",
+        "run_id": run_id,
+        "created_at": chrono::Utc::now().to_rfc3339(),
+        "source_receipts": {
+            "profile_cli_plan": plan_path.display().to_string(),
+            "cli_stage_receipt": cli_stage_path.display().to_string()
+        },
+        "repo": repo,
+        "device": {
+            "device_slug": str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+            "device_instance_hash": "sha256:local-unverified"
+        },
+        "model": {
+            "contract": model_contract_path.display().to_string(),
+            "model_id": str_at(contract, "/model_id").unwrap_or("unknown-model"),
+            "weights_sha256": str_at(contract, "/sha256").unwrap_or(""),
+            "tokenizer_sha256": str_at(contract, "/tokenizer/sha256").unwrap_or(""),
+            "chat_template_hash": sha256_text(str_at(contract, "/chat_template/name").unwrap_or(""))
+        },
+        "backend": {
+            "requested_backend": str_at(cli_stage, "/proof_summary/requested_backend").unwrap_or(planned_backend),
+            "planned_backend": planned_backend,
+            "selected_backend": actual_selected_backend,
+            "execution_backend": actual_execution_backend,
+            "backend_family": backend_family(actual_selected_backend),
+            "fallback_used": fallback_used
+        },
+        "kernel_route": {
+            "route_verified": route_verified,
+            "route_claimable": route_claimable,
+            "route_declared": route_declared,
+            "device_slug": str_at(plan, "/device_slug").unwrap_or("unknown-device"),
+            "selected_backend": planned_backend,
+            "declared_route_id": str_at(cli_stage, "/proof_summary/kernel_route/route_id"),
+            "kernel_variants": [],
+            "not_claims": CRITICAL_NOT_CLAIMS
+        },
+        "benchmark_profile": {
+            "id": profile_id,
+            "profile_hash": sha256_text(&serde_json::to_string(&plan["profile"])?),
+            "profile_identity": identity
+        },
+        "cli_stage_identity_validation": identity,
+        "quality_gate": {
+            "required": true,
+            "quality_passed": quality_passed,
+            "quality_receipt": quality_receipt.display().to_string()
+        },
+        "claim_gate": {
+            "benchmark_claim_allowed": benchmark_claim_allowed,
+            "classification": if benchmark_claim_allowed { "performance_proven" } else { "diagnostic_only" },
+            "model_contract_matched": model_contract_matched,
+            "resource_envelope_complete": resource_envelope_complete,
+            "blocked_reasons": blocked_reasons
+        },
+        "measurements": {
+            "summary": {
+                "prompt_tokens": prompt_tokens,
+                "generated_tokens": generated_tokens,
+                "prefill_ms": prefill_ms,
+                "steady_state_output_tok_s": tokens_per_second,
+                "end_to_end_output_tok_s": tokens_per_second,
+                "peak_rss_bytes": number_at(cli_stage, "/resource_envelope/peak_rss_bytes"),
+                "peak_vram_bytes": Value::Null,
+                "host_device_transfer_bytes": Value::Null,
+                "kernel_invocations": Value::Null
+            }
+        },
+        "not_claims": CRITICAL_NOT_CLAIMS
+    }))
 }
 
 fn build_verify_report(
@@ -107,6 +310,7 @@ fn build_verify_report(
     let repo_dirty = bool_at(&value, "/repo/dirty").unwrap_or(true);
     let fallback_used = bool_at(&value, "/backend/fallback_used").unwrap_or(true);
     let route_verified = bool_at(&value, "/kernel_route/route_verified").unwrap_or(false);
+    let route_claimable = bool_at(&value, "/kernel_route/route_claimable").unwrap_or(false);
     let model_contract_matched = bool_at(&value, "/claim_gate/model_contract_matched");
     let resource_envelope_complete = bool_at(&value, "/claim_gate/resource_envelope_complete");
     let claimable = bool_at(&value, "/claim_gate/benchmark_claim_allowed")
@@ -138,6 +342,9 @@ fn build_verify_report(
     if claimable && !route_verified {
         failures.push("benchmark claim allowed while route_verified=false".to_string());
     }
+    if claimable && !route_claimable {
+        failures.push("benchmark claim allowed while route_claimable=false".to_string());
+    }
     if claimable && model_contract_matched == Some(false) {
         failures.push("benchmark claim allowed while model_contract_matched=false".to_string());
     }
@@ -159,6 +366,9 @@ fn build_verify_report(
     }
     if !route_verified {
         blocked_reasons.push("route_not_verified".to_string());
+    }
+    if !route_claimable {
+        blocked_reasons.push("route_not_claimable".to_string());
     }
     if model_contract_matched == Some(false) {
         blocked_reasons.push("model_contract_not_matched".to_string());
@@ -182,6 +392,7 @@ fn build_verify_report(
         repo_dirty,
         fallback_used,
         route_verified,
+        route_claimable,
         model_contract_matched,
         resource_envelope_complete,
         run_id: str_at(&value, "/run_id").map(ToOwned::to_owned),
@@ -229,6 +440,287 @@ fn array_strings(value: &Value, pointer: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
+fn cli_stage_identity(plan: &Value, cli_stage: &Value, model_contract_path: &Path) -> Value {
+    let deterministic_temperature = Value::from(0.0);
+    let prompt_profile_checks = [
+        (
+            "same_prompt_token_count",
+            plan.pointer("/prompt_identity/prompt_token_count"),
+            cli_stage.pointer("/prompt_identity/prompt_token_count"),
+        ),
+        (
+            "same_rendered_prompt_hash",
+            plan.pointer("/prompt_identity/rendered_prompt_sha256"),
+            cli_stage.pointer("/prompt_identity/rendered_prompt_sha256"),
+        ),
+        (
+            "same_token_ids_hash",
+            plan.pointer("/prompt_identity/prompt_token_ids_sha256"),
+            cli_stage.pointer("/prompt_identity/prompt_token_ids_sha256"),
+        ),
+        (
+            "same_generated_token_count",
+            plan.pointer("/profile/max_new_tokens"),
+            cli_stage.pointer("/tokens/generated"),
+        ),
+        (
+            "same_sampling_temperature",
+            Some(&deterministic_temperature),
+            cli_stage.pointer("/gen_policy/temperature"),
+        ),
+    ];
+
+    let planned_backend = plan.pointer("/backend");
+    let requested_backend = cli_stage.pointer("/proof_summary/requested_backend");
+    let selected_backend = cli_stage.pointer("/proof_summary/selected_backend");
+    let execution_backend = cli_stage.pointer("/proof_summary/execution_backend");
+    let planned_route = plan.pointer("/kernel_route/route_id");
+    let declared_route = cli_stage.pointer("/proof_summary/kernel_route/route_id");
+    let expected_contract_text = model_contract_path.display().to_string();
+    let expected_contract = Value::String(expected_contract_text.clone());
+    let declared_contract = cli_stage.pointer("/proof_summary/model_contract");
+
+    let mut object = serde_json::Map::new();
+    let mut profile_failures = Vec::new();
+    let mut route_failures = Vec::new();
+    let mut model_failures = Vec::new();
+
+    for (name, expected, actual) in prompt_profile_checks {
+        let passed = expected.is_some() && expected == actual;
+        object.insert(name.to_string(), Value::Bool(passed));
+        if !passed {
+            profile_failures.push(field_failure(name, expected, actual));
+        }
+    }
+
+    let requested_backend_matched = planned_backend.is_some()
+        && requested_backend.is_some()
+        && planned_backend == requested_backend;
+    object.insert("requested_backend_matched".to_string(), Value::Bool(requested_backend_matched));
+    if !requested_backend_matched {
+        route_failures.push(field_failure(
+            "requested_backend_matched",
+            planned_backend,
+            requested_backend,
+        ));
+    }
+
+    let selected_backend_matched = planned_backend.is_some()
+        && selected_backend.is_some()
+        && planned_backend == selected_backend;
+    object.insert("selected_backend_matched".to_string(), Value::Bool(selected_backend_matched));
+    if !selected_backend_matched {
+        route_failures.push(field_failure(
+            "selected_backend_matched",
+            planned_backend,
+            selected_backend,
+        ));
+    }
+
+    let execution_backend_matched = planned_backend.is_some()
+        && execution_backend.is_some()
+        && planned_backend == execution_backend;
+    object.insert("execution_backend_matched".to_string(), Value::Bool(execution_backend_matched));
+    if !execution_backend_matched {
+        route_failures.push(field_failure(
+            "execution_backend_matched",
+            planned_backend,
+            execution_backend,
+        ));
+    }
+
+    let route_declared = bool_at(cli_stage, "/proof_summary/route_declared").unwrap_or(false)
+        && declared_route.and_then(Value::as_str).is_some_and(|route| !route.is_empty());
+    object.insert("route_declared".to_string(), Value::Bool(route_declared));
+    if !route_declared {
+        route_failures.push(field_failure(
+            "route_declared",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
+    }
+
+    let same_kernel_route =
+        planned_route.is_some() && declared_route.is_some() && planned_route == declared_route;
+    object.insert("same_kernel_route".to_string(), Value::Bool(same_kernel_route));
+    if !same_kernel_route {
+        route_failures.push(field_failure("same_kernel_route", planned_route, declared_route));
+    }
+
+    let route_claimable =
+        bool_at(cli_stage, "/proof_summary/kernel_route/claimable").unwrap_or(false);
+    object.insert("route_claimable".to_string(), Value::Bool(route_claimable));
+    if !route_claimable {
+        route_failures.push(field_failure(
+            "route_claimable",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
+    }
+
+    let model_matched = declared_contract
+        .and_then(Value::as_str)
+        .is_some_and(|actual| same_path_string(&expected_contract_text, actual));
+    object.insert("model_matched".to_string(), Value::Bool(model_matched));
+    object.insert("same_model_contract".to_string(), Value::Bool(model_matched));
+    if !model_matched {
+        model_failures.push(field_failure(
+            "model_matched",
+            Some(&expected_contract),
+            declared_contract,
+        ));
+    }
+
+    let fallback_false = !bool_at(cli_stage, "/proof_summary/fallback_used").unwrap_or(true);
+    object.insert("fallback_false".to_string(), Value::Bool(fallback_false));
+    if !fallback_false {
+        route_failures.push(field_failure(
+            "fallback_false",
+            Some(&Value::Bool(true)),
+            Some(&Value::Bool(false)),
+        ));
+    }
+
+    let profile_matched = profile_failures.is_empty();
+    let route_identity_matched = requested_backend_matched && same_kernel_route && route_declared;
+    let matched = profile_matched
+        && model_matched
+        && route_identity_matched
+        && execution_backend_matched
+        && fallback_false
+        && route_claimable;
+
+    object.insert("profile_matched".to_string(), Value::Bool(profile_matched));
+    object.insert("route_identity_matched".to_string(), Value::Bool(route_identity_matched));
+    object.insert("matched".to_string(), Value::Bool(matched));
+    object.insert("profile_failures".to_string(), Value::Array(profile_failures));
+    object.insert("route_failures".to_string(), Value::Array(route_failures));
+    object.insert("model_failures".to_string(), Value::Array(model_failures));
+    let failures = object
+        .get("profile_failures")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .chain(object.get("route_failures").and_then(Value::as_array).into_iter().flatten())
+        .chain(object.get("model_failures").and_then(Value::as_array).into_iter().flatten())
+        .cloned()
+        .collect();
+    object.insert("failures".to_string(), Value::Array(failures));
+    Value::Object(object)
+}
+
+fn field_failure(name: &str, expected: Option<&Value>, actual: Option<&Value>) -> Value {
+    serde_json::json!({
+        "field": name,
+        "expected": expected.cloned().unwrap_or(Value::Null),
+        "actual": actual.cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn same_path_string(expected: &str, actual: &str) -> bool {
+    normalize_path_string(expected) == normalize_path_string(actual)
+}
+
+fn normalize_path_string(value: &str) -> String {
+    value.replace('\\', "/")
+}
+
+fn repo_identity() -> Result<Value> {
+    Ok(serde_json::json!({
+        "commit": git_output(&["rev-parse", "HEAD"]).unwrap_or_else(|_| "unknown".to_string()),
+        "tree": git_output(&["rev-parse", "HEAD^{tree}"]).unwrap_or_else(|_| "unknown".to_string()),
+        "dirty": repo_dirty(),
+        "cargo_lock_hash": format!("sha256:{}", sha256_file(Path::new("Cargo.lock")).unwrap_or_else(|_| "unknown".to_string())),
+        "rustc": command_output("rustc", &["--version"]).unwrap_or_else(|_| "unknown".to_string()),
+        "features": ["cpu"],
+    }))
+}
+
+fn repo_dirty() -> bool {
+    Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=all"])
+        .output()
+        .map(|output| !output.status.success() || !output.stdout.is_empty())
+        .unwrap_or(true)
+}
+
+fn git_output(args: &[&str]) -> Result<String> {
+    command_output("git", args)
+}
+
+fn command_output(program: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(program)
+        .args(args)
+        .output()
+        .with_context(|| format!("running {program} {}", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("{program} {} failed", args.join(" "));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn read_json(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn read_yaml(path: &Path) -> Result<Value> {
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_yaml::from_str(&raw).with_context(|| format!("parsing {}", path.display()))
+}
+
+fn emit_json_or_human(value: &Value, format: &str) -> Result<()> {
+    match format {
+        "json" => println!("{}", serde_json::to_string_pretty(value)?),
+        "human" => {
+            println!("bench from-cli-stage: {}", str_at(value, "/run_id").unwrap_or("unknown"));
+            println!(
+                "benchmark_claim_allowed: {}",
+                bool_at(value, "/claim_gate/benchmark_claim_allowed").unwrap_or(false)
+            );
+            println!(
+                "classification: {}",
+                str_at(value, "/claim_gate/classification").unwrap_or("diagnostic_only")
+            );
+            println!(
+                "blocked_reasons: {}",
+                value.pointer("/claim_gate/blocked_reasons").unwrap_or(&Value::Null)
+            );
+        }
+        other => bail!("unsupported bench output format: {other}"),
+    }
+    Ok(())
+}
+
+fn number_at(value: &Value, pointer: &str) -> Option<Value> {
+    value.pointer(pointer).filter(|value| value.is_number()).cloned()
+}
+
+fn backend_family(selected_backend: &str) -> &'static str {
+    if selected_backend == "cpu" {
+        "cpu"
+    } else if selected_backend.contains("a770") || selected_backend.contains("opencl") {
+        "intel-opencl"
+    } else {
+        "unknown"
+    }
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(sha256_bytes(&bytes))
+}
+
+fn sha256_text(value: &str) -> String {
+    sha256_bytes(value.as_bytes())
+}
+
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,6 +756,7 @@ mod tests {
             },
             "kernel_route": {
                 "route_verified": true,
+                "route_claimable": claim_allowed,
                 "device_slug": "amd-5700x-intel-a770",
                 "selected_backend": "intel-arc-a770-opencl",
                 "kernel_variants": [
@@ -306,13 +799,90 @@ mod tests {
         Ok((dir, path))
     }
 
+    fn plan_and_cli_stage_with_route(execution_backend: &str, route_id: &str) -> (Value, Value) {
+        let plan = serde_json::json!({
+            "backend": "intel-arc-a770-opencl",
+            "device_slug": "amd-5700x-intel-a770",
+            "kernel_route": {
+                "route_id": "a770.bitnet.i2s.qk256"
+            },
+            "profile": {
+                "id": "prefill_512_decode_64",
+                "target_prompt_tokens": 512,
+                "max_new_tokens": 64
+            },
+            "prompt_identity": {
+                "prompt_token_count": 512,
+                "rendered_prompt_sha256": "rendered",
+                "prompt_token_ids_sha256": "tokens"
+            }
+        });
+        let cli = serde_json::json!({
+            "prompt_identity": {
+                "prompt_token_count": 512,
+                "rendered_prompt_sha256": "rendered",
+                "prompt_token_ids_sha256": "tokens"
+            },
+            "tokens": {
+                "prompt": 512,
+                "generated": 64
+            },
+            "gen_policy": {
+                "temperature": 0.0
+            },
+            "proof_summary": {
+                "requested_backend": "intel-arc-a770-opencl",
+                "selected_backend": execution_backend,
+                "execution_backend": execution_backend,
+                "fallback_used": false,
+                "model_contract": "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml",
+                "route_declared": true,
+                "kernel_route": {
+                    "route_id": route_id,
+                    "claimable": false
+                }
+            },
+            "throughput": {
+                "tokens_per_second": 12.5
+            },
+            "ttft": {
+                "first_decode_ms": 100.0
+            }
+        });
+        (plan, cli)
+    }
+
+    fn plan_and_cli_stage(execution_backend: &str) -> (Value, Value) {
+        plan_and_cli_stage_with_route(execution_backend, "a770.bitnet.i2s.qk256")
+    }
+
+    fn contract() -> Value {
+        serde_json::json!({
+            "model_id": "microsoft/bitnet-b1.58-2B-4T-gguf",
+            "sha256": "sha256:weights",
+            "tokenizer": {
+                "sha256": "sha256:tokenizer"
+            },
+            "chat_template": {
+                "name": "llama3-chat"
+            }
+        })
+    }
+
     #[test]
     fn diagnostic_receipt_can_verify_without_claim() -> Result<()> {
         let (_dir, path) = write_receipt(&receipt(false, false, true))?;
         let report = build_verify_report(&path, false)?;
-        assert!(report.passed);
-        assert!(!report.claimable);
-        assert!(report.blocked_reasons.iter().any(|reason| reason == "quality_not_passed"));
+        anyhow::ensure!(report.passed, "diagnostic receipt should pass: {report:?}");
+        anyhow::ensure!(
+            !report.claimable,
+            "diagnostic receipt should not be claimable: {report:?}"
+        );
+        anyhow::ensure!(
+            report.blocked_reasons.iter().any(|reason| reason == "quality_not_passed"),
+            "expected quality_not_passed in {:?}",
+            report.blocked_reasons
+        );
         Ok(())
     }
 
@@ -320,8 +890,12 @@ mod tests {
     fn rejects_quality_failed_claim() -> Result<()> {
         let (_dir, path) = write_receipt(&receipt(true, false, false))?;
         let report = build_verify_report(&path, false)?;
-        assert!(!report.passed);
-        assert!(report.failures.iter().any(|failure| failure.contains("quality_passed=false")));
+        anyhow::ensure!(!report.passed, "quality-failed claim should fail: {report:?}");
+        anyhow::ensure!(
+            report.failures.iter().any(|failure| failure.contains("quality_passed=false")),
+            "expected quality_passed=false in {:?}",
+            report.failures
+        );
         Ok(())
     }
 
@@ -329,8 +903,136 @@ mod tests {
     fn rejects_dirty_claim() -> Result<()> {
         let (_dir, path) = write_receipt(&receipt(true, true, true))?;
         let report = build_verify_report(&path, false)?;
-        assert!(!report.passed);
-        assert!(report.failures.iter().any(|failure| failure.contains("dirty repo")));
+        anyhow::ensure!(!report.passed, "dirty claim should fail: {report:?}");
+        anyhow::ensure!(
+            report.failures.iter().any(|failure| failure.contains("dirty repo")),
+            "expected dirty repo failure in {:?}",
+            report.failures
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cli_stage_identity_rejects_cpu_execution_with_declared_a770_route() -> Result<()> {
+        let (plan, cli) = plan_and_cli_stage("cpu");
+        let identity = cli_stage_identity(
+            &plan,
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+        );
+
+        anyhow::ensure!(identity["profile_matched"] == true, "profile should match: {identity}");
+        anyhow::ensure!(identity["model_matched"] == true, "model should match: {identity}");
+        anyhow::ensure!(identity["route_declared"] == true, "route should be declared: {identity}");
+        anyhow::ensure!(
+            identity["same_kernel_route"] == true,
+            "kernel route should match: {identity}"
+        );
+        anyhow::ensure!(
+            identity["requested_backend_matched"] == true,
+            "requested backend should match: {identity}"
+        );
+        anyhow::ensure!(
+            identity["execution_backend_matched"] == false,
+            "CPU execution must not match A770 plan: {identity}"
+        );
+        anyhow::ensure!(
+            identity["route_claimable"] == false,
+            "declared route should remain non-claimable: {identity}"
+        );
+        anyhow::ensure!(
+            identity["matched"] == false,
+            "overall identity should not match: {identity}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn from_cli_stage_blocks_cpu_as_a770_evidence() -> Result<()> {
+        let (plan, cli) = plan_and_cli_stage("cpu");
+        let receipt = build_from_cli_stage_receipt(
+            Path::new("plan.json"),
+            &plan,
+            Path::new("cli.json"),
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            &contract(),
+            Path::new("quality.json"),
+            true,
+        )?;
+
+        anyhow::ensure!(
+            receipt["backend"]["selected_backend"] == "cpu",
+            "selected backend should be cpu: {receipt}"
+        );
+        anyhow::ensure!(
+            receipt["backend"]["execution_backend"] == "cpu",
+            "execution backend should be cpu: {receipt}"
+        );
+        anyhow::ensure!(
+            receipt["kernel_route"]["route_declared"] == true,
+            "route should be declared: {receipt}"
+        );
+        anyhow::ensure!(
+            receipt["kernel_route"]["route_verified"] == false,
+            "CPU execution must not verify A770 route: {receipt}"
+        );
+        anyhow::ensure!(
+            receipt["claim_gate"]["benchmark_claim_allowed"] == false,
+            "CPU CLI stage must not be claimable A770 evidence: {receipt}"
+        );
+        let blocked = receipt["claim_gate"]["blocked_reasons"]
+            .as_array()
+            .context("blocked_reasons should be an array")?;
+        anyhow::ensure!(
+            blocked.iter().any(|reason| reason == "execution_backend_not_a770"),
+            "expected execution_backend_not_a770 in {blocked:?}"
+        );
+        anyhow::ensure!(
+            blocked.iter().any(|reason| reason == "route_not_claimable"),
+            "expected route_not_claimable in {blocked:?}"
+        );
+        anyhow::ensure!(
+            blocked.iter().any(|reason| reason == "resource_envelope_incomplete"),
+            "expected resource_envelope_incomplete in {blocked:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cli_stage_identity_rejects_wrong_declared_kernel_route() -> Result<()> {
+        let (plan, cli) =
+            plan_and_cli_stage_with_route("intel-arc-a770-opencl", "a770.wrong.route");
+        let receipt = build_from_cli_stage_receipt(
+            Path::new("plan.json"),
+            &plan,
+            Path::new("cli.json"),
+            &cli,
+            Path::new("docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml"),
+            &contract(),
+            Path::new("quality.json"),
+            true,
+        )?;
+
+        anyhow::ensure!(
+            receipt["kernel_route"]["route_verified"] == false,
+            "wrong route must not verify: {receipt}"
+        );
+        anyhow::ensure!(
+            receipt["claim_gate"]["benchmark_claim_allowed"] == false,
+            "wrong route must not be claimable: {receipt}"
+        );
+        let blocked = receipt["claim_gate"]["blocked_reasons"]
+            .as_array()
+            .context("blocked_reasons should be an array")?;
+        anyhow::ensure!(
+            blocked.iter().any(|reason| reason == "route_identity_mismatch"),
+            "expected route_identity_mismatch in {blocked:?}"
+        );
+        anyhow::ensure!(
+            blocked.iter().any(|reason| reason == "route_not_verified"),
+            "expected route_not_verified in {blocked:?}"
+        );
         Ok(())
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1376,6 +1376,32 @@ enum PromptSuiteCmd {
 
 #[derive(Subcommand)]
 enum BenchCmd {
+    /// Convert a profile CLI-stage receipt into a quality-gated benchmark receipt.
+    #[command(name = "from-cli-stage")]
+    FromCliStage {
+        /// Profile CLI plan emitted by a profile planner.
+        #[arg(long, default_value = "target/llm-experience/profile-cli-stage-plan.json")]
+        plan: PathBuf,
+        /// CLI-stage JSON receipt emitted by bitnet run --json-out.
+        #[arg(long, default_value = "target/llm-experience/profile-cli-stage.json")]
+        cli_stage_receipt: PathBuf,
+        /// Model contract YAML file.
+        #[arg(long, default_value = "docs/model-contracts/bitnet-b1.58-2b-4t-i2s.yaml")]
+        model_contract: PathBuf,
+        /// Quality receipt path this benchmark depends on.
+        #[arg(long, default_value = "target/quality/a770-bitnet-quality.json")]
+        quality_receipt: PathBuf,
+        /// Whether the referenced quality receipt passed.
+        #[arg(long, default_value_t = false)]
+        quality_passed: bool,
+        /// Output benchmark receipt JSON file.
+        #[arg(long, default_value = "target/bench-runs/profile-cli-stage.json")]
+        output: PathBuf,
+        /// Output format: human or json.
+        #[arg(long, default_value = "human")]
+        format: String,
+    },
+
     /// Verify a quality-gated benchmark receipt.
     #[command(name = "verify-receipt")]
     VerifyReceipt {
@@ -1650,6 +1676,23 @@ fn real_main() -> Result<()> {
             }
         },
         Cmd::Bench { cmd } => match cmd {
+            BenchCmd::FromCliStage {
+                plan,
+                cli_stage_receipt,
+                model_contract,
+                quality_receipt,
+                quality_passed,
+                output,
+                format,
+            } => bench_receipt::from_cli_stage(
+                &plan,
+                &cli_stage_receipt,
+                &model_contract,
+                &quality_receipt,
+                quality_passed,
+                &output,
+                &format,
+            ),
             BenchCmd::VerifyReceipt { receipt, require_claimable, format } => {
                 bench_receipt::verify_receipt(&receipt, &format, require_claimable)
             }


### PR DESCRIPTION
## Summary
- Add `cargo xtask bench from-cli-stage` to convert a profile CLI-stage receipt into a diagnostic benchmark receipt.
- Validate profile identity, model contract identity, declared kernel route, actual selected/execution backend, fallback status, and route claimability as separate fields.
- Keep actual backend evidence honest: a CLI receipt that declares an A770 route but reports CPU execution remains diagnostic and blocked by `execution_backend_not_a770`.

## Claim posture
- No clean A770 rerun and no benchmark promotion.
- `route_claimable=false` and `resource_envelope_complete=false` keep generated receipts non-claimable.
- Selected attention, resident KV, attention scores, softmax, value mix, full support-op residency, full device residency, and completion remain not claimed.

## Verification
- cargo test --locked -p xtask --no-default-features --bin xtask bench_receipt -- --nocapture
- cargo run --locked -p xtask --no-default-features -- bench from-cli-stage --help
- cargo test --locked -p xtask --no-default-features --bin xtask claims -- --nocapture
- git diff --check a770/claim-ledger-rail...HEAD