### PR TITLE
badge: refresh public endpoints

### DIFF
--- a/badges/ripr-plus.json
+++ b/badges/ripr-plus.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "ripr+",
-  "message": "138787",
+  "message": "138828",
   "color": "orange"
 }


### PR DESCRIPTION
Refreshes generated Shields endpoint JSON under `badges/`.

Generated by:

```bash
cargo xtask badges
```

Opened manually because the Badge Endpoints workflow can push `automation/badge-endpoints` but GitHub Actions is not permitted to create pull requests in this repository configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated badge metric value to reflect current count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EffortlessMetrics/BitNet-rs/pull/4736)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->